### PR TITLE
Change argument order of JIT Helpers to proper C linkage order

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2491,7 +2491,12 @@ fast_jitCollapseJNIReferenceFrame(J9VMThread *currentThread)
 }
 
 UDATA J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitInstanceOf(J9VMThread *currentThread, j9object_t object, J9Class *castClass)
+#else /* J9VM_ARCH_X86 */
 fast_jitInstanceOf(J9VMThread *currentThread, J9Class *castClass, j9object_t object)
+#endif /* J9VM_ARCH_X86 */
 {
 	JIT_HELPER_PROLOGUE();
 	UDATA isInstance = 0;
@@ -2540,7 +2545,12 @@ fast_jitNewObjectNoZeroInit(J9VMThread *currentThread, J9Class *objectClass)
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitANewArray(J9VMThread *currentThread, I_32 size, J9Class *elementClass)
+#else /* J9VM_ARCH_X86 */
 fast_jitANewArray(J9VMThread *currentThread, J9Class *elementClass, I_32 size)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitANewArray(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2553,7 +2563,12 @@ fast_jitANewArray(J9VMThread *currentThread, J9Class *elementClass, I_32 size)
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitANewArrayNoZeroInit(J9VMThread *currentThread, I_32 size, J9Class *elementClass)
+#else /* J9VM_ARCH_X86 */
 fast_jitANewArrayNoZeroInit(J9VMThread *currentThread, J9Class *elementClass, I_32 size)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitANewArrayNoZeroInit(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2566,7 +2581,12 @@ fast_jitANewArrayNoZeroInit(J9VMThread *currentThread, J9Class *elementClass, I_
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitNewArray(J9VMThread *currentThread, I_32 size, I_32 arrayType)
+#else /* J9VM_ARCH_X86 */
 fast_jitNewArray(J9VMThread *currentThread, I_32 arrayType, I_32 size)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitNewArray(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2579,7 +2599,12 @@ fast_jitNewArray(J9VMThread *currentThread, I_32 arrayType, I_32 size)
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitNewArrayNoZeroInit(J9VMThread *currentThread, I_32 size, I_32 arrayType)
+#else /* J9VM_ARCH_X86 */
 fast_jitNewArrayNoZeroInit(J9VMThread *currentThread, I_32 arrayType, I_32 size)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitNewArrayNoZeroInit(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2592,7 +2617,12 @@ fast_jitNewArrayNoZeroInit(J9VMThread *currentThread, I_32 arrayType, I_32 size)
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitCheckCast(J9VMThread *currentThread, j9object_t object, J9Class *castClass)
+#else /* J9VM_ARCH_X86 */
 fast_jitCheckCast(J9VMThread *currentThread, J9Class *castClass, j9object_t object)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitCheckCast(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2611,7 +2641,12 @@ fast_jitCheckCast(J9VMThread *currentThread, J9Class *castClass, j9object_t obje
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitCheckCastForArrayStore(J9VMThread *currentThread, j9object_t object, J9Class *castClass)
+#else /* J9VM_ARCH_X86 */
 fast_jitCheckCastForArrayStore(J9VMThread *currentThread, J9Class *castClass, j9object_t object)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitCheckCastForArrayStore(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2628,7 +2663,12 @@ fast_jitCheckCastForArrayStore(J9VMThread *currentThread, J9Class *castClass, j9
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitLookupInterfaceMethod(J9VMThread *currentThread, void *jitEIP, J9Class *receiverClass, UDATA *indexAndLiteralsEA)
+#else /* J9VM_ARCH_X86 */
 fast_jitLookupInterfaceMethod(J9VMThread *currentThread, J9Class *receiverClass, UDATA *indexAndLiteralsEA, void *jitEIP)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitLookupInterfaceMethod(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2706,7 +2746,12 @@ fast_jitMonitorExit(J9VMThread *currentThread, j9object_t syncObject)
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread, j9object_t objectBeingStored, j9object_t destinationObject)
+#else /* J9VM_ARCH_X86 */
 fast_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread, j9object_t destinationObject, j9object_t objectBeingStored)
+#endif /* J9VM_ARCH_X86 */
 {
 //	extern void* slow_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2719,7 +2764,12 @@ fast_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread, j9object_t d
 }
 
 void* J9FASTCALL
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+fast_jitTypeCheckArrayStore(J9VMThread *currentThread, j9object_t objectBeingStored, j9object_t destinationObject)
+#else /* J9VM_ARCH_X86 */
 fast_jitTypeCheckArrayStore(J9VMThread *currentThread, j9object_t destinationObject, j9object_t objectBeingStored)
+#endif /* J9VM_ARCH_X86 */
 {
 	JIT_HELPER_PROLOGUE();
 	/* Not omitting NULL check */

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -173,7 +173,12 @@ void J9FASTCALL fast_jitVolatileWriteDouble(J9VMThread *currentThread, U_64 *add
 #endif /* !J9VM_ENV_DATA64 */
 void J9FASTCALL fast_jitCheckIfFinalizeObject(J9VMThread *currentThread, j9object_t object);
 void J9FASTCALL fast_jitCollapseJNIReferenceFrame(J9VMThread *currentThread);
+#if defined(J9VM_ARCH_X86)
+/* TODO Will be cleaned once all platforms adopt the correct parameter order */
+UDATA J9FASTCALL fast_jitInstanceOf(J9VMThread *currentThread, j9object_t object, J9Class *castClass);
+#else /* J9VM_ARCH_X86 */
 UDATA J9FASTCALL fast_jitInstanceOf(J9VMThread *currentThread, J9Class *castClass, j9object_t object);
+#endif /* J9VM_ARCH_X86 */
 UDATA J9FASTCALL fast_jitObjectHashCode(J9VMThread *currentThread, j9object_t object);
 
 #ifdef __cplusplus

--- a/runtime/tr.source/trj9/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/tr.source/trj9/x/codegen/X86HelperLinkage.cpp
@@ -236,12 +236,11 @@ TR::Register* TR::X86HelperCallSite::BuildCall()
    // Find the return register, EAX/RAX
    TR::Register* EAX = RealRegisters.Use(TR::RealRegister::eax);
 
-   // Build parameters
-   // Note that parameters from the Call Node are Right-to-Left (RTL) which is same as the order of parameters on stack per this linkage
+   // Build parameters, parameters in _Params are Right-to-Left (RTL)
    int NumberOfParamOnStack = 0;
    for (size_t i = 0; i < _Params.size(); i++)
       {
-      size_t index = _Params.size() - i;
+      size_t index = _Params.size() - i - 1;
       if (index < NumberOfIntParamRegisters)
          {
          generateRegRegInstruction(MOVRegReg(),
@@ -268,13 +267,6 @@ TR::Register* TR::X86HelperCallSite::BuildCall()
             }
          }
       }
-
-   // The first param is always VM Thread
-   generateRegRegInstruction(MOVRegReg(),
-                             _Node,
-                             RealRegisters.Use(IntParamRegisters[0]),
-                             cg()->getVMThreadRegister(),
-                             cg());
 
    // Call helper
    TR::X86ImmInstruction* instr = generateImmSymInstruction(CALLImm4,


### PR DESCRIPTION
Argument order of VM's JIT Helpers were the order of Java private linkage,
and the order was kept for historical reasons. Now it is the time to be
corrected.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>