### PR TITLE
Clean up dumping of log files

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/attachAPI/TargetManager.java
+++ b/test/Java8andUp/src/org/openj9/test/attachAPI/TargetManager.java
@@ -25,12 +25,13 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -445,14 +446,8 @@ class TargetManager {
 			if (logName.endsWith(".log")) {
 				if (printLogs) {
 					try {
-						BufferedReader rdr = new BufferedReader(new FileReader(
-								f));
-						logger.debug("Dumping " + f.getName());
-						String l;
-						while (null != (l = rdr.readLine())) {
-							logger.debug(l);
-						}
-						rdr.close();
+						logger.debug("Log file " + f.getName()+":\n" 
+								+ (new String(Files.readAllBytes(Paths.get(f.toURI())))));
 					} catch (FileNotFoundException e) {
 						e.printStackTrace();
 					} catch (IOException e) {

--- a/test/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
+++ b/test/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
@@ -59,7 +59,7 @@ public class TestAttachAPI extends AttachApiTest {
 	final String JVMTITSTNAME = "test:gmhc001";
 	private final String DUMP_LOGS = "j9vm.test.attach.dumplogs";
 	private String myProcessId;
-	final boolean dumpLogs = getDumpLogs();
+	final boolean dumpLogs = Boolean.getBoolean(DUMP_LOGS);
 	private File commonDir;
 	@BeforeMethod
 	protected void setUp(Method testMethod) {
@@ -105,11 +105,6 @@ public class TestAttachAPI extends AttachApiTest {
 				fail("Could not initialize attach API");
 			}
 		}
-	}
-
-	private boolean getDumpLogs() {
-		String keepLogsValue = System.getProperty(DUMP_LOGS, "yes");
-		return keepLogsValue.equalsIgnoreCase("yes");
 	}
 
 	@AfterMethod


### PR DESCRIPTION
This change disables dumping of log files by default. To dump log files, set
com.ibm.tools.attach.logging=yes n the java.sidecar system property (which controls
the child process's command line) and set j9vm.test.attach.dumplogs=true in the
test process's command line.

This also updates the API used to dump the logs to reduce the number of method
calls and emit the contents of the file as a single logger entry.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>