### PR TITLE
Update ExternalMessagesExtension.java for OpenJDK7

### DIFF
--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ExternalMessagesExtension.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/ExternalMessagesExtension.java
@@ -159,7 +159,9 @@ public class ExternalMessagesExtension extends BuilderExtension {
 				// add the existing messages to the found messages (unless the
 				// message was already in the found messages)
 				for (Map.Entry<String, String> entry : existingMessages.entrySet()) {
-					messages.putIfAbsent(entry.getKey(), entry.getValue());
+					if (messages.get(entry.getKey()) == null) {
+						messages.put(entry.getKey(), entry.getValue());
+					}
 				}
 			}
 			writeMessages();


### PR DESCRIPTION
OpenJDK 7's version of the Map library class doesn't have the putIfAbsent method, therefore to compile with OpenJDK 7 we'll need to remove that and substitute the logic instead.

According to the OpenJDK8 build documentation, OpenJDK 7 should be used to build it. If we aspire to do that with OpenJDK8 on OpenJ9, we need this change.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>