### PR TITLE
z/TPF Build Related Updates for DDR in VM29

### DIFF
--- a/buildspecs/linux_ztpf_390-64.spec
+++ b/buildspecs/linux_ztpf_390-64.spec
@@ -188,7 +188,7 @@
 		<flag id="module_cpo_common" value="true"/>
 		<flag id="module_cpo_controller" value="true"/>
 		<flag id="module_ddr" value="true"/>
-		<flag id="module_ddr_gdb_plugin" value="true"/>
+		<flag id="module_ddr_gdb_plugin" value="false"/>
 		<flag id="module_ddrext" value="true"/>
 		<flag id="module_exe" value="true"/>
 		<flag id="module_exe.j9" value="true"/>

--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -174,9 +174,9 @@ ESCAPED_JAVA := $(subst \,/,$(JAVA))
 PLATFORM	 := $(if $(wildcard buildtools/j9ddr-autoblob.jar),$(shell $(JAVA) -cp buildtools/j9ddr-autoblob.jar com.ibm.j9ddr.autoblob.GetNativeDirectory))
 SUPERSET     := superset.$(SPEC).dat
 
-#For z/TPF change platform because of cross-build
+#Trigger cross-compilation & use linux_x86 DDR configuration
 ifeq (linux_ztpf_390-64, $(SPEC))
-	PLATFORM := linux_ztpf_390-64
+	PLATFORM := linux_x86
 	OS := ztpf
 endif
 

--- a/runtime/ddr/ddrcppsupportblob.cpp.stub
+++ b/runtime/ddr/ddrcppsupportblob.cpp.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@ extern "C" {
 
 	const J9DDRStructDefinition* getDDR_CPPStructTable(void* portLib)
 	{
-		OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+		OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
 		omrtty_printf("WARNING: CPP support structure table was not generated and has been stubbed out. See ddr.readme.\n");
 	
 		return structStubs;


### PR DESCRIPTION
Updated z/TPF BuildSpecs no to build ddr_gdb_plugin.
Nitty cast update to stub file to be consistent with the
other stub files otherwise compilation error occurs.
Needed to update buildtools.mk to use linux_x86 as the 
Platform for z/TPF in order for DDR to compile non-stub
files.


Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>