### PR TITLE
Add error handling for <clinit>

### DIFF
--- a/runtime/bcutil/ClassFileParser.hpp
+++ b/runtime/bcutil/ClassFileParser.hpp
@@ -36,7 +36,7 @@
 
 #include "BuildResult.hpp"
 
-typedef  IDATA (*VerifyClassFunction) (J9PortLibrary *aPortLib, J9CfrClassFile* classfile, U_8* segment, U_8* segmentLength, U_8* freePointer, U_32 flags, I_32 *hasRET);
+typedef  IDATA (*VerifyClassFunction) (J9PortLibrary *aPortLib, J9CfrClassFile* classfile, U_8* segment, U_8* segmentLength, U_8* freePointer, U_32 vmVerisonShifted, U_32 flags, I_32 *hasRET);
 
 class ROMClassCreationContext;
 

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1297,3 +1297,20 @@ J9NLS_CFR_ERR_BAD_NEST_TOP_INDEX.user_response=Contact the provider of the class
 
 # END NON-TRANSLATABLE
 
+# <clinit> method at version 51.0 or above does not have static flag set
+J9NLS_CFR_ERR_CLINIT_NOT_STATIC=Method <clinit> is not static
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_CLINIT_NOT_STATIC.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_CLINIT_NOT_STATIC.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_CLINIT_NOT_STATIC.user_response=Contact the provider of the classfile for a corrected version.
+
+# END NON-TRANSLATABLE
+
+# <clinit> method at version 51.0 must be void and take no arguments
+J9NLS_CFR_ERR_CLINIT_ILLEGAL_SIGNATURE=Method <clinit> has illegal signature
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_CLINIT_ILLEGAL_SIGNATURE.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_CLINIT_ILLEGAL_SIGNATURE.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_CLINIT_ILLEGAL_SIGNATURE.user_response=Contact the provider of the classfile for a corrected version.
+
+# END NON-TRANSLATABLE

--- a/runtime/oti/bcutil_api.h
+++ b/runtime/oti/bcutil_api.h
@@ -177,7 +177,7 @@ bcutil_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved);
 * @return I_32
 */
 I_32 
-j9bcutil_readClassFileBytes (J9PortLibrary *portLib, IDATA (*verifyFunction) (J9PortLibrary *aPortLib, J9CfrClassFile* classfile, U_8* segment, U_8* segmentLength, U_8* freePointer, U_32 flags, I_32 *hasRET), U_8* data, UDATA dataLength, U_8* segment, UDATA segmentLength, U_32 flags, U_8** segmentFreePointer, void *verboseContext, UDATA findClassFlags, UDATA romClassSortingThreshold);
+j9bcutil_readClassFileBytes (J9PortLibrary *portLib, IDATA (*verifyFunction) (J9PortLibrary *aPortLib, J9CfrClassFile* classfile, U_8* segment, U_8* segmentLength, U_8* freePointer, U_32 vmVersionShifted, U_32 flags, I_32 *hasRET), U_8* data, UDATA dataLength, U_8* segment, UDATA segmentLength, U_32 flags, U_8** segmentFreePointer, void *verboseContext, UDATA findClassFlags, UDATA romClassSortingThreshold);
 
 /* ---------------- defineclass.c ---------------- */
 

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -270,7 +270,7 @@ j9rtv_verifyBytecodes (J9BytecodeVerificationData *verifyData);
 */
 IDATA 
 j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile, U_8 * segment,
-										U_8 * segmentLength, U_8 * freePointer, U_32 flags, I_32 *hasRET);
+										U_8 * segmentLength, U_8 * freePointer, U_32 vmVersionShifted, U_32 flags, I_32 *hasRET);
 
 /**
  * 	Check the validity of a method signature.


### PR DESCRIPTION
In a class file whose version number is 51.0 or above, a method
has its ACC_STATIC flag set and takes no arguments. This rule is
applicable in the Java 9 spec but not Java 8.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>

@DanHeidinga @tajila 