### PR TITLE
Remove hand-written assembly for STMXCSR test

### DIFF
--- a/runtime/util/sse2enabled.asm
+++ b/runtime/util/sse2enabled.asm
@@ -25,19 +25,6 @@
 	_TEXT SEGMENT PARA USE32 PUBLIC 'CODE'
 
 	public J9SSE2cpuidFeatures
-	public J9SSE2GetMXCSR
-
-; Prototype: U_32 J9SSE2GetMXCSR(void);
-; - throws an Illegal Instruction exception if the OS does not support SSE instructions
-; - otherwise, returns the content of the MXCSR.
-	align	16
-
-J9SSE2GetMXCSR PROC NEAR
-	sub	esp, 4
-	stmxcsr [esp]
-	pop	eax
-	ret
-J9SSE2GetMXCSR ENDP
 
 	align 16
 

--- a/runtime/util/sse2enabled.s
+++ b/runtime/util/sse2enabled.s
@@ -24,23 +24,8 @@
        	##assume cs:flat,ds:flat,ss:flat
         .globl J9SSE2cpuidFeatures
         .type J9SSE2cpuidFeatures,@function
-        .globl J9SSE2GetMXCSR
-        .type J9SSE2GetMXCSR,@function
 
         .text
-
-## Prototype: U_32 J9SSE2GetMXCSR(void)
-## - throws an Illegal Instruction exception if the OS does not support SSE instructions
-## - otherwise, returns the content of the MXCSR.
-	.align	16
-
-J9SSE2GetMXCSR:
-	sub	$4, %esp
-	stmxcsr (%esp)
-	pop	%eax
-	ret
-END_J9SSE2GetMXCSR:
-	.size J9SSE2GetMXCSR,END_J9SSE2GetMXCSR - J9SSE2GetMXCSR
 
 	.align 16
 


### PR DESCRIPTION
Instead of hand-written assembly code, X86 now uses intrinsic
function _mm_getcsr() on Windows and inlined assembly on Linux
to check SSE support.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>