### PR TITLE
Only run findVarHandleMethodRefs when _buildResult is OK

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -240,10 +240,12 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 		_constantPoolMap->computeConstantPoolMapAndSizes();
 		if (!constantPoolMap->isOK()) {
 			_buildResult = _constantPoolMap->getBuildResult();
-		}
-		_constantPoolMap->findVarHandleMethodRefs();
-		if (!constantPoolMap->isOK()) {
-			_buildResult = _constantPoolMap->getBuildResult();
+		} else {
+			/* computeConstantPoolMapAndSizes must complete successfully before calling findVarHandleMethodRefs */
+			_constantPoolMap->findVarHandleMethodRefs();
+			if (!constantPoolMap->isOK()) {
+				_buildResult = _constantPoolMap->getBuildResult();
+			}
 		}
 	}
 


### PR DESCRIPTION
If we return with a failure from `computeConstantPoolMapAndSizes`, we should not call `findVarHandleMethodRefs`, as this would cause us to use uninitialized data (and crash).