### PR TITLE
Fixed trace message in SPMD

### DIFF
--- a/runtime/tr.source/trj9/optimizer/SPMDPreCheck.cpp
+++ b/runtime/tr.source/trj9/optimizer/SPMDPreCheck.cpp
@@ -78,7 +78,7 @@ bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *lo
              }
 
           // unsafe opcode - we will skip LAR and SPMD
-          traceMsg(comp, "SPMD PRE-CHECK FAILURE: found disallowed opcode %s at treetop %p in loop %d\n", comp->getDebug()->getName(node->getOpCodeValue()), tt, loop->getNumber());
+          traceMsg(comp, "SPMD PRE-CHECK FAILURE: found disallowed treetop opcode %s at node %p in loop %d\n", comp->getDebug()->getName(node->getOpCodeValue()), node, loop->getNumber());
           return false;
           }
        }


### PR DESCRIPTION
Trace messages when a tree top was not valid for SPMD were displaying incorrect
addresses of the nodes, this will use the proper address

Signed-off-by: Ryan Santhirarajan <rsanth@ca.ibm.com>