### PR TITLE
Fix the top checking on wide-type bytecodes

### DIFF
--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -2072,7 +2072,8 @@ _illegalPrimitiveReturn:
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 				verboseErrorCode = BCV_ERR_WRONG_TOP_TYPE;
-				errorStackIndex = stackTop - liveStack->stackElements;
+				/* The pair of data types should be printed out once detected as invalid */
+				errorStackIndex = stackTop - liveStack->stackElements + 1;
 				goto _miscError;
 			}
 			break;
@@ -2131,7 +2132,8 @@ _illegalPrimitiveReturn:
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 				verboseErrorCode = BCV_ERR_WRONG_TOP_TYPE;
-				errorStackIndex = stackTop - liveStack->stackElements;
+				/* The pair of data types should be printed out once detected as invalid */
+				errorStackIndex = stackTop - liveStack->stackElements + 1;
 				goto _miscError;
 			}
 			PUSH(type);
@@ -2147,7 +2149,8 @@ _illegalPrimitiveReturn:
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 				verboseErrorCode = BCV_ERR_WRONG_TOP_TYPE;
-				errorStackIndex = stackTop - liveStack->stackElements;
+				/* The pair of data types should be printed out once detected as invalid */
+				errorStackIndex = stackTop - liveStack->stackElements + 1;
 				goto _miscError;
 			}
 			PUSH(temp2);
@@ -2163,7 +2166,8 @@ _illegalPrimitiveReturn:
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 				verboseErrorCode = BCV_ERR_WRONG_TOP_TYPE;
-				errorStackIndex = stackTop - liveStack->stackElements;
+				/* The pair of data types should be printed out once detected as invalid */
+				errorStackIndex = stackTop - liveStack->stackElements + 1;
 				goto _miscError;
 			}
 			POP_TOS_SINGLE(temp2);
@@ -2189,7 +2193,8 @@ _illegalPrimitiveReturn:
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 				verboseErrorCode = BCV_ERR_WRONG_TOP_TYPE;
-				errorStackIndex = stackTop - liveStack->stackElements;
+				/* The pair of data types should be printed out once detected as invalid */
+				errorStackIndex = stackTop - liveStack->stackElements + 1;
 				goto _miscError;
 			}
 			POP_TOS_PAIR(temp2, temp3);
@@ -2198,7 +2203,8 @@ _illegalPrimitiveReturn:
 				/* Jazz 82615: Set the error code (a non-top type is expected on stack). */
 				errorType = J9NLS_BCV_ERR_INCONSISTENT_STACK__ID;
 				verboseErrorCode = BCV_ERR_WRONG_TOP_TYPE;
-				errorStackIndex = stackTop - liveStack->stackElements;
+				/* The pair of data types should be printed out once detected as invalid */
+				errorStackIndex = stackTop - liveStack->stackElements + 1;
 				goto _miscError;
 			}
 			/* should probably do more checking to avoid bogus dup's of long/double pairs */

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -184,6 +184,7 @@ constructRtvMethodContextInfo(MethodContextInfo* methodInfo, J9BytecodeVerificat
 	/* Stackmap table */
 	methodInfo->stackMapData = NULL;
 	methodInfo->stackMapCount = 0;
+	methodInfo->stackMapLength = 0;
 
 	/* It is required to use the compressed stackmap table in the class file for the output format of framework
 	 * to print out data in the stackmap table so as to match Oracle's behavior.
@@ -193,6 +194,7 @@ constructRtvMethodContextInfo(MethodContextInfo* methodInfo, J9BytecodeVerificat
 	if (NULL != stackMapMethod) {
 		methodInfo->stackMapData = (U_8 *)(stackMapMethod + 1);
 		NEXT_U16(methodInfo->stackMapCount, methodInfo->stackMapData);
+		methodInfo->stackMapLength = (U_32)((verifyData->stackSize) * (verifyData->stackMapsCount));
 	}
 
 	/* Register callback functions dealing with the constant pool, the class name list, and the exception handler table */
@@ -886,7 +888,7 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 		printMessage(&msgBuf, "Expected return type 'V' in the function.");
 		break;
 	case BCV_ERR_WRONG_TOP_TYPE:
-		printMessage(&msgBuf, "The data type on 'stack' is long or double rather than a single-slot type.");
+		printMessage(&msgBuf, "The pair of data types on the top of 'stack' must be long, double or two non-top singles.");
 		break;
 	case BCV_ERR_INVALID_ARRAY_REFERENCE:
 	{


### PR DESCRIPTION
The change is to resolve the top checking of
wide-types and non-top singles on the wide-type
bytecode instructions(pop2, dup2, etc) so as
to capture invalid data types in verifier.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>