### PR TITLE
Fix the issue with boolean arrays in verifier

### DIFF
--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -651,7 +651,7 @@ CFR_STACKMAP_TYPE_INT_ARRAY, CFR_STACKMAP_TYPE_LONG_ARRAY,  0,                  
 0,                           0,                             0,                             0,
 0,                           0,                             CFR_STACKMAP_TYPE_SHORT_ARRAY, 0,
 0,                           0,                             0,                             0,
-0,                           CFR_STACKMAP_TYPE_BYTE_ARRAY,  0};
+0,                           CFR_STACKMAP_TYPE_BOOL_ARRAY,  0};
 
 class ROMClassWriter::CallSiteWriter : public ConstantPoolMap::CallSiteVisitor
 {
@@ -880,6 +880,7 @@ private:
 			 *  Encode the primitive array type in the tag field.
 			 *  One of:
 			 *   CFR_STACKMAP_TYPE_BYTE_ARRAY
+			 *   CFR_STACKMAP_TYPE_BOOL_ARRAY
 			 *   CFR_STACKMAP_TYPE_CHAR_ARRAY
 			 *   CFR_STACKMAP_TYPE_DOUBLE_ARRAY
 			 *   CFR_STACKMAP_TYPE_FLOAT_ARRAY

--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2392,7 +2392,7 @@ j9bcv_verifyBytecodes (J9PortLibrary * portLib, J9Class * clazz, J9ROMClass * ro
 	/* save current and set vmState */
 	oldState = verifyData->vmStruct->omrVMThread->vmState;
 	verifyData->vmStruct->omrVMThread->vmState = J9VMSTATE_BCVERIFY;
-	
+
 	verifyData->romClass = romClass;
 	verifyData->errorPC = 0;
 	

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -747,7 +747,8 @@ _inconsistentStack2:
 					break;
 				} else {
 					type = (UDATA) J9JavaBytecodeArrayTypeTable[bc - JBiaload];
-					inconsistentStack |= (type != arrayType);
+					/* The operand checking for baload needs to cover the case of boolean arrays */
+					CHECK_BOOL_ARRAY(JBbaload, bc, type);
 					if (inconsistentStack) {
 						/* Jazz 82615: Set the expected data type (already in type) and the location of wrong data type
 						 * on stack when the verification error occurs.
@@ -924,8 +925,10 @@ _inconsistentStack2:
 						errorStackIndex = (stackTop - liveStack->stackElements) + 2;
 						goto _inconsistentStack;
 					}
+
 					type2 = (UDATA) J9JavaBytecodeArrayTypeTable[bc - JBiastore];
-					inconsistentStack |= (arrayType != type2);
+					/* The operand checking for bastore needs to cover the case of boolean arrays */
+					CHECK_BOOL_ARRAY(JBbastore, bc, type2);
 					if (inconsistentStack) {
 						/* Jazz 82615: Set the expected data type and the location of wrong data type 
 						 * on stack when the verification error occurs.
@@ -1734,8 +1737,6 @@ _illegalPrimitiveReturn:
 				break;
 
 			case JBnewarray:
-				index = PARAM_8(bcIndex, 1);
-				type = (UDATA) newArrayParamConversion[index];
 				POP_TOS_INTEGER;	/* pop the size of the array */
 				if (inconsistentStack) {
 					/* Jazz 82615: Set the expected data type and the location of wrong data type
@@ -1745,6 +1746,9 @@ _illegalPrimitiveReturn:
 					errorStackIndex = stackTop - liveStack->stackElements;
 					goto _inconsistentStack;
 				}
+
+				index = PARAM_8(bcIndex, 1);
+				type = (UDATA) newArrayParamConversion[index];
 				PUSH(type);	/* arity of one implicit */
 				break;
 
@@ -2520,10 +2524,6 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 				}
 
 				objectType = (UDATA) baseTypeCharConversion[*signature - 'A'];
-				/* Jazz 82615: Tagged as 'bool' when baseTypeCharConversion returns BCV_BASE_TYPE_BYTE_BIT for type 'Z' */
-				if ('Z' == *signature) {
-					boolType = TRUE;
-				}
 				signature++;
 
 				if (!objectType) {
@@ -2581,9 +2581,6 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 					mrc = BCV_FAIL;
 					verifyData->errorDetailCode = BCV_ERR_INCOMPATIBLE_TYPE; /* failure - object type mismatch */
 					verifyData->errorTargetType = objectType;
-					if (boolType) {
-						verifyData->errorTargetType |= BCV_BASE_TYPE_BOOL_BIT;
-					}
 					break;
 				}
 			}
@@ -2606,7 +2603,12 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 			}
 
 			baseType = (UDATA) argTypeCharConversion[*signature - 'A'];
-			/* Jazz 82615: Tagged as 'bool' when argTypeCharConversion returns BCV_BASE_TYPE_BYTE_BIT for type 'Z' */
+			/* Jazz 82615: Tagged as 'bool' when argTypeCharConversion returns BCV_BASE_TYPE_INT for type 'Z'
+			 * Note: for base type, type B (byte) and type Z (boolean) correspond to the verification type int.
+			 * In such case, there is no way to determine whether the original type is byte or boolean after the
+			 * conversion of argument type. To ensure type Z is correctly generated to the error messages, we need
+			 * to filter it out here by checking the type in signature.
+			 */
 			if ('Z' == *signature) {
 				boolType = TRUE;
 			}
@@ -2637,10 +2639,7 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 						index, J9UTF8_LENGTH(utf8string), J9UTF8_DATA(utf8string), stackTop[index]);
 				mrc = BCV_FAIL;
 				verifyData->errorDetailCode = BCV_ERR_INCOMPATIBLE_TYPE; /* failure - primitive mismatch */
-				verifyData->errorTargetType = baseType;
-				if (boolType) {
-					verifyData->errorTargetType |= BCV_BASE_TYPE_BOOL_BIT;
-				}
+				verifyData->errorTargetType = (TRUE == boolType) ? BCV_BASE_TYPE_BOOL : baseType;
 				break;
 			}
 
@@ -2657,10 +2656,7 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 							index, J9UTF8_LENGTH(utf8string), J9UTF8_DATA(utf8string));
 					mrc = BCV_FAIL;
 					verifyData->errorDetailCode = BCV_ERR_INCOMPATIBLE_TYPE; /* failure - wide primitive mismatch */
-					verifyData->errorTargetType = baseType;
-					if (boolType) {
-						verifyData->errorTargetType |= BCV_BASE_TYPE_BOOL_BIT;
-					}
+					verifyData->errorTargetType = (TRUE == boolType) ? BCV_BASE_TYPE_BOOL : baseType;
 					break;
 				}
 			}

--- a/runtime/bcverify/vrfyconvert.c
+++ b/runtime/bcverify/vrfyconvert.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ const U_32 newArrayParamConversion[] = {
 0,
 0,
 0,
-(BCV_BASE_TYPE_BYTE_BIT | BCV_TAG_BASE_ARRAY_OR_NULL),		/* 4 */
+(BCV_BASE_TYPE_BOOL_BIT | BCV_TAG_BASE_ARRAY_OR_NULL),		/* 4 */
 (BCV_BASE_TYPE_CHAR_BIT | BCV_TAG_BASE_ARRAY_OR_NULL),		/* 5 */
 (BCV_BASE_TYPE_FLOAT_BIT | BCV_TAG_BASE_ARRAY_OR_NULL),		/* 6 */
 (BCV_BASE_TYPE_DOUBLE_BIT | BCV_TAG_BASE_ARRAY_OR_NULL),	/* 7 */
@@ -67,7 +67,7 @@ BCV_BASE_TYPE_INT_BIT,	BCV_BASE_TYPE_LONG_BIT,		0,							0,
 0,						0,							0,							0,
 0,						0,							BCV_BASE_TYPE_SHORT_BIT,	0, 
 0,						0,							0,							0,
-0,						BCV_BASE_TYPE_BYTE_BIT,		0}; 
+0,						BCV_BASE_TYPE_BOOL_BIT,		0};
 
 /* mapping characters A..Z,[ */
 const U_32 argTypeCharConversion[] = {
@@ -134,5 +134,6 @@ BCV_BASE_ARRAY_TYPE_DOUBLE,		/* B - CFR_STACKMAP_TYPE_DOUBLE_ARRAY */
 BCV_BASE_ARRAY_TYPE_LONG,		/* C - CFR_STACKMAP_TYPE_LONG_ARRAY */
 BCV_BASE_ARRAY_TYPE_SHORT,		/* D - CFR_STACKMAP_TYPE_SHORT_ARRAY */
 BCV_BASE_ARRAY_TYPE_BYTE,		/* E - CFR_STACKMAP_TYPE_BYTE_ARRAY */
-BCV_BASE_ARRAY_TYPE_CHAR		/* F - CFR_STACKMAP_TYPE_CHAR_ARRAY */
+BCV_BASE_ARRAY_TYPE_CHAR,		/* F - CFR_STACKMAP_TYPE_CHAR_ARRAY */
+BCV_BASE_ARRAY_TYPE_BOOL		/* 10 - CFR_STACKMAP_TYPE_BOOL_ARRAY */
 };

--- a/runtime/bcverify/vrfyconvert.h
+++ b/runtime/bcverify/vrfyconvert.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,9 +27,9 @@
 
 extern const U_32 decodeTable[];
 extern const U_32 newArrayParamConversion[];
-extern const U_32 baseTypeCharConversion[]; 
-extern const U_32 argTypeCharConversion[]; 
-extern const U_32 oneArgTypeCharConversion[]; 
+extern const U_32 baseTypeCharConversion[];
+extern const U_32 argTypeCharConversion[];
+extern const U_32 oneArgTypeCharConversion[];
 extern const U_8  verificationBaseTokenEncode[];
 extern const U_8  verificationBaseArrayTokenEncode[];
 extern const U_32 verificationTokenDecode[];

--- a/runtime/oti/bytecodewalk.h
+++ b/runtime/oti/bytecodewalk.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -130,6 +130,7 @@ base types: (in the 19bit class index field)
 #define BCV_BASE_TYPE_SHORT					(BCV_TAG_BASE_TYPE_OR_TOP | BCV_BASE_TYPE_SHORT_BIT)
 #define BCV_BASE_TYPE_BYTE					(BCV_TAG_BASE_TYPE_OR_TOP | BCV_BASE_TYPE_BYTE_BIT)
 #define BCV_BASE_TYPE_CHAR					(BCV_TAG_BASE_TYPE_OR_TOP | BCV_BASE_TYPE_CHAR_BIT)
+#define BCV_BASE_TYPE_BOOL					(BCV_TAG_BASE_TYPE_OR_TOP | BCV_BASE_TYPE_BOOL_BIT)
 
 #define BCV_BASE_ARRAY_TYPE_INT				(BCV_TAG_BASE_ARRAY_OR_NULL | BCV_BASE_TYPE_INT_BIT)
 #define BCV_BASE_ARRAY_TYPE_FLOAT			(BCV_TAG_BASE_ARRAY_OR_NULL | BCV_BASE_TYPE_FLOAT_BIT)
@@ -138,6 +139,7 @@ base types: (in the 19bit class index field)
 #define BCV_BASE_ARRAY_TYPE_SHORT			(BCV_TAG_BASE_ARRAY_OR_NULL | BCV_BASE_TYPE_SHORT_BIT)
 #define BCV_BASE_ARRAY_TYPE_BYTE			(BCV_TAG_BASE_ARRAY_OR_NULL | BCV_BASE_TYPE_BYTE_BIT)
 #define BCV_BASE_ARRAY_TYPE_CHAR			(BCV_TAG_BASE_ARRAY_OR_NULL | BCV_BASE_TYPE_CHAR_BIT)
+#define BCV_BASE_ARRAY_TYPE_BOOL			(BCV_TAG_BASE_ARRAY_OR_NULL | BCV_BASE_TYPE_BOOL_BIT)
 
 #define BCV_INDEX_FROM_TYPE(type) (((type) & BCV_CLASS_INDEX_MASK) >> BCV_CLASS_INDEX_SHIFT)
 #define BCV_ARITY_FROM_TYPE(type) (((type) & BCV_ARITY_MASK) >> BCV_ARITY_SHIFT)

--- a/runtime/oti/cfreader.h
+++ b/runtime/oti/cfreader.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,11 +69,12 @@
 
 #define	CFR_STACKMAP_TYPE_INT_ARRAY				0x09
 #define	CFR_STACKMAP_TYPE_FLOAT_ARRAY			0x0A
-#define	CFR_STACKMAP_TYPE_DOUBLE_ARRAY		0x0B
+#define	CFR_STACKMAP_TYPE_DOUBLE_ARRAY			0x0B
 #define	CFR_STACKMAP_TYPE_LONG_ARRAY			0x0C
 #define	CFR_STACKMAP_TYPE_SHORT_ARRAY			0x0D
 #define	CFR_STACKMAP_TYPE_BYTE_ARRAY			0x0E
 #define	CFR_STACKMAP_TYPE_CHAR_ARRAY			0x0F
+#define	CFR_STACKMAP_TYPE_BOOL_ARRAY			0x10
 
 #define	CFR_METHOD_NAME_INIT	1
 #define	CFR_METHOD_NAME_CLINIT	2

--- a/runtime/util/mthutil.c
+++ b/runtime/util/mthutil.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -332,6 +332,7 @@ walkStackMapSlots(U_8 *framePointer, U_16 typeInfoCount)
 			framePointer += 2; /* Skip offset */
 			break;
 		case CFR_STACKMAP_TYPE_BYTE_ARRAY: /* fall through 7 cases */
+		case CFR_STACKMAP_TYPE_BOOL_ARRAY:
 		case CFR_STACKMAP_TYPE_CHAR_ARRAY:
 		case CFR_STACKMAP_TYPE_DOUBLE_ARRAY:
 		case CFR_STACKMAP_TYPE_FLOAT_ARRAY:

--- a/runtime/verbose/errormessage_internal.c
+++ b/runtime/verbose/errormessage_internal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ const char* dataTypeNames[] = {
 	"S",											/* CFR_STACKMAP_TYPE_SHORT_ARRAY					0x0D */
 	"B",											/* CFR_STACKMAP_TYPE_BYTE_ARRAY						0x0E */
 	"C",											/* CFR_STACKMAP_TYPE_CHAR_ARRAY						0x0F */
-	"Z"												/* STACKMAP_TYPE_BOOL_ARRAY						    0x10 */
+	"Z"												/* CFR_STACKMAP_TYPE_BOOL_ARRAY						0x10 */
 };
 
 /* Length of data type string */

--- a/runtime/verbose/errormessage_internal.h
+++ b/runtime/verbose/errormessage_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,9 +60,6 @@ extern "C" {
 #define INDEX_SIGNATURE				0x02
 #define INDEX_CLASSNAME				0x03
 #define	INDEX_CLASSNAMELIST			0x04
-
-/* Internal use in the error message framework to tag the BOOL array */
-#define STACKMAP_TYPE_BOOL_ARRAY	0x10
 
 #define INDENT(n) (n), " "
 

--- a/runtime/verbose/errormessagehelper.c
+++ b/runtime/verbose/errormessagehelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -665,9 +665,8 @@ bcvToBaseTypeNameIndex(UDATA bcvType)
 	case BCV_BASE_TYPE_CHAR_BIT:
 		index = isArray ? CFR_STACKMAP_TYPE_CHAR_ARRAY : CFR_STACKMAP_TYPE_INT;
 		break;
-	case (BCV_BASE_TYPE_BOOL_BIT | BCV_BASE_TYPE_BYTE_BIT):   /* Jazz 82615: baseTypeCharConversion returns BCV_BASE_TYPE_BYTE_BIT for type 'Z' */
-	case (BCV_BASE_TYPE_BOOL_BIT | BCV_BASE_TYPE_INT_BIT):    /*             argTypeCharConversion returns BCV_BASE_TYPE_INT for type 'Z' */
-		index = isArray ? STACKMAP_TYPE_BOOL_ARRAY : CFR_STACKMAP_TYPE_INT;
+	case BCV_BASE_TYPE_BOOL_BIT:
+		index = isArray ? CFR_STACKMAP_TYPE_BOOL_ARRAY : CFR_STACKMAP_TYPE_INT;
 		break;
 	default:
 		index = isArray ? CFR_STACKMAP_TYPE_NULL : CFR_STACKMAP_TYPE_TOP;
@@ -828,7 +827,7 @@ mapDataTypeToUTF8String(J9UTF8Ref* dataType, StackMapFrame* stackMapFrame, Metho
 	case CFR_STACKMAP_TYPE_SHORT_ARRAY:		/* FALLTHROUGH */
 	case CFR_STACKMAP_TYPE_BYTE_ARRAY:		/* FALLTHROUGH */
 	case CFR_STACKMAP_TYPE_CHAR_ARRAY:		/* FALLTHROUGH */
-	case STACKMAP_TYPE_BOOL_ARRAY:
+	case CFR_STACKMAP_TYPE_BOOL_ARRAY:
 		/* Set the name string for array type (only used for runtime verification) */
 		dataType->bytes = (U_8*)dataTypeNames[tag];
 		dataType->length = dataTypeLength[tag];
@@ -954,7 +953,7 @@ printTypeInfoToBuffer(MessageBuffer* buf, U_8 tag, J9UTF8Ref* dataType, BOOLEAN 
 	case CFR_STACKMAP_TYPE_SHORT_ARRAY:		/* FALLTHROUGH */
 	case CFR_STACKMAP_TYPE_BYTE_ARRAY:		/* FALLTHROUGH */
 	case CFR_STACKMAP_TYPE_CHAR_ARRAY:		/* FALLTHROUGH */
-	case STACKMAP_TYPE_BOOL_ARRAY:
+	case CFR_STACKMAP_TYPE_BOOL_ARRAY:
 		/* Base type array.
 		 * Note: arity 1 is implicitly set to 0 for base type array during verification, which means
 		 * 0 is used for arity 1, 1 for arity 2, 2 for arity 3 and so forth.

--- a/test/VM_Test/src/com/ibm/j9/recreateclass/tests/RecreateClassCompareTest.java
+++ b/test/VM_Test/src/com/ibm/j9/recreateclass/tests/RecreateClassCompareTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -129,10 +129,11 @@ public class RecreateClassCompareTest extends TestCase {
 
 	public void testStackMapTableTestWithBooleanArray() throws Exception {
 		System.out.println("Start testStackMapTableTestWithBooleanArray");
-		/* Recreated StackMapTableWithByteBooleanArrayTest is expected to have byte array instead of boolean array 
-		 * in verification_type array of StackMapTable.
+		/* To follow the Java 9 Spec in which boolean arrays are different from byte arrays
+		 * in terms of verfication type, Recreated StackMapTableWithByteBooleanArrayTest is 
+		 * expected to keep boolean array in verification_type array of StackMapTable.
 		 */
-		runTest(StackMapTableWithByteBooleanArrayTest.class, 1);
+		runTest(StackMapTableWithByteBooleanArrayTest.class, 0);
 		System.out.println("End testStackMapTableTestWithBooleanArray");
 	}
 	


### PR DESCRIPTION
Given that boolean arrays are different from
byte arrays in Java 9 Spec, the change is to
ensure that boolean arrays are correctly
recognized and captured if any mismatch when
comparing with byte arrays in verifier.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>