### PR TITLE
Removed unnecessary classpath entry

### DIFF
--- a/debugtools/DDR_VM/.classpath
+++ b/debugtools/DDR_VM/.classpath
@@ -6,7 +6,6 @@
 	<classpathentry kind="lib" path="/binaries/vm/ibm/dtfj.pkg.tck-head.jar"/>
 	<classpathentry kind="lib" path="/binaries/common/third/ant-1.8.1.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Ant"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
This removes the need for a user to configure the 'Ant' user library in their eclipse workspace.