### PR TITLE
Adopt OMR's Recognized Call Transformer

### DIFF
--- a/runtime/compiler/trj9/build/files/common.mk
+++ b/runtime/compiler/trj9/build/files/common.mk
@@ -150,6 +150,8 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/PreExistence.cpp \
     omr/compiler/optimizer/Reachability.cpp \
     omr/compiler/optimizer/ReachingDefinitions.cpp \
+    omr/compiler/optimizer/OMRRecognizedCallTransformer.cpp \
+    compiler/trj9/optimizer/J9RecognizedCallTransformer.cpp \
     omr/compiler/optimizer/RedundantAsyncCheckRemoval.cpp \
     compiler/trj9/optimizer/RedundantBCDSignElimination.cpp \
     omr/compiler/optimizer/RegisterAnticipatability.cpp \

--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -4178,28 +4178,6 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
    static bool disableARMFMaxMin = true; // (feGetEnv("TR_DisableARMFMaxMin") != NULL);
 
    TR::ILOpCodes opcode = TR::BadILOp;
-
-   if (!comp()->getOption(TR_DisableMaxMinOptimization) &&
-       TR::Compiler->target.cpu.isX86()) // TODO : Implement other max/min routines on X86
-      {
-      switch (symbol->getRecognizedMethod())
-         {
-         case TR::java_lang_Math_max_I:
-            opcode = TR::imax;
-            break;
-         case TR::java_lang_Math_min_I:
-            opcode = TR::imin;
-            break;
-         case TR::java_lang_Math_max_L:
-            opcode = TR::lmax;
-            break;
-         case TR::java_lang_Math_min_L:
-            opcode = TR::lmin;
-            break;
-         default:
-         	break;
-         }
-      }
    switch (symbol->getRecognizedMethod())
       {
       case TR::java_lang_Integer_valueOf:

--- a/runtime/compiler/trj9/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/trj9/optimizer/J9OptimizationManager.cpp
@@ -94,6 +94,9 @@ J9::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFacto
       case OMR::unsafeFastPath:
          _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
          break;
+      case OMR::recognizedCallTransformer:
+         _flags.set(doesNotRequireAliasSets | supportsIlGenOptLevel);
+         break;
       case OMR::samplingJProfiling:
          _flags.set(requiresStructure | checkStructure | dumpStructure);
          break;

--- a/runtime/compiler/trj9/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/trj9/optimizer/J9RecognizedCallTransformer.cpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+* Copyright (c) 2017, 2017 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+* or the Apache License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following
+* Secondary Licenses when the conditions for such availability set
+* forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+* General Public License, version 2 with the GNU Classpath
+* Exception [1] and GNU General Public License, version 2 with the
+* OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*******************************************************************************/
+
+#include "optimizer/RecognizedCallTransformer.hpp"
+
+#include "compile/ResolvedMethod.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/VMJ9.h"
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"                                   // for ILOpCode, etc
+#include "ilgen/IlGenRequest.hpp"
+#include "ilgen/IlGeneratorMethodDetails.hpp"
+#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "optimizer/CallInfo.hpp"
+#include "optimizer/Structure.hpp"
+#include "codegen/CodeGenerator.hpp"                      // for CodeGenerator
+#include "optimizer/TransformUtil.hpp"
+
+
+void J9::RecognizedCallTransformer::processSimpleMath(TR::Node* node, TR::ILOpCodes opcode)
+   {
+   TR::Node::recreate(node, opcode);
+   }
+
+bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
+   {
+   auto node = treetop->getNode()->getFirstChild();
+   switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
+      {
+      case TR::java_lang_Integer_rotateLeft:
+         return TR::Compiler->target.cpu.isX86();
+      case TR::java_lang_Math_max_I:
+      case TR::java_lang_Math_min_I:
+      case TR::java_lang_Math_max_L:
+      case TR::java_lang_Math_min_L:
+         return TR::Compiler->target.cpu.isX86() && !comp()->getOption(TR_DisableMaxMinOptimization);
+      default:
+         return false;
+      }
+   }
+
+void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
+   {
+   auto node = treetop->getNode()->getFirstChild();
+   switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
+      {
+      case TR::java_lang_Integer_rotateLeft:
+         processSimpleMath(node, TR::irol);
+         break;
+      case TR::java_lang_Math_max_I:
+         processSimpleMath(node, TR::imax);
+         break;
+      case TR::java_lang_Math_min_I:
+         processSimpleMath(node, TR::imin);
+         break;
+      case TR::java_lang_Math_max_L:
+         processSimpleMath(node, TR::lmax);
+         break;
+      case TR::java_lang_Math_min_L:
+         processSimpleMath(node, TR::lmin);
+         break;
+      default:
+         break;
+      }
+   }

--- a/runtime/compiler/trj9/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/trj9/optimizer/J9RecognizedCallTransformer.hpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2017, 2017 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+* or the Apache License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following
+* Secondary Licenses when the conditions for such availability set
+* forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+* General Public License, version 2 with the GNU Classpath
+* Exception [1] and GNU General Public License, version 2 with the
+* OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*******************************************************************************/
+
+#ifndef J9RECOGNIZEDCALLTRANSFORMER_INCL
+#define J9RECOGNIZEDCALLTRANSFORMER_INCL
+
+#include "optimizer/OMRRecognizedCallTransformer.hpp"
+
+namespace J9
+{
+
+class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
+   {
+   public:
+   RecognizedCallTransformer(TR::OptimizationManager* manager)
+      : OMR::RecognizedCallTransformer(manager)
+      {}
+
+   protected:
+   virtual bool isInlineable(TR::TreeTop* treetop);
+   virtual void transform(TR::TreeTop* treetop);
+
+   private:
+   void processSimpleMath(TR::Node* node, TR::ILOpCodes opcode);
+   };
+
+}
+#endif

--- a/runtime/compiler/trj9/optimizer/RecognizedCallTransformer.hpp
+++ b/runtime/compiler/trj9/optimizer/RecognizedCallTransformer.hpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2017, 2017 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+* or the Apache License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following
+* Secondary Licenses when the conditions for such availability set
+* forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+* General Public License, version 2 with the GNU Classpath
+* Exception [1] and GNU General Public License, version 2 with the
+* OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*******************************************************************************/
+
+#ifndef TR_RECOGNIZEDCALLTRANSFORMER_INCL
+#define TR_RECOGNIZEDCALLTRANSFORMER_INCL
+
+#include "optimizer/J9RecognizedCallTransformer.hpp"
+
+namespace TR
+{
+
+class RecognizedCallTransformer : public J9::RecognizedCallTransformer
+   {
+   public:
+   RecognizedCallTransformer(TR::OptimizationManager *manager) :
+      J9::RecognizedCallTransformer(manager) {}
+   };
+
+}
+
+#endif


### PR DESCRIPTION
Initial adoption of OMR's Recognized Call Transformer;
converting certain recognized calls to IL OpCode on X86.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>