### PR TITLE
Remove unused flag 'module_jsig' from build specs

### DIFF
--- a/buildspecs/aix_ppc-64.spec
+++ b/buildspecs/aix_ppc-64.spec
@@ -222,7 +222,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/aix_ppc-64_cmprssptrs.spec
+++ b/buildspecs/aix_ppc-64_cmprssptrs.spec
@@ -218,7 +218,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/aix_ppc-64_codecov.spec
+++ b/buildspecs/aix_ppc-64_codecov.spec
@@ -205,7 +205,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/aix_ppc.spec
+++ b/buildspecs/aix_ppc.spec
@@ -220,7 +220,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -1683,10 +1683,6 @@ Only available on zOS</description>
 		<description>Enables compilation of the jnitest module.</description>
 		<ifRemoved>The module will not be compiled.</ifRemoved>
 	</flag>
-	<flag id="module_jsig">
-		<description>Enables compilation of the jsig module.</description>
-		<ifRemoved>The module will not be compiled.</ifRemoved>
-	</flag>
 	<flag id="module_jvmti">
 		<description>Enables compilation of the jvmti module.</description>
 		<ifRemoved>The module will not be compiled.</ifRemoved>

--- a/buildspecs/linux_390-64.spec
+++ b/buildspecs/linux_390-64.spec
@@ -220,7 +220,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_390-64_cmprssptrs.spec
@@ -223,7 +223,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_390-64_cmprssptrs_codecov.spec
+++ b/buildspecs/linux_390-64_cmprssptrs_codecov.spec
@@ -216,7 +216,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_390-64_codecov.spec
+++ b/buildspecs/linux_390-64_codecov.spec
@@ -210,7 +210,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_390.spec
+++ b/buildspecs/linux_390.spec
@@ -222,7 +222,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_arm.spec
+++ b/buildspecs/linux_arm.spec
@@ -222,7 +222,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc-64.spec
+++ b/buildspecs/linux_ppc-64.spec
@@ -218,7 +218,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs.spec
@@ -216,7 +216,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le.spec
@@ -221,7 +221,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
@@ -221,7 +221,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc-64_le.spec
+++ b/buildspecs/linux_ppc-64_le.spec
@@ -221,7 +221,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc-64_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_le_gcc.spec
@@ -220,7 +220,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ppc.spec
+++ b/buildspecs/linux_ppc.spec
@@ -217,7 +217,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86-64.spec
+++ b/buildspecs/linux_x86-64.spec
@@ -220,7 +220,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -214,7 +214,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs_cs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs_cs.spec
@@ -207,7 +207,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs_panama.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs_panama.spec
@@ -215,7 +215,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86-64_codecov.spec
+++ b/buildspecs/linux_x86-64_codecov.spec
@@ -205,7 +205,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86.spec
+++ b/buildspecs/linux_x86.spec
@@ -230,7 +230,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_x86_codecov.spec
+++ b/buildspecs/linux_x86_codecov.spec
@@ -204,7 +204,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ztpf_390-64.spec
+++ b/buildspecs/linux_ztpf_390-64.spec
@@ -209,7 +209,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/linux_ztpf_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_ztpf_390-64_cmprssptrs.spec
@@ -207,7 +207,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/win_x86-64.spec
+++ b/buildspecs/win_x86-64.spec
@@ -223,7 +223,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -218,7 +218,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/win_x86.spec
+++ b/buildspecs/win_x86.spec
@@ -229,7 +229,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -217,7 +217,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -217,7 +217,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>

--- a/buildspecs/zos_390.spec
+++ b/buildspecs/zos_390.spec
@@ -216,7 +216,6 @@
 		<flag id="module_jnichk" value="true"/>
 		<flag id="module_jniinv" value="true"/>
 		<flag id="module_jnitest" value="true"/>
-		<flag id="module_jsig" value="true"/>
 		<flag id="module_jvmti" value="true"/>
 		<flag id="module_jvmtitst" value="true"/>
 		<flag id="module_lifecycle_tests" value="true"/>


### PR DESCRIPTION
The only uses of the flag 'module_jsig' were removed by https://github.com/eclipse/openj9/pull/7.