### PR TITLE
Get correct caller method in realEstimateCodeSize

### DIFF
--- a/runtime/tr.source/trj9/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/tr.source/trj9/optimizer/J9EstimateCodeSize.cpp
@@ -1337,7 +1337,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          callGraphEnabled = false; // TODO: Work out why this doesn't function properly on subsequent passes
       if (callGraphEnabled && recurseDown)
          {
-         TR_OpaqueMethodBlock *method = prevCallStack->_method->getPersistentIdentifier();
+         TR_OpaqueMethodBlock *method = calltarget->_myCallSite->_callerResolvedMethod->getPersistentIdentifier();
          uint32_t bcIndex = calltarget->_myCallSite->_bcInfo.getByteCodeIndex();
          int32_t callCount = profileManager->getCallGraphProfilingCount(method,
                bcIndex, comp());


### PR DESCRIPTION
In a pass of targeted inliner after the first, the method
on top of the callStack is not the immediate caller. The
correct way of getting the caller method is from the
'_callerResolvedMethod' of the call site object.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>