### PR TITLE
Remove deprecated specialized epilogues

### DIFF
--- a/runtime/tr.source/trj9/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/tr.source/trj9/p/codegen/PPCPrivateLinkage.cpp
@@ -1459,8 +1459,7 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
                                        (comp()->isDLT() && !cg()->getSnippetList().empty()) ||
                                        bodySymbol->isEHAware()            ||
                                        cg()->canExceptByTrap()            ||
-                                       (machine->getLinkRegisterKilled() &&
-                                        cg()->restoreRegister(TR::RealRegister::lr, blockNumber)));
+                                       machine->getLinkRegisterKilled());
 
    bool                     saveLR = restoreLR || machine->getLinkRegisterKilled();
 
@@ -1494,11 +1493,8 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
          TR_BitVector *p = cg()->getPreservedRegsInPrologue();
          for (regIndex=savedFirst; regIndex<=TR::RealRegister::LastGPR; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex+1))
             {
-            if (cg()->restoreRegister(regIndex, blockNumber))
-               {
-               if (!p || p->get((uint32_t)regIndex))
-                  cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getPPCRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
-               }
+            if (!p || p->get((uint32_t)regIndex))
+                cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getPPCRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
 
             saveSize = saveSize + TR::Compiler->om.sizeofReferenceAddress();
             }

--- a/runtime/tr.source/trj9/z/codegen/S390StackCheckFailureSnippet.cpp
+++ b/runtime/tr.source/trj9/z/codegen/S390StackCheckFailureSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,11 +82,6 @@ TR::S390StackCheckFailureSnippet::emitSnippetBody()
       requireRAStore = true;
 
    bool requireRALoad  = requireRAStore;
-
-   if (cg()->specializedEpilogues())
-      {
-      requireRALoad = true;
-      }
 
    // These are assumption checks to make sure our offsets to data constants at the end are correct.
    intptrj_t startOfHelperBASR = -1;
@@ -432,11 +427,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390StackCheckFailureSnippet * snippet)
    bool is64BitTarget = TR::Compiler->target.is64Bit();
    bool requireRAStore = !linkage->getRaContextRestoreNeeded();
    bool requireRALoad  = requireRAStore;
-
-   if (_cg->specializedEpilogues())
-      {
-      requireRALoad = true;
-      }
 
    int32_t frameSize = snippet->getFrameSize();
 


### PR DESCRIPTION
Specialized epilogues are deprecated in OMR.  Remove the functionality
in OpenJ9.

See https://github.com/eclipse/omr/issues/1738

Signed-off-by: Daryl Maier <maier@ca.ibm.com>