### PR TITLE
Compressed Reference Support for Loads

### DIFF
--- a/runtime/compiler/trj9/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/trj9/optimizer/SPMDParallelizer.cpp
@@ -573,8 +573,14 @@ bool TR_SPMDKernelParallelizer::visitTreeTopToSIMDize(TR::TreeTop *tt, TR_SPMDKe
          }
       }
    else if (scalarOp.isBranch() || node->getOpCodeValue()==TR::BBEnd ||
-            node->getOpCodeValue()==TR::BBStart || node->getOpCodeValue()==TR::asynccheck)
+            node->getOpCodeValue()==TR::BBStart || node->getOpCodeValue()==TR::asynccheck || 
+            (node->getOpCodeValue()==TR::compressedRefs && node->getFirstChild()->getOpCode().isLoad()))
       {
+      //Compressed ref treetops with a load can be ignored due to the load 
+      // either being present under another tree top in the loop, which
+      // will be processed, or not used at all. Stores under a compressed ref
+      // tree top, will need to be handled differently
+
       //ignore
       return true;
       }

--- a/runtime/compiler/trj9/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/trj9/optimizer/SPMDPreCheck.cpp
@@ -51,8 +51,11 @@ bool SPMDPreCheck::isSPMDCandidate(TR::Compilation *comp, TR_RegionStructure *lo
             case TR::BBStart:
             case TR::BBEnd:
             case TR::asynccheck:
-            case TR::compressedRefs:
                continue;
+               //SIMD Compressed Refs support only for loads
+            case TR::compressedRefs:
+               if (node->getFirstChild()->getOpCode().isLoad())
+                   continue;
             }
 
           // explicitly allowed families of opcodes


### PR DESCRIPTION
Auto SIMD will no longer invalidate an entire loop for vectorization if a
compressed reference load is present. Auto SIMD will ignore this treetop, and
continue to determine if any other tree tops in the loop are candidates for
vectorization. If the load is present elsewhere in the loop, it will be
vectorized later.

This approach cannot be taken with a compressed reference tree top with a
store child. Ignoring the compressed reference treetop will lead to an
unvectorized store within a loop that will be vectorized.


Signed-off-by: Ryan Santhirarajan <rsanth@ca.ibm.com>