### PR TITLE
[ci skip] Set the build desc from last commit

### DIFF
--- a/buildenv/jenkins/omrMirror
+++ b/buildenv/jenkins/omrMirror
@@ -47,6 +47,13 @@ pipeline {
                                 sh 'git push target --tags'
                                 // Remove the bot account username/password from the config
                                 sh "git config remote.target.url ${HTTP}${TARGET_REPO}"
+
+                                // Set the build description
+                                LAST_COMMIT = sh (
+                                        script: 'git log --oneline -1',
+                                        returnStdout: true
+                                    ).trim()
+                                currentBuild.description = "${LAST_COMMIT}"
                             }
                         }
                     }


### PR DESCRIPTION
- Store the oneline git log of the last commit
- Set the buildDescription based on LAST_COMMIT

Issue eclipse/openj9-omr#3

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>