### PR TITLE
Add the MODULE bit to MethodHandles APIs

### DIFF
--- a/test/OpenJ9_Jsr_292_API/build.xml
+++ b/test/OpenJ9_Jsr_292_API/build.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!--
+   Copyright (c) 2017, 2017 IBM Corp. and others
+
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which accompanies this
+   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+   or the Apache License, Version 2.0 which accompanies this distribution and
+   is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+   This Source Code is also Distributed under one or more Secondary Licenses,
+   as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+   General Public License, version 2 with the GNU Classpath Exception [1]
+   and GNU General Public License, version 2 with the OpenJDK Assembly
+   Exception [2].
+
+ [1] https://www.gnu.org/software/classpath/license.html
+ [2] http://openjdk.java.net/legal/assembly-exception.html
+-->
+<project name="OpenJ9 JSR 292 API Tests" default="build" basedir=".">
+	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+	<description>
+		Build OpenJ9 JSR 292 API Tests 
+	</description>
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/OpenJ9_Jsr_292_API" />
+
+	<!--Properties for this particular build-->
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+	<property name="transformerListener" location="../Utils/src"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+		<mkdir dir="${build}"/>
+	</target>
+	
+	<target name="compile_tests" depends="init" description="compile the test source code" >
+		<echo>Compiling the test source code</echo>
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+		<if>
+			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}"/>
+					<src path="${transformerListener}" />
+					<classpath>
+						<pathelement location="../TestConfig/lib/asm-all.jar" />
+						<pathelement location="../TestConfig/lib/testng.jar"/>
+						<pathelement location="../TestConfig/lib/jcommander.jar"/>
+					</classpath>
+				</javac>
+			</then>
+		</if>
+	</target>
+
+	<target name="DEST" depends="compile_tests" description="generate the distribution" >
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.mk,*.xml" />
+		</copy>
+		<jar jarfile="${DEST}/openj9_jsr292test.jar" filesonly="true">
+			<fileset dir="${build}"/>
+		</jar>
+	</target>
+
+	<target name="clean" depends="DEST" description="clean up" >
+		<delete dir="${build}"/>
+		<delete dir="${mods_dir}"/>
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/OpenJ9_Jsr_292_API/playlist.xml
+++ b/test/OpenJ9_Jsr_292_API/playlist.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code is also Distributed under one or more Secondary Licenses,
+  as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+  General Public License, version 2 with the GNU Classpath Exception [1]
+  and GNU General Public License, version 2 with the OpenJDK Assembly
+  Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<test>
+	<testCaseName>openj9_jsr292Test_SE90</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	-cp $(Q)$(TEST_RESROOT)$(D)openj9_jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testngSE90.xml$(Q) \
+	-testnames openj9_jsr292Test \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>sanity</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	
+		<test>
+		<testCaseName>openj9_jsr292Test_JitCount0_SE90</testCaseName>
+		<variations>
+			<variation>-Xjit:count=0</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	-cp $(Q)$(TEST_RESROOT)$(D)openj9_jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testngSE90.xml$(Q) \
+	-testnames openj9_jsr292Test \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<tags>
+			<tag>sanity</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CrossPackageExampleSubclass.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CrossPackageExampleSubclass.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+import examples.PackageExamples;
+
+/**
+ * @author mesbah
+ *
+ */
+public class CrossPackageExampleSubclass extends PackageExamples {
+	public int addPublic(int a, int b) {return a+b+2;} // overridden addPublic that returns something different
+	public int addProtected(int a, int b) {return -1;}
+	public int addPublic_Child(int a, int b) {return a+b+2;} 
+	
+	public int nonStaticPublicField_Child;
+	public static int staticPublicField_Child;
+	
+	private int nonStaticPrivateField_Child;
+	private static int staticPrivateField_Child;
+	
+	protected int nonStaticProtectedField_Child;
+	
+	public static Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+	
+	public String call_finalProtectedMethod() {
+		/* necessary to validate the result of this call from outside the package / hierarchy */
+		return finalProtectedMethod();
+	}
+	
+	public CrossPackageExampleSubclass() { }
+	public CrossPackageExampleSubclass(int a, int b) {
+		super();
+		nonStaticPublicField_Child = a + b; 
+	}
+	
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomClassLoader.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomClassLoader.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Helper class loader used in JSR 292 tests for MethodHandles.Lookup API 
+ */
+public class CustomClassLoader extends ClassLoader {
+	
+	public CustomClassLoader(ClassLoader parent) {
+		super(parent);
+	}
+	
+	@Override
+	public Class<?> loadClass(String className) throws ClassNotFoundException {
+		if (className.equals("com.ibm.j9.jsr292.CustomLoadedClass1") || className.equals("com.ibm.j9.jsr292.CustomLoadedClass2")) {
+			return getClass(className);
+		}
+		return super.loadClass(className);
+	}
+	
+	private Class<?> getClass(String className)throws ClassNotFoundException {
+		String classFile = className.replace(".", "/")+ ".class";
+		try {
+			InputStream classStream = getClass().getClassLoader().getResourceAsStream(classFile);
+			if (classStream == null) {
+				throw new ClassNotFoundException("Error loading class : " + classFile);
+			}
+	        int size = classStream.available();
+	        byte classRep[] = new byte[size];
+	        DataInputStream in = new DataInputStream(classStream);
+	        in.readFully(classRep);
+	        in.close();
+	        Class<?> clazz = defineClass(className, classRep, 0, classRep.length);
+			return clazz;
+		} catch (IOException e) {
+			throw new ClassNotFoundException(e.getMessage());
+		} 
+	}
+}	

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomLoadedClass1.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomLoadedClass1.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+public class CustomLoadedClass1 implements ICustomLoadedClass {
+	public Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+	
+	public int add(int a, int b) { return a + b + 100; }
+	
+	public static int addStatic(int a, int b) { return a + b + 100; }
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomLoadedClass2.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/CustomLoadedClass2.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+public class CustomLoadedClass2 implements ICustomLoadedClass {
+	public Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+	
+	public static int addStatic(int a, int b) { return a + b + 1; }
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/ICustomLoadedClass.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/ICustomLoadedClass.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.lang.invoke.MethodHandles.Lookup;
+
+public interface ICustomLoadedClass {
+	public Lookup getLookup();
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/LookupInTests.java
@@ -7,17 +7,14 @@
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * This Source Code may also be made available under the following
- * Secondary Licenses when the conditions for such availability set
- * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
- * General Public License, version 2 with the GNU Classpath
- * Exception [1] and GNU General Public License, version 2 with the
- * OpenJDK Assembly Exception [2].
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
  *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
- *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 package com.ibm.j9.jsr292;
 import org.testng.annotations.Test;
@@ -44,10 +41,10 @@ import examples.PackageExamples;
 public class LookupInTests {
 	
 	static final int NO_ACCESS = 0;
-	static final int PUBLIC_PACKAGE_MODE =  MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PACKAGE; // 9
-	static final int PUBLIC_PACKAGE_PRIVATE_MODE = MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE | MethodHandles.Lookup.PACKAGE; //11
-	static final int PUBLIC_PACKAGE_PROTECTED_MODE =  MethodHandles.Lookup.PUBLIC |  MethodHandles.Lookup.PACKAGE | MethodHandles.Lookup.PROTECTED; //13
-	static final int FULL_ACCESS_MODE = MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE | MethodHandles.Lookup.PROTECTED | MethodHandles.Lookup.PACKAGE; //15
+	static final int PUBLICLOOKUP_MODE =  MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.UNCONDITIONAL; // 33
+	static final int MODULE_PUBLIC_MODE =  MethodHandles.Lookup.MODULE | MethodHandles.Lookup.PUBLIC; // 17
+	static final int MODULE_PUBLIC_PACKAGE_MODE =  MethodHandles.Lookup.MODULE | MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PACKAGE; // 25
+	static final int FULL_ACCESS_MODE = MethodHandles.Lookup.MODULE |MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE | MethodHandles.Lookup.PROTECTED | MethodHandles.Lookup.PACKAGE; //31
 	
 	final Lookup localLookup = lookup();
 	final Lookup localPublicLookup = publicLookup();
@@ -69,20 +66,20 @@ public class LookupInTests {
 	 * Validates public access mode of a Lookup factory created by a call to MethodHandles.publicLookiup() 
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testPublicLookup() throws Throwable {
-		assertClassAndMode(localPublicLookup, Object.class, MethodHandles.Lookup.PUBLIC);
-		Assert.assertEquals(localPublicLookup.lookupModes(), MethodHandles.Lookup.PUBLIC);
+		assertClassAndMode(localPublicLookup, Object.class, PUBLICLOOKUP_MODE);
+		Assert.assertEquals(localPublicLookup.lookupModes(), PUBLICLOOKUP_MODE);
 		
 		Lookup newLookup = localPublicLookup.in(int[].class);
-		assertClassAndMode(newLookup, int[].class, localPublicLookup.lookupModes());
+		assertClassAndMode(newLookup, int[].class, MethodHandles.Lookup.PUBLIC);
 	}
 	
 	/**
 	 * Validates access restriction stored in a Lookup factory object that are applied to its own lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_inObject_Self() throws Throwable {
 		Lookup newLookup = localLookup.in(LookupInTests.class);
 		assertClassAndMode(newLookup, LookupInTests.class, FULL_ACCESS_MODE);
@@ -93,9 +90,9 @@ public class LookupInTests {
 	 * where the new lookup class is java.lang.Object.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_inObject() throws Throwable {
-		Lookup inObject = packageExamplesLookup.in(Object.class);
+		Lookup inObject = packageExamplesLookup.in(Object.class); 
 		assertClassAndMode(inObject, Object.class, MethodHandles.Lookup.PUBLIC);
 	}
 	
@@ -105,7 +102,7 @@ public class LookupInTests {
 	 * where the new lookup class is java.lang.Object. 
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_inObject_Using_publicLookup() throws Throwable {
 		Lookup lookup = PackageExamples.getPublicLookup();
 		Lookup inObject = lookup.in(int.class);
@@ -120,13 +117,13 @@ public class LookupInTests {
 	
 	/**
 	 * Validates access restrictions stored in a new Lookup object created from the Lookup object of this class (LookupInTests) 
-	 * where the new lookup class is junit.framework.Assert. 
+	 * where the new lookup class is org.testng.Assert. 
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_in_Assert() throws Throwable {
 		Lookup newLookup = localLookup.in(Assert.class);
-		assertClassAndMode(newLookup, Assert.class, MethodHandles.Lookup.PUBLIC);
+		assertClassAndMode(newLookup, Assert.class, MODULE_PUBLIC_MODE); 
 	}
 	
 	/*******************************************************************************
@@ -139,10 +136,10 @@ public class LookupInTests {
 	 * of the original Lookup object.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_SamePackageLookup() throws Throwable {
 		Lookup inObject = samePackageExampleLookup.in(SamePackageSingleMethodInterfaceExample.class);
-		assertClassAndMode(inObject, SamePackageSingleMethodInterfaceExample.class, PUBLIC_PACKAGE_MODE);
+		assertClassAndMode(inObject, SamePackageSingleMethodInterfaceExample.class, MODULE_PUBLIC_PACKAGE_MODE); 
 	}
 	
 	/**
@@ -151,10 +148,10 @@ public class LookupInTests {
 	 * where the new Lookup class is a subclass of the original lookup class. 
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_SamePackageLookup_Subclass() throws Throwable {
 		Lookup inObject = samePackageExampleLookup.in(SamePackageExampleSubclass.class);
-		assertClassAndMode(inObject, SamePackageExampleSubclass.class, PUBLIC_PACKAGE_MODE);
+		assertClassAndMode(inObject, SamePackageExampleSubclass.class, MODULE_PUBLIC_PACKAGE_MODE);
 	}
 	
 	/**
@@ -162,7 +159,7 @@ public class LookupInTests {
 	 * where the new lookup class is the super-class of the original Lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_SamePackageLookup_Superclass() throws Throwable {
 		Lookup inObject = samePackageExampleSubclassLookup.in(SamePackageExample.class);
 		assertClassAndMode(inObject, SamePackageExample.class, FULL_ACCESS_MODE);
@@ -173,10 +170,10 @@ public class LookupInTests {
 	 * where the new lookup class is in a different package than the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_CrossPackageLookup() throws Throwable {
 		Lookup inObject = samePackageExampleLookup.in(PackageExamples.class);
-		assertClassAndMode(inObject, PackageExamples.class, MethodHandles.Lookup.PUBLIC);
+		assertClassAndMode(inObject, PackageExamples.class, MODULE_PUBLIC_MODE);
 	}
 	
 	/**
@@ -185,10 +182,10 @@ public class LookupInTests {
 	 * different package than the original lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_CrossPackageLookup_Subclass() throws Throwable {
 		Lookup inObject = packageExamplesLookup.in(CrossPackageExampleSubclass.class);
-		assertClassAndMode(inObject, CrossPackageExampleSubclass.class, MethodHandles.Lookup.PUBLIC);
+		assertClassAndMode(inObject, CrossPackageExampleSubclass.class, MODULE_PUBLIC_MODE);
 	}
 	
 	/**
@@ -197,11 +194,11 @@ public class LookupInTests {
 	 * different package than the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_CrossPackageLookup_Superclass() throws Throwable {
 		Lookup lookup = CrossPackageExampleSubclass.getLookup();
 		Lookup inObject = lookup.in(PackageExamples.class);
-		assertClassAndMode(inObject, PackageExamples.class, Lookup.PUBLIC);
+		assertClassAndMode(inObject, PackageExamples.class, MODULE_PUBLIC_MODE);
 	}
 	
 	/**
@@ -209,10 +206,10 @@ public class LookupInTests {
 	 * where the new lookup class is a non-public outer class in the same Java source file as the old lookup class
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PrivateOuterClassLookup() throws Throwable {
 		Lookup inObj = localLookup.in(PackageClass.class);
-		assertClassAndMode(inObj, PackageClass.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, PackageClass.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -220,10 +217,10 @@ public class LookupInTests {
 	 * where the new lookup class is a non-public outer class belonging to the same package as the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_SamePackageLookup_PrivateOuterClass() throws Throwable {
 		Lookup inObj = samePackageExampleLookup.in(PackageClass.class);
-		assertClassAndMode(inObj, PackageClass.class, PUBLIC_PACKAGE_MODE);
+		assertClassAndMode(inObj, PackageClass.class, MODULE_PUBLIC_PACKAGE_MODE);
 	}
 	
 	/**
@@ -231,7 +228,7 @@ public class LookupInTests {
 	 * where the new lookup class is a non-public outer class belonging to a different package than the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_CrossPackageLookup_PrivateOuterClass() throws Throwable {
 		Lookup inObj = packageExamplesLookup.in(PackageClass.class);
 		assertClassAndMode(inObj, PackageClass.class, NO_ACCESS);
@@ -246,10 +243,10 @@ public class LookupInTests {
 	 * where the new lookup class is a public inner class under the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicInnerClassLookup() throws Throwable {
 		Lookup inObj = samePackageExampleLookup.in(SamePackageInnerClass.class);
-		assertClassAndMode(inObj, SamePackageInnerClass.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass.class, FULL_ACCESS_MODE);
 	}
 		
 	/**
@@ -257,10 +254,10 @@ public class LookupInTests {
 	 * where the new lookup class is the outer class of the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicOuterClassLookup() throws Throwable {
 		Lookup inObj = samePackageInnerClassLookup.in(SamePackageExample.class);
-		assertClassAndMode(inObj, SamePackageExample.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageExample.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -268,10 +265,10 @@ public class LookupInTests {
 	 * where the new lookup class is a public inner class under the super-class of the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicInnerClassLookup_Subclass() throws Throwable {
 		Lookup inObj = samePackageExampleSubclassLookup.in(SamePackageInnerClass.class);
-		assertClassAndMode(inObj, SamePackageInnerClass.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -280,10 +277,10 @@ public class LookupInTests {
 	 * package as the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicInnerClassLookup_SamePackage() throws Throwable {
 		Lookup inObj = samePackageExample2Lookup.in(SamePackageInnerClass.class);
-		assertClassAndMode(inObj, SamePackageInnerClass.class, PUBLIC_PACKAGE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass.class, MODULE_PUBLIC_PACKAGE_MODE);
 	}
 	
 	/**
@@ -292,10 +289,10 @@ public class LookupInTests {
 	 * package than the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicInnerClassLookup_CrossPackage() throws Throwable {
 		Lookup inObj = packageExamplesLookup.in(SamePackageInnerClass.class);
-		assertClassAndMode(inObj, SamePackageInnerClass.class, MethodHandles.Lookup.PUBLIC);
+		assertClassAndMode(inObj, SamePackageInnerClass.class, MODULE_PUBLIC_MODE);
 	}
 	
 	/***************************************************
@@ -307,10 +304,10 @@ public class LookupInTests {
 	 * where the new lookup class is a protected inner class under the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_ProtectedInnerClassLookup() throws Throwable {
 		Lookup inObj = samePackageExampleLookup.in(SamePackageInnerClass_Protected.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, FULL_ACCESS_MODE);
 	}
 		
 	/**
@@ -318,12 +315,12 @@ public class LookupInTests {
 	 * where the new lookup class is the outer class of the original lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_ProtectedOuterClassLookup() throws Throwable {
 		SamePackageExample spe = new SamePackageExample();
 		Lookup lookup = spe.new SamePackageInnerClass_Protected().getLookup();
 		Lookup inObj = lookup.in(SamePackageExample.class);
-		assertClassAndMode(inObj, SamePackageExample.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageExample.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -331,10 +328,10 @@ public class LookupInTests {
 	 * where the new lookup class is a protected inner class under the super-class of the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_ProtectedInnerClassLookup_Subclass() throws Throwable {
 		Lookup inObj = samePackageExampleSubclassLookup.in(SamePackageInnerClass_Protected.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -343,23 +340,22 @@ public class LookupInTests {
 	 * package as the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_ProtectedInnerClassLookup_SamePackage() throws Throwable {
 		Lookup inObj = samePackageExample2Lookup.in(SamePackageInnerClass_Protected.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, PUBLIC_PACKAGE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, MODULE_PUBLIC_PACKAGE_MODE);
 	}
 	
 	/**
 	 * Validates access restrictions stored in a new Lookup object created from an old Lookup object
 	 * where the new lookup class is a protected inner class inside a top level class belonging to a different 
 	 * package than the old lookup class.
-	 * Note: the access flag of a protected class is set to public when compiled to a class file.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_ProtectedInnerClassLookup_CrossPackage() throws Throwable {
 		Lookup inObj = packageExamplesLookup.in(SamePackageInnerClass_Protected.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, MethodHandles.Lookup.PUBLIC);
+		assertClassAndMode(inObj, SamePackageInnerClass_Protected.class, MODULE_PUBLIC_MODE);
 	}
 	
 	/***************************************************
@@ -371,22 +367,22 @@ public class LookupInTests {
 	 * where the new lookup class is a static inner class under the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_StaticInnerClassLookup() throws Throwable {
 		Lookup inObj = samePackageExampleLookup.in(SamePackageInnerClass_Static.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, FULL_ACCESS_MODE);
 	}
-	
+		
 	/**
 	 * Validates access restrictions stored in a new Lookup object created from an old Lookup object
 	 * where the new lookup class is the outer class of the original lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_StaticdOuterClassLookup() throws Throwable {
 		Lookup lookup = SamePackageExample.SamePackageInnerClass_Static.getLookup();
 		Lookup inObj = lookup.in(SamePackageExample.class);
-		assertClassAndMode(inObj, SamePackageExample.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageExample.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -394,10 +390,10 @@ public class LookupInTests {
 	 * where the new lookup class is a static inner class under the super-class of the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_StaticInnerClassLookup_Subclass() throws Throwable {
 		Lookup inObj = samePackageExampleSubclassLookup.in(SamePackageInnerClass_Static.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -406,10 +402,10 @@ public class LookupInTests {
 	 * package as the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_StaticInnerClassLookup_SamePackage() throws Throwable {
 		Lookup inObj = samePackageExample2Lookup.in(SamePackageInnerClass_Static.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, PUBLIC_PACKAGE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, MODULE_PUBLIC_PACKAGE_MODE);
 	}
 	
 	/**
@@ -418,7 +414,7 @@ public class LookupInTests {
 	 * package than the old lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_StaticInnerClassLookup_CrossPackage() throws Throwable {
 		Lookup inObj = packageExamplesLookup.in(SamePackageInnerClass_Static.class);
 		assertClassAndMode(inObj, SamePackageInnerClass_Static.class, NO_ACCESS);
@@ -434,10 +430,10 @@ public class LookupInTests {
 	 * Basically we validate that a nested class C.D can access private members within another nested class C.D.E.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicNestedInnerClassLookup_Level1() throws Throwable {
 		Lookup inObj = samePackageInnerClassLookup.in(SamePackageInnerClass_Nested_Level2.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Nested_Level2.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Nested_Level2.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -446,10 +442,10 @@ public class LookupInTests {
 	 * Basically we validate that a top level class C can access private members within a nested class C.D.E.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicNestedInnerClassLookup_Level2() throws Throwable {
 		Lookup inObj = samePackageExampleLookup.in(SamePackageInnerClass_Nested_Level2.class);
-		assertClassAndMode(inObj, SamePackageInnerClass_Nested_Level2.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass_Nested_Level2.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -459,10 +455,10 @@ public class LookupInTests {
 	 * nested class C.B.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicInnerClassLookup_ParallelInnerClasses_Level1() throws Throwable {
 		Lookup inObj = samePackageInnerClassLookup.in(SamePackageInnerClass2.class);
-		assertClassAndMode(inObj, SamePackageInnerClass2.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass2.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -472,7 +468,7 @@ public class LookupInTests {
 	 * nested class C.B.F
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_PublicInnerClassLookup_ParallelInnerClasses_Level2() throws Throwable {
 		SamePackageExample spe = new SamePackageExample();
 		SamePackageInnerClass spei_level1 = spe.new SamePackageInnerClass();
@@ -480,7 +476,7 @@ public class LookupInTests {
 		
 		Lookup lookup = spei_level2.getLookup();
 		Lookup inObj = lookup.in(SamePackageInnerClass2_Nested_Level2.class);
-		assertClassAndMode(inObj, SamePackageInnerClass2_Nested_Level2.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass2_Nested_Level2.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -490,10 +486,10 @@ public class LookupInTests {
 	 * another nested class C.D.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
-	public void testLookup_PublicNestedOuterClassLookup_Level2() throws Throwable {		
+	@Test(groups = { "level.sanity" })
+	public void testLookup_PublicNestedOuterClassLookup_Level2() throws Throwable {
 		Lookup inObj = samePackageInnerClass_Nested_Level2Lookup.in(SamePackageInnerClass.class);
-		assertClassAndMode(inObj, SamePackageInnerClass.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageInnerClass.class, FULL_ACCESS_MODE);
 	}
 	
 	/**
@@ -503,10 +499,10 @@ public class LookupInTests {
 	 * the top level outer class C.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
-	public void testLookup_PublicNestedOuterClassLookup_Level1() throws Throwable {
+	@Test(groups = { "level.sanity" })
+	public void testLookup_PublicNestedOuterClassLookup_Level1() throws Throwable {		
 		Lookup inObj = samePackageInnerClass_Nested_Level2Lookup.in(SamePackageExample.class);
-		assertClassAndMode(inObj, SamePackageExample.class, PUBLIC_PACKAGE_PRIVATE_MODE);
+		assertClassAndMode(inObj, SamePackageExample.class, FULL_ACCESS_MODE);
 	}
 	
 	
@@ -520,12 +516,13 @@ public class LookupInTests {
 	 * that loaded the original lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_UnrelatedClassLoaders() throws Throwable {
-		ParentCustomClassLoader unrelatedClassLoader = new ParentCustomClassLoader(LookupInTests.class.getClassLoader());
-		Object customLoadedClass = unrelatedClassLoader.loadClass("com.ibm.j9.jsr292.CustomLoadedClass1" ).newInstance();
+		CustomClassLoader unrelatedClassLoader = new CustomClassLoader(LookupInTests.class.getClassLoader());
+		Object customLoadedClass = unrelatedClassLoader.loadClass("com.ibm.j9.jsr292.CustomLoadedClass1").newInstance();
 		
 		Lookup inObject = samePackageExampleLookup.in(customLoadedClass.getClass());
+		
 		assertClassAndMode(inObject, customLoadedClass.getClass(), MethodHandles.Lookup.PUBLIC);
 	}
 	
@@ -535,22 +532,21 @@ public class LookupInTests {
 	 * of the class loader  that loaded the original lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_RelatedClassLoaders_ChildLookupInParent() throws Throwable {
-		ParentCustomClassLoader parentCustomCL = new ParentCustomClassLoader(LookupInTests.class.getClassLoader());
-		Object customLoadedClass1 = parentCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass1" ).newInstance();
+		CustomClassLoader parentCustomCL = new CustomClassLoader(LookupInTests.class.getClassLoader());
+		Object customLoadedClass1 = parentCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass1").newInstance();
 		
-		Assert.assertTrue(customLoadedClass1.getClass().getClassLoader() instanceof ParentCustomClassLoader);
+		Assert.assertTrue(customLoadedClass1.getClass().getClassLoader() == parentCustomCL);
 		
-		ChildCustomClassLoader childCustomCL = new ChildCustomClassLoader(parentCustomCL);
-		ICustomLoadedClass customLoadedClass2 = (ICustomLoadedClass) childCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass2" ).newInstance();
-		 
-		Assert.assertTrue(customLoadedClass2.getClass().getClassLoader() instanceof ChildCustomClassLoader);
+		CustomClassLoader childCustomCL = new CustomClassLoader(parentCustomCL);
+		ICustomLoadedClass customLoadedClass2 = (ICustomLoadedClass) childCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass2").newInstance();
+		
+		Assert.assertTrue(customLoadedClass2.getClass().getClassLoader() == childCustomCL);
 		
 		Lookup lookup = customLoadedClass2.getLookup();
-	    Lookup inObject = lookup.in(customLoadedClass1.getClass());
-	    
-	    assertClassAndMode(inObject, customLoadedClass1.getClass(), MethodHandles.Lookup.PUBLIC);
+		Lookup inObject = lookup.in(customLoadedClass1.getClass());		
+		assertClassAndMode(inObject, customLoadedClass1.getClass(), MethodHandles.Lookup.PUBLIC);
 	}
 	
 	/**
@@ -559,61 +555,53 @@ public class LookupInTests {
 	 * of the class loader that loaded the original lookup class.
 	 * @throws Throwable
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void testLookup_RelatedClassLoaders_ParentLookupInChild() throws Throwable {
-		ParentCustomClassLoader parentCustomCL = new ParentCustomClassLoader(LookupInTests.class.getClassLoader());
-		ICustomLoadedClass customLoadedClass1 = (ICustomLoadedClass) parentCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass1" ).newInstance();
+		CustomClassLoader parentCustomCL = new CustomClassLoader(LookupInTests.class.getClassLoader());
+		ICustomLoadedClass customLoadedClass1 = (ICustomLoadedClass) parentCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass1").newInstance();
 		
-		Assert.assertTrue(customLoadedClass1.getClass().getClassLoader() instanceof ParentCustomClassLoader);
+		Assert.assertTrue(customLoadedClass1.getClass().getClassLoader() == parentCustomCL);
 		
-		ChildCustomClassLoader childCustomCL = new ChildCustomClassLoader(parentCustomCL);
-		ICustomLoadedClass customLoadedClass2 = (ICustomLoadedClass) childCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass2" ).newInstance();
+		CustomClassLoader childCustomCL = new CustomClassLoader(parentCustomCL);
+		ICustomLoadedClass customLoadedClass2 = (ICustomLoadedClass) childCustomCL.loadClass("com.ibm.j9.jsr292.CustomLoadedClass2").newInstance();
 		 
-		Assert.assertTrue(customLoadedClass2.getClass().getClassLoader() instanceof ChildCustomClassLoader);
+		Assert.assertTrue(customLoadedClass2.getClass().getClassLoader() == childCustomCL);
 		
 		Lookup lookup = customLoadedClass1.getLookup();
-	    Lookup inObject = lookup.in(customLoadedClass2.getClass());
-	    
-	    assertClassAndMode(inObject, customLoadedClass2.getClass(), MethodHandles.Lookup.PUBLIC);
+		Lookup inObject = lookup.in(customLoadedClass2.getClass());
+		assertClassAndMode(inObject, customLoadedClass2.getClass(), MethodHandles.Lookup.PUBLIC);
 	}
 	
 	/**
-	 *Test for MethodHandles.Lookup.toString() class where we check output depending on various access modes. 
+	 *Test for MethodHandles.Lookup.toString() class where we check output depending on various access modes.
 	 */
-	@Test(groups = { "level.extended" })
+	@Test(groups = { "level.sanity" })
 	public void test_Lookup_toString() {
-		Lookup publicLookup = MethodHandles.publicLookup();
-		Assert.assertEquals(publicLookup.toString(), "java.lang.Object/public");
+		Assert.assertEquals("java.lang.Object/publicLookup", localPublicLookup.toString());
 		
-		Lookup lookup = PackageExamples.getLookup();
-		Lookup inObject = lookup.in(Object.class); 
-		Assert.assertEquals(inObject.toString(), "java.lang.Object/public");
+		Lookup inObject = packageExamplesLookup.in(Object.class); 
+		Assert.assertEquals("java.lang.Object/public", inObject.toString());
 		
-		lookup = MethodHandles.lookup();
-		Lookup inAssertObject = lookup.in(Assert.class);
-		Assert.assertEquals(inAssertObject.toString(), "org.testng.Assert/public");
+		Lookup inAssertObject = localLookup.in(Assert.class);
+		Assert.assertEquals("org.testng.Assert/module", inAssertObject.toString());
 	
-		lookup = SamePackageExample.getLookup();
-		Lookup inCrossPackageClass = lookup.in(PackageExamples.class);
-		Assert.assertEquals(inCrossPackageClass.toString(), "examples.PackageExamples/public");
+		Lookup inCrossPackageClass = samePackageExampleLookup.in(PackageExamples.class);
+		Assert.assertEquals("examples.PackageExamples/module", inCrossPackageClass.toString());
 		
-		lookup = SamePackageExample.getLookup();
-		Lookup inSamePackageClass = lookup.in(SamePackageSingleMethodInterfaceExample.class);
-		Assert.assertEquals(inSamePackageClass.toString(), "com.ibm.j9.jsr292.SamePackageSingleMethodInterfaceExample/package");
-
-		lookup = MethodHandles.lookup();
-		Lookup inPrivateClass = lookup.in(PackageClass.class);
-		Assert.assertEquals(inPrivateClass.toString(), "com.ibm.j9.jsr292.LookupInTests$PackageClass/private");
+		Lookup inSamePackageClass = samePackageExampleLookup.in(SamePackageSingleMethodInterfaceExample.class);
+		Assert.assertEquals("com.ibm.j9.jsr292.SamePackageSingleMethodInterfaceExample/package", inSamePackageClass.toString());
 		
-		lookup = MethodHandles.publicLookup();
-		Lookup inNoAccess = lookup.in(PackageClass.class);
-		Assert.assertEquals(inNoAccess.toString(), "com.ibm.j9.jsr292.LookupInTests$PackageClass/noaccess");
+		Lookup inAccessClass = localLookup.in(PackageClass.class);
+		Assert.assertEquals("com.ibm.j9.jsr292.LookupInTests$PackageClass", inAccessClass.toString());
+		
+		Lookup inNoAccess = localPublicLookup.in(PackageClass.class);
+		Assert.assertEquals("com.ibm.j9.jsr292.LookupInTests$PackageClass/noaccess", inNoAccess.toString());
 	}
 	
 	/**
 	 *Non-public outer class used in tests
 	 */
-	class PackageClass { } 
+	class PackageClass { }
 	
 	/**
 	 * Helper validation method. Validates the lookup class and lookup modes of the Lookup object being tested.

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample.java
@@ -1,0 +1,283 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+/**
+ * All the fields, constructors and methods in this class are used by test cases that require fields, methods, and constructors of 
+ * various behavior from a class in the same package as the test class. 
+ * 
+ * @author mesbah
+ *
+ */
+public class SamePackageExample {
+	public static Lookup publicLookupObjectSamePackage = MethodHandles.publicLookup().in(SamePackageExample.class);
+	public static int publicStaticField_doNotDeclareInSubClasses; 
+	
+	public int nonStaticPublicField;
+	public final int nonStaticFinalPublicField;
+	public static int staticPublicField;
+	public final static int staticFinalPublicField = 42;
+	
+	private int nonStaticPrivateField;
+	private static int staticPrivateField;
+	
+	protected int nonStaticProtectedField;
+	
+	public SamePackageExample() {
+		super();
+		nonStaticFinalPublicField = 24;
+	}
+	
+	public SamePackageExample(int a, int b) {
+		this.nonStaticPublicField = a + b;
+		this.nonStaticFinalPublicField = a + b;
+	}
+	
+	public int addPublic(int a, int b) {return a+b;}
+	private int addPrivate(int a, int b) {return a+b;}
+	
+	public static int addPublicStatic (int a,int b) {return a+b;}
+	private static int addPrivateStatic (int a,int b) {return a+b;}
+	protected static int addProtectedStatic(int a, int b) {return a+b;}
+	
+	protected int addProtected(int a, int b) {return a+b;}
+	
+	public int addPublic_Super(int a, int b) {return a+b+5;}
+	
+	public static Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+	
+	public class SamePackageInnerClass{
+		
+		public int nonStaticPublicField_Inner1;
+		
+		private int nonStaticPrivateField_Inner1;
+		
+		protected int nonStaticProtectedField_Inner1; 
+		
+		public int addPublicInner(int a, int b) { return a+b; }
+		
+		private int addPrivateInner(int a, int b) { return a+b; }
+		
+		public Lookup getLookup() {
+			return MethodHandles.lookup();
+		}
+		
+		public class SamePackageInnerClass_Nested_Level2 {
+			
+			public int nonStaticPublicField_Inner2;
+			
+			private int nonStaticPrivateField_Inner2;
+			
+			protected int nonStaticProtectedField_Inner2; 
+			
+			public int addPublicInner_Level2(int a, int b) { return a+b; }
+			
+			public Lookup getLookup() {
+				return MethodHandles.lookup();
+			}
+		}
+	}
+	
+	public class SamePackageInnerClass2{
+		
+		public int nonStaticPublicField_Inner12;
+		public Lookup getLookup() {
+			return MethodHandles.lookup();
+		}
+		
+		public class SamePackageInnerClass2_Nested_Level2 {
+			
+			public int nonStaticPublicField_Inner22;
+			
+			private int nonStaticPrivateField_Inner22;
+			
+			protected int nonStaticProtectedField_Inner22; 
+			
+			public Lookup getLookup() {
+				return MethodHandles.lookup();
+			}
+		}
+		
+		public class SamePackageInnerClass2_Nested_Level2_SubOf_Inner1 extends SamePackageInnerClass {
+			public int addPublicInner(int a, int b) { return a+b+20; } // overridden method
+		}
+	}
+	
+	protected class SamePackageInnerClass_Protected {
+		
+		protected Lookup getLookup() {
+			return MethodHandles.lookup();
+		}
+		
+		public int addPublicInner(int a, int b) { return a+b; }
+		protected int addProtectedInner(int a, int b) { return a+b; }
+		
+		protected class SamePackageInnerClass_Nested_Level2 {
+			public Lookup getLookup() {
+				return MethodHandles.lookup();
+			}
+			public int addPublicInner_Level2(int a, int b) { return a+b; }
+			protected int addProtectedInner_Level2(int a, int b) { return a+b; }
+		}
+	}
+	
+	static class SamePackageInnerClass_Static {
+		public static Lookup getLookup () {
+			return MethodHandles.lookup();
+		}
+	}
+
+	
+	public String arrayToString(String[] o) {
+		String s = "[";
+		
+		if ( o == null || o.length == 0 ) {
+			return s + "]";
+		}
+		
+		for ( int i = 0 ; i < o.length ; i++ ) {
+			s += o[i];
+			if ( i + 1 < o.length ) {
+				s += ",";
+			}
+		}
+		
+		return s + "]";
+	}
+	
+	public int getLength(String[] o) {
+		return o.length;
+	}
+	
+	public int getLength(int[] o) {
+		return o.length;
+	}
+	
+	public int getLength(double[] o) {
+		return o.length;
+	}
+	
+	public int getLength(char[] o) {
+		return o.length;
+	}
+	
+	public int getLength(float[] o) {
+		return o.length;
+	}
+	
+	public int getLength(boolean[] o) {
+		return o.length;
+	}
+	
+	public int getLength(byte[] o) {
+		return o.length;
+	}
+	
+	public int getLength(short[] o) {
+		return o.length;
+	}
+	
+	public int getLength(long[] o) {
+		return o.length;
+	}
+	
+	public static int getLengthStatic(String[] o) {
+		return o.length;
+	}
+	
+	public int addPublicVariableArity(int... n) {
+		int sum = 0 ; 
+		for ( int i = 0 ; i < n.length ; i++ ) {
+			sum += n[i];
+		}
+		return sum;
+	}
+	
+	public int addPublicVariableArity(Object... n) {
+		int sum = 0 ; 
+		for ( int i = 0 ; i < n.length ; i++ ) {
+			sum += (int)n[i];
+		}
+		return sum;
+	}
+	
+	public void takeVariableArityObject(Object... n) {}
+		
+	public static String returnOne() {
+		return "1";
+	}
+
+	public static String returnTwo() {
+		return "2";
+	}
+	
+	public static String returnThree() {
+		return "3";
+	}
+	
+	public int[] makeArray(int...args) { return args; }
+	
+	public String arrayToString(Object [] o) {
+		String s = "[";
+		
+		if ( o == null || o.length == 0 ) {
+			return s + "]";
+		}
+		
+		for ( int i = 0 ; i < o.length ; i++ ) {
+			s += o[i];
+			if ( i + 1 < o.length ) {
+				s += ",";
+			}
+		}
+		
+		return s + "]";
+	}
+	
+	public String toOjectArrayString(Object objArray) {
+		Object [] o = (Object[])objArray;
+		String s = "[";
+		
+		if ( o == null || o.length == 0 ) {
+			return s + "]";
+		}
+		
+		for ( int i = 0 ; i < o.length ; i++ ) {
+			s += o[i];
+			if ( i + 1 < o.length ) {
+				s += ",";
+			}
+		}
+		
+		return s + "]";
+	}
+	
+	/*Variable arity constructor example*/
+	public SamePackageExample(int...n) {
+		nonStaticFinalPublicField = 24;
+	}
+	
+	public boolean isReceiverNull() { return this == null; }
+	public String toString() { return "SamePackageExample.toString()" + ((this == null) ? " null" : "notnull"); }
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample2.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExample2.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+public class SamePackageExample2 {
+
+	public static Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExampleSubclass.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageExampleSubclass.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+/**
+ * Subclass example used by various tests 
+ * 
+ * @author mesbah
+ *
+ */
+public class SamePackageExampleSubclass extends SamePackageExample {
+	
+	public int nonStaticPublicField_Child;
+	public static int staticPublicField_Child;
+	
+	private int nonStaticPrivateField_Child;
+	private static int staticPrivateField_Child;
+	
+	protected int nonStaticProtectedField_Child;
+	
+	public int addPublic(int a, int b) {return a+b+1;} // Overridden addPublic that returns something different
+	
+	public int addPublic_Child(int a, int b) {return a+b+2;} 
+	
+	@Override
+	protected int addProtected(int a, int b) {
+		return super.addProtected(a, b)+10;
+	}
+	
+	public SamePackageExampleSubclass() { }
+	
+	public SamePackageExampleSubclass(int a, int b) {
+		super();
+		nonStaticPublicField_Child = a + b; 
+	}
+}

--- a/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageSingleMethodInterfaceExample.java
+++ b/test/OpenJ9_Jsr_292_API/src/com/ibm/j9/jsr292/SamePackageSingleMethodInterfaceExample.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+/**
+ * Single method interface example used by the MethodHandleProxiesTest 
+ * @author mesbah
+ *
+ */
+public interface SamePackageSingleMethodInterfaceExample {
+	
+	public int singleMethodAdd(int a, int b);
+
+}

--- a/test/OpenJ9_Jsr_292_API/src/examples/PackageExamples.java
+++ b/test/OpenJ9_Jsr_292_API/src/examples/PackageExamples.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code is also Distributed under one or more Secondary Licenses,
+ * as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+ * General Public License, version 2 with the GNU Classpath Exception [1]
+ * and GNU General Public License, version 2 with the OpenJDK Assembly
+ * Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *******************************************************************************/
+package examples;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+/**
+ * All the fields, constructors and methods in this class are used by test cases that require fields, methods, and constructors of 
+ * various behavior from a class in a different package than that of the test class. 
+ * 
+ * @author mesbah
+ *
+ */
+public class PackageExamples {
+	
+	public static Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+	
+	public static Lookup getPublicLookup() {
+		return MethodHandles.publicLookup();
+	}
+	
+	final protected String finalProtectedMethod() { return "finalProtectedMethod"; }
+
+	protected static String protectedMethod () { return "protectedMethod"; }
+	
+	/* default */ static String defaultMethod() { return "defaultMethod"; }
+	
+	public int nonStaticPublicField;
+	public static int staticPublicField;
+	
+	private int nonStaticPrivateField;
+	private static int staticPrivateField;
+	
+	protected int nonStaticProtectedField;
+	
+	public int addPublic(int a, int b){return a+b;}
+	private int addPrivate(int a, int b){return a+b;}
+	
+	public static int addPublicStatic (int a,int b) {return a+b;}
+	private static int addPrivateStatic (int a,int b) {return a+b;}
+	
+	protected static int addProtectedStatic(int a,int b) {return a+b;}
+	
+	public PackageExamples(){
+		super();
+	}
+	
+	public PackageExamples(int a, int b){
+		this.nonStaticPublicField = a + b;
+	}
+	
+
+	public class CrossPackageInnerClass{
+		public int addPublicInner(int a, int b){ return a+b; }
+		public Lookup getLookup() { return MethodHandles.lookup(); }
+		
+		public class CrossPackageInnerClass2_Nested_Level2 {
+			public Lookup getLookup() {
+				return MethodHandles.lookup();
+			}
+			public int addPublicInner_level2(int a, int b){ return a+b; }
+		}
+	}
+	
+	public int getLength(String[] o){
+		return o.length;
+	}
+	
+	public static int getLengthStatic(String[] o){
+		return o.length;
+	}
+	
+	public int addPublicVariableArity(int... n){
+		int sum = 0 ; 
+		for ( int i = 0 ; i < n.length ; i++ ){
+			sum += n[i];
+		}
+		return sum;
+	}
+	
+	public static int addPublicStaticVariableArity(int... n){
+		int sum = 0 ; 
+		for ( int i = 0 ; i < n.length ; i++ ){
+			sum += n[i];
+		}
+		return sum;
+	}
+	
+	protected int addProtected(int a, int b) {return a+b;}
+}

--- a/test/OpenJ9_Jsr_292_API/testngSE90.xml
+++ b/test/OpenJ9_Jsr_292_API/testngSE90.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code is also Distributed under one or more Secondary Licenses,
+  as those terms are defined by the Eclipse Public License, v. 2.0: GNU
+  General Public License, version 2 with the GNU Classpath Exception [1]
+  and GNU General Public License, version 2 with the OpenJDK Assembly
+  Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="OpenJ9_jsr292_Suite_SE90" parallel="none" verbose="2">
+	<listeners>
+		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer"/>
+	</listeners>
+	<test name="openj9_jsr292Test">
+		<classes>
+			<class name="com.ibm.j9.jsr292.LookupInTests"/>
+		</classes>
+	</test>
+</suite>

--- a/test/TestConfig/scripts/build_test.xml
+++ b/test/TestConfig/scripts/build_test.xml
@@ -126,6 +126,7 @@
 					<fileset dir="../../" includes="${build.list}" >
 						<exclude name="TEST_*/build.xml" />
 						<exclude name="Panama/build.xml" />
+						<exclude name="OpenJ9_Jsr_292_API/build.xml" />
 					</fileset>
 				</subant>
 			</else>

--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -111,7 +111,7 @@ sub generateOnDir {
 		# temporarily exclude projects for CCM build (i.e., when JCL_VERSION is latest)
 		my $latestDisabledDir = "cmdline_options_tester cmdline_options_testresources cmdLineTests Jsr292 Jsr335 Panama NativeTest UnsafeTest SharedCPEntryInvokerTests gcCheck classvertest";
 		# Temporarily exclude SVT_Modularity tests from integration build where we are still using b148 JCL level
-		my $currentDisableDir= "SVT_Modularity";
+		my $currentDisableDir= "SVT_Modularity OpenJ9_Jsr_292_API";
 		if ((($JCL_VERSION eq "latest") and ($latestDisabledDir !~ $entry )) or (($JCL_VERSION eq "current") and ($currentDisableDir !~ $entry ))) {
 			my $projectDir  = $absolutedir . '/' . $entry;
 			if (( -f $projectDir ) && ( $entry eq 'playlist.xml' )) {


### PR DESCRIPTION
The code is to add the MODULE bit to the
access modes and modify all APIs involved
against Java 9 API Specification so as to
ensure it works correctly in JCK tests.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>