### PR TITLE
Add test for jars with prepended shell scripts

### DIFF
--- a/test/Java8andUp/build.xml
+++ b/test/Java8andUp/build.xml
@@ -259,7 +259,7 @@
 		<jar jarfile="${DEST}/TestResources.jar" filesonly="true">
 			<fileset dir="${build_resource}" />
 		</jar>
-		<jar jarfile="${RESOURCES_DIR}/vmargs.jar" filesonly="true" manifest="./META-INF/MANIFEST.MF">
+		<jar jarfile="${RESOURCES_DIR}/vmargs_${JAVA_VERSION}.jar" filesonly="true" manifest="./META-INF/MANIFEST.MF">
 			<fileset dir="${build}" includes="org/openj9/test/vmArguments/*.class"/>
 		</jar>
 		<copy todir="${DEST}">


### PR DESCRIPTION
Also fix testJarArguments by creating separate Java 8 and Java 9 versions of
vmargs.jar, though vmargs_SE90.jar is unused at present.

@llxia FYI

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>