### PR TITLE
Update javadoc generation scripts

### DIFF
--- a/jcl/com.ibm.dtfj-javadoc-829.xml
+++ b/jcl/com.ibm.dtfj-javadoc-829.xml
@@ -36,7 +36,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 		<tstamp>
 			<format property="year" pattern="yyyy" />
 		</tstamp>
-		<property name="bottom" value="&amp;copy; Copyright (c) 2004, ${year} IBM Corp. and others" />
+		<property name="bottom" value="Copyright &amp;copy; 2004, ${year} IBM Corp. and others" />
 		<property name="zip.dest.dir" location="../JavaID Development API docs/non-security/80_api/com.ibm.dtfj" />
 		<condition property="zip.dest.exists">
 			<available file="${zip.dest.dir}" />

--- a/jcl/com.ibm.lang.management-javadoc-829.xml
+++ b/jcl/com.ibm.lang.management-javadoc-829.xml
@@ -36,8 +36,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 		<tstamp>
 			<format property="year" pattern="yyyy" />
 		</tstamp>
-		<property name="bottom" value="&amp;copy; Copyright (c) 2003, ${year} IBM Corp. and others" />
-		<property name="zip.dest.dir" location="../JavaID Development API docs/non-security/80_29_api/com.ibm.lang.management" />
+		<property name="bottom" value="Copyright &amp;copy; 2003, ${year} IBM Corp. and others" />
+		<property name="zip.dest.dir" location="../JavaID Development API docs/non-security/80_api/com.ibm.lang.management" />
 		<condition property="zip.dest.exists">
 			<available file="${zip.dest.dir}" />
 		</condition>


### PR DESCRIPTION
* remove redundant '(c)' in copyright notice
* correct destination directory path