### PR TITLE
Store feGetEnv results in statics

### DIFF
--- a/runtime/tr.source/trj9/optimizer/FearPointAnalysis.cpp
+++ b/runtime/tr.source/trj9/optimizer/FearPointAnalysis.cpp
@@ -36,7 +36,8 @@
 
 bool TR_FearPointAnalysis::virtualGuardsKillFear()
    {
-   return feGetEnv("TR_FPAnalaysisGuardsDoNotKillFear") == NULL;
+   static bool kill = (feGetEnv("TR_FPAnalaysisGuardsDoNotKillFear") == NULL);
+   return kill;
    }
 
 static bool containsPrepareForOSR(TR::Block *block)

--- a/runtime/tr.source/trj9/optimizer/MonitorElimination.cpp
+++ b/runtime/tr.source/trj9/optimizer/MonitorElimination.cpp
@@ -405,7 +405,7 @@ int32_t TR::MonitorElimination::perform()
    _monitorStack->push(outerScope);
 
    bool attemptRedundantMonitors = true;
-   bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
+   static bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
    if (comp()->getOption(TR_EnableOSR) && disableOSRwithTM)
       {
       if (trace())


### PR DESCRIPTION
feGetEnv is a common debug tool to disable or enable
behaviour based on environment variables. To avoid
significant compile time overhead, the result of the
call should be stored in a static.