### PR TITLE
Fixed OpenJDK8 test compilation and sanity suite issues.

### DIFF
--- a/test/Java8andUp/build.xml
+++ b/test/Java8andUp/build.xml
@@ -165,6 +165,7 @@
 					<src path="${src}" />
 					<src path="${src_80}" />
 					<src path="${transformerListener}" />
+					<exclude name="**/Cmvc194280.java" />
 					<exclude name="**/resources/**"/>
 					<exclude name="**/gpu/**"/>
 					<!-- requires special compilation methods -->

--- a/test/VM_Test/excluded_playlist.xml
+++ b/test/VM_Test/excluded_playlist.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2016, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+
+        <test>
+                <featureIds>
+                        <featureId>113758</featureId>
+                </featureIds>
+                <testCaseName>recreateClassTest</testCaseName>
+                <variations>
+                        <variation>NoOptions</variation>
+                </variations>
+                <command>
+        $(JAVA_COMMAND) $(JVM_OPTIONS) \
+        -javaagent:$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
+        -cp $(Q)$(LIB_DIR)$(D)junit4.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(P)$(TEST_RESROOT)$(D)VM_Test.jar$(P)$(LIB_DIR)$(D)javassist.jar$(Q) \
+        junit.textui.TestRunner com.ibm.j9.recreateclass.tests.RecreateClassTestSuite; \
+        $(TEST_STATUS)</command>
+                <tags>
+                        <tag>sanity</tag>
+                </tags>
+                <subsets>
+                        <subset>SE80</subset>
+                </subsets>
+        </test>
+
+        <test>
+                <featureIds>
+                        <featureId>133610</featureId>
+                </featureIds>
+                <testCaseName>CFdumptest</testCaseName>
+                <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+        -cp $(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(P)$(LIB_DIR)$(D)junit4.jar$(Q) \
+        junit.textui.TestRunner com.ibm.j9.cfdump.tests.CfdumpTestSuite; \
+        $(TEST_STATUS)</command>
+                <tags>
+                        <tag>sanity</tag>
+                </tags>
+                <subsets>
+                        <subset>SE80</subset>
+                </subsets>
+        </test>
+</playlist>

--- a/test/VM_Test/playlist.xml
+++ b/test/VM_Test/playlist.xml
@@ -78,44 +78,6 @@
 
 	<test>
 		<featureIds>
-			<featureId>113758</featureId>
-		</featureIds>
-		<testCaseName>recreateClassTest</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>
-	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-javaagent:$(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(Q) \
-	-cp $(Q)$(LIB_DIR)$(D)junit4.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(P)$(TEST_RESROOT)$(D)VM_Test.jar$(P)$(LIB_DIR)$(D)javassist.jar$(Q) \
-	junit.textui.TestRunner com.ibm.j9.recreateclass.tests.RecreateClassTestSuite; \
-	$(TEST_STATUS)</command>
-		<tags>
-			<tag>sanity</tag>
-		</tags>
-		<subsets>
-			<subset>SE80</subset>
-		</subsets>
-	</test>
-
-	<test>
-		<featureIds>
-			<featureId>133610</featureId>
-		</featureIds>
-		<testCaseName>CFdumptest</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(TEST_RESROOT)$(D)VM_Test.jar$(P)$(LIB_DIR)$(D)junit4.jar$(Q) \
-	junit.textui.TestRunner com.ibm.j9.cfdump.tests.CfdumpTestSuite; \
-	$(TEST_STATUS)</command>
-		<tags>
-			<tag>sanity</tag>
-		</tags>
-		<subsets>
-			<subset>SE80</subset>
-		</subsets>
-	</test>
-	<test>
-		<featureIds>
 			<featureId>134688</featureId>
 		</featureIds>
 		<testCaseName>SharedClassesSysVTesting</testCaseName>


### PR DESCRIPTION
- Excluded Cmvc194280.java from SE80
- Removed unsupported tests: recreateClassTest and CFdumptest


Signed-off-by: Andrew Leonard <andrew_m_leonard@uk.ibm.com>