### PR TITLE
Java 18.3 makeReinvokerForm method lacks String

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
@@ -52,7 +52,7 @@ abstract class DelegatingMethodHandle extends MethodHandle {
 	}
 	/*[IF Java18.3]*/
 	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError(); 
 	}
 	/*[ENDIF]*/
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
@@ -50,4 +50,9 @@ abstract class DelegatingMethodHandle extends MethodHandle {
 	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, String str, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+	/*[IF Java18.3]*/
+	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	/*[ENDIF]*/
 }


### PR DESCRIPTION
The OpenJDK with Hotspot version of DelegatingMethodHandle.makeReinvokerForm lacks a String argument, and other classes omit this argument when calling it.

Though this is only a stub, we need a matching method signature in order to compile OpenJDK18.3 with OpenJ9.