### PR TITLE
Remove tools_vm.jar

### DIFF
--- a/jcl/j9modules.xml
+++ b/jcl/j9modules.xml
@@ -46,10 +46,6 @@
 					</fileset>
 				</delete>
 			</case>
-			<case value="jdk.attach">
-				<removeexport package="com.ibm.tools.attach.spi" />
-				<removeprovides interface="com.sun.tools.attach.spi.AttachProvider" />
-			</case>
 			<case value="java.base">
 				<removeexport package="com.ibm.cuda" />
 				<removeexport package="com.ibm.dataaccess" />

--- a/jcl/jcl_build.mk
+++ b/jcl/jcl_build.mk
@@ -201,10 +201,6 @@ ifeq ($(JPP_CONFIG), SIDECAR18-SE)
 	cd "$(PCONFIG_DIR)/manifest" $(AND_THEN) zip -D "$(DEST_DIR)/classes-vm.zip" "META-INF/MANIFEST.MF"
 endif
 	cd "$(PCONFIG_DIR)/bin" $(AND_THEN) zip -r "$(DEST_DIR)/classes-vm.zip" $(DASH_U)  . -x "*/java/lang/System\$$Logger*" -x "com/ibm/tools/attach/attacher*"
-# TODO: delete this: attach_class_hack
-ifeq ($(JPP_CONFIG), SIDECAR18-SE)
-	cd "$(PCONFIG_DIR)/bin" $(AND_THEN) zip -r "$(DEST_DIR)/tools_vm.zip"    "com/ibm/tools/attach/attacher"
-endif
 
 	mkdir -p "$(RAS_BINARIES_DIR)"
 ifeq ($(JPP_CONFIG), SIDECAR18-DTFJ)


### PR DESCRIPTION
This file was used to fix up the result of a legacy configuration
of attach API.

attach_class_hack

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>