### PR TITLE
Ensure the variable not overriden by local hard-coded value

### DIFF
--- a/runtime/makelib/mkconstants.mk.ftl
+++ b/runtime/makelib/mkconstants.mk.ftl
@@ -24,9 +24,7 @@
 </#list>
 
 # Define the Java Version we are compiling
-# This VERSION_MAJOR variable will be overridden by command line option 
-# when there is one such as VERSION_MAJOR=xx.
-VERSION_MAJOR:=9
+VERSION_MAJOR?=9
 export VERSION_MAJOR
 
 # Define a default target of the root directory for all targets.


### PR DESCRIPTION
Ensure the variable not overriden by local hard-coded value

`:=` overrides the value set via command line option, and `?=` works correctly in this case, i.e., in this particular case `VERSION_MAJOR 10` for `Java 18.3` is passed in and used by late program/scripts.  

Issue: #293

Reviewer @keithc-ca 
FYI: @DanHeidinga @pshipton 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>