### PR TITLE
WIP: Simplify containsPrepareForOSR check

### DIFF
--- a/runtime/tr.source/trj9/optimizer/FearPointAnalysis.cpp
+++ b/runtime/tr.source/trj9/optimizer/FearPointAnalysis.cpp
@@ -39,18 +39,26 @@ bool TR_FearPointAnalysis::virtualGuardsKillFear()
    return feGetEnv("TR_FPAnalaysisGuardsDoNotKillFear") == NULL;
    }
 
-static bool containsPrepareForOSR(TR::Block *block)
+bool TR_FearPointAnalysis::containsPrepareForOSR(TR::Block *block)
    {
+#ifdef DEBUG
+   bool debugResult = false
    for (TR::TreeTop *tt = block->getEntry(); tt != block->getExit(); tt = tt->getNextTreeTop())
-       {
-       if (tt->getNode()->getOpCode().isCheck() || tt->getNode()->getOpCodeValue() == TR::treetop)
-          {
-          if (tt->getNode()->getFirstChild()->getOpCode().isCall()
-              && tt->getNode()->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
-             return true;
-          }
-       }
-   return false;
+      {
+      if (tt->getNode()->getOpCode().isCheck() || tt->getNode()->getOpCodeValue() == TR::treetop)
+         {
+         if (tt->getNode()->getFirstChild()->getOpCode().isCall()
+             && tt->getNode()->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
+            {
+            debugResult = true;
+            break;
+            }
+         }
+      }
+   TR_ASSERT(debugResult == block->isOSRCodeBlock(), "prepareForOSR calls should only appear in OSRCodeBlocks");
+#endif
+
+   return block->isOSRCodeBlock();
    }
 
 int32_t TR_FearPointAnalysis::getNumberOfBits() { return 1; }

--- a/runtime/tr.source/trj9/optimizer/FearPointAnalysis.hpp
+++ b/runtime/tr.source/trj9/optimizer/FearPointAnalysis.hpp
@@ -27,6 +27,8 @@ class TR_FearPointAnalysis : public TR_BackwardUnionSingleBitContainerAnalysis
    {
    public:
 
+   static bool containsPrepareForOSR(TR::Block *block);
+
    TR_FearPointAnalysis(TR::Compilation *comp, TR::Optimizer *optimizer, TR_Structure *,
       TR_BitVector &fearGeneratingNodes, bool topLevelFearOnly=false, bool trace=false);
 

--- a/runtime/tr.source/trj9/optimizer/HCRGuardAnalysis.cpp
+++ b/runtime/tr.source/trj9/optimizer/HCRGuardAnalysis.cpp
@@ -33,20 +33,8 @@
 #include "infra/Assert.hpp"                // for TR_ASSERT
 #include "infra/BitVector.hpp"             // for TR_BitVector
 #include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "optimizer/FearPointAnalysis.hpp" // for containsPrepareForOSR
 
-static bool containsPrepareForOSR(TR::Block *block)
-   {
-   for (TR::TreeTop *tt = block->getEntry(); tt != block->getExit(); tt = tt->getNextTreeTop())
-       {
-       if (tt->getNode()->getOpCode().isCheck() || tt->getNode()->getOpCodeValue() == TR::treetop)
-          {
-          if (tt->getNode()->getFirstChild()->getOpCode().isCall()
-              && tt->getNode()->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
-             return true;
-          }
-       }
-   return false;
-   }
 
 int32_t TR_HCRGuardAnalysis::getNumberOfBits() { return 1; }
 
@@ -83,7 +71,7 @@ TR_HCRGuardAnalysis::TR_HCRGuardAnalysis(TR::Compilation *comp, TR::Optimizer *o
 
 bool TR_HCRGuardAnalysis::shouldSkipBlock(TR::Block *block)
    {
-   return block->isOSRCatchBlock() || block->isOSRCodeBlock() || containsPrepareForOSR(block);
+   return block->isOSRCatchBlock() || block->isOSRCodeBlock() || TR_FearPointAnalysis::containsPrepareForOSR(block);
    }
 
 void TR_HCRGuardAnalysis::initializeGenAndKillSetInfo()


### PR DESCRIPTION
OSR data flow analysis must skip OSR blocks. This
includes blocks that contain prepareForOSR calls.
However, the check for these blocks consisted of
a walk across its trees. It is cheaper to check
the OSRBlock flag, as prepareForOSR calls must
only appear in such blocks.