### PR TITLE
Fold VarHandle.handleTable and its element

### DIFF
--- a/runtime/tr.source/trj9/env/J9ClassEnv.cpp
+++ b/runtime/tr.source/trj9/env/J9ClassEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -294,4 +294,12 @@ bool
 J9::ClassEnv::getStringFieldByName(TR::Compilation *comp, TR::SymbolReference *stringRef, TR::SymbolReference *fieldRef, void* &pResult)
    {
    return comp->fej9()->getStringFieldByName(comp, stringRef, fieldRef, pResult);
+   }
+
+uintptrj_t
+J9::ClassEnv::getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock* arrayClass)
+   {
+   TR_ASSERT(TR::Compiler->cls.isClassArray(comp, arrayClass), "Class must be array");
+   int32_t logElementSize = ((J9ROMArrayClass*)((J9Class*)arrayClass)->romClass)->arrayShape & 0x0000FFFF;
+   return 1 << logElementSize;
    }

--- a/runtime/tr.source/trj9/env/J9ClassEnv.hpp
+++ b/runtime/tr.source/trj9/env/J9ClassEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,6 +82,8 @@ public:
    bool isString(TR::Compilation *comp, uintptrj_t objectPointer);
    bool jitStaticsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2);
    bool jitFieldsAreSame(TR::Compilation *comp, TR_ResolvedMethod * method1, int32_t cpIndex1, TR_ResolvedMethod * method2, int32_t cpIndex2, int32_t isStatic);
+
+   uintptrj_t getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock* arrayClass);
 
    uintptrj_t persistentClassPointerFromClassPointer(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);
    TR_OpaqueClassBlock *objectClass(TR::Compilation *comp, uintptrj_t objectPointer);

--- a/runtime/tr.source/trj9/env/J9ObjectModel.hpp
+++ b/runtime/tr.source/trj9/env/J9ObjectModel.hpp
@@ -67,8 +67,16 @@ public:
 
    uintptrj_t discontiguousArrayHeaderSizeInBytes();
 
+   // For array access
    bool isDiscontiguousArray(int32_t sizeInBytes);
    bool isDiscontiguousArray(int32_t sizeInElements, int32_t elementSize);
+   bool isDiscontiguousArray(TR::Compilation* comp, uintptrj_t objectPointer);
+   intptrj_t getArrayLengthInElements(TR::Compilation* comp, uintptrj_t objectPointer);
+   uintptrj_t getArrayLengthInBytes(TR::Compilation* comp, uintptrj_t objectPointer);
+   uintptrj_t getArrayElementWidthInBytes(TR::DataType type);
+   uintptrj_t getArrayElementWidthInBytes(TR::Compilation* comp, uintptrj_t objectPointer);
+   uintptrj_t getAddressOfElement(TR::Compilation* comp, uintptrj_t objectPointer, int64_t offset);
+   uintptrj_t decompressReference(TR::Compilation* comp, uintptrj_t compressedReference);
 
    bool generateCompressedObjectHeaders();
 

--- a/runtime/tr.source/trj9/env/VMJ9.cpp
+++ b/runtime/tr.source/trj9/env/VMJ9.cpp
@@ -2002,7 +2002,7 @@ int32_t TR_J9VMBase::getArrayletMask(int32_t width)
    return mask;
    }
 
-int32_t TR_J9VMBase::getArrayletLeafIndex(int32_t index, int32_t elementSize)
+int32_t TR_J9VMBase::getArrayletLeafIndex(int64_t index, int32_t elementSize)
    {
    TR::Compilation* comp = TR::comp();
    TR_ASSERT(TR::Compiler->om.canGenerateArraylets(), "not supposed to be generating arraylets!");
@@ -2014,7 +2014,7 @@ int32_t TR_J9VMBase::getArrayletLeafIndex(int32_t index, int32_t elementSize)
    return  arrayletIndex;
    }
 
-int32_t TR_J9VMBase::getLeafElementIndex(int32_t index , int32_t elementSize)
+int32_t TR_J9VMBase::getLeafElementIndex(int64_t index , int32_t elementSize)
    {
    TR::Compilation* comp = TR::comp();
    TR_ASSERT(TR::Compiler->om.canGenerateArraylets(), "not supposed to be generating arraylets!");
@@ -4410,6 +4410,8 @@ TR_J9VMBase::canDereferenceAtCompileTime(TR::SymbolReference *fieldRef, TR::Comp
    //
    if (fieldRef->isUnresolved())
       return false;
+   if (comp->getSymRefTab()->isImmutableArrayShadow(fieldRef))
+      return true;
    if (fieldRef->getSymbol()->isShadow())
       {
       if (fieldRef->getReferenceNumber() < comp->getSymRefTab()->getNumPredefinedSymbols())
@@ -4422,6 +4424,7 @@ TR_J9VMBase::canDereferenceAtCompileTime(TR::SymbolReference *fieldRef, TR::Comp
          case TR::Symbol::Java_lang_invoke_MethodHandle_defc:         // JTC 83328: Delete once VM changes promote.  Moved to PrimitiveHandle
          case TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers:
          case TR::Symbol::Java_lang_invoke_PrimitiveHandle_defc:
+         case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
             {
             return true;
             }

--- a/runtime/tr.source/trj9/env/VMJ9.h
+++ b/runtime/tr.source/trj9/env/VMJ9.h
@@ -604,8 +604,8 @@ public:
 
    virtual int32_t            getArraySpineShift(int32_t);
    virtual int32_t            getArrayletMask(int32_t);
-   virtual int32_t            getArrayletLeafIndex(int32_t, int32_t);
-   virtual int32_t            getLeafElementIndex(int32_t , int32_t);
+   virtual int32_t            getArrayletLeafIndex(int64_t, int32_t);
+   virtual int32_t            getLeafElementIndex(int64_t , int32_t);
    virtual bool               CEEHDLREnabled();
 
    virtual int32_t            getCAASaveOffset();

--- a/runtime/tr.source/trj9/optimizer/J9TransformUtil.hpp
+++ b/runtime/tr.source/trj9/optimizer/J9TransformUtil.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
handleTable is an immutable array with immutable content, thus we can
fold loads of it and its elements if the containing VarHandle object is
immutable. We will set isArrayWithConstantElements bit for handleTable
when creating an entry in KnownObjectTable. Then VP sees the bit and
will improve array shadows from handleTable to ImmutableArrayShadows,
which is to be detected by transformIndirectLoadChain when trying to
fold an array shadow.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>