### PR TITLE
Implement an onsite cicular buffer for instanceOf

### DIFF
--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+/* Example usage for repo and sha.  This value will be inserted into the
+ * java.fullversion and java.vm.info system properties
+ * #define VENDOR_VERSION_STRING "<repo name> - <sha>"
+ * or descriptive string
+ * #define VENDOR_VERSION_STRING "Add some experimental code to java.base"
+ */

--- a/runtime/jcl/cl_se9/module.xml
+++ b/runtime/jcl/cl_se9/module.xml
@@ -106,9 +106,6 @@
 		<makefilestubs>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
-			<makefilestub data="ifneq ($(OPENJ9_BUILD),true)"/>
-			<makefilestub data="jclcinit$(UMA_DOT_O) : CFLAGS += -DOPENJ9_REPO='&quot;J9VM     - &quot;'"/>
-			<makefilestub data="endif"/>
 		</makefilestubs>
 
 		<vpaths>

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -41,6 +41,7 @@
 #include "omrversionstrings.h"
 #include "j9modron.h"
 #include "omr.h"
+#include "vendor_version.h"
 
 /* The vm version which must match the JCL.
  * It has the format 0xAABBCCCC
@@ -188,6 +189,11 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(vminfo, "\nOMR      - ");
 	strcat(vminfo, gcVersion);
 #endif /* J9VM_GC_MODRON_GC */
+
+#if defined(VENDOR_VERSION_STRING)
+	strcat(fullversion, "\n" VENDOR_VERSION_STRING);
+	strcat(vminfo, "\n" VENDOR_VERSION_STRING);
+#endif /* VENDOR_VERSION_STRING */
 
 	(*VMI)->SetSystemProperty(VMI, "java.vm.info", vminfo);
 	/*[PR 114306] System property java.fullversion is not initialized properly */

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -52,9 +52,6 @@
  */
 #define JCL_VERSION 0x06040270
 
-
-/* this file is owned by the VM-team.  Please do not modify it without consulting the VM team */
-
 extern void *jclConfig;
 
 static UDATA
@@ -161,11 +158,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 			aotEnabled = 1;
 		}
 	}
-
-#if !defined(OPENJ9_REPO)
-#define OPENJ9_REPO "OpenJ9   - "
-#endif /* !OPENJ9_REPO */
-
 	strcat(fullversion, " (JIT ");
 	strcat(fullversion, jitEnabled ? "en" : "dis");
 	strcat(vminfo, " (JIT ");
@@ -174,8 +166,8 @@ jint computeFullVersionString(J9JavaVM* vm)
 	strcat(fullversion, aotEnabled ? "en" : "dis");
 	strcat(vminfo, "abled, AOT ");
 	strcat(vminfo, aotEnabled ? "en" : "dis");
-	strcat(fullversion, "abled)\n" OPENJ9_REPO);
-	strcat(vminfo, "abled)\n" OPENJ9_REPO);
+	strcat(fullversion, "abled)\nOpenJ9   - ");
+	strcat(vminfo, "abled)\nOpenJ9   - ");
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
 	vmVersion = J9VM_VERSION_STRING;

--- a/runtime/tr.source/trj9/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/codegen/J9TreeEvaluator.cpp
@@ -218,6 +218,11 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
    bool isInstanceOf = instanceOfOrCheckCastNode->getOpCodeValue() == TR::instanceof;
    bool mayBeNull = !instanceOfOrCheckCastNode->isReferenceNonNull() && !objectNode->isNonNull();
 
+   // By default maxOnsiteCacheSlotForInstanceOf is set to 0 which means cache is disable.
+   // To enable test pass JIT option maxOnsiteCacheSlotForInstanceOf=<number_of_slots>
+   bool createDynamicCacheTests = cg->comp()->getOptions()->getMaxOnsiteCacheSlotForInstanceOf() != 0;
+
+
    uint32_t i = 0;
    uint32_t numProfiledClasses = 0;
 
@@ -245,6 +250,10 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
       // There is a possibility of attempt to cast object to another class and having cache on that object updated by helper.
       // Before going to helper checking the cache.
       sequences[i++] = CastClassCacheTest;
+#if defined(TR_HOST_S390)
+      if (createDynamicCacheTests)
+         sequences[i++] = DynamicCacheObjectClassTest;
+#endif
       sequences[i++] = HelperCall;
       }
    // Cast class is a runtime variable, still not a lot of room to be fancy.
@@ -261,7 +270,11 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
       if (cg->supportsInliningOfIsInstance() && 
          instanceOfOrCheckCastNode->getOpCodeValue() == TR::instanceof && 
          instanceOfOrCheckCastNode->getSecondChild()->getOpCodeValue() != TR::loadaddr)
-         sequences[i++] = SuperClassTest; 
+         sequences[i++] = SuperClassTest;
+#if defined(TR_HOST_S390)
+      if (createDynamicCacheTests)
+         sequences[i++] = DynamicCacheDynamicCastClassTest;
+#endif
       sequences[i++] = HelperCall;
       }
 
@@ -426,7 +439,10 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
                {
                sequences[i++] = CastClassCacheTest;
                }
-
+#if defined(TR_HOST_S390)
+            if (createDynamicCacheTests)
+               sequences[i++] = DynamicCacheObjectClassTest;
+#endif
             sequences[i++] = HelperCall;
             }
          // Cast class is an abstract class, we can skip the class equality test, a superclass test is enough.

--- a/runtime/tr.source/trj9/codegen/J9TreeEvaluator.hpp
+++ b/runtime/tr.source/trj9/codegen/J9TreeEvaluator.hpp
@@ -54,6 +54,14 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluatorConnector
       ClassEqualityTest,                // Needs object class: y, needs cast class: y
       SuperClassTest,                   // Needs object class: y, needs cast class: y
       CastClassCacheTest,               // Needs object class: y, needs cast class: y
+      /* Currently following two tests are only made available for z Systems
+       * to make sure consumer of this API on other platform do not need to
+       * make any changes in their implementations.
+       */
+#if defined(TR_HOST_S390)
+      DynamicCacheObjectClassTest,      // Needs object class: y, needs cast class: n
+      DynamicCacheDynamicCastClassTest, // Needs object class: y, needs cast class: y
+#endif
       HelperCall,                       // Needs object class: n, needs cast class: y
 
       InstanceOfOrCheckCastMaxSequences

--- a/runtime/tr.source/trj9/control/J9Options.cpp
+++ b/runtime/tr.source/trj9/control/J9Options.cpp
@@ -72,6 +72,7 @@ int32_t J9::Options::_relaxedCompilationLimitsSampleThreshold = 120; // normally
 int32_t J9::Options::_sampleThresholdVariationAllowance = 30;
 
 int32_t J9::Options::_maxCheckcastProfiledClassTests = 3;
+int32_t J9::Options::_maxOnsiteCacheSlotForInstanceOf = 0; // Setting this value to zero will disable onsite cache in instanceof.
 int32_t J9::Options::_cpuEntitlementForConservativeScorching = 801; // 801 means more than 800%, i.e. 8 cpus
                                                                     // A very large number disables the feature
 int32_t J9::Options::_sampleHeartbeatInterval = 10;
@@ -866,6 +867,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_lowVirtualMemoryMBThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"maxCheckcastProfiledClassTests=", "R<nnn>\tnumber inlined profiled classes for profiledclass test in checkcast/instanceof",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_maxCheckcastProfiledClassTests, 0, "%d", NOT_IN_SUBSET},
+   {"maxOnsiteCacheSlotForInstanceOf=", "R<nnn>\tnumber of onsite cache slots for instanceOf",
+      TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_maxOnsiteCacheSlotForInstanceOf, 0, "%d", NOT_IN_SUBSET},
    {"minSamplingPeriod=", "R<nnn>\tminimum number of milliseconds between samples for hotness",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_minSamplingPeriod, 0, "P%d", NOT_IN_SUBSET},
    {"minSuperclassArraySize=", "I<nnn>\t set the size of the minimum superclass array size",

--- a/runtime/tr.source/trj9/control/J9Options.hpp
+++ b/runtime/tr.source/trj9/control/J9Options.hpp
@@ -73,6 +73,9 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _maxCheckcastProfiledClassTests;
    static int32_t getCheckcastMaxProfiledClassTests() {return _maxCheckcastProfiledClassTests;}
 
+   static int32_t _maxOnsiteCacheSlotForInstanceOf;
+   static int32_t getMaxOnsiteCacheSlotForInstanceOf() {return _maxOnsiteCacheSlotForInstanceOf;}
+
    static int32_t _resetCountThreshold;
 
    static int32_t _scorchingSampleThreshold;

--- a/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -5381,6 +5381,257 @@ bool genInstanceOfOrCheckCastNullTest(TR::Node* node, TR::CodeGenerator* cg, TR:
       return isNullTestImplicit;
    }
 
+
+/** \brief
+ *     Generates a helper call for \p node.
+ *
+ *  \details
+ *     Function switches to outlined section and generate a JIT helper dispatch sequence.
+ *     It is responsibility of the caller to switch back to main line.
+ *
+ *  \param node
+ *     The instanceof node
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param **deps
+ *     Place holder for the register dependency conditions which will e filled by buildDirectDispatch to
+ *     attach it to merge label of internal control flow.
+ *
+ *  \return
+ *     <c>TR::Register*</c> Return value register from helper call.
+ */
+static
+TR::Register* genInstanceOfOrCheckCastHelperCall(TR::Node *node, TR::CodeGenerator *cg, TR::Compilation *comp, TR::RegisterDependencyConditions **deps, TR::Register *resultReg, TR::LabelSymbol *callLabel, TR::LabelSymbol *doneLabel, TR_S390OutOfLineCodeSection **outlinedSlowPath)
+   {
+   if (!comp->getOption(TR_DisableOOL))
+      {
+      if (*outlinedSlowPath == NULL)
+         *outlinedSlowPath = new (cg->trHeapMemory()) TR_S390OutOfLineCodeSection(callLabel, doneLabel, cg);
+      cg->getS390OutOfLineCodeSectionList().push_front(*outlinedSlowPath);
+      (*outlinedSlowPath)->swapInstructionListsWithCompilation();
+      }
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, callLabel);
+   // TODO : We can make this function a generic helper call function. Debug counter name then should be changed as per node.
+   cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOf/(%s)/Helper", comp->signature()),1,TR::DebugCounter::Undetermined);
+   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   return helperLink->buildDirectDispatch(node, deps, resultReg);
+   } 
+
+
+/** \brief
+ *     Generates a dynamicCache test with helper call for instanceOf/ifInstanceOf node
+ *
+ *  \details
+ *     This funcition generates a sequence to check per site cache for object class and cast class before calling out to jitInstanceOf helper
+ */
+static
+void genInstanceOfDynamicCacheAndHelperCall(TR::Node *node, TR::CodeGenerator *cg, TR::Register *castClassReg, TR::Register *objClassReg, TR::Register *resultReg, TR_S390ScratchRegisterManager *srm, TR::LabelSymbol *doneLabel, TR::LabelSymbol *helperCallLabel, TR::LabelSymbol *dynamicCacheTestLabel, TR::LabelSymbol *branchLabel, TR::LabelSymbol *trueLabel, TR::LabelSymbol *falseLabel, bool dynamicCastClass, bool generateDynamicCache, bool cacheCastClass, bool ifInstanceOf, bool trueFallThrough )
+   {
+   TR_S390OutOfLineCodeSection *outlinedSlowPath = NULL;
+   TR::Compilation                *comp = cg->comp();
+   bool needResult = resultReg != NULL;
+   if (!castClassReg)
+      castClassReg = cg->evaluate(node->getSecondChild());
+   int32_t maxOnsiteCacheSlots = comp->getOptions()->getMaxOnsiteCacheSlotForInstanceOf();
+   TR::InstOpCode::Mnemonic loadHalfWordImmOp = TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI;
+   bool needToGenerateDynamicCacheTest = generateDynamicCache && maxOnsiteCacheSlots > 0;
+   TR::Register *dynamicCacheReg = NULL;
+   int32_t addressSize = TR::Compiler->target.is64Bit() ? 8 : 4;
+   /* Layout of the writable data snippet
+    * Case - 1 : Cast class is runtime variable
+    * [UpdateIndex][ObjClassSlot-0][CastClassSlot-0]...[ObjClassSlot-N][CastClassSlot-N]
+    * Case - 2 : Cast Class is inetrface / unresolved
+    * [UpdateIndex][ObjClassSlot-0]...[ObjClassSlot-N]
+    * If there is only one cache slot, we will not have header.
+    * Last bit of cached objectClass will set to 1 indicating false cast
+    */
+   int32_t snippetSizeInBytes = ((cacheCastClass ? 2 : 1) * maxOnsiteCacheSlots * addressSize) + (addressSize * (maxOnsiteCacheSlots != 1));
+   if (needToGenerateDynamicCacheTest)
+      {
+      TR::S390WritableDataSnippet *dynamicCacheSnippet = NULL;
+      /* We can only request the snippet size of power 2, following table summarizes bytes needed for corresponding number of cache slots
+       * Case 1 : Cast class is runtime variable
+       * Case 2 : Cast class is interface / unresolved
+       * Number Of Slots |  Bytes needed for Case 1 | Bytes needed for Case 2
+       *        1        |              16          |           8
+       *        2        |              64          |           32
+       *        3        |              64          |           32
+       *        4        |              128         |           64
+       *        5        |              128         |           64
+       *        6        |              128         |           64
+       */
+      int32_t requestedBytes = 1 << (int) (log2(snippetSizeInBytes-1)+1);
+      traceMsg(comp, "Requested Bytes = %d\n",requestedBytes);
+      uintptr_t *initialSnippet = new (cg->trHeapMemory()) uintptr_t[requestedBytes/sizeof(uintptr_t)];
+      // NOTE: For single slot cache, we initialize snippet with addressSize (4/8) assuming which can not be objectClass
+      // In all cases, we use first addressSize bytes to store offset of the circular buffer and rest of buffer will be initialized with 0xff.
+      initialSnippet[0] = addressSize;
+      if (requestedBytes > addressSize)
+         memset(initialSnippet+1,-1,((requestedBytes/sizeof(uintptr_t))-1)*sizeof(initialSnippet));
+      dynamicCacheSnippet = (TR::S390WritableDataSnippet*)cg->CreateConstant(node, initialSnippet, requestedBytes, true);
+      
+      int32_t currentIndex = maxOnsiteCacheSlots > 1 ? addressSize : 0;
+      dynamicCacheReg = srm->findOrCreateScratchRegister();
+      /* Inlined tests for instanceOf node is generated such that, fall through of all test is next test. So we do not need to generate a dynamic cache test label. 
+       * Only exception to this is Super Class test with dynamic cast class. As we don't know dynamic cast class at compile time, we need to check type of cast class at runtime. 
+       * If it is regular class, super class test should yield to result other wise it will branch to dynamic cache test if dynamic cache is enabled.
+       */
+      if (dynamicCacheTestLabel != NULL)
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, dynamicCacheTestLabel);
+      generateRILInstruction(cg, TR::InstOpCode::LARL, node, dynamicCacheReg, dynamicCacheSnippet, 0);
+      TR::Register *cachedObjectClass = srm->findOrCreateScratchRegister();
+      TR::LabelSymbol *gotoNextTest = NULL;
+      /* Dynamic Cache Test
+       * LARL dynamicCacheReg, dynamicCacheSnippet
+       * if (cacheCastClass)
+       *    CG castClassReg, @(dynamicCacheSnippet+currentIndex+addressSize)
+       *    BRC NE,isLastCacheSlot ? helperCall:checkNextSlot
+       * LG cachedOjectClass,@(dynamicCacheSnippet+currentIndex)
+       * XR cachedObjectClass,objClassReg
+       * if (isLastCacheSlot && trueFallThrough)
+       *    CGIJ cachedObjectClass, 1, Equal, falseLabel
+       *    BRC NotZero, helperCallLabel
+       * else if (isLastCacheSlot)
+       *    BRC Zero, trueLabel
+       *    CGIJ cachedObjectClass, 1, NotEqual, helperCallLabel
+       * else
+       *    BRC Zero ,trueLabel
+       *    CGIJ cachedObjectClass,1,Equal,falseLabel
+       * if (isLastCacheSlot)
+       *    fallThroughLabel:
+       * else
+       *    checkNextSlot:
+       */
+      for (auto i=0; i<maxOnsiteCacheSlots; i++)
+         {
+         if (cacheCastClass)
+            {
+            gotoNextTest = (i+1 == maxOnsiteCacheSlots) ? helperCallLabel : generateLabelSymbol(cg);
+            generateRXInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, castClassReg, generateS390MemoryReference(dynamicCacheReg,currentIndex+addressSize,cg));
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, gotoNextTest);
+            }
+         generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, cachedObjectClass, generateS390MemoryReference(dynamicCacheReg,currentIndex,cg));
+         generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node,cachedObjectClass, objClassReg);
+         if (i+1 == maxOnsiteCacheSlots)
+            {
+            if (trueFallThrough)
+               {
+               generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, cachedObjectClass, 1, TR::InstOpCode::COND_BE, falseLabel, false, false);
+               generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, helperCallLabel);
+               }
+            else
+               {
+               generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, trueLabel);
+               generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, cachedObjectClass, 1, TR::InstOpCode::COND_BNE, helperCallLabel, false, false);
+               }
+            }
+         else
+            {  
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, trueLabel);
+            generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, cachedObjectClass, 1, TR::InstOpCode::COND_BE, falseLabel, false, false);
+            }
+         
+         if (gotoNextTest && gotoNextTest != helperCallLabel)
+            generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, gotoNextTest);
+         currentIndex += (cacheCastClass? 2: 1)*addressSize;
+         }
+      srm->reclaimScratchRegister(cachedObjectClass);
+      }
+   else if (!dynamicCastClass)
+      {
+      // If dynamic Cache Test is not generated and it is not dynamicCastClass, we need to generate following branch
+      // In cases of dynamic cache test / dynamic Cast Class, we would have a branch to helper call at appropriate location.
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, helperCallLabel);
+      }
+
+      /* helperCallLabel : jitInstanceOfCall prologue
+       *                   BRASL jitInstanceOf
+       *                   jitInstanceOfCall epilogue
+       *                   CGIJ helperReturnReg,1,skipSettingBitForFalseResult <- Start of Internal Control Flow
+       *                   OILL objClassReg,1
+       * skipSettingBitForFalseResult:
+       *               Case - 1 : maxOnsiteCacheSlots = 1
+       *                   STG objClassReg, @(dynamicCacheReg)    
+       *                   if (cacheCastClass)
+       *                      STG castClassReg, @(dynamicCacheReg,addressSize)
+       *               Case - 2 : maxOnsiteCacheSlots > 1
+       *                   LG offsetRegister,@(dynamicCacheReg)
+       *                   STG objClassReg,@(dynamicCacheReg,offsetRegister)
+       *                   if (cacheCastClass)
+       *                      STG castClassReg, @(dynamicCacheReg,offsetRegister,addressSize)
+       *                   AGHI offsetReg,addressSize
+       *                   CIJ offsetReg,snippetSizeInBytes,NotEqual,skipResetOffset
+       *                   LGHI offsetReg,addressSize
+       * skipResetOffset:
+       *                   STG offsetReg,@(dynamicCacheReg) -> End of Internal Control Flow
+       *                   LT resultReg,helperReturnReg
+       */   
+   resultReg = genInstanceOfOrCheckCastHelperCall(node, cg, comp, NULL, resultReg, helperCallLabel, doneLabel, &outlinedSlowPath);
+   if (needToGenerateDynamicCacheTest)
+      {
+      TR::LabelSymbol *skipSettingBitForFalseResult = generateLabelSymbol(cg);
+      TR::Instruction *cursor = generateRIEInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGIJ : TR::InstOpCode::CIJ, node, resultReg, (uint8_t) 1, skipSettingBitForFalseResult, TR::InstOpCode::COND_BE);
+      // We will set the last bit of objectClassRegister to 1 if helper returns false.
+      generateRIInstruction(cg, TR::InstOpCode::OILL, node, objClassReg, 0x1);
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipSettingBitForFalseResult);
+      // Update cache sequence
+      if (maxOnsiteCacheSlots == 1)
+         {
+         generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, objClassReg, generateS390MemoryReference(dynamicCacheReg,0,cg));
+         if (cacheCastClass)
+            generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, castClassReg, generateS390MemoryReference(dynamicCacheReg,addressSize,cg));
+         }
+      else
+         {
+         TR::Register *offsetRegister = srm->findOrCreateScratchRegister();
+         // NOTE: In OOL helper call is not within ICF hence we can avoid passing dependency to helper call dispatch function and stretching it to merge label.
+         // Although internal control flow starts after returning from helper we need to define starting point and ending point of internal control flow.
+         cursor->setStartInternalControlFlow();
+         generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, offsetRegister, generateS390MemoryReference(dynamicCacheReg,0,cg));    
+         generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, objClassReg, generateS390MemoryReference(dynamicCacheReg,offsetRegister,0,cg));
+         if (cacheCastClass)
+            generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, castClassReg, generateS390MemoryReference(dynamicCacheReg,offsetRegister,addressSize,cg));
+         TR::LabelSymbol *skipResetOffsetLabel = generateLabelSymbol(cg);
+         generateRIInstruction(cg,TR::InstOpCode::getAddHalfWordImmOpCode(),node,offsetRegister,static_cast<int32_t>(cacheCastClass?addressSize*2:addressSize));
+         generateRIEInstruction(cg, TR::InstOpCode::CIJ, node, offsetRegister, snippetSizeInBytes, skipResetOffsetLabel, TR::InstOpCode::COND_BNE);
+         generateRIInstruction(cg, loadHalfWordImmOp , node, offsetRegister, addressSize);
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipResetOffsetLabel);
+         cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, offsetRegister, generateS390MemoryReference(dynamicCacheReg,0,cg));
+         TR::RegisterDependencyConditions * OOLconditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 5, cg);
+         OOLconditions->addPostCondition(objClassReg, TR::RealRegister::AssignAny);
+         OOLconditions->addPostCondition(resultReg, TR::RealRegister::AssignAny);
+         OOLconditions->addPostCondition(dynamicCacheReg, TR::RealRegister::AssignAny);
+         OOLconditions->addPostCondition(offsetRegister, TR::RealRegister::AssignAny);
+         if (cacheCastClass)
+            OOLconditions->addPostCondition(castClassReg, TR::RealRegister::AssignAny);
+         cursor->setEndInternalControlFlow();
+         cursor->setDependencyConditions(OOLconditions);
+         srm->reclaimScratchRegister(offsetRegister);
+         }
+      srm->reclaimScratchRegister(dynamicCacheReg);
+      }
+   generateRRInstruction(cg, TR::InstOpCode::getLoadTestRegOpCode(), node, resultReg, resultReg);
+
+   // WARNING: It is not recommended to have two exit point in OOL section.
+   // In this case we need it in case of ifInstanceOf to save additional complex logic in mainline section
+   // We can take a risk of having two exit points in OOL here as there is no other register instruction between them.
+   if (ifInstanceOf)
+      {
+      if (trueFallThrough)
+         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, branchLabel);
+      else
+         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, branchLabel);
+      }
+   
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, doneLabel);
+   if (outlinedSlowPath)
+      outlinedSlowPath->swapInstructionListsWithCompilation();
+   if (!needResult)
+      cg->stopUsingRegister(resultReg);
+   }
+
 /**   \brief Generates inlined sequence of tests for instanceOf/ifInstanceOf node.
  *    \details
  *    It calls common function to generate list of inlined tests and generates instructions handling both instanceOf and ifInstanceOf case.
@@ -5403,9 +5654,8 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
    TR::Register                  *objClassReg = NULL;
    TR::Register                  *resultReg = NULL;
    TR::Register                  *castClassReg = NULL;
-   TR::Register                  *helperReturnRegister = NULL;
 
-   // In the evaluator, We need at maximum two scratch registers, so creating a pool of scratch registers with 2 size.
+   // In the evaluator, We need at maximum two scratch registers, so creating a pool of scratch registers with 4 size.
    TR_S390ScratchRegisterManager *srm = cg->generateScratchRegisterManager(2);
    bool topClassWasCastClass=false;
    float topClassProbability=0.0;
@@ -5427,7 +5677,6 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
    TR_S390OutOfLineCodeSection *outlinedSlowPath = NULL;
 
    TR::LabelSymbol *doneOOLLabel = NULL;
-   TR::LabelSymbol *startOOLLabel = NULL;
    TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *callLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *doneTestCacheLabel = NULL;
@@ -5435,8 +5684,10 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
    TR::LabelSymbol *helperTrueLabel = NULL;
    TR::LabelSymbol *helperFalseLabel = NULL;
    TR::LabelSymbol *helperReturnLabel = NULL;
-
+   TR::LabelSymbol *dynamicCacheTestLabel = NULL;
    TR::LabelSymbol *branchLabel = NULL;
+   TR::LabelSymbol *jmpLabel = NULL;
+
    TR::InstOpCode::S390BranchCondition branchCond;
    TR_Debug *debugObj = cg->getDebug();
    bool trueFallThrough;
@@ -5451,6 +5702,7 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
          falseLabel = (needResult) ? oppositeResultLabel : doneLabel;
          branchLabel = trueLabel;
          branchCond = TR::InstOpCode::COND_BE;
+         jmpLabel = falseLabel;
          trueFallThrough = false;
          }
       else
@@ -5459,6 +5711,7 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
          trueLabel = (needResult)? oppositeResultLabel : doneLabel;
          branchLabel = falseLabel;
          branchCond = TR::InstOpCode::COND_BNE;
+         jmpLabel = trueLabel;
          trueFallThrough = true;
          }
       }
@@ -5469,16 +5722,21 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
          trueLabel = doneLabel;
          falseLabel = oppositeResultLabel;
          branchCond = TR::InstOpCode::COND_BE;
+         trueFallThrough = false;
          }
       else
          {
          trueLabel = oppositeResultLabel;
          falseLabel = doneLabel;
          branchCond = TR::InstOpCode::COND_BNE;
+         trueFallThrough = true;
          }
       branchLabel = doneLabel;
+      jmpLabel = oppositeResultLabel;
       }
 
+   bool generateDynamicCache = false;
+   bool cacheCastClass = false;
    InstanceOfOrCheckCastSequences *iter = &sequences[0];
    while (numSequencesRemaining >   1 || (numSequencesRemaining==1 && *iter!=HelperCall))
       {
@@ -5554,14 +5812,19 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
                * case-1 instanceof , initial Result = false: BRC 0x8, doneLabel
                * case-2 instanceof , initial Result = true: BRC 0x6, doneLabel
                * case-3 ifInstanceOf , trueLabel == branchLabel : BRC 0x8, branchLabel
-               * case-4 ifInstanceOf , falseLabel == branchLabel : BRC 0x6, branhLabel
+               * case-4 ifInstanceOf , falseLabel == branchLabel : BRC 0x6, branchLabel
                */
             int32_t castClassDepth = castClassNode->getSymbolReference()->classDepth(comp);
+            dynamicCacheTestLabel = *(iter+1) == DynamicCacheDynamicCastClassTest ? generateLabelSymbol(cg) : callLabel;
             if (comp->getOption(TR_TraceCG))
                traceMsg(comp, "%s: Emitting Super Class Test, Cast Class Depth = %d\n", node->getOpCode().getName(),castClassDepth);
             cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOfStats/(%s)/SuperClassTest", comp->signature()),1,TR::DebugCounter::Undetermined);
-            dynamicCastClass = genInstanceOfOrCheckcastSuperClassTest(node, cg, objClassReg, castClassReg, castClassDepth, falseLabel, callLabel, srm);
+            dynamicCastClass = genInstanceOfOrCheckcastSuperClassTest(node, cg, objClassReg, castClassReg, castClassDepth, falseLabel, dynamicCacheTestLabel, srm);
             generateS390BranchInstruction(cg, TR::InstOpCode::BRC, branchCond, node, branchLabel);
+            // If next test is dynamicCacheTest then generate a Branch to Skip it.
+            // In genInstanceOfOrCheckcastSuperClassTest generates the Branch to dynamic cache test
+            if (dynamicCacheTestLabel != callLabel)
+               generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BC, node, jmpLabel);
             generateGoToFalseBRC=false;
             break;
             }
@@ -5578,12 +5841,22 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
                traceMsg(comp, "%s: Emitting ProfiledClass Test\n", node->getOpCode().getName());
             TR::Register *arbitraryClassReg1 = srm->findOrCreateScratchRegister();
             uint8_t numPICs = 0;
+            TR::Instruction *temp= NULL;
             cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOfStats/(%s)/Profile", comp->signature()),1,TR::DebugCounter::Undetermined);
             while (numPICs < numberOfProfiledClass)
                {
-               TR::Instruction *temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, (uintptrj_t)profiledClassesList[numPICs].profiledClass);
+               if (cg->needClassAndMethodPointerRelocations())
+                  temp = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, arbitraryClassReg1, (uintptrj_t) profiledClassesList[numPICs].profiledClass, TR_ClassPointer, NULL, NULL, NULL);
+               else
+                  temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, (uintptrj_t)profiledClassesList[numPICs].profiledClass);
+
+               // Adding profiled class to the static PIC slots.  
+               if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(profiledClassesList[numPICs].profiledClass), comp->getCurrentMethod()))
+                  comp->getStaticPICSites()->push_front(temp);
+               // Adding profiled class to static HCR PIC sites.               
                if (cg->wantToPatchClassPointer(profiledClassesList[numPICs].profiledClass, node))
                   comp->getStaticHCRPICSites()->push_front(temp);
+               
                if (profiledClassesList[numPICs].isProfiledClassInstanceOfCastClass)
                   generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, arbitraryClassReg1, objClassReg, TR::InstOpCode::COND_BE, trueLabel, false, false);
                else
@@ -5642,6 +5915,21 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
             srm->reclaimScratchRegister(castClassCacheReg);
             break;
             }
+         case DynamicCacheObjectClassTest:
+            {
+            generateDynamicCache = true;
+            if (comp->getOption(TR_TraceCG))
+               traceMsg(comp,"Emitting Dynamic Cache for ObjectClass only\n",node->getOpCode().getName());
+            break;
+            }
+         case DynamicCacheDynamicCastClassTest:
+            {
+            generateDynamicCache = true;
+            cacheCastClass = true;
+            if (comp->getOption(TR_TraceCG))
+               traceMsg(comp,"Emitting Dynamic Cache for CastClass and ObjectClass\n",node->getOpCode().getName());
+            break;
+            }
          case HelperCall:
             TR_ASSERT(false, "Doesn't make sense, HelperCall should be the terminal sequence");
             break;
@@ -5651,10 +5939,17 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
       --numSequencesRemaining;
       ++iter;
       }
-   TR::RegisterDependencyConditions *conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(graDeps, 0, 5+srm->numAvailableRegisters(), cg);
-   TR::RegisterDependencyConditions *outlinedConditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
 
-   // Dependency Conditions for main line sequences
+   if (numSequencesRemaining > 0 && *iter == HelperCall)
+      genInstanceOfDynamicCacheAndHelperCall(node, cg, castClassReg, objClassReg, resultReg, srm, doneLabel, callLabel, dynamicCacheTestLabel, branchLabel, trueLabel, falseLabel, dynamicCastClass, generateDynamicCache, cacheCastClass, ifInstanceOf, trueFallThrough);
+
+   if (needResult)
+      {
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, oppositeResultLabel);
+      generateRIInstruction(cg,loadHalfWordImmOp,node,resultReg,static_cast<int32_t>(!initialResult));
+      }
+   
+   TR::RegisterDependencyConditions *conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(graDeps, 0, 4+srm->numAvailableRegisters(), cg);
    if (objClassReg)
       conditions->addPostCondition(objClassReg, TR::RealRegister::AssignAny);
    if (needResult)
@@ -5663,92 +5958,16 @@ J9::Z::TreeEvaluator::VMgenCoreInstanceofEvaluator2(TR::Node * node, TR::CodeGen
    if (castClassReg)
       conditions->addPostConditionIfNotAlreadyInserted(castClassReg, TR::RealRegister::AssignAny);
    srm->addScratchRegistersToDependencyList(conditions);
-   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
-   if (numSequencesRemaining > 0 && *iter == HelperCall)
-      {
-      if (comp->getOption(TR_TraceCG))
-         traceMsg(comp, "%s: Emitting helper call\n",node->getOpCode().getName());
-
-      // Dependency Conditions for outlined section
-      if (!comp->getOption(TR_DisableOOL))
-         {
-         // In case of dynamic cast class, in super class we test if the runtime class is interface or array class, in either case we call helper from super class test
-         // So no need to generate another branch instruction here
-         if (!dynamicCastClass)
-            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, callLabel);
-         doneOOLLabel = doneLabel;
-         outlinedSlowPath = new (cg->trHeapMemory()) TR_S390OutOfLineCodeSection(callLabel, doneOOLLabel, cg);
-         cg->getS390OutOfLineCodeSectionList().push_front(outlinedSlowPath);
-         outlinedSlowPath->swapInstructionListsWithCompilation();
-         }
-
-         //In case we call a helper, we need castClass in R1 and objClass in R2 for the Helper
-         /* callLabel: #IF !(castClass evaluated)
-                       castClassReg= Eval(castClassNode)
-                       #ENDIF
-                       LG R1,castClassReg
-                       LG R2,objClassReg
-                       BRASL jitInstanceOf
-                       LT resultReg,R2
-                       #ifInstanceIf
-                           if trueFallThrough
-                              BRC COND_BNE, branchLabel
-                           else
-                              BRC COND_BE, branchLabel
-                       BRC (JMP),doneLabel
-
-            MainLine:
-            oppositeResLabel: LHI resultReg,!initialResult
-            doneLabel:
-         */
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, callLabel);
-         cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOfStats/(%s)/Helper", comp->signature()),1,TR::DebugCounter::Undetermined);
-         cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOf/(%s)/Helper", comp->signature()),1,TR::DebugCounter::Undetermined);
-         cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "SingleInstanceOf/Helper", comp->signature()),1,TR::DebugCounter::Undetermined);
-      if(!castClassReg)
-         {
-         castClassReg = cg->evaluate(castClassNode);
-         outlinedConditions->addPostConditionIfNotAlreadyInserted(castClassReg, TR::RealRegister::AssignAny);
-         conditions->addPostConditionIfNotAlreadyInserted(castClassReg, TR::RealRegister::AssignAny);
-         }
-         helperReturnLabel = generateLabelSymbol(cg);
-         helperReturnRegister = helperLink->buildDirectDispatch(node);
-         conditions->addPostCondition(helperReturnRegister, TR::RealRegister::AssignAny);
-         outlinedConditions->addPostCondition(helperReturnRegister, TR::RealRegister::AssignAny);
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, helperReturnLabel, outlinedConditions);
-         generateRRInstruction(cg, TR::InstOpCode::getLoadTestRegOpCode(), node, (needResult) ? resultReg:helperReturnRegister, helperReturnRegister);
-
-      if (doneOOLLabel)
-         {
-         // WARNING: It is not recommended to have two exit point in OOL section.
-         // In this case we need it in case of ifInstanceOf to save additional complex logic in mainline section
-         // We can take a risk of having two exit points in OOL here as there is no other register instruction between them.
-         if (ifInstanceOf)
-            {
-            if (trueFallThrough)
-               generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, falseLabel);
-            else
-               generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, trueLabel);
-            }
-         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, doneOOLLabel);
-         outlinedSlowPath->swapInstructionListsWithCompilation();
-         }
-      }
-   if (needResult)
-      {
-      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, oppositeResultLabel);
-      generateRIInstruction(cg,loadHalfWordImmOp,node,resultReg,static_cast<int32_t>(!initialResult));
-      }
-
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneLabel, conditions);
    if (objClassReg)
       cg->stopUsingRegister(objClassReg);
+   if (castClassReg)
+      cg->stopUsingRegister(castClassReg);
    srm->stopUsingRegisters();
    cg->decReferenceCount(objectNode);
    cg->decReferenceCount(castClassNode);
    if (needResult)
       node->setRegister(resultReg);
-   cg->stopUsingRegister(helperReturnRegister);
    return resultReg;
    }
 
@@ -6051,15 +6270,23 @@ J9::Z::TreeEvaluator::VMcheckcastEvaluator2(TR::Node * node, TR::CodeGenerator *
                traceMsg(comp, "%s: Emitting Profiled Class Test\n", node->getOpCode().getName());
             TR::Register *arbitraryClassReg1 = srm->findOrCreateScratchRegister();
             uint8_t numPICs = 0;
+            TR::Instruction *temp= NULL;
             cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "checkCastStats/(%s)/Profiled", comp->signature()),1,TR::DebugCounter::Undetermined);
             while (numPICs < numberOfProfiledClass)
                {
-               TR::Instruction *temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, (uintptrj_t)profiledClassesList[numPICs].profiledClass);
+               if (cg->needClassAndMethodPointerRelocations())
+                  temp = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, arbitraryClassReg1, (uintptrj_t) profiledClassesList[numPICs].profiledClass, TR_ClassPointer, NULL, NULL, NULL);
+               else
+                  temp = generateRILInstruction(cg, TR::InstOpCode::LARL, node, arbitraryClassReg1, (uintptrj_t)profiledClassesList[numPICs].profiledClass);
+
+               // Adding profiled classes to static PIC sites
+               if (fej9->isUnloadAssumptionRequired((TR_OpaqueClassBlock *)(profiledClassesList[numPICs].profiledClass), comp->getCurrentMethod()))
+                  comp->getStaticPICSites()->push_front(temp);
+               // Adding profiled classes to HCR PIC sites
                if (cg->wantToPatchClassPointer(profiledClassesList[numPICs].profiledClass, node))
                   comp->getStaticHCRPICSites()->push_front(temp);
+               
                temp = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, arbitraryClassReg1, objClassReg, TR::InstOpCode::COND_BE, resultLabel, false, false);
-               if (numPICs == 0)
-                  cursor = temp;
                numPICs++;
                }
             cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "checkCastStats/(%s)/ProfiledFail", comp->signature()),1,TR::DebugCounter::Undetermined);


### PR DESCRIPTION
Onsite circular buffer to cache the instance/object classes for which we failed all the inline tests and called JIT helper. This cache will be checked every time before calling JIT helpers. Currently this optimization is disabled by setting `maxOnsiteCacheSlotForInstanceOf` to 0. To enable this feature pass JIT option `-Xjit:maxOnsiteCacheSlotForInstanceOf=n` where n is desired number of cache slots.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>