### PR TITLE
Allow for non-JNI Unsafe methods

### DIFF
--- a/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
@@ -666,7 +666,10 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       if (self()->comp()->useCompressedPointers())
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
+         // Unsafe could be the jdk.internal JNI method or the sun.misc ordinary method wrapper,
+         // so test for isNative to distinguish between them
          if ((methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z) &&
+               methodSymbol->isNative() &&
                (!TR::Compiler->om.canGenerateArraylets() || parent->isUnsafeGetPutCASCallOnNonArray()) && parent->isSafeForCGToFastPathUnsafeCall())
             {
             TR_BitVector childrenToBeLowered(parent->getNumChildren(), self()->comp()->trMemory(), stackAlloc);

--- a/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
+++ b/runtime/tr.source/trj9/codegen/J9CodeGenerator.cpp
@@ -666,8 +666,9 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       if (self()->comp()->useCompressedPointers())
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
-         // Unsafe could be the jdk.internal JNI method or the sun.misc ordinary method wrapper,
-         // so test for isNative to distinguish between them
+         // In Java9 Unsafe could be the jdk.internal JNI method or the sun.misc ordinary method wrapper,
+         // while in Java8 it can only be the sun.misc package which will itself contain the JNI method.
+         // Test for isNative to distinguish between them.
          if ((methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z) &&
                methodSymbol->isNative() &&
                (!TR::Compiler->om.canGenerateArraylets() || parent->isUnsafeGetPutCASCallOnNonArray()) && parent->isSafeForCGToFastPathUnsafeCall())

--- a/runtime/tr.source/trj9/optimizer/EscapeAnalysis.cpp
+++ b/runtime/tr.source/trj9/optimizer/EscapeAnalysis.cpp
@@ -3917,9 +3917,12 @@ void TR_EscapeAnalysis::checkEscapeViaCall(TR::Node *node, TR::NodeChecklist& vi
    Candidate               *candidate, *next;
    bool                     needToSniff = false;
 
+   // In Java9 sun_misc_Unsafe_putInt might be the wrapper which could potentially be redefined,
+   // so add a check for isNative to be conservative.
    if (methodSymbol && _methodSymbol &&
        (_methodSymbol->getRecognizedMethod() == TR::java_math_BigDecimal_longString1C) &&
-       (methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_putInt_jlObjectII_V))
+       (methodSymbol->getRecognizedMethod() == TR::sun_misc_Unsafe_putInt_jlObjectII_V) &&
+       (methodSymbol->isNative()))
       {
       if (trace())
          traceMsg(comp(), "Ignoring escapes via call [%p] \n", node);
@@ -8471,6 +8474,3 @@ bool TR_LocalFlushElimination::examineNode(TR::Node *node, TR::NodeChecklist& vi
 
    return true;
    }
-
-
-

--- a/runtime/tr.source/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/tr.source/trj9/optimizer/InlinerTempForJ9.cpp
@@ -349,57 +349,71 @@ TR_J9InlinerPolicy::mustBeInlinedEvenInDebug(TR_ResolvedMethod * calleeMethod, T
    return false;
    }
 
+/* Identify methods for which the benefits of inlining them into the caller
+   are particularly significant.
+*/
 bool
 TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::Node *callNode)
    {
-   if (calleeMethod && isInlineableJNI(calleeMethod, callNode))
+   // if we are passed a null calleeMethod then we can only return false
+   if (!calleeMethod) return false;
+
+   if (isInlineableJNI(calleeMethod, callNode))
       return true;
 
-   if (calleeMethod && calleeMethod->isDAAWrapperMethod())
+   if (calleeMethod->isDAAWrapperMethod())
       return true;
 
-   if (calleeMethod)
+   switch (calleeMethod->convertToMethod()->getMandatoryRecognizedMethod())
       {
-      switch (calleeMethod->convertToMethod()->getMandatoryRecognizedMethod())
-         {
-         case TR::java_lang_invoke_MethodHandle_asType:
-         case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress:
-            return true;
-         default:
-          break;
-         }
+      case TR::java_lang_invoke_MethodHandle_asType:
+      case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress:
+         return true;
+      default:
+       break;
+      }
 
-      // we rely on inlining compareAndSwap so we see the inner native call and can special case it
-      // get/putLongVolatile is not supported by all codegens so we want to inline to expose the native
-      // if we haven't special cased it in the walker
-      switch (calleeMethod->getRecognizedMethod())
-         {
-         case TR::java_lang_J9VMInternals_fastIdentityHashCode:
-         case TR::java_lang_Class_getSuperclass:
-         case TR::java_lang_String_regionMatches:
-         case TR::java_lang_Class_newInstance:
-         case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInObject:
-         case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInObject:
-         case TR::com_ibm_jit_JITHelpers_compareAndSwapObjectInObject:
-         case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInArray:
-         case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInArray:
-         case TR::com_ibm_jit_JITHelpers_compareAndSwapObjectInArray:
-         case TR::com_ibm_jit_JITHelpers_jitHelpers:
-         case TR::java_lang_String_charAtInternal_I:
-         case TR::java_lang_String_charAtInternal_IB:
-         case TR::java_lang_String_length:
-         case TR::java_lang_String_lengthInternal:
-         case TR::java_lang_String_isCompressed:
-         case TR::java_lang_StringBuffer_capacityInternal:
-         case TR::java_lang_StringBuffer_lengthInternalUnsynchronized:
-         case TR::java_lang_StringBuilder_capacityInternal:
-         case TR::java_lang_StringBuilder_lengthInternal:
-         case TR::java_util_HashMap_get:
-         case TR::java_util_HashMap_getNode:
-            return true;
-         default:
-          break;
-         }
+   // we rely on inlining compareAndSwap so we see the inner native call and can special case it
+   // get/putLongVolatile is not supported by all codegens so we want to inline to expose the native
+   // if we haven't special cased it in the walker
+   switch (calleeMethod->getRecognizedMethod())
+      {
+      case TR::java_lang_J9VMInternals_fastIdentityHashCode:
+      case TR::java_lang_Class_getSuperclass:
+      case TR::java_lang_String_regionMatches:
+      case TR::java_lang_Class_newInstance:
+      case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInObject:
+      case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInObject:
+      case TR::com_ibm_jit_JITHelpers_compareAndSwapObjectInObject:
+      case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInArray:
+      case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInArray:
+      case TR::com_ibm_jit_JITHelpers_compareAndSwapObjectInArray:
+      case TR::com_ibm_jit_JITHelpers_jitHelpers:
+      case TR::java_lang_String_charAtInternal_I:
+      case TR::java_lang_String_charAtInternal_IB:
+      case TR::java_lang_String_length:
+      case TR::java_lang_String_lengthInternal:
+      case TR::java_lang_String_isCompressed:
+      case TR::java_lang_StringBuffer_capacityInternal:
+      case TR::java_lang_StringBuffer_lengthInternalUnsynchronized:
+      case TR::java_lang_StringBuilder_capacityInternal:
+      case TR::java_lang_StringBuilder_lengthInternal:
+      case TR::java_util_HashMap_get:
+      case TR::java_util_HashMap_getNode:
+         return true;
+      case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
+      case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
+      case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
+         // In Java9 the above enum values match both sun.misc.Unsafe and
+         // jdk.internal.misc.Unsafe The sun.misc.Unsafe methods are simple
+         // wrappers to call jdk.internal impls, and we want to inline them.
+         // Since the same code can run with Java8 classes where sun.misc.Unsafe
+         // has the JNI impl, we need to differentiate by testing with
+         // isNative(). If it is native, then we don't need to inline it as it
+         // will be handled elsewhere.
+         return !calleeMethod->isNative();
+      default:
+       break;
       }
 
    return false;
@@ -2016,10 +2030,6 @@ TR_J9InlinerPolicy::inlineUnsafeCall(TR::ResolvedMethodSymbol *calleeSymbol, TR:
    }
 
 
-/* PLEASE, PLEASE KEEP THIS FUNCTION IN SYNC WITH isInlineableJNI in VMJ9.cpp
-   When we refactor inlineCallTarget2 and findInlineTargets it will be COMPLETELY
-   removed from TR_InlinerBase
-*/
 bool
 TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode)
    {
@@ -2101,11 +2111,15 @@ TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode
       case TR::sun_misc_Unsafe_loadFence:
       case TR::sun_misc_Unsafe_storeFence:
       case TR::sun_misc_Unsafe_fullFence:
+         return true;
 
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
-         return true;
+         // In Java9 sun/misc/Unsafe methods are simple Java wrappers to JNI
+         // methods in jdk.internal, and the enum values above match both. Only
+         // return true for the methods that are native.
+         return method->isNative();
 
       case TR::sun_misc_Unsafe_staticFieldBase:
          return false; // todo
@@ -2150,6 +2164,7 @@ TR_J9InlinerPolicy::tryToInline(TR_CallTarget * calltarget, TR_CallStack * callS
 
    if (OMR_InlinerPolicy::tryToInlineGeneral(calltarget, callStack, toInline))
       return true;
+
    return false;
    }
 

--- a/runtime/tr.source/trj9/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/p/codegen/J9TreeEvaluator.cpp
@@ -12874,6 +12874,12 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          break;
 
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
+        // In Java9 this can be either the jdk.internal JNI method or the sun.misc Java wrapper.
+        // In Java8 it will be sun.misc which will contain the JNI directly.
+        // We only want to inline the JNI methods, so add an explicit test for isNative().
+        if (!methodSymbol->isNative())
+           break;
+
         if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
             resultReg = VMinlineCompareAndSwap(node, cg, false);
@@ -12883,6 +12889,10 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
          traceMsg(comp, "In evaluator for compareAndSwapLong. node = %p node->isSafeForCGToFastPathUnsafeCall = %p\n", node, node->isSafeForCGToFastPathUnsafeCall());
+         // As above, we only want to inline the JNI methods, so add an explicit test for isNative()
+         if (!methodSymbol->isNative())
+            break;
+
          if (TR::Compiler->target.is64Bit() && (node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
             resultReg = VMinlineCompareAndSwap(node, cg, true);
@@ -12896,6 +12906,10 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          break;
 
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
+         // As above, we only want to inline the JNI methods, so add an explicit test for isNative()
+         if (!methodSymbol->isNative())
+            break;
+
          if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
             resultReg = VMinlineCompareAndSwapObject(node, cg);

--- a/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -12221,6 +12221,12 @@ J9::Z::CodeGenerator::inlineDirectCall(
    switch (methodSymbol->getRecognizedMethod())
       {
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
+         // In Java9 this can be either the jdk.internal JNI method or the sun.misc Java wrapper.
+         // In Java8 it will be sun.misc which will contain the JNI directly.
+         // We only want to inline the JNI methods, so add an explicit test for isNative().
+         if (!methodSymbol->isNative())
+            break;
+
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
             resultReg = VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CS, IS_NOT_OBJ);
@@ -12228,6 +12234,10 @@ J9::Z::CodeGenerator::inlineDirectCall(
             }
 
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
+         // As above, we only want to inline the JNI methods, so add an explicit test for isNative()
+         if (!methodSymbol->isNative())
+            break;
+
          if (TR::Compiler->target.is64Bit() && (!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
             resultReg = VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CSG, IS_NOT_OBJ);
@@ -12237,6 +12247,10 @@ J9::Z::CodeGenerator::inlineDirectCall(
          break;
 
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
+         // As above, we only want to inline the JNI methods, so add an explicit test for isNative()
+         if (!methodSymbol->isNative())
+            break;
+
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
             resultReg = VMinlineCompareAndSwap(node, cg, (comp->useCompressedPointers() ? TR::InstOpCode::CS : TR::InstOpCode::getCmpAndSwapOpCode()), IS_OBJ);


### PR DESCRIPTION
In Java9 sun.misc.Unsafe JNI methods are moved to jdk.internal and
replaced with simple wrappers. This leads to a few places in the
code where we do the wrong thing by assuming that the recognized
Unsafe method is a JNI method.
This commit adds explicit tests to differentiate between the JNI
methods and the non-JNI wrappers.

Signed-off-by: James Kingdon <jkingdon@ca.ibm.com>