### PR TITLE
Fix Java 18.3 compile errors

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -116,7 +116,13 @@ class LambdaForm {
 	}
 	/*[IF Java18.3]*/
 	enum Kind {
-		PLACEHOLDER;
+		CONVERT,
+		SPREAD,
+		COLLECT,
+		GUARD,
+		GUARD_WITH_CATCH,
+		LOOP,
+		TRY_FINALLY
 	}
 	/*[ENDIF]*/
 	


### PR DESCRIPTION
Fix `Java 18.3` compile errors

Added `j.l.i.LambdaForm.Kind` enum constants to fix `Java 18.3` compilation errors.

Closes: #268

Reviewer @pshipton
FYI: @danheidinga @adamfarley

Signed-off-by: Jason Feng <fengj@ca.ibm.com>