### PR TITLE
Sink `suppressInliningOfRecognizedMethod` functionality to OpenJ9

### DIFF
--- a/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
@@ -4616,3 +4616,31 @@ J9::CodeGenerator::needRelocationsForStatics()
    {
    return self()->fej9()->needRelocationsForStatics();
    }
+
+
+bool
+J9::CodeGenerator::isMethodInAtomicLongGroup(TR::RecognizedMethod rm)
+   {
+   switch (rm)
+      {
+      case TR::java_util_concurrent_atomic_AtomicLong_addAndGet:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_addAndGet:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_decrementAndGet:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_getAndAdd:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_getAndDecrement:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_getAndIncrement:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_getAndSet:
+      case TR::java_util_concurrent_atomic_AtomicLongArray_incrementAndGet:
+      case TR::java_util_concurrent_atomic_AtomicLong_decrementAndGet:
+      case TR::java_util_concurrent_atomic_AtomicLong_getAndAdd:
+      case TR::java_util_concurrent_atomic_AtomicLong_getAndDecrement:
+      case TR::java_util_concurrent_atomic_AtomicLong_getAndIncrement:
+      case TR::java_util_concurrent_atomic_AtomicLong_getAndSet:
+      case TR::java_util_concurrent_atomic_AtomicLong_incrementAndGet:
+         return true;
+
+      default:
+         return false;
+      }
+   }
+

--- a/runtime/tr.source/trj9/codegen/J9CodeGenerator.hpp
+++ b/runtime/tr.source/trj9/codegen/J9CodeGenerator.hpp
@@ -39,6 +39,7 @@ namespace J9 { typedef J9::CodeGenerator CodeGeneratorConnector; }
 #include "env/IO.hpp"      // for POINTER_PRINTF_FORMAT
 #include "env/jittypes.h"  // for uintptr_t
 #include "infra/List.hpp"  // for List, etc
+#include "codegen/RecognizedMethods.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "optimizer/Dominators.hpp"
@@ -104,6 +105,8 @@ public:
    TR::Linkage *createLinkageForCompilation();
 
    bool enableAESInHardwareTransformations() {return false;}
+
+   bool isMethodInAtomicLongGroup(TR::RecognizedMethod rm);
 
    // OSR
    //

--- a/runtime/tr.source/trj9/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/p/codegen/J9CodeGenerator.cpp
@@ -272,8 +272,9 @@ J9::Power::CodeGenerator::lowerTreeIfNeeded(
    }
 
 
-bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method) {
-   if (OMR::Power::CodeGenerator::suppressInliningOfRecognizedMethod(method))
+bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
+   {
+   if (self()->isMethodInAtomicLongGroup(method))
       {
       return true;
       }

--- a/runtime/tr.source/trj9/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/x/codegen/J9CodeGenerator.cpp
@@ -383,3 +383,18 @@ J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    else
       return false;
    }
+
+bool
+J9::X86::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
+   {
+   if ((method==TR::java_lang_Object_clone) ||
+      (method==TR::java_lang_Integer_rotateLeft))
+      {
+      return true;
+      }
+   else
+      {
+      return false;
+      }
+   }
+

--- a/runtime/tr.source/trj9/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/tr.source/trj9/x/codegen/J9CodeGenerator.hpp
@@ -65,6 +65,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    bool enableAESInHardwareTransformations();
 
+   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
+
    };
 
 }

--- a/runtime/tr.source/trj9/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9CodeGenerator.cpp
@@ -3826,3 +3826,91 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperPrePrologue(TR::Instr
 
    return cursor;
    }
+
+bool
+J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
+   {
+   if (self()->isMethodInAtomicLongGroup(method))
+      return true;
+
+   if (!self()->comp()->compileRelocatableCode() && !self()->comp()->getOption(TR_DisableDFP) && TR::Compiler->target.cpu.getS390SupportsDFP())
+      {
+      if (method == TR::java_math_BigDecimal_DFPIntConstructor ||
+          method == TR::java_math_BigDecimal_DFPLongConstructor || 
+          method == TR::java_math_BigDecimal_DFPLongExpConstructor ||
+          method == TR::java_math_BigDecimal_DFPAdd ||
+          method == TR::java_math_BigDecimal_DFPSubtract ||
+          method == TR::java_math_BigDecimal_DFPMultiply ||
+          method == TR::java_math_BigDecimal_DFPDivide || 
+          method == TR::java_math_BigDecimal_DFPScaledAdd ||
+          method == TR::java_math_BigDecimal_DFPScaledSubtract ||
+          method == TR::java_math_BigDecimal_DFPScaledMultiply ||
+          method == TR::java_math_BigDecimal_DFPScaledDivide ||
+          method == TR::java_math_BigDecimal_DFPRound || 
+          method == TR::java_math_BigDecimal_DFPSetScale ||
+          method == TR::java_math_BigDecimal_DFPCompareTo || 
+          method == TR::java_math_BigDecimal_DFPSignificance ||
+          method == TR::java_math_BigDecimal_DFPExponent ||
+          method == TR::java_math_BigDecimal_DFPBCDDigits ||
+          method == TR::java_math_BigDecimal_DFPUnscaledValue ||
+          method == TR::java_math_BigDecimal_DFPConvertPackedToDFP ||
+          method == TR::java_math_BigDecimal_DFPConvertDFPToPacked)
+         {
+         return true;
+         }
+
+      if (method == TR::com_ibm_dataaccess_DecimalData_DFPConvertPackedToDFP ||
+          method == TR::com_ibm_dataaccess_DecimalData_DFPConvertDFPToPacked)
+         {
+         return true;
+         }
+      }
+
+   if (method == TR::java_lang_Integer_highestOneBit ||
+       method == TR::java_lang_Integer_numberOfLeadingZeros ||
+       method == TR::java_lang_Integer_numberOfTrailingZeros ||
+       method == TR::java_lang_Long_highestOneBit ||
+       method == TR::java_lang_Long_numberOfLeadingZeros ||
+       method == TR::java_lang_Long_numberOfTrailingZeros)
+      {
+      return true;
+      }
+
+   if (method == TR::java_lang_Long_reverseBytes  ||
+       method == TR::java_lang_Integer_reverseBytes  ||
+       method == TR::java_lang_Short_reverseBytes ||
+       method == TR::java_util_concurrent_atomic_AtomicBoolean_getAndSet ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_getAndAdd ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_getAndIncrement ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_getAndDecrement ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_getAndSet ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_addAndGet ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_decrementAndGet ||
+       method == TR::java_util_concurrent_atomic_AtomicInteger_incrementAndGet ||
+       method == TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_incrementAndGet ||
+       method == TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_decrementAndGet ||
+       method == TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_addAndGet ||
+       method == TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_getAndIncrement ||
+       method == TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_getAndDecrement ||
+       method == TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_getAndAdd)
+      {
+      return true;
+      }
+
+   // Transactional Memory
+   if (self()->getSupportsTM())
+      {
+      if (method == TR::java_util_concurrent_ConcurrentHashMap_tmEnabled ||
+          method == TR::java_util_concurrent_ConcurrentHashMap_tmPut ||
+          method == TR::java_util_concurrent_ConcurrentHashMap_tmRemove ||
+          method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer ||
+          method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmPoll ||
+          method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmEnabled)
+          {
+          return true;
+          }
+      }
+
+   return false;
+   }
+

--- a/runtime/tr.source/trj9/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/tr.source/trj9/z/codegen/J9CodeGenerator.hpp
@@ -253,6 +253,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
       }
 #endif
 
+   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
+
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION


### PR DESCRIPTION
* relocate CodeGenerator `suppressInliningOfRecognizedMethod()` functionality into
  OpenJ9 as it is exclusively specialized for OpenJ9
* relocate CodeGenerator `isMethodInAtomicLongGroup()` to OpenJ9

This is the first step in the relocation of both functions.  The corresponding
code must be removed from OMR once this PR is merged.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>