### PR TITLE
Incorporate vendor details into javacore

### DIFF
--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -20,9 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-/* Example usage for repo and sha.  This value will be inserted into the
- * java.fullversion and java.vm.info system properties
- * #define VENDOR_VERSION_STRING "<repo name> - <sha>"
- * or descriptive string
- * #define VENDOR_VERSION_STRING "Add some experimental code to java.base"
+/* Example usage for inclusion of a vendor name and repository sha.  These values
+ * will be inserted into the java.fullversion and java.vm.info system properties
+ * and in a generated javacore file.
+ *
+ * #define VENDOR_SHORT_NAME "ABC"
+ * #define VENDOR_SHA "1a2b3c4"
  */

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -182,10 +182,10 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(vminfo, gcVersion);
 #endif /* J9VM_GC_MODRON_GC */
 
-#if defined(VENDOR_VERSION_STRING)
-	strcat(fullversion, "\n" VENDOR_VERSION_STRING);
-	strcat(vminfo, "\n" VENDOR_VERSION_STRING);
-#endif /* VENDOR_VERSION_STRING */
+#if defined(VENDOR_SHORT_NAME) && defined(VENDOR_SHA)
+	strcat(fullversion, "\n" VENDOR_SHORT_NAME "      - " VENDOR_SHA);
+	strcat(vminfo, "\n" VENDOR_SHORT_NAME "      - " VENDOR_SHA);
+#endif /* VENDOR_SHORT_NAME && VENDOR_SHA */
 
 	(*VMI)->SetSystemProperty(VMI, "java.vm.info", vminfo);
 	/*[PR 114306] System property java.fullversion is not initialized properly */

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -48,6 +48,7 @@
 #include "omr.h"
 #include "omrutilbase.h"
 #include "j9version.h"
+#include "vendor_version.h"
 
 #include "zip_api.h"
 
@@ -992,6 +993,11 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 	_OutputStream.writeCharacters("1CIOMRVERSION  ");
 	_OutputStream.writeCharacters(_VirtualMachine->memoryManagerFunctions->omrgc_get_version(_VirtualMachine->omrVM));
 	_OutputStream.writeCharacters("\n");
+
+#if defined(VENDOR_SHORT_NAME) && defined(VENDOR_SHA)
+	/* Write the Vendor version data */
+	_OutputStream.writeCharacters("1CI" VENDOR_SHORT_NAME "VERSION  " VENDOR_SHA "\n");
+#endif /* VENDOR_SHORT_NAME && VENDOR_SHA */
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	_OutputStream.writeCharacters("1CIJITMODES    ");


### PR DESCRIPTION
* converted single VENDOR version string into name & sha
* added VENDOR* details to ENVINFO section of the javacore
* modified java.fullversion and java.vm.info sys props to use new VENDOR* details

Signed-off-by: Joe Dekoning <joe_dekoning@ca.ibm.com>

[skip ci]