### PR TITLE
Improve string coding

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -2423,14 +2423,19 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int currentLength = lengthInternal();
 		
 		/*[IF Sidecar19-SE]*/
+		byte[] buffer = value;
 		// Check if the String is compressed
 		if (enableCompression && count >= 0) {
-			byte[] buffer = new byte[currentLength];
-			compressedArrayCopy(value, 0, buffer, 0, currentLength);
+			if (buffer.length != currentLength) {
+				buffer = new byte[currentLength];
+				compressedArrayCopy(value, 0, buffer, 0, currentLength);
+			}
 			return StringCoding.encode(String.LATIN1, buffer);
 		} else {
-			byte[] buffer = new byte[currentLength * 2];
-			decompressedArrayCopy(value, 0, buffer, 0, currentLength);
+			if (buffer.length != currentLength << 1) {
+				buffer = new byte[currentLength << 1];
+				decompressedArrayCopy(value, 0, buffer, 0, currentLength);
+			}
 			return StringCoding.encode(String.UTF16, buffer);
 		}
 		/*[ELSE]*/
@@ -2521,16 +2526,20 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 
 		int currentLength = lengthInternal();
-		
 		/*[IF Sidecar19-SE]*/
+		byte[] buffer = value;
 		// Check if the String is compressed
 		if (enableCompression && count >= 0) {
-			byte[] buffer = new byte[currentLength];
-			compressedArrayCopy(value, 0, buffer, 0, currentLength);
+			if (buffer.length != currentLength) {
+				buffer = new byte[currentLength];
+				compressedArrayCopy(value, 0, buffer, 0, currentLength);
+			}
 			return StringCoding.encode(encoding, String.LATIN1, buffer);
 		} else {
-			byte[] buffer = new byte[currentLength * 2];
-			decompressedArrayCopy(value, 0, buffer, 0, currentLength);
+			if (buffer.length != currentLength << 1) {
+				buffer = new byte[currentLength << 1];
+				decompressedArrayCopy(value, 0, buffer, 0, currentLength);
+			}
 			return StringCoding.encode(encoding, String.UTF16, buffer);
 		}
 		/*[ELSE]*/
@@ -5102,14 +5111,19 @@ written authorization of the copyright holder.
 		int currentLength = lengthInternal();
 		
 		/*[IF Sidecar19-SE]*/
+		byte[] buffer = value;
 		// Check if the String is compressed
 		if (enableCompression && count >= 0) {
-			byte[] buffer = new byte[currentLength];
-			compressedArrayCopy(value, 0, buffer, 0, currentLength);
+			if (buffer.length != currentLength) {
+				buffer = new byte[currentLength];
+				compressedArrayCopy(value, 0, buffer, 0, currentLength);
+			}
 			return StringCoding.encode(charset, String.LATIN1, buffer);
 		} else {
-			byte[] buffer = new byte[currentLength * 2];
-			decompressedArrayCopy(value, 0, buffer, 0, currentLength);
+			if (buffer.length != currentLength << 1) {
+				buffer = new byte[currentLength << 1];
+				decompressedArrayCopy(value, 0, buffer, 0, currentLength);
+			}
 			return StringCoding.encode(charset, String.UTF16, buffer);
 		}
 		/*[ELSE]*/

--- a/runtime/tr.source/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/tr.source/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -196,6 +196,8 @@
    java_lang_String_unsafeCharAt,
    java_lang_String_split_str_int,
 
+   java_lang_StringUTF16_getChar,
+
    java_lang_StringBuffer_append,
    java_lang_StringBuffer_capacityInternal,
    java_lang_StringBuffer_ensureCapacityImpl,

--- a/runtime/tr.source/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/tr.source/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -1088,6 +1088,7 @@
    java_lang_StringCoding_encode,
    java_lang_StringCoding_StringDecoder_decode,
    java_lang_StringCoding_StringEncoder_encode,
+   java_lang_StringCoding_implEncodeISOArray,
 
    java_util_Arrays_copyOf_byte,
    java_util_Arrays_copyOf_short,

--- a/runtime/tr.source/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/tr.source/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -1089,6 +1089,9 @@
    java_lang_StringCoding_StringDecoder_decode,
    java_lang_StringCoding_StringEncoder_encode,
    java_lang_StringCoding_implEncodeISOArray,
+   java_lang_StringCoding_encode8859_1,
+   java_lang_StringCoding_encodeASCII,
+   java_lang_StringCoding_encodeUTF8,
 
    java_util_Arrays_copyOf_byte,
    java_util_Arrays_copyOf_short,

--- a/runtime/tr.source/trj9/compile/J9Compilation.cpp
+++ b/runtime/tr.source/trj9/compile/J9Compilation.cpp
@@ -368,6 +368,7 @@ J9::Compilation::isConverterMethod(TR::RecognizedMethod rm)
    switch (rm)
       {
       case TR::sun_nio_cs_ISO_8859_1_Encoder_encodeISOArray:
+      case TR::java_lang_StringCoding_implEncodeISOArray:
       case TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1:
       case TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII:
       case TR::sun_nio_cs_US_ASCII_Decoder_decodeASCII:
@@ -402,6 +403,7 @@ J9::Compilation::canTransformConverterMethod(TR::RecognizedMethod rm)
    switch (rm)
       {
       case TR::sun_nio_cs_ISO_8859_1_Encoder_encodeISOArray:
+      case TR::java_lang_StringCoding_implEncodeISOArray:
          return genTRxx || self()->cg()->getSupportsArrayTranslateTRTO255() || self()->cg()->getSupportsArrayTranslateTRTO() || genSIMD;
 
       case TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1:

--- a/runtime/tr.source/trj9/env/VMJ9.cpp
+++ b/runtime/tr.source/trj9/env/VMJ9.cpp
@@ -3305,6 +3305,7 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
       case TR::com_ibm_jit_JITHelpers_getJ9ClassFromObject32:
       case TR::com_ibm_jit_JITHelpers_getJ9ClassFromObject64:
       case TR::com_ibm_jit_JITHelpers_getClassInitializeStatus:
+      case TR::java_lang_StringUTF16_getChar:
             return DontInline_Callee;
       default:
          break;

--- a/runtime/tr.source/trj9/env/j9method.cpp
+++ b/runtime/tr.source/trj9/env/j9method.cpp
@@ -3302,6 +3302,12 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {  TR::unknownMethod}
       };
 
+   static X StringUTF16Methods[] =
+      {
+      { x(TR::java_lang_StringUTF16_getChar,                                  "getChar", "([BI)C")},
+      { TR::unknownMethod }
+      };
+
    static X DecimalFormatHelperMethods[] =
       {
       {x(TR::com_ibm_jit_DecimalFormatHelper_formatAsDouble,                  "formatAsDouble", "(Ljava/text/DecimalFormat;Ljava/math/BigDecimal;)Ljava/lang/String;")},
@@ -4158,6 +4164,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
    static Y class21[] =
       {
       { "java/lang/ClassLoader", ClassLoaderMethods },
+      { "java/lang/StringUTF16", StringUTF16Methods },
       { 0 }
       };
 

--- a/runtime/tr.source/trj9/env/j9method.cpp
+++ b/runtime/tr.source/trj9/env/j9method.cpp
@@ -2987,6 +2987,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {
       {x(TR::java_lang_StringCoding_decode, "decode", "(Ljava/nio/charset/Charset;[BII)[C")},
       {x(TR::java_lang_StringCoding_encode, "encode", "(Ljava/nio/charset/Charset;[CII)[B")},
+      {x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/tr.source/trj9/env/j9method.cpp
+++ b/runtime/tr.source/trj9/env/j9method.cpp
@@ -2988,6 +2988,9 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {x(TR::java_lang_StringCoding_decode, "decode", "(Ljava/nio/charset/Charset;[BII)[C")},
       {x(TR::java_lang_StringCoding_encode, "encode", "(Ljava/nio/charset/Charset;[CII)[B")},
       {x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
+      {x(TR::java_lang_StringCoding_encode8859_1,       "encode8859_1",       "(B[B)[B")},
+      {x(TR::java_lang_StringCoding_encodeASCII,        "encodeASCII",        "(B[B)[B")},
+      {x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[B)[B")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/tr.source/trj9/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/tr.source/trj9/il/symbol/J9MethodSymbol.cpp
@@ -538,6 +538,9 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    //TR::java_util_Arrays_copyOf,
    TR::java_io_Writer_write_lStringII,
    TR::java_io_Writer_write_I,
+   TR::java_lang_StringCoding_encode8859_1,
+   TR::java_lang_StringCoding_encodeASCII,
+   TR::java_lang_StringCoding_encodeUTF8,
    TR::unknownMethod
    };
 

--- a/runtime/tr.source/trj9/optimizer/UnsafeFastPath.cpp
+++ b/runtime/tr.source/trj9/optimizer/UnsafeFastPath.cpp
@@ -406,6 +406,15 @@ int32_t TR_UnsafeFastPath::perform()
             {
             TR::SymbolReference * unsafeSymRef = comp()->getSymRefTab()->findOrCreateUnsafeSymbolRef(type, true, false, isVolatile);
 
+            // some helpers are special - we know they are accessing an array and we know the kind of that array
+            // so use the more helpful symref if we can
+            switch (calleeMethod)
+               {
+               case TR::java_lang_StringUTF16_getChar:
+                  unsafeSymRef = comp()->getSymRefTab()->findOrCreateArrayShadowSymbolRef(TR::Int8);
+                  break;
+               }
+
             // Change the object child to the starting address of static fields in J9Class
             if (isStatic)
                {


### PR DESCRIPTION
This pull request is to improve the handling of string encoding in Java 9 by accelerating the fastpath pathways that exist for ISO-8859-1 ASCII and UTF8. This is done by reducing array copying, zero initialization of arrays and supporting the StringUTF16.getChar method.