### PR TITLE
Move constraint checks to vTable creation

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -2615,16 +2615,6 @@ _fallBack:
 		
 		romMethod = J9_NEXT_ROM_METHOD(romMethod);
 	}
-	
-	if (clazz && (result == BCV_SUCCESS)) {
-		verifyData->romMethod = checkAllClassLoadingConstraints (verifyData, clazz);
-		if (verifyData->romMethod) {
-			verifyData->errorModule = J9NLS_BCV_ERR_CLASSLOADING_CONSTRAINT__MODULE;
-			verifyData->errorCode = J9NLS_BCV_ERR_CLASSLOADING_CONSTRAINT__ID;
-			result = BCV_ERR_INTERNAL_ERROR;
-		}
-	}
-
 
 _done:
 	verifyData->vmStruct->omrVMThread->vmState = oldState;

--- a/runtime/bcverify/j9bcverify.tdf
+++ b/runtime/bcverify/j9bcverify.tdf
@@ -95,12 +95,12 @@ TraceAssert=Assert_RTV_validateClassLoadingConstraints Overhead=2 Level=5 NoEnv 
 TraceAssert=Assert_RTV_true Overhead=1 Level=1 NoEnv Assert="P1"
 TraceAssert=Assert_RTV_notEqual Overhead=1 Level=1 NoEnv Assert="P1 != P2"
 
-TraceEntry=Trc_RTV_checkAllClassLoadingConstraints_Entry NoEnv Overhead=1 Level=2 Template="checkAllClassLoadingConstraints(ramClass=%p -- %.*s)"
-TraceEvent=Trc_RTV_checkAllClassLoadingConstraints_CheckSuperclassMethod NoEnv Overhead=1 Level=2 Template="Found method overridden from a superclass in a different loader: %p"
-TraceException=Trc_RTV_checkAllClassLoadingConstraints_SuperclassViolation NoEnv Overhead=1 Level=1 Template="Method overridden from superclass violates a class loading constraint: romMethod %p in %.*s"
-TraceEvent=Trc_RTV_checkAllClassLoadingConstraints_CheckInterfaceMethod NoEnv Overhead=1 Level=2 Template="Found method overridden from an interface in a different loader: %p"
-TraceException=Trc_RTV_checkAllClassLoadingConstraints_InterfaceViolation NoEnv Overhead=1 Level=1 Template="Method overridden from interface violates a class loading constraint: romMethod %p in %.*s"
-TraceExit=Trc_RTV_checkAllClassLoadingConstraints_Exit NoEnv Overhead=1 Level=2 Template="checkAllClassLoadingConstraints -- return %p"
+TraceEntry=Trc_RTV_checkAllClassLoadingConstraints_Entry Obsolete NoEnv Overhead=1 Level=2 Template="checkAllClassLoadingConstraints(ramClass=%p -- %.*s)"
+TraceEvent=Trc_RTV_checkAllClassLoadingConstraints_CheckSuperclassMethod Obsolete NoEnv Overhead=1 Level=2 Template="Found method overridden from a superclass in a different loader: %p"
+TraceException=Trc_RTV_checkAllClassLoadingConstraints_SuperclassViolation Obsolete NoEnv Overhead=1 Level=1 Template="Method overridden from superclass violates a class loading constraint: romMethod %p in %.*s"
+TraceEvent=Trc_RTV_checkAllClassLoadingConstraints_CheckInterfaceMethod Obsolete NoEnv Overhead=1 Level=2 Template="Found method overridden from an interface in a different loader: %p"
+TraceException=Trc_RTV_checkAllClassLoadingConstraints_InterfaceViolation Obsolete NoEnv Overhead=1 Level=1 Template="Method overridden from interface violates a class loading constraint: romMethod %p in %.*s"
+TraceExit=Trc_RTV_checkAllClassLoadingConstraints_Exit Obsolete NoEnv Overhead=1 Level=2 Template="checkAllClassLoadingConstraints -- return %p"
 
 TraceEntry=Trc_RTV_checkClassLoadingConstraintsForSignature_Entry Overhead=1 Level=3 Template="checkClassLoadingConstraintsForSignature(loader1=%p, loader2=%p, sig1=%p, sig2=%p -- %.*s)"
 TraceExit=Trc_RTV_checkClassLoadingConstraintsForSignature_Exit Overhead=1 Level=3 Template="checkClassLoadingConstraintsForSignature(result=%zu)"

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1746,3 +1746,39 @@ J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.explanation=The JVM failed to load t
 J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.system_action=The JVM continues.
 J9NLS_VM_FAILED_TO_LOAD_MODULE_REQUIRED_DLL.user_response=No action required if the specified library won't be referenced.
 # END NON-TRANSLATABLE
+
+# Message for LinkageError when a class loading constraint violation occurs when overriding a method
+# arguments 1 and 2 are the overridden method's class's name
+# arguments 3 and 4 are the overridden method name
+# arguments 5 and 6 are the overridden method's signature
+# arguments 7 and 8 are classloader name
+# argument 9 is the classloader's identity hashcode
+# arguments 10 and 11 are classloader's class
+# arguments 12 and 13 are the other classloader name
+# argument 14 is the other classloader's identity hashcode
+# arguments 15 and 16 are the other classloader's class
+# arguments 17 and 18 are the name of class being created
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION=loading constraint violation when overriding method \"%2$.*1$s.%4$.*3$s%6$.*5$s\" during creation of class \"%18$.*17$s\": loader \"%8$.*7$s@%9$x\" of class \"%11$.*10$s\" and loader \"%13$.*12$s@%14$x\" of class \"%16$.*15$s\" have different types for the method signature
+# START NON-TRANSLATABLE
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_1=4
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_2=Main
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_3=4
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_4=method
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_5=15
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_6=()LLoadedTwice;
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_7=4
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_8=Main
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_9=2011a4e
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_10=8
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_11=Violator
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_12=6
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_13=Loader
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_14=200b50c
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_15=4
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_16=Main
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_17=4
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.sample_input_18=Main
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.explanation=A class loading constraint has been violated.  The two class loader's have different classes for one of the class names in the signature.
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.system_action=A java/lang/LinkageError will be thrown
+J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION.user_response=Examine the use of ClassLoaders to determine why a class of the same name is loaded in two different loaders
+# END NON-TRANSLATABLE

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -164,16 +164,6 @@ bcvIsInitOrClinit (J9CfrConstantPoolInfo * info);
 
 /**
 * @brief
-* @param verifyData
-* @param ramClass
-* @return J9ROMMethod *
-*/
-J9ROMMethod *
-checkAllClassLoadingConstraints (J9BytecodeVerificationData * verifyData, J9Class * ramClass);
-
-
-/**
-* @brief
 * @param vmThread
 * @param loader1
 * @param loader2

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -805,6 +805,9 @@ struct J9Class;
 void  
 setClassLoadingConstraintSignatureError(J9VMThread *currentThread, J9ClassLoader *loader1, J9Class *class1, J9ClassLoader *loader2, J9Class *class2, J9Class *exceptionClass, U_8 *methodName, UDATA methodNameLength, U_8 *signature, UDATA signatureLength);
 
+void  
+setClassLoadingConstraintOverrideError(J9VMThread *currentThread, J9UTF8 *newClassNameUTF, J9ClassLoader *loader1, J9UTF8 *class1NameUTF, J9ClassLoader *loader2, J9UTF8 *class2NameUTF, J9UTF8 *exceptionClassNameUTF, U_8 *methodName, UDATA methodNameLength, U_8 *signature, UDATA signatureLength);
+
 /* ---------------- gphandle.c ---------------- */
 
 struct J9PortLibrary;

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -832,9 +832,7 @@ setClassLoadingConstraintError(J9VMThread * currentThread, J9ClassLoader * initi
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char * msg = NULL;
-	const char * nlsMessage;
-
-	nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_LOADING_CONSTRAINT_VIOLATION, NULL);
+	const char * nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_LOADING_CONSTRAINT_VIOLATION, NULL);
 	if (nlsMessage != NULL) {
 		j9object_t initiatingLoaderObject = initiatingLoader->classLoaderObject;
 		J9Class * initiatingLoaderClass = J9OBJECT_CLAZZ(currentThread, initiatingLoaderObject);
@@ -852,9 +850,7 @@ setClassLoadingConstraintError(J9VMThread * currentThread, J9ClassLoader * initi
 		J9UTF8 * existingClassNameUTF = J9ROMCLASS_CLASSNAME(existingClass->romClass);
 		U_16 existingClassNameLength = J9UTF8_LENGTH(existingClassNameUTF);
 		U_8 * existingClassName = J9UTF8_DATA(existingClassNameUTF);
-		UDATA msgLen;
-
-		msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
 			initiatingLoaderClassNameLength, initiatingLoaderClassName, initiatingLoaderHash,
 			existingClassNameLength, existingClassName,
 			definingLoaderClassNameLength, definingLoaderClassName, definingLoaderHash);
@@ -875,9 +871,7 @@ setClassLoadingConstraintSignatureError(J9VMThread *currentThread, J9ClassLoader
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char * msg = NULL;
-	const char * nlsMessage;
-
-	nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_LOADING_CONSTRAINT_SIG_VIOLATION, NULL);
+	const char * nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_LOADING_CONSTRAINT_SIG_VIOLATION, NULL);
 	if (nlsMessage != NULL) {
 		/* Loader1 name and length */
 		j9object_t loader1Object = loader1->classLoaderObject;
@@ -910,9 +904,7 @@ setClassLoadingConstraintSignatureError(J9VMThread *currentThread, J9ClassLoader
 		U_16 exceptionClassNameLength = J9UTF8_LENGTH(exceptionClassNameUTF);
 		U_8 * exceptionClassName = J9UTF8_DATA(exceptionClassNameUTF);
 
-		UDATA msgLen;
-
-		msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
 				exceptionClassNameLength, exceptionClassName,
 				methodNameLength, methodName,
 				signatureLength, signature,
@@ -940,6 +932,73 @@ setClassLoadingConstraintSignatureError(J9VMThread *currentThread, J9ClassLoader
 }
 
 
+void  
+setClassLoadingConstraintOverrideError(J9VMThread *currentThread, J9UTF8 *newClassNameUTF, J9ClassLoader *loader1, J9UTF8 *class1NameUTF, J9ClassLoader *loader2, J9UTF8 *class2NameUTF, J9UTF8 *exceptionClassNameUTF, U_8 *methodName, UDATA methodNameLength, U_8 *signature, UDATA signatureLength)
+{
+	PORT_ACCESS_FROM_VMC(currentThread);
+	char * msg = NULL;
+	const char * nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_LOADING_CONSTRAINT_OVERRIDE_VIOLATION, NULL);
+	if (nlsMessage != NULL) {
+		/* Loader1 name and length */
+		j9object_t loader1Object = loader1->classLoaderObject;
+		J9Class * loader1Class = J9OBJECT_CLAZZ(currentThread, loader1Object);
+		J9UTF8 * loader1ClassNameUTF = J9ROMCLASS_CLASSNAME(loader1Class->romClass);
+		U_16 loader1ClassNameLength = J9UTF8_LENGTH(loader1ClassNameUTF);
+		U_8 * loader1ClassName = J9UTF8_DATA(loader1ClassNameUTF);
+		I_32 loader1Hash = objectHashCode(currentThread->javaVM, loader1Object);
+
+		/* Loader2 name and length */
+		j9object_t loader2Object = loader2->classLoaderObject;
+		J9Class * loader2Class = J9OBJECT_CLAZZ(currentThread, loader2Object);
+		J9UTF8 * loader2ClassNameUTF = J9ROMCLASS_CLASSNAME(loader2Class->romClass);
+		U_16 loader2ClassNameLength = J9UTF8_LENGTH(loader2ClassNameUTF);
+		U_8 * loader2ClassName = J9UTF8_DATA(loader2ClassNameUTF);
+		I_32 loader2Hash = objectHashCode(currentThread->javaVM, loader2Object);
+
+		/* Class1 name and length */
+		U_16 class1ClassNameLength = J9UTF8_LENGTH(class1NameUTF);
+		U_8 * class1ClassName = J9UTF8_DATA(class1NameUTF);
+
+		/* Class2 name and length */
+		U_16 class2ClassNameLength = J9UTF8_LENGTH(class2NameUTF);
+		U_8 * class2ClassName = J9UTF8_DATA(class2NameUTF);
+
+		/* ExceptionClass name and length */
+		U_16 exceptionClassNameLength = J9UTF8_LENGTH(exceptionClassNameUTF);
+		U_8 * exceptionClassName = J9UTF8_DATA(exceptionClassNameUTF);
+
+		/* New class name and length */
+		U_16 newClassNameLength = J9UTF8_LENGTH(newClassNameUTF);
+		U_8 * newClassName = J9UTF8_DATA(newClassNameUTF);
+
+		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+				exceptionClassNameLength, exceptionClassName,
+				methodNameLength, methodName,
+				signatureLength, signature,
+				loader1ClassNameLength, loader1ClassName, loader1Hash,
+				class1ClassNameLength, class1ClassName,
+				loader2ClassNameLength, loader2ClassName, loader2Hash,
+				class2ClassNameLength, class2ClassName,
+				newClassNameLength, newClassName
+
+		);
+		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
+		/* msg NULL check omitted since str_printf accepts NULL (as above) */
+		j9str_printf(PORTLIB, msg, msgLen, nlsMessage,
+				exceptionClassNameLength, exceptionClassName,
+				methodNameLength, methodName,
+				signatureLength, signature,
+				 loader1ClassNameLength, loader1ClassName, loader1Hash,
+				 class1ClassNameLength, class1ClassName,
+				 loader2ClassNameLength, loader2ClassName, loader2Hash,
+				 class2ClassNameLength, class2ClassName
+			);
+	}
+
+	setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, msg);
+	j9mem_free_memory(msg);
+}
+
 
 
 static char *
@@ -947,9 +1006,7 @@ nlsMessageForMethod(J9VMThread * currentThread, J9Method * method, U_32 module_n
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char * msg = NULL;
-	const char * nlsMessage;
-
-	nlsMessage = OMRPORT_FROM_J9PORT(PORTLIB)->nls_lookup_message(OMRPORT_FROM_J9PORT(PORTLIB), J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, module_name, message_num, NULL);
+	const char * nlsMessage = OMRPORT_FROM_J9PORT(PORTLIB)->nls_lookup_message(OMRPORT_FROM_J9PORT(PORTLIB), J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, module_name, message_num, NULL);
 	if (nlsMessage != NULL) {
 		J9Class * methodClass = J9_CLASS_FROM_METHOD(method);
 		J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
@@ -962,9 +1019,7 @@ nlsMessageForMethod(J9VMThread * currentThread, J9Method * method, U_32 module_n
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
 		U_16 methodSignatureLength = J9UTF8_LENGTH(methodSignatureUTF);
 		U_8 * methodSignature = J9UTF8_DATA(methodSignatureUTF);
-		UDATA msgLen;
-
-		msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
 					classNameLength, className,
 					methodNameLength, methodName,
 					methodSignatureLength, methodSignature);
@@ -1048,12 +1103,10 @@ setNativeOutOfMemoryError(J9VMThread * vmThread, U_32 moduleName, U_32 messageNu
 void  
 setIncompatibleClassChangeErrorForDefaultConflict(J9VMThread * vmThread, J9Method *method)
 {
-	char * msg = NULL;
-	const char * nlsMessage;
 	PORT_ACCESS_FROM_VMC(vmThread);
-
+	char * msg = NULL;
 	/* J9NLS_VM_DEFAULT_METHOD_CONFLICT=class %2$.*1$s has conflicting defaults for method %4$.*3$s%6$.*5$s */
-	nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_DEFAULT_METHOD_CONFLICT, NULL);
+	const char * nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_DEFAULT_METHOD_CONFLICT, NULL);
 	if (nlsMessage != NULL) {
 		/* Fetch defining class using constantPool*/
 		J9Class * currentClass = J9_CLASS_FROM_METHOD(method);
@@ -1068,9 +1121,7 @@ setIncompatibleClassChangeErrorForDefaultConflict(J9VMThread * vmThread, J9Metho
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
 		U_16 methodSignatureLength = J9UTF8_LENGTH(methodSignatureUTF);
 		U_8 * methodSignature = J9UTF8_DATA(methodSignatureUTF);
-		UDATA msgLen;
-
-		msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
 					classNameLength, className,
 					methodNameLength, methodName,
 					methodSignatureLength, methodSignature);
@@ -1091,10 +1142,8 @@ setIllegalAccessErrorNonPublicInvokeInterface(J9VMThread *vmThread, J9Method *me
 {
 	PORT_ACCESS_FROM_VMC(vmThread);
 	char * msg = NULL;
-	const char * nlsMessage;
-
 	/* J9NLS_VM_INVOKEINTERFACE_OF_NONPUBLIC_METHOD=invokeinterface of non-public method '%4$.*3$s%6$.*5$s' in %2$.*1$s */
-	nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_INVOKEINTERFACE_OF_NONPUBLIC_METHOD, NULL);
+	const char * nlsMessage = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_INVOKEINTERFACE_OF_NONPUBLIC_METHOD, NULL);
 	if (nlsMessage != NULL) {
 		J9Class *clazz = J9_CLASS_FROM_METHOD(method);
 		J9UTF8 *classNameUTF = J9ROMCLASS_CLASSNAME(clazz->romClass);
@@ -1109,9 +1158,7 @@ setIllegalAccessErrorNonPublicInvokeInterface(J9VMThread *vmThread, J9Method *me
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
 		U_16 methodSignatureLength = J9UTF8_LENGTH(methodSigUTF);
 		U_8 * methodSignature = J9UTF8_DATA(methodSigUTF);
-		UDATA msgLen = -1;
-
-		msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
 				classNameLength, className,
 				methodNameLength, methodName,
 				methodSignatureLength, methodSignature);


### PR DESCRIPTION
Optimize loading constraint checks when creating a class by moving them
from the verifier into vTable creation.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>