### PR TITLE
WIP Enable use of varargs for panama native calls

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangInvokeAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangInvokeAccess.java
@@ -25,6 +25,7 @@ package com.ibm.oti.vm;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.NativeMethodHandle;
+import java.lang.invoke.NativeMethodHandleVararg;
 import java.nicl.LibrarySymbol;
 
 /**
@@ -34,6 +35,17 @@ import java.nicl.LibrarySymbol;
  */
 
 public interface VMLangInvokeAccess {
+	/**
+	 * Create a new NativeMethodHandleVararg
+	 *
+	 * @param methodName - the name of the method
+	 * @param type - the MethodType of the method
+	 * @param symbol - the LibrarySymbol containing the address of the method
+	 * @return A new NativeMethodHandleVararg
+	 * @throws IllegalAccessException if fails to extract native address from symbol
+	 */
+	public NativeMethodHandle generateNativeMethodHandleVararg(String methodName, MethodType type, LibrarySymbol symbol) throws IllegalAccessException;
+
 	/**
 	 * Create a new NativeMethodHandle
 	 *

--- a/jcl/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
@@ -61,6 +61,12 @@ public class NativeMethodHandle extends PrimitiveHandle {
 		initJ9NativeCalloutDataRef(null);
 	}
 
+	/* This constructor is used via NativeInvoker for vararg methods. J9NativeCalloutDataRef is not initialized here. */
+	NativeMethodHandle(String methodName, MethodType type, LibrarySymbol symbol) throws IllegalAccessException {
+		super(type, null, methodName, KIND_NATIVE, 0, null);
+		this.vmSlot = symbol.getAddress().addr(new PointerTokenImpl());
+	}
+
 	@Override
 	protected ThunkTable thunkTable(){ return _thunkTable; }
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/NativeMethodHandleVararg.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/NativeMethodHandleVararg.java
@@ -1,0 +1,28 @@
+/*[INCLUDE-IF Panama]*/
+/*
+ * Licensed Materials - Property of IBM,
+ *     Copyright IBM Corp. 2009, 2017  All Rights Reserved
+ */
+package java.lang.invoke;
+
+import java.nicl.LibrarySymbol;
+
+
+/**
+ * NativeMethodHandleVargarg is a specialized version of NativeMethodHandle
+ * where the method contains varargs. 
+ * 
+ * The reference to J9NativeCalloutData is not stored for varargs because 
+ * the argument types of the varargs will only be known in the MHInterpreter, 
+ * after the method has been called. 
+ * 
+ * Therefore, the J9NativeCalloutData needs to created every time a ffi_call 
+ * is made in the MHInterpreter.
+ */
+
+public class NativeMethodHandleVararg extends NativeMethodHandle {
+	
+	NativeMethodHandleVararg(String methodName, MethodType type, LibrarySymbol symbol) throws IllegalAccessException {
+		super(methodName, type, symbol);
+	}
+}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VMInvokeAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VMInvokeAccess.java
@@ -34,6 +34,19 @@ import com.ibm.oti.vm.VMLangInvokeAccess;
  */
 final class VMInvokeAccess implements VMLangInvokeAccess {
 	/**
+	 * Create a new NativeMethodHandleVararg
+	 *
+	 * @param methodName - the name of the method
+	 * @param type - the MethodType of the method
+	 * @param symbol - the LibrarySymbol containing the address of the method
+	 * @return A new NativeMethodHandleVararg
+	 * @throws IllegalAccessException if fails to extract native address from symbol
+	 */
+	public NativeMethodHandle generateNativeMethodHandleVararg(String methodName, MethodType type, LibrarySymbol symbol) throws IllegalAccessException {
+		return new NativeMethodHandleVararg(methodName, type, symbol);
+	}
+
+	/**
 	 * Create a new NativeMethodHandle
 	 *
 	 * @param methodName - the name of the method

--- a/runtime/libffi/module.xml
+++ b/runtime/libffi/module.xml
@@ -18,6 +18,7 @@
 				<exclude-if condition="spec.win_x86-64.*" />
 			</group>
 			<export name="ffi_prep_cif" />
+			<export name="ffi_prep_cif_var" />
 			<export name="ffi_call" />
 			<export name="ffi_type_void" />
 			<export name="ffi_type_uint8" />

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -92,6 +92,7 @@
 	<classref name="java/lang/invoke/MethodHandle" flags="opt_methodHandle"/>
 	<classref name="java/lang/invoke/PrimitiveHandle" flags="opt_methodHandle"/>
 	<classref name="java/lang/invoke/NativeMethodHandle" flags="opt_panama"/>
+	<classref name="java/lang/invoke/NativeMethodHandleVararg" flags="opt_panama"/>
 	<classref name="java/lang/invoke/ReceiverBoundHandle" flags="opt_methodHandle"/>
 	<classref name="java/lang/invoke/ConvertHandle" flags="opt_methodHandle"/>
 	<classref name="java/lang/invoke/CollectHandle" flags="opt_methodHandle"/>

--- a/runtime/vm/FFITypeHelpers.cpp
+++ b/runtime/vm/FFITypeHelpers.cpp
@@ -23,6 +23,55 @@
 #include "FFITypeHelpers.hpp"
 
 #ifdef J9VM_OPT_PANAMA
+ffi_type*
+FFITypeHelpers::getFFITypeVararg(j9object_t vararg, void **varargValue)
+{
+	PORT_ACCESS_FROM_JAVAVM(_vm);
+
+	ffi_type* typeFFI = NULL;
+	J9Class *varargClass = J9OBJECT_CLAZZ(_currentThread, vararg);
+
+	if (varargClass == J9VMJAVALANGINTEGER_OR_NULL(_vm)) {
+
+		U_32 *value = (U_32 *)j9mem_allocate_memory(sizeof(U_32), OMRMEM_CATEGORY_VM);
+		if (NULL == value) {
+			setNativeOutOfMemoryError(_currentThread, 0, 0);
+			goto done;
+		}
+		*value = J9VMJAVALANGINTEGER_VALUE(_currentThread, vararg);
+
+		*varargValue = value;
+		typeFFI = &ffi_type_sint32;
+	} else if (varargClass == J9VMJAVALANGDOUBLE_OR_NULL(_vm)) {
+
+		U_64 *value = (U_64 *)j9mem_allocate_memory(sizeof(U_64), OMRMEM_CATEGORY_VM);
+		if (NULL == value) {
+			setNativeOutOfMemoryError(_currentThread, 0, 0);
+			goto done;
+		}
+		*value = J9VMJAVALANGDOUBLE_VALUE(_currentThread, vararg);
+
+		*varargValue = value;
+		typeFFI = &ffi_type_double;
+	} else if (varargClass == J9VMJAVALANGCHARACTER_OR_NULL(_vm)) {
+
+		char *value = (char *)j9mem_allocate_memory(sizeof(char), OMRMEM_CATEGORY_VM);
+		if (NULL == value) {
+			setNativeOutOfMemoryError(_currentThread, 0, 0);
+			goto done;
+		}
+		*value = J9VMJAVALANGCHARACTER_VALUE(_currentThread, vararg);
+
+		*varargValue = value;
+		typeFFI = &ffi_type_uint16;
+	} else {
+		Assert_VM_unreachable();
+	}
+
+done:
+	return typeFFI;
+}
+
 ffi_type**
 FFITypeHelpers::getStructFFITypeElements(char **layout, bool inPtr)
 {

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -256,6 +256,16 @@ doneGetArrayFFIType:
 	}
 
 	/**
+	 * @brief Convert argument or return type from J9Class to ffi_type for varargs.
+	 * Only primitive types are currently supported.
+	 * @param vararg[in] An object containing a vararg argument.
+	 * @param varargValue[in] A pointer that will store the value of the vararg argument.
+	 * @return The pointer to the ffi_type corresponding to the J9Class of the vararg argument.
+	 */
+	ffi_type*
+	getFFITypeVararg(j9object_t vararg, void **varagValue);
+
+	/**
 	 * @brief Create an array of elements for a custom FFI type
 	 * @param layout[in] A pointer to a c string describing the types of the struct elements
 	 * @param inPtr[in] Describes whether the current symbols are in a pointer

--- a/runtime/vm/MHInterpreter.hpp
+++ b/runtime/vm/MHInterpreter.hpp
@@ -36,6 +36,9 @@
 #include "FFITypeHelpers.hpp"
 #include "ObjectAllocationAPI.hpp"
 #include "ObjectAccessBarrierAPI.hpp"
+#ifdef J9VM_OPT_PANAMA
+#include "FFITypeHelpers.hpp"
+#endif /* J9VM_OPT_PANAMA */
 
 typedef struct ClassCastExceptionData {
 	J9Class * currentClass;
@@ -585,7 +588,10 @@ foundITable:
 #ifdef J9VM_OPT_PANAMA
 	VMINLINE VM_BytecodeAction
 	runNativeMethodHandle(j9object_t methodHandle);
-	
+
+	VMINLINE FFI_Return
+	nativeMethodHandleVarargCallout(void *function, UDATA *javaArgs, U_8 *returnType, j9object_t methodHandle, void *returnStorage, UDATA *structSize);
+
 	VMINLINE FFI_Return
 	callFunctionFromNativeMethodHandle(void * nativeMethodStartAddress, UDATA *javaArgs, U_8 *returnType, j9object_t methodHandle);
 


### PR DESCRIPTION
Enable use of varargs for panama native calls

Only primitives are currently supported.

Signed-off-by: amarsingh0 <Amarpreet.A.Singh@ibm.com>