### PR TITLE
Jenkins copyright checks

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -60,6 +60,9 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
 - To trigger a Line Endings Check
    - `Jenkins line endings check`
 
+- To trigger a Copyright Check
+   - `Jenkins copyright check`
+
 ### Overview of Builds
 
 #### Build
@@ -193,6 +196,14 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - Trigger:
         - Automatically builds on every PR
         - Retrigger with `Jenkins line endings check`
+
+- PullRequest-CopyrightCheck/badge
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=PullRequest-CopyrightCheck)](https://ci.eclipse.org/openj9/job/PullRequest-CopyrightCheck)
+    - Description:
+        - Checks the files modified in a pull request have copyright with current year
+    - Trigger:
+        - Automatically builds on every PR
+        - Retrigger with `Jenkins copyright check`
 
 #### Test
 

--- a/buildenv/jenkins/copyrightCheck
+++ b/buildenv/jenkins/copyrightCheck
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+Boolean FAIL = false
+String SRC_REPO = 'https://github.com/eclipse/openj9.git'
+def BAD_FILES = []
+String HASHES = '###################################'
+
+stage('Copyright Check') {
+    node ('master') {
+        timestamps {
+            git url: SRC_REPO
+            sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
+            sh "git checkout --detach ${sha1}"
+            sh 'git fetch origin'
+            FILES = sh (
+                script: "git diff --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
+                returnStdout: true
+            ).trim()
+            echo FILES
+            def FILES_LIST = FILES.split("\\r?\\n")
+            DATE_YEAR = sh (
+                script: "date +%Y",
+                returnStdout: true
+            ).trim()
+            FILES_LIST.each() {
+                println "Checking file: '${it}'"
+                RESULT = sh (
+                    script: "grep -qE 'Copyright \\(c\\) ([0-9]{4}), ${DATE_YEAR} IBM Corp. and others' '${it}'",
+                    returnStatus: true)
+                if(RESULT != 0) {
+                    echo "FAILURE - Copyright date in file: '${it}' appears to be incorrect"
+                    FAIL = true
+                    BAD_FILES << "${it}"
+                } else {
+                    echo "Copyright date in file: appears to be correct"
+                }
+
+            }
+            if (FAIL) {
+                echo "${HASHES}"
+                echo "The following files were modified and have incorrect copyrights"
+                BAD_FILES.each() {
+                    echo "${it}"
+                }
+                echo "${HASHES}"
+                sh 'exit 1'
+            } else {
+                echo "All modified files appear to have correct copyrights"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Initial commit of copyrightCheck file
    
- Get list of added, copied, modified files
- For each file ensure there is a valid copyright line
- Ensure the second year matches current year
- Collect files that do not pass check and print at end of run
- Fail if at least 1 file fails check

[skip ci]

Fixes Issue #64

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>