### PR TITLE
Make XX:IdleTuningGcOnIdle part of Xtune:virtualized

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1823,7 +1823,13 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				IDATA argIndexIgnoreUnrecognizedOptionsEnable = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXIDLETUNINGIGNOREUNRECOGNIZEDOPTIONSENABLE, NULL);
 				IDATA argIndexIgnoreUnrecognizedOptionsDisable = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXIDLETUNINGIGNOREUNRECOGNIZEDOPTIONSDISABLE, NULL);
 
-				if (argIndexGcOnIdleEnable > argIndexGcOnIdleDisable) {
+				/* 
+				 * idle heap tuning is enabled only if -XX:+IdleTuningGcOnIdle is set 
+				 * or if java version is 9 or above and -Xtune:virtualized is set as VM option
+				 */
+				if ((argIndexGcOnIdleEnable > argIndexGcOnIdleDisable) 
+				|| ((J2SE_VERSION(vm) >= J2SE_19) && (argIndexGcOnIdleDisable == -1) && J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_TUNE_VIRTUALIZED))
+				) {
 					vm->vmRuntimeStateListener.idleTuningFlags |= (UDATA)J9_IDLE_TUNING_GC_ON_IDLE;
 				} else {
 					vm->vmRuntimeStateListener.idleTuningFlags &= ~(UDATA)J9_IDLE_TUNING_GC_ON_IDLE;


### PR DESCRIPTION
Make IdleTuningGcOnIdle optimization is covered/included part of the
option(Xtune:virtualized) which grouped the optimizations relevant for virtualized
environment.

closes #124
Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>