### PR TITLE
Enable onsite cache for instanceOf on IBM Z

### DIFF
--- a/runtime/tr.source/trj9/control/J9Options.cpp
+++ b/runtime/tr.source/trj9/control/J9Options.cpp
@@ -1911,6 +1911,8 @@ J9::Options::fePreProcess(void * base)
    // SR5. In addition several performance issues on SPARK workloads have been reported which seem to concurrently
    // access StringBuffer objects from multiple threads.
    self()->setOption(TR_DisableLockResevation);
+   // Setting number of onsite cache slots for instanceOf node to 4 on IBM Z
+   self()->setMaxOnsiteCacheSlotForInstanceOf(4);
 #endif
 
    // Process the deterministic mode


### PR DESCRIPTION
Enabling dynamic cache test for instanceOf in which we cache
object/cast classes for which we failed all inlined tests and
called out JIT helper. Before calling out we check cache to get
instanceOf results. Cache test is enabled with four slots.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>