### PR TITLE
VarHandles - Remove typeTable

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -23,6 +23,7 @@
 package java.lang.invoke;
 
 import static java.lang.invoke.MethodType.methodType;
+import static java.lang.invoke.ArrayVarHandle.ArrayVarHandleOperations.*;
 
 /**
  * {@link VarHandle} subclass for array element {@link VarHandle} instances.
@@ -43,32 +44,32 @@ final class ArrayVarHandle extends VarHandle {
 		
 		if (!type.isPrimitive()) {
 			type = Object.class;
-			operationsClass = ArrayVarHandleOperations.OpObject.class;
+			operationsClass = OpObject.class;
 		} else if (int.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpInt.class;
+			operationsClass = OpInt.class;
 		} else if (long.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpLong.class;
+			operationsClass = OpLong.class;
 		} else if (boolean.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpBoolean.class;
+			operationsClass = OpBoolean.class;
 		} else if (byte.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpByte.class;
+			operationsClass = OpByte.class;
 		} else if (char.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpChar.class;
+			operationsClass = OpChar.class;
 		} else if (double.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpDouble.class;
+			operationsClass = OpDouble.class;
 		} else if (float.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpFloat.class;
+			operationsClass = OpFloat.class;
 		} else if (short.class == type) {
-			operationsClass = ArrayVarHandleOperations.OpShort.class;
+			operationsClass = OpShort.class;
 		} else {
 			/*[MSG "K0626", "Unable to handle type {0}."]*/
 			throw new InternalError(com.ibm.oti.util.Msg.getString("K0626", type)); //$NON-NLS-1$
 		}
 		
 		// Populate the MethodHandle[] using MethodHandles to methods in ArrayVarHandleOperations
-		MethodType getter = methodType(type, Object.class, int.class, ArrayVarHandle.class);
-		MethodType setter = methodType(void.class, Object.class, int.class, type, ArrayVarHandle.class);
-		MethodType compareAndSet = methodType(boolean.class, Object.class, int.class, type, type, ArrayVarHandle.class);
+		MethodType getter = methodType(type, Object.class, int.class, VarHandle.class);
+		MethodType setter = methodType(void.class, Object.class, int.class, type, VarHandle.class);
+		MethodType compareAndSet = methodType(boolean.class, Object.class, int.class, type, type, VarHandle.class);
 		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
 		MethodType getAndSet = setter.changeReturnType(type);
 		
@@ -76,34 +77,15 @@ final class ArrayVarHandle extends VarHandle {
 		MethodType[] lookupTypes = populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
 		MethodType[] exactTypes = lookupTypes;
 		if (initType == type) {
-			MethodType exactGetter = methodType(initType, arrayType, int.class, ArrayVarHandle.class);
-			MethodType exactSetter = methodType(void.class, arrayType, int.class, initType, ArrayVarHandle.class);
-			MethodType exactCompareAndSet = methodType(boolean.class, arrayType, int.class, initType, initType, ArrayVarHandle.class);
-			MethodType exactCompareAndExchange = compareAndSet.changeReturnType(initType);
-			MethodType exactGetAndSet = setter.changeReturnType(initType);
+			MethodType exactGetter = methodType(initType, arrayType, int.class, VarHandle.class);
+			MethodType exactSetter = methodType(void.class, arrayType, int.class, initType, VarHandle.class);
+			MethodType exactCompareAndSet = methodType(boolean.class, arrayType, int.class, initType, initType, VarHandle.class);
+			MethodType exactCompareAndExchange = exactCompareAndSet.changeReturnType(initType);
+			MethodType exactGetAndSet = exactSetter.changeReturnType(initType);
 			exactTypes = populateMTs(exactGetter, exactSetter, exactCompareAndSet, exactCompareAndExchange, exactGetAndSet);
 		}
 		
 		return populateMHs(operationsClass, lookupTypes, exactTypes);
-	}
-	
-	/**
-	 * Populates the static MethodType[] corresponding to the provided type. 
-	 * 
-	 * @param type The type to create MethodType for.
-	 * @return The populated MethodType[].
-	 */
-	static final MethodType[] populateMTs(Class<?> arrayType) {
-		Class<?> type = arrayType.getComponentType();
-		
-		// Create generic MethodTypes
-		MethodType getter = methodType(type, arrayType, int.class);
-		MethodType setter = methodType(void.class, arrayType, int.class, type);
-		MethodType compareAndSet = methodType(boolean.class, arrayType, int.class, type, type);
-		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
-		MethodType getAndSet = setter.changeReturnType(type);
-		
-		return populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
 	}
 	
 	/**
@@ -112,7 +94,7 @@ final class ArrayVarHandle extends VarHandle {
 	 * @param arrayType The array type (i.e. not the componentType) this VarHandle will access.
 	 */
 	ArrayVarHandle(Class<?> arrayType) {
-		super(arrayType.getComponentType(), new Class<?>[] {arrayType, int.class}, populateMHs(arrayType), populateMTs(arrayType), 0);
+		super(arrayType.getComponentType(), new Class<?>[] {arrayType, int.class}, populateMHs(arrayType), 0);
 	}
 
 	/**
@@ -157,59 +139,59 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final Object get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final Object get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				return _unsafe.getObject(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				_unsafe.putObject(receiver, computeOffset(index), value);
 			}
 
-			private static final Object getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final Object getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				return _unsafe.getObjectVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				_unsafe.putObjectVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final Object getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final Object getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				return _unsafe.getObjectOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				_unsafe.putObjectOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final Object getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final Object getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				return _unsafe.getObjectAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				_unsafe.putObjectRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
@@ -220,7 +202,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final Object compareAndExchange(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final Object compareAndExchange(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
@@ -231,21 +213,21 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final Object compareAndExchangeAcquire(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final Object compareAndExchangeAcquire(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
 				return _unsafe.compareAndExchangeObjectAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final Object compareAndExchangeRelease(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final Object compareAndExchangeRelease(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
 				return _unsafe.compareAndExchangeObjectRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
@@ -256,7 +238,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
@@ -267,7 +249,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
@@ -278,7 +260,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, Object testValue, Object newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
@@ -289,72 +271,72 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final Object getAndSet(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndSet(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				return _unsafe.getAndSetObject(receiver, computeOffset(index), value);
 			}
 
-			private static final Object getAndSetAcquire(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndSetAcquire(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				return _unsafe.getAndSetObjectAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final Object getAndSetRelease(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndSetRelease(Object receiver, int index, Object value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(value, receiver.getClass().getComponentType());
 				return _unsafe.getAndSetObjectRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final Object getAndAdd(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndAdd(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndAddAcquire(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndAddAcquire(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndAddRelease(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndAddRelease(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseAnd(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseAnd(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseAndAcquire(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseAndAcquire(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseAndRelease(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseAndRelease(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseOr(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseOr(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseOrAcquire(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseOrAcquire(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseOrRelease(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseOrRelease(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseXor(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseXor(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseXorAcquire(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseXorAcquire(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseXorRelease(Object receiver, int index, Object value, ArrayVarHandle varHandle) {
+			private static final Object getAndBitwiseXorRelease(Object receiver, int index, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -367,55 +349,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final byte get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final byte get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getByte(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				_unsafe.putByte(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final byte getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getByteVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				_unsafe.putByteVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final byte getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getByteOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				_unsafe.putByteOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final byte getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getByteAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				_unsafe.putByteRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -425,7 +407,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final byte compareAndExchange(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final byte compareAndExchange(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -435,19 +417,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final byte compareAndExchangeAcquire(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final byte compareAndExchangeAcquire(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.compareAndExchangeByteAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final byte compareAndExchangeRelease(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final byte compareAndExchangeRelease(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.compareAndExchangeByteRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -457,7 +439,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -467,7 +449,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -477,7 +459,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, byte testValue, byte newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -487,91 +469,91 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final byte getAndSet(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndSet(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndSetByte(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndSetAcquire(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndSetAcquire(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndSetByteAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndSetRelease(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndSetRelease(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndSetByteRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndAdd(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndAdd(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndAddByte(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndAddAcquire(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndAddAcquire(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndAddByteAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndAddRelease(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndAddRelease(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndAddByteRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseAnd(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseAnd(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndByte(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseAndAcquire(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseAndAcquire(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndByteAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseAndRelease(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseAndRelease(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndByteRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseOr(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseOr(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrByte(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseOrAcquire(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseOrAcquire(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrByteAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseOrRelease(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseOrRelease(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrByteRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseXor(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseXor(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorByte(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseXorAcquire(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseXorAcquire(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorByteAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final byte getAndBitwiseXorRelease(Object receiver, int index, byte value, ArrayVarHandle varHandle) {
+			private static final byte getAndBitwiseXorRelease(Object receiver, int index, byte value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorByteRelease(receiver, computeOffset(index), value);
@@ -586,55 +568,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final char get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final char get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getChar(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				_unsafe.putChar(receiver, computeOffset(index), value);
 			}
 
-			private static final char getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final char getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getCharVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				_unsafe.putCharVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final char getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final char getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getCharOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				_unsafe.putCharOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final char getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getCharAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				_unsafe.putCharRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -644,7 +626,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final char compareAndExchange(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final char compareAndExchange(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -654,19 +636,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final char compareAndExchangeAcquire(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final char compareAndExchangeAcquire(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.compareAndExchangeCharAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final char compareAndExchangeRelease(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final char compareAndExchangeRelease(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.compareAndExchangeCharRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -676,7 +658,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -686,7 +668,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -696,7 +678,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, char testValue, char newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -706,91 +688,91 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final char getAndSet(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndSet(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndSetChar(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndSetAcquire(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndSetAcquire(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndSetCharAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndSetRelease(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndSetRelease(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndSetCharRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndAdd(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndAdd(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndAddChar(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndAddAcquire(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndAddAcquire(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndAddCharAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndAddRelease(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndAddRelease(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndAddCharRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseAnd(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseAnd(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndChar(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseAndAcquire(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseAndAcquire(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndCharAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseAndRelease(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseAndRelease(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndCharRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseOr(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseOr(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrChar(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseOrAcquire(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseOrAcquire(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrCharAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseOrRelease(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseOrRelease(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrCharRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseXor(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseXor(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorChar(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseXorAcquire(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseXorAcquire(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorCharAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final char getAndBitwiseXorRelease(Object receiver, int index, char value, ArrayVarHandle varHandle) {
+			private static final char getAndBitwiseXorRelease(Object receiver, int index, char value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorCharRelease(receiver, computeOffset(index), value);
@@ -805,55 +787,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final double get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final double get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getDouble(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				_unsafe.putDouble(receiver, computeOffset(index), value);
 			}
 
-			private static final double getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final double getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getDoubleVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				_unsafe.putDoubleVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final double getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final double getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getDoubleOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				_unsafe.putDoubleOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final double getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getDoubleAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				_unsafe.putDoubleRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -863,7 +845,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchange(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final double compareAndExchange(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/
@@ -873,19 +855,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchangeAcquire(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final double compareAndExchangeAcquire(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.compareAndExchangeDoubleAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final double compareAndExchangeRelease(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final double compareAndExchangeRelease(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.compareAndExchangeDoubleRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/
@@ -895,7 +877,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -905,7 +887,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -915,7 +897,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, double testValue, double newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -925,75 +907,75 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double getAndSet(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndSet(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getAndSetDouble(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAndSetAcquire(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndSetAcquire(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getAndSetDoubleAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAndSetRelease(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndSetRelease(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getAndSetDoubleRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAndAdd(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndAdd(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getAndAddDouble(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAndAddAcquire(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndAddAcquire(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getAndAddDoubleAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAndAddRelease(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndAddRelease(Object receiver, int index, double value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
 				return _unsafe.getAndAddDoubleRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final double getAndBitwiseAnd(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndAcquire(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndRelease(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOr(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseOr(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrAcquire(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrRelease(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXor(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseXor(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorAcquire(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorRelease(Object receiver, int index, double value, ArrayVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(Object receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1006,55 +988,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final float get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final float get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getFloat(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				_unsafe.putFloat(receiver, computeOffset(index), value);
 			}
 
-			private static final float getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final float getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getFloatVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				_unsafe.putFloatVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final float getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final float getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getFloatOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				_unsafe.putFloatOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final float getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getFloatAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				_unsafe.putFloatRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1064,7 +1046,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchange(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final float compareAndExchange(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1074,19 +1056,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchangeAcquire(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final float compareAndExchangeAcquire(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.compareAndExchangeFloatAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final float compareAndExchangeRelease(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final float compareAndExchangeRelease(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.compareAndExchangeFloatRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1096,7 +1078,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1106,7 +1088,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1116,7 +1098,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, float testValue, float newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1126,75 +1108,75 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float getAndSet(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndSet(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getAndSetFloat(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAndSetAcquire(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndSetAcquire(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getAndSetFloatAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAndSetRelease(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndSetRelease(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getAndSetFloatRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAndAdd(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndAdd(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getAndAddFloat(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAndAddAcquire(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndAddAcquire(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getAndAddFloatAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAndAddRelease(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndAddRelease(Object receiver, int index, float value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
 				return _unsafe.getAndAddFloatRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final float getAndBitwiseAnd(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndAcquire(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndRelease(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOr(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseOr(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrAcquire(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrRelease(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXor(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseXor(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorAcquire(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorRelease(Object receiver, int index, float value, ArrayVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(Object receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1207,55 +1189,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final int get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final int get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getInt(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				_unsafe.putInt(receiver, computeOffset(index), value);
 			}
 
-			private static final int getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final int getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getIntVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				_unsafe.putIntVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final int getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final int getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getIntOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				_unsafe.putIntOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final int getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getIntAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				_unsafe.putIntRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1265,7 +1247,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchange(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final int compareAndExchange(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1275,19 +1257,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchangeAcquire(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final int compareAndExchangeAcquire(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.compareAndExchangeIntAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final int compareAndExchangeRelease(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final int compareAndExchangeRelease(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.compareAndExchangeIntRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1297,7 +1279,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1307,7 +1289,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1317,7 +1299,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, int testValue, int newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1327,91 +1309,91 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int getAndSet(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndSet(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndSetInt(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndSetAcquire(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndSetAcquire(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndSetIntAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndSetRelease(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndSetRelease(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndSetIntRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndAdd(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndAdd(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndAddInt(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndAddAcquire(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndAddAcquire(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndAddIntAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndAddRelease(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndAddRelease(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndAddIntRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseAnd(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseAnd(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndInt(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseAndAcquire(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseAndAcquire(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndIntAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseAndRelease(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseAndRelease(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndIntRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseOr(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseOr(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrInt(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseOrAcquire(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseOrAcquire(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrIntAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseOrRelease(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseOrRelease(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrIntRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseXor(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseXor(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorInt(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseXorAcquire(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseXorAcquire(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorIntAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final int getAndBitwiseXorRelease(Object receiver, int index, int value, ArrayVarHandle varHandle) {
+			private static final int getAndBitwiseXorRelease(Object receiver, int index, int value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorIntRelease(receiver, computeOffset(index), value);
@@ -1426,55 +1408,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final long get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final long get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getLong(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				_unsafe.putLong(receiver, computeOffset(index), value);
 			}
 
-			private static final long getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final long getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getLongVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				_unsafe.putLongVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final long getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final long getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getLongOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				_unsafe.putLongOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final long getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getLongAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				_unsafe.putLongRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1484,7 +1466,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final long compareAndExchange(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final long compareAndExchange(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1494,19 +1476,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchangeAcquire(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final long compareAndExchangeAcquire(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.compareAndExchangeLongAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final long compareAndExchangeRelease(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final long compareAndExchangeRelease(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.compareAndExchangeLongRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1516,7 +1498,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1526,7 +1508,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1536,7 +1518,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, long testValue, long newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1546,91 +1528,91 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long getAndSet(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndSet(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndSetLong(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndSetAcquire(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndSetAcquire(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndSetLongAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndSetRelease(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndSetRelease(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndSetLongRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndAdd(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndAdd(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndAddLong(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndAddAcquire(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndAddAcquire(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndAddLongAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndAddRelease(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndAddRelease(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndAddLongRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseAnd(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseAnd(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndLong(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseAndAcquire(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseAndAcquire(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndLongAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseAndRelease(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseAndRelease(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndLongRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseOr(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseOr(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrLong(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseOrAcquire(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseOrAcquire(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrLongAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseOrRelease(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseOrRelease(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrLongRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseXor(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseXor(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorLong(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseXorAcquire(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseXorAcquire(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorLongAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final long getAndBitwiseXorRelease(Object receiver, int index, long value, ArrayVarHandle varHandle) {
+			private static final long getAndBitwiseXorRelease(Object receiver, int index, long value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorLongRelease(receiver, computeOffset(index), value);
@@ -1645,55 +1627,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final short get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final short get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getShort(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				_unsafe.putShort(receiver, computeOffset(index), value);
 			}
 
-			private static final short getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final short getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getShortVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				_unsafe.putShortVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final short getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final short getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getShortOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				_unsafe.putShortOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final short getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getShortAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				_unsafe.putShortRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1703,7 +1685,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final short compareAndExchange(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final short compareAndExchange(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1713,19 +1695,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final short compareAndExchangeAcquire(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final short compareAndExchangeAcquire(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.compareAndExchangeShortAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final short compareAndExchangeRelease(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final short compareAndExchangeRelease(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.compareAndExchangeShortRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/
@@ -1735,7 +1717,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1745,7 +1727,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1755,7 +1737,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, short testValue, short newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1765,91 +1747,91 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final short getAndSet(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndSet(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndSetShort(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndSetAcquire(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndSetAcquire(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndSetShortAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndSetRelease(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndSetRelease(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndSetShortRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndAdd(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndAdd(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndAddShort(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndAddAcquire(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndAddAcquire(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndAddShortAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndAddRelease(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndAddRelease(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndAddShortRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseAnd(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseAnd(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndShort(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseAndAcquire(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseAndAcquire(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndShortAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseAndRelease(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseAndRelease(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndShortRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseOr(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseOr(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrShort(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseOrAcquire(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseOrAcquire(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrShortAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseOrRelease(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseOrRelease(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrShortRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseXor(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseXor(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorShort(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseXorAcquire(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseXorAcquire(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorShortAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final short getAndBitwiseXorRelease(Object receiver, int index, short value, ArrayVarHandle varHandle) {
+			private static final short getAndBitwiseXorRelease(Object receiver, int index, short value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorShortRelease(receiver, computeOffset(index), value);
@@ -1864,55 +1846,55 @@ final class ArrayVarHandle extends VarHandle {
 				return computeOffset(index, BASE_OFFSET, INDEX_SCALE);
 			}
 			
-			private static final boolean get(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final boolean get(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getBoolean(receiver, computeOffset(index));
 			}
 
-			private static final void set(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final void set(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				_unsafe.putBoolean(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getVolatile(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final boolean getVolatile(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getBooleanVolatile(receiver, computeOffset(index));
 			}
 
-			private static final void setVolatile(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				_unsafe.putBooleanVolatile(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getOpaque(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final boolean getOpaque(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getBooleanOpaque(receiver, computeOffset(index));
 			}
 
-			private static final void setOpaque(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				_unsafe.putBooleanOpaque(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAcquire(Object receiver, int index, ArrayVarHandle varHandle) {
+			private static final boolean getAcquire(Object receiver, int index, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getBooleanAcquire(receiver, computeOffset(index));
 			}
 
-			private static final void setRelease(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				_unsafe.putBooleanRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1922,7 +1904,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean compareAndExchange(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndExchange(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1932,19 +1914,19 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean compareAndExchangeAcquire(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndExchangeAcquire(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.compareAndExchangeBooleanAcquire(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean compareAndExchangeRelease(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean compareAndExchangeRelease(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.compareAndExchangeBooleanRelease(receiver, computeOffset(index), testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1954,7 +1936,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1964,7 +1946,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1974,7 +1956,7 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int index, boolean testValue, boolean newValue, ArrayVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 /*[IF Sidecar19-SE-B174]*/				
@@ -1984,85 +1966,85 @@ final class ArrayVarHandle extends VarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean getAndSet(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndSet(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndSetBoolean(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndSetAcquire(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndSetAcquire(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndSetBooleanAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndSetRelease(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndSetRelease(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndSetBooleanRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndAdd(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndAdd(Object receiver, int index, boolean value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndAddAcquire(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndAddAcquire(Object receiver, int index, boolean value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndAddRelease(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndAddRelease(Object receiver, int index, boolean value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndBitwiseAnd(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseAnd(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndBoolean(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseAndAcquire(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseAndAcquire(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndBooleanAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseAndRelease(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseAndRelease(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseAndBooleanRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseOr(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseOr(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrBoolean(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseOrAcquire(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseOrAcquire(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrBooleanAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseOrRelease(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseOrRelease(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseOrBooleanRelease(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseXor(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseXor(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorBoolean(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseXorAcquire(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseXorAcquire(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorBooleanAcquire(receiver, computeOffset(index), value);
 			}
 
-			private static final boolean getAndBitwiseXorRelease(Object receiver, int index, boolean value, ArrayVarHandle varHandle) {
+			private static final boolean getAndBitwiseXorRelease(Object receiver, int index, boolean value, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
 				return _unsafe.getAndBitwiseXorBooleanRelease(receiver, computeOffset(index), value);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ByteArrayViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ByteArrayViewVarHandle.java
@@ -22,11 +22,10 @@
  *******************************************************************************/
 package java.lang.invoke;
 
-import static java.lang.invoke.MethodType.methodType;
 import static java.lang.invoke.ByteArrayViewVarHandle.ByteArrayViewVarHandleOperations.*;
+import static java.lang.invoke.MethodType.methodType;
 
 import java.nio.ByteOrder;
-import java.util.Objects;
 import jdk.internal.misc.Unsafe;
 
 final class ByteArrayViewVarHandle extends ViewVarHandle {
@@ -59,9 +58,9 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K0624", type)); //$NON-NLS-1$
 		}
 		
-		MethodType getter = methodType(type, byte[].class, int.class, ByteArrayViewVarHandle.class);
-		MethodType setter = methodType(void.class, byte[].class, int.class, type, ByteArrayViewVarHandle.class);
-		MethodType compareAndSet = methodType(boolean.class, byte[].class, int.class, type, type, ByteArrayViewVarHandle.class);
+		MethodType getter = methodType(type, byte[].class, int.class, VarHandle.class);
+		MethodType setter = methodType(void.class, byte[].class, int.class, type, VarHandle.class);
+		MethodType compareAndSet = methodType(boolean.class, byte[].class, int.class, type, type, VarHandle.class);
 		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
 		MethodType getAndSet = setter.changeReturnType(type);
 		MethodType[] lookupTypes = populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
@@ -70,28 +69,12 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 	}
 	
 	/**
-	 * Populates the static MethodType[] corresponding to the provided type. 
-	 * 
-	 * @param type The type to create MethodType for.
-	 * @return The populated MethodType[].
-	 */
-	static final MethodType[] populateMTs(Class<?> type) {
-		MethodType getter = methodType(type, byte[].class, int.class);
-		MethodType setter = methodType(void.class, byte[].class, int.class, type);
-		MethodType compareAndSet = methodType(boolean.class, byte[].class, int.class, type, type);
-		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
-		MethodType getAndSet = setter.changeReturnType(type);
-		
-		return populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
-	}
-	
-	/**
 	 * Constructs a VarHandle that can access elements of a byte array as wider types.
 	 * 
 	 * @param viewArrayType The component type used when viewing elements of the array. 
 	 */
 	ByteArrayViewVarHandle(Class<?> viewArrayType, ByteOrder byteOrder) {
-		super(viewArrayType, COORDINATE_TYPES, populateMHs(viewArrayType, byteOrder), populateMTs(viewArrayType), 0);
+		super(viewArrayType, COORDINATE_TYPES, populateMHs(viewArrayType, byteOrder), 0);
 	}
 
 	/**
@@ -118,135 +101,135 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpChar extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Character.BYTES;
 			
-			private static final char get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				return _unsafe.getChar(receiver, offset);
 			}
 
-			private static final void set(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putChar(receiver, offset, value);
 			}
 
-			private static final char getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getCharVolatile(receiver, offset);
 			}
 
-			private static final void setVolatile(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putCharVolatile(receiver, offset, value);
 			}
 
-			private static final char getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getCharOpaque(receiver, offset);
 			}
 
-			private static final void setOpaque(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putCharOpaque(receiver, offset, value);
 			}
 
-			private static final char getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getCharAcquire(receiver, offset);
 			}
 
-			private static final void setRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putCharRelease(receiver, offset, value);
 			}
 
-			private static final boolean compareAndSet(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchange(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final char compareAndExchange(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeAcquire(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final char compareAndExchangeAcquire(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeRelease(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final char compareAndExchangeRelease(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSet(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndSet(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndSetAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndSetRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAdd(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndAdd(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndAddAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndAddRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAnd(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseAnd(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOr(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseOr(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXor(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseXor(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -254,47 +237,47 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpDouble extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Double.BYTES;
 			
-			private static final double get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				return _unsafe.getDouble(receiver, offset);
 			}
 
-			private static final void set(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putDouble(receiver, offset, value);
 			}
 
-			private static final double getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getDoubleVolatile(receiver, offset);
 			}
 
-			private static final void setVolatile(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putDoubleVolatile(receiver, offset, value);
 			}
 
-			private static final double getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getDoubleOpaque(receiver, offset);
 			}
 
-			private static final void setOpaque(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putDoubleOpaque(receiver, offset, value);
 			}
 
-			private static final double getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getDoubleAcquire(receiver, offset);
 			}
 
-			private static final void setRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putDoubleRelease(receiver, offset, value);
 			}
 
-			private static final boolean compareAndSet(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetDouble(receiver, offset, testValue, newValue);
@@ -303,7 +286,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchange(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final double compareAndExchange(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeDouble(receiver, offset, testValue, newValue);
@@ -312,17 +295,17 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchangeAcquire(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final double compareAndExchangeAcquire(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeDoubleAcquire(receiver, offset, testValue, newValue);
 			}
 
-			private static final double compareAndExchangeRelease(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final double compareAndExchangeRelease(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeDoubleRelease(receiver, offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, testValue, newValue);
@@ -331,7 +314,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, offset, testValue, newValue);
@@ -340,7 +323,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(receiver, offset, testValue, newValue);
@@ -349,7 +332,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, testValue, newValue);
@@ -358,66 +341,66 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double getAndSet(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndSet(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetDouble(receiver, offset, value);
 			}
 
-			private static final double getAndSetAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndSetAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetDoubleAcquire(receiver, offset, value);
 			}
 
-			private static final double getAndSetRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndSetRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetDoubleRelease(receiver, offset, value);
 			}
 
-			private static final double getAndAdd(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndAdd(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndAddAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndAddAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndAddRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndAddRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAnd(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOr(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseOr(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXor(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseXor(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -425,47 +408,47 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpFloat extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Float.BYTES;
 			
-			private static final float get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				return _unsafe.getFloat(receiver, offset);
 			}
 
-			private static final void set(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putFloat(receiver, offset, value);
 			}
 
-			private static final float getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getFloatVolatile(receiver, offset);
 			}
 
-			private static final void setVolatile(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putFloatVolatile(receiver, offset, value);
 			}
 
-			private static final float getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getFloatOpaque(receiver, offset);
 			}
 
-			private static final void setOpaque(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putFloatOpaque(receiver, offset, value);
 			}
 
-			private static final float getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getFloatAcquire(receiver, offset);
 			}
 
-			private static final void setRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putFloatRelease(receiver, offset, value);
 			}
 
-			private static final boolean compareAndSet(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetFloat(receiver, offset, testValue, newValue);
@@ -474,7 +457,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchange(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final float compareAndExchange(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeFloat(receiver, offset, testValue, newValue);
@@ -483,17 +466,17 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchangeAcquire(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final float compareAndExchangeAcquire(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeFloatAcquire(receiver, offset, testValue, newValue);
 			}
 
-			private static final float compareAndExchangeRelease(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final float compareAndExchangeRelease(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeFloatRelease(receiver, offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, testValue, newValue);
@@ -502,7 +485,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(receiver, offset, testValue, newValue);
@@ -511,7 +494,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetFloatRelease(receiver, offset, testValue, newValue);
@@ -520,7 +503,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, testValue, newValue);
@@ -529,66 +512,66 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float getAndSet(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndSet(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetFloat(receiver, offset, value);
 			}
 
-			private static final float getAndSetAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndSetAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetFloatAcquire(receiver, offset, value);
 			}
 
-			private static final float getAndSetRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndSetRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetFloatRelease(receiver, offset, value);
 			}
 		
-			private static final float getAndAdd(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndAdd(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndAddAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndAddAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndAddRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndAddRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAnd(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOr(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseOr(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXor(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseXor(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -596,47 +579,47 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpInt extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Integer.BYTES;
 			
-			private static final int get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				return _unsafe.getInt(receiver, offset);
 			}
 
-			private static final void set(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putInt(receiver, offset, value);
 			}
 
-			private static final int getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getIntVolatile(receiver, offset);
 			}
 
-			private static final void setVolatile(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putIntVolatile(receiver, offset, value);
 			}
 
-			private static final int getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getIntOpaque(receiver, offset);
 			}
 
-			private static final void setOpaque(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putIntOpaque(receiver, offset, value);
 			}
 
-			private static final int getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getIntAcquire(receiver, offset);
 			}
 
-			private static final void setRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putIntRelease(receiver, offset, value);
 			}
 
-			private static final boolean compareAndSet(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetInt(receiver, offset, testValue, newValue);
@@ -645,7 +628,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final int compareAndExchange(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final int compareAndExchange(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeInt(receiver, offset, testValue, newValue);
@@ -654,17 +637,17 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchangeAcquire(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final int compareAndExchangeAcquire(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeIntAcquire(receiver, offset, testValue, newValue);
 			}
 
-			private static final int compareAndExchangeRelease(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final int compareAndExchangeRelease(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeIntRelease(receiver, offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, testValue, newValue);
@@ -673,7 +656,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, offset, testValue, newValue);
@@ -682,7 +665,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, offset, testValue, newValue);
@@ -691,7 +674,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, testValue, newValue);
@@ -700,77 +683,77 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int getAndSet(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndSet(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetInt(receiver, offset, value);
 			}
 
-			private static final int getAndSetAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndSetAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetIntAcquire(receiver, offset, value);
 			}
 
-			private static final int getAndSetRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndSetRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetIntRelease(receiver, offset, value);
 			}
 
-			private static final int getAndAdd(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndAdd(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndAddInt(receiver, offset, value);
 			}
 
-			private static final int getAndAddAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndAddAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndAddIntAcquire(receiver, offset, value);
 			}
 
-			private static final int getAndAddRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndAddRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndAddIntRelease(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseAnd(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseAnd(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseAndInt(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseAndAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseAndIntAcquire(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseAndRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseAndIntRelease(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseOr(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseOr(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseOrInt(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseOrAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseOrIntAcquire(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseOrRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseOrIntRelease(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseXor(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseXor(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseXorInt(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseXorAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseXorIntAcquire(receiver, offset, value);
 			}
 
-			private static final int getAndBitwiseXorRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseXorIntRelease(receiver, offset, value);
 			}
@@ -779,47 +762,47 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpLong extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Long.BYTES;
 			
-			private static final long get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				return _unsafe.getLong(receiver, offset);
 			}
 
-			private static final void set(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putLong(receiver, offset, value);
 			}
 
-			private static final long getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getLongVolatile(receiver, offset);
 			}
 
-			private static final void setVolatile(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putLongVolatile(receiver, offset, value);
 			}
 
-			private static final long getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getLongOpaque(receiver, offset);
 			}
 
-			private static final void setOpaque(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putLongOpaque(receiver, offset, value);
 			}
 
-			private static final long getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getLongAcquire(receiver, offset);
 			}
 
-			private static final void setRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putLongRelease(receiver, offset, value);
 			}
 
-			private static final boolean compareAndSet(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetLong(receiver, offset, testValue, newValue);
@@ -828,7 +811,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchange(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final long compareAndExchange(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeLong(receiver, offset, testValue, newValue);
@@ -837,17 +820,17 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchangeAcquire(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final long compareAndExchangeAcquire(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeLongAcquire(receiver, offset, testValue, newValue);
 			}
 
-			private static final long compareAndExchangeRelease(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final long compareAndExchangeRelease(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.compareAndExchangeLongRelease(receiver, offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, testValue, newValue);
@@ -856,7 +839,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(receiver, offset, testValue, newValue);
@@ -865,7 +848,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongRelease(receiver, offset, testValue, newValue);
@@ -874,7 +857,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, testValue, newValue);
@@ -883,77 +866,77 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long getAndSet(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndSet(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetLong(receiver, offset, value);
 			}
 
-			private static final long getAndSetAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndSetAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetLongAcquire(receiver, offset, value);
 			}
 
-			private static final long getAndSetRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndSetRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndSetLongRelease(receiver, offset, value);
 			}
 
-			private static final long getAndAdd(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndAdd(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndAddLong(receiver, offset, value);
 			}
 
-			private static final long getAndAddAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndAddAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndAddLongAcquire(receiver, offset, value);
 			}
 
-			private static final long getAndAddRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndAddRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndAddLongRelease(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseAnd(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseAnd(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseAndLong(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseAndAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseAndLongAcquire(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseAndRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseAndLongRelease(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseOr(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseOr(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseOrLong(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseOrAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseOrLongAcquire(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseOrRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseOrLongRelease(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseXor(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseXor(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseXorLong(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseXorAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseXorLongAcquire(receiver, offset, value);
 			}
 
-			private static final long getAndBitwiseXorRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getAndBitwiseXorLongRelease(receiver, offset, value);
 			}
@@ -962,135 +945,135 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpShort extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Short.BYTES;
 			
-			private static final short get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				return _unsafe.getShort(receiver, offset);
 			}
 
-			private static final void set(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putShort(receiver, offset, value);
 			}
 
-			private static final short getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getShortVolatile(receiver, offset);
 			}
 
-			private static final void setVolatile(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putShortVolatile(receiver, offset, value);
 			}
 
-			private static final short getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getShortOpaque(receiver, offset);
 			}
 
-			private static final void setOpaque(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putShortOpaque(receiver, offset, value);
 			}
 
-			private static final short getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				return _unsafe.getShortAcquire(receiver, offset);
 			}
 
-			private static final void setRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putShortRelease(receiver, offset, value);
 			}
 
-			private static final boolean compareAndSet(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchange(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final short compareAndExchange(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeAcquire(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final short compareAndExchangeAcquire(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeRelease(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final short compareAndExchangeRelease(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSet(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndSet(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndSetAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndSetRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAdd(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndAdd(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndAddAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndAddRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAnd(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseAnd(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOr(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseOr(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXor(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseXor(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1098,139 +1081,139 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpCharConvertEndian extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Character.BYTES;
 			
-			private static final char get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				char result = _unsafe.getChar(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void set(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putChar(receiver, offset, convertEndian(value));
 			}
 		
-			private static final char getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				char result = _unsafe.getCharVolatile(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setVolatile(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putCharVolatile(receiver, offset, convertEndian(value));
 			}
 		
-			private static final char getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				char result = _unsafe.getCharOpaque(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setOpaque(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putCharOpaque(receiver, offset, convertEndian(value));
 			}
 		
-			private static final char getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final char getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				char result = _unsafe.getCharAcquire(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putCharRelease(receiver, offset, convertEndian(value));
 			}
 		
-			private static final boolean compareAndSet(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchange(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final char compareAndExchange(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeAcquire(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final char compareAndExchangeAcquire(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeRelease(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final char compareAndExchangeRelease(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, char testValue, char newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSet(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndSet(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndSetAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndSetRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAdd(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndAdd(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndAddAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndAddRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAnd(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseAnd(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOr(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseOr(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXor(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseXor(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorAcquire(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorAcquire(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorRelease(byte[] receiver, int index, char value, ByteArrayViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorRelease(byte[] receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1238,51 +1221,51 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpDoubleConvertEndian extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Double.BYTES;
 			
-			private static final double get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				double result = _unsafe.getDouble(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void set(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putDouble(receiver, offset, convertEndian(value));
 			}
 		
-			private static final double getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.getDoubleVolatile(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setVolatile(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putDoubleVolatile(receiver, offset, convertEndian(value));
 			}
 		
-			private static final double getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.getDoubleOpaque(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setOpaque(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putDoubleOpaque(receiver, offset, convertEndian(value));
 			}
 		
-			private static final double getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final double getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.getDoubleAcquire(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putDoubleRelease(receiver, offset, convertEndian(value));
 			}
 		
-			private static final boolean compareAndSet(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1291,7 +1274,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final double compareAndExchange(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final double compareAndExchange(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				double result = _unsafe.compareAndExchangeDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1301,19 +1284,19 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 		
-			private static final double compareAndExchangeAcquire(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final double compareAndExchangeAcquire(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.compareAndExchangeDoubleAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final double compareAndExchangeRelease(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final double compareAndExchangeRelease(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.compareAndExchangeDoubleRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1322,7 +1305,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1331,7 +1314,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1340,7 +1323,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, double testValue, double newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1349,69 +1332,69 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final double getAndSet(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndSet(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.getAndSetDouble(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final double getAndSetAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndSetAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.getAndSetDoubleAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final double getAndSetRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndSetRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				double result = _unsafe.getAndSetDoubleRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final double getAndAdd(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndAdd(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndAddAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndAddAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndAddRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndAddRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseAnd(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseAndAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseAndRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseOr(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseOr(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseOrAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseOrRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseXor(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseXor(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseXorAcquire(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final double getAndBitwiseXorRelease(byte[] receiver, int index, double value, ByteArrayViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(byte[] receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1419,51 +1402,51 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpFloatConvertEndian extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Float.BYTES;
 			
-			private static final float get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				float result = _unsafe.getFloat(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void set(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putFloat(receiver, offset, convertEndian(value));
 			}
 		
-			private static final float getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.getFloatVolatile(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setVolatile(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putFloatVolatile(receiver, offset, convertEndian(value));
 			}
 		
-			private static final float getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.getFloatOpaque(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setOpaque(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putFloatOpaque(receiver, offset, convertEndian(value));
 			}
 		
-			private static final float getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final float getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.getFloatAcquire(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putFloatRelease(receiver, offset, convertEndian(value));
 			}
 		
-			private static final boolean compareAndSet(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1472,7 +1455,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final float compareAndExchange(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final float compareAndExchange(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				float result = _unsafe.compareAndExchangeFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1482,19 +1465,19 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 		
-			private static final float compareAndExchangeAcquire(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final float compareAndExchangeAcquire(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.compareAndExchangeFloatAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final float compareAndExchangeRelease(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final float compareAndExchangeRelease(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.compareAndExchangeFloatRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1503,7 +1486,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1512,7 +1495,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetFloatRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1521,7 +1504,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, float testValue, float newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1530,69 +1513,69 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final float getAndSet(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndSet(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.getAndSetFloat(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final float getAndSetAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndSetAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.getAndSetFloatAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final float getAndSetRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndSetRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				float result = _unsafe.getAndSetFloatRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final float getAndAdd(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndAdd(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndAddAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndAddAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndAddRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndAddRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseAnd(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseAndAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseAndRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseOr(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseOr(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseOrAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseOrRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseXor(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseXor(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseXorAcquire(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		
-			private static final float getAndBitwiseXorRelease(byte[] receiver, int index, float value, ByteArrayViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(byte[] receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1600,51 +1583,51 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpIntConvertEndian extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Integer.BYTES;
 			
-			private static final int get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				int result = _unsafe.getInt(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void set(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putInt(receiver, offset, convertEndian(value));
 			}
 		
-			private static final int getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getIntVolatile(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setVolatile(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putIntVolatile(receiver, offset, convertEndian(value));
 			}
 		
-			private static final int getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getIntOpaque(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setOpaque(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putIntOpaque(receiver, offset, convertEndian(value));
 			}
 		
-			private static final int getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final int getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getIntAcquire(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putIntRelease(receiver, offset, convertEndian(value));
 			}
 		
-			private static final boolean compareAndSet(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1653,7 +1636,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final int compareAndExchange(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final int compareAndExchange(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				int result = _unsafe.compareAndExchangeInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1663,19 +1646,19 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 		
-			private static final int compareAndExchangeAcquire(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final int compareAndExchangeAcquire(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.compareAndExchangeIntAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final int compareAndExchangeRelease(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final int compareAndExchangeRelease(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.compareAndExchangeIntRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1684,7 +1667,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1693,7 +1676,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1702,7 +1685,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, int testValue, int newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1711,91 +1694,91 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final int getAndSet(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndSet(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndSetInt(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndSetAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndSetAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndSetIntAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndSetRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndSetRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndSetIntRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndAdd(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndAdd(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndAddInt(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndAddAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndAddAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndAddIntAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndAddRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndAddRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndAddIntRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseAnd(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseAnd(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseAndInt(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseAndAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseAndIntAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseAndRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseAndIntRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseOr(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseOr(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseOrInt(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseOrAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseOrIntAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseOrRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseOrIntRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseXor(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseXor(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseXorInt(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseXorAcquire(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorAcquire(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseXorIntAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final int getAndBitwiseXorRelease(byte[] receiver, int index, int value, ByteArrayViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorRelease(byte[] receiver, int index, int value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				int result = _unsafe.getAndBitwiseXorIntRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
@@ -1805,51 +1788,51 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpLongConvertEndian extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Long.BYTES;
 			
-			private static final long get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				long result = _unsafe.getLong(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void set(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putLong(receiver, offset, convertEndian(value));
 			}
 		
-			private static final long getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getLongVolatile(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setVolatile(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putLongVolatile(receiver, offset, convertEndian(value));
 			}
 		
-			private static final long getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getLongOpaque(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setOpaque(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putLongOpaque(receiver, offset, convertEndian(value));
 			}
 		
-			private static final long getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final long getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getLongAcquire(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putLongRelease(receiver, offset, convertEndian(value));
 			}
 		
-			private static final boolean compareAndSet(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1858,7 +1841,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final long compareAndExchange(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final long compareAndExchange(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				long result = _unsafe.compareAndExchangeLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1868,19 +1851,19 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 		
-			private static final long compareAndExchangeAcquire(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final long compareAndExchangeAcquire(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.compareAndExchangeLongAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final long compareAndExchangeRelease(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final long compareAndExchangeRelease(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.compareAndExchangeLongRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 		
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1889,7 +1872,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1898,7 +1881,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1907,7 +1890,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, long testValue, long newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1916,91 +1899,91 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 		
-			private static final long getAndSet(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndSet(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndSetLong(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndSetAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndSetAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndSetLongAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndSetRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndSetRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndSetLongRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndAdd(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndAdd(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndAddLong(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndAddAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndAddAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndAddLongAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndAddRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndAddRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndAddLongRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseAnd(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseAnd(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseAndLong(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseAndAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseAndLongAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseAndRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseAndLongRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseOr(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseOr(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseOrLong(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseOrAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseOrLongAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseOrRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseOrLongRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseXor(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseXor(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseXorLong(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseXorAcquire(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorAcquire(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseXorLongAcquire(receiver, offset, convertEndian(value));
 				return convertEndian(result);
 			}
 		
-			private static final long getAndBitwiseXorRelease(byte[] receiver, int index, long value, ByteArrayViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorRelease(byte[] receiver, int index, long value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				long result = _unsafe.getAndBitwiseXorLongRelease(receiver, offset, convertEndian(value));
 				return convertEndian(result);
@@ -2010,139 +1993,139 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		static final class OpShortConvertEndian extends ByteArrayViewVarHandleOperations {
 			private static final int BYTES = Short.BYTES;
 			
-			private static final short get(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short get(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				short result = _unsafe.getShort(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void set(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void set(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, true);
 				_unsafe.putShort(receiver, offset, convertEndian(value));
 			}
 		
-			private static final short getVolatile(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short getVolatile(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				short result = _unsafe.getShortVolatile(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setVolatile(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void setVolatile(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putShortVolatile(receiver, offset, convertEndian(value));
 			}
 		
-			private static final short getOpaque(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short getOpaque(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				short result = _unsafe.getShortOpaque(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setOpaque(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void setOpaque(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putShortOpaque(receiver, offset, convertEndian(value));
 			}
 		
-			private static final short getAcquire(byte[] receiver, int index, ByteArrayViewVarHandle varHandle) {
+			private static final short getAcquire(byte[] receiver, int index, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				short result = _unsafe.getShortAcquire(receiver, offset);
 				return convertEndian(result);
 			}
 		
-			private static final void setRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final void setRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
 				_unsafe.putShortRelease(receiver, offset, convertEndian(value));
 			}
 			
-			private static final boolean compareAndSet(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean compareAndSet(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchange(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final short compareAndExchange(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeAcquire(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final short compareAndExchangeAcquire(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeRelease(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final short compareAndExchangeRelease(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, short testValue, short newValue, ByteArrayViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSet(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndSet(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndSetAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndSetRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAdd(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndAdd(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndAddAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndAddRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAnd(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseAnd(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOr(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseOr(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXor(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseXor(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorAcquire(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorAcquire(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorRelease(byte[] receiver, int index, short value, ByteArrayViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorRelease(byte[] receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ByteBufferViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ByteBufferViewVarHandle.java
@@ -22,15 +22,14 @@
  *******************************************************************************/
 package java.lang.invoke;
 
+import static java.lang.invoke.ByteBufferViewVarHandle.ByteBufferViewVarHandleOperations.*;
 import static java.lang.invoke.MethodHandles.Lookup.internalPrivilegedLookup;
 import static java.lang.invoke.MethodType.methodType;
-import static java.lang.invoke.ByteBufferViewVarHandle.ByteBufferViewVarHandleOperations.*;
 
 import com.ibm.oti.util.Msg;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.Objects;
 import jdk.internal.misc.Unsafe;
 
 final class ByteBufferViewVarHandle extends ViewVarHandle {
@@ -64,9 +63,9 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K0624", type)); //$NON-NLS-1$
 		}
 		
-		MethodType getter = methodType(type, ByteBuffer.class, int.class, ByteBufferViewVarHandle.class);
-		MethodType setter = methodType(void.class, ByteBuffer.class, int.class, type, ByteBufferViewVarHandle.class);
-		MethodType compareAndSet = methodType(boolean.class, ByteBuffer.class, int.class, type, type, ByteBufferViewVarHandle.class);
+		MethodType getter = methodType(type, ByteBuffer.class, int.class, VarHandle.class);
+		MethodType setter = methodType(void.class, ByteBuffer.class, int.class, type, VarHandle.class);
+		MethodType compareAndSet = methodType(boolean.class, ByteBuffer.class, int.class, type, type, VarHandle.class);
 		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
 		MethodType getAndSet = setter.changeReturnType(type);
 		MethodType[] lookupTypes = populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
@@ -75,28 +74,12 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 	}
 	
 	/**
-	 * Populates the static MethodType[] corresponding to the provided type. 
-	 * 
-	 * @param type The type to create MethodType for.
-	 * @return The populated MethodType[].
-	 */
-	static final MethodType[] populateMTs(Class<?> type) {
-		MethodType getter = methodType(type, ByteBuffer.class, int.class);
-		MethodType setter = methodType(void.class, ByteBuffer.class, int.class, type);
-		MethodType compareAndSet = methodType(boolean.class, ByteBuffer.class, int.class, type, type);
-		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
-		MethodType getAndSet = setter.changeReturnType(type);
-		
-		return populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
-	}
-	
-	/**
 	 * Constructs a VarHandle that can access elements of a byte array as wider types.
 	 * 
 	 * @param viewArrayType The component type used when viewing elements of the array. 
 	 */
 	ByteBufferViewVarHandle(Class<?> viewArrayType, ByteOrder byteOrder) {
-		super(viewArrayType, COORDINATE_TYPES, populateMHs(viewArrayType, byteOrder), populateMTs(viewArrayType), 0);
+		super(viewArrayType, COORDINATE_TYPES, populateMHs(viewArrayType, byteOrder), 0);
 	}
 
 	/**
@@ -188,139 +171,139 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpChar extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Character.BYTES;
 			
-			private static final char get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				return _unsafe.getChar(be.base, be.offset);
 
 			}
 
-			private static final void set(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putChar(be.base, be.offset, value);
 			}
 
-			private static final char getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getCharVolatile(be.base, be.offset);
 
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putCharVolatile(be.base, be.offset, value);
 			}
 
-			private static final char getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getCharOpaque(be.base, be.offset);
 
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putCharOpaque(be.base, be.offset, value);
 			}
 
-			private static final char getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getCharAcquire(be.base, be.offset);
 
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putCharRelease(be.base, be.offset, value);
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchange(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final char compareAndExchange(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeAcquire(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final char compareAndExchangeAcquire(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeRelease(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final char compareAndExchangeRelease(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSet(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndSet(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndSetAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndSetRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAdd(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndAdd(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndAddAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndAddRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAnd(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseAnd(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOr(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseOr(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXor(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseXor(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -328,47 +311,47 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpDouble extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Double.BYTES;
 			
-			private static final double get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				return _unsafe.getDouble(be.base, be.offset);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putDouble(be.base, be.offset, value);
 			}
 
-			private static final double getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getDoubleVolatile(be.base, be.offset);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putDoubleVolatile(be.base, be.offset, value);
 			}
 
-			private static final double getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getDoubleOpaque(be.base, be.offset);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putDoubleOpaque(be.base, be.offset, value);
 			}
 
-			private static final double getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getDoubleAcquire(be.base, be.offset);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putDoubleRelease(be.base, be.offset, value);
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetDouble(be.base, be.offset, testValue, newValue);	
@@ -377,7 +360,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchange(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final double compareAndExchange(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeDouble(be.base, be.offset, testValue, newValue);
@@ -386,17 +369,17 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchangeAcquire(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final double compareAndExchangeAcquire(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeDoubleAcquire(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final double compareAndExchangeRelease(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final double compareAndExchangeRelease(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeDoubleRelease(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, testValue, newValue);
@@ -405,7 +388,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(be.base, be.offset, testValue, newValue);
@@ -414,7 +397,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(be.base, be.offset, testValue, newValue);
@@ -423,7 +406,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, testValue, newValue);
@@ -432,66 +415,66 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final double getAndSet(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndSet(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetDouble(be.base, be.offset, value);
 			}
 
-			private static final double getAndSetAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndSetAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetDoubleAcquire(be.base, be.offset, value);
 			}
 
-			private static final double getAndSetRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndSetRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetDoubleRelease(be.base, be.offset, value);
 			}
 
-			private static final double getAndAdd(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndAdd(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndAddAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndAddAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndAddRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndAddRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAnd(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOr(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseOr(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXor(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseXor(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -499,47 +482,47 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpFloat extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Float.BYTES;
 			
-			private static final float get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				return _unsafe.getFloat(be.base, be.offset);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putFloat(be.base, be.offset, value);
 			}
 
-			private static final float getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getFloatVolatile(be.base, be.offset);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putFloatVolatile(be.base, be.offset, value);
 			}
 
-			private static final float getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getFloatOpaque(be.base, be.offset);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putFloatOpaque(be.base, be.offset, value);
 			}
 
-			private static final float getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getFloatAcquire(be.base, be.offset);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putFloatRelease(be.base, be.offset, value);
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetFloat(be.base, be.offset, testValue, newValue);
@@ -548,7 +531,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchange(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final float compareAndExchange(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeFloat(be.base, be.offset, testValue, newValue);
@@ -557,17 +540,17 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchangeAcquire(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final float compareAndExchangeAcquire(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeFloatAcquire(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final float compareAndExchangeRelease(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final float compareAndExchangeRelease(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeFloatRelease(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, testValue, newValue);
@@ -576,7 +559,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(be.base, be.offset, testValue, newValue);
@@ -585,7 +568,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(be.base, be.offset, testValue, newValue);
@@ -594,7 +577,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, testValue, newValue);
@@ -603,66 +586,66 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float getAndSet(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndSet(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetFloat(be.base, be.offset, value);
 			}
 
-			private static final float getAndSetAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndSetAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetFloatAcquire(be.base, be.offset, value);
 			}
 
-			private static final float getAndSetRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndSetRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetFloatRelease(be.base, be.offset, value);
 			}
 
-			private static final float getAndAdd(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndAdd(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndAddAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndAddAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndAddRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndAddRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAnd(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOr(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseOr(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXor(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseXor(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -670,47 +653,47 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpInt extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Integer.BYTES;
 			
-			private static final int get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				return _unsafe.getInt(be.base, be.offset);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putInt(be.base, be.offset, value);
 			}
 
-			private static final int getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getIntVolatile(be.base, be.offset);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putIntVolatile(be.base, be.offset, value);
 			}
 
-			private static final int getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getIntOpaque(be.base, be.offset);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putIntOpaque(be.base, be.offset, value);
 			}
 
-			private static final int getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getIntAcquire(be.base, be.offset);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putIntRelease(be.base, be.offset, value);
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetInt(be.base, be.offset, testValue, newValue);
@@ -719,7 +702,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchange(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final int compareAndExchange(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeInt(be.base, be.offset, testValue, newValue);
@@ -728,17 +711,17 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchangeAcquire(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final int compareAndExchangeAcquire(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeIntAcquire(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final int compareAndExchangeRelease(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final int compareAndExchangeRelease(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeIntRelease(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, testValue, newValue);
@@ -747,7 +730,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(be.base, be.offset, testValue, newValue);
@@ -756,7 +739,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntRelease(be.base, be.offset, testValue, newValue);
@@ -765,7 +748,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, testValue, newValue);
@@ -774,77 +757,77 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int getAndSet(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndSet(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetInt(be.base, be.offset, value);
 			}
 
-			private static final int getAndSetAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndSetAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetIntAcquire(be.base, be.offset, value);
 			}
 
-			private static final int getAndSetRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndSetRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetIntRelease(be.base, be.offset, value);
 			}
 
-			private static final int getAndAdd(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndAdd(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndAddInt(be.base, be.offset, value);
 			}
 
-			private static final int getAndAddAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndAddAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndAddIntAcquire(be.base, be.offset, value);
 			}
 
-			private static final int getAndAddRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndAddRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndAddIntRelease(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseAnd(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseAnd(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseAndInt(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseAndAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseAndIntAcquire(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseAndRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseAndIntRelease(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseOr(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseOr(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseOrInt(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseOrAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseOrIntAcquire(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseOrRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseOrIntRelease(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseXor(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseXor(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseXorInt(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseXorAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseXorIntAcquire(be.base, be.offset, value);
 			}
 
-			private static final int getAndBitwiseXorRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseXorIntRelease(be.base, be.offset, value);
 			}
@@ -853,47 +836,47 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpLong extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Long.BYTES;
 			
-			private static final long get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				return _unsafe.getLong(be.base, be.offset);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putLong(be.base, be.offset, value);
 			}
 
-			private static final long getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getLongVolatile(be.base, be.offset);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putLongVolatile(be.base, be.offset, value);
 			}
 
-			private static final long getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getLongOpaque(be.base, be.offset);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putLongOpaque(be.base, be.offset, value);
 			}
 
-			private static final long getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getLongAcquire(be.base, be.offset);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putLongRelease(be.base, be.offset, value);
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetLong(be.base, be.offset, testValue, newValue);
@@ -902,7 +885,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchange(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final long compareAndExchange(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndExchangeLong(be.base, be.offset, testValue, newValue);
@@ -911,17 +894,17 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchangeAcquire(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final long compareAndExchangeAcquire(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeLongAcquire(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final long compareAndExchangeRelease(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final long compareAndExchangeRelease(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.compareAndExchangeLongRelease(be.base, be.offset, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, testValue, newValue);
@@ -930,7 +913,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(be.base, be.offset, testValue, newValue);
@@ -939,7 +922,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongRelease(be.base, be.offset, testValue, newValue);
@@ -948,7 +931,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, testValue, newValue);
@@ -957,77 +940,77 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long getAndSet(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndSet(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetLong(be.base, be.offset, value);
 			}
 
-			private static final long getAndSetAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndSetAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetLongAcquire(be.base, be.offset, value);
 			}
 
-			private static final long getAndSetRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndSetRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndSetLongRelease(be.base, be.offset, value);
 			}
 
-			private static final long getAndAdd(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndAdd(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndAddLong(be.base, be.offset, value);
 			}
 
-			private static final long getAndAddAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndAddAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndAddLongAcquire(be.base, be.offset, value);
 			}
 
-			private static final long getAndAddRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndAddRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndAddLongRelease(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseAnd(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseAnd(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseAndLong(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseAndAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseAndLongAcquire(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseAndRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseAndLongRelease(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseOr(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseOr(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseOrLong(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseOrAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseOrLongAcquire(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseOrRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseOrLongRelease(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseXor(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseXor(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseXorLong(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseXorAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseXorLongAcquire(be.base, be.offset, value);
 			}
 
-			private static final long getAndBitwiseXorRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				return _unsafe.getAndBitwiseXorLongRelease(be.base, be.offset, value);
 			}
@@ -1036,135 +1019,135 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpShort extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Short.BYTES;
 			
-			private static final short get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				return _unsafe.getShort(be.base, be.offset);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putShort(be.base, be.offset, value);
 			}
 
-			private static final short getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getShortVolatile(be.base, be.offset);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putShortVolatile(be.base, be.offset, value);
 			}
 
-			private static final short getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getShortOpaque(be.base, be.offset);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putShortOpaque(be.base, be.offset, value);
 			}
 
-			private static final short getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				return _unsafe.getShortAcquire(be.base, be.offset);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putShortRelease(be.base, be.offset, value);
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchange(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final short compareAndExchange(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeAcquire(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final short compareAndExchangeAcquire(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeRelease(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final short compareAndExchangeRelease(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSet(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndSet(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndSetAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndSetRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAdd(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndAdd(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndAddAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndAddRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAnd(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseAnd(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOr(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseOr(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXor(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseXor(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1172,139 +1155,139 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpCharConvertEndian extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Character.BYTES;
 			
-			private static final char get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				char result = _unsafe.getChar(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putChar(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final char getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				char result = _unsafe.getCharVolatile(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putCharVolatile(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final char getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				char result = _unsafe.getCharOpaque(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putCharOpaque(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final char getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final char getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				char result = _unsafe.getCharAcquire(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putCharRelease(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchange(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final char compareAndExchange(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeAcquire(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final char compareAndExchangeAcquire(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char compareAndExchangeRelease(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final char compareAndExchangeRelease(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, char testValue, char newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSet(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndSet(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndSetAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndSetRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndSetRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAdd(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndAdd(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndAddAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndAddRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndAddRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAnd(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseAnd(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseAndRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseAndRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOr(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseOr(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseOrRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseOrRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXor(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseXor(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorAcquire(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorAcquire(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final char getAndBitwiseXorRelease(ByteBuffer receiver, int index, char value, ByteBufferViewVarHandle varHandle) {
+			private static final char getAndBitwiseXorRelease(ByteBuffer receiver, int index, char value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1312,51 +1295,51 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpDoubleConvertEndian extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Double.BYTES;
 			
-			private static final double get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				double result = _unsafe.getDouble(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putDouble(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final double getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				double result = _unsafe.getDoubleVolatile(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putDoubleVolatile(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final double getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				double result = _unsafe.getDoubleOpaque(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putDoubleOpaque(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final double getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final double getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				double result = _unsafe.getDoubleAcquire(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putDoubleRelease(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1365,7 +1348,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchange(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final double compareAndExchange(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				double result = _unsafe.compareAndExchangeDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1375,19 +1358,19 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 
-			private static final double compareAndExchangeAcquire(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final double compareAndExchangeAcquire(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				double result = _unsafe.compareAndExchangeDoubleAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final double compareAndExchangeRelease(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final double compareAndExchangeRelease(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				double result = _unsafe.compareAndExchangeDoubleRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1396,7 +1379,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1405,7 +1388,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1414,7 +1397,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, double testValue, double newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1423,69 +1406,69 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/
 			}
 
-			private static final double getAndSet(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndSet(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				double result = _unsafe.getAndSetDouble(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final double getAndSetAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndSetAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				double result = _unsafe.getAndSetDoubleAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final double getAndSetRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndSetRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				double result = _unsafe.getAndSetDoubleRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final double getAndAdd(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndAdd(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndAddAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndAddAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndAddRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndAddRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAnd(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOr(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseOr(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXor(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseXor(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorAcquire(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorRelease(ByteBuffer receiver, int index, double value, ByteBufferViewVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(ByteBuffer receiver, int index, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1493,51 +1476,51 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpFloatConvertEndian extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Float.BYTES;
 			
-			private static final float get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				float result = _unsafe.getFloat(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putFloat(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final float getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				float result = _unsafe.getFloatVolatile(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putFloatVolatile(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final float getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				float result = _unsafe.getFloatOpaque(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putFloatOpaque(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final float getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final float getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				float result = _unsafe.getFloatAcquire(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putFloatRelease(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1546,7 +1529,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchange(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final float compareAndExchange(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				float result = _unsafe.compareAndExchangeFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1556,19 +1539,19 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 
-			private static final float compareAndExchangeAcquire(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final float compareAndExchangeAcquire(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				float result = _unsafe.compareAndExchangeFloatAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final float compareAndExchangeRelease(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final float compareAndExchangeRelease(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				float result = _unsafe.compareAndExchangeFloatRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1577,7 +1560,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1586,7 +1569,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1595,7 +1578,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, float testValue, float newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1604,69 +1587,69 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final float getAndSet(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndSet(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				float result = _unsafe.getAndSetFloat(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final float getAndSetAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndSetAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				float result = _unsafe.getAndSetFloatAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final float getAndSetRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndSetRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				float result = _unsafe.getAndSetFloatRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final float getAndAdd(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndAdd(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndAddAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndAddAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndAddRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndAddRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAnd(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOr(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseOr(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXor(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseXor(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorAcquire(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorRelease(ByteBuffer receiver, int index, float value, ByteBufferViewVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(ByteBuffer receiver, int index, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
@@ -1674,51 +1657,51 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpIntConvertEndian extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Integer.BYTES;
 			
-			private static final int get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				int result = _unsafe.getInt(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putInt(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final int getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				int result = _unsafe.getIntVolatile(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putIntVolatile(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final int getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				int result = _unsafe.getIntOpaque(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putIntOpaque(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final int getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final int getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				int result = _unsafe.getIntAcquire(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putIntRelease(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1727,7 +1710,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchange(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final int compareAndExchange(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				int result = _unsafe.compareAndExchangeInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1737,19 +1720,19 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 
-			private static final int compareAndExchangeAcquire(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final int compareAndExchangeAcquire(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.compareAndExchangeIntAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final int compareAndExchangeRelease(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final int compareAndExchangeRelease(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.compareAndExchangeIntRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1758,7 +1741,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1767,7 +1750,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetIntRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1776,7 +1759,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, int testValue, int newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1785,91 +1768,91 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final int getAndSet(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndSet(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndSetInt(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndSetAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndSetAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndSetIntAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndSetRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndSetRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndSetIntRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndAdd(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndAdd(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndAddInt(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndAddAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndAddAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndAddIntAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndAddRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndAddRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndAddIntRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseAnd(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseAnd(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseAndInt(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseAndAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseAndIntAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseAndRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseAndRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseAndIntRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseOr(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseOr(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseOrInt(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseOrAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseOrIntAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseOrRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseOrRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseOrIntRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseXor(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseXor(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseXorInt(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseXorAcquire(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorAcquire(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseXorIntAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final int getAndBitwiseXorRelease(ByteBuffer receiver, int index, int value, ByteBufferViewVarHandle varHandle) {
+			private static final int getAndBitwiseXorRelease(ByteBuffer receiver, int index, int value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				int result = _unsafe.getAndBitwiseXorIntRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
@@ -1879,51 +1862,51 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpLongConvertEndian extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Long.BYTES;
 			
-			private static final long get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				long result = _unsafe.getLong(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putLong(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final long getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				long result = _unsafe.getLongVolatile(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putLongVolatile(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final long getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				long result = _unsafe.getLongOpaque(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putLongOpaque(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final long getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final long getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				long result = _unsafe.getLongAcquire(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putLongRelease(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.compareAndSetLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1932,7 +1915,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchange(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final long compareAndExchange(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				long result = _unsafe.compareAndExchangeLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1942,19 +1925,19 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 				return convertEndian(result);
 			}
 
-			private static final long compareAndExchangeAcquire(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final long compareAndExchangeAcquire(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.compareAndExchangeLongAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final long compareAndExchangeRelease(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final long compareAndExchangeRelease(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.compareAndExchangeLongRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 				return convertEndian(result);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1963,7 +1946,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1972,7 +1955,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/				
 				return _unsafe.weakCompareAndSetLongRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1981,7 +1964,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, long testValue, long newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 /*[IF Sidecar19-SE-B174]*/
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1990,91 +1973,91 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 /*[ENDIF]*/				
 			}
 
-			private static final long getAndSet(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndSet(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndSetLong(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndSetAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndSetAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndSetLongAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndSetRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndSetRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndSetLongRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndAdd(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndAdd(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndAddLong(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndAddAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndAddAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndAddLongAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndAddRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndAddRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndAddLongRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseAnd(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseAnd(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseAndLong(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseAndAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseAndLongAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseAndRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseAndRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseAndLongRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseOr(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseOr(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseOrLong(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseOrAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseOrLongAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseOrRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseOrRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseOrLongRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseXor(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseXor(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseXorLong(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseXorAcquire(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorAcquire(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseXorLongAcquire(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
 			}
 
-			private static final long getAndBitwiseXorRelease(ByteBuffer receiver, int index, long value, ByteBufferViewVarHandle varHandle) {
+			private static final long getAndBitwiseXorRelease(ByteBuffer receiver, int index, long value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				long result = _unsafe.getAndBitwiseXorLongRelease(be.base, be.offset, convertEndian(value));
 				return convertEndian(result);
@@ -2084,139 +2067,139 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 		static final class OpShortConvertEndian extends ByteBufferViewVarHandleOperations {
 			private static final int BYTES = Short.BYTES;
 			
-			private static final short get(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short get(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, true);
 				short result = _unsafe.getShort(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void set(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void set(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, true);
 				_unsafe.putShort(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final short getVolatile(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short getVolatile(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				short result = _unsafe.getShortVolatile(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setVolatile(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void setVolatile(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putShortVolatile(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final short getOpaque(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short getOpaque(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				short result = _unsafe.getShortOpaque(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setOpaque(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void setOpaque(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putShortOpaque(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final short getAcquire(ByteBuffer receiver, int index, ByteBufferViewVarHandle varHandle) {
+			private static final short getAcquire(ByteBuffer receiver, int index, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, true, false);
 				short result = _unsafe.getShortAcquire(be.base, be.offset);
 				return convertEndian(result);
 			}
 
-			private static final void setRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final void setRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
 				_unsafe.putShortRelease(be.base, be.offset, convertEndian(value));
 			}
 
-			private static final boolean compareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean compareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchange(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final short compareAndExchange(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeAcquire(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final short compareAndExchangeAcquire(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short compareAndExchangeRelease(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final short compareAndExchangeRelease(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, short testValue, short newValue, ByteBufferViewVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSet(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndSet(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndSetAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndSetRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndSetRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAdd(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndAdd(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndAddAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndAddRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndAddRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAnd(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseAnd(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseAndRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseAndRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOr(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseOr(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseOrRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseOrRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXor(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseXor(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorAcquire(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorAcquire(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final short getAndBitwiseXorRelease(ByteBuffer receiver, int index, short value, ByteBufferViewVarHandle varHandle) {
+			private static final short getAndBitwiseXorRelease(ByteBuffer receiver, int index, short value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -46,8 +46,8 @@ abstract class FieldVarHandle extends VarHandle {
 	 * @param handleTable The array of MethodHandles implementing the AccessModes.
 	 * @param typeTable The VarHandle instance specific MethodTypes used to validate invocations.
 	 */
-	FieldVarHandle(Class<?> lookupClass, String fieldName, Class<?> fieldType, Class<?> accessClass, boolean isStatic, Class<?>[] coordinateTypes, MethodHandle[] handleTable, MethodType[] typeTable) {
-		super(fieldType, coordinateTypes, handleTable, typeTable, 0);
+	FieldVarHandle(Class<?> lookupClass, String fieldName, Class<?> fieldType, Class<?> accessClass, boolean isStatic, Class<?>[] coordinateTypes, MethodHandle[] handleTable) {
+		super(fieldType, coordinateTypes, handleTable, 0);
 		this.definingClass = lookupClass;
 		this.fieldName = fieldName;
 		int header = (isStatic ? 0 : VM.OBJECT_HEADER_SIZE);
@@ -64,8 +64,8 @@ abstract class FieldVarHandle extends VarHandle {
 	 * @param handleTable The array of MethodHandles implementing the AccessModes.
 	 * @param typeTable The VarHandle instance specific MethodTypes used to validate invocations.
 	 */
-	FieldVarHandle(Field field, boolean isStatic, Class<?>[] coordinateTypes, MethodHandle[] handleTable, MethodType[] typeTable) {
-		super(field.getType(), coordinateTypes, handleTable, typeTable, 0);
+	FieldVarHandle(Field field, boolean isStatic, Class<?>[] coordinateTypes, MethodHandle[] handleTable) {
+		super(field.getType(), coordinateTypes, handleTable, 0);
 		this.definingClass = field.getDeclaringClass();
 		this.fieldName = field.getName();
 		int header = (isStatic ? 0 : VM.OBJECT_HEADER_SIZE);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InstanceFieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InstanceFieldVarHandle.java
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package java.lang.invoke;
 
+import static java.lang.invoke.InstanceFieldVarHandle.InstanceFieldVarHandleOperations.*;
 import static java.lang.invoke.MethodType.methodType;
 
 import java.lang.reflect.Field;
@@ -42,23 +43,23 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 		
 		if (!initFieldType.isPrimitive()) {
 			fieldType = Object.class;
-			operationsClass = InstanceFieldVarHandleOperations.OpObject.class;
+			operationsClass = OpObject.class;
 		} else if (int.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpInt.class;
+			operationsClass = OpInt.class;
 		} else if (long.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpLong.class;
+			operationsClass = OpLong.class;
 		} else if (boolean.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpBoolean.class;
+			operationsClass = OpBoolean.class;
 		} else if (byte.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpByte.class;
+			operationsClass = OpByte.class;
 		} else if (char.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpChar.class;
+			operationsClass = OpChar.class;
 		} else if (double.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpDouble.class;
+			operationsClass = OpDouble.class;
 		} else if (float.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpFloat.class;
+			operationsClass = OpFloat.class;
 		} else if (short.class == initFieldType) {
-			operationsClass = InstanceFieldVarHandleOperations.OpShort.class;
+			operationsClass = OpShort.class;
 		} else if (void.class == initFieldType) {
 			throw new NoSuchFieldError();
 		} else {
@@ -66,37 +67,21 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 			throw new InternalError(com.ibm.oti.util.Msg.getString("K0626", initFieldType)); //$NON-NLS-1$
 		}
 
-		MethodType getter = methodType(fieldType, Object.class, InstanceFieldVarHandle.class);
-		MethodType setter = methodType(void.class, Object.class, fieldType, InstanceFieldVarHandle.class);
-		MethodType compareAndSet = methodType(boolean.class, Object.class, fieldType, fieldType, InstanceFieldVarHandle.class);
+		MethodType getter = methodType(fieldType, Object.class, VarHandle.class);
+		MethodType setter = methodType(void.class, Object.class, fieldType, VarHandle.class);
+		MethodType compareAndSet = methodType(boolean.class, Object.class, fieldType, fieldType, VarHandle.class);
 		MethodType compareAndExchange = compareAndSet.changeReturnType(fieldType);
 		MethodType getAndSet = setter.changeReturnType(fieldType);
 		MethodType[] lookupTypes = populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
 		
-		MethodType exactGetter = methodType(initFieldType, receiverType, InstanceFieldVarHandle.class);
-		MethodType exactSetter = methodType(void.class, receiverType, initFieldType, InstanceFieldVarHandle.class);
-		MethodType exactCompareAndSet = methodType(boolean.class, receiverType, initFieldType, initFieldType, InstanceFieldVarHandle.class);
-		MethodType exactCompareAndExchange = compareAndSet.changeReturnType(initFieldType);
-		MethodType exactGetAndSet = setter.changeReturnType(initFieldType);
+		MethodType exactGetter = methodType(initFieldType, receiverType, VarHandle.class);
+		MethodType exactSetter = methodType(void.class, receiverType, initFieldType, VarHandle.class);
+		MethodType exactCompareAndSet = methodType(boolean.class, receiverType, initFieldType, initFieldType, VarHandle.class);
+		MethodType exactCompareAndExchange = exactCompareAndSet.changeReturnType(initFieldType);
+		MethodType exactGetAndSet = exactSetter.changeReturnType(initFieldType);
 		MethodType[]exactTypes = populateMTs(exactGetter, exactSetter, exactCompareAndSet, exactCompareAndExchange, exactGetAndSet);
 				
 		return populateMHs(operationsClass, lookupTypes, exactTypes);
-	}
-
-	/**
-	 * Populates a MethodType[] corresponding to the provided type. 
-	 * 
-	 * @param type The type to create MethodType for.
-	 * @return The populated MethodType[].
-	 */
-	static final MethodType[] populateMTs(Class<?> type, Class<?> receiverType) {
-		MethodType getter = methodType(type, receiverType);
-		MethodType setter = methodType(void.class, receiverType, type);
-		MethodType compareAndSet = methodType(boolean.class, receiverType, type, type);
-		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
-		MethodType getAndSet = setter.changeReturnType(type);
-		
-		return populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
 	}
 
 	/**
@@ -108,7 +93,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 	 * @param accessClass The class being used to look up the field
 	 */
 	InstanceFieldVarHandle(Class<?> lookupClass, String fieldName, Class<?> fieldType, Class<?> accessClass) {
-		super(lookupClass, fieldName, fieldType, accessClass, false, new Class<?>[] {lookupClass}, populateMHs(lookupClass, fieldType), populateMTs(fieldType, lookupClass));
+		super(lookupClass, fieldName, fieldType, accessClass, false, new Class<?>[] {lookupClass}, populateMHs(lookupClass, fieldType));
 	}
 	
 	/**
@@ -117,7 +102,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 	 * @param field The {@link java.lang.reflect.Field} to create a VarHandle for.
 	 */
 	InstanceFieldVarHandle(Field field, Class<?> lookupClass, Class<?> fieldType) {
-		super(field, false, new Class<?>[] {lookupClass}, populateMHs(lookupClass, fieldType), populateMTs(lookupClass, fieldType));
+		super(field, false, new Class<?>[] {lookupClass}, populateMHs(lookupClass, fieldType));
 	}
 	
 	/**
@@ -126,1598 +111,1598 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 	@SuppressWarnings("unused")
 	static class InstanceFieldVarHandleOperations extends VarHandleOperations {
 		static final class OpObject extends InstanceFieldVarHandleOperations {
-			private static final Object get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final Object get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getObject(receiver, varHandle.vmslot);
+				return _unsafe.getObject(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putObject(receiver, varHandle.vmslot, value);
+				_unsafe.putObject(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final Object getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final Object getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getObjectVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getObjectVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putObjectVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putObjectVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final Object getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final Object getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getObjectOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getObjectOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putObjectOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putObjectOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final Object getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final Object getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getObjectAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putObjectRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetObject(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapObject(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final Object compareAndExchange(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final Object compareAndExchange(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeObject(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeObjectVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeObjectVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final Object compareAndExchangeAcquire(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final Object compareAndExchangeAcquire(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeObjectAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final Object compareAndExchangeRelease(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final Object compareAndExchangeRelease(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeObjectRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObject(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObjectAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObjectRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, Object testValue, Object newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObject(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final Object getAndSet(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndSet(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetObject(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetObject(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final Object getAndSetAcquire(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndSetAcquire(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetObjectAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final Object getAndSetRelease(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndSetRelease(Object receiver, Object value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetObjectRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final Object getAndAdd(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndAdd(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndAddAcquire(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndAddAcquire(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndAddRelease(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndAddRelease(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseAnd(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseAnd(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseAndAcquire(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseAndAcquire(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseAndRelease(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseAndRelease(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseOr(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseOr(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseOrAcquire(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseOrAcquire(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseOrRelease(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseOrRelease(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseXor(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseXor(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseXorAcquire(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseXorAcquire(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final Object getAndBitwiseXorRelease(Object receiver, Object value, InstanceFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseXorRelease(Object receiver, Object value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
 		
 		static final class OpByte extends InstanceFieldVarHandleOperations {
-			private static final byte get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final byte get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getByte(receiver, varHandle.vmslot);
+				return _unsafe.getByte(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putByte(receiver, varHandle.vmslot, value);
+				_unsafe.putByte(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final byte getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getByteVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getByteVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putByteVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putByteVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final byte getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getByteOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getByteOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putByteOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putByteOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final byte getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getByteAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getByteAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putByteRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putByteRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final byte compareAndExchange(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final byte compareAndExchange(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return (byte)_unsafe.compareAndExchangeInt(receiver, varHandle.vmslot, testValue, newValue);
+				return (byte)_unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return (byte)_unsafe.compareAndExchangeIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return (byte)_unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final byte compareAndExchangeAcquire(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final byte compareAndExchangeAcquire(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.compareAndExchangeIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return (byte)_unsafe.compareAndExchangeIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final byte compareAndExchangeRelease(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final byte compareAndExchangeRelease(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.compareAndExchangeIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return (byte)_unsafe.compareAndExchangeIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, byte testValue, byte newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final byte getAndSet(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndSet(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndSetInt(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndSetAcquire(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndSetAcquire(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndSetIntAcquire(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndSetRelease(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndSetRelease(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndSetIntRelease(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndAdd(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndAdd(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndAddInt(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndAddInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndAddAcquire(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndAddAcquire(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndAddIntAcquire(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndAddIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndAddRelease(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndAddRelease(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndAddIntRelease(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndAddIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseAnd(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseAnd(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseAndInt(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseAndInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseAndAcquire(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseAndAcquire(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseAndIntAcquire(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseAndIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseAndRelease(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseAndRelease(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseAndIntRelease(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseAndIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseOr(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseOr(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseOrInt(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseOrInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseOrAcquire(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseOrAcquire(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseOrIntAcquire(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseOrIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseOrRelease(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseOrRelease(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseOrIntRelease(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseOrIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseXor(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseXor(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseXorInt(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseXorInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseXorAcquire(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseXorAcquire(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseXorIntAcquire(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseXorIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final byte getAndBitwiseXorRelease(Object receiver, byte value, InstanceFieldVarHandle varHandle) {
+			private static final byte getAndBitwiseXorRelease(Object receiver, byte value, VarHandle varHandle) {
 				receiver.getClass();
-				return (byte)_unsafe.getAndBitwiseXorIntRelease(receiver, varHandle.vmslot, value);
+				return (byte)_unsafe.getAndBitwiseXorIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 		}
 
 		static final class OpChar extends InstanceFieldVarHandleOperations {
-			private static final char get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final char get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getChar(receiver, varHandle.vmslot);
+				return _unsafe.getChar(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putChar(receiver, varHandle.vmslot, value);
+				_unsafe.putChar(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final char getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getCharVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getCharVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putCharVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putCharVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final char getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getCharOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getCharOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putCharOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putCharOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final char getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getCharAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getCharAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putCharRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putCharRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final char compareAndExchange(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final char compareAndExchange(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/
-				return (char)_unsafe.compareAndExchangeInt(receiver, varHandle.vmslot, testValue, newValue);
+				return (char)_unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return (char)_unsafe.compareAndExchangeIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return (char)_unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final char compareAndExchangeAcquire(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final char compareAndExchangeAcquire(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.compareAndExchangeIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return (char)_unsafe.compareAndExchangeIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final char compareAndExchangeRelease(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final char compareAndExchangeRelease(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.compareAndExchangeIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return (char)_unsafe.compareAndExchangeIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, char testValue, char newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final char getAndSet(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndSet(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndSetInt(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndSetAcquire(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndSetAcquire(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndSetIntAcquire(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndSetRelease(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndSetRelease(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndSetIntRelease(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndAdd(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndAdd(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndAddInt(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndAddInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndAddAcquire(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndAddAcquire(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndAddIntAcquire(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndAddIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndAddRelease(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndAddRelease(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndAddIntRelease(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndAddIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseAnd(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseAnd(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseAndInt(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseAndInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseAndAcquire(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseAndAcquire(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseAndIntAcquire(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseAndIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseAndRelease(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseAndRelease(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseAndIntRelease(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseAndIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseOr(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseOr(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseOrInt(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseOrInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseOrAcquire(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseOrAcquire(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseOrIntAcquire(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseOrIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseOrRelease(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseOrRelease(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseOrIntRelease(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseOrIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseXor(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseXor(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseXorInt(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseXorInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseXorAcquire(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseXorAcquire(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseXorIntAcquire(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseXorIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final char getAndBitwiseXorRelease(Object receiver, char value, InstanceFieldVarHandle varHandle) {
+			private static final char getAndBitwiseXorRelease(Object receiver, char value, VarHandle varHandle) {
 				receiver.getClass();
-				return (char)_unsafe.getAndBitwiseXorIntRelease(receiver, varHandle.vmslot, value);
+				return (char)_unsafe.getAndBitwiseXorIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 		}
 
 		static final class OpDouble extends InstanceFieldVarHandleOperations {
-			private static final double get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final double get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getDouble(receiver, varHandle.vmslot);
+				return _unsafe.getDouble(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putDouble(receiver, varHandle.vmslot, value);
+				_unsafe.putDouble(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final double getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getDoubleVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getDoubleVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putDoubleVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putDoubleVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final double getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getDoubleOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getDoubleOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putDoubleOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putDoubleOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final double getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getDoubleAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putDoubleRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetDouble(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapDouble(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchange(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final double compareAndExchange(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeDouble(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeDoubleVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeDoubleVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final double compareAndExchangeAcquire(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final double compareAndExchangeAcquire(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeDoubleAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final double compareAndExchangeRelease(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final double compareAndExchangeRelease(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeDoubleRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetDouble(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDoubleVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDoubleVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDoubleAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.weakCompareAndSetDoubleRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDoubleRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, double testValue, double newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetDoublePlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDoublePlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDouble(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final double getAndSet(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndSet(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetDouble(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetDouble(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAndSetAcquire(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndSetAcquire(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetDoubleAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAndSetRelease(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndSetRelease(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetDoubleRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAndAdd(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndAdd(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddDouble(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddDouble(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAndAddAcquire(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndAddAcquire(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddDoubleAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAndAddRelease(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndAddRelease(Object receiver, double value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddDoubleRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final double getAndBitwiseAnd(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndAcquire(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseAndRelease(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOr(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseOr(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrAcquire(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseOrRelease(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXor(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseXor(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorAcquire(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final double getAndBitwiseXorRelease(Object receiver, double value, InstanceFieldVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(Object receiver, double value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
 
 		static final class OpFloat extends InstanceFieldVarHandleOperations {
-			private static final float get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final float get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getFloat(receiver, varHandle.vmslot);
+				return _unsafe.getFloat(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putFloat(receiver, varHandle.vmslot, value);
+				_unsafe.putFloat(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final float getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getFloatVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getFloatVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putFloatVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putFloatVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final float getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getFloatOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getFloatOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putFloatOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putFloatOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final float getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getFloatAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putFloatRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetFloat(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapFloat(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchange(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final float compareAndExchange(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeFloat(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeFloatVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeFloatVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final float compareAndExchangeAcquire(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final float compareAndExchangeAcquire(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeFloatAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final float compareAndExchangeRelease(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final float compareAndExchangeRelease(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeFloatRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloat(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloatVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloatVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloatAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloatAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloatRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloatRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, float testValue, float newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloatPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloatPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloat(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final float getAndSet(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndSet(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetFloat(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetFloat(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAndSetAcquire(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndSetAcquire(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetFloatAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAndSetRelease(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndSetRelease(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetFloatRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAndAdd(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndAdd(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddFloat(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddFloat(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAndAddAcquire(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndAddAcquire(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddFloatAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAndAddRelease(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndAddRelease(Object receiver, float value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddFloatRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final float getAndBitwiseAnd(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndAcquire(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseAndRelease(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOr(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseOr(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrAcquire(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseOrRelease(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXor(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseXor(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorAcquire(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final float getAndBitwiseXorRelease(Object receiver, float value, InstanceFieldVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(Object receiver, float value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 		}
 		
 		static final class OpInt extends InstanceFieldVarHandleOperations {
-			private static final int get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final int get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getInt(receiver, varHandle.vmslot);
+				return _unsafe.getInt(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putInt(receiver, varHandle.vmslot, value);
+				_unsafe.putInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final int getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getIntVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putIntVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final int getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getIntOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getIntOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putIntOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putIntOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final int getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getIntAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putIntRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchange(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final int compareAndExchange(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final int compareAndExchangeAcquire(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final int compareAndExchangeAcquire(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final int compareAndExchangeRelease(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final int compareAndExchangeRelease(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, int testValue, int newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final int getAndSet(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndSet(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetInt(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndSetAcquire(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndSetAcquire(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetIntAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndSetRelease(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndSetRelease(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetIntRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndAdd(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndAdd(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddInt(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndAddAcquire(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndAddAcquire(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddIntAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndAddRelease(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndAddRelease(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddIntRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseAnd(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseAnd(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseAndInt(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseAndInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseAndAcquire(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseAndAcquire(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseAndIntAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseAndIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseAndRelease(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseAndRelease(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseAndIntRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseAndIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseOr(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseOr(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseOrInt(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseOrInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseOrAcquire(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseOrAcquire(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseOrIntAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseOrIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseOrRelease(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseOrRelease(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseOrIntRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseOrIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseXor(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseXor(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseXorInt(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseXorInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseXorAcquire(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseXorAcquire(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseXorIntAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseXorIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final int getAndBitwiseXorRelease(Object receiver, int value, InstanceFieldVarHandle varHandle) {
+			private static final int getAndBitwiseXorRelease(Object receiver, int value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseXorIntRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseXorIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 		}
 		
 		static final class OpLong extends InstanceFieldVarHandleOperations {
-			private static final long get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final long get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getLong(receiver, varHandle.vmslot);
+				return _unsafe.getLong(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putLong(receiver, varHandle.vmslot, value);
+				_unsafe.putLong(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final long getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getLongVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getLongVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putLongVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putLongVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final long getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getLongOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getLongOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putLongOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putLongOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final long getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getLongAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putLongRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetLong(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapLong(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchange(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final long compareAndExchange(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeLong(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeLongVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeLongVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final long compareAndExchangeAcquire(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final long compareAndExchangeAcquire(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeLongAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final long compareAndExchangeRelease(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final long compareAndExchangeRelease(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.compareAndExchangeLongRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetLong(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLongVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLongVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetLongAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLongAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetLongRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLongRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, long testValue, long newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetLongPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLongPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLong(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final long getAndSet(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndSet(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetLong(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetLong(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndSetAcquire(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndSetAcquire(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetLongAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndSetRelease(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndSetRelease(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndSetLongRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndSetLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndAdd(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndAdd(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddLong(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddLong(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndAddAcquire(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndAddAcquire(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddLongAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndAddRelease(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndAddRelease(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndAddLongRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndAddLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseAnd(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseAnd(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseAndLong(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseAndLong(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseAndAcquire(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseAndAcquire(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseAndLongAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseAndLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseAndRelease(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseAndRelease(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseAndLongRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseAndLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseOr(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseOr(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseOrLong(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseOrLong(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseOrAcquire(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseOrAcquire(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseOrLongAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseOrLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseOrRelease(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseOrRelease(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseOrLongRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseOrLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseXor(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseXor(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseXorLong(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseXorLong(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseXorAcquire(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseXorAcquire(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseXorLongAcquire(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseXorLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final long getAndBitwiseXorRelease(Object receiver, long value, InstanceFieldVarHandle varHandle) {
+			private static final long getAndBitwiseXorRelease(Object receiver, long value, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getAndBitwiseXorLongRelease(receiver, varHandle.vmslot, value);
+				return _unsafe.getAndBitwiseXorLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 		}
 
 		static final class OpShort extends InstanceFieldVarHandleOperations {
-			private static final short get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final short get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getShort(receiver, varHandle.vmslot);
+				return _unsafe.getShort(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putShort(receiver, varHandle.vmslot, value);
+				_unsafe.putShort(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final short getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getShortVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getShortVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putShortVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putShortVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final short getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getShortOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getShortOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putShortOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putShortOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final short getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getShortAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getShortAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putShortRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putShortRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final short compareAndExchange(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final short compareAndExchange(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return (short)_unsafe.compareAndExchangeInt(receiver, varHandle.vmslot, testValue, newValue);
+				return (short)_unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return (short)_unsafe.compareAndExchangeIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return (short)_unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final short compareAndExchangeAcquire(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final short compareAndExchangeAcquire(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.compareAndExchangeIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return (short)_unsafe.compareAndExchangeIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final short compareAndExchangeRelease(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final short compareAndExchangeRelease(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.compareAndExchangeIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return (short)_unsafe.compareAndExchangeIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntVolatile(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, short testValue, short newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(receiver, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final short getAndSet(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndSet(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndSetInt(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndSetAcquire(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndSetAcquire(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndSetIntAcquire(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndSetRelease(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndSetRelease(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndSetIntRelease(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndAdd(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndAdd(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndAddInt(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndAddInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndAddAcquire(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndAddAcquire(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndAddIntAcquire(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndAddIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndAddRelease(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndAddRelease(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndAddIntRelease(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndAddIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseAnd(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseAnd(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseAndInt(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseAndInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseAndAcquire(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseAndAcquire(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseAndIntAcquire(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseAndIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseAndRelease(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseAndRelease(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseAndIntRelease(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseAndIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseOr(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseOr(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseOrInt(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseOrInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseOrAcquire(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseOrAcquire(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseOrIntAcquire(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseOrIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseOrRelease(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseOrRelease(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseOrIntRelease(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseOrIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseXor(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseXor(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseXorInt(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseXorInt(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseXorAcquire(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseXorAcquire(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseXorIntAcquire(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseXorIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final short getAndBitwiseXorRelease(Object receiver, short value, InstanceFieldVarHandle varHandle) {
+			private static final short getAndBitwiseXorRelease(Object receiver, short value, VarHandle varHandle) {
 				receiver.getClass();
-				return (short)_unsafe.getAndBitwiseXorIntRelease(receiver, varHandle.vmslot, value);
+				return (short)_unsafe.getAndBitwiseXorIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 		}
 		
 		static final class OpBoolean extends InstanceFieldVarHandleOperations {
-			private static final boolean get(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final boolean get(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getBoolean(receiver, varHandle.vmslot);
+				return _unsafe.getBoolean(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void set(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final void set(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putBoolean(receiver, varHandle.vmslot, value);
+				_unsafe.putBoolean(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean getVolatile(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final boolean getVolatile(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getBooleanVolatile(receiver, varHandle.vmslot);
+				return _unsafe.getBooleanVolatile(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setVolatile(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final void setVolatile(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putBooleanVolatile(receiver, varHandle.vmslot, value);
+				_unsafe.putBooleanVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean getOpaque(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final boolean getOpaque(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getBooleanOpaque(receiver, varHandle.vmslot);
+				return _unsafe.getBooleanOpaque(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setOpaque(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final void setOpaque(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putBooleanOpaque(receiver, varHandle.vmslot, value);
+				_unsafe.putBooleanOpaque(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean getAcquire(Object receiver, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAcquire(Object receiver, VarHandle varHandle) {
 				receiver.getClass();
-				return _unsafe.getBooleanAcquire(receiver, varHandle.vmslot);
+				return _unsafe.getBooleanAcquire(receiver, ((FieldVarHandle)varHandle).vmslot);
 			}
 
-			private static final void setRelease(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final void setRelease(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				_unsafe.putBooleanRelease(receiver, varHandle.vmslot, value);
+				_unsafe.putBooleanRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value);
 			}
 
-			private static final boolean compareAndSet(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean compareAndExchange(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndExchange(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return (0 != _unsafe.compareAndExchangeInt(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0));
+				return (0 != _unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0));
 /*[ELSE]
-				return (0 != _unsafe.compareAndExchangeIntVolatile(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0));
+				return (0 != _unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0));
 /*[ENDIF]*/				
 			}
 
-			private static final boolean compareAndExchangeAcquire(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndExchangeAcquire(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.compareAndExchangeIntAcquire(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0));
+				return (0 != _unsafe.compareAndExchangeIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0));
 			}
 
-			private static final boolean compareAndExchangeRelease(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean compareAndExchangeRelease(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.compareAndExchangeIntRelease(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0));
+				return (0 != _unsafe.compareAndExchangeIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0));
 			}
 
-			private static final boolean weakCompareAndSet(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetInt(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntVolatile(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(Object receiver, boolean testValue, boolean newValue, InstanceFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(receiver, varHandle.vmslot, testValue ? 1: 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean getAndSet(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndSet(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndSetInt(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndSetAcquire(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndSetAcquire(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndSetIntAcquire(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndSetRelease(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndSetRelease(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndSetIntRelease(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndAdd(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndAdd(Object receiver, boolean value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndAddAcquire(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndAddAcquire(Object receiver, boolean value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndAddRelease(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndAddRelease(Object receiver, boolean value, VarHandle varHandle) {
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndBitwiseAnd(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseAnd(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseAndInt(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseAndInt(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseAndAcquire(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseAndAcquire(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseAndIntAcquire(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseAndIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseAndRelease(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseAndRelease(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseAndIntRelease(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseAndIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseOr(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseOr(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseOrInt(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseOrInt(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseOrAcquire(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseOrAcquire(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseOrIntAcquire(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseOrIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseOrRelease(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseOrRelease(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseOrIntRelease(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseOrIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseXor(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseXor(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseXorInt(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseXorInt(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseXorAcquire(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseXorAcquire(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseXorIntAcquire(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseXorIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseXorRelease(Object receiver, boolean value, InstanceFieldVarHandle varHandle) {
+			private static final boolean getAndBitwiseXorRelease(Object receiver, boolean value, VarHandle varHandle) {
 				receiver.getClass();
-				return (0 != _unsafe.getAndBitwiseXorIntRelease(receiver, varHandle.vmslot, value ? 1 : 0));
+				return (0 != _unsafe.getAndBitwiseXorIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, value ? 1 : 0));
 			}
 		}
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1114,25 +1114,6 @@ public abstract class MethodHandle {
 		return asType(newType);
 	}
 	
-	/*[IF Sidecar19-SE]*/
-	/*
-	 * Used to convert an invokehandlegeneric bytecode into an AsTypeHandle + invokeExact OR to
-	 * convert an InvokeGenericHandle into an AsTypeHandle.
-	 * 
-	 * Allows us to only have the conversion logic for the AsTypeHandle and not worry about any
-	 * other similar conversions.
-	 */
-	@SuppressWarnings("unused")  /* Used by builder */
-	@VMCONSTANTPOOL_METHOD
-	private final MethodHandle forGenericInvokeVarHandle(MethodType newType, VarHandle varHandle) {
-		newType = newType.appendParameterTypes(varHandle.getClass());
-		if (this.type == newType) {
-			return this;
-		}
-		return asType(newType);
-	}
-	/*[ENDIF]*/
-	
 	@SuppressWarnings("unused")
 	@VMCONSTANTPOOL_METHOD
 	private static final MethodHandle sendResolveMethodHandle(

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -360,6 +360,22 @@ public final class MethodType implements Serializable {
 		return mt;
 	}
 	
+	/**
+	 * Internal helper method for generating a MethodType from a descriptor string,
+	 * and append an extra argument type.
+	 * 
+	 * VarHandle call sites use this method to generate the MethodType that matches
+	 * the VarHandle method implementation (extra VarHandle argument).
+	 */
+	@SuppressWarnings("unused")  /* Used by native code */
+	private static final MethodType fromMethodDescriptorStringAppendArg(String methodDescriptor, ClassLoader loader, Class<?> appendArgumentType) {
+		List<Class<?>> types = parseIntoClasses(methodDescriptor, loader);
+		Class<?> returnType = types.remove(types.size() - 1);
+		types.add(appendArgumentType);
+		
+		return methodType(returnType, types);
+	}
+	
 	/*
 	 * Convert the string from bytecode format to the format needed for ClassLoader#loadClass().
 	 * Change all '/' to '.'.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldVarHandle.java
@@ -23,6 +23,7 @@
 package java.lang.invoke;
 
 import static java.lang.invoke.MethodType.methodType;
+import static java.lang.invoke.StaticFieldVarHandle.StaticFieldVarHandleOperations.*;
 
 import java.lang.reflect.Field;
 
@@ -44,23 +45,23 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 		
 		if (!type.isPrimitive()) {
 			type = Object.class;
-			operationsClass = StaticFieldVarHandleOperations.OpObject.class;
+			operationsClass = OpObject.class;
 		} else if (int.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpInt.class;
+			operationsClass = OpInt.class;
 		} else if (long.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpLong.class;
+			operationsClass = OpLong.class;
 		} else if (boolean.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpBoolean.class;
+			operationsClass = OpBoolean.class;
 		} else if (byte.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpByte.class;
+			operationsClass = OpByte.class;
 		} else if (char.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpChar.class;
+			operationsClass = OpChar.class;
 		} else if (double.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpDouble.class;
+			operationsClass = OpDouble.class;
 		} else if (float.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpFloat.class;
+			operationsClass = OpFloat.class;
 		} else if (short.class == type) {
-			operationsClass = StaticFieldVarHandleOperations.OpShort.class;
+			operationsClass = OpShort.class;
 		} else if (void.class == type) {
 			throw new NoSuchFieldError();
 		} else {
@@ -68,9 +69,9 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			throw new InternalError(com.ibm.oti.util.Msg.getString("K0626", type)); //$NON-NLS-1$
 		}
 
-		MethodType getter = methodType(type, StaticFieldVarHandle.class);
-		MethodType setter = methodType(void.class, type, StaticFieldVarHandle.class);
-		MethodType compareAndSet = methodType(boolean.class, type, type, StaticFieldVarHandle.class);
+		MethodType getter = methodType(type, VarHandle.class);
+		MethodType setter = methodType(void.class, type, VarHandle.class);
+		MethodType compareAndSet = methodType(boolean.class, type, type, VarHandle.class);
 		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
 		MethodType getAndSet = setter.changeReturnType(type);
 		
@@ -78,32 +79,16 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 		MethodType[] exactTypes = lookupTypes;
 		
 		if (initType != type) {
-			MethodType exactGetter = methodType(initType, StaticFieldVarHandle.class);
-			MethodType exactSetter = methodType(void.class, initType, StaticFieldVarHandle.class);
-			MethodType exactCompareAndSet = methodType(boolean.class, initType, initType, StaticFieldVarHandle.class);
-			MethodType exactCompareAndExchange = compareAndSet.changeReturnType(initType);
-			MethodType exactGetAndSet = setter.changeReturnType(initType);
+			MethodType exactGetter = methodType(initType, VarHandle.class);
+			MethodType exactSetter = methodType(void.class, initType, VarHandle.class);
+			MethodType exactCompareAndSet = methodType(boolean.class, initType, initType, VarHandle.class);
+			MethodType exactCompareAndExchange = exactCompareAndSet.changeReturnType(initType);
+			MethodType exactGetAndSet = exactSetter.changeReturnType(initType);
 			
 			exactTypes = populateMTs(exactGetter, exactSetter, exactCompareAndSet, exactCompareAndExchange, exactGetAndSet);
 		}
 				
 		return populateMHs(operationsClass, lookupTypes, exactTypes);
-	}
-	
-	/**
-	 * Populates a MethodType[] corresponding to the provided type. 
-	 * 
-	 * @param type The type to create MethodType for.
-	 * @return The populated MethodType[].
-	 */
-	static final MethodType[] populateMTs(Class<?> type) {
-		MethodType getter = methodType(type);
-		MethodType setter = methodType(void.class, type);
-		MethodType compareAndSet = methodType(boolean.class, type, type);
-		MethodType compareAndExchange = compareAndSet.changeReturnType(type);
-		MethodType getAndSet = setter.changeReturnType(type);
-		
-		return populateMTs(getter, setter, compareAndSet, compareAndExchange, getAndSet);
 	}
 
 	/**
@@ -115,7 +100,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 	 * @param accessClass The class being used to look up the field
 	 */
 	StaticFieldVarHandle(Class<?> lookupClass, String fieldName, Class<?> fieldType, Class<?> accessClass) {
-		super(lookupClass, fieldName, fieldType, accessClass, true, COORDINATE_TYPES, populateMHs(fieldType), populateMTs(fieldType));
+		super(lookupClass, fieldName, fieldType, accessClass, true, COORDINATE_TYPES, populateMHs(fieldType));
 	}
 	
 	/**
@@ -124,7 +109,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 	 * @param field The {@link java.lang.reflect.Field} to create a VarHandle for.
 	 */
 	StaticFieldVarHandle(Field field, Class<?> fieldType) {
-		super(field, true, COORDINATE_TYPES, populateMHs(fieldType), populateMTs(fieldType));
+		super(field, true, COORDINATE_TYPES, populateMHs(fieldType));
 	}
 
 	/**
@@ -133,1348 +118,1627 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 	@SuppressWarnings("unused")
 	static class StaticFieldVarHandleOperations extends VarHandleOperations {
 		static final class OpObject extends StaticFieldVarHandleOperations {
-			private static final Object get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getObject(varHandle.definingClass, varHandle.vmslot);
+			private static final Object get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(Object value, StaticFieldVarHandle varHandle) {
-				_unsafe.putObject(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final Object getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getObjectVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final Object getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getObjectVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(Object value, StaticFieldVarHandle varHandle) {
-				_unsafe.putObjectVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putObjectVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final Object getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getObjectOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final Object getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getObjectOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(Object value, StaticFieldVarHandle varHandle) {
-				_unsafe.putObjectOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putObjectOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final Object getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getObjectAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final Object getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(Object value, StaticFieldVarHandle varHandle) {
-				_unsafe.putObjectRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetObject(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapObject(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final Object compareAndExchange(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
+			private static final Object compareAndExchange(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeObject(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeObjectVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeObjectVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final Object compareAndExchangeAcquire(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeObjectAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final Object compareAndExchangeAcquire(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final Object compareAndExchangeRelease(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeObjectRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final Object compareAndExchangeRelease(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObject(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObjectAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetObjectRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObjectRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(Object testValue, Object newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(Object testValue, Object newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.weakCompareAndSetObjectPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetObjectPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapObject(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final Object getAndSet(Object value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetObject(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final Object getAndSet(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final Object getAndSetAcquire(Object value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetObjectAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final Object getAndSetAcquire(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final Object getAndSetRelease(Object value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetObjectRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final Object getAndSetRelease(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final Object getAndAdd(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndAdd(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndAddAcquire(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndAddAcquire(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndAddRelease(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndAddRelease(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseAnd(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseAnd(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseAndAcquire(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseAndAcquire(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseAndRelease(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseAndRelease(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseOr(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseOr(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseOrAcquire(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseOrAcquire(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseOrRelease(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseOrRelease(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseXor(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseXor(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseXorAcquire(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseXorAcquire(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final Object getAndBitwiseXorRelease(Object value, StaticFieldVarHandle varHandle) {
+			private static final Object getAndBitwiseXorRelease(Object value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 		}
 		
 		static final class OpByte extends StaticFieldVarHandleOperations {
-			private static final byte get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getByte(varHandle.definingClass, varHandle.vmslot);
+			private static final byte get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getByte(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(byte value, StaticFieldVarHandle varHandle) {
-				_unsafe.putByte(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putByte(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final byte getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getByteVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final byte getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getByteVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(byte value, StaticFieldVarHandle varHandle) {
-				_unsafe.putByteVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putByteVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final byte getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getByteOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final byte getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getByteOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(byte value, StaticFieldVarHandle varHandle) {
-				_unsafe.putByteOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putByteOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final byte getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getByteAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final byte getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getByteAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(byte value, StaticFieldVarHandle varHandle) {
-				_unsafe.putByteRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putByteRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final byte compareAndExchange(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
+			private static final byte compareAndExchange(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return (byte)_unsafe.compareAndExchangeInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return (byte)_unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return (byte)_unsafe.compareAndExchangeIntVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return (byte)_unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final byte compareAndExchangeAcquire(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.compareAndExchangeIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final byte compareAndExchangeAcquire(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.compareAndExchangeIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final byte compareAndExchangeRelease(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.compareAndExchangeIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final byte compareAndExchangeRelease(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.compareAndExchangeIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.weakCompareAndSetIntPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(byte testValue, byte newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(byte testValue, byte newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final byte getAndSet(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndSetInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndSet(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndSetAcquire(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndSetAcquire(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndSetRelease(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndSetRelease(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndAdd(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndAddInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndAdd(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndAddInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndAddAcquire(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndAddIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final byte getAndAddAcquire(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndAddIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final byte getAndAddRelease(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndAddIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final byte getAndAddRelease(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndAddIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final byte getAndBitwiseAnd(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseAndInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseAnd(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseAndInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseAndAcquire(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseAndIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseAndAcquire(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseAndIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseAndRelease(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseAndIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseAndRelease(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseAndIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseOr(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseOrInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseOr(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseOrInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseOrAcquire(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseOrIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseOrAcquire(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseOrIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseOrRelease(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseOrIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseOrRelease(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseOrIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseXor(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseXorInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseXor(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseXorInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseXorAcquire(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseXorIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseXorAcquire(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseXorIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final byte getAndBitwiseXorRelease(byte value, StaticFieldVarHandle varHandle) {
-				return (byte)_unsafe.getAndBitwiseXorIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final byte getAndBitwiseXorRelease(byte value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (byte)_unsafe.getAndBitwiseXorIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 		}
 		
 		static final class OpChar extends StaticFieldVarHandleOperations {
-			private static final char get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getChar(varHandle.definingClass, varHandle.vmslot);
+			private static final char get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getChar(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(char value, StaticFieldVarHandle varHandle) {
-				_unsafe.putChar(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putChar(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final char getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getCharVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final char getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getCharVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(char value, StaticFieldVarHandle varHandle) {
-				_unsafe.putCharVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putCharVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final char getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getCharOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final char getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getCharOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(char value, StaticFieldVarHandle varHandle) {
-				_unsafe.putCharOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putCharOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final char getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getCharAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final char getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getCharAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(char value, StaticFieldVarHandle varHandle) {
-				_unsafe.putCharRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putCharRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(char testValue, char newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final char compareAndExchange(char testValue, char newValue, StaticFieldVarHandle varHandle) {
+			private static final char compareAndExchange(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return (char)_unsafe.compareAndExchangeInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return (char)_unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return (char)_unsafe.compareAndExchangeIntVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return (char)_unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final char compareAndExchangeAcquire(char testValue, char newValue, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.compareAndExchangeIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final char compareAndExchangeAcquire(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.compareAndExchangeIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final char compareAndExchangeRelease(char testValue, char newValue, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.compareAndExchangeIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final char compareAndExchangeRelease(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.compareAndExchangeIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(char testValue, char newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(char testValue, char newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(char testValue, char newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(char testValue, char newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(char testValue, char newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final char getAndSet(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndSetInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndSet(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndSetAcquire(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndSetAcquire(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndSetRelease(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndSetRelease(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndAdd(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndAddInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndAdd(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndAddInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndAddAcquire(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndAddIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final char getAndAddAcquire(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndAddIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final char getAndAddRelease(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndAddIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final char getAndAddRelease(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndAddIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final char getAndBitwiseAnd(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseAndInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseAnd(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseAndInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseAndAcquire(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseAndIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseAndAcquire(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseAndIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseAndRelease(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseAndIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseAndRelease(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseAndIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseOr(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseOrInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseOr(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseOrInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseOrAcquire(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseOrIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseOrAcquire(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseOrIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseOrRelease(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseOrIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseOrRelease(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseOrIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseXor(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseXorInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseXor(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseXorInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseXorAcquire(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseXorIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseXorAcquire(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseXorIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final char getAndBitwiseXorRelease(char value, StaticFieldVarHandle varHandle) {
-				return (char)_unsafe.getAndBitwiseXorIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final char getAndBitwiseXorRelease(char value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (char)_unsafe.getAndBitwiseXorIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 		}
 		
 		static final class OpDouble extends StaticFieldVarHandleOperations {
-			private static final double get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getDouble(varHandle.definingClass, varHandle.vmslot);
+			private static final double get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(double value, StaticFieldVarHandle varHandle) {
-				_unsafe.putDouble(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final double getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getDoubleVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final double getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getDoubleVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(double value, StaticFieldVarHandle varHandle) {
-				_unsafe.putDoubleVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putDoubleVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final double getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getDoubleOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final double getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getDoubleOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(double value, StaticFieldVarHandle varHandle) {
-				_unsafe.putDoubleOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putDoubleOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final double getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getDoubleAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final double getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(double value, StaticFieldVarHandle varHandle) {
-				_unsafe.putDoubleRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(double testValue, double newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetDouble(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapDouble(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final double compareAndExchange(double testValue, double newValue, StaticFieldVarHandle varHandle) {
+			private static final double compareAndExchange(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeDouble(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeDoubleVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeDoubleVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final double compareAndExchangeAcquire(double testValue, double newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeDoubleAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final double compareAndExchangeAcquire(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final double compareAndExchangeRelease(double testValue, double newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeDoubleRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final double compareAndExchangeRelease(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(double testValue, double newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.weakCompareAndSetDoublePlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDoublePlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDouble(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(double testValue, double newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetDoubleAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDoubleAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(double testValue, double newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetDoubleRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapDoubleRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(double testValue, double newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(double testValue, double newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetDouble(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapDouble(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final double getAndSet(double value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetDouble(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final double getAndSet(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final double getAndSetAcquire(double value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetDoubleAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final double getAndSetAcquire(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final double getAndSetRelease(double value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetDoubleRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final double getAndSetRelease(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final double getAndAdd(double value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddDouble(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final double getAndAdd(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final double getAndAddAcquire(double value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddDoubleAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final double getAndAddAcquire(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final double getAndAddRelease(double value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddDoubleRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final double getAndAddRelease(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final double getAndBitwiseAnd(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseAnd(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseAndAcquire(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseAndAcquire(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseAndRelease(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseAndRelease(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseOr(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseOr(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseOrAcquire(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseOrAcquire(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseOrRelease(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseOrRelease(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseXor(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseXor(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseXorAcquire(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseXorAcquire(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final double getAndBitwiseXorRelease(double value, StaticFieldVarHandle varHandle) {
+			private static final double getAndBitwiseXorRelease(double value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 		}
 		
 		static final class OpFloat extends StaticFieldVarHandleOperations {
-			private static final float get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getFloat(varHandle.definingClass, varHandle.vmslot);
+			private static final float get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(float value, StaticFieldVarHandle varHandle) {
-				_unsafe.putFloat(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final float getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getFloatVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final float getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getFloatVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(float value, StaticFieldVarHandle varHandle) {
-				_unsafe.putFloatVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putFloatVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final float getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getFloatOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final float getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getFloatOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(float value, StaticFieldVarHandle varHandle) {
-				_unsafe.putFloatOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putFloatOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final float getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getFloatAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final float getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(float value, StaticFieldVarHandle varHandle) {
-				_unsafe.putFloatRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(float testValue, float newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetFloat(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapFloat(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final float compareAndExchange(float testValue, float newValue, StaticFieldVarHandle varHandle) {
+			private static final float compareAndExchange(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeFloat(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeFloatVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeFloatVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final float compareAndExchangeAcquire(float testValue, float newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeFloatAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final float compareAndExchangeAcquire(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final float compareAndExchangeRelease(float testValue, float newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeFloatRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final float compareAndExchangeRelease(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(float testValue, float newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloatPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloatPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloat(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(float testValue, float newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloatAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloatAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(float testValue, float newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetFloatRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapFloatRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(float testValue, float newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(float testValue, float newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetFloat(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapFloat(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final float getAndSet(float value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetFloat(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final float getAndSet(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final float getAndSetAcquire(float value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetFloatAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final float getAndSetAcquire(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final float getAndSetRelease(float value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetFloatRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final float getAndSetRelease(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final float getAndAdd(float value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddFloat(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final float getAndAdd(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final float getAndAddAcquire(float value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddFloatAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final float getAndAddAcquire(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final float getAndAddRelease(float value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddFloatRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final float getAndAddRelease(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final float getAndBitwiseAnd(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseAnd(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseAndAcquire(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseAndAcquire(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseAndRelease(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseAndRelease(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseOr(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseOr(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseOrAcquire(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseOrAcquire(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseOrRelease(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseOrRelease(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseXor(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseXor(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseXorAcquire(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseXorAcquire(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 			
-			private static final float getAndBitwiseXorRelease(float value, StaticFieldVarHandle varHandle) {
+			private static final float getAndBitwiseXorRelease(float value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 		}
 		
 		static final class OpInt extends StaticFieldVarHandleOperations {
-			private static final int get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getInt(varHandle.definingClass, varHandle.vmslot);
+			private static final int get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(int value, StaticFieldVarHandle varHandle) {
-				_unsafe.putInt(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final int getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getIntVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final int getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(int value, StaticFieldVarHandle varHandle) {
-				_unsafe.putIntVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final int getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getIntOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final int getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getIntOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(int value, StaticFieldVarHandle varHandle) {
-				_unsafe.putIntOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putIntOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final int getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getIntAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final int getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(int value, StaticFieldVarHandle varHandle) {
-				_unsafe.putIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(int testValue, int newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final int compareAndExchange(int testValue, int newValue, StaticFieldVarHandle varHandle) {
+			private static final int compareAndExchange(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndExchangeInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeIntVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final int compareAndExchangeAcquire(int testValue, int newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final int compareAndExchangeAcquire(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final int compareAndExchangeRelease(int testValue, int newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final int compareAndExchangeRelease(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(int testValue, int newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(int testValue, int newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(int testValue, int newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(int testValue, int newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(int testValue, int newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final int getAndSet(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndSet(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndSetAcquire(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndSetAcquire(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndSetRelease(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndSetRelease(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndAdd(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndAdd(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndAddAcquire(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final int getAndAddAcquire(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final int getAndAddRelease(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final int getAndAddRelease(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final int getAndBitwiseAnd(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseAndInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseAnd(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseAndInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseAndAcquire(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseAndIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseAndAcquire(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseAndIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseAndRelease(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseAndIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseAndRelease(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseAndIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseOr(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseOrInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseOr(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseOrInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseOrAcquire(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseOrIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseOrAcquire(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseOrIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseOrRelease(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseOrIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseOrRelease(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseOrIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseXor(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseXorInt(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseXor(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseXorInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseXorAcquire(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseXorIntAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseXorAcquire(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseXorIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final int getAndBitwiseXorRelease(int value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseXorIntRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final int getAndBitwiseXorRelease(int value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseXorIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 		}
 		
 		static final class OpLong extends StaticFieldVarHandleOperations {
-			private static final long get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getLong(varHandle.definingClass, varHandle.vmslot);
+			private static final long get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(long value, StaticFieldVarHandle varHandle) {
-				_unsafe.putLong(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final long getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getLongVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final long getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getLongVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(long value, StaticFieldVarHandle varHandle) {
-				_unsafe.putLongVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putLongVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final long getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getLongOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final long getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getLongOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(long value, StaticFieldVarHandle varHandle) {
-				_unsafe.putLongOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putLongOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final long getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getLongAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final long getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(long value, StaticFieldVarHandle varHandle) {
-				_unsafe.putLongRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(long testValue, long newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetLong(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapLong(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final long compareAndExchange(long testValue, long newValue, StaticFieldVarHandle varHandle) {
+			private static final long compareAndExchange(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.compareAndExchangeLong(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndExchangeLongVolatile(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndExchangeLongVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final long compareAndExchangeAcquire(long testValue, long newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeLongAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final long compareAndExchangeAcquire(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final long compareAndExchangeRelease(long testValue, long newValue, StaticFieldVarHandle varHandle) {
-				return _unsafe.compareAndExchangeLongRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final long compareAndExchangeRelease(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.compareAndExchangeLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final boolean weakCompareAndSet(long testValue, long newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.weakCompareAndSetLongPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLongPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLong(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetAcquire(long testValue, long newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetLongAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLongAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetRelease(long testValue, long newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetLongRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapLongRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final boolean weakCompareAndSetPlain(long testValue, long newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(long testValue, long newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetLong(varHandle.definingClass, varHandle.vmslot, testValue, newValue);	
+				return _unsafe.compareAndSetLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);	
 /*[ELSE]
-				return _unsafe.compareAndSwapLong(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final long getAndSet(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetLong(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndSet(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndSetAcquire(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetLongAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndSetAcquire(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndSetRelease(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndSetLongRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndSetRelease(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndSetLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndAdd(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddLong(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndAdd(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndAddAcquire(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddLongAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final long getAndAddAcquire(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final long getAndAddRelease(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndAddLongRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final long getAndAddRelease(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndAddLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final long getAndBitwiseAnd(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseAndLong(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseAnd(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseAndLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseAndAcquire(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseAndLongAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseAndAcquire(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseAndLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseAndRelease(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseAndLongRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseAndRelease(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseAndLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseOr(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseOrLong(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseOr(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseOrLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseOrAcquire(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseOrLongAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseOrAcquire(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseOrLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseOrRelease(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseOrLongRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseOrRelease(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseOrLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseXor(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseXorLong(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseXor(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseXorLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseXorAcquire(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseXorLongAcquire(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseXorAcquire(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseXorLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 			
-			private static final long getAndBitwiseXorRelease(long value, StaticFieldVarHandle varHandle) {
-				return _unsafe.getAndBitwiseXorLongRelease(varHandle.definingClass, varHandle.vmslot, value); 
+			private static final long getAndBitwiseXorRelease(long value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getAndBitwiseXorLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value); 
 			}
 		}
 		
 		static final class OpShort extends StaticFieldVarHandleOperations {
-			private static final short get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getShort(varHandle.definingClass, varHandle.vmslot);
+			private static final short get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getShort(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(short value, StaticFieldVarHandle varHandle) {
-				_unsafe.putShort(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putShort(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final short getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getShortVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final short getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getShortVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(short value, StaticFieldVarHandle varHandle) {
-				_unsafe.putShortVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putShortVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final short getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getShortOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final short getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getShortOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(short value, StaticFieldVarHandle varHandle) {
-				_unsafe.putShortOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putShortOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final short getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getShortAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final short getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getShortAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(short value, StaticFieldVarHandle varHandle) {
-				_unsafe.putShortRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putShortRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(short testValue, short newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 			
-			private static final short compareAndExchange(short testValue, short newValue, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.compareAndExchangeIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final short compareAndExchange(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.compareAndExchangeIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 			
-			private static final short compareAndExchangeAcquire(short testValue, short newValue, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.compareAndExchangeIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final short compareAndExchangeAcquire(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.compareAndExchangeIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 
-			private static final short compareAndExchangeRelease(short testValue, short newValue, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.compareAndExchangeIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+			private static final short compareAndExchangeRelease(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.compareAndExchangeIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 			}
 
-			private static final boolean weakCompareAndSet(short testValue, short newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntPlain(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(short testValue, short newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(short testValue, short newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(short testValue, short newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(short testValue, short newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue, newValue);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ENDIF]*/				
 			}
 
-			private static final short getAndSet(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndSetInt(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndSet(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndSetAcquire(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndSetAcquire(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndSetRelease(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndSetRelease(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndAdd(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndAddInt(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndAdd(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndAddInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndAddAcquire(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndAddIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndAddAcquire(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndAddIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndAddRelease(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndAddIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndAddRelease(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndAddIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseAnd(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseAndInt(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseAnd(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseAndInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseAndAcquire(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseAndIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseAndAcquire(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseAndIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseAndRelease(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseAndIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseAndRelease(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseAndIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseOr(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseOrInt(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseOr(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseOrInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseOrAcquire(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseOrIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseOrAcquire(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseOrIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseOrRelease(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseOrIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseOrRelease(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseOrIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseXor(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseXorInt(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseXor(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseXorInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseXorAcquire(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseXorIntAcquire(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseXorAcquire(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseXorIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 
-			private static final short getAndBitwiseXorRelease(short value, StaticFieldVarHandle varHandle) {
-				return (short)_unsafe.getAndBitwiseXorIntRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final short getAndBitwiseXorRelease(short value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (short)_unsafe.getAndBitwiseXorIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 		}
 		
 		static final class OpBoolean extends StaticFieldVarHandleOperations {
-			private static final boolean get(StaticFieldVarHandle varHandle) {
-				return _unsafe.getBoolean(varHandle.definingClass, varHandle.vmslot);
+			private static final boolean get(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getBoolean(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void set(boolean value, StaticFieldVarHandle varHandle) {
-				_unsafe.putBoolean(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void set(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putBoolean(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean getVolatile(StaticFieldVarHandle varHandle) {
-				return _unsafe.getBooleanVolatile(varHandle.definingClass, varHandle.vmslot);
+			private static final boolean getVolatile(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getBooleanVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setVolatile(boolean value, StaticFieldVarHandle varHandle) {
-				_unsafe.putBooleanVolatile(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setVolatile(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putBooleanVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean getOpaque(StaticFieldVarHandle varHandle) {
-				return _unsafe.getBooleanOpaque(varHandle.definingClass, varHandle.vmslot);
+			private static final boolean getOpaque(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getBooleanOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setOpaque(boolean value, StaticFieldVarHandle varHandle) {
-				_unsafe.putBooleanOpaque(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setOpaque(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putBooleanOpaque(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean getAcquire(StaticFieldVarHandle varHandle) {
-				return _unsafe.getBooleanAcquire(varHandle.definingClass, varHandle.vmslot);
+			private static final boolean getAcquire(VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return _unsafe.getBooleanAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot);
 			}
 			
-			private static final void setRelease(boolean value, StaticFieldVarHandle varHandle) {
-				_unsafe.putBooleanRelease(varHandle.definingClass, varHandle.vmslot, value);
+			private static final void setRelease(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				_unsafe.putBooleanRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value);
 			}
 			
-			private static final boolean compareAndSet(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndSet(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean compareAndExchange(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean compareAndExchange(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return (0 != _unsafe.compareAndExchangeInt(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
+				return (0 != _unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
 /*[ELSE]
-				return (0 != _unsafe.compareAndExchangeIntVolatile(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
+				return (0 != _unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
 /*[ENDIF]*/				
 			}
 
-			private static final boolean compareAndExchangeAcquire(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.compareAndExchangeIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
+			private static final boolean compareAndExchangeAcquire(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.compareAndExchangeIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
 			}
 
-			private static final boolean compareAndExchangeRelease(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.compareAndExchangeIntRelease(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
+			private static final boolean compareAndExchangeRelease(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.compareAndExchangeIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
 			}
 
-			private static final boolean weakCompareAndSet(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSet(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/
-				return _unsafe.weakCompareAndSetIntPlain(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetAcquire(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetAcquire(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntAcquire(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetRelease(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetRelease(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.weakCompareAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.weakCompareAndSwapIntRelease(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean weakCompareAndSetPlain(boolean testValue, boolean newValue, StaticFieldVarHandle varHandle) {
+			private static final boolean weakCompareAndSetPlain(boolean testValue, boolean newValue, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 /*[IF Sidecar19-SE-B174]*/				
-				return _unsafe.compareAndSetInt(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
-				return _unsafe.compareAndSwapInt(varHandle.definingClass, varHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
+				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ENDIF]*/				
 			}
 
-			private static final boolean getAndSet(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndSetInt(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndSet(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndSetAcquire(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndSetIntAcquire(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndSetAcquire(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndSetRelease(boolean value, StaticFieldVarHandle varHandle) {	
-				return (0 != _unsafe.getAndSetIntRelease(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndSetRelease(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndAdd(boolean value, StaticFieldVarHandle varHandle) {
+			private static final boolean getAndAdd(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndAddAcquire(boolean value, StaticFieldVarHandle varHandle) {
+			private static final boolean getAndAddAcquire(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndAddRelease(boolean value, StaticFieldVarHandle varHandle) {
+			private static final boolean getAndAddRelease(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
 				throw operationNotSupported(varHandle);
 			}
 
-			private static final boolean getAndBitwiseAnd(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseAndInt(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseAnd(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseAndInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseAndAcquire(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseAndIntAcquire(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseAndAcquire(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseAndIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseAndRelease(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseAndIntRelease(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseAndRelease(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseAndIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseOr(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseOrInt(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseOr(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseOrInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseOrAcquire(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseOrIntAcquire(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseOrAcquire(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseOrIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseOrRelease(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseOrIntRelease(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseOrRelease(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseOrIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseXor(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseXorInt(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseXor(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseXorInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseXorAcquire(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseXorIntAcquire(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseXorAcquire(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseXorIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 
-			private static final boolean getAndBitwiseXorRelease(boolean value, StaticFieldVarHandle varHandle) {
-				return (0 != _unsafe.getAndBitwiseXorIntRelease(varHandle.definingClass, varHandle.vmslot, value ? 1 : 0));
+			private static final boolean getAndBitwiseXorRelease(boolean value, VarHandle varHandle) {
+				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
+				return (0 != _unsafe.getAndBitwiseXorIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, value ? 1 : 0));
 			}
 		}
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -23,8 +23,8 @@
 package java.lang.invoke;
 
 abstract class ViewVarHandle extends VarHandle {
-	ViewVarHandle(Class<?> fieldType, Class<?>[] coordinateTypes, MethodHandle[] handleTable, MethodType[] typeTable, int modifiers) {
-		super(fieldType, coordinateTypes, handleTable, typeTable, modifiers);
+	ViewVarHandle(Class<?> fieldType, Class<?>[] coordinateTypes, MethodHandle[] handleTable, int modifiers) {
+		super(fieldType, coordinateTypes, handleTable, modifiers);
 	}
 	
 	@Override

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4678,7 +4678,6 @@ typedef struct J9InternalVMFunctions {
 	void*  ( *jniArrayAllocateMemoryFromThread)(struct J9VMThread* vmThread, UDATA sizeInBytes) ;
 	void  ( *jniArrayFreeMemoryFromThread)(struct J9VMThread* vmThread, void* location) ;
 	void  (JNICALL *sendForGenericInvoke)(struct J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg, UDATA reserved4) ;
-	void  (JNICALL *sendForGenericInvokeVarHandle)(struct J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, j9object_t varHandle, UDATA reserved4) ;
 	void  (JNICALL *jitFillOSRBuffer)(struct J9VMThread *vmContext, void *osrBlock, UDATA reserved1, UDATA reserved2, UDATA reserved3) ;
 	void  (JNICALL *sendResolveMethodHandle)(struct J9VMThread *vmThread, UDATA cpIndex, J9ConstantPool *ramCP, J9Class *definingClass, J9ROMNameAndSignature* nameAndSig) ;
 	j9object_t  ( *resolveInvokeDynamic)(struct J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4666,7 +4666,7 @@ typedef struct J9InternalVMFunctions {
 	struct J9Method*  ( *findJNIMethod)(struct J9VMThread* currentThread, J9Class* clazz, char* name, char* signature) ;
 	const char*  ( *getJ9VMVersionString)(struct J9JavaVM * vm) ;
 	j9object_t  ( *resolveMethodTypeRef)(struct J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags) ;
-	void  (JNICALL *sendFromMethodDescriptorString)(struct J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, UDATA reserved3, UDATA reserved4) ;
+	void  (JNICALL *sendFromMethodDescriptorString)(struct J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType, UDATA reserved4) ;
 	UDATA  ( *addToBootstrapClassLoaderSearch)(struct J9JavaVM * vm, const char * pathSegment, UDATA classLoaderType, BOOLEAN enforceJarRestriction) ;
 	UDATA  ( *addToSystemClassLoaderSearch)(struct J9JavaVM * vm, const char * pathSegment, UDATA classLoaderType, BOOLEAN enforceJarRestriction) ;
 	UDATA  ( *queryLogOptions)(struct J9JavaVM *vm, I_32 buffer_size, void *options_buffer, I_32 *data_size) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1305,7 +1305,6 @@ extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructorImpl (J9VMThread *v
 extern J9_CFUNC void  JNICALL sendFromMethodDescriptorString (J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType, UDATA reserved4);
 extern J9_CFUNC void  JNICALL sendResolveMethodHandle (J9VMThread *vmThread, UDATA cpIndex, J9ConstantPool *ramCP, J9Class *definingClass, J9ROMNameAndSignature* nameAndSig);
 extern J9_CFUNC void  JNICALL sendForGenericInvoke (J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg, UDATA reserved4);
-extern J9_CFUNC void  JNICALL sendForGenericInvokeVarHandle (J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, j9object_t varHandle, UDATA reserved4);
 extern J9_CFUNC void  JNICALL sendResolveInvokeDynamic (J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA callSiteIndex, J9ROMNameAndSignature* nameAndSig, U_16* bsmData);
 extern J9_CFUNC void  JNICALL jitFillOSRBuffer (struct J9VMThread *vmContext, void *osrBlock, UDATA reserved1, UDATA reserved2, UDATA reserved3);
 extern J9_CFUNC void  JNICALL sendRunThread(J9VMThread *vmContext, j9object_t tenantContext, UDATA reserved1, UDATA reserved2, UDATA reserved3);

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1302,7 +1302,7 @@ extern J9_CFUNC void  JNICALL internalRunStaticMethod (J9VMThread *vmContext, J9
 extern J9_CFUNC void  JNICALL sendCheckPackageAccess (J9VMThread *vmContext, J9Class * clazz, j9object_t protectionDomain, UDATA reserved1, UDATA reserved2);
 extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructor (J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused);
 extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructorImpl (J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused);
-extern J9_CFUNC void  JNICALL sendFromMethodDescriptorString (J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, UDATA reserved3, UDATA reserved4);
+extern J9_CFUNC void  JNICALL sendFromMethodDescriptorString (J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType, UDATA reserved4);
 extern J9_CFUNC void  JNICALL sendResolveMethodHandle (J9VMThread *vmThread, UDATA cpIndex, J9ConstantPool *ramCP, J9Class *definingClass, J9ROMNameAndSignature* nameAndSig);
 extern J9_CFUNC void  JNICALL sendForGenericInvoke (J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg, UDATA reserved4);
 extern J9_CFUNC void  JNICALL sendForGenericInvokeVarHandle (J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, j9object_t varHandle, UDATA reserved4);

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -312,7 +312,7 @@
 	<fieldref class="java/lang/invoke/ConstantDoubleHandle" name="value" signature="D" cast="U_64" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/InvokeGenericHandle" name="castType" signature="Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/VarHandle" name="handleTable" signature="[Ljava/lang/invoke/MethodHandle;" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/invoke/VarHandle" name="typeTable" signature="[Ljava/lang/invoke/MethodType;" jcl="se9_before_b165,se9"/>
+	<!--fieldref class="java/lang/invoke/VarHandle" name="typeTable" signature="[Ljava/lang/invoke/MethodType;" jcl="se9_before_b165,se9"/-->
 	<fieldref class="java/lang/invoke/VarHandle" name="modifiers" signature="I" jcl="se9_before_b165,se9"/>
 	<fieldref class="java/lang/invoke/FoldHandle" name="foldPosition" signature="I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/FoldHandle" name="argumentIndices" signature="[I" flags="opt_methodHandle"/>
@@ -335,6 +335,7 @@
 	<staticmethodref class="java/lang/J9VMInternals" name="newInstanceImpl" signature="(Ljava/lang/Class;)Ljava/lang/Object;" flags="jit_newInstancePrototype"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="formatNoSuchMethod" signature="(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/String;"/>
 	<staticmethodref class="java/lang/invoke/MethodType" name="fromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
+	<staticmethodref class="java/lang/invoke/MethodType" name="fromMethodDescriptorStringAppendArg" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="sendResolveMethodHandle" signature="(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="resolveInvokeDynamic" signature="(JLjava/lang/String;Ljava/lang/String;J)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="invokeWithArgumentsHelper" signature="(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/> 

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -312,7 +312,6 @@
 	<fieldref class="java/lang/invoke/ConstantDoubleHandle" name="value" signature="D" cast="U_64" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/InvokeGenericHandle" name="castType" signature="Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/VarHandle" name="handleTable" signature="[Ljava/lang/invoke/MethodHandle;" jcl="se9_before_b165,se9"/>
-	<!--fieldref class="java/lang/invoke/VarHandle" name="typeTable" signature="[Ljava/lang/invoke/MethodType;" jcl="se9_before_b165,se9"/-->
 	<fieldref class="java/lang/invoke/VarHandle" name="modifiers" signature="I" jcl="se9_before_b165,se9"/>
 	<fieldref class="java/lang/invoke/FoldHandle" name="foldPosition" signature="I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/FoldHandle" name="argumentIndices" signature="[I" flags="opt_methodHandle"/>
@@ -341,7 +340,6 @@
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="invokeWithArgumentsHelper" signature="(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="constructorPlaceHolder" signature="(Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="forGenericInvoke" signature="(Ljava/lang/invoke/MethodType;Z)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
-	<specialmethodref class="java/lang/invoke/MethodHandle" name="forGenericInvokeVarHandle" signature="(Ljava/lang/invoke/MethodType;Ljava/lang/invoke/VarHandle;)Ljava/lang/invoke/MethodHandle;" jcl="se9_before_b165,se9"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="returnFilterPlaceHolder" signature="()Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="foldHandlePlaceHolder" signature="()Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>
 	<specialmethodref class="java/lang/invoke/MethodHandle" name="guardWithTestPlaceHolder" signature="()Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/>

--- a/runtime/tr.source/trj9/env/VMJ9.cpp
+++ b/runtime/tr.source/trj9/env/VMJ9.cpp
@@ -5423,12 +5423,6 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    }
 
 uint32_t
-TR_J9VMBase::getVarHandleTypeTableOffset(TR::Compilation * comp)
-   {
-   return uint32_t(J9VMJAVALANGINVOKEVARHANDLE_TYPETABLE_OFFSET(vmThread()));
-   }
-
-uint32_t
 TR_J9VMBase::getVarHandleHandleTableOffset(TR::Compilation * comp)
    {
    return uint32_t(J9VMJAVALANGINVOKEVARHANDLE_HANDLETABLE_OFFSET(vmThread()));

--- a/runtime/tr.source/trj9/env/VMJ9.h
+++ b/runtime/tr.source/trj9/env/VMJ9.h
@@ -736,7 +736,6 @@ public:
    virtual char     *getStringUTF8      (uintptrj_t objectPointer, char *buffer, intptrj_t bufferSize);
 
    virtual uint32_t getVarHandleHandleTableOffset(TR::Compilation *);
-   virtual uint32_t getVarHandleTypeTableOffset(TR::Compilation *);
 
    virtual void reportILGeneratorPhase();
    virtual void reportOptimizationPhase(OMR::Optimizations);

--- a/runtime/tr.source/trj9/il/symbol/J9Symbol.cpp
+++ b/runtime/tr.source/trj9/il/symbol/J9Symbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,7 +155,6 @@ J9::Symbol::searchRecognizedField(TR::Compilation * comp, TR_ResolvedMethod * ow
        {r(TR::Symbol::Java_math_BigInteger_useLongRepresentation,     "java/math/BigInteger", "useLongRepresentation", "Z")},
        {r(TR::Symbol::Java_lang_ref_SoftReference_age,                "java/lang/ref/SoftReference", "age", "I")},
        {r(TR::Symbol::Java_lang_invoke_VarHandle_handleTable,         "java/lang/invoke/VarHandle", "handleTable", "[Ljava/lang/invoke/MethodHandle;")},
-       {r(TR::Symbol::Java_lang_invoke_VarHandle_typeTable,           "java/lang/invoke/VarHandle", "typeTable", "[Ljava/lang/invoke/MethodType;")},
        {TR::Symbol::UnknownField}
       };
 

--- a/runtime/tr.source/trj9/il/symbol/J9Symbol.hpp
+++ b/runtime/tr.source/trj9/il/symbol/J9Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -158,7 +158,6 @@ public:
       Java_math_BigInteger_ZERO,
       Java_math_BigInteger_useLongRepresentation,
       Java_lang_invoke_VarHandle_handleTable,
-      Java_lang_invoke_VarHandle_typeTable,
       assertionsDisabled,
       NumRecognizedFields
       };

--- a/runtime/tr.source/trj9/optimizer/VarHandleTransformer.cpp
+++ b/runtime/tr.source/trj9/optimizer/VarHandleTransformer.cpp
@@ -77,7 +77,7 @@ addAndGet
 #define VarHandleParam "Ljava/lang/invoke/VarHandle;"
 #define JSR292_MethodHandle   "java/lang/invoke/MethodHandle"
 #define JSR292_asType              "asType"
-#define JSR292_asTypeSig           "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/VarHandle;)Ljava/lang/invoke/MethodHandle;"
+#define JSR292_asTypeSig           "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;"
 #define JSR292_invokeExactTargetAddress    "invokeExactTargetAddress"
 #define JSR292_invokeExactTargetAddressSig "()J"
 #define JSR292_invokeExact    "invokeExact"
@@ -301,7 +301,7 @@ int32_t TR_VarHandleTransformer::perform()
                }
             // Convert MH
             TR::SymbolReference *typeConversionSymRef = comp()->getSymRefTab()->methodSymRefFromName(methodSymbol, JSR292_MethodHandle, JSR292_asType, JSR292_asTypeSig, OMR::MethodSymbol::Static);
-            TR::Node * convertedMethodHandle = TR::Node::createWithSymRef(TR::acall, 3, 3, methodHandle, callSiteMethodType, varHandle, typeConversionSymRef);
+            TR::Node * convertedMethodHandle = TR::Node::createWithSymRef(TR::acall, 2, 2, methodHandle, callSiteMethodType, typeConversionSymRef);
             convertedMethodHandle->copyByteCodeInfo(node);
             callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, convertedMethodHandle)));
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7755,12 +7755,9 @@ done:
 			/* Get MethodHandle for this operation from the VarHandles handleTable */
 			j9object_t handleTable = J9VMJAVALANGINVOKEVARHANDLE_HANDLETABLE(_currentThread, varHandle);
 			j9object_t methodHandle = J9JAVAARRAYOFOBJECT_LOAD(_currentThread, handleTable, operation);
+			j9object_t handleType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodHandle);
 
-			/* Get expected MethodType */
-			j9object_t typeTable = J9VMJAVALANGINVOKEVARHANDLE_TYPETABLE(_currentThread, varHandle);
-			j9object_t handleType = J9JAVAARRAYOFOBJECT_LOAD(_currentThread, typeTable, operation);
-
-			/* Get call site MethodType using binary search */
+			/* Get call site MethodType */
 			j9object_t volatile callSiteType = NULL;
 			J9Class *ramClass = J9_CLASS_FROM_CP(ramConstantPool);
 			J9ROMClass *romClass = ramClass->romClass;
@@ -7774,7 +7771,8 @@ done:
 				if (cachedHandle != NULL) {
 					cachedHandleType = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, cachedHandle);
 				}
-				if (cachedHandleType != NULL && VM_VMHelpers::doMethodTypesMatchIgnoringLastArgument(_currentThread, callSiteType, cachedHandleType)) {
+				if (cachedHandleType == callSiteType) {
+					/* The cached AsTypeHandle was applicable to this call site. Use the cache. */
 					methodHandle = cachedHandle;
 				} else {
 					/* Create generic invocation handle */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7779,7 +7779,7 @@ done:
 					buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 					pushObjectInSpecialFrame(REGISTER_ARGS, varHandle);
 					updateVMStruct(REGISTER_ARGS);
-					sendForGenericInvokeVarHandle(_currentThread, methodHandle, callSiteType, varHandle, 0 /* reserved */);
+					sendForGenericInvoke(_currentThread, methodHandle, callSiteType, FALSE /* dropFirstArg */, 0 /* reserved */);
 					VMStructHasBeenUpdated(REGISTER_ARGS);
 					varHandle = popObjectInSpecialFrame(REGISTER_ARGS);
 					restoreGenericSpecialStackFrame(REGISTER_ARGS);

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -544,11 +544,7 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 			/* Get MethodHandle for this operation from the VarHandle's handleTable */
 			j9object_t handleTable = J9VMJAVALANGINVOKEVARHANDLE_HANDLETABLE(_currentThread, varHandle);
 			j9object_t methodHandleFromTable = J9JAVAARRAYOFOBJECT_LOAD(_currentThread, handleTable, operation);
-
-			/* Get expected MethodType */
-			j9object_t typeTable = J9VMJAVALANGINVOKEVARHANDLE_TYPETABLE(_currentThread, varHandle);
-			j9object_t handleTypeFromTable = J9JAVAARRAYOFOBJECT_LOAD(_currentThread, typeTable, operation);
-
+			j9object_t handleTypeFromTable = J9VMJAVALANGINVOKEMETHODHANDLE_TYPE(_currentThread, methodHandleFromTable);
 			j9object_t accessModeType = J9VMJAVALANGINVOKEVARHANDLEINVOKEHANDLE_ACCESSMODETYPE(_currentThread, methodHandle);
 
 			if (accessModeType == handleTypeFromTable) {

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -559,7 +559,7 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 				IDATA spOffset = spPriorToFrameBuild - _currentThread->arg0EA;
 				IDATA frameOffset = (UDATA*)currentTypeFrame - _currentThread->arg0EA;
 
-				sendForGenericInvoke(_currentThread, methodHandleFromTable, accessModeType, 0 /* reserved */, 0 /* reserved */);
+				sendForGenericInvoke(_currentThread, methodHandleFromTable, accessModeType, FALSE /* dropFirstArg */, 0 /* reserved */);
 				methodHandle = (j9object_t)_currentThread->returnValue;
 
 				if (VM_VMHelpers::exceptionPending(_currentThread)) {

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -559,7 +559,7 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 				IDATA spOffset = spPriorToFrameBuild - _currentThread->arg0EA;
 				IDATA frameOffset = (UDATA*)currentTypeFrame - _currentThread->arg0EA;
 
-				sendForGenericInvokeVarHandle(_currentThread, methodHandleFromTable, accessModeType, varHandle, 0 /* reserved */);
+				sendForGenericInvoke(_currentThread, methodHandleFromTable, accessModeType, 0 /* reserved */, 0 /* reserved */);
 				methodHandle = (j9object_t)_currentThread->returnValue;
 
 				if (VM_VMHelpers::exceptionPending(_currentThread)) {

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -944,25 +944,6 @@ sendForGenericInvoke(J9VMThread *currentThread, j9object_t methodHandle, j9objec
 }
 
 void JNICALL
-sendForGenericInvokeVarHandle(J9VMThread *currentThread, j9object_t methodHandle, j9object_t methodType, j9object_t varHandle, UDATA reserved4)
-{
-	Trc_VM_sendForGenericInvokeVarHandle_Entry(currentThread);
-	J9VMEntryLocalStorage newELS;
-	
-	/* Run the method */
-	if (buildCallInStackFrame(currentThread, &newELS, true, false)) {
-		*--currentThread->sp = (UDATA)methodHandle;
-		*--currentThread->sp = (UDATA)methodType;
-		*--currentThread->sp = (UDATA)varHandle;
-		currentThread->returnValue = J9_BCLOOP_RUN_METHOD;
-		currentThread->returnValue2 = (UDATA)J9VMJAVALANGINVOKEMETHODHANDLE_FORGENERICINVOKEVARHANDLE_METHOD(currentThread->javaVM);
-		c_cInterpreter(currentThread);
-		restoreCallInFrame(currentThread);
-	}
-	Trc_VM_sendForGenericInvokeVarHandle_Exit(currentThread);
-}
-
-void JNICALL
 sendResolveInvokeDynamic(J9VMThread *currentThread, J9ConstantPool *ramCP, UDATA callSiteIndex, J9ROMNameAndSignature *nameAndSig, U_16 *bsmData)
 {
 	Trc_VM_sendResolveInvokeDynamic_Entry(currentThread);

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -304,7 +304,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jniArrayAllocateMemoryFromThread,
 	jniArrayFreeMemoryFromThread,
 	sendForGenericInvoke,
-	sendForGenericInvokeVarHandle,
 	jitFillOSRBuffer,
 	sendResolveMethodHandle,
 	resolveInvokeDynamic,

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1306,7 +1306,7 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 				/* Call VM Entry point to create the MethodType - Result is put into the
 				 * vmThread->returnValue as entry points don't "return" in the expected way
 				 */
-				sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, 0, 0);
+				sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, NULL, 0);
 				methodType = (j9object_t) vmStruct->returnValue;
 
 				/* check if an exception is already pending */
@@ -1466,8 +1466,13 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 
 					/* Call VM Entry point to create the MethodType - Result is put into the
 					 * vmThread->returnValue as entry points don't "return" in the expected way
+					 *
+					 * NB! An extra VarHandle argument is appended to the MethodType's argument list,
+					 * so the returned MethodType doesn't represent the provided method signature.
+					 * E.g. the MethodType for "(I)I" will have the following descriptor string:
+					 *     "(Ijava/lang/invoke/VarHandle;)I"
 					 */
-					sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, 0, 0);
+					sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, J9VMJAVALANGINVOKEVARHANDLE_OR_NULL(vm), 0);
 					methodType = (j9object_t)vmStruct->returnValue;
 
 					/* Check if an exception is already pending */
@@ -1568,7 +1573,7 @@ resolveMethodTypeRefInto(J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIn
 	 */
 	romMethodTypeRef = ((J9ROMMethodTypeRef *) &(J9_ROM_CP_FROM_CP(ramCP)[cpIndex]));
 	lookupSig = J9ROMMETHODTYPEREF_SIGNATURE(romMethodTypeRef);
-	sendFromMethodDescriptorString(vmThread, lookupSig, J9_CLASS_FROM_CP(ramCP)->classLoader, 0, 0);
+	sendFromMethodDescriptorString(vmThread, lookupSig, J9_CLASS_FROM_CP(ramCP)->classLoader, NULL, 0);
 	methodType = (j9object_t) vmThread->returnValue;
 
 	/* check if an exception is already pending */


### PR DESCRIPTION
Previously, we kept an array of MethodTypes (`typeTable`) for each VarHandle, where each index in the array matched the `type` of the MethodHandle at the same index in the `handleTable`, except for the last argument. This was done so that we could keep extra arguments in the internal method, while exposing the expected public API. For example:
    `public int getAndSet(int value)` --> `private static int getAndSet(int value, VarHandle vh)`

In order to simplify the design, both in the VM and for future JIT optimizations, we have decided to remove the `typeTable`, and instead store a MethodType with the added VarHandle argument per call site.

The other changes in this PR are side-effects of removing the `typeTable` (plus some general VarHandle code cleanup).