### PR TITLE
Make DDR table accessor functions more specific

### DIFF
--- a/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GenerateBlobC.java
+++ b/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GenerateBlobC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,6 +55,7 @@ import com.ibm.j9ddr.autoblob.xmlparser.StructureXMLParser;
  * @author andhall
  *
  */
+@SuppressWarnings("nls")
 public class GenerateBlobC
 {
 
@@ -211,7 +212,7 @@ public class GenerateBlobC
 		}
 	}
 	
-	private static void loadTypes(SortedSet<UserDefinedType> typesToWrite, Collection<? extends UserDefinedType> toLoad, GenerateBlobCConfig config)
+	static void loadTypes(SortedSet<UserDefinedType> typesToWrite, Collection<? extends UserDefinedType> toLoad, GenerateBlobCConfig config)
 	{
 		for (UserDefinedType t : toLoad) {
 			if (t.shouldBeInBlob()) {
@@ -270,10 +271,10 @@ public class GenerateBlobC
 			out.println("class " + className);
 			out.println("{");
 			out.println("public:");
-			out.println("\tstatic const J9DDRStructDefinition* getStructTable();");
+			out.println("\tstatic const J9DDRStructDefinition *getStructTable();");
 			out.println("};");
 			out.println();
-			out.println("const J9DDRStructDefinition* " + className + "::getStructTable()");
+			out.println("const J9DDRStructDefinition *" + className + "::getStructTable()");
 			out.println("{");
 		}
 	}
@@ -302,7 +303,7 @@ public class GenerateBlobC
 		}
 		out.println("J9DDRStructTableEnd");
 		out.println();
-		out.println("const J9DDRStructDefinition* get" + config.autoblobConfiguration.getName() + "StructTable(void * portLib)");
+		out.println("const J9DDRStructDefinition *get" + config.autoblobConfiguration.getName() + "StructTable(struct OMRPortLibrary *portLib)");
 		out.println("{");
 		out.println("\treturn J9DDR_" + config.autoblobConfiguration.getName() + "_structs;");
 		out.println("}");
@@ -322,7 +323,7 @@ public class GenerateBlobC
 		out.println("}");
 		out.println("extern \"C\" {");
 		out.println();
-		out.println("\tconst J9DDRStructDefinition* get" + config.autoblobConfiguration.getName() + "StructTable(void * portLib)");
+		out.println("\tconst J9DDRStructDefinition *get" + config.autoblobConfiguration.getName() + "StructTable(struct OMRPortLibrary *portLib)");
 		out.println("\t{");
 		out.println("\t\treturn " + getCPlusPlusClassName(config) + "::getStructTable();");
 		out.println("\t}");

--- a/runtime/ddr/ddrcppsupportblob.cpp.stub
+++ b/runtime/ddr/ddrcppsupportblob.cpp.stub
@@ -24,15 +24,14 @@
 #include "j9.h"
 #include "j9ddr.h"
 
-extern "C" {
-	static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
+static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-	const J9DDRStructDefinition* getDDR_CPPStructTable(void* portLib)
-	{
-		OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-		omrtty_printf("WARNING: CPP support structure table was not generated and has been stubbed out. See ddr.readme.\n");
-	
-		return structStubs;
-	}
-};
+extern "C"
+const J9DDRStructDefinition *
+getDDR_CPPStructTable(struct OMRPortLibrary *portLib)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: CPP support structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
+	return structStubs;
+}

--- a/runtime/ddr/ddrtable.c
+++ b/runtime/ddr/ddrtable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,43 +22,47 @@
 #include "j9ddr.h"
 #include "ddrtable.h"
 
-extern const J9DDRStructDefinition* getJITStructTable(void);
-extern const J9DDRStructDefinition* getAlgorithmVersionStructTable(void);
-/* Generated struct table functions take a portLib to allow stub functions
- * to print warning messages.*/
-extern const J9DDRStructDefinition* getJITAutomatedStructTable(void* portLib);
-extern const J9DDRStructDefinition* getOmrStructTable(void* portLib);
-extern const J9DDRStructDefinition* getVMStructTable(void* portLib);
-extern const J9DDRStructDefinition* getStackWalkerStructTable(void* portLib);
-extern const J9DDRStructDefinition* getHyPortStructTable(void* portLib);
-extern const J9DDRStructDefinition* getJ9PortStructTable(void* portLib);
-extern const J9DDRStructDefinition* getGCStructTable(void *portLib);
-extern const J9DDRStructDefinition* getDDR_CPPStructTable(void *portLib);
+extern const J9DDRStructDefinition *getJITStructTable(void);
+extern const J9DDRStructDefinition *getAlgorithmVersionStructTable(void);
 
-const J9DDRStructDefinition**
-initializeDDRComponents(OMRPortLibrary* portLib)
+/*
+ * Generated struct table functions take a portLib
+ * to allow stub functions to print warning messages.
+ */
+extern const J9DDRStructDefinition *getJITAutomatedStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getOmrStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getVMStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getStackWalkerStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getHyPortStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getJ9PortStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getGCStructTable(struct OMRPortLibrary *portLib);
+extern const J9DDRStructDefinition *getDDR_CPPStructTable(struct OMRPortLibrary *portLib);
+
+const J9DDRStructDefinition **
+initializeDDRComponents(OMRPortLibrary *portLib)
 {
-	const J9DDRStructDefinition** list;
-	UDATA i = 0;
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 
-	list = omrmem_allocate_memory((J9DDR_COMPONENT_COUNT+1) * sizeof(J9DDRStructDefinition*), OMRMEM_CATEGORY_VM);
-	if(NULL == list) {
-		return NULL;
-	}
+	const J9DDRStructDefinition **list = omrmem_allocate_memory(
+			(J9DDR_COMPONENT_COUNT + 1) * sizeof(J9DDRStructDefinition *),
+			OMRMEM_CATEGORY_VM);
 
-	list[i++] = getOmrStructTable(portLib);
-	list[i++] = getVMStructTable(portLib);
-	list[i++] = getStackWalkerStructTable(portLib);
-	list[i++] = getGCStructTable(portLib);
-	list[i++] = getHyPortStructTable(portLib);
-	list[i++] = getJ9PortStructTable(portLib);
-	list[i++] = getAlgorithmVersionStructTable();
-	list[i++] = getJITStructTable();
-	list[i++] = getJITAutomatedStructTable(portLib);
-	list[i++] = getDDR_CPPStructTable(portLib);
-	list[i] = NULL;
-	/*increment i here if it needs to be used further*/
+	if (NULL != list) {
+		UDATA i = 0;
+
+		list[i++] = getOmrStructTable(portLib);
+		list[i++] = getVMStructTable(portLib);
+		list[i++] = getStackWalkerStructTable(portLib);
+		list[i++] = getGCStructTable(portLib);
+		list[i++] = getHyPortStructTable(portLib);
+		list[i++] = getJ9PortStructTable(portLib);
+		list[i++] = getAlgorithmVersionStructTable();
+		list[i++] = getJITStructTable();
+		list[i++] = getJITAutomatedStructTable(portLib);
+		list[i++] = getDDR_CPPStructTable(portLib);
+		list[i] = NULL;
+		/* increment i here if it needs to be used further */
+	}
 
 	return list;
 }

--- a/runtime/ddr/hyportddrblob.c.stub
+++ b/runtime/ddr/hyportddrblob.c.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,11 @@
 
 static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-
-const J9DDRStructDefinition* getHyPortStructTable(void* portLib)
+const J9DDRStructDefinition *
+getHyPortStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-	OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: HyPort Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: HyPort Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/j9portddrblob.c.stub
+++ b/runtime/ddr/j9portddrblob.c.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,11 @@
 
 static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-
-const J9DDRStructDefinition* getJ9PortStructTable(void* portLib)
+const J9DDRStructDefinition *
+getJ9PortStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-	OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: J9Port Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: J9Port Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/jitddrblob.c.stub
+++ b/runtime/ddr/jitddrblob.c.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,10 +26,11 @@
 
 static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-const J9DDRStructDefinition* getJITAutomatedStructTable(void* portLib)
+const J9DDRStructDefinition *
+getJITAutomatedStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-	OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: JIT Automated structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: JIT Automated structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/omrddrblob.c.stub
+++ b/runtime/ddr/omrddrblob.c.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,11 @@
 
 static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-const J9DDRStructDefinition* getOmrStructTable(void* portLib)
+const J9DDRStructDefinition *
+getOmrStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-	OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: Omr structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: OMR structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }
-

--- a/runtime/ddr/stackwalkddrblob.c.stub
+++ b/runtime/ddr/stackwalkddrblob.c.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,10 +26,11 @@
 
 static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-const J9DDRStructDefinition* getStackWalkerStructTable(void* portLib)
+const J9DDRStructDefinition *
+getStackWalkerStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-	OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: StackWalker structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: StackWalker structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/vmddrblob.c.stub
+++ b/runtime/ddr/vmddrblob.c.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,11 @@
 
 static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-const J9DDRStructDefinition* getVMStructTable(void* portLib)
+const J9DDRStructDefinition *
+getVMStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-	OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: VM structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
+	omrtty_printf("WARNING: VM structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }
-


### PR DESCRIPTION
Rather than accept any pointer (`void *`), adjust the signature of ddr table accessor functions to require
an OMRPortLibrary pointer (`struct OMRPortLibrary *`) as assumed by the stub implementations. This way the compiler will signal any misuse of these funcitons. The code to generate the real implementations is also updated.