### PR TITLE
Implement an onsite cicular buffer for instanceOf

### DIFF
--- a/runtime/tr.source/trj9/codegen/J9TreeEvaluator.hpp
+++ b/runtime/tr.source/trj9/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluatorConnector
       ClassEqualityTest,                // Needs object class: y, needs cast class: y
       SuperClassTest,                   // Needs object class: y, needs cast class: y
       CastClassCacheTest,               // Needs object class: y, needs cast class: y
+      DynamicCacheObjectClassTest,      // Needs object class: y, needs cast class: n
+      DynamicCacheDynamicCastClassTest, // Needs object class: y, needs cast class: y
       HelperCall,                       // Needs object class: n, needs cast class: y
 
       InstanceOfOrCheckCastMaxSequences

--- a/runtime/tr.source/trj9/control/J9Options.cpp
+++ b/runtime/tr.source/trj9/control/J9Options.cpp
@@ -72,6 +72,7 @@ int32_t J9::Options::_relaxedCompilationLimitsSampleThreshold = 120; // normally
 int32_t J9::Options::_sampleThresholdVariationAllowance = 30;
 
 int32_t J9::Options::_maxCheckcastProfiledClassTests = 3;
+int32_t J9::Options::_maxOnsiteCacheSlotForInstanceOf = 0; // Setting this value to zero will disable onsite cache in instanceof.
 int32_t J9::Options::_cpuEntitlementForConservativeScorching = 801; // 801 means more than 800%, i.e. 8 cpus
                                                                     // A very large number disables the feature
 int32_t J9::Options::_sampleHeartbeatInterval = 10;
@@ -866,6 +867,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_lowVirtualMemoryMBThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"maxCheckcastProfiledClassTests=", "R<nnn>\tnumber inlined profiled classes for profiledclass test in checkcast/instanceof",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_maxCheckcastProfiledClassTests, 0, "%d", NOT_IN_SUBSET},
+   {"maxOnsiteCacheSlotForInstanceOf=", "R<nnn>\tnumber of onsite cache slots for instanceOf",
+      TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_maxOnsiteCacheSlotForInstanceOf, 0, "%d", NOT_IN_SUBSET},
    {"minSamplingPeriod=", "R<nnn>\tminimum number of milliseconds between samples for hotness",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_minSamplingPeriod, 0, "P%d", NOT_IN_SUBSET},
    {"minSuperclassArraySize=", "I<nnn>\t set the size of the minimum superclass array size",

--- a/runtime/tr.source/trj9/control/J9Options.hpp
+++ b/runtime/tr.source/trj9/control/J9Options.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,22 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    
    static int32_t _maxCheckcastProfiledClassTests;
    static int32_t getCheckcastMaxProfiledClassTests() {return _maxCheckcastProfiledClassTests;}
+
+   static int32_t _maxOnsiteCacheSlotForInstanceOf;
+   /** \brief
+    *     Returns the _maxOnsiteCacheSlotForInstanceOf
+    *
+    *  \details
+    *     maxOnsiteCacheSlotForInstanceOf node defines number of onsite cache slots to generate per site of instanceOf
+    *     Set this value to 0 to disable generation of onsite cache test for instanceOf
+    *
+    */
+   static int32_t getMaxOnsiteCacheSlotForInstanceOf() {return _maxOnsiteCacheSlotForInstanceOf;}
+   /** \brief
+    *     Setter for _maxOnsiteCacheSlotForInstanceOf
+    *
+    */
+   static int32_t setMaxOnsiteCacheSlotForInstanceOf(int32_t m) {return _maxOnsiteCacheSlotForInstanceOf = m;}
 
    static int32_t _resetCountThreshold;
 

--- a/runtime/tr.source/trj9/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/p/codegen/J9TreeEvaluator.cpp
@@ -3797,6 +3797,12 @@ TR::Register *J9::Power::TreeEvaluator::VMinstanceOfEvaluator2(TR::Node *node, T
             if (comp->getOption(TR_TraceCG)) traceMsg(comp, "%s: Emitting ArrayOfJavaLangObjectTest\n", node->getOpCode().getName());
             genInstanceOfOrCheckCastObjectArrayTest(node, cr0Reg, objectClassReg, nextSequenceLabel, srm, cg);
             break;
+         case DynamicCacheObjectClassTest:
+            TR_ASSERT_FATAL(false, "%s: DynamicCacheObjectClassTest is not implemented on P\n", node->getOpCode().getName());
+            break;
+         case DynamicCacheDynamicCastClassTest: 
+            TR_ASSERT_FATAL(false, "%s: DynamicCacheDynamicCastClassTest is not implemented on P\n", node->getOpCode().getName());
+            break;
          case HelperCall:
             TR_ASSERT(false, "Doesn't make sense, HelperCall should be the terminal sequence");
             break;


### PR DESCRIPTION
Onsite circular buffer to cache the instance/object
classes for which we failed all the inline tests
and called JIT helper. This cache will be checked everytime
before calling JIT helpers.
Currently this codegen optimization is disabled by setting
maxOnsiteCacheSlotForInstanceOf to 0. To enable this feature
pass JIT option -Xjit:maxOnsiteCacheSlotForInstanceOf=n where
n is desired number of cache slots.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>