### PR TITLE
Reduce compile time in OSRGuardInsertion

### DIFF
--- a/runtime/tr.source/trj9/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/tr.source/trj9/optimizer/OSRGuardInsertion.cpp
@@ -243,6 +243,8 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
    // will potentially slow down manipulations to the CFG, so it is remove
    comp()->getFlowGraph()->invalidateStructure();
 
+   TR::TreeTop * cfgEnd = comp()->getFlowGraph()->findLastTreeTop();
+
    TR::Block *block = NULL;
    TR_SingleBitContainer fear(1, trMemory(), stackAlloc);
    int32_t initialNodeCount = comp()->getNodeCount();
@@ -304,7 +306,7 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
 
          // If something went wrong with bookkeeping, due to the nature of the implicit OSR point,
          // this will return false
-         bool induceOSR = comp()->getMethodSymbol()->induceOSRAfter(cursor, nodeBCI, guard, false, 0);
+         bool induceOSR = comp()->getMethodSymbol()->induceOSRAfter(cursor, nodeBCI, guard, false, 0, &cfgEnd);
          if (trace())
             {
             if (induceOSR)
@@ -404,7 +406,7 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
                guard->getNode()->getFirstChild()->setByteCodeInfo(guardBCI);
                guard->getNode()->getSecondChild()->setByteCodeInfo(guardBCI);
 
-               bool induceOSR = targetMethod->induceOSRAfter(inductionPoint, nodeBCI, guard, false, comp()->getOSRInductionOffset(cursor->getNode()));
+               bool induceOSR = targetMethod->induceOSRAfter(inductionPoint, nodeBCI, guard, false, comp()->getOSRInductionOffset(cursor->getNode()), &cfgEnd);
                if (trace() && induceOSR)
                   traceMsg(comp(), "  OSR induction added successfully\n");
                else if (trace())

--- a/runtime/tr.source/trj9/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/tr.source/trj9/optimizer/OSRGuardInsertion.cpp
@@ -152,7 +152,7 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes)
       requiresAnalysis = false;
 
    // Create the fake region
-   TR_Structure *structure = fakeRegion(comp());
+   TR_Structure *structure = requiresAnalysis ? fakeRegion(comp()) : NULL;
    comp()->getFlowGraph()->setStructure(structure);
    TR_HCRGuardAnalysis *guardAnalysis = requiresAnalysis ? new (comp()->allocator()) TR_HCRGuardAnalysis(comp(), optimizer(), structure) : NULL;
 
@@ -249,6 +249,9 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes)
 int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
    {
    static char *forceOSRInsertion = feGetEnv("TR_ForceOSRGuardInsertion");
+
+   if (!comp()->getFlowGraph()->getStructure())
+      comp()->getFlowGraph()->setStructure(fakeRegion(comp()));
 
    TR_FearPointAnalysis fearAnalysis(comp(), optimizer(), comp()->getFlowGraph()->getStructure(),
       fearGeneratingNodes, true, trace());


### PR DESCRIPTION
This contains a series of compile time improvements for
OSRGuardInsertion:

- Use the cached end of treetops in induceOSRAfter
- Support replacing a merged HCR guard with an OSR guard when removing
- Delay creating fake structure until it is absolutely necessary