### PR TITLE
Throw NoClassDefFoundError: MH.resolveInvokeDynamic(...)

### DIFF
--- a/runtime/jcl/uma/se7_exports.xml
+++ b/runtime/jcl/uma/se7_exports.xml
@@ -57,6 +57,7 @@
 	<export name="Java_java_lang_invoke_MethodHandle_getCPTypeAt" />
 	<export name="Java_java_lang_invoke_MethodHandle_getCPMethodTypeAt" />
 	<export name="Java_java_lang_invoke_MethodHandle_getCPMethodHandleAt" />
+	<export name="Java_java_lang_invoke_MethodHandle_getCPClassNameAt" />
 	<export name="Java_java_lang_invoke_ThunkTuple_registerNatives" />
 	<export name="Java_java_lang_invoke_InterfaceHandle_registerNatives" />
 	<export name="Java_java_lang_invoke_MethodType_makeTenured" />

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -992,6 +992,7 @@ jobject JNICALL Java_sun_reflect_ConstantPool_getUTF8At0(JNIEnv *env, jobject un
 jint JNICALL Java_java_lang_invoke_MethodHandle_getCPTypeAt(JNIEnv *env, jclass unusedClass, jobject constantPoolOop, jint cpIndex);
 jobject JNICALL Java_java_lang_invoke_MethodHandle_getCPMethodTypeAt(JNIEnv *env, jclass unusedClass, jobject constantPoolOop, jint cpIndex);
 jobject JNICALL Java_java_lang_invoke_MethodHandle_getCPMethodHandleAt(JNIEnv *env, jclass unusedClass, jobject constantPoolOop, jint cpIndex);
+jobject JNICALL Java_java_lang_invoke_MethodHandle_getCPClassNameAt(JNIEnv *env, jobject unusedObject, jobject constantPoolOop, jint cpIndex);
 jint JNICALL Java_jdk_internal_reflect_ConstantPool_getClassRefIndexAt0(JNIEnv *env, jobject unusedObject, jobject constantPoolOop, jint cpIndex);
 jint JNICALL Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefIndexAt0(JNIEnv *env, jobject unusedObject, jobject constantPoolOop, jint cpIndex);
 jobject JNICALL Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefInfoAt0(JNIEnv *env, jobject unusedObject, jobject constantPoolOop, jint cpIndex);


### PR DESCRIPTION
If ConstantPool.getClassAt(...) returns null while resolving bootstrap
method handles, then we should throw NoClassDefFoundError, and the
cause of NoClassDefFoundError should be ClassNotFoundException. The
message of NoClassDefFoundError and ClassNotFoundException should
contain the name of the class, which wasn't found.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>