### PR TITLE
WIP: Adopt OMR's Runtime Helper for CRC32

### DIFF
--- a/runtime/compiler/trj9/build/files/common.mk
+++ b/runtime/compiler/trj9/build/files/common.mk
@@ -370,8 +370,10 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/trj9/runtime/GPUHelpers.cpp \
     compiler/trj9/runtime/CRuntimeImpl.cpp \
     compiler/trj9/runtime/JitRuntime.cpp \
+    omr/compiler/runtime/RuntimeHelpers.cpp \
     compiler/trj9/runtime/RuntimeAssumptions.cpp \
     compiler/trj9/runtime/ValueProfiler.cpp
+
 
 -include $(JIT_MAKE_DIR)/files/extra.mk
 include $(JIT_MAKE_DIR)/files/host/$(HOST_ARCH).mk

--- a/runtime/compiler/trj9/build/files/target/x.mk
+++ b/runtime/compiler/trj9/build/files/target/x.mk
@@ -52,6 +52,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/OMRRealRegister.cpp \
     omr/compiler/x/codegen/OMRRegisterDependency.cpp \
     omr/compiler/x/codegen/OMRSnippet.cpp \
+    omr/compiler/x/codegen/X86FastCallLinkage.cpp \
     omr/compiler/x/codegen/X86SystemLinkage.cpp \
     omr/compiler/x/codegen/XMMBinaryArithmeticAnalyser.cpp \
     omr/compiler/x/codegen/OMRCodeGenerator.cpp \
@@ -76,7 +77,6 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/trj9/x/codegen/WriteBarrierSnippet.cpp \
     compiler/trj9/x/codegen/J9AheadOfTimeCompile.cpp \
     compiler/trj9/x/codegen/X86PrivateLinkage.cpp \
-    compiler/trj9/x/codegen/X86HelperLinkage.cpp \
     compiler/trj9/x/codegen/X86Recompilation.cpp \
     compiler/trj9/x/codegen/J9LinkageUtils.cpp \
     compiler/trj9/x/env/J9CPU.cpp \

--- a/runtime/compiler/trj9/il/J9Node.cpp
+++ b/runtime/compiler/trj9/il/J9Node.cpp
@@ -323,7 +323,7 @@ J9::Node::processJNICall(TR::TreeTop * callNodeTreeTop, TR::ResolvedMethodSymbol
       return self();
       }
 
-#if defined(TR_TARGET_POWER)
+#if defined(TR_TARGET_POWER) || defined(TR_TARGET_X86)
    if (((methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_update) ||
         (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateBytes) ||
         (methodSymbol->getRecognizedMethod() == TR::java_util_zip_CRC32_updateByteBuffer)) &&

--- a/runtime/compiler/trj9/runtime/JitRuntime.cpp
+++ b/runtime/compiler/trj9/runtime/JitRuntime.cpp
@@ -1157,6 +1157,8 @@ JIT_HELPER(_induceRecompilation);
 
 void initializeJitRuntimeHelperTable(char isSMP)
    {
+   runtimeHelpers.initialize();
+
    #define SET runtimeHelpers.setAddress
    #define SET_CONST runtimeHelpers.setConstant
 

--- a/runtime/compiler/trj9/x/amd64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/x/amd64/codegen/J9CodeGenerator.cpp
@@ -39,6 +39,9 @@ J9::X86::AMD64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 
    switch (lc)
       {
+      case TR_FastCall:
+         linkage = new (self()->trHeapMemory()) TR::X86FastCallLinkage(self());
+         break;
       case TR_CHelper:
          linkage = new (self()->trHeapMemory()) TR::X86HelperLinkage(self());
          break;

--- a/runtime/compiler/trj9/x/codegen/X86HelperLinkage.hpp
+++ b/runtime/compiler/trj9/x/codegen/X86HelperLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,108 +23,67 @@
 #ifndef X86_HELPERLINKAGE_INCL
 #define X86_HELPERLINKAGE_INCL
 
-#include "codegen/Linkage.hpp"
-#include "env/jittypes.h"
+#include "codegen/X86FastCallLinkage.hpp"
 
-namespace TR { class CodeGenerator; }
-namespace TR { class Instruction; }
-namespace TR { class LabelSymbol; }
-namespace TR { class Node; }
-namespace TR { class RegisterDependencyConditions; }
-
-#define IMCOMPLETELINKAGE  "This class is only used to generate call-out sequence but no call-in sequence, so it is not used as a complete linkage."
-
-// This class implements following calling conventions on different platforms:
-//     X86-32 Windows and Linux: fastcall
-//     X86-64 Windows          : Microsoft x64 calling convention, an extension of fastcall
-//     X86-64 Linux            : System V AMD64 ABI
-// This initial version has following limitations:
-//     1. Floating point parameters are not currently in-support.
-//     2. Return value can only be at most pointer size, i.e. DWORD on X86-32 and QWORD on X86-64.
 namespace TR {
-class X86HelperCallSite
+
+class X86HelperLinkage : public X86FastCallLinkage
    {
    public:
-   X86HelperCallSite(TR::Node* callNode, TR::CodeGenerator* cg) :
-      _cg(cg),
-      _Node(callNode),
-      _ReturnType(callNode->getDataType()),
-      _SymRef(callNode->getSymbolReference()),
-      _Params(cg->trMemory())
-      {}
-   X86HelperCallSite(TR::Node* callNode, TR::DataType callReturnType, TR::SymbolReference* callSymRef, TR::CodeGenerator* cg) :
-      _cg(cg),
-      _Node(callNode),
-      _ReturnType(callReturnType),
-      _SymRef(callSymRef),
-      _Params(cg->trMemory())
-      {}
-   void AddParam(TR::Register* param)
-      {
-      TR_ASSERT(param->getKind() == TR_GPR, "HelperCallSite now only support GPR");
-      _Params.add(param);
-      }
-   TR::Register* BuildCall();
-   TR::CodeGenerator* cg() const
-      {
-      return _cg;
-      }
-   static const uint32_t                 PreservedRegisterMapForGC;
-   static const bool                     CalleeCleanup;
-   static const bool                     RegisterParameterShadowOnStack;
-   static const size_t                   StackSlotSize;
-   static const size_t                   NumberOfIntParamRegisters;;
-   static const size_t                   StackIndexAdjustment;
-   static const TR::RealRegister::RegNum IntParamRegisters[];
-   static const TR::RealRegister::RegNum CallerSavedRegisters[];
-   static const TR::RealRegister::RegNum CalleeSavedRegisters[];
-
-   private:
-   TR::CodeGenerator*      _cg;
-   TR::Node*               _Node;
-   TR::SymbolReference*    _SymRef;
-   TR::DataType            _ReturnType;
-   TR_Array<TR::Register*> _Params;
-   };
-
-class X86HelperLinkage : public TR::Linkage
-   {
-   public:
-   X86HelperLinkage(TR::CodeGenerator *cg) : TR::Linkage(cg) {}
-   const X86LinkageProperties& getProperties() { return _Properties; }
-   virtual void createPrologue(TR::Instruction *cursor) { TR_ASSERT(false, IMCOMPLETELINKAGE); }
-   virtual void createEpilogue(TR::Instruction *cursor) { TR_ASSERT(false, IMCOMPLETELINKAGE); }
-   virtual TR::Register* buildIndirectDispatch(TR::Node *callNode) { TR_ASSERT(false, "Indirect dispatch is not currently supported"); return NULL; }
+   X86HelperLinkage(TR::CodeGenerator *cg) : X86FastCallLinkage(cg) {}
    virtual TR::Register* buildDirectDispatch(TR::Node* callNode, bool spillFPRegs)
       {
-      X86HelperCallSite CallSite(callNode, cg());
-      // Evaluate children
-      for (int i = 0; i < callNode->getNumChildren(); i++)
+      switch (callNode->getSymbolReference()->getReferenceNumber())
          {
-         cg()->evaluate(callNode->getChild(i));
+         case TR_checkCast:
+         case TR_checkCastForArrayStore:
+         case TR_instanceOf:
+         case TR_monitorEntry:
+         case TR_methodMonitorEntry:
+         case TR_monitorExit:
+         case TR_methodMonitorExit:
+         case TR_newObject:
+         case TR_newArray:
+         case TR_aNewArray:
+         case TR_newObjectNoZeroInit:
+         case TR_newArrayNoZeroInit:
+         case TR_aNewArrayNoZeroInit:
+         case TR_typeCheckArrayStore:
+         case TR_jitCheckIfFinalizeObject:
+#ifdef TR_TARGET_64BIT
+         case TR_AMD64JitMonitorEnterReserved:
+         case TR_AMD64JitMonitorEnterReservedPrimitive:
+         case TR_AMD64JitMonitorEnterPreservingReservation:
+         case TR_AMD64JitMonitorExitReserved:
+         case TR_AMD64JitMonitorExitReservedPrimitive:
+         case TR_AMD64JitMonitorExitPreservingReservation:
+         case TR_AMD64JitMethodMonitorEnterReserved:
+         case TR_AMD64JitMethodMonitorEnterReservedPrimitive:
+         case TR_AMD64JitMethodMonitorEnterPreservingReservation:
+         case TR_AMD64JitMethodMonitorExitPreservingReservation:
+         case TR_AMD64JitMethodMonitorExitReservedPrimitive:
+         case TR_AMD64JitMethodMonitorExitReserved:
+#endif
+#ifdef TR_TARGET_32BIT
+         case TR_IA32JitMonitorEnterReserved:
+         case TR_IA32JitMonitorEnterReservedPrimitive:
+         case TR_IA32JitMonitorEnterPreservingReservation:
+         case TR_IA32JitMonitorExitReserved:
+         case TR_IA32JitMonitorExitReservedPrimitive:
+         case TR_IA32JitMonitorExitPreservingReservation:
+         case TR_IA32JitMethodMonitorEnterReserved:
+         case TR_IA32JitMethodMonitorEnterReservedPrimitive:
+         case TR_IA32JitMethodMonitorEnterPreservingReservation:
+         case TR_IA32JitMethodMonitorExitPreservingReservation:
+         case TR_IA32JitMethodMonitorExitReservedPrimitive:
+         case TR_IA32JitMethodMonitorExitReserved:
+#endif
+            return buildCall(callNode, cg()->getVMThreadRegister());
+         default:
+            return buildCall(callNode);
          }
-      // Setup parameters
-      for (int i = callNode->getNumChildren() - 1; i >= 0; i--)
-         {
-         CallSite.AddParam(callNode->getChild(i)->getRegister());
-         }
-      // Supply VMThread as the first parameter if necessary
-      if (!callNode->getSymbol()->getMethodSymbol()->isSystemLinkageDispatch())
-         {
-         CallSite.AddParam(cg()->getVMThreadRegister());
-         }
-      TR::Register* ret = CallSite.BuildCall();
-      // Release children
-      for (int i = 0; i < callNode->getNumChildren(); i++)
-         {
-         cg()->decReferenceCount(callNode->getChild(i));
-         }
-      return ret;
       }
-
-   private:
-   X86LinkageProperties _Properties;
-};
+   };
 
 }
 #endif

--- a/runtime/compiler/trj9/x/i386/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/x/i386/codegen/J9CodeGenerator.cpp
@@ -36,6 +36,9 @@ J9::X86::i386::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 
    switch (lc)
       {
+      case TR_FastCall:
+         linkage = new (self()->trHeapMemory()) TR::X86FastCallLinkage(self());
+         break;
       case TR_CHelper:
          linkage = new (self()->trHeapMemory()) TR::X86HelperLinkage(self());
          break;

--- a/runtime/tr.source/trj9/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/tr.source/trj9/optimizer/J9RecognizedCallTransformer.cpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+* Copyright (c) 2017, 2017 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+* or the Apache License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following
+* Secondary Licenses when the conditions for such availability set
+* forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+* General Public License, version 2 with the GNU Classpath
+* Exception [1] and GNU General Public License, version 2 with the
+* OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*******************************************************************************/
+
+#include "optimizer/RecognizedCallTransformer.hpp"
+
+#include "compile/ResolvedMethod.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/VMJ9.h"
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "optimizer/CallInfo.hpp"
+#include "optimizer/J9CallGraph.hpp"
+#include "optimizer/PreExistence.hpp"
+#include "optimizer/Structure.hpp"
+#include "codegen/CodeGenerator.hpp"                      // for CodeGenerator
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"                                   // for ILOpCode, etc
+#include "ilgen/IlGenRequest.hpp"
+#include "ilgen/IlGeneratorMethodDetails.hpp"
+#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "optimizer/Structure.hpp"                        // TR_RegionAnalysis
+#include "optimizer/StructuralAnalysis.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "env/SharedCache.hpp"                            // for TR_SharedCache
+#include "env/VMJ9.h"
+#include "ras/DebugCounter.hpp"
+
+void J9::RecognizedCallTransformer::processSimpleMath(TR::Node* node, TR::ILOpCodes opcode)
+   {
+   TR::Node::recreate(node, opcode);
+   }
+
+void J9::RecognizedCallTransformer::processCRC32(TR::Node* node)
+   {
+   //TR::Node::recreate(node, opcode);
+   while (node->getNumChildren() > 4)
+      {
+      node->removeChild(0);
+      }
+   auto iv     = node->getAndDecChild(0);
+   auto object = node->getAndDecChild(1);
+   auto offset = node->getAndDecChild(2);
+   auto size   = node->getAndDecChild(3);
+
+   node->setAndIncChild(0, iv);
+   node->setAndIncChild(1, TR::Node::create(TR::aiadd, 2, TR::Node::create(TR::aiadd, 2, object,
+                                                                           TR::Node::iconst(8)), // TODO: 8 be replaced of array header size
+                                            offset));
+   node->setAndIncChild(2, size);
+   node->setChild(3, NULL);
+   node->setNumChildren(3);
+   node->setSymbolReference(comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_CRC32, true, true, true));
+   }
+
+bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
+   {
+   auto node = treetop->getNode()->getFirstChild();
+   switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
+      {
+      case TR::java_lang_Integer_rotateLeft:
+         return TR::Compiler->target.cpu.isX86();
+      case TR::java_lang_Math_max_I:
+      case TR::java_lang_Math_min_I:
+      case TR::java_lang_Math_max_L:
+      case TR::java_lang_Math_min_L:
+         return TR::Compiler->target.cpu.isX86() && !comp()->getOption(TR_DisableMaxMinOptimization);
+      case TR::java_util_zip_CRC32_updateBytes:
+         return TR::Compiler->target.cpu.isX86();
+      default:
+         return false;
+      }
+   }
+
+void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
+   {
+   auto node = treetop->getNode()->getFirstChild();
+   switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
+      {
+      case TR::java_lang_Integer_rotateLeft:
+         processSimpleMath(node, TR::irol);
+         break;
+      case TR::java_lang_Math_max_I:
+         processSimpleMath(node, TR::imax);
+         break;
+      case TR::java_lang_Math_min_I:
+         processSimpleMath(node, TR::imin);
+         break;
+      case TR::java_lang_Math_max_L:
+         processSimpleMath(node, TR::lmax);
+         break;
+      case TR::java_lang_Math_min_L:
+         processSimpleMath(node, TR::lmin);
+         break;
+      case TR::java_util_zip_CRC32_updateBytes:
+         processCRC32(node);
+         break;
+      default:
+         break;
+      }
+   }

--- a/runtime/tr.source/trj9/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/tr.source/trj9/optimizer/J9RecognizedCallTransformer.hpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright (c) 2017, 2017 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+* or the Apache License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following
+* Secondary Licenses when the conditions for such availability set
+* forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+* General Public License, version 2 with the GNU Classpath
+* Exception [1] and GNU General Public License, version 2 with the
+* OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*******************************************************************************/
+
+#ifndef J9RECOGNIZEDCALLTRANSFORMER_INCL
+#define J9RECOGNIZEDCALLTRANSFORMER_INCL
+
+#include "optimizer/OMRRecognizedCallTransformer.hpp"
+
+namespace J9
+{
+
+class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
+   {
+   public:
+   RecognizedCallTransformer(TR::OptimizationManager* manager)
+      : OMR::RecognizedCallTransformer(manager)
+      {}
+
+   protected:
+   virtual bool isInlineable(TR::TreeTop* treetop);
+   virtual void transform(TR::TreeTop* treetop);
+
+   private:
+   void processSimpleMath(TR::Node* node, TR::ILOpCodes opcode);
+   void processCRC32(TR::Node* node);
+   };
+
+}
+#endif

--- a/runtime/tr.source/trj9/optimizer/RecognizedCallTransformer.hpp
+++ b/runtime/tr.source/trj9/optimizer/RecognizedCallTransformer.hpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2017, 2017 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+* or the Apache License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following
+* Secondary Licenses when the conditions for such availability set
+* forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+* General Public License, version 2 with the GNU Classpath
+* Exception [1] and GNU General Public License, version 2 with the
+* OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*******************************************************************************/
+
+#ifndef TR_RECOGNIZEDCALLTRANSFORMER_INCL
+#define TR_RECOGNIZEDCALLTRANSFORMER_INCL
+
+#include "optimizer/J9RecognizedCallTransformer.hpp"
+
+namespace TR
+{
+
+class RecognizedCallTransformer : public J9::RecognizedCallTransformer
+   {
+   public:
+   RecognizedCallTransformer(TR::OptimizationManager *manager) :
+      J9::RecognizedCallTransformer(manager) {}
+   };
+
+}
+
+#endif


### PR DESCRIPTION
OMR introduced an utility for CRC32, and OpenJ9 can
leverage it to accerlate CRC32 calculation.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>