### PR TITLE
Incorporate usage of a vendor supplied versioning string

### DIFF
--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+/* Example usage for repo and sha.  This value will be inserted into the
+ * java.fullversion and java.vm.info system properties
+ * #define VENDOR_VERSION_STRING "<repo name> - <sha>"
+ * or descriptive string
+ * #define VENDOR_VERSION_STRING "Add some experimental code to java.base"
+ */

--- a/runtime/jcl/cl_se9/module.xml
+++ b/runtime/jcl/cl_se9/module.xml
@@ -106,9 +106,6 @@
 		<makefilestubs>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
-			<makefilestub data="ifneq ($(OPENJ9_BUILD),true)"/>
-			<makefilestub data="jclcinit$(UMA_DOT_O) : CFLAGS += -DOPENJ9_REPO='&quot;J9VM     - &quot;'"/>
-			<makefilestub data="endif"/>
 		</makefilestubs>
 
 		<vpaths>

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -41,6 +41,7 @@
 #include "omrversionstrings.h"
 #include "j9modron.h"
 #include "omr.h"
+#include "vendor_version.h"
 
 /* The vm version which must match the JCL.
  * It has the format 0xAABBCCCC
@@ -188,6 +189,11 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(vminfo, "\nOMR      - ");
 	strcat(vminfo, gcVersion);
 #endif /* J9VM_GC_MODRON_GC */
+
+#if defined(VENDOR_VERSION_STRING)
+	strcat(fullversion, "\n" VENDOR_VERSION_STRING);
+	strcat(vminfo, "\n" VENDOR_VERSION_STRING);
+#endif /* VENDOR_VERSION_STRING */
 
 	(*VMI)->SetSystemProperty(VMI, "java.vm.info", vminfo);
 	/*[PR 114306] System property java.fullversion is not initialized properly */

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -52,9 +52,6 @@
  */
 #define JCL_VERSION 0x06040270
 
-
-/* this file is owned by the VM-team.  Please do not modify it without consulting the VM team */
-
 extern void *jclConfig;
 
 static UDATA
@@ -161,11 +158,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 			aotEnabled = 1;
 		}
 	}
-
-#if !defined(OPENJ9_REPO)
-#define OPENJ9_REPO "OpenJ9   - "
-#endif /* !OPENJ9_REPO */
-
 	strcat(fullversion, " (JIT ");
 	strcat(fullversion, jitEnabled ? "en" : "dis");
 	strcat(vminfo, " (JIT ");
@@ -174,8 +166,8 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(fullversion, aotEnabled ? "en" : "dis");
 	strcat(vminfo, "abled, AOT ");
 	strcat(vminfo, aotEnabled ? "en" : "dis");
-	strcat(fullversion, "abled)\n" OPENJ9_REPO);
-	strcat(vminfo, "abled)\n" OPENJ9_REPO);
+	strcat(fullversion, "abled)\nOpenJ9   - ");
+	strcat(vminfo, "abled)\nOpenJ9   - ");
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
 	vmVersion = J9VM_VERSION_STRING;


### PR DESCRIPTION
- if supplied a vendor can add output to the fullversion and vminfo system properties
- also impacts -version output
- clean up references to previous development team
- remove repo name/sha override

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>