### PR TITLE
Add support for nopable breakpoint guard

### DIFF
--- a/runtime/tr.source/trj9/env/CHTable.hpp
+++ b/runtime/tr.source/trj9/env/CHTable.hpp
@@ -167,6 +167,21 @@ class TR_PatchNOPedGuardSiteOnMutableCallSiteChange : public TR::PatchNOPedGuard
    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnMutableCallSiteChange; }
    };
 
+class TR_PatchNOPedGuardSiteOnMethodBreakPoint : public TR::PatchNOPedGuardSite
+   {
+   protected:
+   TR_PatchNOPedGuardSiteOnMethodBreakPoint(TR_PersistentMemory *pm, TR_OpaqueMethodBlock *j9method,
+                       uint8_t *location, uint8_t *destination)
+      : TR::PatchNOPedGuardSite(pm, (uintptrj_t)j9method, RuntimeAssumptionOnMethodBreakPoint, location, destination) {}
+
+   public: 
+   static TR_PatchNOPedGuardSiteOnMethodBreakPoint *make(
+      TR_FrontEnd *fe, TR_PersistentMemory * pm, TR_OpaqueMethodBlock *j9method, uint8_t *location, uint8_t *destination,
+      OMR::RuntimeAssumption **sentinel);
+ 
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnMethodBreakPoint; }
+   };
+
 class TR_PatchJNICallSite : public OMR::ValueModifyRuntimeAssumption
    {
    protected:

--- a/runtime/tr.source/trj9/env/RuntimeAssumptionTable.hpp
+++ b/runtime/tr.source/trj9/env/RuntimeAssumptionTable.hpp
@@ -45,6 +45,7 @@ enum TR_RuntimeAssumptionKind
    RuntimeAssumptionOnClassRedefinitionUPIC,
    RuntimeAssumptionOnClassRedefinitionNOP,
    RuntimeAssumptionOnMutableCallSiteChange,
+   RuntimeAssumptionOnMethodBreakPoint,
    LastAssumptionKind,
    // If you add another kind, add its name to the runtimeAssumptionKindNames array
    RuntimeAssumptionSentinel // This is special as there is no hashtable associated with it and we only create one of them
@@ -61,6 +62,7 @@ char const * const runtimeAssumptionKindNames[LastAssumptionKind] =
    "ClassRedefinitionUPIC",
    "ClassRedefinitionNOP",
    "MutableCallSiteChange",
+   "OnMethodBreakpoint",
    };
 
 struct TR_RatHT

--- a/runtime/tr.source/trj9/env/VMJ9.cpp
+++ b/runtime/tr.source/trj9/env/VMJ9.cpp
@@ -235,6 +235,11 @@ TR_J9VMBase::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueCla
    return false;
    }
 
+bool
+TR_J9VMBase::isMethodBreakpointed(TR_OpaqueMethodBlock *method)
+   {
+   return jitIsMethodBreakpointed(vmThread(), (J9Method *)method);
+   }
 
 // Points to address: what if vmThread is not the compilation thread.
 // What if the compilation thread does not have the classUnloadMonitor.

--- a/runtime/tr.source/trj9/env/VMJ9.h
+++ b/runtime/tr.source/trj9/env/VMJ9.h
@@ -989,6 +989,7 @@ public:
    virtual bool shouldDelayAotLoad() { return false; }
 
    virtual void *getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *classPointer);
+   virtual bool isMethodBreakpointed(TR_OpaqueMethodBlock *method);
 
    protected:
 #if defined(TR_TARGET_S390)

--- a/runtime/tr.source/trj9/runtime/RuntimeAssumptions.cpp
+++ b/runtime/tr.source/trj9/runtime/RuntimeAssumptions.cpp
@@ -107,6 +107,15 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize::matches(char *sig, uint32_t sigLen)
    return true;
    }
 
+TR_PatchNOPedGuardSiteOnMethodBreakPoint* TR_PatchNOPedGuardSiteOnMethodBreakPoint::make(
+      TR_FrontEnd *fe, TR_PersistentMemory * pm, TR_OpaqueMethodBlock *method, uint8_t *location, uint8_t *destination,
+      OMR::RuntimeAssumption **sentinel)
+   {
+   TR_PatchNOPedGuardSiteOnMethodBreakPoint *result = new (pm) TR_PatchNOPedGuardSiteOnMethodBreakPoint(pm, method, location, destination);
+   result->addToRAT(pm, RuntimeAssumptionOnMethodBreakPoint, fe, sentinel);
+   return result;
+   }
+
 
 void
 TR_PreXRecompile::compensate(TR_FrontEnd *fe, bool, void *)

--- a/runtime/tr.source/trj9/runtime/codertinit.cpp
+++ b/runtime/tr.source/trj9/runtime/codertinit.cpp
@@ -100,6 +100,8 @@ extern "C" UDATA jitAMD64Handler(J9VMThread* vmThread, U_32 sigType, void* sigIn
 extern "C" void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRedefinedClass *classList);
 #endif
 
+extern "C" void jitMethodBreakpointed(J9VMThread * currentThread, J9Method *j9method);
+
 extern "C" void jitDiscardPendingCompilationsOfNatives(J9VMThread *vmThread, J9Class *clazz);
 
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
@@ -516,6 +518,7 @@ void codert_init_helpers_and_targets(J9JITConfig * jitConfig, char isSMP)
    jitConfig->jitClassesRedefined = jitClassesRedefined;
 #endif
    jitConfig->jitDiscardPendingCompilationsOfNatives = jitDiscardPendingCompilationsOfNatives;
+   jitConfig->jitMethodBreakpointed = jitMethodBreakpointed;
 
    initializeCodertFunctionTable(javaVM);
 


### PR DESCRIPTION
To lower the overhead for the breakpoint guard instruction sequence,
the guard is nopped when compiling a method and patched
only when a breakpoint is set for that method. This changeset contains
the code for doing patching both at the end of a compilation and at
runtime.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>