### PR TITLE
Fix packed decimal left shift skipping

### DIFF
--- a/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -23201,7 +23201,8 @@ J9::Z::TreeEvaluator::pdshlVectorEvaluatorHelper(TR::Node *node, TR::CodeGenerat
    // skip the shift and just return i2pd results.
    bool isSkipShift = node->getOpCodeValue() == TR::pdshlOverflow &&
            (firstChild->getOpCodeValue() == TR::i2pd ||
-            firstChild->getOpCodeValue() == TR::l2pd);
+            firstChild->getOpCodeValue() == TR::l2pd) &&
+           firstChild->isSingleRefUnevaluated();
 
    int32_t shiftAmount = (int32_t)shiftAmountNode->get64bitIntegralValue();
    uint8_t decimalPrecision = node->getDecimalPrecision();


### PR DESCRIPTION
With vector packed decimal instructions, i2pd and l2pd conversions and
truncations can be done in one instruction. Thus, the
pdshlOverflow above i2pd or l2pd nodes can be omitted.

This change makes sure we skip the left shift only if the
i2pd or l2pd is an unevaluated single reference node.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>