### PR TITLE
Configure z/TPF native stack walks as unsupported (Take II)

### DIFF
--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -321,9 +321,9 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 		  400,
 
 		  J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS
-#ifndef J9ZOS390
+#if !defined(J9ZOS390) && !defined(J9ZTPF)
 			| J9RAS_DUMP_DO_PREEMPT_THREADS
-#endif
+#endif /* !defined(J9ZOS390) && !defined(J9ZTPF) */
 		  , NULL
 		}
 	},

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -4335,11 +4335,11 @@ JavaCoreDumpWriter::writeThread(J9VMThread* vmThread, J9PlatformThread *nativeTh
 			frame = frame->parent_frame;
 		}
 	} else {
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) || defined(J9ZTPF)
 		_OutputStream.writeCharacters("3XMTHREADINFO3           No native callstack available on this platform\n");
-#else
+#else /* defined(J9ZOS390) || defined(J9ZTPF) */
 		_OutputStream.writeCharacters("3XMTHREADINFO3           No native callstack available for this thread\n");
-#endif
+#endif /* defined(J9ZOS390) || defined(J9ZTPF) */
 		_OutputStream.writeCharacters("NULL\n");
 	}
 


### PR DESCRIPTION
Configure z/TPF native stack walks as unsupported (Take II)
Followed z/OS configurations.
Re-submission because of a bad update on my part from PR #393.
My Apologies.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>