### PR TITLE
Compile JIT with SSE/SSE2 on X86

### DIFF
--- a/runtime/compiler/trj9/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/trj9/build/toolcfg/gnu/common.mk
@@ -114,13 +114,15 @@ CX_OPTFLAG?=$(CX_DEFAULTOPT)
 CX_FLAGS_PROD+=$(CX_OPTFLAG)
 
 ifeq ($(HOST_ARCH),x)
+    CX_FLAGS+=-mfpmath=sse -msse -msse2 -fno-strict-aliasing -fno-math-errno -fno-rounding-math -fno-trapping-math -fno-signaling-nans
+    
     ifeq ($(HOST_BITS),32)
-        CX_FLAGS+=-m32 -fpic -fno-strict-aliasing
+        CX_FLAGS+=-m32 -fpic
     endif
     
     ifeq ($(HOST_BITS),64)
         CX_DEFINES+=J9HAMMER
-        CX_FLAGS+=-m64 -fPIC -fno-strict-aliasing
+        CX_FLAGS+=-m64 -fPIC
     endif
 endif
 

--- a/runtime/compiler/trj9/build/toolcfg/win-msvc/common.mk
+++ b/runtime/compiler/trj9/build/toolcfg/win-msvc/common.mk
@@ -117,6 +117,10 @@ CX_FLAGS_DEBUG+=-Zi
 
 CX_FLAGS_PROD+=-Ox -Zi
 
+ifeq ($(HOST_BITS),32)
+    CX_FLAGS+=-arch:SSE2
+endif
+
 ifeq ($(HOST_BITS),64)
     CX_DEFINES+=\
         _WIN32_WINNT=0x0400 \


### PR DESCRIPTION
As JVM guarantees that SSE and SSE2 are available,
JIT should be compiled with SSE/SSE2 enabled to
achieve better performance.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>