### PR TITLE
Add a dummy new header for DDR

### DIFF
--- a/runtime/ddr/dummy_headers/new
+++ b/runtime/ddr/dummy_headers/new
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#if !defined(DDR_DUMMY_NEW_)
+#define DDR_DUMMY_NEW_
+
+#include <stdint.h>
+
+namespace std {
+
+typedef ::size_t size_t;
+
+struct nothrow_t {};
+extern const nothrow_t nothrow;
+
+} /* namespace std */
+
+void* operator new(std::size_t);
+void* operator new(std::size_t, const std::nothrow_t&) throw();
+
+#endif /* DDR_DUMMY_NEW_ */


### PR DESCRIPTION
new is a C++ standard header which defines the different new operators.
We're using it in OMR to define an operator new for the GC/Forge.

Signed-off-by: Robert Young <rwy0717@gmail.com>