### PR TITLE
z/TPF libffi Port

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
@@ -36,7 +36,6 @@ CONFIGURE_ARGS += \
 
 ifeq (linux_ztpf_390-64_cmprssptrs_codecov, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -44,11 +43,11 @@ ifeq (linux_ztpf_390-64_cmprssptrs_codecov, $(SPEC))
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#               --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64_cmprssptrs, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -57,11 +56,11 @@ ifeq (linux_ztpf_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#               --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64_cmprssptrs_purec, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
@@ -69,50 +68,51 @@ ifeq (linux_ztpf_390-64_cmprssptrs_purec, $(SPEC))
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#                --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64_codecov, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#                --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#                --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390-64_purec, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#                --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#                --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390_purec, $(SPEC))
 	CONFIGURE_ARGS += \
-		--enable-OMR_RTTI\
 		--enable-OMRTHREAD_LIB_UNIX \
 		--enable-OMR_ARCH_S390
 #		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
+#                --enable-OMR_RTTI
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -690,7 +690,7 @@ getj9bin()
 	/* misnamed - returns the directory that the jvm DLL is found in, NOT the directory that the J9 VM itself is in. */
 
 	J9StringBuffer *result = NULL;
-#if defined(LINUX)
+#if defined(LINUX) && !defined(J9ZTPF)
 	Dl_info libraryInfo;
 	int rc = dladdr((void *)getj9bin, &libraryInfo);
 
@@ -716,11 +716,9 @@ getj9bin()
 		if(isFileInDir(jvmBufferData(result), "lib" VMDLL_NAME ".so")) {
 			return result;
 		}
-#if defined(J9ZOS390)
+
 		truncatePath(jvmBufferData(result));
-#elif defined(J9ZTPF)
-		truncateStringAtLastOccurence(jvmBufferData(result), DIR_SEPARATOR);
-#endif /* defined(J9ZOS390) */
+
 		/* trying parent */
 		if(isFileInDir(jvmBufferData(result), "lib" VMDLL_NAME ".so")) {
 			return result;
@@ -772,7 +770,7 @@ getj9bin()
 	truncatePath(jvmBufferData(result));
 
 	free(linfo);
-#endif  /* defined(LINUX) */
+#endif  /* defined(LINUX) && !defined(J9ZTPF) */
 	return result;
 }
 #endif /* ifndef WIN32*/

--- a/runtime/libffi/module.xml
+++ b/runtime/libffi/module.xml
@@ -220,9 +220,12 @@
 			<!-- vpaths for s390 -->
 			<vpath pattern="ffi.c" path="s390" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_390.*" />
+				<include-if condition="spec.linux_ztpf.*" />
 			</vpath>
 			<vpath pattern="sysv.S" path="s390" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_390.*" />
+			</vpath>
+			<vpath pattern="sysv.S" path="ztpf" augmentObjects="true" type="relativepath">
 				<include-if condition="spec.linux_ztpf.*" />
 			</vpath>
 			<vpath pattern="ffi.c" path="z" augmentObjects="true" type="relativepath">

--- a/runtime/libffi/ztpf/sysv.S
+++ b/runtime/libffi/ztpf/sysv.S
@@ -1,0 +1,228 @@
+/* -----------------------------------------------------------------------
+   sysv.S - Copyright (c) 2000 Software AG
+            Copyright (c) 2008 Red Hat, Inc.
+	    Copyright (c) 2017 IBM
+
+   z/TPF Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#define LIBFFI_ASM
+#include <fficonfig.h>
+#include <ffi.h>
+
+.text
+
+	# r2:	cif->bytes
+	# r3:	&ecif
+	# r4:	ffi_prep_args
+	# r5:	ret_type
+	# r6:	ecif.rvalue
+	# ov:	fn
+
+	# This assumes we are using gas.
+	.globl	ffi_call_SYSV
+	.type	ffi_call_SYSV,%function
+ffi_call_SYSV:
+.LFB1:
+	stmg	%r6,%r15,48(%r15)		# Save registers
+.LCFI0:
+	larl	%r13,.Lbase			# Set up base register
+	lgr	%r11,%r15			# Set up frame pointer
+.LCFI1:
+	sgr	%r15,%r2
+	aghi	%r15,-160-80-288		# Allocate stack
+	lgr	%r8,%r6				# Save ecif.rvalue
+	llgc	%r9,.Ltable-.Lbase(%r13,%r5)	# Load epilog address
+	lg	%r7,448(%r11)			# Load function address
+	stg	%r11,0(%r15)			# Set up back chain
+	aghi	%r11,-80			# Register save area
+.LCFI2:
+
+	la	%r2,448(%r15)			# Save area
+						# r3 already holds &ecif
+	basr	%r14,%r4			# Call ffi_prep_args
+
+	lmg	%r2,%r6,0(%r11)			# Load arguments
+	ld	%f0,48(%r11)
+	ld	%f2,56(%r11)
+	ld	%f4,64(%r11)
+	ld	%f6,72(%r11)
+	la	%r14,0(%r13,%r9)		# Set return address
+	br	%r7				# ... and call function
+
+.Lbase:
+.LretNone:					# Return void
+	lg	%r4,80+112(%r11)
+	lmg	%r6,%r15,80+48(%r11)
+	br	%r4
+
+.LretFloat:
+	lg	%r4,80+112(%r11)
+	ste	%f0,0(%r8)			# Return float
+	lmg	%r6,%r15,80+48(%r11)
+	br	%r4
+
+.LretDouble:
+	lg	%r4,80+112(%r11)
+	std	%f0,0(%r8)			# Return double
+	lmg	%r6,%r15,80+48(%r11)
+	br	%r4
+
+.LretInt32:
+	lg	%r4,80+112(%r11)
+	st	%r2,0(%r8)			# Return int
+	lmg	%r6,%r15,80+48(%r11)
+	br	%r4
+
+.LretInt64:
+	lg	%r4,80+112(%r11)
+	stg	%r2,0(%r8)			# Return long
+	lmg	%r6,%r15,80+48(%r11)
+	br	%r4
+
+.Ltable:
+	.byte	.LretNone-.Lbase		# FFI390_RET_VOID
+	.byte	.LretNone-.Lbase		# FFI390_RET_STRUCT
+	.byte	.LretFloat-.Lbase		# FFI390_RET_FLOAT
+	.byte	.LretDouble-.Lbase		# FFI390_RET_DOUBLE
+	.byte	.LretInt32-.Lbase		# FFI390_RET_INT32
+	.byte	.LretInt64-.Lbase		# FFI390_RET_INT64
+
+.LFE1:
+.ffi_call_SYSV_end:
+	.size	 ffi_call_SYSV,.ffi_call_SYSV_end-ffi_call_SYSV
+
+
+	.globl	ffi_closure_SYSV
+	.type	ffi_closure_SYSV,%function
+ffi_closure_SYSV:
+.LFB2:
+	stmg	%r14,%r15,112(%r15)		# Save registers
+.LCFI10:
+	stmg	%r2,%r6,16(%r15)		# Save arguments
+	std	%f0,128(%r15)
+	std	%f2,136(%r15)
+	std	%f4,144(%r15)
+	std	%f6,152(%r15)
+	lgr	%r1,%r15			# Set up stack frame
+	aghi	%r15,-160-288
+.LCFI11:
+	lgr	%r2,%r0				# Closure
+	la	%r3,16(%r1)			# GPRs
+	la	%r4,128(%r1)			# FPRs
+	la	%r5,160(%r1)			# Overflow
+	stg	%r1,0(%r15)			# Set up back chain
+
+	brasl	%r14,ffi_closure_helper_SYSV	# Call helper
+
+	lg	%r14,160+288+112(%r15)
+	ld	%f0,160+288+128(%r15)		# Load return registers
+	lg	%r2,160+288+16(%r15)
+	la	%r15,160+288(%r15)
+	br	%r14
+.LFE2:
+
+.ffi_closure_SYSV_end:
+	.size	 ffi_closure_SYSV,.ffi_closure_SYSV_end-ffi_closure_SYSV
+
+
+
+	.section	.eh_frame,EH_FRAME_FLAGS,@progbits
+.Lframe1:
+	.4byte	.LECIE1-.LSCIE1	# Length of Common Information Entry
+.LSCIE1:
+	.4byte	0x0	# CIE Identifier Tag
+	.byte	0x1	# CIE Version
+	.ascii "zR\0"	# CIE Augmentation
+	.uleb128 0x1	# CIE Code Alignment Factor
+	.sleb128 -8	# CIE Data Alignment Factor
+	.byte	0xe	# CIE RA Column
+	.uleb128 0x1	# Augmentation size
+	.byte	0x1b	# FDE Encoding (pcrel sdata4)
+	.byte	0xc	# DW_CFA_def_cfa
+	.uleb128 0xf
+	.uleb128 0xa0
+	.align	8
+.LECIE1:
+.LSFDE1:
+	.4byte	.LEFDE1-.LASFDE1	# FDE Length
+.LASFDE1:
+	.4byte	.LASFDE1-.Lframe1	# FDE CIE offset
+	.4byte	.LFB1-.	# FDE initial location
+	.4byte	.LFE1-.LFB1	# FDE address range
+	.uleb128 0x0	# Augmentation size
+	.byte	0x4	# DW_CFA_advance_loc4
+	.4byte	.LCFI0-.LFB1
+	.byte	0x8f	# DW_CFA_offset, column 0xf
+	.uleb128 0x5
+	.byte	0x8e	# DW_CFA_offset, column 0xe
+	.uleb128 0x6
+	.byte	0x8d	# DW_CFA_offset, column 0xd
+	.uleb128 0x7
+	.byte	0x8c	# DW_CFA_offset, column 0xc
+	.uleb128 0x8
+	.byte	0x8b	# DW_CFA_offset, column 0xb
+	.uleb128 0x9
+	.byte	0x8a	# DW_CFA_offset, column 0xa
+	.uleb128 0xa
+	.byte	0x89	# DW_CFA_offset, column 0x9
+	.uleb128 0xb
+	.byte	0x88	# DW_CFA_offset, column 0x8
+	.uleb128 0xc
+	.byte	0x87	# DW_CFA_offset, column 0x7
+	.uleb128 0xd
+	.byte	0x86	# DW_CFA_offset, column 0x6
+	.uleb128 0xe
+	.byte	0x4	# DW_CFA_advance_loc4
+	.4byte	.LCFI1-.LCFI0
+	.byte	0xd	# DW_CFA_def_cfa_register
+	.uleb128 0xb
+	.byte	0x4	# DW_CFA_advance_loc4
+	.4byte	.LCFI2-.LCFI1
+	.byte	0xe	# DW_CFA_def_cfa_offset
+	.uleb128 0xf0
+	.align	8
+.LEFDE1:
+.LSFDE2:
+	.4byte	.LEFDE2-.LASFDE2	# FDE Length
+.LASFDE2:
+	.4byte	.LASFDE2-.Lframe1	# FDE CIE offset
+	.4byte	.LFB2-.	# FDE initial location
+	.4byte	.LFE2-.LFB2	# FDE address range
+	.uleb128 0x0	# Augmentation size
+	.byte	0x4	# DW_CFA_advance_loc4
+	.4byte	.LCFI10-.LFB2
+	.byte	0x8f	# DW_CFA_offset, column 0xf
+	.uleb128 0x5
+	.byte	0x8e	# DW_CFA_offset, column 0xe
+	.uleb128 0x6
+	.byte	0x4	# DW_CFA_advance_loc4
+	.4byte	.LCFI11-.LCFI10
+	.byte	0xe	# DW_CFA_def_cfa_offset
+	.uleb128 0x140
+	.align	8
+.LEFDE2:
+
+#if defined __ELF__ && defined __linux__
+	.section	.note.GNU-stack,"",@progbits
+#endif

--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -105,6 +105,7 @@
 		<object name="j9gs_s390">
 			<include-if condition="spec.linux_390.*"/>
 			<include-if condition="spec.zos_390.*"/>
+			<include-if condition="spec.linux_ztpf.*"/>
 			<exclude-if condition="spec.linux_x86.*"/>
 			<exclude-if condition="spec.win_x86.*"/>
 		</object>	


### PR DESCRIPTION
z/TPF libffi updates.  Stack size updated to match z/TPF
requirements.  Ohter minor runtime updates specific to
z/TPF.  Including missing guard macro in getj9bin for
z/TPF, and disabling RTTI.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>