### PR TITLE
fix sha1 sum check failure of asmtools.jar

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -132,6 +132,10 @@ if ( $task eq "default" ) {
 			}
 		}
 
+		# TODO check samtools.jar file
+		if ($jars_info[$i]{fname} eq "asmtools.jar") {
+			next;
+		}
 		# validate dependencies sha1 sum
 		$sha->addfile($filename);
 		$digest = $sha->hexdigest ;


### PR DESCRIPTION
* asmtools.jar is updated weekly
* we don't have a up-to-date sha1 value to match updated asmtools.jar
* temporarily exclude this file sha check
* will add this sha check when we can get up-to-date sha1 sum value

[skip ci]
Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>