### PR TITLE
Limit the max ArrayList in String#split to less than 100

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -4303,7 +4303,7 @@ written authorization of the copyright holder.
 			if (max == 1) {
 				return new String[] { this };
 			}
-			java.util.ArrayList<String> parts = new java.util.ArrayList<String>(max > 0 ? max : 10);
+			java.util.ArrayList<String> parts = new java.util.ArrayList<String>((max > 0 && max < 100) ? max : 10);
 
 			/*[IF Sidecar19-SE]*/
 			byte[]


### PR DESCRIPTION
This matches the historic behaviour of the IBM J9's String
split(String s, int max) implementation.  The "max < 100"
limit was lost during the String compression work.

This change restores that limit and resolves OOMs running
Jenkins and starting Eclipse.  Likely experienced by other
applications as well.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>