### PR TITLE
Simplify OMR_TARGET_DATASIZE configuration

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_390.mk
@@ -21,12 +21,10 @@
 ###############################################################################
 
 include $(CONFIG_INCL_DIR)/configure_common.mk
-# Detect 64-bit vs. 31-bit
-# This overrides the value calculated in configure_common.mk
-ifneq (,$(findstring -64,$(SPEC)))
-  TEMP_TARGET_DATASIZE:=64
-else
-  TEMP_TARGET_DATASIZE:=31
+
+# Override datasize for 31-bit specs.
+ifeq (,$(findstring -64,$(SPEC)))
+  TEMP_TARGET_DATASIZE := 31
 endif
 
 CONFIGURE_ARGS += \

--- a/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ztpf_390.mk
@@ -21,12 +21,10 @@
 ###############################################################################
 
 include $(CONFIG_INCL_DIR)/configure_common.mk
-# Detect 64-bit vs. 31-bit
-# This overrides the value calculated in configure_common.mk
-ifneq (,$(findstring -64,$(SPEC)))
-	TEMP_TARGET_DATASIZE:=64
-else
-	TEMP_TARGET_DATASIZE:=31
+
+# Override datasize for 31-bit specs.
+ifeq (,$(findstring -64,$(SPEC)))
+  TEMP_TARGET_DATASIZE := 31
 endif
 
 CONFIGURE_ARGS += \

--- a/runtime/gc_glue_java/configure_includes/configure_osx.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_osx.mk
@@ -19,8 +19,6 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-TEMP_TARGET_DATASIZE:=64
-
 include $(CONFIG_INCL_DIR)/configure_common.mk
 
 CONFIGURE_ARGS += \
@@ -42,7 +40,6 @@ CONFIGURE_ARGS += \
   --enable-OMR_THR_YIELD_ALG \
   --enable-OMR_GC_ARRAYLETS \
   --enable-OMR_THR_SPIN_WAKE_CONTROL
-
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.dylib arlibext=.a objext=.o
 

--- a/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
+++ b/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
@@ -21,12 +21,10 @@
 ###############################################################################
 
 include $(CONFIG_INCL_DIR)/configure_common.mk
-# Detect 64-bit vs. 31-bit
-# This overrides the value calculated in configure_common.mk
-ifneq (,$(findstring -64,$(SPEC)))
-  TEMP_TARGET_DATASIZE:=64
-else
-  TEMP_TARGET_DATASIZE:=31
+
+# Override datasize for 31-bit specs.
+ifeq (,$(findstring -64,$(SPEC)))
+  TEMP_TARGET_DATASIZE := 31
 endif
 
 # Notes (on disabled flags):


### PR DESCRIPTION
configure_common.mk (derived from configure_common.mk.ftl) defines `OMR_TARGET_DATASIZE` as 32 or 64 based on the value of `SPEC`. Other configuration makefile fragments only need to override that macro if a different value is needed.