### PR TITLE
 Add support for 64-bit synchronized field load

### DIFF
--- a/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.cpp
+++ b/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.cpp
@@ -144,7 +144,7 @@ ReduceSynchronizedFieldLoad::inlineSynchronizedFieldLoad(TR::Node* node, TR::Cod
             // This is because we must use LPDG to load a 32-bit value using displacement -4
             TR_ASSERT_SAFE_FATAL((loadMemoryReference->getOffset() & 3) == 0, "Field must be aligned on a word boundary\n");
 
-            loadRegisterRequires32BitLogicalSignExtension = true;
+            loadRegisterRequires32BitLogicalSignExtension = loadNode->getDataType().isAddress();
             alignedLoadMemoryReference = generateS390MemoryReference(*loadMemoryReference, -4, cg);
             }
          }

--- a/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.hpp
+++ b/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,27 +31,25 @@
 #include "infra/ILWalk.hpp"
 
 /** \brief
- *
- *  Reduces synchronized regions around a single field load into a codegen inlined recognized method call which
- *  generates a hardware optimized instruction sequence which is semantically equivalent to the synchronized field
- *  load.
+ *     Reduces synchronized regions around a single field load into a codegen inlined recognized method call which
+ *     generates a hardware optimized instruction sequence which is semantically equivalent to the synchronized field
+ *     load.
  *
  *  \details
+ *     This codegen phase pass pattern matches the following tree sequences (modulo NOP trees such as aRegLoad):
  *
- *  This codegen phase pass pattern matches the following tree sequences (modulo NOP trees such as aRegLoad):
+ *     \code
+ *     monent
+ *       object
+ *     aloadi / iloadi / i2a
+ *       ==> object
+ *     monexitfence
+ *     monexit
+ *       ==> object
+ *     \endcode
  *
- *  <code>
- *  monent
- *    object
- *  aloadi / iloadi / i2a
- *    ==> object
- *  monexitfence
- *  monexit
- *    ==> object
- *  </code>
- *
- *  And replaces the entire treetop sequence, excluding the monexitfence, with a call to a codegen inlined method
- *  <synchronizedFieldLoad>.
+ *     And replaces the entire treetop sequence, excluding the monexitfence, with a call to a codegen inlined method
+ *     <synchronizedFieldLoad>.
  */
 class ReduceSynchronizedFieldLoad
    {
@@ -104,47 +102,47 @@ class ReduceSynchronizedFieldLoad
    static void inlineSynchronizedFieldLoad(TR::Node* node, TR::CodeGenerator* cg);
 
    /** \brief
-    *      Performs the optimization on this compilation unit.
+    *     Performs the optimization on this compilation unit.
     *
     *  \return
-    *      true if any transformation was performed; false otherwise.
+    *     true if any transformation was performed; false otherwise.
     */
    bool perform();
 
    /** \brief
-    *      Performs the optimization on this compilation unit.
+    *     Performs the optimization on this compilation unit.
     *
     *  \param startTreeTop
-    *      The tree top on which to begin looking for opportunities to perform this optimization.
+    *     The tree top on which to begin looking for opportunities to perform this optimization.
     *
     *  \param endTreeTop
-    *      The tree top on which to end looking for opportunities to perform this optimization.
+    *     The tree top on which to end looking for opportunities to perform this optimization.
     *
     *  \return
-    *      true if any transformation was performed; false otherwise.
+    *     true if any transformation was performed; false otherwise.
     */
    bool performOnTreeTops(TR::TreeTop* startTreeTop, TR::TreeTop* endTreeTop);
 
    private:
 
    /** \brief
-    *      Advances \p iter one tree top forward, ignoring extended basic block boundaries by skipping over
-    *      <c>TR::BBStart</c> and <c>TR::BBEnd</c> nodes, and while taking into account the \p endTreeTop.
+    *     Advances \p iter one tree top forward, ignoring extended basic block boundaries by skipping over
+    *     <c>TR::BBStart</c> and <c>TR::BBEnd</c> nodes, and while taking into account the \p endTreeTop.
     *
     *  \param iter
-    *      The iterator used to look for opportunities to advance forward.
+    *     The iterator used to look for opportunities to advance forward.
     *
     *  \param endTreeTop
-    *      The tree top on which to end looking for opportunities to perform this optimization.
+    *     The tree top on which to end looking for opportunities to perform this optimization.
     *
     *  \return
-    *      True if the iterator was successfully advanced and the search for optimization opportunity should continue;
-    *      false otherwise.
+    *     true if the iterator was successfully advanced and the search for optimization opportunity should continue;
+    *     false otherwise.
     */
    bool advanceIterator(TR::TreeTopIterator& iter, TR::TreeTop* endTreeTop);
 
    /** \brief
-    *      The cached code generator used to generate the instructions.
+    *     The cached code generator used to generate the instructions.
     */
    TR::CodeGenerator * cg;
    };

--- a/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.hpp
+++ b/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.hpp
@@ -78,12 +78,12 @@ class ReduceSynchronizedFieldLoad
     *
     *     call <synchronizedFieldLoad>
     *       object
-    *       aloadi / iloadi / l2a
+    *       aloadi / iloadi / lloadi / l2a
     *       iconst
     *       call jitMonitorEntry
-    *          ==> object
+    *          ==>object
     *       call jitMonitorExit
-    *          ==> object
+    *          ==>object
     *
     *     It carries five children:
     *


### PR DESCRIPTION
Enhance ReduceSynchronizedFieldLoad with 64-bit field loading support.
This feature further improves the optimization with additional asserts
around the use of the LPDG instruction. All 8 possibilities are
considered:

1. 31-bit JVM loading a 32-bit field
2. 31-bit JVM loading a 64-bit field
3. 64-bit JVM loading a 32-bit field
4. 64-bit JVM loading a 64-bit field
5. 64-bit JVM loading a 32-bit field with a compressed lockword
6. 64-bit JVM loading a 64-bit field with a compressed lockword

Only 2. is not supported due to register pairs. The optimization will
ensure that alignment restrictions of LPD(G) are enforced in all
scenarios.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>