### PR TITLE
Workaround for hash mismatch error from apt-get

### DIFF
--- a/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
@@ -25,7 +25,7 @@
 FROM ubuntu:16.04
 
 # Install required OS tools
-RUN apt-get update \
+RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     autoconf \
     ca-certificates \


### PR DESCRIPTION
apt-get upgrade fails with hash mismatch error on linux x86-64
Root cause yet to be figured out. Adding in the workaround for
the mean time as it might benefit others who might see a similar
issue

Issue: #14
Signed-off-by: sabkrish <sabkrish@in.ibm.com>