### PR TITLE
Stack underflow checking in verifier

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -1675,11 +1675,9 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 				if ((*J9UTF8_DATA(utf8string) == 'D') || (*J9UTF8_DATA(utf8string) == 'J')) {
 					DROP(1);
 				}
-				CHECK_STACK_UNDERFLOW;
 
 			} else {
 				/* JBgetfield/JBgetstatic - even bc's */
-				CHECK_STACK_UNDERFLOW;
 				stackTop = pushFieldType(verifyData, utf8string, stackTop);
 			}
 			break;
@@ -1713,7 +1711,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 				) {
 
 					type = POP;
-					CHECK_STACK_UNDERFLOW;
 					if (J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_NAME(J9ROMMETHODREF_NAMEANDSIGNATURE((J9ROMMethodRef *) info)))[0] == '<') {
 
 						/* This is <init>, verify that this is a NEW or INIT object */
@@ -1738,7 +1735,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 				} 
 			}
 
-			CHECK_STACK_UNDERFLOW;
 			stackTop = pushReturnType(verifyData, utf8string, stackTop);
 			break;
 
@@ -1891,7 +1887,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 
 		case RTV_BYTECODE_DUP:
 			type = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(type);
 			PUSH(type);
 			break;
@@ -1899,7 +1894,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 		case RTV_BYTECODE_DUPX1:
 			type = POP;
 			temp1 = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(type);
 			PUSH(temp1);
 			PUSH(type);
@@ -1909,7 +1903,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 			type = POP;
 			temp1 = POP;
 			temp2 = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(type);
 			PUSH(temp2);
 			PUSH(temp1);
@@ -1919,7 +1912,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 		case RTV_BYTECODE_DUP2:
 			temp1 = POP;
 			temp2 = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(temp2);
 			PUSH(temp1);
 			PUSH(temp2);
@@ -1930,7 +1922,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 			type = POP;
 			temp1 = POP;
 			temp2 = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(temp1);
 			PUSH(type);
 			PUSH(temp2);
@@ -1943,7 +1934,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 			temp1 = POP;
 			temp2 = POP;
 			temp3 = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(temp1);
 			PUSH(type);
 			PUSH(temp3);
@@ -1955,7 +1945,6 @@ simulateStack (J9BytecodeVerificationData * verifyData)
 		case RTV_BYTECODE_SWAP:
 			type = POP;
 			temp1 = POP;
-			CHECK_STACK_UNDERFLOW;
 			PUSH(type);
 			PUSH(temp1);
 			break;

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1383,8 +1383,6 @@ _illegalPrimitiveReturn:
 					/* Jazz 82615: Save the location of receiver */
 					receiverPtr = stackTop;
 				}
-				CHECK_STACK_UNDERFLOW;
-
 			} else {
 				/* JBgetfield/JBgetstatic - even bc's */
 				if (bc == JBgetfield) {
@@ -1392,7 +1390,6 @@ _illegalPrimitiveReturn:
 					/* Jazz 82615: Save the location of receiver */
 					receiverPtr = stackTop;
 				}
-				CHECK_STACK_UNDERFLOW;
 				stackTop = pushFieldType(verifyData, utf8string, stackTop);
 			}
 
@@ -1446,6 +1443,7 @@ _illegalPrimitiveReturn:
 				utf8string = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMMETHODREF_NAMEANDSIGNATURE((J9ROMMethodRef *) info))));
 				/* Removes the args from the stack and verify the stack shape is consistent */
 				rc = j9rtv_verifyArguments(verifyData, utf8string, &stackTop);
+				CHECK_STACK_UNDERFLOW;
 				if (BCV_ERR_INSUFFICIENT_MEMORY == rc) {
 					goto _outOfMemoryError;
 				}
@@ -1482,7 +1480,6 @@ _illegalPrimitiveReturn:
 					errorStackIndex = stackTop - liveStack->stackElements;
 					goto _inconsistentStack2;
 				}
-				CHECK_STACK_UNDERFLOW;
 				stackTop = pushReturnType(verifyData, utf8string, stackTop);
 
 				break;
@@ -1493,6 +1490,7 @@ _illegalPrimitiveReturn:
 				utf8string = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(SRP_PTR_GET(callSiteData + index, J9ROMNameAndSignature*))));
 				/* Removes the args from the stack and verify the stack shape is consistent */
 				rc = j9rtv_verifyArguments(verifyData, utf8string, &stackTop);
+				CHECK_STACK_UNDERFLOW;
 				if (BCV_ERR_INSUFFICIENT_MEMORY == rc) {
 					goto _outOfMemoryError;
 				}
@@ -1511,7 +1509,6 @@ _illegalPrimitiveReturn:
 					errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 					goto _verifyError;
 				}
-				CHECK_STACK_UNDERFLOW;
 				stackTop = pushReturnType(verifyData, utf8string, stackTop);
 				break;
 			}
@@ -1531,6 +1528,7 @@ _illegalPrimitiveReturn:
 			cpIndex = ((J9ROMMethodRef *) info)->classRefCPIndex;
 			classRef = (J9ROMStringRef *) &constantPool[cpIndex];
 			rc = j9rtv_verifyArguments(verifyData, utf8string, &stackTop);	/* Removes the args from the stack */
+			CHECK_STACK_UNDERFLOW;
 			if (BCV_ERR_INSUFFICIENT_MEMORY == rc) {
 				goto _outOfMemoryError;
 			}
@@ -1723,7 +1721,6 @@ _illegalPrimitiveReturn:
 				}
 			}
 
-			CHECK_STACK_UNDERFLOW;
 			utf8string = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMMETHODREF_NAMEANDSIGNATURE((J9ROMMethodRef *) info))));
 			stackTop = pushReturnType(verifyData, utf8string, stackTop);
 			break;
@@ -2079,7 +2076,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_DUP:
 			POP_TOS_SINGLE(type);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2093,7 +2089,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_DUPX1:
 			POP_TOS_SINGLE(type);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2102,7 +2097,6 @@ _illegalPrimitiveReturn:
 				goto _miscError;
 			}
 			POP_TOS_SINGLE(temp1);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2117,7 +2111,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_DUPX2:
 			POP_TOS_SINGLE(type);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2126,7 +2119,6 @@ _illegalPrimitiveReturn:
 				goto _miscError;
 			}
 			POP_TOS_PAIR(temp1, temp2); /* use nverifyPop2 ?? */
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2142,7 +2134,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_DUP2:
 			POP_TOS_PAIR(temp1, temp2);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2158,7 +2149,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_DUP2X1:
 			POP_TOS_PAIR(type, temp1);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2167,7 +2157,6 @@ _illegalPrimitiveReturn:
 				goto _miscError;
 			}
 			POP_TOS_SINGLE(temp2);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2184,7 +2173,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_DUP2X2:
 			POP_TOS_PAIR(type, temp1);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2193,7 +2181,6 @@ _illegalPrimitiveReturn:
 				goto _miscError;
 			}
 			POP_TOS_PAIR(temp2, temp3);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2212,7 +2199,6 @@ _illegalPrimitiveReturn:
 
 		case RTV_BYTECODE_SWAP:
 			POP_TOS_SINGLE(type);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
@@ -2221,7 +2207,6 @@ _illegalPrimitiveReturn:
 				goto _miscError;
 			}
 			POP_TOS_SINGLE(temp1);
-			CHECK_STACK_UNDERFLOW;
 			if (inconsistentStack) {
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;

--- a/runtime/oti/bcverify.h
+++ b/runtime/oti/bcverify.h
@@ -87,10 +87,12 @@ typedef struct J9BCVAlloc {
 	}
 
 #define DROP( x )	\
-	stackTop -= x;
+	stackTop -= x;	\
+	CHECK_STACK_UNDERFLOW
 
 #define POP	\
-	*(--stackTop)
+	*(--stackTop); \
+	CHECK_STACK_UNDERFLOW
 
 #define PUSH( t ) \
 	*stackTop = (UDATA) (t); \
@@ -147,7 +149,10 @@ typedef struct J9BCVAlloc {
 	inconsistentStack2 |= (foundType != expectedType);
 	
 #define POP_TOS( baseType )	\
-	inconsistentStack |= (POP != (UDATA) (baseType));
+	{	\
+		UDATA popTemp = POP;	\
+		inconsistentStack |= (popTemp != (UDATA) (baseType)); \
+	}
 
 #define POP_TOS_INTEGER	\
 	POP_TOS( BCV_BASE_TYPE_INT );


### PR DESCRIPTION
The change is to add the checking of
stack underflow whenever popping up
data types on the current stack so
as to generate the correct exception
as well as the detailed error message.

fixes: #148

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>