### PR TITLE
Use a bitset for shouldNotBeNewlyExtended

### DIFF
--- a/runtime/tr.source/trj9/control/CompilationRuntime.hpp
+++ b/runtime/tr.source/trj9/control/CompilationRuntime.hpp
@@ -91,16 +91,7 @@ struct TR_SignatureCountPair
    int32_t count;
 };
 
-// Must be less than 8 because in some parts of the code (CHTable) we keep flags on a byte variable
-// Also, if this increases past 10, we need to expand the _activeThreadName and _suspendedThreadName
-// fields in TR::CompilationInfoPerThread as currently they have 1 char available for the thread number.
-//
-#define MAX_USABLE_COMP_THREADS 7
-#define MAX_DIAGNOSTIC_COMP_THREADS 1
-#define MAX_TOTAL_COMP_THREADS (MAX_USABLE_COMP_THREADS + MAX_DIAGNOSTIC_COMP_THREADS)
-#if (MAX_TOTAL_COMP_THREADS > 8)
-#error "MAX_TOTAL_COMP_THREADS should be less than 8"
-#endif
+#include "env/MaxCompilationThreads.hpp"
 
 #ifndef J9_INVOCATION_COUNT_MASK
 #define J9_INVOCATION_COUNT_MASK                   0x00000000FFFFFFFF
@@ -723,8 +714,8 @@ public:
    TR::CompilationInfoPerThread *getCompInfoForThread(J9VMThread *vmThread);
    int32_t getNumUsableCompilationThreads() const { return _compThreadIndex; }
    int32_t getNumTotalCompilationThreads() const { return _compThreadIndex + _numDiagnosticThreads; }
-   TR::CompilationInfoPerThreadBase *getCompInfoWithID(int32_t ID);
-   TR::Compilation *getCompilationWithID(int32_t ID);
+   TR::CompilationInfoPerThreadBase *getCompInfoWithID(size_t ID);
+   TR::Compilation *getCompilationWithID(size_t ID);
    TR::CompilationInfoPerThread *getFirstSuspendedCompilationThread();
    bool useMultipleCompilationThreads() { return (getNumUsableCompilationThreads() + _numDiagnosticThreads) > 1; }
    bool getRampDownMCT() const { return _rampDownMCT; }

--- a/runtime/tr.source/trj9/control/CompilationThread.cpp
+++ b/runtime/tr.source/trj9/control/CompilationThread.cpp
@@ -885,12 +885,12 @@ bool TR::CompilationInfo::initializeCompilationOnApplicationThread()
    return true;
    }
 
-TR::CompilationInfoPerThreadBase *TR::CompilationInfo::getCompInfoWithID(int32_t ID)
+TR::CompilationInfoPerThreadBase *TR::CompilationInfo::getCompInfoWithID(size_t ID)
    {
    if (_compInfoForCompOnAppThread)
       return _compInfoForCompOnAppThread;
 
-   for (uint8_t i = 0; i < getNumTotalCompilationThreads(); i++)
+   for (size_t i = 0; i < getNumTotalCompilationThreads(); i++)
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
@@ -923,7 +923,7 @@ TR::CompilationInfoPerThread *TR::CompilationInfo::getFirstSuspendedCompilationT
    return NULL;
    }
 
-TR::Compilation *TR::CompilationInfo::getCompilationWithID(int32_t ID)
+TR::Compilation *TR::CompilationInfo::getCompilationWithID(size_t ID)
    {
    TR::CompilationInfoPerThreadBase *ciptb = getCompInfoWithID(ID);
    return ciptb ? ciptb->getCompilation() : NULL;

--- a/runtime/tr.source/trj9/env/MaxCompilationThreads.hpp
+++ b/runtime/tr.source/trj9/env/MaxCompilationThreads.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef MAXCOMPILATIONTHREADS_HPP
+#define MAXCOMPILATIONTHREADS_HPP
+
+// Must be less than 8 because in some parts of the code (CHTable) we keep flags on a byte variable
+// Also, if this increases past 10, we need to expand the _activeThreadName and _suspendedThreadName
+// fields in TR::CompilationInfoPerThread as currently they have 1 char available for the thread number.
+//
+#define MAX_USABLE_COMP_THREADS 7
+#define MAX_DIAGNOSTIC_COMP_THREADS 1
+#define MAX_TOTAL_COMP_THREADS (MAX_USABLE_COMP_THREADS + MAX_DIAGNOSTIC_COMP_THREADS)
+#if (MAX_TOTAL_COMP_THREADS > 8)
+#error "MAX_TOTAL_COMP_THREADS should be less than 8"
+#endif
+
+#endif // MAXCOMPILATIONTHREADS_HPP

--- a/runtime/tr.source/trj9/runtime/RuntimeAssumptions.cpp
+++ b/runtime/tr.source/trj9/runtime/RuntimeAssumptions.cpp
@@ -226,10 +226,10 @@ TR_PersistentCHTable::classGotExtended(
    if (cl->shouldNotBeNewlyExtended())
       {
       TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
-      uint8_t mask = cl->getShouldNotBeNewlyExtendedMask().getValue();
-      for (int32_t ID = 0; mask; mask>>=1, ++ID)
+      auto mask = cl->getShouldNotBeNewlyExtendedMask();
+      for (size_t ID = 0; ID < mask.size(); ++ID)
          {
-         if (mask & 0x1)
+         if (mask[ID])
             {
             // Determine the compilation thread that has this ID
             // and set the fail flag into its corresponding compilation object

--- a/runtime/tr.source/trj9/runtime/RuntimeAssumptions.hpp
+++ b/runtime/tr.source/trj9/runtime/RuntimeAssumptions.hpp
@@ -26,12 +26,14 @@
 #include <algorithm>                       // for std::max, etc
 #include <stddef.h>                        // for NULL
 #include <stdint.h>                        // for int32_t, uint8_t, etc
+#include <bitset>
 #include "env/RuntimeAssumptionTable.hpp"  // for TR_RuntimeAssumptionKind, etc
 #include "env/TRMemory.hpp"                // for TR_Memory, etc
 #include "env/jittypes.h"                  // for uintptrj_t
 #include "infra/Flags.hpp"                 // for flags8_t
 #include "infra/Link.hpp"                  // for TR_LinkHead0, TR_Link0
 #include "runtime/OMRRuntimeAssumptions.hpp"  // for OMR::RuntimeAssumption
+#include "env/MaxCompilationThreads.hpp"
 
 
 class TR_FrontEnd;
@@ -127,12 +129,12 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    void setReservable(bool v = true)              { _flags.set(_isReservable, v); }
    bool isReservable()                            { return _flags.testAny(_isReservable); }
 
-   void setShouldNotBeNewlyExtended(int32_t ID) { _shouldNotBeNewlyExtended.set(1 << ID); }
-   void resetShouldNotBeNewlyExtended(int32_t ID){ _shouldNotBeNewlyExtended.reset(1 << ID); }
-   void clearShouldNotBeNewlyExtended()          { _shouldNotBeNewlyExtended.clear(); }
-   bool shouldNotBeNewlyExtended()               { return _shouldNotBeNewlyExtended.testAny(0xff); }
-   bool shouldNotBeNewlyExtended(int32_t ID)     { return _shouldNotBeNewlyExtended.testAny(1 << ID); }
-   flags8_t getShouldNotBeNewlyExtendedMask() const { return _shouldNotBeNewlyExtended; }
+   void setShouldNotBeNewlyExtended(size_t ID)   { _shouldNotBeNewlyExtended.set(ID); }
+   void resetShouldNotBeNewlyExtended(size_t ID) { _shouldNotBeNewlyExtended.reset(ID); }
+   void clearShouldNotBeNewlyExtended()          { _shouldNotBeNewlyExtended.reset(); }
+   bool shouldNotBeNewlyExtended()               { return _shouldNotBeNewlyExtended.any(); }
+   bool shouldNotBeNewlyExtended(size_t ID)      { return _shouldNotBeNewlyExtended[ID]; }
+   std::bitset<MAX_TOTAL_COMP_THREADS> getShouldNotBeNewlyExtendedMask() const { return _shouldNotBeNewlyExtended; }
 
    void setHasRecognizedAnnotations(bool v = true){ _flags.set(_containsRecognizedAnnotations, v); }
    bool hasRecognizedAnnotations()                { return _flags.testAny(_containsRecognizedAnnotations); }
@@ -179,7 +181,7 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    uint16_t                            _timeStamp;
    int32_t                             _nameLength;
    flags8_t                            _flags;
-   flags8_t                            _shouldNotBeNewlyExtended; // one bit for each possible compilation thread
+   std::bitset<MAX_TOTAL_COMP_THREADS> _shouldNotBeNewlyExtended; // one bit for each possible compilation thread
    };
 
 class TR_AddressRange


### PR DESCRIPTION
Move the definition of MAX_TOTAL_COMP_THREADS to its own header.

Change the definiton of the _shouldNotBeNewlyExtended field in
TR_PersistentClassInfo to use a std::bitset with a size of
MAX_TOTAL_COMP_THREADS, and update implemntation to work with the new
format.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>