### PR TITLE
Update to for changes coming in OMR PR1764

### DIFF
--- a/runtime/oti/j9comp.h
+++ b/runtime/oti/j9comp.h
@@ -26,5 +26,8 @@
 #include "omrcomp.h"
 
 #define J9_GET_CALLSITE() OMR_GET_CALLSITE()
+#define J9_ARE_ANY_BITS_SET(value, bits) OMR_ARE_ANY_BITS_SET((value), (bits))
+#define J9_ARE_ALL_BITS_SET(value, bits) OMR_ARE_ALL_BITS_SET((value), (bits))
+#define J9_ARE_NO_BITS_SET(value, bits) OMR_ARE_NO_BITS_SET((value), (bits))
 
 #endif /* j9comp_h */

--- a/runtime/port/zos390/j9sysinfo_helpers.c
+++ b/runtime/port/zos390/j9sysinfo_helpers.c
@@ -125,7 +125,7 @@ computeCpuTime(struct J9PortLibrary *portLibrary, int64_t *cpuTime)
 	Trc_PRT_computeCpuTime_Entered();
 
 	/* First things first: Query size of the LPDAT structure. */
-	lpdatlen = j9req_lpdatlen();
+	lpdatlen = omrreq_lpdatlen();
 	if (lpdatlen < 0) {
 		/* The query failed!! */
 		Trc_PRT_computeCpuTime_unexpectedLPDataBuffSz(lpdatlen);
@@ -146,7 +146,7 @@ computeCpuTime(struct J9PortLibrary *portLibrary, int64_t *cpuTime)
 	lpdatp->length = lpdatlen;
 
 	/* We now query for the LPAR Data to obtain the CPU service units. */
-	rc = j9req_lpdat((char*)lpdatp);
+	rc = omrreq_lpdat((char*)lpdatp);
 	if (0 != rc) {
 		omrmem_free_memory(lpdatp);
 		Trc_PRT_computeCpuTime_failedRetrievingLparData(rc);

--- a/runtime/port/zos390/j9sysinfo_helpers.h
+++ b/runtime/port/zos390/j9sysinfo_helpers.h
@@ -201,10 +201,10 @@ retrieveZGuestProcessorStats(struct J9PortLibrary *portLibrary, struct J9GuestPr
 }
 #endif /* __cplusplus */
 
-#pragma linkage(j9req_lpdatlen, OS_NOSTACK)
-#pragma linkage(j9req_lpdat, OS_NOSTACK)
+#pragma linkage(omrreq_lpdatlen, OS_NOSTACK)
+#pragma linkage(omrreq_lpdat, OS_NOSTACK)
 
-extern int j9req_lpdatlen(void);
-extern int j9req_lpdat(char* bufp);
+extern int omrreq_lpdatlen(void);
+extern int omrreq_lpdat(char* bufp);
 
 #endif /* SYSINFO_HELPERS_H_ */


### PR DESCRIPTION
This change provides defines for macros that were renamed in OMR and also changes function calls to the new names used in OMR.

This change is dependent on eclipse/omr#1764 and should only be merged once the OMR PR is merged.