### PR TITLE
fix illegal-access behaviour

### DIFF
--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -267,6 +267,11 @@ isPackageExportedToModuleHelper(J9VMThread *currentThread, J9Module *fromModule,
 				 */
 				isExported = (*targetPtr == toModule);
 			}
+		} else if (J9_ARE_NO_BITS_SET(vm->runtimeFlags, J9_RUNTIME_DENY_ILLEGAL_ACCESS)) {
+			/* in Java9 --illegal-access=permit is turned on by default. This opens
+			 * each package to all-unnamed modules unless illegal-access=deny is specified
+			 */
+			isExported = TRUE;
 		}
 	}
 	return isExported;

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -64,7 +64,6 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 				&& (J2SE_VERSION(vm) >= J2SE_19) 
 				&& J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)
 				&& !J9ROMCLASS_IS_PRIMITIVE_TYPE(destClass->romClass)
-				&& J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_DENY_ILLEGAL_ACCESS)
 			) {
 				j9object_t srcClassObject = sourceClass->classObject;
 				j9object_t destClassObject = destClass->classObject;


### PR DESCRIPTION
fix illegal-access behaviour

This is the first set of changes to address illegal-access behaviour.

The illegal-access (--illegal-access=[permit|debug|warn]) option opens
all packages in the runtime image to unnamed modules if those package
existed in JDK8. 

The previous implementation also provided add-reads access to all
modules which is incorrect. The 'if that package existed in JDK8' part
will be addressed in a future PR.

The default behaviour in JDK9 is '--illegal-access=permit'. In order to
turn this off one must supply '--illegal-access=deny', which will be the
default for Java10+ java releases.

Signed-off-by: tajila <atobia@ca.ibm.com>

Reviewer: @pshipton 