### PR TITLE
Allow J9 tools to build on OpenJDK7

### DIFF
--- a/sourcetools/buildj9tools.mk
+++ b/sourcetools/buildj9tools.mk
@@ -57,7 +57,7 @@ endif
 JAVAC       := $(JAVA_BIN)javac
 JAR         := $(JAVA_BIN)jar
 
-SPEC_LEVEL  ?= 8
+SPEC_LEVEL  ?= 7
 JAVAC_FLAGS := -nowarn -source $(SPEC_LEVEL) -target $(SPEC_LEVEL)
 
 JAR_TARGETS :=


### PR DESCRIPTION
The documentation for building OpenJDK8 says to use OpenJDK7 as the
boot java. This means that the tools compilation fails because it
tries to use java 8 as the target level. Java 7 doesn't know about
target 8. Since the tools compile fine on Java 7, we should changing
the SPEC_LEVEL (target) to 7 so we can compile the tools with the same
boot java we use to build OpenJDK8.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>