### PR TITLE
Comple ELF object file support

### DIFF
--- a/runtime/tr.source/trj9/build/files/common.mk
+++ b/runtime/tr.source/trj9/build/files/common.mk
@@ -195,6 +195,8 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/OMRRealRegister.cpp \
     omr/compiler/codegen/OMRRegisterPair.cpp \
     omr/compiler/codegen/OMRInstruction.cpp \
+    omr/compiler/codegen/ELFObjectFileGenerator.cpp \
+    omr/compiler/codegen/OMRELFRelocationResolver.cpp \
     tr.source/trj9/control/J9Recompilation.cpp \
     omr/compiler/codegen/OMRMemoryReference.cpp \
     omr/compiler/codegen/OMRMachine.cpp \

--- a/runtime/tr.source/trj9/build/files/target/amd64.mk
+++ b/runtime/tr.source/trj9/build/files/target/amd64.mk
@@ -24,7 +24,9 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/amd64/codegen/OMRMemoryReference.cpp \
     omr/compiler/x/amd64/codegen/OMRRealRegister.cpp \
     omr/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp \
-    omr/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+    omr/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp \
+    omr/compiler/x/amd64/codegen/OMRELFRelocationResolver.cpp \
+
 
 JIT_PRODUCT_SOURCE_FILES+=\
     tr.source/trj9/x/amd64/codegen/J9CodeGenerator.cpp \


### PR DESCRIPTION
Add the source files for ELF object file generation to the list of files
to be built in order to satisfy link-time symbol resolution.

Signed-off-by: Luc des Trois Maisons <lmaisons@ca.ibm.com>