### PR TITLE
Remove deprecated getColdCodeStart()

### DIFF
--- a/runtime/tr.source/trj9/control/CompilationThread.cpp
+++ b/runtime/tr.source/trj9/control/CompilationThread.cpp
@@ -7801,15 +7801,6 @@ TR::CompilationInfoPerThreadBase::compile(
                compiler->cg()->getCodeStart()
                );
 
-            if (compiler->cg()->getColdCodeStart())
-               {
-               TR_VerboseLog::write(
-                  POINTER_PRINTF_FORMAT "] & [" POINTER_PRINTF_FORMAT "-",
-                  compiler->cg()->getWarmCodeEnd(),
-                  compiler->cg()->getColdCodeStart()
-                  );
-               }
-
             TR_VerboseLog::write(
                POINTER_PRINTF_FORMAT "] for %s @ %s",
                compiler->cg()->getCodeEnd(),

--- a/runtime/tr.source/trj9/runtime/MetaData.cpp
+++ b/runtime/tr.source/trj9/runtime/MetaData.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1465,17 +1465,8 @@ createMethodMetaData(
 
    data->startPC = (UDATA)comp->cg()->getCodeStart();
    data->endPC = (UDATA)comp->cg()->getCodeEnd();
-   data->startColdPC = (UDATA)comp->cg()->getColdCodeStart();
-
-   if (data->startColdPC)
-      {
-      data->endWarmPC = (UDATA)comp->cg()->getWarmCodeEnd();
-      }
-   else
-      {
-      data->endWarmPC = data->endPC;
-      }
-
+   data->startColdPC = (UDATA)0;
+   data->endWarmPC = data->endPC;
    data->codeCacheAlloc = (UDATA)comp->cg()->getBinaryBufferStart();
 
    data->flags = 0;


### PR DESCRIPTION
Remove and fold code from deprecated `getColdCodeStart()` function in
`OMR::CodeGenerator`, which only returned 0.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>