### PR TITLE
A MethodHandles API privateLookupIn

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1239,6 +1239,11 @@ K065O=The parameter types of init doesn't match that of iterator: {0} != {1}
 K065P=The external parameter types of body: {0} doesn't match the external parameter list: {1}
 K065Q=The loop body must be non-null
 K065R=The requested lookup mode: 0x{0} is not one of the existing access modes: 0x{1}
+K065S=Both the requested class and the caller lookup must not be null
+K065T=The target class: {0} must not be a primitive type or an array class
+K065U=The module: {0} containing the old lookup can't read the module: {1}
+K065V=The package: {0} containing the target class is not opened to the module: {1}
+K065W=The access mode: 0x{0} of the caller lookup doesn't have the MODULE mode : 0x{1}
 
 #java.lang.StackWalker
 K0639="Stack walker not configured with RETAIN_CLASS_REFERENCE"

--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ReflectPermissions.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ReflectPermissions.java
@@ -1,5 +1,8 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+package com.ibm.oti.util;
+
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +22,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.ReflectPermission;
 
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
-		return MethodHandles.lookup();
-	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
+/**
+ * ReflectPermission objects represent access to reflection
+ * support.
+ *
+ * @author		IBM
+ * @version		initial
+ */
+public class ReflectPermissions {
+	/**
+	 * ReflectPermission "suppressAccessChecks"
+	 */
+	public static final ReflectPermission permissionSuppressAccessChecks = new ReflectPermission("suppressAccessChecks");	//$NON-NLS-1$
 }

--- a/test/OpenJ9_Jsr_292_API/build.xml
+++ b/test/OpenJ9_Jsr_292_API/build.xml
@@ -2,20 +2,23 @@
 <!--
    Copyright (c) 2017, 2017 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code is also Distributed under one or more Secondary Licenses,
-   as those terms are defined by the Eclipse Public License, v. 2.0: GNU
-   General Public License, version 2 with the GNU Classpath Exception [1]
-   and GNU General Public License, version 2 with the OpenJDK Assembly
-   Exception [2].
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
 
- [1] https://www.gnu.org/software/classpath/license.html
- [2] http://openjdk.java.net/legal/assembly-exception.html
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 <project name="OpenJ9 JSR 292 API Tests" default="build" basedir=".">
 	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
@@ -31,12 +34,93 @@
 	<property name="build" location="./bin"/>
 	<property name="transformerListener" location="../Utils/src"/>
 
+	<property name="mods_name" value="mods"/>
+	<property name="modulea_name" value="mods.modulea"/>
+	<property name="moduleb_name" value="mods.moduleb"/>
+	<property name="modulec_name" value="mods.modulec"/>
+
+	<property name="modulea_src" location="./modules/mods.modulea"/>
+	<property name="moduleb_src" location="./modules/mods.moduleb"/>
+	<property name="modulec_src" location="./modules/mods.modulec"/>
+	
+	<property name="mods_dir" location="./mods"/>
+	<property name="modulea_bin" location="./mods/mods.modulea"/>
+	<property name="moduleb_bin" location="./mods/mods.moduleb"/>
+	<property name="modulec_bin" location="./mods/mods.modulec"/>
+	
 	<target name="init">
 		<mkdir dir="${DEST}"/>
 		<mkdir dir="${build}"/>
+		<mkdir dir="${mods_dir}"/>
+		<mkdir dir="${modulea_bin}"/>
+		<mkdir dir="${moduleb_bin}"/>
+		<mkdir dir="${modulec_bin}"/>
 	</target>
 	
-	<target name="compile_tests" depends="init" description="compile the test source code" >
+	<target name="compile_modulec" depends="init" description="Compile the module files in mods.modulec">
+		<echo>Compiling the module files in mods.modulec</echo>
+		<echo>Ant version is ${ant.version}</echo>
+		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+		<if>
+			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<then>
+				<property name="modulec_path" value="--module-path ${mods_dir} -d ${modulec_bin}" />
+				<javac srcdir="${modulec_src}" destdir="${modulec_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${modulec_src}"/>
+					<compilerarg line='${modulec_path}' />
+				</javac>
+			</then>
+		</if>
+	</target>
+
+	<target name="compile_moduleb" depends="init" description="Compile the module files in mods.moduleb">
+		<echo>Compiling the module files in mods.moduleb</echo>
+		<echo>Ant version is ${ant.version}</echo>
+		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+		<if>
+			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<then>
+				<property name="moduleb_path" value="--module-path ${mods_dir} -d ${moduleb_bin}" />
+				<javac srcdir="${moduleb_src}" destdir="${moduleb_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${moduleb_src}"/>
+					<compilerarg line='${moduleb_path}' />
+				</javac>
+			</then>
+		</if>
+	</target>
+	
+	<target name="compile_modulea" depends="init,compile_moduleb,compile_modulec" description="Compile the module files in mods.modulea">
+		<echo>Compiling the module files in mods.modulea</echo>
+		<echo>Ant version is ${ant.version}</echo>
+		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+		<if>
+			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<then>
+				<property name="modulea_path" value="--module-path ${mods_dir} -d ${modulea_bin}" />
+				<javac srcdir="${modulea_src}" destdir="${modulea_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${modulea_src}"/>
+					<compilerarg line='${modulea_path}' />
+				</javac>
+			</then>
+		</if>
+	</target>
+	
+	<target name="compile_tests" depends="init,compile_modulea,compile_moduleb,compile_modulec" description="compile the test source code" >
 		<echo>Compiling the test source code</echo>
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
@@ -47,9 +131,11 @@
 		<if>
 			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
 			<then>
+				<property name="addModules" value="--add-modules ${modulea_name},${moduleb_name},${modulec_name}  --module-path ${mods_dir}" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}"/>
 					<src path="${transformerListener}" />
+					<compilerarg line='${addModules}' />
 					<classpath>
 						<pathelement location="../TestConfig/lib/asm-all.jar" />
 						<pathelement location="../TestConfig/lib/testng.jar"/>
@@ -63,6 +149,9 @@
 	<target name="DEST" depends="compile_tests" description="generate the distribution" >
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.mk,*.xml" />
+		</copy>
+		<copy todir="${DEST}/${mods_name}">
+			<fileset dir="${mods_dir}"/>
 		</copy>
 		<jar jarfile="${DEST}/openj9_jsr292test.jar" filesonly="true">
 			<fileset dir="${build}"/>

--- a/test/OpenJ9_Jsr_292_API/modules/mods.modulea/mods/modulea/package1/AnotherModuleExample.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.modulea/mods/modulea/package1/AnotherModuleExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
+package mods.modulea.package1;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
+public class AnotherModuleExample {
+	public static Lookup getLookup() {
 		return MethodHandles.lookup();
 	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.modulea/mods/modulea/package1/ModuleExample.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.modulea/mods/modulea/package1/ModuleExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
+package mods.modulea.package1;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
+public class ModuleExample {
+	public static Lookup getLookup() {
 		return MethodHandles.lookup();
 	}
 	
-	public static int addStatic(int a, int b) { return a + b + 1; }
+	public static Lookup getPublicLookup() {
+		return MethodHandles.publicLookup();
+	}
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.modulea/mods/modulea/package2/SameModuleExample.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.modulea/mods/modulea/package2/SameModuleExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
+package mods.modulea.package2;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
+public class SameModuleExample {
+	public static Lookup getLookup() {
 		return MethodHandles.lookup();
 	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.modulea/module-info.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.modulea/module-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
-
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
-
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
-		return MethodHandles.lookup();
-	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
+module mods.modulea {
+	requires mods.moduleb;
+	exports mods.modulea.package1;
+	exports mods.modulea.package2;
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.moduleb/mods/moduleb/package1/DifferentModuleExample1.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.moduleb/mods/moduleb/package1/DifferentModuleExample1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
+package mods.moduleb.package1;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
+public class DifferentModuleExample1 {
+	public static Lookup getLookup() {
 		return MethodHandles.lookup();
 	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.moduleb/module-info.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.moduleb/module-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
-
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
-
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
-		return MethodHandles.lookup();
-	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
+module mods.moduleb {
+	exports mods.moduleb.package1;
+	opens mods.moduleb.package1;
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.modulec/mods/modulec/package1/DifferentModuleExample2.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.modulec/mods/modulec/package1/DifferentModuleExample2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
+package mods.modulec.package1;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
+public class DifferentModuleExample2 {
+	public static Lookup getLookup() {
 		return MethodHandles.lookup();
 	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
 }

--- a/test/OpenJ9_Jsr_292_API/modules/mods.modulec/module-info.java
+++ b/test/OpenJ9_Jsr_292_API/modules/mods.modulec/module-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-package com.ibm.j9.jsr292;
-
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
-
-public class CustomLoadedClass2 implements ICustomLoadedClass {
-	public Lookup getLookup() {
-		return MethodHandles.lookup();
-	}
-	
-	public static int addStatic(int a, int b) { return a + b + 1; }
+module mods.modulec {
+	exports mods.modulec.package1;
 }

--- a/test/OpenJ9_Jsr_292_API/playlist.xml
+++ b/test/OpenJ9_Jsr_292_API/playlist.xml
@@ -9,20 +9,24 @@
   or the Apache License, Version 2.0 which accompanies this distribution and
   is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code is also Distributed under one or more Secondary Licenses,
-  as those terms are defined by the Eclipse Public License, v. 2.0: GNU
-  General Public License, version 2 with the GNU Classpath Exception [1]
-  and GNU General Public License, version 2 with the OpenJDK Assembly
-  Exception [2].
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
 
   [1] https://www.gnu.org/software/classpath/license.html
   [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
-	<testCaseName>openj9_jsr292Test_SE90</testCaseName>
+		<testCaseName>openj9_jsr292Test_SE90</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-modules mods.modulea,mods.moduleb,mods.modulec --module-path $(Q)$(TEST_RESROOT)$(D)mods$(Q) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-cp $(Q)$(TEST_RESROOT)$(D)openj9_jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testngSE90.xml$(Q) \
@@ -38,12 +42,13 @@
 		</subsets>
 	</test>
 	
-		<test>
+	<test>
 		<testCaseName>openj9_jsr292Test_JitCount0_SE90</testCaseName>
 		<variations>
 			<variation>-Xjit:count=0</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-modules mods.modulea,mods.moduleb,mods.modulec --module-path $(Q)$(TEST_RESROOT)$(D)mods$(Q) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	-cp $(Q)$(TEST_RESROOT)$(D)openj9_jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testngSE90.xml$(Q) \

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CrossPackageExampleSubclass.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CrossPackageExampleSubclass.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomClassLoader.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomClassLoader.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomLoadedClass1.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomLoadedClass1.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/ICustomLoadedClass.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/ICustomLoadedClass.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 import org.testng.annotations.Test;

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample2.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample2.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExampleSubclass.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExampleSubclass.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageSingleMethodInterfaceExample.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageSingleMethodInterfaceExample.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/api/MethodHandleAPI_privateLookupIn.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/api/MethodHandleAPI_privateLookupIn.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package com.ibm.j9.jsr292.api;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import static java.lang.invoke.MethodHandles.privateLookupIn;
+import mods.modulea.package1.ModuleExample;
+import mods.modulea.package1.AnotherModuleExample;
+import mods.modulea.package2.SameModuleExample;
+import mods.moduleb.package1.DifferentModuleExample1;
+import mods.modulec.package1.DifferentModuleExample2;
+
+public class MethodHandleAPI_privateLookupIn {
+	final static Lookup callerLookup = ModuleExample.getLookup();
+	final static Lookup callerPublicLookup = ModuleExample.getPublicLookup();
+	
+	/**
+	 * privateLookupIn test for a null target class.
+	 */
+	@Test(expectedExceptions = NullPointerException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_NullTargetClass() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(null, callerLookup);
+		Assert.fail("The test case failed to detect a null target class");
+	}
+	
+	/**
+	 * privateLookupIn test for a null caller lookup.
+	 */
+	@Test(expectedExceptions = NullPointerException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_NullcallerLookup() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(Object.class, null);
+		Assert.fail("The test case failed to detect a null caller lookup");
+	}
+	
+	/**
+	 * privateLookupIn test for a target class with a primitive type.
+	 */
+	@Test(expectedExceptions = IllegalArgumentException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_PrimitiveType() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(int.class, callerLookup);
+		Assert.fail("The test case failed to detect a target class with a primitive type");
+	}
+	
+	/**
+	 * privateLookupIn test for a target class with the array type.
+	 */
+	@Test(expectedExceptions = IllegalArgumentException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_ArrayType() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(Object[].class, callerLookup);
+		Assert.fail("The test case failed to detect a target class with the array type");
+	}
+	
+	/**
+	 * privateLookupIn test for a named module containing the caller lookup
+	 */
+	@Test(expectedExceptions = IllegalAccessException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_callerLookup_NamedModule() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(DifferentModuleExample2.class, callerLookup);
+		Assert.fail("The test case failed to detect that the module containing the target class is unreadable by"
+				+ "the named module containing the caller lookup");
+	}
+	
+	/**
+	 * privateLookupIn test for an package (containing the target class) which is not opened to
+	 * the module containing the caller lookup.
+	 */
+	@Test(expectedExceptions = IllegalAccessException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_UnOpenedPackage() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(Object.class, callerLookup);
+		Assert.fail("The test case failed to detect the unopened package containing the target class");
+	}
+	
+	/**
+	 * privateLookupIn test for a caller lookup without the MODULE access mode
+	 */
+	@Test(expectedExceptions = IllegalAccessException.class, groups = { "level.sanity" })
+	public static void test_privateLookupIn_Lookup_NoModuleMode() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(callerPublicLookup.lookupClass(), callerPublicLookup);
+		Assert.fail("The test case failed to detect a caller lookup without the MODULE access mode");
+	}
+	
+	/**
+	 * privateLookupIn test for a target class which is the caller class in an unnamed module
+	 */
+	@Test(groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_Itself_UnnamedModule() throws Throwable {
+		Lookup lookup = MethodHandles.lookup();
+		Class<?> targetClass = lookup.lookupClass();
+		Lookup mhprivateLookupIn = privateLookupIn(targetClass, lookup);
+		Assert.assertEquals(targetClass, mhprivateLookupIn.lookupClass());
+		Assert.assertEquals(Lookup.PRIVATE, mhprivateLookupIn.lookupModes() & Lookup.PRIVATE);
+	}
+	
+	/**
+	 * privateLookupIn test for a target class which is the caller class in a named module
+	 */
+	@Test(groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_Itself_NamedModule() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(ModuleExample.class, callerLookup);
+		Assert.assertEquals(ModuleExample.class, mhprivateLookupIn.lookupClass());
+		Assert.assertEquals(Lookup.PRIVATE, mhprivateLookupIn.lookupModes() & Lookup.PRIVATE);
+	}
+	
+	/**
+	 * privateLookupIn test for a target class and a caller lookup within the same package
+	 */
+	@Test(groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_callerLookup_SamePackage_SameModule() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(AnotherModuleExample.class, callerLookup);
+		Assert.assertEquals(AnotherModuleExample.class, mhprivateLookupIn.lookupClass());
+		Assert.assertEquals(Lookup.PRIVATE, mhprivateLookupIn.lookupModes() & Lookup.PRIVATE);
+	}
+	
+	/**
+	 * privateLookupIn test for a target class and a caller lookup from different packages within the same module
+	 */
+	@Test(groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_callerLookup_DiffferentPackage_SameModule() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(SameModuleExample.class, callerLookup);
+		Assert.assertEquals(SameModuleExample.class, mhprivateLookupIn.lookupClass());
+		Assert.assertEquals(Lookup.PRIVATE, mhprivateLookupIn.lookupModes() & Lookup.PRIVATE);
+	}
+	
+	/**
+	 * privateLookupIn test for a target class and a caller lookup from different modules
+	 */
+	@Test(groups = { "level.sanity" })
+	public static void test_privateLookupIn_TargetClass_callerLookup_DifferentModule() throws Throwable {
+		Lookup mhprivateLookupIn = privateLookupIn(DifferentModuleExample1.class, callerLookup);
+		Assert.assertEquals(DifferentModuleExample1.class, mhprivateLookupIn.lookupClass());
+		Assert.assertEquals(Lookup.PRIVATE, mhprivateLookupIn.lookupModes() & Lookup.PRIVATE);
+	}
+}

--- a/test/OpenJ9_Jsr_292_API/src/examples/PackageExamples.java
+++ b/test/OpenJ9_Jsr_292_API/src/examples/PackageExamples.java
@@ -7,14 +7,17 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code is also Distributed under one or more Secondary Licenses,
- * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
- * General Public License, version 2 with the GNU Classpath Exception [1]
- * and GNU General Public License, version 2 with the OpenJDK Assembly
- * Exception [2].
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package examples;
 

--- a/test/OpenJ9_Jsr_292_API/testngSE90.xml
+++ b/test/OpenJ9_Jsr_292_API/testngSE90.xml
@@ -9,14 +9,17 @@
   or the Apache License, Version 2.0 which accompanies this distribution and
   is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code is also Distributed under one or more Secondary Licenses,
-  as those terms are defined by the Eclipse Public License, v. 2.0: GNU
-  General Public License, version 2 with the GNU Classpath Exception [1]
-  and GNU General Public License, version 2 with the OpenJDK Assembly
-  Exception [2].
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
 
   [1] https://www.gnu.org/software/classpath/license.html
   [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
@@ -27,6 +30,7 @@
 	<test name="openj9_jsr292Test">
 		<classes>
 			<class name="com.ibm.j9.jsr292.LookupInTests"/>
+			<class name="com.ibm.j9.jsr292.api.MethodHandleAPI_privateLookupIn"/>
 		</classes>
 	</test>
 </suite>


### PR DESCRIPTION
The code is to introduce a new API called
privateLookupIn to produce a lookup object
with private access to the  request class.

fixes #41

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>