### PR TITLE
Fix NLS message type

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1956,7 +1956,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				if (!idleGCTuningSupported) {
 					vm->vmRuntimeStateListener.idleTuningFlags &= ~(J9_IDLE_TUNING_GC_ON_IDLE | J9_IDLE_TUNING_COMPACT_ON_IDLE);
 					if (J9_IDLE_TUNING_IGNORE_UNRECOGNIZED_OPTIONS != (vm->vmRuntimeStateListener.idleTuningFlags & J9_IDLE_TUNING_IGNORE_UNRECOGNIZED_OPTIONS)) {
-						j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_IDLE_TUNING_PLATFORM_OR_GC_POLICY_NOT_SUPPORTED);
+						j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_IDLE_TUNING_PLATFORM_OR_GC_POLICY_NOT_SUPPORTED);
 						goto _error;
 					}
 				}


### PR DESCRIPTION
J9NLS_VM_IDLE_TUNING_PLATFORM_OR_GC_POLICY_NOT_SUPPORTED should be
an error instead of a warning as it causes JVM to exit.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>