### PR TITLE
Set default graphSepcs to SPEC in testKitGen

### DIFF
--- a/test/TestConfig/run_configure.mk
+++ b/test/TestConfig/run_configure.mk
@@ -37,12 +37,19 @@ ifneq (,$(findstring Win,$(OS)))
 CURRENT_DIR := $(subst \,/,$(CURRENT_DIR))
 endif
 
+ifndef SPEC
+$(error Please provide SPEC that matches the current platform (e.g. SPEC=linux_x86-64))
+else
+export SPEC:=$(SPEC)
+$(info set SPEC to $(SPEC))
+endif
+
 autoconfig:
 	perl configure.pl
 
 autogen: autoconfig
 	cd $(CURRENT_DIR)$(D)scripts$(D)testKitGen; \
-	perl testKitGen.pl $(OPTS); \
+	perl testKitGen.pl --graphSpecs=$(SPEC) $(OPTS); \
 	cd $(CURRENT_DIR);
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)

--- a/test/TestConfig/scripts/testKitGen/testKitGen.pl
+++ b/test/TestConfig/scripts/testKitGen/testKitGen.pl
@@ -84,9 +84,7 @@ if ( !$projectRootDir ) {
 }
 
 if ( !$graphSpecs ) {
-	$graphSpecs =
-	"aix_ppc,aix_ppc-64,aix_ppc-64_cmprssptrs,aix_ppc-64_cmprssptrs_purec,aix_ppc-64_purec,aix_ppc_purec,linux_390,linux_390-64,linux_390-64_cmprssptrs,linux_390-64_cmprssptrs_purec,linux_390-64_cs,linux_390-64_purec,linux_390_purec,linux_arm,linux_ppc-64_cmprssptrs_le,linux_ppc-64_cmprssptrs_le_cs,linux_ppc-64_cmprssptrs_le_purec,linux_ppc-64_le,linux_ppc-64_le_purec,linux_x86,linux_x86-64,linux_x86-64_cmprssptrs,linux_x86-64_cmprssptrs_cs,linux_x86-64_cmprssptrs_purec,linux_x86-64_purec,linux_x86_purec,win_x86,win_x86-64,win_x86-64_cmprssptrs,win_x86-64_cmprssptrs_purec,win_x86-64_purec,win_x86_purec,zos_390,zos_390-64,zos_390-64_cmprssptrs,zos_390-64_cmprssptrs_cs,zos_390-64_cmprssptrs_purec,zos_390-64_purec,zos_390_purec";
-	print "graphSpecs is not provided. Set graphSpecs = $graphSpecs\n";
+	die "Please provide graphSpecs!"
 }
 
 # run make file generator


### PR DESCRIPTION
- Remove hard coded graphSepcs and replace it with environment variable
SPEC provided by user

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>