### PR TITLE
Updated CompareAndSwap and PatchFence

### DIFF
--- a/runtime/tr.source/trj9/runtime/JitRuntime.cpp
+++ b/runtime/tr.source/trj9/runtime/JitRuntime.cpp
@@ -64,6 +64,10 @@
 #include "runtime/Runtime.hpp"
 #endif
 
+#if defined(TR_HOST_X86)
+#include "x/runtime/X86Runtime.hpp"
+#endif
+
 #include "runtime/J9ValueProfiler.hpp"
 
 #if defined(J9ZOS390)
@@ -1268,9 +1272,7 @@ void initializeJitRuntimeHelperTable(char isSMP)
    #undef SET
    }
 
-#if defined (TR_TARGET_X86)
-extern "C" int32_t compareAndExchange4(uint32_t *ptr, uint32_t, uint32_t);
-#elif defined (TR_HOST_S390)
+#if defined (TR_HOST_S390)
 extern "C" int32_t _CompareAndSwap4(int32_t * addr, uint32_t, uint32_t);
 #elif defined (TR_HOST_PPC)
 extern "C" _tr_try_lock(uint32_t *a, uint32_t b, uint32_t c); // return 1 if compareAndSwap "c" successfully into "a"; otherwise 0;
@@ -1293,7 +1295,7 @@ uint8_t platformLightweightLockingIsSupported()
 uint32_t platformTryLock(uint32_t *ptr)
    {
 #if defined(TR_TARGET_X86)
-   return compareAndExchange4(ptr, PLATFORM_MONITOR_UNLOCKED, PLATFORM_MONITOR_LOCKED);
+   return AtomicCompareAndSwap(ptr, PLATFORM_MONITOR_UNLOCKED, PLATFORM_MONITOR_LOCKED);
 #elif defined (TR_HOST_S390)
    return _CompareAndSwap4((int32_t *)ptr, PLATFORM_MONITOR_UNLOCKED, PLATFORM_MONITOR_LOCKED);
 #elif defined (TR_HOST_PPC)
@@ -1306,7 +1308,7 @@ uint32_t platformTryLock(uint32_t *ptr)
 void platformUnlock(uint32_t *ptr)
    {
 #if defined(TR_TARGET_X86)
-   compareAndExchange4(ptr, PLATFORM_MONITOR_LOCKED, PLATFORM_MONITOR_UNLOCKED);
+   AtomicCompareAndSwap(ptr, PLATFORM_MONITOR_LOCKED, PLATFORM_MONITOR_UNLOCKED);
 #elif defined (TR_HOST_S390)
    _CompareAndSwap4((int32_t *)ptr, PLATFORM_MONITOR_LOCKED, PLATFORM_MONITOR_UNLOCKED);
 #elif defined (TR_HOST_PPC)

--- a/runtime/tr.source/trj9/runtime/Trampoline.cpp
+++ b/runtime/tr.source/trj9/runtime/Trampoline.cpp
@@ -502,6 +502,7 @@ void ppcCodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *
 #endif /*(TR_TARGET_POWER)*/
 
 #if defined(TR_TARGET_X86) && defined(TR_TARGET_64BIT)
+#include "x/runtime/X86Runtime.hpp"
 
 // Hack markers
 //
@@ -514,7 +515,6 @@ void ppcCodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *
 #define IS_32BIT_RIP(x,rip)  ((intptrj_t)(x) == (intptrj_t)(rip) + (int32_t)((intptrj_t)(x) - (intptrj_t)(rip)))
 #define TRAMPOLINE_SIZE    16
 #define CALL_INSTR_LENGTH  5
-extern "C" void _patchingFence16(void *startAddr);
 
 void amd64CodeCacheConfig(int32_t ccSizeInByte, uint32_t *numTempTrampolines)
    {
@@ -641,11 +641,11 @@ int32_t amd64CodePatching(void *theMethod, void *callSite, void *currentPC, void
 
             // Self-loop
             *(uint16_t *)currentTramp = 0xfeeb;
-            _patchingFence16(currentTramp);
+            patchingFence16(currentTramp);
 
             // Store the new address
             *(intptrj_t *)((uint8_t *)currentTramp + 2) = (intptrj_t)entryAddress;
-            _patchingFence16(currentTramp);
+            patchingFence16(currentTramp);
 
             // Restore the MOV instruction
             *(uint16_t *)currentTramp = 0xbf48;
@@ -676,12 +676,12 @@ int32_t amd64CodePatching(void *theMethod, void *callSite, void *currentPC, void
          // time.)
 
          *(uint16_t *)patchAddr = 0xfeeb;
-         _patchingFence16(patchAddr);
+         patchingFence16(patchAddr);
 
          patchAddr[2] = (distance>>8) & 0xff;
          patchAddr[3] = (distance>>16) & 0xff;
          patchAddr[4] = (distance>>24) & 0xff;
-         _patchingFence16(patchAddr);
+         patchingFence16(patchAddr);
 
          *(uint16_t *)patchAddr = 0xe8 | ((distance<<8) & 0xff00);
          }

--- a/runtime/tr.source/trj9/x/runtime/X86Codert.asm
+++ b/runtime/tr.source/trj9/x/runtime/X86Codert.asm
@@ -1580,8 +1580,6 @@ ifndef TR_HOST_64BIT
 
       public   clearFPStack
 
-include x/i386/runtime/IA32AsmUtil.inc
-
 jitReleaseVMAccess PROC NEAR
                 pusha
                 push       ebp
@@ -1615,8 +1613,6 @@ else
 ;                                    64-BIT
 ;
 ; --------------------------------------------------------------------------------
-
-include x/amd64/runtime/AMD64AsmUtil.inc
 
 jitReleaseVMAccess proc
         ; Save system-linkage volatile regs


### PR DESCRIPTION
OMR has migrated CompareAndSwap and PatchFence to Intrinsics.
This is related update on J9.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>