### PR TITLE
Get test dependent jars automatically before compilation

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -87,8 +87,7 @@ check_env:
 configure:
 ifeq ($(AUTOGEN_FILES),)
 	(cd $(OPENJ9TEST_SRC_DIR)/TestConfig && \
-		$(MAKE) -f run_configure.mk $(ADD_CMD_ARGS) && \
-		$(MAKE) $(ADD_CMD_ARGS) getdependency )
+		$(MAKE) -f run_configure.mk $(ADD_CMD_ARGS) )
 endif
 
 compile: configure

--- a/test/README.md
+++ b/test/README.md
@@ -36,7 +36,6 @@ cd openj9/test/TestConfig
 export JAVA_BIN=<path to java bin that you wish to test>
 export SPEC=linux_x86-64_cmprssptrs
 make -f run_configure.mk
-make getdependency
 make test
 ```
 
@@ -59,9 +58,7 @@ JAVA_VERSION=[SE80|SE90] (SE90 default value)
 	* jcommander-1.48.jar
 	* asmtools-6.0.jar
 
-	The above jars will be downloaded by running command:
-
-            make getdependency
+	The above jars will be downloaded automatically when you begin to compile test source codes.
 
 2. Compile tests:
   * compile and run all tests

--- a/test/TestConfig/makefile
+++ b/test/TestConfig/makefile
@@ -225,7 +225,7 @@ endif
 $(DIRTARGET): JVM_TEST_ROOT := $(BUILD_ROOT)
 test_$(DIRTARGET): rmResultFile $(DIRTARGET)_$(JAVA_VERSION) resultsSummary
 
-test: getdependency compile runtest
+test: compile runtest
 	@$(ECHO) "All Tests Completed"
 
 ifndef JCL_VERSION
@@ -236,7 +236,7 @@ endif
 $(info set JAVA_VERSION to $(JAVA_VERSION))
 
 # compile all tests under $(SRC_ROOT)
-compile:
+compile: getdependency
 	ant -f $(SRC_ROOT)$(D)TestConfig$(D)scripts$(D)build_test.xml -DSRC_ROOT=$(SRC_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJAVA_BIN=$(JAVA_BIN) -DJAVA_VERSION=$(JAVA_VERSION) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST} -DRESOURCES_DIR=${RESOURCES_DIR}
 
 #######################################


### PR DESCRIPTION
* change compile `target` to depend on `getdependency` target
* remove dependency of `getdependency` target from `test` target 

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>