### PR TITLE
Root the J9DRRStructTableGC friend decl

### DIFF
--- a/runtime/gc_ddr/gc_xlat.sed
+++ b/runtime/gc_ddr/gc_xlat.sed
@@ -24,10 +24,12 @@
 s/[^[:print:][:blank:]]$//
 1i\
 /* Preprocessed to add J9DDRStructTableGC as a friend. Do not edit this version! */
+1i\
+class J9DDRStructTableGC;
 s/class .*{$/&\
-        friend class J9DDRStructTableGC;/
+        friend class ::J9DDRStructTableGC;/
 /class .*[^;{]$/{
         N
         s/^\(.*\n{.*\)$/\1\
-        friend class J9DDRStructTableGC;/
+        friend class ::J9DDRStructTableGC;/
 }


### PR DESCRIPTION
We need to ensure we are always friending the correct class. The
J9DDRStructTableGC class is defined in the root namespace. When we start
to use the OMR::GC namespace, the friend declaration no longer
references the correct DDR class.

Signed-off-by: Robert Young <rwy0717@gmail.com>