### PR TITLE
Automatic clearing of phantom references in Java 9

### DIFF
--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -28,6 +28,7 @@
 #include "j9cp.h"
 #include "j9modron.h"
 #include "j9nongenerated.h"
+#include "j2sever.h"
 #include "omrcomp.h"
 #include "omrsrp.h"
 
@@ -561,7 +562,9 @@ MM_MarkingDelegate::processReferenceList(MM_EnvironmentBase *env, MM_HeapRegionD
 
 				referenceStats->_cleared += 1;
 
-				if (J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) {
+				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
+				J9JavaVM * javaVM = (J9JavaVM*)env->getLanguageVM();
+				if ((J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) && ((J2SE_VERSION(javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
 					_markingScheme->fixupForwardedSlot(&referentSlotObject);
 					referent = referentSlotObject.readReferenceFromSlot();
 

--- a/runtime/gc_glue_java/ScavengerRootClearer.cpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "j9cfg.h"
+#include "j2sever.h"
 #include "ModronAssertions.h"
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
@@ -75,8 +76,10 @@ MM_ScavengerRootClearer::processReferenceList(MM_EnvironmentStandard *env, MM_He
 
 				referenceStats->_cleared += 1;
 
-				if (J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) {
-					/* Phantom objects keep their referent - scanning will be done after the enqueuing */
+				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
+				J9JavaVM * javaVM = (J9JavaVM*)env->getLanguageVM();
+				if ((J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) && ((J2SE_VERSION(javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+					/* Scanning will be done after the enqueuing */
 					_scavenger->copyObjectSlot(env, &referentSlotObject);
 				} else {
 					referentSlotObject.writeReferenceToSlot(NULL);

--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "j9.h"
+#include "j2sever.h"
 #include "modron.h"
 
 #include "ArrayletObjectModel.hpp"
@@ -1208,8 +1209,9 @@ MM_RealtimeMarkingScheme::processReferenceList(MM_EnvironmentRealtime *env, MM_H
 
 				referenceStats->_cleared += 1;
 
-				if (J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) {
-					/* Phantom objects keep their referent - scanning will be done after the enqueuing */
+				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
+				if ((J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+					/* Scanning will be done after the enqueuing */
 					markObject(env, referent);
 				} else {
 					referentSlotObject.writeReferenceToSlot(NULL);

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -25,6 +25,7 @@
 #include "j9cfg.h"
 #include "j9protos.h"
 #include "j9consts.h"
+#include "j2sever.h"
 #include "modronopt.h"
 #include "ModronAssertions.h"
 
@@ -5103,8 +5104,9 @@ MM_CopyForwardScheme::processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegi
 				referenceStats->_cleared += 1;
 				J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj) = GC_ObjectModel::REF_STATE_CLEARED;
 				
-				if (J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) {
-					/* Phantom objects keep their referent - scanning will be done after the enqueuing */
+				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
+				if ((J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+					/* Scanning will be done after the enqueuing */
 					copyAndForward(env, region->_allocateData._owningContext, referenceObj, &referentSlotObject);
 					if (GC_ObjectModel::REF_STATE_REMEMBERED == previousState) {
 						Assert_MM_true(NULL != env->_cycleState->_externalCycleState);

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -26,6 +26,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
+#include "j2sever.h"
 #include "ModronAssertions.h"
 
 #include <string.h>
@@ -1670,8 +1671,9 @@ MM_GlobalMarkingScheme::processReferenceList(MM_EnvironmentVLHGC *env, J9Object*
 				referenceStats->_cleared += 1;
 				J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj) = GC_ObjectModel::REF_STATE_CLEARED;
 
-				if (J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) {
-					/* Phantom objects keep their referent - scanning will be done after the enqueuing */
+				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
+				if ((J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+					/* Scanning will be done after the enqueuing */
 					markObject(env, referent);
 					_interRegionRememberedSet->rememberReferenceForMark(env, referenceObj, referent);
 				} else {

--- a/runtime/gc_vlhgc/PartialMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.cpp
@@ -26,6 +26,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
+#include "j2sever.h"
 #include "ModronAssertions.h"
 
 #include <string.h>
@@ -1784,8 +1785,9 @@ MM_PartialMarkingScheme::processReferenceList(MM_EnvironmentVLHGC *env, J9Object
 				referenceStats->_cleared += 1;
 				J9GC_J9VMJAVALANGREFERENCE_STATE(env, referenceObj) = GC_ObjectModel::REF_STATE_CLEARED;
 
-				if (J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) {
-					/* Phantom objects keep their referent - scanning will be done after the enqueuing */
+				/* Phantom references keep it's referent alive in Java 8 and doesn't in Java 9 and later */
+				if ((J9_JAVA_CLASS_REFERENCE_PHANTOM == referenceObjectType) && ((J2SE_VERSION(_javaVM) & J2SE_VERSION_MASK) <= J2SE_18)) {
+					/* Scanning will be done after the enqueuing */
 					markObject(env, referent);
 					_interRegionRememberedSet->rememberReferenceForMark(env, referenceObj, referent);
 					if (GC_ObjectModel::REF_STATE_REMEMBERED == previousState) {


### PR DESCRIPTION
Phantom references use to keep referent alive forever. This behavior is
changed in Java 9:

This enhancement changes phantom references to be automatically cleared
by the garbage collector as soft and weak references. 
 
 An object becomes phantom reachable after it has been finalized. This
change may cause the phantom reachable objects to be GC'ed earlier -
previously the referent is kept alive until PhantomReference objects are
GC'ed. This potential behavioral change might only impact existing code
that would depend on PhantomReference being enqueued rather than when
the referent be freed from the heap. 

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>