### PR TITLE
Add a warning message if the SCC module presents but its dll not loaded

### DIFF
--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -32,6 +32,7 @@
 #include "jclprots.h"
 #include "jvminit.h"
 #include "util_api.h"
+#include "j9vmnls.h"
 
 #define J9TIME_NANOSECONDS_PER_SECOND         ((jlong) 1000000000)
 /* Need to do a |currentSecondsTime - secondsOffset| < (2^32) check to ensure that the
@@ -989,6 +990,18 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 							success = vmFuncs->setBootLoaderModulePatchPaths(vm, j9mod, (const char *)nameUTF);
 							if (FALSE == success) {
 								goto nativeOOM;
+							} else {
+								const char* moduleName = "openj9.sharedclasses";
+
+								if (0 == strcmp(nameUTF, moduleName)) {
+									J9VMDllLoadInfo *entry = FIND_DLL_TABLE_ENTRY(J9_SHARED_DLL_NAME);
+
+									if ((NULL == entry)
+										|| (J9_ARE_ALL_BITS_SET(entry->loadFlags, FAILED_TO_LOAD))
+									) {
+										j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL, J9_SHARED_DLL_NAME, moduleName);
+									}
+								}
 							}
 						}
 					} else {

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1736,3 +1736,13 @@ J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP.system_action=The JVM will throw a 
 J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
 
+# First argument is the library name
+# Second argument is the module name
+J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL=Failed to load library %1$s required by module: %2$s
+# START NON-TRANSLATABLE
+J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.sample_input_1=j9shr29
+J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.sample_input_2=openj9.sharedclasses
+J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.explanation=The JVM failed to load the library required by the specified module.
+J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.system_action=The JVM continues.
+J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.user_response=No action required if the specified library won't be referenced.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
1. Add a NLS message J9NLS_VM_FAILED_TO_LOAD_DLL_REQUIRED_BY_MODULE
2. Print this new warning message when module openj9.sharedclasses
presents but j9shr29 dll failed to be loaded.

Fixes #162

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>