### PR TITLE
Enable unsafe test on OpenJ9

### DIFF
--- a/test/TestConfig/scripts/build_test.xml
+++ b/test/TestConfig/scripts/build_test.xml
@@ -81,7 +81,6 @@
 						<exclude name="Jsr292/build.xml" />
 						<exclude name="Jsr335/build.xml" />
 						<exclude name="NativeTest/build.xml" />
-						<exclude name="UnsafeTest/build.xml" />
 						<exclude name="SharedCPEntryInvokerTests/build.xml" />
 						<exclude name="Valhalla/build.xml" />
 						<exclude name="Panama/build.xml" />

--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -109,7 +109,7 @@ sub generateOnDir {
 	while ( my $entry = readdir $dir ) {
 		next if $entry eq '.' or $entry eq '..';
 		# temporarily exclude projects for CCM build (i.e., when JCL_VERSION is latest)
-		my $latestDisabledDir = "jvmtitests proxyFieldAccess classesdbgddrext dumpromtests jep178staticLinkingTest getCallerClassTests pltest Jsr292 Jsr335 Panama NativeTest UnsafeTest SharedCPEntryInvokerTests gcCheck classvertest";
+		my $latestDisabledDir = "jvmtitests proxyFieldAccess classesdbgddrext dumpromtests jep178staticLinkingTest getCallerClassTests pltest Jsr292 Jsr335 Panama NativeTest SharedCPEntryInvokerTests gcCheck classvertest";
 		# Temporarily exclude SVT_Modularity tests from integration build where we are still using b148 JCL level
 		my $currentDisableDir= "SVT_Modularity OpenJ9_Jsr_292_API";
 		if ((($JCL_VERSION eq "latest") and ($latestDisabledDir !~ $entry )) or (($JCL_VERSION eq "current") and ($currentDisableDir !~ $entry ))) {

--- a/test/UnsafeTest/build.xml
+++ b/test/UnsafeTest/build.xml
@@ -22,10 +22,10 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 
-<project name="OpenJ9 Unsupported Tests" default="build" basedir=".">
+<project name="OpenJ9 Unsafe Tests" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
-		Build OpenJ9 Unsupported Tests
+		Build OpenJ9 Unsafe Tests
 	</description>
 
 	<!-- set global properties for this build -->
@@ -76,7 +76,7 @@
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
-		<jar jarfile="${DEST}/OpenJ9Unsupported.jar" filesonly="true">
+		<jar jarfile="${DEST}/OpenJ9Unsafe.jar" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}/../" includes="*.properties,*.xml" />
 		</jar>

--- a/test/UnsafeTest/playlist.xml
+++ b/test/UnsafeTest/playlist.xml
@@ -33,7 +33,7 @@
 			<variation>-DScenario=Compiled</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
- 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsupported.jar$(P).$(Q) \
+ 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames UnsafeTests \
 	-groups $(TEST_GROUP) \
@@ -56,7 +56,7 @@
 			<variation>-DScenario=Compiled</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
- 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsupported.jar$(P).$(Q) \
+ 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames UnsafeTests \
 	-groups $(TEST_GROUP) \

--- a/test/UnsafeTest/src_80/org/openj9/test/unsafe/UnsafeTestBase.java
+++ b/test/UnsafeTest/src_80/org/openj9/test/unsafe/UnsafeTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/UnsafeTest/src_90/org/openj9/test/unsafe/UnsafeTestBase.java
+++ b/test/UnsafeTest/src_90/org/openj9/test/unsafe/UnsafeTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -460,10 +460,11 @@ public class UnsafeTestBase implements ITest {
 					+ ", Data: " + modelInt[i] + ", Index: " + i);
 			if (method.equals(VOLATILE)) {
 				myUnsafe.putIntVolatile(base(target, i), offset, modelInt[i]);
-			} else if (method.equals(COMPAREANDSWAP)) {
-				myUnsafe.putInt(base(target, i), offset, -1);
-				myUnsafe.compareAndSwapInt(base(target, i), offset, -1,
-						modelInt[i]);
+			// API is not supported in b181 java9, need to verify if test case is needed
+//			} else if (method.equals(COMPAREANDSWAP)) {
+//				myUnsafe.putInt(base(target, i), offset, -1);
+//				myUnsafe.compareAndSwapInt(base(target, i), offset, -1,
+//						modelInt[i]);
 			} else if (method.equals(ORDERED)) {
 				myUnsafe.putIntRelease(base(target, i), offset, modelInt[i]);
 			} else {
@@ -483,10 +484,11 @@ public class UnsafeTestBase implements ITest {
 				myUnsafe.putLongVolatile(base(target, i), offset, modelLong[i]);
 			} else if (method.equals(ORDERED)) {
 				myUnsafe.putLongRelease(base(target, i), offset, modelLong[i]);
-			} else if (method.equals(COMPAREANDSWAP)) {
-				myUnsafe.putLong(base(target, i), offset, -1);
-				myUnsafe.compareAndSwapLong(base(target, i), offset, -1,
-						modelLong[i]);
+			// API is not supported in b181 java9, need to verify if test case is needed
+//			} else if (method.equals(COMPAREANDSWAP)) {
+//				myUnsafe.putLong(base(target, i), offset, -1);
+//				myUnsafe.compareAndSwapLong(base(target, i), offset, -1,
+//						modelLong[i]);
 			} else {
 				myUnsafe.putLong(base(target, i), offset, modelLong[i]);
 			}
@@ -753,9 +755,10 @@ public class UnsafeTestBase implements ITest {
 				myUnsafe.putIntVolatile(null, pointers[i], modelInt[i]);
 			} else if (method.equals(DEFAULT)) {
 				myUnsafe.putInt(null, pointers[i], modelInt[i]);
-			} else if (method.equals(COMPAREANDSWAP)) {
-				myUnsafe.putInt(null, pointers[i], -1);
-				myUnsafe.compareAndSwapInt(null, pointers[i], -1, modelInt[i]);
+			// API is not supported in b181 java9, need to verify if test case is needed
+//			} else if (method.equals(COMPAREANDSWAP)) {
+//				myUnsafe.putInt(null, pointers[i], -1);
+//				myUnsafe.compareAndSwapInt(null, pointers[i], -1, modelInt[i]);
 			} else if (method.equals(ORDERED)) {
 				myUnsafe.putIntRelease(null, pointers[i], modelInt[i]);
 			} else if (method.equals(ADDRESS)) {
@@ -780,9 +783,10 @@ public class UnsafeTestBase implements ITest {
 				myUnsafe.putLongVolatile(null, pointers[i], modelLong[i]);
 			} else if (method.equals(DEFAULT)) {
 				myUnsafe.putLong(null, pointers[i], modelLong[i]);
-			} else if (method.equals(COMPAREANDSWAP)) {
-				myUnsafe.putLong(null, pointers[i], -1);
-				myUnsafe.compareAndSwapLong(null, pointers[i], -1, modelLong[i]);
+			// API is not supported in b181 java9, need to verify if test case is needed
+//			} else if (method.equals(COMPAREANDSWAP)) {
+//				myUnsafe.putLong(null, pointers[i], -1);
+//				myUnsafe.compareAndSwapLong(null, pointers[i], -1, modelLong[i]);
 			} else if (method.equals(ORDERED)) {
 				myUnsafe.putLongRelease(null, pointers[i], modelLong[i]);
 			} else if (method.equals(ADDRESS)) {

--- a/test/UnsafeTest/testng.xml
+++ b/test/UnsafeTest/testng.xml
@@ -23,7 +23,7 @@
 -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="OpenJ9 Unsupported Tests" parallel="none" verbose="2">
+<suite name="OpenJ9 Unsafe Tests" parallel="none" verbose="2">
 	<listeners>
 		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer"/>
 	</listeners>


### PR DESCRIPTION
* enable unsafe test on OpenJ9
* some test cases are deleted due to:
  - APIs in jdk.internal.misc.Unsafe are not supported in latest JCL

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>