### PR TITLE
Implement Reference.waitForReferenceProcessing()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -50,10 +50,18 @@ public abstract class Reference<T> extends Object {
 	static {
 		SharedSecrets.setJavaLangRefAccess(new JavaLangRefAccess() {
 			public boolean waitForReferenceProcessing() throws InterruptedException {
-				return false;
+				return waitForReferenceProcessingImpl();
 			}
 		});
 	}
+	
+	/**
+	 *  Wait for progress in reference processing.
+	 * return false if there is no processing reference,
+	 * return true after wait the notification from the reference processing thread if currently the thread is processing references. 
+	 */
+	static private native boolean waitForReferenceProcessingImpl();
+	
 	/*[ENDIF]*/
 	
 /**

--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -58,6 +58,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 #if defined(J9VM_GC_FINALIZATION)
 	j9gc_finalizer_startup,
 	j9gc_finalizer_shutdown,
+	j9gc_wait_for_reference_processing,
 	runFinalization,
 #endif /* J9VM_GC_FINALIZATION */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -122,6 +122,7 @@ extern J9_CFUNC void J9ResetThreadLocalHeap(J9VMThread *vmContext, UDATA flush);
 extern J9_CFUNC void j9gc_objaccess_storeObjectToInternalVMSlot(J9VMThread *vmThread, j9object_t *destSlot, j9object_t value);
 extern J9_CFUNC jint  JNICALL queryGCStatus(JavaVM *vm, jint *nHeaps, GCStatus *status, jint statusSize);
 extern J9_CFUNC int j9gc_finalizer_startup(J9JavaVM * vm);
+extern J9_CFUNC UDATA j9gc_wait_for_reference_processing(J9JavaVM *vm);
 extern J9_CFUNC UDATA j9gc_get_maximum_heap_size(J9JavaVM *javaVM);
 extern J9_CFUNC I_32 j9gc_get_jit_string_dedup_policy(J9JavaVM *javaVM);
 extern J9_CFUNC void* j9gc_objaccess_staticReadAddress(J9VMThread *vmThread, J9Class *clazz, void **srcSlot, UDATA isVolatile);

--- a/runtime/jcl/common/java_lang_ref_Reference.cpp
+++ b/runtime/jcl/common/java_lang_ref_Reference.cpp
@@ -54,4 +54,19 @@ Java_java_lang_ref_Reference_reprocess(JNIEnv *env, jobject recv)
 	}
 }
 
+/* java.lang.ref.Reference: static private native boolean waitForReferenceProcessingImpl(); */
+jboolean JNICALL
+Java_java_lang_ref_Reference_waitForReferenceProcessingImpl(JNIEnv *env, jclass recv)
+{
+	jboolean result = JNI_FALSE;
+#if defined(J9VM_GC_FINALIZATION)
+	J9JavaVM *vm = ((J9VMThread*)env)->javaVM;
+	J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
+	if (0 != mmFuncs->j9gc_wait_for_reference_processing(vm)) {
+		result = JNI_TRUE;
+	}
+#endif
+	return result;
+}
+
 }

--- a/runtime/jcl/uma/se9_exports.xml
+++ b/runtime/jcl/uma/se9_exports.xml
@@ -50,6 +50,7 @@
 	<export name="Java_java_lang_System_startSNMPAgent" />
 	<export name="Java_java_lang_StackWalker_walkWrapperImpl" />
 	<export name="Java_java_lang_StackWalker_getImpl" />
+	<export name="Java_java_lang_ref_Reference_waitForReferenceProcessingImpl" />
 	<export name="Java_java_lang_invoke_MethodHandles_findNativeAddress">
 		<include-if condition="spec.flags.opt_panama" />
 	</export>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4183,6 +4183,7 @@ typedef struct J9MemoryManagerFunctions {
 #if defined(J9VM_GC_FINALIZATION)
 	int  ( *j9gc_finalizer_startup)(struct J9JavaVM * vm) ;
 	void  ( *j9gc_finalizer_shutdown)(struct J9JavaVM * vm) ;
+	UDATA ( *j9gc_wait_for_reference_processing)(struct J9JavaVM * vm) ;
 	void  ( *runFinalization)(struct J9VMThread *vmThread) ;
 #endif /* J9VM_GC_FINALIZATION */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
@@ -5125,6 +5126,8 @@ typedef struct J9JavaVM {
 	UDATA daemonThreadCount;
 	omrthread_t finalizeMasterThread;
 	omrthread_monitor_t finalizeMasterMonitor;
+	omrthread_monitor_t processReferenceMonitor; /* the monitor for synchronizing between reference process and j9gc_wait_for_reference_processing() (only for Java 9 and later) */
+	UDATA processReferenceActive;
 	IDATA finalizeMasterFlags;
 	UDATA exclusiveAccessResponseCount;
 	j9object_t destroyVMState;


### PR DESCRIPTION
implement Reference.waitForReferenceProcessing() in order to
be compatible with Hotspot and increasing the performance of
Bits.reserveMemory(long,int). 
 - java native method waitForReferenceProcessingImpl()
 - new vm memoryFunction j9gc_wait_for_reference_processing() 
   return true if the references are currently in process. 
 - new processReferenceMonitor to avoid the race condition between
   processingReference and waitForReferenceProcessing()
 - the implementation is only for Java 9 and later
 
Closes: #373

Signed-off-by: Lin Hu <linhu@ca.ibm.com>