### PR TITLE
add vim to Dockerfile for image used for openj9 build - issue #67

### DIFF
--- a/buildenv/docker/jdk9/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/ppc64le/ubuntu16/Dockerfile
@@ -55,6 +55,12 @@ RUN apt-get update \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
+# Install optional tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+
 # Create links for c++,g++,cc,gcc
 RUN ln -s g++ /usr/bin/c++ \
   && ln -s g++-4.8 /usr/bin/g++ \

--- a/buildenv/docker/jdk9/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/s390x/ubuntu16/Dockerfile
@@ -54,6 +54,12 @@ RUN apt-get update \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
+# Install optional tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+
 # Create links for c++,g++,cc,gcc
 RUN ln -s g++ /usr/bin/c++ \
   && ln -s g++-4.8 /usr/bin/g++ \

--- a/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
@@ -56,6 +56,12 @@ RUN apt-get update \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
+# Install optional tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+
 # Create links for c++,g++,cc,gcc
 RUN ln -s g++ /usr/bin/c++ \
   && ln -s g++-4.8 /usr/bin/g++ \


### PR DESCRIPTION
add vim to Dockerfile for image used for openj9 build - issue #67 

Most linux users will expect vi to be available at every command line, so this update adds vim to the Dockerfile for the docker images used for building openj9