### PR TITLE
Use shallow clone of the openj9-openjdk-jdk9 repo in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,8 @@ before_script:
   - wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz
   - tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2
   - cd ..
-  - git clone https://github.com/ibmruntimes/openj9-openjdk-jdk9.git
+  # Shallow clone of the openj9-openjdk-jdk9 repo to speed up clone / reduce server load
+  - git clone --depth 1 https://github.com/ibmruntimes/openj9-openjdk-jdk9.git
 script:
   # Clear this option so it doesn't interfere with configure detecting the bootjdk
   - unset _JAVA_OPTIONS


### PR DESCRIPTION
Attempt to work around timeouts cloning this repo in the CI builds
by cloning less material.  This is fine since the build doesn't
commit back to that repo (or other repos for that matter)

Issue #116

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>