### PR TITLE
Initial commit for Line Endings Check

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -55,6 +55,11 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
 
 **Note:** Dependent changes can only be requested from an OpenJ9 Pull Request
 
+##### Other Pull Requests builds
+
+- To trigger a Line Endings Check
+   - `Jenkins line endings check`
+
 ### Overview of Builds
 
 #### Build
@@ -180,6 +185,14 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
         - Compile and Sanity tests on linux_ppc-64_cmprssptrs_le
     - Trigger:
         - Github PR comment `Jenkins test sanity`
+
+- PullRequest-LineEndingsCheck
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=PullRequest-LineEndingsCheck)](https://ci.eclipse.org/openj9/job/PullRequest-LineEndingsCheck)
+    - Description:
+        - Checks the files modified in a pull request have correct line endings
+    - Trigger:
+        - Automatically builds on every PR
+        - Retrigger with `Jenkins line endings check`
 
 #### Test
 

--- a/buildenv/jenkins/lineEndingsCheck
+++ b/buildenv/jenkins/lineEndingsCheck
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+Boolean FAIL = false
+String SRC_REPO = 'https://github.com/eclipse/openj9.git'
+String[] BAD_FILES
+String HASH = '#'
+String HASHES = '###################################'
+
+stage('Line Endings Check') {
+    node ('master') {
+        timestamps {
+            git url: SRC_REPO
+            sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
+            sh "git checkout --detach ${sha1}"
+            sh 'git fetch origin'
+            FILES = sh (
+                script: "git diff --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
+                returnStdout: true
+            ).trim()
+            echo FILES
+            def FILES_LIST = FILES.split("\\r?\\n")
+            FILES_LIST.each() {
+                println "Checking file: '${it}'"
+                TYPE = sh (
+                    script: "file -b '${it}'",
+                    returnStdout: true
+                ).trim()
+
+                switch (TYPE) {
+                    case ~/empty/:
+                        echo "Empty file: '${it}'"
+                        break
+                    case ~/.*text.*/:
+                        switch (it.toLowerCase()) {
+                            case ~/.*\.bat|.*\.cmd/:
+                                switch(TYPE) {
+                                    case ~/.*CRLF line terminators.*/:
+                                        echo "Good windows script: '${it}' type: '${TYPE}'"
+                                        break
+                                    default:
+                                        echo "ERROR - should have CRLF line terminators: '${it}' type: '${TYPE}'"
+                                        FAIL = true
+                                        BAD_FILES << new String("${it}")
+                                }
+                            default:
+                                switch (TYPE) {
+                                    case ~/.*CR.* line terminators.*/:
+                                        echo "ERROR - should have LF line terminators: '${it}' type: '${TYPE}'"
+                                        FAIL = true
+                                        BAD_FILES << new String("${it}")
+                                        break
+                                    default:
+                                        echo "Good text file: '${it}' type: '${TYPE}'"
+                                        break
+                                }
+                        }
+                    default:
+                        echo "Non-text file: '${it}' type: '${TYPE}'"
+                }
+            }
+            if (FAIL) {
+                echo "${HASHES}"
+                echo "${HASH}"
+                echo "${HASH} The following files were modified and have incorrect line endings"
+                BAD_FILES.each() {
+                    echo "# ${it}"
+                }
+                echo "${HASH}"
+                echo "${HASHES}"
+                sh 'exit 1'
+            } else {
+                echo "All modified files appear to have correct line endings"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Get list of added, copied, modified files
- For each file, check type
- Check text files for LF/CRLF line endings depending on extension
- bat/cmd must have CRLF all others must have LF
- Collect files that do not pass check and print at end of run
- Fail if at least 1 file fails check

[skip ci]

Fixes Issue #63

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>