### PR TITLE
Initial support for Java 18.3 raw builds (b23)

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -299,6 +299,33 @@
 	</configuration>
 
 	<configuration
+		  label="JAVA18.3"
+		  outputpath="JAVA18.3/src"
+		  flags="Java18.3"
+		  dependencies="SIDECAR19-SE-B175"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/com.ibm.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/com.ibm.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/com.ibm.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/com.ibm.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/com.ibm.traceformat/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190b174.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+
+	<configuration
 		  label="PANAMA"
 		  outputpath="PANAMA/src"
 		  flags="Panama"

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -257,7 +257,16 @@ public abstract class ClassLoader {
 		
 		/*[IF Sidecar19-SE]*/
 		jdk.internal.misc.VM.initLevel(1);
-		System.bootLayer = jdk.internal.module.ModuleBootstrap.boot();
+		/*[IF Java18.3]*/
+		try {
+		/*[ENDIF]*/
+			System.bootLayer = jdk.internal.module.ModuleBootstrap.boot();
+		/*[IF Java18.3]*/
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			System.exit(1);
+		}
+		/*[ENDIF]*/
 		jdk.internal.misc.VM.initLevel(2);
 		String javaSecurityManager = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
 		if (null != javaSecurityManager) {

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -71,6 +71,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	static final boolean enableCompression = com.ibm.oti.vm.VM.J9_STRING_COMPRESSION_ENABLED;
 	
 	/*[IF Sidecar19-SE]*/
+	/*[IF Java18.3]*/
+	private final byte coder;
+	/*[ENDIF]*/
 	static final byte LATIN1 = 0;
 	static final byte UTF16 = 1;
 	static final boolean COMPACT_STRINGS;
@@ -415,6 +418,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value = byteArray;
 			count = byteArray.length / 2;
 		}
+		/*[IF Java18.3]*/
+		this.coder = coder();
+		/*[ENDIF]*/
 	}
 
 	static void checkBoundsOffCount(int offset, int count, int length) {
@@ -436,6 +442,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String() {
 		value = emptyValue;
 		count = 0;
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -562,6 +571,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -644,6 +656,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -725,6 +740,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -817,6 +835,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value[slen] = c;
 			/*[ENDIF]*/
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -878,6 +899,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(data, 0, value, 0, data.length);
 			/*[ENDIF]*/
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -939,6 +963,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/*[IF Sidecar19-SE]*/
@@ -1058,6 +1085,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				}
 			}
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 	
 	/*[IF Sidecar19-SE]*/
@@ -1173,6 +1203,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				}
 			}
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -1184,8 +1217,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String(String string) {
 		value = string.value;
 		count = string.count;
-		
 		hashCode = string.hashCode;
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -1210,6 +1245,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			/*[ENDIF]*/
 			count = numChars;
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -1241,6 +1279,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				count = buffer.length();
 			}
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/*
@@ -1318,6 +1359,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(s2.value, 0, value, s1len, s2len);
 			/*[ENDIF]*/
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/*
@@ -1415,6 +1459,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(s3.value, 0, value, (s1len + s2len), s3len);
 			/*[ENDIF]*/
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/*
@@ -1555,6 +1602,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(s1.value, 0, value, 0, s1len);
 			/*[ENDIF]*/
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/*
@@ -1853,6 +1903,9 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				/*[ENDIF]*/
 			}
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/*
@@ -4522,6 +4575,9 @@ written authorization of the copyright holder.
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -4553,6 +4609,9 @@ written authorization of the copyright holder.
 			value = chars;
 			count = builder.lengthInternal();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**
@@ -5025,6 +5084,9 @@ written authorization of the copyright holder.
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
+		/*[IF Java18.3]*/
+		coder = coder();
+		/*[ENDIF]*/
 	}
 
 	/**

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1150,6 +1150,7 @@ VersionSetting SHAPE_SETTINGS[] = {
 		{"b135", J2SE_SHAPE_B136},
 		{"b148", J2SE_SHAPE_B148},
 		{"b165", J2SE_SHAPE_B165},
+		{"b1803", J2SE_SHAPE_B1803},
 };
 #define NUM_SHAPE_SETTINGS (sizeof(SHAPE_SETTINGS) / sizeof(VersionSetting))
 

--- a/runtime/jcl/common/annparser.c
+++ b/runtime/jcl/common/annparser.c
@@ -43,7 +43,7 @@ Java_com_ibm_oti_reflect_AnnotationParser_getAnnotationsData__Ljava_lang_reflect
 	enterVMFromJNI(vmThread);
 	fieldObject = J9_JNI_UNWRAP_REFERENCE(jlrField);
 	if (NULL != fieldObject) {
-		J9JNIFieldID *fieldID = vmThread->javaVM->reflectFunctions.idFromFieldObject(vmThread, fieldObject);
+		J9JNIFieldID *fieldID = vmThread->javaVM->reflectFunctions.idFromFieldObject(vmThread, NULL, fieldObject);
 
 		j9object_t annotationsData = getFieldAnnotationData(vmThread, fieldID->declaringClass, fieldID);
 		if (NULL != annotationsData) {

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -564,7 +564,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField(JNIEnv *
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 	/* Can't fail as we know the field is not null */
 	fieldObject = J9_JNI_UNWRAP_REFERENCE(reflectField);
-	fieldID = reflectFunctions->idFromFieldObject(vmThread, fieldObject);
+	fieldID = reflectFunctions->idFromFieldObject(vmThread, NULL, fieldObject);
 
 	fieldOffset = fieldID->offset;
 	if (J9_JAVA_STATIC == (fieldID->field->modifiers & J9_JAVA_STATIC)) {

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -130,7 +130,7 @@ Java_java_lang_invoke_FieldVarHandle_unreflectField(JNIEnv *env, jobject handle,
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 	/* Can't fail as we know the field is not null */
 	fieldObject = J9_JNI_UNWRAP_REFERENCE(reflectField);
-	fieldID = reflectFunctions->idFromFieldObject(vmThread, fieldObject);
+	fieldID = reflectFunctions->idFromFieldObject(vmThread, NULL, fieldObject);
 
 	fieldOffset = fieldID->offset;
 	if (isStatic) {

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -29,6 +29,7 @@
 #include "j9port.h"
 #include "j2sever.h"
 #include "jclglob.h"
+#include "jcl_internal.h"
 #include "vmhook.h"
 
 #include <string.h>
@@ -539,7 +540,7 @@ Java_sun_misc_Unsafe_objectFieldOffset(JNIEnv *env, jobject receiver, jobject fi
 	if (NULL == field) {
 		vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 	} else {
-		J9JNIFieldID *fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, J9_JNI_UNWRAP_REFERENCE(field));
+		J9JNIFieldID *fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, NULL, J9_JNI_UNWRAP_REFERENCE(field));
 		J9ROMFieldShape *romField = fieldID->field;
 		if (NULL == romField) {
 			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
@@ -595,7 +596,7 @@ Java_sun_misc_Unsafe_staticFieldBase__Ljava_lang_reflect_Field_2(JNIEnv *env, jo
 	if (NULL == field) {
 		vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 	} else {
-		J9JNIFieldID *fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, J9_JNI_UNWRAP_REFERENCE(field));
+		J9JNIFieldID *fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, NULL, J9_JNI_UNWRAP_REFERENCE(field));
 		J9ROMFieldShape *romField = fieldID->field;
 		if (NULL == romField) {
 			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
@@ -621,7 +622,7 @@ Java_sun_misc_Unsafe_staticFieldOffset(JNIEnv *env, jobject receiver, jobject fi
 	if (NULL == field) {
 		vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
 	} else {
-		J9JNIFieldID *fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, J9_JNI_UNWRAP_REFERENCE(field));
+		J9JNIFieldID *fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, NULL, J9_JNI_UNWRAP_REFERENCE(field));
 		J9ROMFieldShape *romField = fieldID->field;
 		if (NULL == romField) {
 			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
@@ -683,234 +684,164 @@ Java_jdk_internal_misc_Unsafe_shouldBeInitialized(JNIEnv *env, jobject receiver,
 	return JNI_FALSE;
 }
 
-void
-registerJdkInternalMiscUnsafeNatives(JNIEnv *env, jclass clazz) {
-	/* clazz can't be null */
-	JNINativeMethod natives[] = {
-		{
-			(char*)"defineClass",
-			(char*)"(Ljava/lang/String;[BIILjava/lang/ClassLoader;Ljava/security/ProtectionDomain;)Ljava/lang/Class;",
-			(void *)&Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader_2Ljava_security_ProtectionDomain_2
-		},
-		{
-			(char*)"defineAnonymousClass",
-			(char*)"(Ljava/lang/Class;[B[Ljava/lang/Object;)Ljava/lang/Class;",
-			(void *)&Java_sun_misc_Unsafe_defineAnonymousClass
-		},
-		{
-			(char*)"pageSize",
-			(char*)"()I",
-			(void *)&Java_sun_misc_Unsafe_pageSize
-		},
-		{
-			(char*)"getLoadAverage",
-			(char*)"([DI)I",
-			(void *)&Java_sun_misc_Unsafe_getLoadAverage
-		},
-		{
-			(char*)"allocateMemory",
-			(char*)"(J)J",
-			(void *)&Java_sun_misc_Unsafe_allocateMemory
-		},
-		{
-			(char*)"freeMemory",
-			(char*)"(J)V",
-			(void *)&Java_sun_misc_Unsafe_freeMemory
-		},
-		{
-			(char*)"reallocateMemory",
-			(char*)"(JJ)J",
-			(void *)&Java_sun_misc_Unsafe_reallocateMemory
-		},
-		{
-			(char*)"ensureClassInitialized",
-			(char*)"(Ljava/lang/Class;)V",
-			(void *)&Java_sun_misc_Unsafe_ensureClassInitialized
-		},
-		{
-			(char*)"park",
-			(char*)"(ZJ)V",
-			(void *)&Java_sun_misc_Unsafe_park
-		},
-		{
-			(char*)"unpark",
-			(char*)"(Ljava/lang/Object;)V",
-			(void *)&Java_sun_misc_Unsafe_unpark
-		},
-		{
-			(char*)"throwException",
-			(char*)"(Ljava/lang/Throwable;)V",
-			(void *)&Java_sun_misc_Unsafe_throwException
-		},
-		{
-			(char*)"copyMemory",
-			(char*)"(Ljava/lang/Object;JLjava/lang/Object;JJ)V",
-			(void *)&Java_sun_misc_Unsafe_copyMemory__Ljava_lang_Object_2JLjava_lang_Object_2JJ
-		},
-		{
-			(char*)"objectFieldOffset",
-			(char*)"(Ljava/lang/reflect/Field;)J",
-			(void *)&Java_sun_misc_Unsafe_objectFieldOffset
-		},
-		{
-			(char*)"setMemory",
-			(char*)"(Ljava/lang/Object;JJB)V",
-			(void *)&Java_sun_misc_Unsafe_setMemory__Ljava_lang_Object_2JJB
-		},
-		{
-			(char*)"staticFieldBase",
-			(char*)"(Ljava/lang/reflect/Field;)Ljava/lang/Object;",
-			(void *)&Java_sun_misc_Unsafe_staticFieldBase__Ljava_lang_reflect_Field_2
-		},
-		{
-			(char*)"staticFieldOffset",
-			(char*)"(Ljava/lang/reflect/Field;)J",
-			(void *)&Java_sun_misc_Unsafe_staticFieldOffset
-		},
-		{
-			(char*)"unalignedAccess0",
-			(char*)"()Z",
-			(void *)&Java_sun_misc_Unsafe_unalignedAccess0
-		},
-		{
-			(char*)"isBigEndian0",
-			(char*)"()Z",
-			(void *)&Java_sun_misc_Unsafe_isBigEndian0
-		},
-		{
-			(char*)"getUncompressedObject",
-			(char*)"(J)Ljava/lang/Object;",
-			(void *)&Java_sun_misc_Unsafe_getUncompressedObject
-		},
-		{
-			(char*)"getJavaMirror",
-			(char*)"(J)Ljava/lang/Class;",
-			(void *)&Java_sun_misc_Unsafe_getJavaMirror
-		},
-		{
-			(char*)"getKlassPointer",
-			(char*)"(Ljava/lang/Object;)J",
-			(void *)&Java_sun_misc_Unsafe_getKlassPointer
-		},
-	};
-	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
+jlong JNICALL
+Java_jdk_internal_misc_Unsafe_objectFieldOffset1(JNIEnv *env, jobject receiver, jclass clazz, jstring name)
+{
+	J9VMThread *currentThread = (J9VMThread*)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	j9object_t fieldObj = NULL;
+	jlong offset = 0;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	fieldObj = getFieldObjHelper(currentThread, clazz, name);
+	if (NULL != fieldObj) {
+		J9JNIFieldID *fieldID = NULL;
+		J9ROMFieldShape *romField = NULL;
+
+		fieldID = vm->reflectFunctions.idFromFieldObject(currentThread, J9_JNI_UNWRAP_REFERENCE(clazz), fieldObj);
+		romField = fieldID->field;
+		if (NULL == romField) {
+			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+		} else if (J9_ARE_ANY_BITS_SET(romField->modifiers, J9AccStatic)) {
+			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
+		} else {
+			offset = (jlong)fieldID->offset + J9_OBJECT_HEADER_SIZE;
+		}
+	}
+	vmFuncs->internalReleaseVMAccess(currentThread);
+	
+	return offset;
 }
 
-void
-registerJdkInternalMiscUnsafeNativesB136(JNIEnv *env, jclass clazz) {
+/* register jdk.internal.misc.Unsafe natives common to Java 9, 18.3 and beyond */
+static void
+registerJdkInternalMiscUnsafeNativesCommon(JNIEnv *env, jclass clazz) {
 	/* clazz can't be null */
 	JNINativeMethod natives[] = {
 		{
 			(char*)"defineClass0",
 			(char*)"(Ljava/lang/String;[BIILjava/lang/ClassLoader;Ljava/security/ProtectionDomain;)Ljava/lang/Class;",
-			(void *)&Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader_2Ljava_security_ProtectionDomain_2
+			(void*)&Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader_2Ljava_security_ProtectionDomain_2
 		},
 		{
 			(char*)"defineAnonymousClass0",
 			(char*)"(Ljava/lang/Class;[B[Ljava/lang/Object;)Ljava/lang/Class;",
-			(void *)&Java_sun_misc_Unsafe_defineAnonymousClass
+			(void*)&Java_sun_misc_Unsafe_defineAnonymousClass
 		},
 		{
 			(char*)"pageSize",
 			(char*)"()I",
-			(void *)&Java_sun_misc_Unsafe_pageSize
+			(void*)&Java_sun_misc_Unsafe_pageSize
 		},
 		{
 			(char*)"getLoadAverage0",
 			(char*)"([DI)I",
-			(void *)&Java_sun_misc_Unsafe_getLoadAverage
+			(void*)&Java_sun_misc_Unsafe_getLoadAverage
 		},
 		{
 			(char*)"allocateMemory0",
 			(char*)"(J)J",
-			(void *)&Java_sun_misc_Unsafe_allocateMemory
+			(void*)&Java_sun_misc_Unsafe_allocateMemory
 		},
 		{
 			(char*)"freeMemory0",
 			(char*)"(J)V",
-			(void *)&Java_sun_misc_Unsafe_freeMemory
+			(void*)&Java_sun_misc_Unsafe_freeMemory
 		},
 		{
 			(char*)"reallocateMemory0",
 			(char*)"(JJ)J",
-			(void *)&Java_sun_misc_Unsafe_reallocateMemory
+			(void*)&Java_sun_misc_Unsafe_reallocateMemory
 		},
 		{
 			(char*)"ensureClassInitialized0",
 			(char*)"(Ljava/lang/Class;)V",
-			(void *)&Java_sun_misc_Unsafe_ensureClassInitialized
+			(void*)&Java_sun_misc_Unsafe_ensureClassInitialized
 		},
 		{
 			(char*)"park",
 			(char*)"(ZJ)V",
-			(void *)&Java_sun_misc_Unsafe_park
+			(void*)&Java_sun_misc_Unsafe_park
 		},
 		{
 			(char*)"unpark",
 			(char*)"(Ljava/lang/Object;)V",
-			(void *)&Java_sun_misc_Unsafe_unpark
+			(void*)&Java_sun_misc_Unsafe_unpark
 		},
 		{
 			(char*)"throwException",
 			(char*)"(Ljava/lang/Throwable;)V",
-			(void *)&Java_sun_misc_Unsafe_throwException
+			(void*)&Java_sun_misc_Unsafe_throwException
 		},
 		{
 			(char*)"copyMemory0",
 			(char*)"(Ljava/lang/Object;JLjava/lang/Object;JJ)V",
-			(void *)&Java_sun_misc_Unsafe_copyMemory__Ljava_lang_Object_2JLjava_lang_Object_2JJ
+			(void*)&Java_sun_misc_Unsafe_copyMemory__Ljava_lang_Object_2JLjava_lang_Object_2JJ
 		},
 		{
 			(char*)"objectFieldOffset0",
 			(char*)"(Ljava/lang/reflect/Field;)J",
-			(void *)&Java_sun_misc_Unsafe_objectFieldOffset
+			(void*)&Java_sun_misc_Unsafe_objectFieldOffset
 		},
 		{
 			(char*)"setMemory0",
 			(char*)"(Ljava/lang/Object;JJB)V",
-			(void *)&Java_sun_misc_Unsafe_setMemory__Ljava_lang_Object_2JJB
+			(void*)&Java_sun_misc_Unsafe_setMemory__Ljava_lang_Object_2JJB
 		},
 		{
 			(char*)"staticFieldBase0",
 			(char*)"(Ljava/lang/reflect/Field;)Ljava/lang/Object;",
-			(void *)&Java_sun_misc_Unsafe_staticFieldBase__Ljava_lang_reflect_Field_2
+			(void*)&Java_sun_misc_Unsafe_staticFieldBase__Ljava_lang_reflect_Field_2
 		},
 		{
 			(char*)"staticFieldOffset0",
 			(char*)"(Ljava/lang/reflect/Field;)J",
-			(void *)&Java_sun_misc_Unsafe_staticFieldOffset
+			(void*)&Java_sun_misc_Unsafe_staticFieldOffset
 		},
 		{
 			(char*)"unalignedAccess0",
 			(char*)"()Z",
-			(void *)&Java_sun_misc_Unsafe_unalignedAccess0
+			(void*)&Java_sun_misc_Unsafe_unalignedAccess0
 		},
 		{
 			(char*)"isBigEndian0",
 			(char*)"()Z",
-			(void *)&Java_sun_misc_Unsafe_isBigEndian0
+			(void*)&Java_sun_misc_Unsafe_isBigEndian0
 		},
 		{
 			(char*)"getUncompressedObject",
 			(char*)"(J)Ljava/lang/Object;",
-			(void *)&Java_sun_misc_Unsafe_getUncompressedObject
+			(void*)&Java_sun_misc_Unsafe_getUncompressedObject
 		},
 	};
 	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
 }
 
+/* register jdk.internal.misc.Unsafe natives for Java 18.3 */
+static void
+registerJdkInternalMiscUnsafeNativesJava18_3(JNIEnv *env, jclass clazz) {
+	/* clazz can't be null */
+	JNINativeMethod natives[] = {
+		{
+			(char*)"objectFieldOffset1",
+			(char*)"(Ljava/lang/Class;Ljava/lang/String;)J",
+			(void*)&Java_jdk_internal_misc_Unsafe_objectFieldOffset1
+		}
+	};
+	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
+}
+
+/* class jdk.internal.misc.Unsafe only presents in Java 9 and beyond */
 void JNICALL
 Java_jdk_internal_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 {
 	J9VMThread *currentThread = (J9VMThread*)env;
-	J9JavaVM *vm = currentThread->javaVM;
 
 	Java_sun_misc_Unsafe_registerNatives(env, clazz);
-	
-	if (J2SE_VERSION(vm) >= J2SE_19) {
-		registerJdkInternalMiscUnsafeNativesB136(env, clazz);
-	} else {
-		registerJdkInternalMiscUnsafeNatives(env, clazz);
+	registerJdkInternalMiscUnsafeNativesCommon(env, clazz);
+	if (J2SE_SHAPE(currentThread->javaVM) >= J2SE_SHAPE_B1803) {
+		registerJdkInternalMiscUnsafeNativesJava18_3(env, clazz);
 	}
 }
 

--- a/runtime/jcl/jcl_internal.h
+++ b/runtime/jcl/jcl_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,6 +66,17 @@ jbyteArray getMethodTypeAnnotationsAsByteArray(JNIEnv *env, jobject jlrMethod);
 j9object_t getMethodDefaultAnnotationData(struct J9VMThread *vmThread, struct J9Class *declaringClass, J9Method *ramMethod);
 
 jobjectArray getMethodParametersAsArray(JNIEnv *env, jobject jlrMethod);
+
+/**
+ * The caller must have VM access. 
+ * Build a java.lang.reflect.Field object for a field specified with a name and a declaring class.
+ * @param[in] vmThread The current vmThread.
+ * @param[in] declaringClass The declaring class. Must be non-null.
+ * @param[in] fieldName The name of the field.
+ * @return j9object_t a java.lang.reflect.Field
+ */
+j9object_t
+getFieldObjHelper(J9VMThread *vmThread, jclass declaringClass, jstring fieldName);
 
 /**
  * Build a java.lang.reflect.Field for a specified declared field.

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -29,6 +29,15 @@
 /*
  * Note: J2SE_LATEST has to be updated to highest Java version supported by VM
  * 		 This allows JVM operates with latest version when classlib.properties doesn't present.
+ * Additional note:
+ * 		 J2SE_LATEST will be kept as J2SE_19 while Java 18.3 raw build is being built.
+ * 		 When a separate Java 18.3 binary is required, a #ifdef flag will be introduced to define
+ * 		 J2SE_LATEST to different values accordingly such as following:
+ * 		 #if J9VM_JAVA9_BUILD > 9
+ * 		 	#define J2SE_LATEST  J2SE_1803
+ * 		 #else
+ * 		 	#define J2SE_LATEST  J2SE_19
+ * 		 #endif
  */
 #define J2SE_15  0x1500
 #define J2SE_16  0x1600
@@ -52,12 +61,22 @@
 /*
  * Note: J2SE_SHAPE_LATEST has to be updated to highest JCL level supported by VM
  * 		 This allows JVM operates with latest level when classlib.properties doesn't present.
+ * Additional note:
+ * 		 J2SE_SHAPE_LATEST will be kept as J2SE_SHAPE_B165 while Java 18.3 raw build is being built.
+ * 		 When a separate Java 18.3 binary is required, a #ifdef flag will be introduced to define
+ * 		 J2SE_SHAPE_B165 to different values accordingly such as following:
+ * 		 #if J9VM_JAVA9_BUILD > 9
+ * 		 	#define J2SE_SHAPE_LATEST  J2SE_SHAPE_B1803
+ * 		 #else
+ * 		 	#define J2SE_SHAPE_LATEST  J2SE_SHAPE_B165
+ * 		 #endif
  */
 #define J2SE_SHAPE_LATEST    	J2SE_SHAPE_B165
 #define J2SE_SHAPE_SUN     		0x10000
 #define J2SE_SHAPE_B136    		0x40000
 #define J2SE_SHAPE_B148    		0x50000
 #define J2SE_SHAPE_B165    		0x60000
+#define J2SE_SHAPE_B1803		0x70000
 #define J2SE_SHAPE_RAWPLUSJ9	0x80000
 #define J2SE_SHAPE_RAW	 		0x90000
 #define J2SE_SHAPE_MASK 		0xF0000

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4988,7 +4988,7 @@ typedef struct J9ReflectFunctionTable {
 	j9object_t  ( *createDeclaredMethodObject)(struct J9Method *ramMethod, struct J9Class *declaringClass, j9array_t parameterTypes, struct J9VMThread* vmThread) ;
 	j9object_t  ( *createMethodObject)(struct J9Method *ramMethod, struct J9Class *declaringClass, j9array_t parameterTypes, struct J9VMThread* vmThread) ;
 	void  ( *fillInReflectMethod)(j9object_t methodObject, struct J9Class *declaringClass, jmethodID methodID, struct J9VMThread *vmThread) ;
-	struct J9JNIFieldID*  ( *idFromFieldObject)(struct J9VMThread* vmStruct, j9object_t fieldObject) ;
+	struct J9JNIFieldID*  ( *idFromFieldObject)(struct J9VMThread* vmStruct, j9object_t declaringClassObject, j9object_t fieldObject) ;
 	struct J9JNIMethodID*  ( *idFromMethodObject)(struct J9VMThread* vmStruct, j9object_t methodObject) ;
 	struct J9JNIMethodID*  ( *idFromConstructorObject)(struct J9VMThread* vmStruct, j9object_t constructorObject) ;
 } J9ReflectFunctionTable;


### PR DESCRIPTION
Initial support for `Java 18.3` raw builds (`b23`)

1. Added a `Java 18.3` pConfig `JAVA18.3` (along with JPP flag
`Java18.3`) which depends on `SIDECAR19-SE-B175`, i.e., it will be a
super-set of current `Java 9` configuration;
2. Use flag `Java18.3` to decorate Java code only for `Java 18.3` so
no changes made to `Java 8 & 9`;
3. Introduced a vm shape `b1803` (will be set in `classlib.properties`
during SDK composing) to denote the native code only applying to `Java
18.3` via runtime checking;
4. For simplicity purpose, no new `J2SE` version introduced such as
`J2SE_18.3` yet. There are two reasons for this, one is that currently vm
shape `b1803` is sufficient to identify the code only for `Java 18.3`, the
other reason also main one is that `OpenJ9` build takes latest `J2SE`
(`J2SE_19`) because `classlib.properties` file doesn't present during `OpenJ9`
build process. A newer `J2SE` value but not for `OpenJ9` `Java 9` appears
confusing. This can be fixed when `Java 18.3` Extensions for `OpenJDK` is
available;
5. Implemented `Java 18.3` only native
`jdk.internal.misc.Unsafe.objectFieldOffset1(Class<?>, String)`, also
refactored `J9ReflectFunctionTable.idFromFieldObject()` and added helper
method `getFieldObjHelper()` to avoid code duplication;
6. Divided `jdk.internal.misc.Unsafe` natives registration into two
groups, `Java 9` (implicitly for `Java 18.3` as well) and `Java 18.3` only.
Note this class only presents in `Java 9` and beyond;
7. No refactoring for `Java 9` `b136` etc. within this pull request. (leave
the cleanup in a separated pull request/issue).

-version output from a `Java 18.3` raw build:
openjdk version "10-internal"
OpenJDK Runtime Environment (build 10-internal+0-adhoc.arnold.jdk10)
IBM J9 VM (build 2.9, JRE 9 Linux amd64-64 Compressed References 20170928_365605 (JIT enabled, AOT enabled)
J9VM     - b35cb2e
OMR      - 94eaf83)

Fixes: #152

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>