### PR TITLE
Re-enable StringCoding optimization

### DIFF
--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -2987,11 +2987,10 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {
       {x(TR::java_lang_StringCoding_decode, "decode", "(Ljava/nio/charset/Charset;[BII)[C")},
       {x(TR::java_lang_StringCoding_encode, "encode", "(Ljava/nio/charset/Charset;[CII)[B")},
-      //Temporarily disable these recognitions due to failures
-      //{x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
-      //{x(TR::java_lang_StringCoding_encode8859_1,       "encode8859_1",       "(B[B)[B")},
-      //{x(TR::java_lang_StringCoding_encodeASCII,        "encodeASCII",        "(B[B)[B")},
-      //{x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[B)[B")},
+      {x(TR::java_lang_StringCoding_implEncodeISOArray, "implEncodeISOArray", "([BI[BII)I")},
+      {x(TR::java_lang_StringCoding_encode8859_1,       "encode8859_1",       "(B[B)[B")},
+      {x(TR::java_lang_StringCoding_encodeASCII,        "encodeASCII",        "(B[B)[B")},
+      {x(TR::java_lang_StringCoding_encodeUTF8,         "encodeUTF8",         "(B[B)[B")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/trj9/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/compiler/trj9/il/symbol/J9MethodSymbol.cpp
@@ -538,9 +538,6 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] =
    //TR::java_util_Arrays_copyOf,
    TR::java_io_Writer_write_lStringII,
    TR::java_io_Writer_write_I,
-   TR::java_lang_StringCoding_encode8859_1,
-   TR::java_lang_StringCoding_encodeASCII,
-   TR::java_lang_StringCoding_encodeUTF8,
    TR::unknownMethod
    };
 

--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -6912,8 +6912,11 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
    if (_methodSymbol->skipZeroInitializationOnNewarrays())
      node->setCanSkipZeroInitialization(true);
 
+   bool generateArraylets = comp()->generateArraylets();
+
    // special case for handling Arrays.copyOf in the StringEncoder fast paths for Java 9+
    if (!comp()->isOutermostMethod() && !comp()->isPeekingMethod()
+       && !generateArraylets
        && _methodSymbol->getRecognizedMethod() == TR::java_util_Arrays_copyOf_byte)
      {
      int32_t callerIndex = comp()->getCurrentInlinedCallSite()->_byteCodeInfo.getCallerIndex();
@@ -6955,8 +6958,6 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
       }
 
    TR::Node *initNode = NULL;
-
-   bool generateArraylets = comp()->generateArraylets();
 
    if (!comp()->getOption(TR_DisableSeparateInitFromAlloc) &&
        !node->canSkipZeroInitialization() &&


### PR DESCRIPTION
An issue was found in testing with recent changes to accelerate
StringCoding in Java9. The cause of the issue was a change to skip array
zero initialization. When running with arraylets enabled (eg GC modes
like balanced) the zero initialization is required). This guards the
zero initialization skipping with a test for arraylets.
