### PR TITLE
Improve out of memory (OOM) verbose log messages

### DIFF
--- a/runtime/tr.source/trj9/control/CompilationThread.cpp
+++ b/runtime/tr.source/trj9/control/CompilationThread.cpp
@@ -3276,6 +3276,7 @@ TR::CompilationInfoPerThread::initializeSegmentCache(J9::J9SegmentProvider &segm
       }
    catch (const std::bad_alloc &allocationFailure)
       {
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Failed to initialize segment cache of size 1 << 24");
       }
    try
       {
@@ -3284,6 +3285,7 @@ TR::CompilationInfoPerThread::initializeSegmentCache(J9::J9SegmentProvider &segm
       }
    catch (const std::bad_alloc &allocationFailure)
       {
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Failed to initialize segment cache of size 1 << 21");
       }
    J9::J9SegmentCache segmentCache(1 << 16, segmentProvider);
    return segmentCache;
@@ -3467,7 +3469,7 @@ TR::CompilationInfoPerThread::processEntries()
          compInfo->getPersistentInfo()->setDisableFurtherCompilation(true);
          if (TR::Options::getVerboseOption(TR_VerboseCompilationThreads) || TR::Options::getVerboseOption(TR_VerbosePerformance))
             {
-            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,"t=%6u Disable further compilation. OOM", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,"t=%6u Disable further compilation due to OOM while processing compile entries", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
             }
          compInfo->purgeMethodQueue(compilationVirtualAddressExhaustion);
          }

--- a/runtime/tr.source/trj9/control/rossa.cpp
+++ b/runtime/tr.source/trj9/control/rossa.cpp
@@ -369,7 +369,7 @@ j9jit_testarossa_err(
          compInfo->getPersistentInfo()->setDisableFurtherCompilation(true);
          if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
             {
-            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,"t=%6u Disable further compilation. OOM", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,"t=%6u Disable further compilation due to OOM while creating an optimization plan", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
             }
          }
       }

--- a/runtime/tr.source/trj9/runtime/JitRuntime.cpp
+++ b/runtime/tr.source/trj9/runtime/JitRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -332,7 +332,7 @@ void induceRecompilation_unwrapper(void **argsPtr, void **resultPtr)
       compInfo->getPersistentInfo()->setDisableFurtherCompilation(true);
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
          {
-         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,"t=%6u Disable further compilation. OOM", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,"t=%6u Disable further compilation due to OOM while inducing a recompilation", (uint32_t)compInfo->getPersistentInfo()->getElapsedTime());
          }
       }
    }


### PR DESCRIPTION
Improve messages seen in the verbose log by avoiding duplicate trace
messages and printing information when std::bad_alloc exceptions are
thrown in the J9SegmentCache allocation sequence.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>