### PR TITLE
Fix casting issues in generateRILInstruction() API

### DIFF
--- a/runtime/tr.source/trj9/z/codegen/DFPTreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/DFPTreeEvaluator.cpp
@@ -124,16 +124,16 @@ genClearFPCBits(
       {
       maskRegister = cg->allocateRegister();
       generateRRInstruction(cg, TR::InstOpCode::LR, node, maskRegister, fpcRegister); //make a copy
-      generateRILInstruction(cg, TR::InstOpCode::NILF, node, maskRegister, (int32_t)0xFF000000);
+      generateRILInstruction(cg, TR::InstOpCode::NILF, node, maskRegister, 0xFF000000);
       }
 
    // Perform the clear
    if (mask & maskIEEEMask && !(mask & maskIEEEException)) //clear only the IEEE exception mask bits
-      generateRILInstruction(cg, TR::InstOpCode::NILF, node, fpcRegister, (int32_t)0x07FFFFFF);
+      generateRILInstruction(cg, TR::InstOpCode::NILF, node, fpcRegister, 0x07FFFFFF);
    else if (mask & maskIEEEException && !(mask & maskIEEEMask)) //clear only the IEEE exception bits
-      generateRILInstruction(cg, TR::InstOpCode::NILF, node, fpcRegister, (int32_t)0xFF07FFFF);
+      generateRILInstruction(cg, TR::InstOpCode::NILF, node, fpcRegister, 0xFF07FFFF);
    else if (mask & (maskIEEEMask|maskIEEEException))//maskIEEEBoth) //both types of FPC bits
-      generateRILInstruction(cg, TR::InstOpCode::NILF, node, fpcRegister, (int32_t)0x0707FFFF);
+      generateRILInstruction(cg, TR::InstOpCode::NILF, node, fpcRegister, 0x0707FFFF);
 
    generateRRInstruction(cg, TR::InstOpCode::SFPC, node, fpcRegister, fpcRegister);
    cg->stopUsingRegister(fpcRegister);
@@ -993,7 +993,7 @@ inlineBigDecimalScaledDivide(
    // check inexact exception bits for a failure
    generateRRInstruction(cg, TR::InstOpCode::EFPC, node, retRegister, retRegister);
    generateRILInstruction(cg, TR::InstOpCode::NILF, node, retRegister, excInexactFlag);
-   generateRILInstruction(cg, TR::InstOpCode::CLFI, node, retRegister, (uintptrj_t)0); //compare against 0
+   generateRILInstruction(cg, TR::InstOpCode::CLFI, node, retRegister, 0); //compare against 0
 
    // assume inexact fail
    generateLoad32BitConstant(cg, node, 0, retRegister, false);
@@ -1126,7 +1126,7 @@ inlineBigDecimalDivide(
       // need to check for inexact exception
       generateRRInstruction(cg, TR::InstOpCode::EFPC, node, retRegister, retRegister);
       generateRILInstruction(cg, TR::InstOpCode::NILF, node, retRegister, excInexactFlag);
-      generateRILInstruction(cg, TR::InstOpCode::CLFI, node, retRegister, (uintptrj_t)0); //compare against 0
+      generateRILInstruction(cg, TR::InstOpCode::CLFI, node, retRegister, 0); //compare against 0
 
       // did we fail?
       // 0 already loaded in return register
@@ -1415,7 +1415,7 @@ inlineBigDecimalSetScale(
       {
       generateRRInstruction(cg, TR::InstOpCode::EFPC, node, retRegister, retRegister);
       generateRILInstruction(cg, TR::InstOpCode::NILF, node, retRegister, excInexactFlag);
-      generateRILInstruction(cg, TR::InstOpCode::CLFI, node, retRegister, (uintptrj_t)0); //compare against 0
+      generateRILInstruction(cg, TR::InstOpCode::CLFI, node, retRegister, 0); //compare against 0
 
       // did we fail?
       // 0 already loaded in return register

--- a/runtime/tr.source/trj9/z/codegen/J9MemoryReference.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9MemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -360,7 +360,7 @@ J9::Z::MemoryReference::createPatchableDataInLitpool(TR::Node * node, TR::CodeGe
       {
       litpool->resetNeedLitPoolBasePtr();
       TR::S390RILInstruction * LRLinst;
-      LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, tempReg, 0xBABE, 0);
+      LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, tempReg, reinterpret_cast<uintptrj_t*>(0xBABE), 0);
       uds->setDataReferenceInstruction(LRLinst);
       LRLinst->setSymbolReference(uds->getDataSymbolReference());
       LRLinst->setTargetSnippet(litpool);

--- a/runtime/tr.source/trj9/z/codegen/J9S390CHelperLinkage.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9S390CHelperLinkage.cpp
@@ -363,7 +363,7 @@ TR::Register * TR::S390CHelperLinkage::buildDirectDispatch(TR::Node * callNode, 
 #endif
       }
    TR::SymbolReference * callSymRef = callNode->getSymbolReference();
-   intptrj_t destAddr = (intptrj_t) callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethodAddress();
+   void * destAddr = callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethodAddress();
    cursor = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, regRA, destAddr, callSymRef, cg());
    cursor->setDependencyConditions(preDeps);
    if (isFastPathOnly)

--- a/runtime/tr.source/trj9/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9S390PrivateLinkage.cpp
@@ -2229,7 +2229,7 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
 
             if (useProfiledValues)
                {
-               TR::Instruction * unloadableConstInstr = generateRILInstruction(cg(), TR::InstOpCode::LARL, callNode, RegZero, (uintptrj_t)profiledClass);
+               TR::Instruction * unloadableConstInstr = generateRILInstruction(cg(), TR::InstOpCode::LARL, callNode, RegZero, reinterpret_cast<uintptrj_t*>(profiledClass));
                if (fej9->isUnloadAssumptionRequired(profiledClass, comp()->getCurrentMethod()))
                   {
                   comp()->getStaticPICSites()->push_front(unloadableConstInstr);
@@ -2573,20 +2573,20 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
 
                // We will generate CLFI / BRCL sequence to dispatch to target branches.
                // First CLFI/BRCL
-               cursor = generateRILInstruction(cg(), TR::InstOpCode::CLFI, callNode, vftReg, (uintptrj_t)0x0, cursor); //compare against 0
+               cursor = generateRILInstruction(cg(), TR::InstOpCode::CLFI, callNode, vftReg, 0x0, cursor); //compare against 0
 
                ifcSnippet->getDataConstantSnippet()->setFirstCLFI(cursor);
 
                // BRCL
-               cursor = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRCL, callNode, (uint32_t)0x0, (uintptrj_t)0x0, cursor, cg());
+               cursor = generateRILInstruction(cg(), TR::InstOpCode::BRCL, callNode, static_cast<uint32_t>(0x0), reinterpret_cast<void*>(0x0), cursor);
 
                for(i = 1; i < numInterfaceCallCacheSlots; i++)
                   {
                   // We will generate CLFI / BRCL sequence to dispatch to target branches.
-                  cursor = generateRILInstruction(cg(), TR::InstOpCode::CLFI, callNode, vftReg, (uintptrj_t)0x0, cursor); //compare against 0
+                  cursor = generateRILInstruction(cg(), TR::InstOpCode::CLFI, callNode, vftReg, 0x0, cursor); //compare against 0
 
                   // BRCL
-                  cursor = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRCL, callNode, (uint32_t) 0x0, (uintptrj_t)0x0, cursor, cg());
+                  cursor = generateRILInstruction(cg(), TR::InstOpCode::BRCL, callNode, static_cast<uint32_t>(0x0), reinterpret_cast<void*>(0x0), cursor);
                   }
                }
             else

--- a/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -818,7 +818,7 @@ genTestIsSuper(TR::CodeGenerator * cg, TR::Node * node,
       TR_ASSERT(((J9AccInterface | J9AccClassArray) < UINT_MAX && (J9AccInterface | J9AccClassArray) > 0),
             "genTestIsSuper::(J9AccInterface | J9AccClassArray) is not a 32-bit number\n");
 
-      cursor = generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratch1Reg, (int32_t) (J9AccInterface | J9AccClassArray), cursor);
+      cursor = generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratch1Reg, static_cast<int32_t>((J9AccInterface | J9AccClassArray)), cursor);
 
       if (debugObj)
          debugObj->addInstructionComment(cursor, "Check if castClass is an interface or class array and jump to helper sequence");
@@ -1018,7 +1018,7 @@ static void genIsReferenceArrayTest(TR::Node        *node,
                             generateS390MemoryReference(objectClassReg, offsetof(J9Class,romClass), cg));
       generateRXInstruction(cg, TR::InstOpCode::L, node, scratchReg1,
                             generateS390MemoryReference(scratchReg1, offsetof(J9ROMClass, modifiers), cg));
-      generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, J9AccClassArray);
+      generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, static_cast<int32_t>(J9AccClassArray));
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, failLabel);
 
       generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, scratchReg1,
@@ -1027,7 +1027,7 @@ static void genIsReferenceArrayTest(TR::Node        *node,
                             generateS390MemoryReference(scratchReg1, offsetof(J9Class,romClass), cg));
       generateRXInstruction(cg, TR::InstOpCode::L, node, scratchReg1,
                             generateS390MemoryReference(scratchReg1, offsetof(J9ROMClass, modifiers), cg));
-      generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, J9AccClassInternalPrimitiveType);
+      generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, static_cast<int32_t>(J9AccClassInternalPrimitiveType));
 
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, failLabel);
       if (needsResult)
@@ -1170,7 +1170,7 @@ static bool generateInlineTest(TR::CodeGenerator * cg, TR::Node * node, TR::Node
       if (cg->needClassAndMethodPointerRelocations())
          unloadableConstInstr[i] = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, scratchReg,(uintptrj_t) guessClassArray[i], TR_ClassPointer, NULL, NULL, NULL);
       else
-         unloadableConstInstr[i] = generateRILInstruction(cg, TR::InstOpCode::LARL, node, scratchReg, (uintptrj_t)guessClassArray[i]);
+         unloadableConstInstr[i] = generateRILInstruction(cg, TR::InstOpCode::LARL, node, scratchReg, guessClassArray[i]);
 
       if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(guessClassArray[i]), comp->getCurrentMethod()))
          comp->getStaticPICSites()->push_front(unloadableConstInstr[i]);
@@ -1294,15 +1294,17 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
       TR::InstOpCode::Mnemonic opSubtractReg = TR::InstOpCode::getSubstractRegOpCode();
       TR::InstOpCode::Mnemonic opSubtract = TR::InstOpCode::getSubstractOpCode();
       TR::InstOpCode::Mnemonic opCmpLog = TR::InstOpCode::getCmpLogicalOpCode();
-      uintptrj_t heapSize = (uintptrj_t) comp->getOptions()->getHeapSizeForBarrierRange0();
-      uintptrj_t heapBase = (uintptrj_t) comp->getOptions()->getHeapBaseForBarrierRange0();
       bool disableSrcObjCheck = true; //cg->comp()->getOption(TR_DisableWrtBarSrcObjCheck);
       bool constantHeapCase = ((!comp->compileRelocatableCode()) && isConstantHeapBase && isConstantHeapSize && shiftAmount == 0 && (!is64Bit || TR::Compiler->om.generateCompressedObjectHeaders()));
       if (constantHeapCase)
          {
+         // these return uintptrj_t but because of the if(constantHeapCase) they are guaranteed to be <= MAX(uint32_t). The uses of heapSize, heapBase, and heapSum need to be uint32_t.
+         uint32_t heapSize =  comp->getOptions()->getHeapSizeForBarrierRange0();
+         uint32_t heapBase =  comp->getOptions()->getHeapBaseForBarrierRange0();
+
          if (!doCrdMrk && !disableSrcObjCheck)
             {
-            uintptrj_t heapSum = heapBase + heapSize;
+            uint32_t heapSum = heapBase + heapSize;
             generateRRInstruction(cg, opLoadReg, node, temp1Reg, owningObjectReg);
             generateRILInstruction(cg, TR::InstOpCode::IILF, node, temp2Reg, heapSum);
             generateRRInstruction(cg, opSubtractReg, node, temp1Reg, temp2Reg);
@@ -1314,7 +1316,7 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
             {
             generateRRInstruction(cg, opLoadReg, node, temp1Reg, owningObjectReg); //copy owning into temp
             generateRILInstruction(cg, is64Bit ? TR::InstOpCode::SLGFI : TR::InstOpCode::SLFI, node, temp1Reg, heapBase); //temp = temp - heapbase
-            generateS390CompareAndBranchInstruction(cg, is64Bit ? TR::InstOpCode::CLG: TR::InstOpCode::CL, node, temp1Reg, heapSize, TR::InstOpCode::COND_BH, doneLabel, false);
+            generateS390CompareAndBranchInstruction(cg, is64Bit ? TR::InstOpCode::CLG : TR::InstOpCode::CL, node, temp1Reg, heapSize, TR::InstOpCode::COND_BH, doneLabel, false);
             }
          }
       else
@@ -1397,8 +1399,10 @@ VMnonNullSrcWrtBarCardCheckEvaluator(
          generateRRInstruction(cg, opLoadReg, node, temp1Reg, srcReg);
          if (constantHeapCase)
             {
+            // this returns a uintptrj_t but because of the if(constantHeapCase) it's guaranteed to be <= MAX(uint32_t). The use of  heapBase needs to be uint32_t.
+            uint32_t heapBase =  comp->getOptions()->getHeapBaseForBarrierRange0();
             generateRILInstruction(cg, is64Bit ? TR::InstOpCode::SLGFI : TR::InstOpCode::SLFI, node, temp1Reg, heapBase);
-            generateS390CompareAndBranchInstruction(cg, is64Bit ? TR::InstOpCode::CLG: TR::InstOpCode::CL, node, temp1Reg, heapSize, TR::InstOpCode::COND_BL, doneLabel, false);
+            generateS390CompareAndBranchInstruction(cg, is64Bit ? TR::InstOpCode::CLG : TR::InstOpCode::CL, node, temp1Reg, heapSize, TR::InstOpCode::COND_BL, doneLabel, false);
             }
          else
             {
@@ -3636,7 +3640,7 @@ VMarrayStoreCHKEvaluator(
     * However, TR_J9SharedCacheVM::getSystemClassFromClassName can return 0 when it's impossible to relocate j9class later for AOT loads
     * in that case we don't want to generate the Object arrays check
     */
-   bool doObjectArrayCheck = objectClass != NULL;
+   bool doObjectArrayCheck = objectClass != 0;
 
    if (doObjectArrayCheck && (cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)objectClass, node) || cg->needClassAndMethodPointerRelocations()))
       {
@@ -5238,14 +5242,14 @@ void genInstanceOfOrCheckcastArrayOfJavaLangObjectTest(TR::Node *node, TR::CodeG
    TR::Register *scratchReg1 = srm->findOrCreateScratchRegister();
    generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, scratchReg1, generateS390MemoryReference(objectClassReg, offsetof(J9Class,romClass), cg));
    generateRXInstruction(cg, TR::InstOpCode::L, node, scratchReg1, generateS390MemoryReference(scratchReg1, offsetof(J9ROMClass, modifiers), cg));
-   generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, J9AccClassArray);
+   generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, static_cast<int32_t>(J9AccClassArray));
    cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, failLabel);
    if (debugObj)
       debugObj->addInstructionComment(cursor,"Fail instanceOf/checkCast if Not Array");
    generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, scratchReg1, generateS390MemoryReference(objectClassReg, offsetof(J9ArrayClass,componentType), cg));
    generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, scratchReg1, generateS390MemoryReference(scratchReg1, offsetof(J9Class,romClass), cg));
    generateRXInstruction(cg, TR::InstOpCode::L, node, scratchReg1, generateS390MemoryReference(scratchReg1, offsetof(J9ROMClass, modifiers), cg));
-   generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, J9AccClassInternalPrimitiveType);
+   generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchReg1, static_cast<int32_t>(J9AccClassInternalPrimitiveType));
    srm->reclaimScratchRegister(scratchReg1);
    }
 
@@ -5295,7 +5299,7 @@ bool genInstanceOfOrCheckcastSuperClassTest(TR::Node *node, TR::CodeGenerator *c
             generateS390MemoryReference(scratchRegister1, offsetof(J9ROMClass, modifiers), cg), cursor);
       TR_ASSERT(((J9AccInterface | J9AccClassArray) < UINT_MAX && (J9AccInterface | J9AccClassArray) > 0),
             "genTestIsSuper::(J9AccInterface | J9AccClassArray) is not a 32-bit number\n");
-      cursor = generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchRegister1, (int32_t) (J9AccInterface | J9AccClassArray), cursor);
+      cursor = generateRILInstruction(cg, TR::InstOpCode::NILF, node, scratchRegister1, static_cast<int32_t>((J9AccInterface | J9AccClassArray)), cursor);
       cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, callHelperLabel, cursor);
       castClassDepthReg = srm->findOrCreateScratchRegister();
       cursor = generateRXInstruction(cg, loadOp, node, castClassDepthReg,
@@ -5814,7 +5818,7 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
                if (cg->needClassAndMethodPointerRelocations())
                   temp = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, arbitraryClassReg1, (uintptrj_t) profiledClassesList[numPICs].profiledClass, TR_ClassPointer, NULL, NULL, NULL);
                else
-                  temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, (uintptrj_t)profiledClassesList[numPICs].profiledClass);
+                  temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, profiledClassesList[numPICs].profiledClass);
 
                // Adding profiled class to the static PIC slots.  
                if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(profiledClassesList[numPICs].profiledClass), comp->getCurrentMethod()))
@@ -6245,7 +6249,7 @@ J9::Z::TreeEvaluator::VMcheckcastEvaluator2(TR::Node * node, TR::CodeGenerator *
                if (cg->needClassAndMethodPointerRelocations())
                   temp = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, arbitraryClassReg1, (uintptrj_t) profiledClassesList[numPICs].profiledClass, TR_ClassPointer, NULL, NULL, NULL);
                else
-                  temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, (uintptrj_t)profiledClassesList[numPICs].profiledClass);
+                  temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, profiledClassesList[numPICs].profiledClass);
 
                // Adding profiled classes to static PIC sites
                if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(profiledClassesList[numPICs].profiledClass), comp->getCurrentMethod()))
@@ -7969,7 +7973,7 @@ genInitObjectHeader(TR::Node * node, TR::Instruction *& iCursor, TR_OpaqueClassB
             }
          if (canUseIIHF)
             {
-            iCursor = generateRILInstruction(cg, TR::InstOpCode::IIHF, node, enumReg, (intptr_t) classAddress | (intptrj_t)orFlag, iCursor);
+            iCursor = generateRILInstruction(cg, TR::InstOpCode::IIHF, node, enumReg, static_cast<uint32_t>(reinterpret_cast<uintptr_t>(classAddress)) | orFlag, iCursor);
             }
          else
             {
@@ -10289,9 +10293,9 @@ static TR::Register *inlineAtomicOps(
                   {
                   // load the immediate into one 64bit reg
                   int64_t value= deltaChild->getLongInt();
-                  generateRILInstruction(cg, TR::InstOpCode::LGFI, node, deltaReg, (int32_t)(value));
+                  generateRILInstruction(cg, TR::InstOpCode::LGFI, node, deltaReg, static_cast<int32_t>(value));
                   if (value < MIN_IMMEDIATE_VAL || value > MAX_IMMEDIATE_VAL)
-                     generateRILInstruction(cg, TR::InstOpCode::IIHF, node, deltaReg, (int32_t)(value >> 32));
+                     generateRILInstruction(cg, TR::InstOpCode::IIHF, node, deltaReg, static_cast<int32_t>(value >> 32));
                   }
                else
                   {
@@ -18258,7 +18262,7 @@ J9::Z::TreeEvaluator::ddInsExpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          else if (biasedExpValue >= GE_MIN_IMMEDIATE_VAL && biasedExpValue <= GE_MAX_IMMEDIATE_VAL)
             {
             biasedExpReg = cg->allocate64bitRegister();
-            generateRILInstruction(cg, TR::InstOpCode::LGFI, node, biasedExpReg, (int32_t)biasedExpValue);
+            generateRILInstruction(cg, TR::InstOpCode::LGFI, node, biasedExpReg, static_cast<int32_t>(biasedExpValue));
             }
          }
 


### PR DESCRIPTION
Splitting the generateRILInstruction() API to handle the different
types of immediates that RIL instructions can take separately.
One kind is a pure immediate which is used for say an ADD
instruction. The other is when the immediate is used as a relative
offset for address calculation like LARL or BRASL instructions.
This allows calls to the API to have more sensible casting.
They are modified for this change and unsafe casting is switched
to static casting and some code has its style improved.

Signed-off-by: Simon Hirst <shirst@ca.ibm.com>