### PR TITLE
Ignore OSR points due to call references in IlGen

### DIFF
--- a/runtime/tr.source/trj9/ilgen/IlGenerator.cpp
+++ b/runtime/tr.source/trj9/ilgen/IlGenerator.cpp
@@ -59,7 +59,8 @@ TR_J9ByteCodeIlGenerator::TR_J9ByteCodeIlGenerator(
      _invokeSpecialInterface(NULL),
      _invokeSpecialInterfaceCalls(NULL),
      _invokeSpecialSeen(false),
-     _couldOSRAtNextBC(false)
+     _couldOSRAtNextBC(false),
+     _processedOSRNodes(NULL)
    {
    static const char *noLookahead = feGetEnv("TR_noLookahead");
    _noLookahead = (noLookahead || comp->getOption(TR_DisableLookahead)) ? true : false;
@@ -106,6 +107,12 @@ TR_J9ByteCodeIlGenerator::TR_J9ByteCodeIlGenerator(
          }
       _argPlaceholderSignatureOffset = curArg - signatureChars;
       }
+
+   if (comp->getOption(TR_EnableOSR)
+       && !comp->isPeekingMethod()
+       && comp->isOSRTransitionTarget(TR::postExecutionOSR)
+       && !_cannotAttemptOSR)
+      _processedOSRNodes = new (trStackMemory()) TR::NodeChecklist(comp);
    }
 
 bool

--- a/runtime/tr.source/trj9/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/tr.source/trj9/ilgen/J9ByteCodeIlGenerator.hpp
@@ -374,6 +374,9 @@ private:
    TR_OpaqueClassBlock              *_invokeSpecialInterface;
    TR_BitVector                     *_invokeSpecialInterfaceCalls;
    bool                              _invokeSpecialSeen;
+
+   // OSR
+   TR::NodeChecklist                *_processedOSRNodes;
    };
 
 #endif


### PR DESCRIPTION
References to a call under a check treetop resemble
OSR points. This results in IlGen generating
additional OSR points than necessary. This fix
identifies these additional points based on their
reference count and will not treat them as OSR points.