### PR TITLE
Create an OpenJ9 JCL preprocessor config for Java 8

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -84,7 +84,31 @@
 		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
-
+	
+	<configuration
+		  label="SIDECAR18-SE-OPENJ9"
+		  outputpath="SIDECAR18-SE-OPENJ9/src"
+		  flags="Sidecar18-SE-OpenJ9,CUDA4J,DAA"
+		  dependencies="SIDECAR18-SE"
+		  jdkcompliance="1.8">
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun180.jar"/>
+		<source path="src/java.base/share/classes"/>
+		<source path="src/java.desktop/share/classes"/>
+		<source path="src/java.logging/share/classes"/>
+		<source path="src/java.management/share/classes"/>
+		<source path="src/jdk.attach/share/classes"/>
+		<source path="src/openj9.jvm/share/classes"/>
+		<source path="src/jdk.management/share/classes"/>
+		<source path="src/openj9.cuda/share/classes" />
+		<source path="src/com.ibm.dataaccess/share/classes"/>
+		<source path="src/openj9.gpu/share/classes" />
+		<source path="src/com.ibm.management/share/classes"/>
+		<source path="src/openj9.sharedclasses/share/classes"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+	
 	<configuration
 		  label="SIDECAR19-SE-B148"
 		  outputpath="SIDECAR19-SE-B148/src"
@@ -223,7 +247,7 @@
 	<configuration
 		  label="SIDECAR19-SE-OPENJ9"
 		  outputpath="SIDECAR19-SE-OpenJ9/src"
-		  flags="Sidecar19-SE-OpenJ9"
+		  flags="Sidecar18-SE-OpenJ9,Sidecar19-SE-OpenJ9"
 		  dependencies="SIDECAR19-SE-B174"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -968,6 +968,17 @@ static void completeInitialization() {
 	initSystemClassLoader = true;
 }
 
+/*[IF Sidecar18-SE-OpenJ9|Sidecar19-SE]*/
+//Returns incoming class's classloader without going through security checking
+static ClassLoader getClassLoader(Class<?> clz) {
+	if (null != clz) {
+		return clz.getClassLoader0();
+	} else {
+		return null;
+	}
+}
+/*[ENDIF]*/
+
 /*[IF Sidecar19-SE]*/
 @CallerSensitive
 public static ClassLoader getPlatformClassLoader() {
@@ -980,15 +991,6 @@ public static ClassLoader getPlatformClassLoader() {
 		}
 	}
 	return platformClassLoader;
-}
-
-// Returns incoming class's classloader without going through security checking
-static ClassLoader getClassLoader(Class<?> clz) {
-	if (null != clz) {
-		return clz.getClassLoader0();
-	} else {
-		return null;
-	}
 }
 
 // Loads a class in a module defined to this classloader

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -173,14 +173,17 @@ public final class System {
 		// Check the default encoding
 		/*[Bug 102075] J2SE Setting -Dfile.encoding=junk fails to run*/
 		/*[IF Sidecar19-SE]*/
+		StringCoding.encode(String.LATIN1, new byte[1]);
+		/*[ELSE]*/
+		StringCoding.encode(new char[1], 0, 1);
+		/*[ENDIF]*/
+		/*[IF Sidecar18-SE-OpenJ9|Sidecar19-SE]*/
 		setErr(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true));
 		setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), true));
 		/*[IF Sidecar19-SE_RAWPLUSJ9]*/
 		setIn(new BufferedInputStream(new FileInputStream(FileDescriptor.in)));
 		/*[ENDIF]*/
-		StringCoding.encode(String.LATIN1, new byte[1]);
 		/*[ELSE]*/
-		StringCoding.encode(new char[1], 0, 1);
 		/*[PR s66168] - ConsoleInputStream initialization may write to System.err */
 		/*[PR s73550, s74314] ConsolePrintStream incorrectly initialized */
 		setErr(com.ibm.jvm.io.ConsolePrintStream.localize(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true));
@@ -215,7 +218,7 @@ static void completeInitialization() {
 	} catch (Exception e) {
 		throw new InternalError(e.toString());
 	}
-	/*[IF Sidecar19-SE]*/
+	/*[IF Sidecar18-SE-OpenJ9|Sidecar19-SE]*/
 	setIn(new BufferedInputStream(new FileInputStream(FileDescriptor.in)));
 	/*[ELSE]*/
 	/*[PR 100718] Initialize System.in after the main thread*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others
@@ -59,6 +59,12 @@ class LambdaForm {
 		MethodHandle resolvedHandle() {
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
+
+		/*[IF Sidecar18-SE-OpenJ9&!Sidecar19-SE-OpenJ9]*/
+		MethodHandle resolve() {
+			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		}
+		/*[ENDIF]*/
 	}
 	
 	enum BasicType {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormBuffer.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others
@@ -29,6 +29,12 @@ package java.lang.invoke;
  */
 
 final class MemberName {
+	/*[IF Sidecar18-SE-OpenJ9&!Sidecar19-SE-OpenJ9]*/
+	static final class Factory {
+		public static Factory INSTANCE = null;
+	}
+	/*[ENDIF]*/
+
 	public boolean isVarargs() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -39,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.SharedSecrets;
 import jdk.internal.reflect.ConstantPool;
-/*[IF Sidecar19-SE-OpenJ9]
+/*[IF Sidecar18-SE-OpenJ9]
 import java.lang.invoke.LambdaForm;
 /*[ENDIF]*/
 /*[ELSE]*/
@@ -117,7 +117,7 @@ public abstract class MethodHandle {
 	static final byte KIND_DEFAULTVALUE = 33;
 	/*[ENDIF]*/
 
-/*[IF Sidecar19-SE-OpenJ9]
+/*[IF Sidecar18-SE-OpenJ9]
 	MethodHandle asTypeCache = null;
 	LambdaForm form = null;	
 /*[ENDIF]*/	
@@ -1203,7 +1203,7 @@ public abstract class MethodHandle {
 		return "KIND_#"+kind; //$NON-NLS-1$
 	}
 
-/*[IF Sidecar19-SE-OpenJ9]*/
+/*[IF Sidecar18-SE-OpenJ9]*/
 	MethodHandle(MethodType mt, LambdaForm lf) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -1236,9 +1236,11 @@ public abstract class MethodHandle {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
+/*[IF Sidecar19-SE-OpenJ9]*/
 	void customize() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+/*[ENDIF]*/
 	
 	void updateForm(LambdaForm lf) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4358,7 +4358,7 @@ public class MethodHandles {
 		}
 	}
 
-/*[IF Sidecar19-SE-OpenJ9]*/	
+/*[IF Sidecar18-SE-OpenJ9]*/	
 	static MethodHandle basicInvoker(MethodType mt) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -44,7 +44,7 @@ import java.util.WeakHashMap;
 import com.ibm.oti.util.Msg;
 import com.ibm.oti.vm.VM;
 
-/*[IF Sidecar19-SE-OpenJ9]*/
+/*[IF Sidecar18-SE-OpenJ9]*/
 import java.lang.invoke.MethodTypeForm;
 /*[ENDIF]*/
 
@@ -1114,7 +1114,7 @@ public final class MethodType implements Serializable {
 		return invoker;
 	}
 	
-/*[IF Sidecar19-SE-OpenJ9]*/	
+/*[IF Sidecar18-SE-OpenJ9]*/	
 	MethodType basicType() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -1134,10 +1134,16 @@ public final class MethodType implements Serializable {
 	Class<?> rtype() {
 		return returnType;
 	}
-	
+
+/*[IF Sidecar19-SE-OpenJ9]*/	
 	MethodType asCollectorType(Class<?> clz, int num1, int num2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-/*[ENDIF]*/	
+/*[ELSE]*/
+	MethodType asCollectorType(Class<?> clz, int num1) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF]*/
+/*[ENDIF]*/
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others
@@ -33,8 +33,10 @@ final class MethodTypeForm {
 	static final int LF_DELEGATE_BLOCK_INLINING = 9;
 	static final int LF_GWC = 16;
 	static final int LF_GWT = 17;
+	/*[IF Sidecar19-SE-OpenJ9]*/
 	static final int LF_TF = 18;
 	static final int LF_LOOP = 19;
+	/*[ENDIF]*/
 	
 	public LambdaForm cachedLambdaForm(int num) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/OpenJDKCompileStub.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/OpenJDKCompileStub.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/SimpleMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/SimpleMethodHandle.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2017 IBM Corp. and others


### PR DESCRIPTION
Create a new preprocessor configuration SIDECAR18-SE-OPENJ9 based on the
existing SIDECAR18-SE configuration which is used internally by IBM to
create Java 8 builds. Add the additional flag Sidecar18-SE-OpenJ9 and
use this flag to include additional stub classes and code that are
required to compile the OpenJDK JCL code when the OpenJ9 JCL is
overlayed.

Also enable the CUDA4J flag to include the com.ibm.cuda classes.

@keithc-ca @DanHeidinga @JasonFengJ9 @andrew-m-leonard

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>