### PR TITLE
Refactor and clean up CodeCacheManager

### DIFF
--- a/runtime/tr.source/trj9/control/rossa.cpp
+++ b/runtime/tr.source/trj9/control/rossa.cpp
@@ -1245,7 +1245,7 @@ onLoadInternal(
    memset(codeCacheManager, 0, sizeof(TR::CodeCacheManager));
 
    // must initialize manager using the global (not thread specific) fe because current thread isn't guaranteed to live longer than the manager
-   new (codeCacheManager) TR::CodeCacheManager(feWithoutThread);
+   new (codeCacheManager) TR::CodeCacheManager(feWithoutThread, TR::Compiler->rawAllocator);
 
    TR::CodeCacheConfig &codeCacheConfig = codeCacheManager->codeCacheConfig();
 

--- a/runtime/tr.source/trj9/env/RawAllocator.hpp
+++ b/runtime/tr.source/trj9/env/RawAllocator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,7 @@ using J9::RawAllocator;
 #endif // #ifndef TR_RAW_ALLOCATOR
 
 #include <new>
+#include "env/TypedAllocator.hpp"
 #include "j9.h"
 #undef min
 #undef max
@@ -94,6 +95,12 @@ public:
       }
 
    friend class SegmentAllocator;
+
+   template < typename T >
+   operator TR::typed_allocator< T, TR::RawAllocator >()
+      {
+      return TR::typed_allocator< T, TR::RawAllocator >(*this);
+      }
 
 private:
 

--- a/runtime/tr.source/trj9/runtime/CodeCacheManager.hpp
+++ b/runtime/tr.source/trj9/runtime/CodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,10 @@ namespace TR {
 class OMR_EXTENSIBLE CodeCacheManager : public J9::CodeCacheManagerConnector
     {
     public:
-    CodeCacheManager(TR_FrontEnd *fe) : J9::CodeCacheManagerConnector(fe) { }
+    CodeCacheManager(TR_FrontEnd *fe, TR::RawAllocator rawAllocator) :
+       J9::CodeCacheManagerConnector(fe, rawAllocator)
+       {
+       }
     };
 
 }

--- a/runtime/tr.source/trj9/runtime/J9CodeCacheManager.cpp
+++ b/runtime/tr.source/trj9/runtime/J9CodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,12 @@ J9::CodeCacheManager::self()
    return static_cast<TR::CodeCacheManager *>(this);
    }
 
+TR_FrontEnd *
+J9::CodeCacheManager::fe()
+   {
+   return _fe;
+   }
+
 TR_J9VMBase *
 J9::CodeCacheManager::fej9()
    {
@@ -71,21 +77,6 @@ J9::CodeCacheManager::initialize(bool useConsolidatedCache, uint32_t numberOfCod
 
    return self()->OMR::CodeCacheManager::initialize(useConsolidatedCache, numberOfCodeCachesToCreateAtStartup);
    }
-
-void *
-J9::CodeCacheManager::getMemory(size_t sizeInBytes)
-   {
-   PORT_ACCESS_FROM_JITCONFIG(TR::CodeCacheManager::jitConfig());
-   return j9mem_allocate_memory(sizeInBytes, J9MEM_CATEGORY_JIT);
-   }
-
-void
-J9::CodeCacheManager::freeMemory(void *memoryToFree)
-   {
-   PORT_ACCESS_FROM_JITCONFIG(TR::CodeCacheManager::jitConfig());
-   j9mem_free_memory(memoryToFree);
-   }
-
 
 void
 J9::CodeCacheManager::addCodeCache(TR::CodeCache *codeCache)

--- a/runtime/tr.source/trj9/runtime/J9CodeCacheManager.hpp
+++ b/runtime/tr.source/trj9/runtime/J9CodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,9 @@ class OMR_EXTENSIBLE CodeCacheManager : public OMR::CodeCacheManagerConnector
    TR::CodeCacheManager *self();
 
 public:
-   CodeCacheManager(TR_FrontEnd *fe) : OMR::CodeCacheManagerConnector(fe)
+   CodeCacheManager(TR_FrontEnd *fe, TR::RawAllocator rawAllocator) :
+      OMR::CodeCacheManagerConnector(rawAllocator),
+      _fe(fe)
       {
       _codeCacheManager = reinterpret_cast<TR::CodeCacheManager *>(this);
       }
@@ -62,12 +64,10 @@ public:
    static J9JITConfig *jitConfig()         { return _jitConfig; }
    static J9JavaVM *javaVM()               { return _javaVM; }
 
+   TR_FrontEnd *fe();
    TR_J9VMBase *fej9();
 
    TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
-
-   void *getMemory(size_t sizeInBytes);
-   void  freeMemory(void *memoryToFree);
 
    void addCodeCache(TR::CodeCache *codeCache);
 
@@ -104,6 +104,7 @@ public:
    void onClassRedefinition(TR_OpaqueMethodBlock *oldMethod, TR_OpaqueMethodBlock *newMethod);
 
 private :
+   TR_FrontEnd *_fe;
    static TR::CodeCacheManager *_codeCacheManager;
    static J9JITConfig *_jitConfig;
    static J9JavaVM *_javaVM;


### PR DESCRIPTION
- Change invocation parameters of superclass constructor, removing the
TR_FrontEnd parameter and replacing it with a TR::RawAllocator.

- Add a TR::RawAllocator parameter to the J9::CodeCacheManager
constructor.

- Add a TR_FrontEnd field in the J9::CodeCacheManger to replace the one
removed from the OMR layer.

- Remove the implementations of getMemory and freeMemory methods as they
are now satisfied by the OMR::CodeCacheManager.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>