### PR TITLE
Correct Shift child type

### DIFF
--- a/runtime/tr.source/trj9/optimizer/J9TransformUtil.cpp
+++ b/runtime/tr.source/trj9/optimizer/J9TransformUtil.cpp
@@ -1393,7 +1393,7 @@ TR::Node * J9::TransformUtil::calculateOffsetFromIndexInContiguousArray(TR::Comp
 
    if (shift)
       {
-      TR::Node *shiftNode = TR::Node::create(constOp, 0);
+      TR::Node *shiftNode = TR::Node::create(TR::iconst, 0);
       shiftNode->setConstValue(shift);
       offset = TR::Node::create(shlOp, 2, offset, shiftNode);
       }


### PR DESCRIPTION
Shifts always take a 32 bit shift amount.

Caught with the ILValidator, contribues to #277

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>