### PR TITLE
Fix openj9 compile errors when ddr enabled (take 2)

### DIFF
--- a/runtime/ddr/ddr_stubs.mk
+++ b/runtime/ddr/ddr_stubs.mk
@@ -20,20 +20,14 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-#Target to copy the stub files into place iff the automated files
-#haven't been generated.
 ifndef DISABLE_STUBS
+
+# Copy stubs into place if generated files are not available.
+
 %.c : %.c.stub
-	( \
-	if [ ! -f $@ ] ; then \
-		cp $^ $@;\
-	fi ;\
-	)
+	test -f $@ || cp $^ $@
 
 %.cpp : %.cpp.stub
-	( \
-	if [ ! -f $@ ] ; then \
-		cp $^ $@;\
-	fi ;\
-	)
-endif
+	test -f $@ || cp $^ $@
+
+endif # DISABLE_STUBS

--- a/runtime/ddr/ddrcppsupportblob.cpp.stub
+++ b/runtime/ddr/ddrcppsupportblob.cpp.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -30,8 +29,7 @@ extern "C"
 const J9DDRStructDefinition *
 getDDR_CPPStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: CPP support structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: CPP support structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/hyportddrblob.c.stub
+++ b/runtime/ddr/hyportddrblob.c.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -29,8 +28,7 @@ static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 const J9DDRStructDefinition *
 getHyPortStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: HyPort Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: HyPort Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/j9portddrblob.c.stub
+++ b/runtime/ddr/j9portddrblob.c.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -29,8 +28,7 @@ static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 const J9DDRStructDefinition *
 getJ9PortStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: J9Port Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: J9Port Structure Table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/jitddrblob.c.stub
+++ b/runtime/ddr/jitddrblob.c.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -29,8 +28,7 @@ static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 const J9DDRStructDefinition *
 getJITAutomatedStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: JIT Automated structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: JIT Automated structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/omrddrblob.c.stub
+++ b/runtime/ddr/omrddrblob.c.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -29,8 +28,7 @@ static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 const J9DDRStructDefinition *
 getOmrStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: OMR structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: OMR structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/stackwalkddrblob.c.stub
+++ b/runtime/ddr/stackwalkddrblob.c.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -29,8 +28,7 @@ static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 const J9DDRStructDefinition *
 getStackWalkerStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: StackWalker structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: StackWalker structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/ddr/vmddrblob.c.stub
+++ b/runtime/ddr/vmddrblob.c.stub
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
@@ -29,8 +28,7 @@ static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 const J9DDRStructDefinition *
 getVMStructTable(struct OMRPortLibrary *portLib)
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
-	omrtty_printf("WARNING: VM structure table was not generated and has been stubbed out. See ddr.readme.\n");
+	portLib->tty_printf(portLib, "WARNING: VM structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
 	return structStubs;
 }

--- a/runtime/gc_ddr/gcddrblob.cpp.stub
+++ b/runtime/gc_ddr/gcddrblob.cpp.stub
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2010 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,19 +20,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
 #include "j9.h"
 #include "j9ddr.h"
 
-extern "C" {
-	static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
+static const J9DDRStructDefinition structStubs[] = { { 0, 0, 0, 0, 0 } };
 
-	const J9DDRStructDefinition* getGCStructTable(void* portLib)
-	{
-		OMRPORT_ACCESS_FROM_OMRPORT((OMRPortLibrary *)portLib);
-		OMRPORTLIB->tty_printf(OMRPORTLIB, "WARNING: GC structure table was not generated and has been stubbed out. See ddr.readme.\n");
-	
-		return structStubs;
-	}
-};
+extern "C"
+const J9DDRStructDefinition *
+getGCStructTable(struct OMRPortLibrary *portLib)
+{
+	portLib->tty_printf(portLib, "WARNING: GC structure table was not generated and has been stubbed out. See ddr.readme.\n");
 
+	return structStubs;
+}


### PR DESCRIPTION
* remove use of omrtty_printf macro in blob stubs
* simplify make rules for using blob stubs
* remove unneeded #include <stdlib.h> in stubs

This is a better version of #405.