### PR TITLE
Fix rmiregistry AccessControlException

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1205,10 +1205,15 @@ protected Class<?> loadClass(final String className, boolean resolveClass) throw
  */
 final Class<?> loadClass(Module module, String className) {
 	Class<?> localClass = null;
-	try {
-		localClass = loadClassHelper(className, false, false, module);
-	} catch (ClassNotFoundException e) {
-		// returns null if the class can't be found
+	
+	if ((bootstrapClassLoader == null) || (this == bootstrapClassLoader)) {
+		localClass = VMAccess.findClassOrNull(className, bootstrapClassLoader);
+	} else {
+		try {
+			localClass = loadClassHelper(className, false, false, module);
+		} catch (ClassNotFoundException e) {
+			// returns null if the class can't be found
+		}
 	}
 	return localClass;
 }

--- a/test/Java9andUp/playlist.xml
+++ b/test/Java9andUp/playlist.xml
@@ -197,20 +197,37 @@
 		</subsets>
 	</test>
 
-        <test>
-                <testCaseName>constantPoolTagTests</testCaseName>
-                <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-        -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
-        org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-        -testnames constantPoolTagTests \
-        -groups $(TEST_GROUP) \
-        -excludegroups $(DEFAULT_EXCLUDE); \
-        $(TEST_STATUS)</command>
-                <tags>
-                        <tag>extended</tag>
-                </tags>
-                <subsets>
-                        <subset>SE90</subset>
-                </subsets>
-        </test>
+	<test>
+		<testCaseName>constantPoolTagTests</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames constantPoolTagTests \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	
+	<test>
+		<testCaseName>Test_Class</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames Test_Class \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>sanity</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>	
 </playlist>

--- a/test/Java9andUp/src_current/org/openj9/test/java/lang/Test_Class.java
+++ b/test/Java9andUp/src_current/org/openj9/test/java/lang/Test_Class.java
@@ -1,0 +1,64 @@
+package org.openj9.test.java.lang;
+
+import java.lang.Class;
+import java.lang.ClassNotFoundException;
+import java.lang.reflect.Module;
+import java.security.AllPermission;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+@Test(groups = { "level.sanity" })
+@SuppressWarnings("nls")
+public class Test_Class {
+	
+	public static AllPermission		ALL_PERMISSION = new AllPermission();
+
+/**
+ * @tests java.lang.Class#forName(java.lang.String)
+ * @tests java.lang.Class#forName(java.lang.Module, java.lang.String)
+ */
+@Test
+public void test_forName() {
+	try {
+		// package java.rmi exported by module java.rmi
+		Class<?> jrAccessExceptionClz = Class.forName("java.rmi.AccessException");
+		AssertJUnit.assertNotNull(jrAccessExceptionClz);
+		if (!jrAccessExceptionClz.getProtectionDomain().implies(ALL_PERMISSION)) {
+			AssertJUnit.fail("java.rmi.AccessException should have all permission!");
+		}
+
+		Module  jrModule = jrAccessExceptionClz.getModule();
+		Class<?> jrAlreadyBoundExceptionClz = Class.forName(jrModule, "java.rmi.AlreadyBoundException");
+		if ((jrAlreadyBoundExceptionClz == null) || !jrAlreadyBoundExceptionClz.getProtectionDomain().implies(ALL_PERMISSION)) {
+			AssertJUnit.fail("java.rmi.AlreadyBoundException should have all permission as well!");
+		}
+	} catch (ClassNotFoundException e) {
+		AssertJUnit.fail("Unexpected ClassNotFoundException: " + e.getMessage());
+	}
+}
+
+}

--- a/test/Java9andUp/src_latest/org/openj9/test/java/lang/Test_Class.java
+++ b/test/Java9andUp/src_latest/org/openj9/test/java/lang/Test_Class.java
@@ -1,0 +1,64 @@
+package org.openj9.test.java.lang;
+
+import java.lang.Class;
+import java.lang.ClassNotFoundException;
+import java.lang.Module;
+import java.security.AllPermission;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.AssertJUnit;
+
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+@Test(groups = { "level.sanity" })
+@SuppressWarnings("nls")
+public class Test_Class {
+	
+	public static AllPermission		ALL_PERMISSION = new AllPermission();
+
+/**
+ * @tests java.lang.Class#forName(java.lang.String)
+ * @tests java.lang.Class#forName(java.lang.Module, java.lang.String)
+ */
+@Test
+public void test_forName() {
+	try {
+		// package java.rmi exported by module java.rmi
+		Class<?> jrAccessExceptionClz = Class.forName("java.rmi.AccessException");
+		AssertJUnit.assertNotNull(jrAccessExceptionClz);
+		if (!jrAccessExceptionClz.getProtectionDomain().implies(ALL_PERMISSION)) {
+			AssertJUnit.fail("java.rmi.AccessException should have all permission!");
+		}
+
+		Module  jrModule = jrAccessExceptionClz.getModule();
+		Class<?> jrAlreadyBoundExceptionClz = Class.forName(jrModule, "java.rmi.AlreadyBoundException");
+		if ((jrAlreadyBoundExceptionClz == null) || !jrAlreadyBoundExceptionClz.getProtectionDomain().implies(ALL_PERMISSION)) {
+			AssertJUnit.fail("java.rmi.AlreadyBoundException should have all permission as well!");
+		}
+	} catch (ClassNotFoundException e) {
+		AssertJUnit.fail("Unexpected ClassNotFoundException: " + e.getMessage());
+	}
+}
+
+}

--- a/test/Java9andUp/testng.xml
+++ b/test/Java9andUp/testng.xml
@@ -88,8 +88,13 @@
 		</classes>
 	</test>
 	<test name="constantPoolTagTests">
-                <classes>
-                        <class name="org.openj9.test.constantPoolTags.ConstantPoolTagTests" />
-                </classes>
-        </test>
+		<classes>
+			<class name="org.openj9.test.constantPoolTags.ConstantPoolTagTests" />
+		</classes>
+	</test>
+	<test name="Test_Class">
+		<classes>
+			<class name="org.openj9.test.java.lang.Test_Class" />
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
Fix `rmiregistry AccessControlException`

bootstrap classloader should load a class via `VMAccess.findClassOrNull()` instead of `ClassLoader.defineClass()`. `VMAccess.findClassOrNull()` will load class with all permissions while `ClassLoader.defineClass()` loads class with a protection domain within the security context.
Added a test for this scenario.

Issue: #301

Reviewer @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>