### PR TITLE
Update resolveInvokeDynamic to use ramClass

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -3,8 +3,15 @@ package com.ibm.oti.vm;
 
 import java.util.Properties;
 
+/*[IF Sidecar19-SE]*/
+import jdk.internal.reflect.ConstantPool;
+/*[ELSE]*/
+import sun.reflect.ConstantPool;
+/*[ENDIF]*/
+
+
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corp. and others
+ * Copyright (c) 2012, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -122,4 +129,19 @@ public interface VMLangAccess {
 	public Package getSystemPackage(String name);
 	/*[ENDIF]*/
 	
+	/**
+	 * Returns an InternalRamClass object.
+	 * 
+	 * @param addr - the native addr of the J9Class
+	 * @return An InternalRamClass object
+	 */ 
+	public Object createInternalRamClass(long addr);
+	
+	/**
+	 * Returns a ConstanPool object
+	 * 
+	 * @param internalRamClass An object ref to an internalRamClass
+	 * @return ContanstPool instance
+	 */
+	public ConstantPool getConstantPool(Object internalRamClass);
 }

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -83,6 +83,14 @@ final class Access implements JavaLangAccess {
 	
 	/** Return the constant pool for a class. */
 	public native ConstantPool getConstantPool(java.lang.Class<?> arg0);
+	
+	/** 
+	 * Return the constant pool for a class. This will call the exact same
+	 * native as 'getConstantPool(java.lang.Class<?> arg0)'. We need this 
+	 * version so we can call it with InternRamClass instead of j.l.Class
+	 * (which is required by JAVALANGACCESS).
+	 */
+	public static native ConstantPool getConstantPool(Object arg0);
 
     /**
      * Returns the elements of an enum class or null if the

--- a/jcl/src/java.base/share/classes/java/lang/InternalRamClass.java
+++ b/jcl/src/java.base/share/classes/java/lang/InternalRamClass.java
@@ -1,0 +1,36 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+package java.lang;
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+/**
+ * Represents the internal J9Class
+ * 
+ */
+final class InternalRamClass {
+	@SuppressWarnings("unused")
+	private final long vmref;
+	
+	public InternalRamClass(long addr) {
+		vmref = addr;
+	}
+}

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -24,6 +24,14 @@ package java.lang;
  *******************************************************************************/
 
 import java.util.Properties;
+
+/*[IF Sidecar19-SE]*/
+import jdk.internal.reflect.ConstantPool;
+/*[ELSE]*/
+import sun.reflect.ConstantPool;
+/*[ENDIF]*/
+
+
 import com.ibm.oti.vm.*;
 
 /**
@@ -174,4 +182,25 @@ final class VMAccess implements VMLangAccess {
 		return Package.getSystemPackage(name);
 	}
 	/*[ENDIF]*/
+
+	/**
+	 * Returns a InternalRamClass object.
+	 * 
+	 * @param addr - the native addr of the J9Class
+	 * @return A InternalRamClass reference object
+	 */ 
+	@Override
+	public Object createInternalRamClass(long addr) {
+		return new InternalRamClass(addr);
+	}
+	
+	/**
+	 * Returns a ConstanPool object
+	 * @param internalRamClass An object ref to a j9class
+	 * @return ContanstPool instance
+	 */
+	@Override
+	public ConstantPool getConstantPool(Object internalRamClass) {
+		return Access.getConstantPool(internalRamClass);
+	}
 }

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -80,7 +80,7 @@
 	<classref name="java/lang/ClassFormatError"/>
 	<classref name="java/lang/StackTraceElement"/>
 	<classref name="java/lang/StackWalker$StackFrameImpl"/>
-	
+	<classref name="java/lang/InternalRamClass"/>
 	<classref name="java/lang/ExceptionInInitializerError"/>
 	<classref name="java/io/UTFDataFormatException"/>
 	<classref name="java/lang/reflect/InvocationTargetException" flags="opt_reflect"/>
@@ -324,7 +324,9 @@
 	<fieldref class="java/lang/Module" name="loader" signature="Ljava/lang/ClassLoader;" jcl="se9" flags="opt_module"/>
 	<fieldref class="java/lang/reflect/Module" name="name" signature="Ljava/lang/String;" jcl="se9_before_b165" flags="opt_module"/>
 	<fieldref class="java/lang/Module" name="name" signature="Ljava/lang/String;" jcl="se9" flags="opt_module"/>
-
+	
+	<fieldref class="java/lang/InternalRamClass" name="vmref" signature="J" cast="struct J9Class *"/>
+	
 	<fieldref class="com/ibm/oti/util/WeakReferenceNode" name="next" signature="Lcom/ibm/oti/util/WeakReferenceNode;" jcl="se7_basic,se9" flags="opt_methodHandle"/>
 
 	<staticmethodref class="java/lang/J9VMInternals" name="completeInitialization" signature="()V"/>
@@ -334,7 +336,7 @@
 	<staticmethodref class="java/lang/J9VMInternals" name="formatNoSuchMethod" signature="(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/String;"/>
 	<staticmethodref class="java/lang/invoke/MethodType" name="fromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="sendResolveMethodHandle" signature="(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
-	<staticmethodref class="java/lang/invoke/MethodHandle" name="resolveInvokeDynamic" signature="(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
+	<staticmethodref class="java/lang/invoke/MethodHandle" name="resolveInvokeDynamic" signature="(JLjava/lang/String;Ljava/lang/String;J)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="invokeWithArgumentsHelper" signature="(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="constructorPlaceHolder" signature="(Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="forGenericInvoke" signature="(Ljava/lang/invoke/MethodType;Z)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -974,7 +974,19 @@ sendResolveInvokeDynamic(J9VMThread *currentThread, J9ConstantPool *ramCP, UDATA
 			nameString = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 			if (NULL != sigString) {
 				/* Run the method */
-				*--currentThread->sp = (UDATA)J9VM_J9CLASS_TO_HEAPCLASS(ramCP->ramClass);
+				/* skip one slot because we are passing a long */
+				currentThread->sp -= 2;
+				/*
+				 * Need to pass the ramClass so that we can get the
+				 * correct ramConstantPool. If we pass the classObject
+				 * we will always get the latest ramClass, which is not always
+				 * the correct one. In cases where we can have an
+				 * old method (caused by class redefinition) on the stack,
+				 * we will need to search the old ramClass to get the correct
+				 * constanPool. It is difficult to do this if we pass the
+				 * classObject.
+				 */
+				*(U_64*)currentThread->sp = (U_64)ramCP->ramClass;
 				*--currentThread->sp = (UDATA)nameString;
 				*--currentThread->sp = (UDATA)sigString;
 				currentThread->sp -= 2;


### PR DESCRIPTION
In cases where class redefinition causes an old version of a method to
be active on the stack, using the class Object to resolve invokeDynamic
calls will result in searching cpIndexes with the wrong constantPool
since (in fastHCR) the classObject always points to the newest version
of the class. 

This change modifies 'resolveInvokeDynamic' so that it uses the ramClass
instead of the classObject so it always looks up indexes in the correct
constantPool.

Signed-off-by: tajila <atobia@ca.ibm.com>

Reviewer @DanHeidinga 