### PR TITLE
Add .vs directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ com.ibm.jvmti.tests
 
 # Root level .project should be ignored as Eclipse automatically creates this file when new repositories are added as Projects for C/C++ indexing
 /.project
+
+# Visual Studio
+/.vs


### PR DESCRIPTION
Visual Studio 2017 uses the .vs directory to store metadata on folder
type projects such as OpenJ9. These files should never be committed to
the repository and as such are great candidates to be ignored during
staging of git commits.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>