### PR TITLE
Link to C++ library statically on some platforms

### DIFF
--- a/runtime/tr.source/trj9/build/toolcfg/gnu/common.mk
+++ b/runtime/tr.source/trj9/build/toolcfg/gnu/common.mk
@@ -453,7 +453,8 @@ endif
 
 SOLINK_EXTRA_ARGS+=-Wl,--version-script=$(SOLINK_VERSION_SCRIPT)
 
-ifeq ($(LIBCXX_STATIC),1)
+SUPPORT_STATIC_LIBCXX = $(shell $(SOLINK_CMD) -static-libstdc++ 2>&1 | grep "unrecognized option" > /dev/null; echo $$?)
+ifneq ($(SUPPORT_STATIC_LIBCXX),0)
     SOLINK_FLAGS+=-static-libstdc++
 endif
 


### PR DESCRIPTION
JIT on a platform that use GNU toolchain now link to libstdc++ statically.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>