### PR TITLE
Focus dead load cleanup on OSR blocks

### DIFF
--- a/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
@@ -4296,8 +4296,18 @@ J9::CodeGenerator::setUpForInstructionSelection()
 
    if (self()->comp()->getOption(TR_EnableOSR))
       {
+      TR::Block *block;
       for (tt = self()->comp()->getStartTree(); tt; tt = tt->getNextTreeTop())
          {
+         if (tt->getNode()->getOpCodeValue() == TR::BBStart)
+            {
+            block = tt->getNode()->getBlock();
+            if (!block->isOSRCodeBlock())
+               {
+               tt = block->getExit();
+               continue;
+               }
+            }
          self()->eliminateLoadsOfLocalsThatAreNotStored(tt->getNode(), -1);
          }
 


### PR DESCRIPTION
In certain OSR modes, dead stores will purposely be
introduced to limit the OSR overhead. These stores
are removed during lowering and can result in loads
of locals that were never stored to. Identifying
these loads can be costly, so it should be limited
to the OSR code blocks.