### PR TITLE
There is no need to export com.ibm.oti.shared through CML

### DIFF
--- a/test/VM_Test/build.xml
+++ b/test/VM_Test/build.xml
@@ -79,7 +79,7 @@
 		<if>
 			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
 			<then>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports openj9.sharedclasses/com.ibm.oti.shared=ALL-UNNAMED --add-exports=java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports=com.ibm.management/com.ibm.lang.management.internal=ALL-UNNAMED" />
+				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports=java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports=com.ibm.management/com.ibm.lang.management.internal=ALL-UNNAMED" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
 					<src path="${excludeFiles}"/>
 					<!-- 133609: ClassPathSettingClassLoaderTest failed in SE90 -->

--- a/test/VM_Test/src/j9vm/test/intermediateclasscreate/IntermediateClassCreateTestRunner.java
+++ b/test/VM_Test/src/j9vm/test/intermediateclasscreate/IntermediateClassCreateTestRunner.java
@@ -104,9 +104,6 @@ public class IntermediateClassCreateTestRunner extends Runner {
 			customOptions += "-Xshareclasses:name=intermediateclasscreatetest,destroy ";
 			break;
 		}
-		if (Integer.parseInt(javaVersion) >= 90) {
-			customOptions += " --add-exports=openj9.sharedclasses/com.ibm.oti.shared=ALL-UNNAMED ";
-		}
 		return customOptions;
 	}
 	

--- a/test/VM_Test/src/j9vm/test/invalidclasspath/SetClasspathTestRunner.java
+++ b/test/VM_Test/src/j9vm/test/invalidclasspath/SetClasspathTestRunner.java
@@ -85,9 +85,6 @@ public class SetClasspathTestRunner extends Runner {
 			customOptions += "-Xshareclasses:name=setclasspathtest,destroy ";
 			break;
 		}
-		if (Integer.parseInt(javaVersion) >= 90) {
-			customOptions += " --add-exports=openj9.sharedclasses/com.ibm.oti.shared=ALL-UNNAMED ";
-		}
 		return customOptions;
 	}
 	

--- a/test/VM_Test/src/j9vm/test/jarfileupdate/JarFileUpdateTestRunner.java
+++ b/test/VM_Test/src/j9vm/test/jarfileupdate/JarFileUpdateTestRunner.java
@@ -106,9 +106,6 @@ public class JarFileUpdateTestRunner extends Runner {
 			customOptions += "-Xshareclasses:name=jarfileupdatetest,destroy ";
 			break;
 		}
-		if (Integer.parseInt(javaVersion) >= 90) {
-			customOptions += " --add-exports=openj9.sharedclasses/com.ibm.oti.shared=ALL-UNNAMED ";
-		}
 		return customOptions;
 	}
 	

--- a/test/VM_Test/src/j9vm/test/multipleorphans/InvokeDynamicWithMultipleOrphanComparisonTestRunner.java
+++ b/test/VM_Test/src/j9vm/test/multipleorphans/InvokeDynamicWithMultipleOrphanComparisonTestRunner.java
@@ -74,9 +74,6 @@ public class InvokeDynamicWithMultipleOrphanComparisonTestRunner extends Runner 
 			/* cleanup the cache */
 			customOptions += " -Xshareclasses:enableBCI,destroy,name=invokedynamictestcache";
 		}
-		if (Integer.parseInt(javaVersion) >= 90) {
-			customOptions += " --add-exports=openj9.sharedclasses/com.ibm.oti.shared=ALL-UNNAMED ";
-		}
 		return customOptions;
 	}
 	


### PR DESCRIPTION
Package com.ibm.oti.shared is already exported in
openj9.sharedclasses/module-info.java. It is unnecessary to export
openj9.sharedclasses/com.ibm.oti.shared again in the command line.

Fixes issue #142

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>