### PR TITLE
Fix calculation of hidden field offsets

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -349,10 +349,10 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		 * Give instance fields priority for backfill slots.
 		 * Note that the hidden fields remember their offsets, so this need be done once only.
 		 */
-		if (!extraHiddenFields.isEmpty()) {
+		if (!hiddenInstanceFieldList.isEmpty()) {
 			UDATA hiddenSingleOffset = firstSingleOffset.add(J9Object.SIZEOF + (fieldInfo.getNonBackfilledInstanceSingleCount() * U32.SIZEOF));
 			UDATA hiddenDoubleOffset = firstDoubleOffset.add(J9Object.SIZEOF + (fieldInfo.getInstanceDoubleCount() * U64.SIZEOF));
-			UDATA hiddenObjectOffset =  firstObjectOffset.add(J9Object.SIZEOF + (fieldInfo.getNonBackfilledInstanceObjectCount() * J9Object.SIZEOF));
+			UDATA hiddenObjectOffset =  firstObjectOffset.add(J9Object.SIZEOF + (fieldInfo.getNonBackfilledInstanceObjectCount() * fj9object_t_SizeOf));
 			boolean useBackfillForObject = false;
 			boolean useBackfillForSingle = false;
 
@@ -365,7 +365,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				}
 			}
 
-			for (HiddenInstanceField hiddenField: extraHiddenFields) {
+			for (HiddenInstanceField hiddenField: hiddenInstanceFieldList) {
 				U32 modifiers = hiddenField.shape().modifiers();
 
 				if (modifiers.allBitsIn(J9FieldFlagObject)) {
@@ -374,7 +374,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 						useBackfillForObject = false;
 					} else {
 						hiddenField.setFieldOffset(hiddenObjectOffset);
-						hiddenObjectOffset = hiddenObjectOffset.add(J9Object.SIZEOF);
+						hiddenObjectOffset = hiddenObjectOffset.add(fj9object_t_SizeOf);
 					}
 				} else if (modifiers.allBitsIn(J9FieldSizeDouble)) {
 					hiddenField.setFieldOffset(hiddenDoubleOffset);


### PR DESCRIPTION
The previous code iterated over the extraHiddenFields list to add hidden fields
to the class's list of hidden fields.  This introduced spurious hidden fields
before the actual hidden fields, affecting the offset.  The correct list is
hiddenInstanceFieldList.

This command:

!j9classshape java/lang/ref/Reference

gave

offset     name signature       (declaring class)
...
8       queue   Ljava/lang/ref/ReferenceQueue;  (java/lang/ref/Reference)
16      state   I       (java/lang/ref/Reference)
16      gcLink  Ljava/lang/ref/Reference;       (java/lang/ref/Reference) <hidden>

Correct offset for gcLink is 12.

Also fixed a disparity between native code and DDR (J9Object.SIZEOF should be fj9object_t_SizeOf).

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>