### PR TITLE
Add flag to windows specs to enable rebase

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -2316,4 +2316,8 @@ Pass J9PORT_SIG_OPTIONS_ZOS_USE_CEEHDLR into j9sig_set_options()  before the fir
 		<description>Compile tracegenc and run it to generate tracefiles</description>
 		<ifRemoved>Run java version of tracegenc</ifRemoved>
 	</flag>
+	<flag id="uma_windowsRebase">
+		<description>This enables the rebase targets generation for windows platforms</description>
+		<ifRemoved></ifRemoved>
+	</flag>
 </flags>

--- a/buildspecs/win_x86-64.spec
+++ b/buildspecs/win_x86-64.spec
@@ -281,5 +281,6 @@
 		<flag id="thr_lockNursery" value="true"/>
 		<flag id="thr_lockReservation" value="true"/>
 		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_windowsRebase" value="true"/>
 	</flags>
 </spec>

--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -276,5 +276,6 @@
 		<flag id="thr_lockNursery" value="true"/>
 		<flag id="thr_lockReservation" value="true"/>
 		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_windowsRebase" value="true"/>
 	</flags>
 </spec>

--- a/buildspecs/win_x86.spec
+++ b/buildspecs/win_x86.spec
@@ -290,5 +290,6 @@
 		<flag id="thr_lockNursery" value="true"/>
 		<flag id="thr_lockReservation" value="true"/>
 		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_windowsRebase" value="true"/>
 	</flags>
 </spec>

--- a/sourcetools/com.ibm.uma/com/ibm/j9/uma/platform/PlatformWindows.java
+++ b/sourcetools/com.ibm.uma/com/ibm/j9/uma/platform/PlatformWindows.java
@@ -549,7 +549,7 @@ public class PlatformWindows extends PlatformImplementation {
 	public void writeTopLevelTargets(StringBuffer buffer) throws UMAException {
 		super.writeTopLevelTargets(buffer);
 
-		if ( configuration.isFlagSet("build_openj9") ) {
+		if ( !configuration.isFlagSet("uma_windowsRebase") ) {
 			// No rebase in openj9 builds
 			// ReBase.exe has been removed since Windows SDK 8. It could be replaced with "editbin /REBASE":
 			//	e.g.


### PR DESCRIPTION
Update UMA to generate the rebase targets when the flag is enabled.
Enable the flag in the specs to run rebase IBM sdk only.

Issues: #55 

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>