### PR TITLE
Remove Java_com_ibm_jit_crypto_* from jithelpers uma object

### DIFF
--- a/runtime/jcl/cl_se7_basic/module.xml
+++ b/runtime/jcl/cl_se7_basic/module.xml
@@ -35,7 +35,11 @@
 	<xi:include href="../uma/se8_exports.xml"></xi:include>
 	<xi:include href="../uma/se829_exports.xml"></xi:include>
 	<xi:include href="../uma/se8only_exports.xml"></xi:include>
-	
+
+	<xi:include href="../uma/vendor_jcl_exports.xml">
+		<xi:fallback/>
+	</xi:include>
+
 	<xi:include href="../uma/sun_misc_Unsafe_objects.xml"></xi:include>	
 	<xi:include href="../uma/se6_vm-side_natives_objects.xml"></xi:include>
 	<xi:include href="../uma/se6_vm-side_lifecycle_objects.xml"></xi:include>

--- a/runtime/jcl/cl_se9/module.xml
+++ b/runtime/jcl/cl_se9/module.xml
@@ -35,7 +35,11 @@
 	<xi:include href="../uma/se8_exports.xml"></xi:include>
 	<xi:include href="../uma/se829_exports.xml"></xi:include>
 	<xi:include href="../uma/se9_exports.xml"></xi:include>
-	
+
+	<xi:include href="../uma/vendor_jcl_exports.xml">
+		<xi:fallback/>
+	</xi:include>
+
 	<xi:include href="../uma/sun_misc_Unsafe_objects.xml"></xi:include>	
 	<xi:include href="../uma/se6_vm-side_natives_objects.xml"></xi:include>
 	<xi:include href="../uma/se6_vm-side_lifecycle_objects.xml"></xi:include>

--- a/runtime/jcl/cl_se9_before_b165/module.xml
+++ b/runtime/jcl/cl_se9_before_b165/module.xml
@@ -35,7 +35,11 @@
 	<xi:include href="../uma/se8_exports.xml"></xi:include>
 	<xi:include href="../uma/se829_exports.xml"></xi:include>
 	<xi:include href="../uma/se9_exports.xml"></xi:include>
-	
+
+	<xi:include href="../uma/vendor_jcl_exports.xml">
+		<xi:fallback/>
+	</xi:include>
+
 	<xi:include href="../uma/sun_misc_Unsafe_objects.xml"></xi:include>	
 	<xi:include href="../uma/se6_vm-side_natives_objects.xml"></xi:include>
 	<xi:include href="../uma/se6_vm-side_lifecycle_objects.xml"></xi:include>

--- a/runtime/jcl/uma/jithelpers_jni_exports.xml
+++ b/runtime/jcl/uma/jithelpers_jni_exports.xml
@@ -20,34 +20,6 @@
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 <exports group="jithelpers">
-	 <export name="Java_com_ibm_jit_crypto_JITAESCryptInHardware_isAESSupportedByHardwareImpl" />
-	 <export name="Java_com_ibm_jit_crypto_JITAESCryptInHardware_expandAESKeyInHardware" />
-	 <export name="Java_com_ibm_jit_crypto_JITAESCryptInHardware_doAESInHardware" />
-
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_z_1kimd_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_z_1kimd_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_z_1klmd_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_z_1klmd_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_getCryptoHardwareFeatures" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_sha256" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_sha512" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1km_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1km_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_z_1kmac_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareDigest_z_1kmac_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmc_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmc_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmctr_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmctr_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmgcm_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmgcm_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmf_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmf_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmo_1native" />
-	 <export name="Java_com_ibm_jit_crypto_JITFullHardwareCrypt_z_1kmo_1supported" />
-	 <export name="Java_com_ibm_jit_crypto_JITTRNGInHardware_isTRNGSupportedByHardwareImpl" />
-	 <export name="Java_com_ibm_jit_crypto_JITTRNGInHardware_randomImpl" />
-
 	<export name="Java_com_ibm_jit_JITHelpers_javaLangClassJ9ClassOffset" />
 	<export name="Java_com_ibm_jit_JITHelpers_j9ObjectJ9ClassOffset" />
 	<export name="Java_com_ibm_jit_JITHelpers_objectHeaderHasBeenMovedInClass" />

--- a/sourcetools/com.ibm.uma/com/ibm/uma/om/Exports.java
+++ b/sourcetools/com.ibm.uma/com/ibm/uma/om/Exports.java
@@ -43,6 +43,10 @@ public class Exports extends PredicateList {
 		exports.add(export);
 	}
 	
+	public void addExports(Exports exps) {
+		exports.addAll(exps.getExports());
+	}
+	
 	public Vector<Export> getExports() {
 		return exports;
 	}

--- a/sourcetools/com.ibm.uma/com/ibm/uma/om/Module.java
+++ b/sourcetools/com.ibm.uma/com/ibm/uma/om/Module.java
@@ -64,7 +64,11 @@ public class Module extends PredicateList {
 	}
 	
 	public void addExports(String group, Exports exps) {
-		exports.put(group, exps);
+		if ( exports.containsKey(group) ) {
+			exports.get(group).addExports(exps);
+		} else {
+			exports.put(group, exps);
+		}
 	}
 	
 	public void addObjects(String group, Objects objs) {


### PR DESCRIPTION
Move crypto exports to vendors jcl exports files.
Update module.xml to include the export file when available.
Fixed uma exports parser.
This fix is related to issue: #55.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>