### PR TITLE
remove -Xzero option from OpenJ9 VM

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -850,9 +850,12 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
-	rc = addSystemProperty(vm, "com.ibm.zero.version", "2", 0);
-	if (J9SYSPROP_ERROR_NONE != rc) {
-		goto fail;
+	/* -Xzero option is removed from Java 9 */
+	if (j2seVersion < J2SE_19) {
+		rc = addSystemProperty(vm, "com.ibm.zero.version", "2", 0);
+		if (J9SYSPROP_ERROR_NONE != rc) {
+			goto fail;
+		}
 	}
 
 	/* Set the system agent path, which is necessary for system agents such as JDWP to load the libraries they need. */

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
@@ -39,6 +39,49 @@
 		<reason>Java 6 SDK is missing for the platform</reason>
 	</exclude>
 	
+	<exclude id="Test 7: ensure zip cache sharing works and zip cache number is not 0" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 8: ensure zip cache info is printed in printAllStats output" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 10s: JAZZ 31726 setup for Test 10, 11" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 10: JAZZ 31726 test 1 ensure -Xzero:sharebootzip creates zip caches" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 11: JAZZ 31726 test 2 ensure -Xzero:describe shows -Xzero:sharebootzip" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 12s: JAZZ 31726 setup for Test 12" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 12: JAZZ 31726 test 3 ensure -Xzero:nosharebootzip doesn't create zip caches" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 13s: JAZZ 31726 setup for Tests 13, 14 and 15" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 13: JAZZ 31723 test 2 ensure opened non-cached zip files are calling the VM_ZIP_LOAD hook" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 14: JAZZ 31726 test 4 ensure -Xzero:none doesn't create zip caches" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 15: JAZZ 31726 test 5 ensure -Xzero:nosharebootzip,describe shows -Xzero:none" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 16s: JAZZ 31726 setup for Test 16" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 16: JAZZ 31726 test 6 ensure -Xzero creates boot zip caches" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+	<exclude id="Test 17: JAZZ 31726 test 7 ensure -Xzero -Xzero:describe shows sharebootzip" platform="SE90">
+		<reason>Java 9 removed option -Xzero</reason>
+	</exclude>
+
 	<exclude id="Test 206-a: Create a new cache with -Xshareclasses:mprotect=default option." platform="zos_390-64.*">
 		<reason>This test is not required on 64-bit z/OS as the memory protection is always disabled on it.</reason>
 	</exclude>

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -39,7 +39,7 @@
 	-DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DJAVA_HOME='$(JDK_HOME)' -DSCMODE=204 -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)$(JAVA_VERSION)$(D)utils.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>


### PR DESCRIPTION
added runtime checks to remove -Xzero option in Java 9
default zeroOptions flag to 0 and removed system property
"com.ibm.zero.version" in Java 9
excluded test of -Xzero option in cmdLineTest from Java 9 builds

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>