### PR TITLE
Fix bug in calculating cpu entitlement by JIT

### DIFF
--- a/runtime/tr.source/trj9/env/CpuUtilization.cpp
+++ b/runtime/tr.source/trj9/env/CpuUtilization.cpp
@@ -389,18 +389,19 @@ void TR_CpuEntitlement::computeAndCacheCpuEntitlement()
    _numTargetCpu = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
    if (_numTargetCpu == 0)
       _numTargetCpu = 1; // some correction in case we get it wrong
+   uint32_t numTargetCpuEntitlement = _numTargetCpu * 100;
    if (isHypervisorPresent())
       {
       _guestCpuEntitlement = computeGuestCpuEntitlement();
       // If the number of target CPUs is smaller (bind the JVM to a subset of CPUs), use that value
-      if (_numTargetCpu < _guestCpuEntitlement || _guestCpuEntitlement <= 0)
-         _jvmCpuEntitlement = _numTargetCpu * 100;
+      if (numTargetCpuEntitlement < _guestCpuEntitlement || _guestCpuEntitlement <= 0)
+         _jvmCpuEntitlement = numTargetCpuEntitlement;
       else
          _jvmCpuEntitlement = _guestCpuEntitlement;
       }
    else
       {
-      _jvmCpuEntitlement = _numTargetCpu * 100;
+      _jvmCpuEntitlement = numTargetCpuEntitlement;
       }
    }
 

--- a/runtime/tr.source/trj9/env/CpuUtilization.hpp
+++ b/runtime/tr.source/trj9/env/CpuUtilization.hpp
@@ -187,7 +187,12 @@ struct TR_CpuEntitlement
 public:
    // The constructor cannot set all fields correctly because we have to make
    // sure te portlib is up and running
-   void init(J9JITConfig *jitConfig) { _jitConfig = jitConfig; computeAndCacheCpuEntitlement();}
+   void init(J9JITConfig *jitConfig)
+      {
+      _hypervisorPresent = TR_maybe;
+      _jitConfig = jitConfig;
+      computeAndCacheCpuEntitlement();
+      }
    bool isHypervisorPresent();
    void computeAndCacheCpuEntitlement(); // used during bootstrap and periodically in samplerThreadProc
    uint32_t getNumTargetCPUs()     const { return _numTargetCpu; }  // num CPUs the JVM is pinned to. Guaranteed >= 1


### PR DESCRIPTION
Initialize TR_CpuEntitlement::_hypervisorPresent to TR::maybe.
Fix the condition in TR_CpuEntitlement::computeAndCacheCpuEntitlement
that compares _numTargetCpu with _guestCpuEntitlement.

fixes #30
Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>