### PR TITLE
Revert "Fix bug in calculating cpu entitlement by JIT"

### DIFF
--- a/runtime/tr.source/trj9/env/CpuUtilization.cpp
+++ b/runtime/tr.source/trj9/env/CpuUtilization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -389,19 +389,18 @@ void TR_CpuEntitlement::computeAndCacheCpuEntitlement()
    _numTargetCpu = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
    if (_numTargetCpu == 0)
       _numTargetCpu = 1; // some correction in case we get it wrong
-   uint32_t numTargetCpuEntitlement = _numTargetCpu * 100;
    if (isHypervisorPresent())
       {
       _guestCpuEntitlement = computeGuestCpuEntitlement();
       // If the number of target CPUs is smaller (bind the JVM to a subset of CPUs), use that value
-      if (numTargetCpuEntitlement < _guestCpuEntitlement || _guestCpuEntitlement <= 0)
-         _jvmCpuEntitlement = numTargetCpuEntitlement;
+      if (_numTargetCpu < _guestCpuEntitlement || _guestCpuEntitlement <= 0)
+         _jvmCpuEntitlement = _numTargetCpu * 100;
       else
          _jvmCpuEntitlement = _guestCpuEntitlement;
       }
    else
       {
-      _jvmCpuEntitlement = numTargetCpuEntitlement;
+      _jvmCpuEntitlement = _numTargetCpu * 100;
       }
    }
 

--- a/runtime/tr.source/trj9/env/CpuUtilization.hpp
+++ b/runtime/tr.source/trj9/env/CpuUtilization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -187,12 +187,7 @@ struct TR_CpuEntitlement
 public:
    // The constructor cannot set all fields correctly because we have to make
    // sure te portlib is up and running
-   void init(J9JITConfig *jitConfig)
-      {
-      _hypervisorPresent = TR_maybe;
-      _jitConfig = jitConfig;
-      computeAndCacheCpuEntitlement();
-      }
+   void init(J9JITConfig *jitConfig) { _jitConfig = jitConfig; computeAndCacheCpuEntitlement();}
    bool isHypervisorPresent();
    void computeAndCacheCpuEntitlement(); // used during bootstrap and periodically in samplerThreadProc
    uint32_t getNumTargetCPUs()     const { return _numTargetCpu; }  // num CPUs the JVM is pinned to. Guaranteed >= 1


### PR DESCRIPTION
Reverts eclipse/openj9#45

This change results in some java.lang.Math tests to fail when JVM is running on VMWare hypervisor.
It also causes JVM to core dump when an application is using libjsig.so (for signal chaining) and is running on VMWare hypervisor.

Signed-off-by: Ashutosh Mehra asmehra1@in.ibm.com