### PR TITLE
Fix the locals of stackmap in verifier

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -478,16 +478,21 @@ parseLocals (J9BytecodeVerificationData * verifyData, U_8** stackMapData, J9Bran
 			}
 			liveStack->stackElements[localsCount] = BCV_BASE_TYPE_TOP;
 
-			/* Possibly remove a double or long (counts as 1 local, but two slots).
-			 * A double or a long is pushed as <top, double|long>
+			/* Check long/double type as long as there still remains local variables
+			 * in the stackmap frame.
 			 */
-			stackEntry = liveStack->stackElements[localsCount - 1];
-			if ((stackEntry == BCV_BASE_TYPE_DOUBLE) || (stackEntry == BCV_BASE_TYPE_LONG)) {
-				localsCount--;
-				if (localsCount < 0) {
-					goto _underflow;
+			if (localsCount > 0) {
+				/* Possibly remove a double or long (counts as 1 local, but two slots).
+				 * A double or a long is pushed as <top, double|long>
+				 */
+				stackEntry = liveStack->stackElements[localsCount - 1];
+				if ((BCV_BASE_TYPE_DOUBLE == stackEntry) || (BCV_BASE_TYPE_LONG == stackEntry)) {
+					localsCount--;
+					if (localsCount < 0) {
+						goto _underflow;
+					}
+					liveStack->stackElements[localsCount] = BCV_BASE_TYPE_TOP;
 				}
-				liveStack->stackElements[localsCount] = BCV_BASE_TYPE_TOP;
 			}
 		}
 
@@ -499,7 +504,7 @@ parseLocals (J9BytecodeVerificationData * verifyData, U_8** stackMapData, J9Bran
 				goto _overflow;
 			}
 			liveStack->stackElements[localsCount++] = stackEntry;
-			if ((stackEntry == BCV_BASE_TYPE_DOUBLE) || (stackEntry == BCV_BASE_TYPE_LONG)) {
+			if ((BCV_BASE_TYPE_DOUBLE == stackEntry) || (BCV_BASE_TYPE_LONG == stackEntry)) {
 				if (localsCount >= maxLocals) {
 					/* Oveflow */
 					goto _overflow;

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -230,7 +230,7 @@ pushLiveStackToVerificationTypeBuffer(StackMapFrame* stackMapFrame, J9BytecodeVe
 
 	/* 'locals' on liveStack */
 
-	/* Determine the count of local varibles on 'locals' (liveStack) starting from the right end of 'locals'.
+	/* Determine the count of local variables on 'locals' (liveStack) starting from the right end of 'locals'.
 	 * Note: It is true that placeholders ('top') always occur on the right end of 'locals'.
 	 * e.g. data1, data2, data3, top, top, top, ...
 	 * However, local variables can be updated at any place of 'locals' in the bytecode
@@ -868,7 +868,7 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 		printCurrentStack = printStackFrame;
 		break;
 	case BCV_ERR_STACKMAP_FRAME_LOCALS_UNDERFLOW:
-		printMessage(&msgBuf, "The count of local varibles in the stackmap frame is less than 0.");
+		printMessage(&msgBuf, "The count of local variables in the stackmap frame is less than 0.");
 		break;
 	case BCV_ERR_STACKMAP_FRAME_LOCALS_OVERFLOW:
 		printMessage(&msgBuf, "Exceeded max local size %u in the stackmap frame.", verifyData->errorTempData);


### PR DESCRIPTION
The change is to ensure verifier checks
long/double type only when there still
are local variables left in the stackmap 
frame.

Fixes: #302

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>