### PR TITLE
Modify xhelpers.m4 and m4 build options to work on OSX

### DIFF
--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -28,7 +28,7 @@ define({CALL_SLOW_PATH_ONLY_HELPER},{
 	SAVE_ALL_REGS
 	FASTCALL_C_WITH_VMTHREAD(old_slow_$1,1)
 	test _rax,_rax
-	je short LABEL(L_done_$1)
+	je SHORT_JMP LABEL(L_done_$1)
 	jmp _rax
 LABEL(L_done_$1):
 	RESTORE_ALL_REGS
@@ -43,7 +43,7 @@ define({CALL_SLOW_PATH_ONLY_HELPER_NO_RETURN_VALUE},{
 	SAVE_ALL_REGS
 	FASTCALL_C_WITH_VMTHREAD(old_slow_$1,1)
 	test _rax,_rax
-	je short LABEL(L_done_$1)
+	je SHORT_JMP LABEL(L_done_$1)
 	jmp _rax
 LABEL(L_done_$1):
 	RESTORE_ALL_REGS
@@ -145,12 +145,12 @@ define({OLD_DUAL_MODE_HELPER},{
 	SAVE_C_VOLATILE_REGS
 	FASTCALL_C_WITH_VMTHREAD(old_fast_$1,1)
 	test _rax,_rax
-	je LABEL(L_done_$1)
+	je SHORT_JMP LABEL(L_done_$1)
 	SAVE_C_NONVOLATILE_REGS
 	SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
-	je short LABEL(L_slow_$1)
+	je SHORT_JMP LABEL(L_slow_$1)
 	jmp _rax
 LABEL(L_slow_$1):
 	RESTORE_C_NONVOLATILE_REGS
@@ -170,12 +170,12 @@ define({OLD_DUAL_MODE_HELPER_NO_RETURN_VALUE},{
 	SAVE_C_VOLATILE_REGS
 	FASTCALL_C_WITH_VMTHREAD(old_fast_$1,1)
 	test _rax,_rax
-	je LABEL(L_done_$1)
+	je SHORT_JMP LABEL(L_done_$1)
 	SAVE_C_NONVOLATILE_REGS
 	SAVE_C_NONVOLATILE_JIT_FP_ARG_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
-	je short LABEL(L_slow_$1)
+	je SHORT_JMP LABEL(L_slow_$1)
 	jmp _rax
 LABEL(L_slow_$1):
 	RESTORE_C_NONVOLATILE_REGS
@@ -192,7 +192,7 @@ define({NEW_DUAL_MODE_HELPER},{
 	pop uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	call FASTCALL_SYMBOL(fast_$1,$2+1)
 	test _rax,_rax
-	jne short LABEL(L_slow_$1)
+	jne SHORT_JMP LABEL(L_slow_$1)
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	mov _rax,uword ptr J9TR_VMThread_returnValue[_rbp]
 	ret
@@ -201,7 +201,7 @@ LABEL(L_slow_$1):
 	SAVE_C_NONVOLATILE_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
-	jne short LABEL(L_exception_$1)
+	jne SHORT_JMP LABEL(L_exception_$1)
 	RESTORE_C_NONVOLATILE_REGS
 	SWITCH_TO_JAVA_STACK
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
@@ -218,7 +218,7 @@ define({NEW_DUAL_MODE_HELPER_NO_RETURN_VALUE},{
 	pop uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	call FASTCALL_SYMBOL(fast_$1,$2+1)
 	test _rax,_rax
-	jne short LABEL(L_slow_$1)
+	jne SHORT_JMP LABEL(L_slow_$1)
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	ret
 LABEL(L_slow_$1):
@@ -226,7 +226,7 @@ LABEL(L_slow_$1):
 	SAVE_C_NONVOLATILE_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
-	jne short LABEL(L_exception_$1)
+	jne SHORT_JMP LABEL(L_exception_$1)
 	RESTORE_C_NONVOLATILE_REGS
 	SWITCH_TO_JAVA_STACK
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
@@ -247,7 +247,7 @@ define({NEW_DUAL_MODE_ALLOCATION_HELPER},{
 	SWITCH_TO_C_STACK
 	call FASTCALL_SYMBOL(fast_$1,$2+1)
 	test _rax,_rax
-	jne short LABEL(L_slow_$1)
+	jne SHORT_JMP LABEL(L_slow_$1)
 	SWITCH_TO_JAVA_STACK
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	mov _rax,uword ptr J9TR_VMThread_returnValue[_rbp]
@@ -256,7 +256,7 @@ LABEL(L_slow_$1):
 	SAVE_C_NONVOLATILE_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
-	jne short LABEL(L_exception_$1)
+	jne SHORT_JMP LABEL(L_exception_$1)
 	RESTORE_C_NONVOLATILE_REGS
 	SWITCH_TO_JAVA_STACK
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
@@ -287,7 +287,7 @@ define({NEW_DUAL_MODE_ALLOCATION_HELPER},{
 	ifelse($2,0,,$2,1,,$2,2,{push eax})
 	call FASTCALL_SYMBOL(fast_$1,$2+1)
 	test _rax,_rax
-	jne short LABEL(L_slow_$1)
+	jne SHORT_JMP LABEL(L_slow_$1)
 	SWITCH_TO_JAVA_STACK
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
 	mov _rax,uword ptr J9TR_VMThread_returnValue[_rbp]
@@ -296,7 +296,7 @@ LABEL(L_slow_$1):
 	SAVE_C_NONVOLATILE_REGS
 	FASTCALL_INDIRECT_WITH_VMTHREAD(_rax)
 	test _rax,_rax
-	jne short LABEL(L_exception_$1)
+	jne SHORT_JMP LABEL(L_exception_$1)
 	RESTORE_C_NONVOLATILE_REGS
 	SWITCH_TO_JAVA_STACK
 	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -442,7 +442,17 @@ UMA_PASM_INCLUDES:=$(addprefix -I ,$(UMA_INCLUDES))
 	-rm -f $*.i2
 	$(AS) $(ASFLAGS) -o $*.o $*.s
 	-rm -f $*.s
+</#if>
 
+<#if uma.spec.type.osx>
+#compilation rule for .m4 files
+%$(UMA_DOT_O): %.m4
+	m4 -DOSX $(UMA_M4_FLAGS) $(UMA_C_INCLUDES) $< > $*.s
+	$(AS) $(ASFLAGS) -o $*.o $*.s
+	-mv -f $*.s $*.hold
+</#if>
+
+<#if uma.spec.type.linux>
 #compilation rule for .m4 files
 %$(UMA_DOT_O): %.m4
 	m4 $(UMA_M4_FLAGS) $(UMA_C_INCLUDES) $< > $*.s

--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -24,6 +24,8 @@ define({CINTERP_STACK_SIZE},{J9CONST(J9TR_cframe_sizeof,$1,$2)})
 
 ifdef({WIN32},{
 
+define({SHORT_JMP},{short})
+
 ifdef({ASM_J9VM_ENV_DATA64},{
 
 define({FILE_START},{
@@ -64,11 +66,26 @@ define({LABEL},$1)
 
 },{	dnl WIN32
 
+ifdef({OSX},{ 
+
+define({SHORT_JMP},{})
+
+define({FILE_START},{
+	.intel_syntax noprefix
+	.text
+})
+
+},{	dnl OSX
+
+define({SHORT_JMP},{short})
+
 define({FILE_START},{
 	.intel_syntax noprefix
 	.arch pentium4
 	.text
 })
+
+})	dnl OSX
 
 define({FILE_END})
 
@@ -80,14 +97,22 @@ define({START_PROC},{
 
 define({END_PROC},{
 END_$1:
+ifdef({OSX},{
+
+},{	dnl OSX
 	.size $1,END_$1 - $1
+})	dnl OSX
 })
 
 define({DECLARE_PUBLIC},{.global $1})
 
 define({DECLARE_EXTERN},{.extern $1})
 
+ifdef({OSX},{
+define({LABEL},$1)
+},{	dnl OSX
 define({LABEL},.$1)
+})	dnl OSX
 
 })	dnl WIN32
 

--- a/runtime/vm/xcinterp.m4
+++ b/runtime/vm/xcinterp.m4
@@ -167,7 +167,7 @@ cInterpreter:
 	mov _rax,uword ptr J9TR_VMThread_javaVM[_rbp]
 	CALL_C_WITH_VMTHREAD(uword ptr J9TR_JavaVM_bytecodeLoop[_rax],0)
 	cmp _rax,J9TR_bcloop_exit_interpreter
-	je short cInterpExit
+	je SHORT_JMP cInterpExit
 	RESTORE_PRESERVED_REGS
 	SWITCH_TO_JAVA_STACK
 	jmp uword ptr J9TR_VMThread_tempSlot[_rbp]


### PR DESCRIPTION
Duplicated M4 UMA rule to be able to pass the `-DOSX` to
m4.  This follows the pattern used by other platforms.

Workaround the OSX assembler not supporting `je short`.
Add a define to the xhelpers.m4 for SHORT_JMP which
is turned into `short` on windows and linux-x86.  On
OSX it defines away to nothing.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>