### PR TITLE
Disable late attach to self by default

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1262,3 +1262,4 @@ K0644="Caller-sensitive method called StackWalker.getCallerClass()"
 #java.lang.ClassLoader
 K0645="The given class loader name can't be empty."
 
+K0646="Late attach connection to self disabled. Set jdk.attach.allowAttachSelf=true"

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -50,6 +50,8 @@ import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.AgentInitializationException;
 import com.sun.tools.attach.AgentLoadException;
 
+import static com.ibm.oti.util.Msg.getString;
+
 /**
  * Handles the initiator end of an attachment to a target VM
  * 
@@ -96,7 +98,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 		super(provider, id);
 		if ((null == id) || (null == provider)) {
 			/*[MSG "K0554", "Virtual machine ID or display name is null"]*/
-			throw new NullPointerException(com.ibm.oti.util.Msg.getString("K0554")); //$NON-NLS-1$
+			throw new NullPointerException(getString("K0554")); //$NON-NLS-1$
 		}
 		new IPC();
 		this.targetId = id;
@@ -113,7 +115,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 	void attachTarget() throws IOException, AttachNotSupportedException {
 		if (null == descriptor) {
 			/*[MSG "K0531", "target not found"]*/
-			throw new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0531")); //$NON-NLS-1$
+			throw new AttachNotSupportedException(getString("K0531")); //$NON-NLS-1$
 		}
 		AttachNotSupportedException lastException = null;
 		/*[PR CMVC 182802 ]*/
@@ -187,7 +189,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 	public Properties getAgentProperties() throws IOException {
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		}
 		Properties props = getTargetProperties(false);
 
@@ -198,7 +200,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 	public Properties getSystemProperties() throws IOException {
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		}
 		Properties props = getTargetProperties(true);
 		return props;
@@ -225,7 +227,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		}
 		AttachmentConnection.streamSend(commandStream, (createLoadAgent(agent, options)));
 		String response = AttachmentConnection.streamReceiveString(responseStream);
@@ -239,7 +241,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		}
 		AttachmentConnection.streamSend(commandStream, createLoadAgentLibrary(
 				agentLibrary, options, false));
@@ -253,11 +255,11 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 			IOException {
 		if (null == agentPath) {
 			/*[MSG "K0577", "loadAgentPath: null agent path"]*/
-			throw new AgentLoadException(com.ibm.oti.util.Msg.getString("K0577")); //$NON-NLS-1$
+			throw new AgentLoadException(getString("K0577")); //$NON-NLS-1$
 		}
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		}
 		AttachmentConnection.streamSend(commandStream, createLoadAgentLibrary(agentPath,
 				options, true));
@@ -318,7 +320,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 			}
 			if (response.contains(EXCEPTION_IOEXCEPTION)) {
 				/*[MSG "K0576","IOException from target: {0}"]*/
-				throw new IOException(com.ibm.oti.util.Msg.getString("K0576", trimmedResponse)); //$NON-NLS-1$
+				throw new IOException(getString("K0576", trimmedResponse)); //$NON-NLS-1$
 			} else if (response.contains(EXCEPTION_AGENT_INITIALIZATION_EXCEPTION)) {
 				Integer status = getStatusValue(trimmedResponse);
 				if (null == status) {
@@ -330,13 +332,13 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 				throw new AgentLoadException(trimmedResponse);
 			} else 	if (response.contains(EXCEPTION_IOEXCEPTION)) {
 				/*[MSG "K0576","IOException from target: {0}"]*/
-				throw new IOException(com.ibm.oti.util.Msg.getString("K0576", trimmedResponse)); //$NON-NLS-1$
+				throw new IOException(getString("K0576", trimmedResponse)); //$NON-NLS-1$
 			} else if (response.contains(EXCEPTION_ILLEGAL_ARGUMENT_EXCEPTION)) {
 				/*[MSG "K05de","IllegalArgumentException from target: {0}"]*/
-				throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K05de", trimmedResponse)); //$NON-NLS-1$
+				throw new IllegalArgumentException(getString("K05de", trimmedResponse)); //$NON-NLS-1$
 			} else if (response.contains(EXCEPTION_ATTACH_OPERATION_FAILED_EXCEPTION)) {
 				/*[MSG "k05dc","AttachOperationFailedException from target: {0}"]*/
-				throw new AttachOperationFailedException(com.ibm.oti.util.Msg.getString("k05dc", trimmedResponse)); //$NON-NLS-1$
+				throw new AttachOperationFailedException(getString("k05dc", trimmedResponse)); //$NON-NLS-1$
 			}
 			return false;
 		} else	if (response.startsWith(ACK) || response.startsWith(ATTACH_RESULT)) {
@@ -397,18 +399,24 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 										 * to attach
 										 */
 					/*[MSG "K0457", "Target no longer available"]*/
-					AttachNotSupportedException exc = new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0457")); //$NON-NLS-1$
+					AttachNotSupportedException exc = new AttachNotSupportedException(getString("K0457")); //$NON-NLS-1$
 					exc.initCause(e);
 					throw exc;
 				}
 
 				if (descriptor.id().equals(AttachHandler.getVmId())) {
+					String allowAttachSelf_Value = AttachHandler.allowAttachSelf;
+					boolean selfAttachAllowed = "".equals(allowAttachSelf_Value) || Boolean.parseBoolean(allowAttachSelf_Value); //$NON-NLS-1$
+					if (!selfAttachAllowed) {
+						/*[MSG "K0646", "Late attach connection to self disabled. Set jdk.attach.allowAttachSelf=true"]*/
+						throw new IOException(getString("K0646")); //$NON-NLS-1$
+					}
 					/* I am connecting to myself: bypass the notification and launch the attachment thread directly */
 					if (AttachHandler.isAttachApiInitialized()) {
 						AttachHandler.getMainHandler().connectToAttacher();
 					} else {
 						/*[MSG "K0558", "Attach API initialization failed"]*/
-						throw new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0558")); //$NON-NLS-1$
+						throw new AttachNotSupportedException(getString("K0558")); //$NON-NLS-1$
 					}
 				} else {
 					lockAllAttachNotificationSyncFiles(vmds);
@@ -417,7 +425,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 					/*[MSG "K0532", "status={0}"]*/
 					if ((IPC.JNI_OK != status)
 							&& (CommonDirectory.J9PORT_INFO_SHSEM_OPENED_STALE != status)) {
-						throw new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0532", status)); //$NON-NLS-1$
+						throw new AttachNotSupportedException(getString("K0532", status)); //$NON-NLS-1$
 					}
 				}
 
@@ -429,7 +437,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 					targetServer.close();
 					IPC.logMessage("attachTarget SocketTimeoutException on " + portNumber + " to " + targetId); //$NON-NLS-1$ //$NON-NLS-2$
 					/*[MSG "K0539","acknowledgement timeout from {0} on port {1}"]*/
-					AttachNotSupportedException exc = new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0539", targetId, portNumber)); //$NON-NLS-1$
+					AttachNotSupportedException exc = new AttachNotSupportedException(getString("K0539", targetId, portNumber)); //$NON-NLS-1$
 					exc.initCause(e);
 					throw exc;
 				}
@@ -443,7 +451,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 				String response = AttachmentConnection.streamReceiveString(responseStream, ATTACH_CONNECTED_MESSAGE_LENGTH_LIMIT);
 				/*[MSG "K0533", "key error: {0}"]*/
 				if (!response.contains(' ' + key + ' ')) {
-					throw new AttachNotSupportedException(com.ibm.oti.util.Msg.getString("K0533", response)); //$NON-NLS-1$
+					throw new AttachNotSupportedException(getString("K0533", response)); //$NON-NLS-1$
 				}
 				IPC.logMessage("attachTarget connected on ", portNumber.toString()); //$NON-NLS-1$
 				targetAttached = true;
@@ -493,7 +501,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 			throws IOException, IllegalArgumentException, AttachOperationFailedException {
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		} else if (null == agentProperties) {
 			throw new NullPointerException();
 		}
@@ -516,7 +524,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 	public String startLocalManagementAgent() throws IOException {
 		if (!targetAttached) {
 			/*[MSG "K0544", "Target not attached"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0544")); //$NON-NLS-1$
+			throw new IOException(getString("K0544")); //$NON-NLS-1$
 		}
 		AttachmentConnection.streamSend(commandStream, Command.START_LOCAL_MANAGEMENT_AGENT);
 		String response = AttachmentConnection.streamReceiveString(responseStream);
@@ -525,14 +533,14 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 		try {
 			if (!parseResponse(response)) {
 				/*[MSG "k05dd", "unrecognized response: {0}"]*/
-				throw new IOException(com.ibm.oti.util.Msg.getString("k05dd", response)); //$NON-NLS-1$
+				throw new IOException(getString("k05dd", response)); //$NON-NLS-1$
 			} else if (response.startsWith(ACK)) { /* this came from a legacy VM with dummy start*Agent()s */
 				result = response.substring(ACK.length());
 			} else if (response.startsWith(ATTACH_RESULT)) {
 				result = response.substring(ATTACH_RESULT.length());
 			} else {
 				/*[MSG "k05dd", "unrecognized response: {0}"]*/
-				throw new IOException(com.ibm.oti.util.Msg.getString("k05dd", response)); //$NON-NLS-1$
+				throw new IOException(getString("k05dd", response)); //$NON-NLS-1$
 			}
 		} catch (AgentLoadException | IllegalArgumentException | AgentInitializationException e) {
 			IPC.logMessage("Unexpected exception " + e + " in startLocalManagementAgent");  //$NON-NLS-1$//$NON-NLS-2$

--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -190,6 +190,7 @@
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	-Djava.sidecar="--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED" \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames AttachAPISanity \
@@ -276,6 +277,7 @@
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
 	-Dcom.ibm.tools.attach.timeout=15000 \
 	-Djava.sidecar="--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED" \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestAttachAPIEnabling \
@@ -365,6 +367,7 @@
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	-Dcom.ibm.tools.attach.enable=yes \
 	-Dcom.ibm.tools.attach.timeout=15000 \
+	-Djdk.attach.allowAttachSelf=true \
 	-Djava.sidecar="--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED" \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestSunAttachClasses \
 	-groups $(TEST_GROUP) \

--- a/test/Java9andUp/playlist.xml
+++ b/test/Java9andUp/playlist.xml
@@ -230,4 +230,26 @@
 			<subset>SE90</subset>
 		</subsets>
 	</test>	
+	<test>
+		<featureIds>
+			<featureId>openj9 issue #126</featureId>
+		</featureIds>
+		<testCaseName>TestJava9AttachAPI</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	-Djava.sidecar="--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED" \
+	-Dcom.ibm.tools.attach.enable=yes \
+	-Dcom.ibm.tools.attach.timeout=15000 \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJava9AttachAPI \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
 </playlist>

--- a/test/Java9andUp/src/org/openj9/test/attachAPI/SelfAttacher.java
+++ b/test/Java9andUp/src/org/openj9/test/attachAPI/SelfAttacher.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package org.openj9.test.attachAPI;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.testng.log4testng.Logger;
+
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
+
+public class SelfAttacher {
+
+	protected static Logger logger = Logger.getLogger(SelfAttacher.class);
+	static final int ATTACH_ERROR_CODE = 10;
+	static final int ATTACH_NOT_SUPPORTED_CODE = 11;
+	static final int ATTACH_SELF_IOEXCEPTION_CODE = 12;
+	static final int ATTACH_SELF_API_SUCCEEDED_CODE = 13;
+	public static void main(String[] args) {
+		/*
+		 * This is launched as a child process by thge test process.
+		 * It uses stderr to communicate its process ID to the test process
+		 * and its exit code to indicate the result of the late attach attempt.
+		 */
+		try {
+			String myId = VmIdGetter.getVmId();
+			System.err.println("myId="+myId);
+			boolean found = false;
+			for (int i = 0; i <10 && !found; ++i) {
+				Thread.sleep(100);
+				for (VirtualMachineDescriptor v: VirtualMachine.list()) {
+					if (v.id().equals(myId)) {
+						found = true;
+						break;
+					}
+				}
+			}
+			VirtualMachine vm = VirtualMachine.attach(myId);
+			Properties props = vm.getSystemProperties();
+			props.list(System.out);
+		} catch (AttachNotSupportedException e) {
+			e.printStackTrace();
+			System.exit(ATTACH_NOT_SUPPORTED_CODE);
+		} catch (IOException e) {
+			e.printStackTrace();
+			System.exit(ATTACH_SELF_IOEXCEPTION_CODE);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			System.exit(ATTACH_ERROR_CODE);
+		}
+		System.exit(ATTACH_SELF_API_SUCCEEDED_CODE);
+	}
+
+}

--- a/test/Java9andUp/src/org/openj9/test/attachAPI/TestJava9AttachAPI.java
+++ b/test/Java9andUp/src/org/openj9/test/attachAPI/TestJava9AttachAPI.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.openj9.test.attachAPI;
+
+import static org.openj9.test.attachAPI.SelfAttacher.ATTACH_SELF_API_SUCCEEDED_CODE;
+import static org.openj9.test.attachAPI.SelfAttacher.ATTACH_SELF_IOEXCEPTION_CODE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/**
+ * This test must be invoked via testng.  Running the main method will return only the status of the attach API.
+ *
+ */
+@Test(groups = { "level.extended" })
+public class TestJava9AttachAPI  {
+	protected static Logger logger = Logger.getLogger(TestJava9AttachAPI.class);
+	private static boolean verbose = Boolean.getBoolean("org.openj9.test.java9AttachAPI.verbose");
+	static final String ATTACH_ENABLE_PROPERTY = "-Dcom.ibm.tools.attach.enable=";
+	static final String ATTACH_SELF_ENABLE_PROPERTY = "-Djdk.attach.allowAttachSelf";
+
+	private String testName;
+	@BeforeMethod(alwaysRun=true)
+	protected void setUp(Method testMethod) throws Exception {
+		testName = testMethod.getName(); 
+		logger.debug("\n------------------------------------------------------\nstarting " + testName);
+		TargetManager.verbose = verbose;
+	}
+
+	@Test
+	public void testAllowAttachSelfDefault() {
+		String targetClass = SelfAttacher.class.getCanonicalName();
+		TargetManager target = new TargetManager(targetClass, null, Arrays.asList(new String[] {ATTACH_ENABLE_PROPERTY}), null);
+		try {
+			int status = target.waitFor();
+			assertEquals(status, ATTACH_SELF_IOEXCEPTION_CODE, "wrong exit status");
+		} catch (InterruptedException e) {
+			fail("unexpected exception", e);
+		}
+	}
+	
+	@Test
+	public void testAllowAttachSelfBareEnable() {
+		String targetClass = SelfAttacher.class.getCanonicalName();
+		TargetManager target = new TargetManager(targetClass, null, 
+				Arrays.asList(new String[] {ATTACH_ENABLE_PROPERTY,  ATTACH_SELF_ENABLE_PROPERTY}), null);
+		try {
+			int status = target.waitFor();
+			assertEquals(status, ATTACH_SELF_API_SUCCEEDED_CODE, "wrong exit status");
+		} catch (InterruptedException e) {
+			fail("unexpected exception", e);
+		}
+	}
+	
+	@Test
+	public void testAllowAttachSelfEnable() {
+		String targetClass = SelfAttacher.class.getCanonicalName();
+		TargetManager target = new TargetManager(targetClass, null, 
+				Arrays.asList(new String[] {ATTACH_ENABLE_PROPERTY,  ATTACH_SELF_ENABLE_PROPERTY+"=true"}), null);
+		try {
+			int status = target.waitFor();
+			assertEquals(status, ATTACH_SELF_API_SUCCEEDED_CODE, "wrong exit status");
+		} catch (InterruptedException e) {
+			fail("unexpected exception", e);
+		}
+	}
+	
+	@Test
+	public void testAllowAttachSelfDisable() {
+		String targetClass = SelfAttacher.class.getCanonicalName();
+		TargetManager target = new TargetManager(targetClass, null, 
+				Arrays.asList(new String[] {ATTACH_ENABLE_PROPERTY,  ATTACH_SELF_ENABLE_PROPERTY+"=false"}), null);
+		try {
+			int status = target.waitFor();
+			assertEquals(status, ATTACH_SELF_IOEXCEPTION_CODE, "wrong exit status");
+		} catch (InterruptedException e) {
+			fail("unexpected exception", e);
+		}
+	}
+}

--- a/test/Java9andUp/src_current/org/openj9/test/attachAPI/VmIdGetter.java
+++ b/test/Java9andUp/src_current/org/openj9/test/attachAPI/VmIdGetter.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package org.openj9.test.attachAPI;
+/* This class is separated from the main test because we need two
+ * copies to accommodate old and new versions of ProcessHandle
+ */
+import java.lang.ProcessHandle;
+public class VmIdGetter {
+
+	static String getVmId() {
+		long myPid = ProcessHandle.current().getPid();
+		String myId = Long.toString(myPid);
+		return myId;
+	}
+
+}

--- a/test/Java9andUp/src_latest/org/openj9/test/attachAPI/VmIdGetter.java
+++ b/test/Java9andUp/src_latest/org/openj9/test/attachAPI/VmIdGetter.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package org.openj9.test.attachAPI;
+import java.lang.ProcessHandle;
+/* This class is separated from the main test because we need two
+ * copies to accommodate old and new versions of ProcessHandle
+ */
+public class VmIdGetter {
+
+	static String getVmId() {
+		long myPid = ProcessHandle.current().pid();
+		String myId = Long.toString(myPid);
+		return myId;
+	}
+
+}

--- a/test/Java9andUp/testng.xml
+++ b/test/Java9andUp/testng.xml
@@ -95,6 +95,11 @@
 	<test name="Test_Class">
 		<classes>
 			<class name="org.openj9.test.java.lang.Test_Class" />
+ 		</classes>
+	</test>
+	<test name="TestJava9AttachAPI">
+		<classes>
+			<class name="org.openj9.test.attachAPI.TestJava9AttachAPI" />
 		</classes>
 	</test>
 </suite> <!-- Suite -->

--- a/test/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
+++ b/test/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
@@ -35,6 +35,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.testng.log4testng.Logger;
 
@@ -173,19 +174,19 @@ class TargetManager {
 	}
 
 	public TargetManager(String cmdName, String targetId,
-			ArrayList<String> appArgs) {
+			List<String> appArgs) {
 		this.targetId = targetId;
 		this.proc = launchTarget(cmdName, targetId, null, null, appArgs);
 	}
 
 	public TargetManager(String cmdName, String targetId,
-			ArrayList<String> vmArgs, ArrayList<String> appArgs) {
+			List<String> vmArgs, ArrayList<String> appArgs) {
 		this.targetId = targetId;
 		this.proc = launchTarget(cmdName, targetId, null, vmArgs, appArgs);
 	}
 
 	public TargetManager(String cmdName, String targetId, String displayName,
-			ArrayList<String> vmArgs, ArrayList<String> appArgs) {
+			List<String> vmArgs, ArrayList<String> appArgs) {
 		this.targetId = targetId;
 		this.proc = launchTarget(cmdName, targetId, displayName, vmArgs,
 				appArgs);
@@ -197,8 +198,8 @@ class TargetManager {
 	 * @return launched process
 	 */
 	private Process launchTarget(String cmdName, String tgtId,
-			String myDisplayName, ArrayList<String> vmArgs,
-			ArrayList<String> appArgs) {
+			String myDisplayName, List<String> vmArgs,
+			List<String> appArgs) {
 		ArrayList<String> argBuffer = new ArrayList<String>();
 		String[] args = {};
 		this.displayName = myDisplayName;
@@ -465,6 +466,14 @@ class TargetManager {
 
 	public boolean isActive() {
 		return active;
+	}
+
+	public int waitFor() throws InterruptedException {
+		int result = -1;
+		if (!Objects.isNull(proc)) {
+			result = proc.waitFor();
+		}
+		return result;
 	}
 
 }


### PR DESCRIPTION
This addresses openj9 issue #126
fixes #126

Prevent a JVM from late attaching to itself unless the system property
"jdk.attach.allowAttachSelf" is set either to "true" or an empty string, per
the reference implementation. Enforce this in Java 9 only. Update existing
tests to enable this feature by default so they will continue to run. Add new
Java 9 tests to exercise this feature.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>