### PR TITLE
migrate classesdbgddrext test to openj9 repo

### DIFF
--- a/test/cmdLineTests/classesdbgddrext/build.xml
+++ b/test/cmdLineTests/classesdbgddrext/build.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests classesddrtests
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/cmdLineTests/classesdbgddrext" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml,*.jar"/>
+			<fileset dir="${src}" includes="*.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/cmdLineTests/classesdbgddrext/classesddrtests.xml
+++ b/test/cmdLineTests/classesdbgddrext/classesddrtests.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 shared cache dbgext Tests" timeout="600">
+
+ <variable name="CP" value="-cp $UTILSJAR$" />
+ <variable name="PROGRAM" value="org.openj9.test.ivj.Hanoi 2" />
+ <variable name="CACHENAME" value="shareddbgext" />
+ <variable name="DUMPFILE" value="j9core.dmp" />
+ <variable name="DUMPDIR" value="dumpdir" />
+ <variable name="XDUMP" value="-Xdump:system:file=$DUMPFILE$,events=vmstop" />
+
+ <!-- override the JDMPVIEW_EXE command on win32 since jdmpview.exe is failing on Windows XP - CMVC 200287 -->
+ <variable name="JDMPVIEW_EXE" value="$EXE$ com.ibm.jvm.dtfjview.DTFJView" platforms="win_x86-32" />
+
+ <!-- override the -Xdump command on z/OS -->
+ <variable name="XDUMP" value="-Xdump:system:opts=IEATDUMP,dsn=%uid.J9CORE.DMP,events=vmstop,request=exclusive+compact" platforms="zos.*" />
+
+ <test id="Create new shared cache with partition">
+  <command>$EXE$ -Xaot:forceaot,count=0,disableAsyncCompilation -Xshareclasses:name=$CACHENAME$,reset,modified=mod1</command>
+  <output regex="no" type="success">Usage:</output>
+ </test>
+
+ <test id="Create core file">
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+  <exec command="rm -f $DUMPFILE$" />
+  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <output regex="no" type="success">Moved disk 0 to 1</output>
+  <output regex="no" type="success">System dump written</output>
+  <!-- check for unexpected core dumps -->
+  <output regex="no" type="failure">0001.dmp</output>
+ </test>
+
+ <test id="Remove shared cache">
+  <command>$EXE$ -Xshareclasses:name=$CACHENAME$,destroy</command>
+  <output regex="no" type="success">destroyed</output>
+ </test>
+
+ <test id="Run !allclasses">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!allclasses</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">java/lang/Object</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">unable to read</output>
+  <output regex="no" type="failure">could not read</output>
+  <output regex="no" type="failure">dump event</output>
+ </test>
+
+ <test id="Run !dumpallromclasslinear 10"  timeout="1200">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!dumpallromclasslinear 10</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">java/lang/Object</output>
+  <output regex="no" type="required">!dumpromclasslinear</output>
+  <output regex="no" type="required">ROM Class</output>
+  <output regex="no" type="required">romHeader</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">unable to read</output>
+  <output regex="no" type="failure">could not read</output>
+  <output regex="no" type="failure">dump event</output>
+ </test>
+
+ <test id="Run !dumpallramclasslinear 10">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!dumpallramclasslinear 10</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">java/lang/Object</output>
+  <output regex="no" type="required">!dumpramclasslinear</output>
+  <output regex="no" type="required">RAM Class</output>
+  <output regex="no" type="required">ramHeader</output>
+  <output regex="no" type="required">RAM methods</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">unable to read</output>
+  <output regex="no" type="failure">could not read</output>
+  <output regex="no" type="failure">dump event</output>
+ </test>
+
+ <test id="Run !romclasssummary">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!romclasssummary</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">classes, using:</output>
+  <output regex="no" type="required">romHeader</output>
+  <output regex="no" type="required">fields</output>
+  <output regex="no" type="required">interfacesSRPs</output>
+  <output regex="no" type="required">innerClassesSRPs</output>
+  <output regex="no" type="required">cpNamesAndSignaturesSRPs</output>
+  <output regex="no" type="required">methods</output>
+  <output regex="no" type="required">cpShapeDescription</output>
+  <output regex="no" type="required">enclosingObject</output>
+  <output regex="no" type="required">optionalInfo</output>
+  <output regex="no" type="required">Padding</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">unable to read</output>
+  <output regex="no" type="failure">could not read</output>
+  <output regex="no" type="failure">dump event</output>
+ </test>
+
+ <test id="Run !ramclasssummary">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!ramclasssummary</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">jitVTables</output>
+  <output regex="no" type="required">ramHeader</output>
+  <output regex="no" type="required">vTable</output>
+  <output regex="no" type="required">RAM methods</output>
+  <output regex="no" type="required">Constant Pool</output>
+  <output regex="no" type="required">J9CPTYPE_CLASS</output>
+  <output regex="no" type="required">J9CPTYPE_FLOAT</output>
+  <output regex="no" type="required">J9CPTYPE_INT</output>
+  <output regex="no" type="required">J9CPTYPE_INTERFACE_METHOD</output>
+  <output regex="no" type="required">J9CPTYPE_STATIC_METHOD</output>
+  <output regex="no" type="required">J9CPTYPE_STRING</output>
+  <output regex="no" type="required">J9CPTYPE_UNUSED</output>
+  <output regex="no" type="required">Ram static</output>
+  <output regex="no" type="required">Superclasses</output>
+  <output regex="no" type="required">iTable</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">unable to read</output>
+  <output regex="no" type="failure">could not read</output>
+  <output regex="no" type="failure">dump event</output>
+ </test>
+
+
+</suite>
+
+

--- a/test/cmdLineTests/classesdbgddrext/dbgextddrtests_excludes.xml
+++ b/test/cmdLineTests/classesdbgddrext/dbgextddrtests_excludes.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+
+<suite id="J9 shared cache dbgext Tests">
+
+<!-- Define all the platforms that are supported by the J9 VM-->
+<!--none --> <platform id="none"/>
+<!--all --> <platform id="all"/>
+<!--j2se --> <platform id="j2se"/>
+<!--AIX --> <platform id="aix_ppc-32"/>
+<!--AIX64 --> <platform id="aix_ppc-64"/>
+<!--Linux Hammer --> <platform id="linux_x86-64"/>
+<!--Linux IA32 --> <platform id="linux_x86-32"/>
+<!--Linux PPC --> <platform id="linux_ppc-32"/>
+<!--Linux PPC 64bit --> <platform id="linux_ppc-64"/>
+<!--Linux S390 --> <platform id="linux_390-31"/>
+<!--Linux S390 64bit --> <platform id="linux_390-64"/>
+<!--Linux IA32 Realtime --> <platform id="linux_x86_rtj"/>
+<!--Win64 Hammer --> <platform id="win_x86-64"/>
+<!--Windows IA32 --> <platform id="win_x86-32"/>
+<!--z/OS S390 64bit JIT Modron --> <platform id="zos_390-64"/>
+<!--z/OS S390 JIT Modron --> <platform id="zos_390-31"/>
+
+</suite>
+

--- a/test/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/cmdLineTests/classesdbgddrext/playlist.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_classesdbgddrext_zos</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
+	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
+	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
+	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>os.zos</platformRequirements>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_classesdbgddrext</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
+	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
+	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
+	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>^os.zos,^os.zos</platformRequirements>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_classesdbgddrext_aix</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl aix ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
+	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
+	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
+	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<platformRequirements>os.aix</platformRequirements>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
+
+</playlist>


### PR DESCRIPTION
* migrate cmdline classesdbgddrext test to openj9 repo
* remove `-Xint` option which only applied to cmdline test framework
* add `-Xmx1G` to ensure there will be no OOM exception

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>