### PR TITLE
Evaluator changes for helper call

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2491,12 +2491,12 @@ fast_jitCollapseJNIReferenceFrame(J9VMThread *currentThread)
 }
 
 UDATA J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitInstanceOf(J9VMThread *currentThread, j9object_t object, J9Class *castClass)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitInstanceOf(J9VMThread *currentThread, J9Class *castClass, j9object_t object)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 	JIT_HELPER_PROLOGUE();
 	UDATA isInstance = 0;
@@ -2545,12 +2545,12 @@ fast_jitNewObjectNoZeroInit(J9VMThread *currentThread, J9Class *objectClass)
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitANewArray(J9VMThread *currentThread, I_32 size, J9Class *elementClass)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86  || J9VM_ARCH_S390*/
 fast_jitANewArray(J9VMThread *currentThread, J9Class *elementClass, I_32 size)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitANewArray(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2563,12 +2563,12 @@ fast_jitANewArray(J9VMThread *currentThread, J9Class *elementClass, I_32 size)
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitANewArrayNoZeroInit(J9VMThread *currentThread, I_32 size, J9Class *elementClass)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitANewArrayNoZeroInit(J9VMThread *currentThread, J9Class *elementClass, I_32 size)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitANewArrayNoZeroInit(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2581,12 +2581,12 @@ fast_jitANewArrayNoZeroInit(J9VMThread *currentThread, J9Class *elementClass, I_
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitNewArray(J9VMThread *currentThread, I_32 size, I_32 arrayType)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitNewArray(J9VMThread *currentThread, I_32 arrayType, I_32 size)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitNewArray(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2599,12 +2599,12 @@ fast_jitNewArray(J9VMThread *currentThread, I_32 arrayType, I_32 size)
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitNewArrayNoZeroInit(J9VMThread *currentThread, I_32 size, I_32 arrayType)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitNewArrayNoZeroInit(J9VMThread *currentThread, I_32 arrayType, I_32 size)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitNewArrayNoZeroInit(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2617,12 +2617,12 @@ fast_jitNewArrayNoZeroInit(J9VMThread *currentThread, I_32 arrayType, I_32 size)
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitCheckCast(J9VMThread *currentThread, j9object_t object, J9Class *castClass)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitCheckCast(J9VMThread *currentThread, J9Class *castClass, j9object_t object)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitCheckCast(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2641,12 +2641,12 @@ fast_jitCheckCast(J9VMThread *currentThread, J9Class *castClass, j9object_t obje
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitCheckCastForArrayStore(J9VMThread *currentThread, j9object_t object, J9Class *castClass)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitCheckCastForArrayStore(J9VMThread *currentThread, J9Class *castClass, j9object_t object)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitCheckCastForArrayStore(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2746,12 +2746,12 @@ fast_jitMonitorExit(J9VMThread *currentThread, j9object_t syncObject)
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread, j9object_t objectBeingStored, j9object_t destinationObject)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread, j9object_t destinationObject, j9object_t objectBeingStored)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 //	extern void* slow_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread);
 	JIT_HELPER_PROLOGUE();
@@ -2764,12 +2764,12 @@ fast_jitTypeCheckArrayStoreWithNullCheck(J9VMThread *currentThread, j9object_t d
 }
 
 void* J9FASTCALL
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 fast_jitTypeCheckArrayStore(J9VMThread *currentThread, j9object_t objectBeingStored, j9object_t destinationObject)
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 fast_jitTypeCheckArrayStore(J9VMThread *currentThread, j9object_t destinationObject, j9object_t objectBeingStored)
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 {
 	JIT_HELPER_PROLOGUE();
 	/* Not omitting NULL check */

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -173,12 +173,12 @@ void J9FASTCALL fast_jitVolatileWriteDouble(J9VMThread *currentThread, U_64 *add
 #endif /* !J9VM_ENV_DATA64 */
 void J9FASTCALL fast_jitCheckIfFinalizeObject(J9VMThread *currentThread, j9object_t object);
 void J9FASTCALL fast_jitCollapseJNIReferenceFrame(J9VMThread *currentThread);
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_S390)
 /* TODO Will be cleaned once all platforms adopt the correct parameter order */
 UDATA J9FASTCALL fast_jitInstanceOf(J9VMThread *currentThread, j9object_t object, J9Class *castClass);
-#else /* J9VM_ARCH_X86 */
+#else /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 UDATA J9FASTCALL fast_jitInstanceOf(J9VMThread *currentThread, J9Class *castClass, j9object_t object);
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_S390*/
 UDATA J9FASTCALL fast_jitObjectHashCode(J9VMThread *currentThread, j9object_t object);
 
 #ifdef __cplusplus

--- a/runtime/tr.source/trj9/z/codegen/J9S390CHelperLinkage.hpp
+++ b/runtime/tr.source/trj9/z/codegen/J9S390CHelperLinkage.hpp
@@ -122,50 +122,6 @@ public:
       return buildDirectDispatch(callNode, NULL, returnReg);
       }
 
-   /** \brief
-    *       Overloaded function that builds the direct dispatch sequence for given node using C Helper linkage
-    *       using already evaluated parameters from paramInRegister and is passed stores result in returnReg
-    *
-    *  \param callNode
-    *       TR::Node* for which helper dispatch sequence will be generated
-    *
-    *  \param &paramInRegister
-    *       A stack of TR::Register* which will be used to prepare arguments for helper call instead of evaluating children of callNode
-    * 
-    *  \param returnReg
-    *       TR::Register* allocated by consumer of this API. If passed dispatch sequence will use this register to store return value from helper
-    *       instead from allocating new register.
-    *
-    *  \return
-    *      Returns TR::Register* which contains return value from helper call
-    */  
-   TR::Register* buildDirectDispatch(TR::Node *callNode, TR_Stack<TR::Register*>& paramInRegister, TR::Register *returnReg=NULL)
-   	{
-   	return buildDirectDispatch(callNode, NULL, paramInRegister, returnReg);
-   	}
-
-   /** \brief
-    *       Overloaded function to be used within internal control flow to build the direct dispatch sequence for given node using C Helper linkage
-    *
-    *  \param callNode
-    *       TR::Node* for which helper dispatch sequence will be generated
-    *
-    *  \param **deps
-    *       A register dependency condition which will be filled with helper call condition so that consumer can combine with the dependency condition
-    *       of internal control flow and attach it to merge label
-    * 
-    *  \param returnReg
-    *       TR::Register* allocated by consumer of this API. If passed dispatch sequence will use this register to store return value from helper
-    *       instead from allocating new register.
-    *
-    *  \return
-    *      Returns TR::Register* which contains return value from helper call
-    */  
-   TR::Register *buildDirectDispatch(TR::Node *callNode, TR::RegisterDependencyConditions** deps, TR::Register *returnReg=NULL)
-   	{
-   	TR_Stack<TR::Register*> paramInRegisters(cg()->trMemory());
-   	return buildDirectDispatch(callNode, deps, paramInRegisters, returnReg);
-   	}
-   TR::Register *buildDirectDispatch(TR::Node *callNode, TR::RegisterDependencyConditions** deps, TR_Stack<TR::Register*>& paramInRegisters, TR::Register *returnReg);
+   TR::Register *buildDirectDispatch(TR::Node *callNode, TR::RegisterDependencyConditions** deps, TR::Register *returnReg=NULL);
    };
 }

--- a/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -2072,7 +2072,7 @@ J9::Z::TreeEvaluator::instanceofEvaluator(TR::Node * node, TR::CodeGenerator * c
    if (comp->getOption(TR_OptimizeForSpace) || comp->getOption(TR_DisableInlineInstanceOf))
       {
       TR::ILOpCodes opCode = node->getOpCodeValue();
-      TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+      TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
       TR::Node::recreate(node, TR::icall);
       TR::Register * targetRegister = helperLink->buildDirectDispatch(node);
       for (auto i=0; i < node->getNumChildren(); i++)
@@ -3940,7 +3940,7 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
       // as it needs not be exec'd
       generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCodeFromNode(sourceChild), node, srcReg, 0, TR::InstOpCode::COND_BE, (doWrtBar || doCrdMrk)?simpleStoreLabel:wbLabel, false, true);
       }
-   TR::S390CHelperLinkage *helperLink = static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   TR::S390CHelperLinkage *helperLink = static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
    if (nopASC)
       {
       // Speculatively NOP the array store check if VP is able to prove that the ASC
@@ -5533,7 +5533,7 @@ void genInstanceOfDynamicCacheAndHelperCall(TR::Node *node, TR::CodeGenerator *c
       outlinedSlowPath->swapInstructionListsWithCompilation();
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, helperCallLabel);
    cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "instanceOf/(%s)/Helper", comp->signature()),1,TR::DebugCounter::Undetermined);
-   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
    resultReg = helperLink->buildDirectDispatch(node, resultReg);
    if (generateDynamicCache)
       {
@@ -6327,7 +6327,7 @@ J9::Z::TreeEvaluator::VMcheckcastEvaluator2(TR::Node * node, TR::CodeGenerator *
 
 
    srm->addScratchRegistersToDependencyList(conditions);
-   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
    // We will be generating sequence to call Helper if we have either GoToFalse or HelperCall Test
    if (numSequencesRemaining > 0 && *iter != GoToTrue)
       {
@@ -6704,7 +6704,7 @@ J9::Z::TreeEvaluator::VMmonentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
-   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
 
    if (comp->getOption(TR_OptimizeForSpace) ||
        (comp->getOption(TR_FullSpeedDebug) && node->isSyncMethodMonitor()) ||
@@ -7146,7 +7146,7 @@ J9::Z::TreeEvaluator::VMmonexitEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    int32_t lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
-   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
    if (comp->getOption(TR_OptimizeForSpace) ||
        comp->getOption(TR_DisableInlineMonExit) ||
        comp->getOption(TR_FullSpeedDebug))  // Required for Live Monitor Meta Data in FSD.

--- a/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/tr.source/trj9/z/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *instanceofEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *checkcastEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *checkcastAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *generateHelperCallForVMNewEvaluators(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *generateHelperCallForVMNewEvaluators(TR::Node *node, TR::CodeGenerator *cg, bool doInlineAllocation = false, TR::Register *resReg = NULL);
    static TR::Register *newObjectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *newArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *anewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.cpp
+++ b/runtime/tr.source/trj9/z/codegen/ReduceSynchronizedFieldLoad.cpp
@@ -229,7 +229,7 @@ ReduceSynchronizedFieldLoad::inlineSynchronizedFieldLoad(TR::Node* node, TR::Cod
 
    TR::LabelSymbol* helperCallLabel = generateLabelSymbol(cg);
    TR::Instruction* helperCallLabelInstr = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, helperCallLabel);
-   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->createLinkage(TR_CHelper));
+   TR::S390CHelperLinkage *helperLink =  static_cast<TR::S390CHelperLinkage*>(cg->getLinkage(TR_CHelper));
    
    // Calling helper with call node which should NULL
    helperLink->buildDirectDispatch(monentSymbolReferenceNode);


### PR DESCRIPTION
This PR consists of following changes. 
1. Correcting argument order of VM's JIT helpers to match proper C linkage which was previously following private linkage for historical reasons. x86 has already fixed this and in this commit we are correcting argument order on IBM Z.
2. Corresponding changes in `S390CHelperLinkage` to load argument register in correct order. 
3. We do not need to construct a new linkage every time we want to generate a helper call so use `getLinkage(TR_CHelper)` instead of `createLinkage(TR_CHelper)` in evaluators to generate helper call.
4. For 64-bit VM when we pass arguments to JIT helper for new allocations, we need to sign extend type/size child node of newarray or anewarray node as C helper linkage uses whole 64-bit register and evaluating 32-bit child of node only changes lower half of the register. This commit creates a call node `acall` for generating helper call sequence for new allocation node with 64-bit extended child if needed. 