### PR TITLE
Use CHelper Linkage to call JIT Profiler functions

### DIFF
--- a/runtime/tr.source/trj9/optimizer/JitProfiler.cpp
+++ b/runtime/tr.source/trj9/optimizer/JitProfiler.cpp
@@ -248,12 +248,11 @@ TR::Block *TR_JitProfiler::createProfilingBlocks(TR::Node *profilingNode, TR::Bl
    TR::Node *vmThread = TR::Node::createWithSymRef(profilingNode, TR::loadaddr, 0, new (trHeapMemory()) TR::SymbolReference(getSymRefTab(), TR::RegisterMappedSymbol::createMethodMetaDataSymbol(trHeapMemory(),"vmThread")));
 
    TR::SymbolReference *parser = getSymRefTab()->findOrCreateRuntimeHelper(TR_jitProfileParseBuffer, false, false, true);
-#if defined(TR_TARGET_X86)
-   parser->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
-#else
+#ifndef TR_TARGET_X86
    parser->getSymbol()->castToMethodSymbol()->setPreservesAllRegisters();
-   parser->getSymbol()->castToMethodSymbol()->setSystemLinkageDispatch();
 #endif
+   parser->getSymbol()->castToMethodSymbol()->setSystemLinkageDispatch();
+
    TR::Node *parserCall = TR::Node::createWithSymRef(profilingNode, TR::call, 1, parser);
    parserCall->setAndIncChild(0, vmThread);
 

--- a/runtime/tr.source/trj9/runtime/J9Profiler.cpp
+++ b/runtime/tr.source/trj9/runtime/J9Profiler.cpp
@@ -33,7 +33,7 @@
 #include "control/OptionsUtil.hpp"
 #include "control/Options_inlines.hpp"            // for TR::Options, etc
 #include "control/Recompilation.hpp"              // for TR_Recompilation, etc
-#include "control/RecompilationInfo.hpp"              // for TR_Recompilation, etc
+#include "control/RecompilationInfo.hpp"          // for TR_Recompilation, etc
 #include "env/IO.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/PersistentInfo.hpp"                 // for PersistentInfo
@@ -818,11 +818,12 @@ TR_ValueProfiler::addProfilingTrees(
    TR::SymbolReference *profiler = comp()->getSymRefTab()->findOrCreateRuntimeHelper
       ((node->getDataType() == TR::Address? ( decrementRecompilationCounter ? TR_jitProfileWarmCompilePICAddress : (doBigDecimalProfiling ? TR_jitProfileBigDecimalValue : (doStringProfiling ? TR_jitProfileStringValue : TR_jitProfileAddress))) : (node->getType().isInt64() ? TR_jitProfileLongValue : TR_jitProfileValue)),
        false, false, true);
-
-#if defined(TR_TARGET_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_ARM)
+#if defined(TR_HOST_POWER) || defined(TR_HOST_ARM)
    profiler->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
 #else
+#ifndef TR_HOST_X86
    profiler->getSymbol()->castToMethodSymbol()->setPreservesAllRegisters();
+#endif
    profiler->getSymbol()->castToMethodSymbol()->setSystemLinkageDispatch();
 #endif
 

--- a/runtime/tr.source/trj9/runtime/JitRuntime.cpp
+++ b/runtime/tr.source/trj9/runtime/JitRuntime.cpp
@@ -342,7 +342,7 @@ void induceRecompilation_unwrapper(void **argsPtr, void **resultPtr)
 extern "C" {
 
 
-void _jitProfileParseBuffer(uintptrj_t vmThread)
+void J9FASTCALL _jitProfileParseBuffer(uintptrj_t vmThread)
    {
    J9VMThread *currentThread = (J9VMThread *)vmThread;
    J9JITConfig * jitConfg = currentThread->javaVM->jitConfig;
@@ -370,7 +370,7 @@ void _jitProfileParseBuffer(uintptrj_t vmThread)
 
 extern "C" {
 
-void _jitProfileWarmCompilePICAddress(uintptrj_t address, TR_WarmCompilePICAddressInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
+void J9FASTCALL _jitProfileWarmCompilePICAddress(uintptrj_t address, TR_WarmCompilePICAddressInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
    {
    if (recompilationCounter)
       {
@@ -405,7 +405,7 @@ void _jitProfileWarmCompilePICAddress(uintptrj_t address, TR_WarmCompilePICAddre
    return;
 }
 
-void _jitProfileAddress(uintptrj_t value, TR_AddressInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
+void J9FASTCALL _jitProfileAddress(uintptrj_t value, TR_AddressInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
    {
    if (recompilationCounter)
       {
@@ -461,7 +461,7 @@ void _jitProfileAddress(uintptrj_t value, TR_AddressInfo *info, int32_t maxNumVa
 
 
 extern "C" {
-void _jitProfileLongValue(uint64_t value, TR_LongValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
+void J9FASTCALL _jitProfileLongValue(uint64_t value, TR_LongValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
    {
    if (recompilationCounter)
       {
@@ -526,7 +526,7 @@ void _jitProfileBigDecimalValue(uintptrj_t value, uintptrj_t bigdecimalj9class, 
     #endif
 #endif
 
-void _jitProfileBigDecimalValue(uintptrj_t value, uintptrj_t bigdecimalj9class, int32_t scaleOffset, int32_t flagOffset, TR_BigDecimalValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
+void J9FASTCALL _jitProfileBigDecimalValue(uintptrj_t value, uintptrj_t bigdecimalj9class, int32_t scaleOffset, int32_t flagOffset, TR_BigDecimalValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
    {
    if (recompilationCounter)
       {
@@ -610,7 +610,7 @@ void _jitProfileBigDecimalValue(uintptrj_t value, uintptrj_t bigdecimalj9class, 
 
 
 extern "C" {
-void _jitProfileStringValue(uintptrj_t value, int32_t charsOffset, int32_t lengthOffset, TR_StringValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
+void J9FASTCALL _jitProfileStringValue(uintptrj_t value, int32_t charsOffset, int32_t lengthOffset, TR_StringValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
    {
 
    // charsOffset is the offset to the 'value' field in a String object relative to the start of the object.
@@ -714,7 +714,7 @@ void _jitProfileStringValue(uintptrj_t value, int32_t charsOffset, int32_t lengt
 }
 
 extern "C" {
-void _jitProfileValue(uint32_t value, TR_ValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
+void J9FASTCALL _jitProfileValue(uint32_t value, TR_ValueInfo *info, int32_t maxNumValuesProfiled, int32_t *recompilationCounter)
    {
 
    if (info->getMaxValue() > value)
@@ -1173,6 +1173,15 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileLongValue,                  (void *)_jitProfileLongValueWrap,         TR_Helper);
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValueWrap,   TR_Helper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValueWrap,       TR_Helper);
+   SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_Helper);
+#elif defined(TR_HOST_X86)
+   SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_CHelper);
+   SET(TR_jitProfileAddress,                    (void *)_jitProfileAddress,               TR_CHelper);
+   SET(TR_jitProfileValue,                      (void *)_jitProfileValue,                 TR_CHelper);
+   SET(TR_jitProfileLongValue,                  (void *)_jitProfileLongValue,             TR_CHelper);
+   SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValue,       TR_CHelper);
+   SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValue,           TR_CHelper);
+   SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_CHelper);
 #else
    SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_Helper);
    SET(TR_jitProfileAddress,                    (void *)_jitProfileAddress,               TR_Helper);
@@ -1180,10 +1189,10 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileLongValue,                  (void *)_jitProfileLongValue,             TR_Helper);
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValue,       TR_Helper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValue,           TR_Helper);
+   SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_Helper);
 #endif // TR_HOST_S390
 #endif // TR_HOST_POWER
 
-   SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer, TR_Helper);
 #if defined(J9ZOS390)
    SET_CONST(TR_prepareForOSR,                  (void *)_prepareForOSR);
 #else


### PR DESCRIPTION
JIT Profiler functions are C functions; and hence can be called
via CHelper Linkage. CHelper Linkage has less overhead comparing
to System Linkage.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>