### PR TITLE
Properly initalize superclass of IlGeneratorMethodDetails

### DIFF
--- a/runtime/tr.source/trj9/ilgen/J9IlGeneratorMethodDetails.hpp
+++ b/runtime/tr.source/trj9/ilgen/J9IlGeneratorMethodDetails.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,12 +59,16 @@ class OMR_EXTENSIBLE IlGeneratorMethodDetails : public OMR::IlGeneratorMethodDet
    friend class IlGeneratorMethodDetailsOverrideForReplay;
 
 public:
-   IlGeneratorMethodDetails()
+   IlGeneratorMethodDetails() :
+      OMR::IlGeneratorMethodDetailsConnector()
       {
       _method = NULL;
       }
 
-   IlGeneratorMethodDetails(J9Method * const method) : _method(method) { }
+   IlGeneratorMethodDetails(J9Method * const method) :
+      OMR::IlGeneratorMethodDetailsConnector(),
+      _method(method)
+   { }
 
    IlGeneratorMethodDetails(TR_ResolvedMethod *method);
 


### PR DESCRIPTION
Currently we don't properly IlGeneratorMethodDetails, however that
hasn't harmed us because it has no state. However, I'm trying to add a
field to the OMR::IlGeneratorMethodDetails which will require it to be
initalized, so this commit adds the required call to the parent
constructor.

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>