### PR TITLE
Use VMSupport to get attach API localConnectorAddress

### DIFF
--- a/test/TestConfig/resources/excludes/openj9_exclude.txt
+++ b/test/TestConfig/resources/excludes/openj9_exclude.txt
@@ -58,5 +58,4 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generi
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
-org.openj9.test.attachAPI.TestManagementAgent:test_startLocalManagementAgent											241 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all


### PR DESCRIPTION
Java 9 moved this property from the System properties to another Properties
object.  Use the new API VMSupport.getAgentProperties() to get this property.

Fixes #386

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>