### PR TITLE
Replace J9VM and JIT repo references with OpenJ9

### DIFF
--- a/runtime/jcl/cl_se9/module.xml
+++ b/runtime/jcl/cl_se9/module.xml
@@ -102,6 +102,9 @@
 		<makefilestubs>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="ifneq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="jclcinit$(UMA_DOT_O) : CFLAGS += -DOPENJ9_REPO='&quot;J9VM     - &quot;'"/>
+			<makefilestub data="endif"/>
 		</makefilestubs>
 
 		<vpaths>

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -151,7 +151,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(vminfo, EsBuildVersionString);
 
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)
-#ifdef J9VM_INTERP_NATIVE_SUPPORT
 	jitConfig = vm->jitConfig;
 	if (NULL != jitConfig) {
 		if (jitConfig->runtimeFlags & J9JIT_JIT_ATTACHED) {
@@ -161,7 +160,11 @@ jint computeFullVersionString(J9JavaVM* vm)
 			aotEnabled = 1;
 		}
 	}
-#endif
+
+#if !defined(OPENJ9_REPO)
+#define OPENJ9_REPO "OpenJ9   - "
+#endif /* !OPENJ9_REPO */
+
 	strcat(fullversion, " (JIT ");
 	strcat(fullversion, jitEnabled ? "en" : "dis");
 	strcat(vminfo, " (JIT ");
@@ -170,30 +173,21 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(fullversion, aotEnabled ? "en" : "dis");
 	strcat(vminfo, "abled, AOT ");
 	strcat(vminfo, aotEnabled ? "en" : "dis");
-	strcat(fullversion, "abled)\nJ9VM - ");
-	strcat(vminfo, "abled)\nJ9VM - ");
+	strcat(fullversion, "abled)\n" OPENJ9_REPO);
+	strcat(vminfo, "abled)\n" OPENJ9_REPO);
+#endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
-#endif
 	vmVersion = J9VM_VERSION_STRING;
 	strcat(fullversion, vmVersion);
 	strcat(vminfo, vmVersion);
 
-#ifdef J9VM_INTERP_NATIVE_SUPPORT
-	if ( jitConfig && jitConfig->jitLevelName ) {
-		strcat(fullversion, "\nJIT  - ");
-		strcat(fullversion, jitConfig->jitLevelName);
-		strcat(vminfo, "\nJIT  - ");
-		strcat(vminfo, jitConfig->jitLevelName);
-	}
-#endif
-
 #if defined(J9VM_GC_MODRON_GC)
 	gcVersion = OMR_VERSION_STRING;
-	strcat(fullversion, "\nOMR  - ");
+	strcat(fullversion, "\nOMR      - ");
 	strcat(fullversion, gcVersion);
-	strcat(vminfo, "\nOMR  - ");
+	strcat(vminfo, "\nOMR      - ");
 	strcat(vminfo, gcVersion);
-#endif
+#endif /* J9VM_GC_MODRON_GC */
 
 	(*VMI)->SetSystemProperty(VMI, "java.vm.info", vminfo);
 	/*[PR 114306] System property java.fullversion is not initialized properly */


### PR DESCRIPTION
Signed-off-by: Joe Dekoning <joe_dekoning@ca.ibm.com>

I added spacing so the repos line up in the output, it doesn't line up well pasted into here but each line is 11 characters before the sha. 

Before :
openjdk version "9-internal"
OpenJDK Runtime Environment (build 9-internal+0-adhoc.jdekonin.openjdk-jdk9)
Eclipse OpenJ9 VM (build 2.9, JRE 9 Linux amd64-64 Compressed References 20170921_000000 (JIT enabled, AOT enabled)
J9VM - 1ee80ad
JIT  - 1ee80ad
OMR  - 0366145
OpenJDK  - a3670d2 based on jdk-9+181)

After :
openjdk version "9-internal"
OpenJDK Runtime Environment (build 9-internal+0-adhoc.jdekonin.openjdk-jdk9)
Eclipse OpenJ9 VM (build 2.9, JRE 9 Linux amd64-64 Compressed References 20170921_000000 (JIT enabled, AOT enabled)
OpenJ9   - 1ee80ad
OMR      - 0366145
OpenJDK  - a3670d2 based on jdk-9+181)

and of course the system property

java.vm.info=JRE 9 Linux amd64-64 Compressed References 20170921_000000 (JIT enabled, AOT enabled)
OpenJ9   - 1ee80ad
OMR      - 0366145
