### PR TITLE
WIP: enable OSX support

### DIFF
--- a/runtime/exelib/common/rconsole.c
+++ b/runtime/exelib/common/rconsole.c
@@ -60,7 +60,7 @@ remoteConsole_parseCmdLine(J9PortLibrary *portLibrary, UDATA lastLegalArg, char 
 	port = NULL;
 	filepath = NULL;
 	for (i = 1; i <= lastLegalArg; i++) {
-		if ((argv[i][0] == '-')) {
+		if (argv[i][0] == '-') {
 			if ((strncmp(&argv[i][1], "IO", 2) == 0) ||
 			    (strncmp(&argv[i][1], "io", 2) == 0)) {
 


### PR DESCRIPTION
removed additional parenthesis in rconsole.c to allow compilation on osx

Signed-off-by: Steve Wallin <stevewallin@gmail.com>