### PR TITLE
Solve pending push liveness in IlGen

### DIFF
--- a/runtime/tr.source/trj9/compile/J9Compilation.cpp
+++ b/runtime/tr.source/trj9/compile/J9Compilation.cpp
@@ -1183,6 +1183,17 @@ J9::Compilation::addClassForOSRRedefinition(TR_OpaqueClassBlock *clazz)
    _classForOSRRedefinition.add(clazz);
    }
 
+/*
+ * Controls if pending push liveness is stashed during IlGen to reduce OSRLiveRange
+ * overhead.
+ */
+bool
+J9::Compilation::pendingPushLivenessDuringIlgen()
+   {
+   static bool enabled = (feGetEnv("TR_DisablePendingPushLivenessDuringIlGen") == NULL);
+   return enabled;
+   }
+
 bool
 J9::Compilation::supportsQuadOptimization()
    {

--- a/runtime/tr.source/trj9/compile/J9Compilation.hpp
+++ b/runtime/tr.source/trj9/compile/J9Compilation.hpp
@@ -164,6 +164,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool isJProfilingCompilation();
 
+   bool pendingPushLivenessDuringIlgen();
+
    TR::list<TR_MethodValueProfileInfo*> &getMethodVPInfos() { return _methodVPInfoList; }
    TR::list<TR_MethodValueProfileInfo*> &getMethodHWVPInfos() { return _methodHWVPInfoList; }
 

--- a/runtime/tr.source/trj9/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/tr.source/trj9/ilgen/J9ByteCodeIlGenerator.hpp
@@ -261,6 +261,9 @@ private:
    // Dynamic Loop Transfer
    void         genDLTransfer(TR::Block *);
 
+   // OSR
+   void stashPendingPushLivenessForOSR(int32_t offset = 0);
+
    void inlineJitCheckIfFinalizeObject(TR::Block *);
 
    // support for dual symbols, to generate adjunct symbol of the dual


### PR DESCRIPTION
OSRLiveRangeAnalysis will perform structural
analysis and liveness analysis during IlGenOpts
for every generated method, which can be costly.
To reduce or avoid that overhead, pending push
liveness can be estimated during IlGen, based on the
Walker's stack contents.