### PR TITLE
Allow Kickoff for class unloading by default

### DIFF
--- a/runtime/gc_glue_java/ConfigurationDelegate.hpp
+++ b/runtime/gc_glue_java/ConfigurationDelegate.hpp
@@ -111,12 +111,18 @@ public:
 		/* Enable string constant collection by default if we support class unloading */
 		extensions->collectStringConstants = true;
 
-		/* note that these are the default thresholds but Realtime Configurations override these values, in their initialize methods (hence it is key for them to call their super initialize, first) */
+		/*
+		 *  note that these are the default thresholds but Realtime Configurations override these values, in their initialize methods
+		 * (hence it is key for them to call their super initialize, first)
+		 */
+#define DYNAMIC_CLASS_UNLOADING_THRESHOLD			6
+#define DYNAMIC_CLASS_UNLOADING_KICKOFF_THRESHOLD	80000
+
 		if (!extensions->dynamicClassUnloadingThresholdForced) {
-			extensions->dynamicClassUnloadingThreshold = 6;
+			extensions->dynamicClassUnloadingThreshold = DYNAMIC_CLASS_UNLOADING_THRESHOLD;
 		}
 		if (!extensions->dynamicClassUnloadingKickoffThresholdForced) {
-			extensions->dynamicClassUnloadingKickoffThreshold = 0;
+			extensions->dynamicClassUnloadingKickoffThreshold = DYNAMIC_CLASS_UNLOADING_KICKOFF_THRESHOLD;
 		}
 		return true;
 	}


### PR DESCRIPTION
Currently Kickoff for class unloading reason is enabled only for case if
it is explicitly specified by command line option
-Xgc:classUnloadingKickoffThreshold=<N>. The intention is to extend this
behavior and do it by default if number of classes loaded since last
Global GC is larger then threshold. The threshold value is selected is
80000. The Concurrent Kickoff would be selected automatically if
Concurrent GC is available.

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>