### PR TITLE
Temporarily disable ReduceSynchronizedFieldLoad

### DIFF
--- a/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.cpp
+++ b/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.cpp
@@ -263,9 +263,14 @@ ReduceSynchronizedFieldLoad::perform()
       {
       if (!cg->comp()->getOption(TR_DisableSynchronizedFieldLoad))
          {
-         traceMsg(cg->comp(), "Performing ReduceSynchronizedFieldLoad\n");
+         static const bool enableReduceSynchronizedFieldLoad = feGetEnv("TR_EnableReduceSynchronizedFieldLoad") != NULL;
 
-         transformed = performOnTreeTops(cg->comp()->getStartTree(), NULL);
+         if (enableReduceSynchronizedFieldLoad)
+            {
+            traceMsg(cg->comp(), "Performing ReduceSynchronizedFieldLoad\n");
+
+            transformed = performOnTreeTops(cg->comp()->getStartTree(), NULL);
+            }
          }
       }
 


### PR DESCRIPTION
Disable ReduceSynchronizedFieldLoad until internal bugs discovered by
asserts triggered are resolved.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>