### PR TITLE
Revert "Configure z/TPF native stack walks as unsupported."

### DIFF
--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -321,9 +321,9 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 		  400,
 
 		  J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS
-#if !defined(J9ZOS390) || !defined(J9ZTPF)
+#ifndef J9ZOS390
 			| J9RAS_DUMP_DO_PREEMPT_THREADS
-#endif /* !defined(J9ZOS390) || !defined(J9ZTPF) */
+#endif
 		  , NULL
 		}
 	},

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -4335,11 +4335,11 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 			frame = frame->parent_frame;
 		}
 	} else {
-#if defined(J9ZOS390) || defined(J9ZTPF)
+#if defined(J9ZOS390)
 		_OutputStream.writeCharacters("3XMTHREADINFO3           No native callstack available on this platform\n");
-#else /* defined(J9ZOS390) || defined(J9ZTPF) */
+#else
 		_OutputStream.writeCharacters("3XMTHREADINFO3           No native callstack available for this thread\n");
-#endif /* defined(J9ZOS390) || defined(J9ZTPF) */
+#endif
 		_OutputStream.writeCharacters("NULL\n");
 	}
 


### PR DESCRIPTION
Reverts eclipse/openj9#393

Change has incorrect logic.