### PR TITLE
Remove deprecated estimated cold length

### DIFF
--- a/runtime/tr.source/trj9/arm/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/arm/codegen/J9CodeGenerator.cpp
@@ -248,11 +248,10 @@ void J9::ARM::CodeGenerator::doBinaryEncoding()
       }
 
    self()->setEstimatedWarmLength(estimate);
-   self()->setEstimatedColdLength(0);
 
    cursorInstruction = comp->getFirstInstruction();
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), self()->getEstimatedColdLength(), &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);


### PR DESCRIPTION
The CodeGenerator functions `getEstimatedColdLength()` and `setEstimatedColdLength()`
are deprecated in OMR.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>