### PR TITLE
[ci skip] Initial commit of omrMirror pipeline script

### DIFF
--- a/buildenv/jenkins/omrMirror
+++ b/buildenv/jenkins/omrMirror
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+pipeline {
+    agent {label 'master'}
+
+    environment {
+        HTTP        = 'https://'
+        SRC_REPO    = 'github.com/eclipse/omr.git'
+        TARGET_REPO = 'github.com/eclipse/openj9-omr.git'
+    }
+    stages {
+        stage('Mirror') {
+            steps {
+                timestamps {
+                    script {
+                        withCredentials([usernamePassword(credentialsId: 'b6987280-6402-458f-bdd6-7affc2e360d4', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                            if (!fileExists('omr/HEAD')) {
+                                sh "git clone --mirror ${HTTP}${SRC_REPO} omr"
+                            } else {
+                                dir('omr') {
+                                    sh 'git remote update --prune'
+                                }
+                            }
+                            dir('omr') {
+                                sh "git config remote.target.url ${HTTP}${USERNAME}:${PASSWORD}@${TARGET_REPO}"
+                                sh 'git push target --all'
+                                sh 'git push target --tags'
+                                // Remove the bot account username/password from the config
+                                sh "git config remote.target.url ${HTTP}${TARGET_REPO}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Mirror eclipse/omr to eclipse/openj9-omr
- Does a bare clone with push --all and --tags
- Uses the genie-openj9 github bot id for authorization

Fixes eclipse/openj9-omr#3

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>