### PR TITLE
WIP: Cache layout string in nativeStructDataHashTable

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3053,6 +3053,10 @@ typedef struct J9ClassLoader {
 	struct J9HashTable* packageHashTable;
 	struct J9HashTable* moduleExtraInfoHashTable;
 	struct J9HashTable* classLocationHashTable;
+#ifdef J9VM_OPT_PANAMA
+	struct J9HashTable* nativeCalloutDataHashTable;
+	struct J9HashTable* nativeStructDataHashTable;
+#endif /* J9VM_OPT_PANAMA */
 } J9ClassLoader;
 
 #define J9CLASSLOADER_TENANT_SHARING_CLASSLOADER  0x200
@@ -4716,6 +4720,10 @@ typedef struct J9InternalVMFunctions {
 	struct J9HashTable* ( *hashPackageTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashModuleExtraInfoTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashClassLocationTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
+#ifdef J9VM_OPT_PANAMA
+	struct J9HashTable* ( *hashNativeCalloutDataNew)(struct J9JavaVM * vm, U_32 initialSize) ;
+	struct J9HashTable* ( *hashNativeStructDataNew)(struct J9JavaVM * vm, U_32 initialSize) ;
+#endif /* J9VM_OPT_PANAMA */
 	struct J9Module* ( *findModuleForPackageUTF8)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, struct J9UTF8 *packageName);
 	struct J9Module* ( *findModuleForPackage)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, U_8 *packageName, U_32 packageNameLen);
 	struct J9ModuleExtraInfo* ( *findModuleInfoForModule)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, J9Module *j9module);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1798,6 +1798,35 @@ findModuleForPackage(J9VMThread *currentThread, J9ClassLoader *classLoader, U_8 
 J9ModuleExtraInfo *
 findModuleInfoForModule(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module *j9module);
 
+/* ---------------- NativeCalloutDataHashTable.c ---------------- */
+
+#ifdef J9VM_OPT_PANAMA
+/**
+ * @brief Create the J9NativeCalloutData hash table
+ * @param initialSize initial size
+ * @return Pointer to new hash table
+ */
+J9HashTable*
+hashNativeCalloutDataNew(J9JavaVM *javaVM, U_32 initialSize);
+
+/**
+ * @brief Create the J9NativeStructData hash table
+ * @param initialSize initial size
+ * @return Pointer to new hash table
+ */
+J9HashTable*
+hashNativeStructDataNew(J9JavaVM *javaVM, U_32 initialSize);
+
+/**
+ * @brief Locates J9NativeStructData struct with the ffi_type of the layoutString from nativeStructDataHashTable
+ * @param hashTable J9HashTable that stores J9NativeStructData
+ * @param layoutString A char pointer to a string describing the type contents of the struct
+ * @return Void pointer to a J9NativeStructData struct for the given layoutString, or NULL if not found
+ */
+void*
+nativeStructDataHashTableFind(J9HashTable *hashTable, char *layoutString);
+#endif /* J9VM_OPT_PANAMA */
+
 /* ---------------- lookupmethod.c ---------------- */
 
 /**

--- a/runtime/vm/NativeCalloutDataHashTable.c
+++ b/runtime/vm/NativeCalloutDataHashTable.c
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Licensed Materials - Property of IBM
+ * "Restricted Materials of IBM"
+ * 
+ * (c) Copyright IBM Corp. 2017 All Rights Reserved
+ * 
+ * US Government Users Restricted Rights - Use, duplication or disclosure
+ * restricted by GSA ADP Schedule Contract with IBM Corp.
+ ********************************************************************************/
+
+#include "j9.h"
+#include "j9protos.h"
+#include "ut_j9vm.h"
+#ifdef J9VM_OPT_PANAMA
+#include "NativeCalloutHelpers.h"
+
+static UDATA NativeCalloutDataHashFn(void *key, void *userData);
+static UDATA NativeStructDataHashFn(void *key, void *userData);
+static UDATA NativeCalloutDataHashEqualFn(void *tableNode, void *queryNode, void *userData);
+static UDATA NativeStructDataHashEqualFn(void *tableNode, void *queryNode, void *userData);
+
+static UDATA
+NativeCalloutDataHashFn(void *key, void *userData)
+{
+	J9NativeCalloutData *entry = (J9NativeCalloutData*) key;
+
+	return (UDATA)entry;
+}
+
+static UDATA
+NativeCalloutDataHashEqualFn(void *tableNode, void *queryNode, void *userData)
+{
+	J9NativeCalloutData *tableNodePatchPath = (J9NativeCalloutData *)tableNode;
+	J9NativeCalloutData *queryNodePatchPath = (J9NativeCalloutData *)queryNode;
+
+	return (tableNodePatchPath == queryNodePatchPath);
+}
+
+
+static UDATA
+NativeStructDataHashFn(void *key, void *userData)
+{
+	J9NativeStructData *entry = (J9NativeStructData*) key;
+	UDATA hash = 0;
+	U_32 c = 0;
+	char *str = entry->layoutString;
+
+    while ((c = *str++)) {
+    	hash = (hash << 5) - hash + c;
+    }
+
+	return hash;
+}
+
+static UDATA
+NativeStructDataHashEqualFn(void *tableNode, void *queryNode, void *userData)
+{
+	J9NativeStructData *tableNodePatchPath = (J9NativeStructData *)tableNode;
+	J9NativeStructData *queryNodePatchPath = (J9NativeStructData *)queryNode;
+
+	return (0 == strcmp(tableNodePatchPath->layoutString, queryNodePatchPath->layoutString));
+}
+
+J9HashTable*
+hashNativeCalloutDataNew(J9JavaVM *javaVM, U_32 initialSize)
+{
+	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
+
+	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(J9NativeCalloutData), sizeof(char *), flags, J9MEM_CATEGORY_MODULES, NativeCalloutDataHashFn, NativeCalloutDataHashEqualFn, NULL, javaVM);
+}
+
+J9HashTable*
+hashNativeStructDataNew(J9JavaVM *javaVM, U_32 initialSize)
+{
+	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
+
+	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(J9NativeStructData), sizeof(char *), flags, J9MEM_CATEGORY_MODULES, NativeStructDataHashFn, NativeStructDataHashEqualFn, NULL, javaVM);
+}
+
+void*
+nativeStructDataHashTableFind(J9HashTable *hashTable, char *layoutString)
+{
+	J9NativeStructData entry = {0};
+	J9NativeStructData *result = NULL;
+	void *structType = NULL;
+
+	entry.layoutString = layoutString;
+	result = (J9NativeStructData *)hashTableFind(hashTable, (void *)&entry);
+	if (NULL != result) {
+		structType = (void *)result->structType;
+	}
+
+	return structType;
+}
+#endif /* J9VM_OPT_PANAMA */

--- a/runtime/vm/NativeCalloutHelpers.h
+++ b/runtime/vm/NativeCalloutHelpers.h
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Licensed Materials - Property of IBM
+ * "Restricted Materials of IBM"
+ *
+ * (c) Copyright IBM Corp. 1991, 2017 All Rights Reserved
+ *
+ * US Government Users Restricted Rights - Use, duplication or disclosure
+ * restricted by GSA ADP Schedule Contract with IBM Corp.
+ *******************************************************************************/
+
+#ifndef _NATIVECALLOUTHELPERS_H
+#define _NATIVECALLOUTHELPERS_H
+
+#ifdef J9VM_OPT_PANAMA
+#include "ffi.h"
+
+typedef struct J9NativeCalloutData {
+	ffi_type **arguments;
+	ffi_cif *cif;
+} J9NativeCalloutData;
+
+typedef struct J9NativeStructData {
+	char *layoutString;
+	ffi_type *structType;
+} J9NativeStructData;
+#endif /* J9VM_OPT_PANAMA */
+
+#endif /* NATIVECALLOUTHELPERS_H */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -344,6 +344,10 @@ J9InternalVMFunctions J9InternalFunctions = {
 	hashPackageTableNew,
 	hashModuleExtraInfoTableNew,
 	hashClassLocationTableNew,
+#ifdef J9VM_OPT_PANAMA
+	hashNativeCalloutDataNew,
+	hashNativeStructDataNew,
+#endif /* J9VM_OPT_PANAMA */
 	findModuleForPackageUTF8,
 	findModuleForPackage,
 	findModuleInfoForModule,

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -329,6 +329,16 @@ convertByteArrayToCString(J9VMThread *currentThread, j9object_t byteArray);
 j9object_t
 convertCStringToByteArray(J9VMThread *currentThread, const char *byteArray);
 
+#ifdef J9VM_OPT_PANAMA
+/**
+ * @brief Free J9NativeCalloutData from J9ClassLoader->nativeCalloutDataHashTable
+ * @param currentThread[in] the current J9VMThread
+ * @param nativeCalloutData[in] Void pointer that will be casted to J9NativeCalloutData within the function
+ */
+void
+freeJ9NativeCalloutDataRef(J9VMThread *currentThread, void *nativeCalloutData);
+#endif /* J9VM_OPT_PANAMA */
+
 /* ------------------- romclasses.c ----------------- */
 
 /**


### PR DESCRIPTION
Cache layout string in nativeStructDataHashTable

Only unique layout strings are parsed to create the ffi_type of a
struct. Part 2 of this commit will address cleaning up the cached data.
 
Signed-off-by: amarsingh0 <Amarpreet.A.Singh@ibm.com>