### PR TITLE
Prevent access to call stack when peeking

### DIFF
--- a/runtime/tr.source/trj9/ilgen/Walker.cpp
+++ b/runtime/tr.source/trj9/ilgen/Walker.cpp
@@ -6900,7 +6900,7 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
      node->setCanSkipZeroInitialization(true);
 
    // special case for handling Arrays.copyOf in the StringEncoder fast paths for Java 9+
-   if (!comp()->isOutermostMethod()
+   if (!comp()->isOutermostMethod() && !comp()->isPeekingMethod()
        && _methodSymbol->getRecognizedMethod() == TR::java_util_Arrays_copyOf_byte)
      {
      int32_t callerIndex = comp()->getCurrentInlinedCallSite()->_byteCodeInfo.getCallerIndex();


### PR DESCRIPTION
A recent change to the IlGen walker required
checks against the call stack to verify an
optimization. These checks are not valid in
a peeking compilation and should be skipped.