### PR TITLE
Add java.lang.string.substring.share System property

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -197,6 +197,12 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			}
 		}
 	}
+	
+	/**
+	 * This is a System property to enable sharing of the underlying value array in {@link #String.substring(int)} and 
+	 * {@link #String.substring(int, int)} if the offset is zero.
+	 */
+	static boolean enableSharingInSubstringWhenOffsetIsZero;
 
 	/*[IF Sidecar19-SE]*/
 	private final byte[] value;
@@ -3352,9 +3358,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (0 <= start && start <= len) {
 			// Check if the String is compressed
 			if (enableCompression && count >= 0) {
-				return new String(value, start, len - start, true);
+				return new String(value, start, len - start, true, enableSharingInSubstringWhenOffsetIsZero);
 			} else {
-				return new String(value, start, len - start, false);
+				return new String(value, start, len - start, false, enableSharingInSubstringWhenOffsetIsZero);
 			}
 		} else {
 			throw new StringIndexOutOfBoundsException(start);
@@ -3383,9 +3389,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		if (0 <= start && start <= end && end <= len) {
 			// Check if the String is compressed
 			if (enableCompression && count >= 0) {
-				return new String(value, start, end - start, true);
+				return new String(value, start, end - start, true, enableSharingInSubstringWhenOffsetIsZero);
 			} else {
-				return new String(value, start, end - start, false);
+				return new String(value, start, end - start, false, enableSharingInSubstringWhenOffsetIsZero);
 			}
 		} else {
 			throw new StringIndexOutOfBoundsException(start);

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -167,6 +167,13 @@ public final class System {
 			unsafe.putObject(unsafe.staticFieldBase(f2), unsafe.staticFieldOffset(f2), com.ibm.jit.JITHelpers.getHelpers());
 		} catch (NoSuchFieldException e) { }
 		
+		/**
+		 * When the System Property == true, then enable sharing in String.substring(int) and String.substring(int, int)
+		 * methods whenever offset is zero. Otherwise, disable sharing of the underlying value array. 
+		 */
+		String enableSharingInSubstringWhenOffsetIsZeroProperty = internalGetProperties().getProperty("java.lang.string.substring.share"); //$NON-NLS-1$
+		String.enableSharingInSubstringWhenOffsetIsZero = enableSharingInSubstringWhenOffsetIsZeroProperty == null || enableSharingInSubstringWhenOffsetIsZeroProperty.equalsIgnoreCase("true"); //$NON-NLS-1$
+		
 		// Set up standard in, out, and err.
 		/*[PR CMVC 193070] - OTT:Java 8 Test_JITHelpers test_getSuperclass NoSuchMet*/
 		/*[PR JAZZ 58297] - continue with the rules defined by JAZZ 57070 - Build a Java 8 J9 JCL using the SIDECAR18 preprocessor configuration */


### PR DESCRIPTION
In some scenarios it may be undesirable to share the underlying value
array for substring operations as this transparently increases the life
of the respective array. For carefully crafted user applications this
can cause us to run out of heap memory when performing repeated
substring operations, e.x. repeatedly calling substring to extract parts
of a large string into an array.

This change introduces a system property which can be used to disable
sharing of the value array in substring operations, regardless of
whether the value array can be shared between the receiver string and
the resulting substring.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>