### PR TITLE
Use -Xint run cmdLineTester_XcheckJNI.memorycheck test

### DIFF
--- a/test/cmdLineTests/xcheckjni/xcheckjni.xml
+++ b/test/cmdLineTests/xcheckjni/xcheckjni.xml
@@ -57,7 +57,7 @@
  </test>
 
  <test id="memorycheck">
-  <command>$EXE$ $CP$ -Xcheck:jni -Xgcthreads1 -Xcheck:memory j9vm.test.jnichk.BufferOverrun</command>
+  <command>$EXE$ $CP$ -Xint -Xcheck:jni -Xgcthreads1 -Xcheck:memory j9vm.test.jnichk.BufferOverrun</command>
   <output regex="no">Memory error(s) discovered</output>
  </test>
 


### PR DESCRIPTION
Using -Xint to avoid test timeout failure
[skip ci]

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>