### PR TITLE
Export JVM state part of RuntimeMXBean

### DIFF
--- a/jcl/src/com.ibm.management/share/classes/com/ibm/lang/management/RuntimeMXBean.java
+++ b/jcl/src/com.ibm.management/share/classes/com/ibm/lang/management/RuntimeMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corp. and others
+ * Copyright (c) 2012, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,35 @@ package com.ibm.lang.management;
  * The IBM-specific interface for the runtime system of the virtual machine.
  */
 public interface RuntimeMXBean extends java.lang.management.RuntimeMXBean {
+
+	/**
+	 * enum type defines the different states of the VM Idle 
+	 */
+	public enum VMIdleStates {
+		/* Below constant values reflect J9VMRuntimeStateListener.vmRuntimeState
+		 * from the VM and the VM constants J9VM_RUNTIME_STATE_ACTIVE and
+		 * J9VM_RUNTIME_STATE_IDLE. These values need to match the VM values.
+		 */
+		INVALID(-1, "Invalid"),
+		ACTIVE(1, "Active"),
+		IDLE(2, "Idle");
+
+		private int stateVal;
+		private String stateName;
+
+		private VMIdleStates(int val, String name) {
+			this.stateVal = val;
+			this.stateName = name;
+		}
+
+		public int idleStateValue() {
+			return this.stateVal;
+		}
+
+		public String idleStateName() {
+			return this.stateName;
+		}
+	}
 
 	/**
 	 * Returns a double value which holds the system load average calculated for
@@ -68,4 +97,15 @@ public interface RuntimeMXBean extends java.lang.management.RuntimeMXBean {
 	 */
 	public double getVMGeneratedCPULoad();
 
+	/**
+	 * Returns current JVM Idle state.
+	 *
+	 * @return JVM idle state value - i.e active / idle
+	 */
+	public VMIdleStates getVMIdleState();
+
+	/**
+	 * Return true if JVM state is idle. Otherwise returns false
+	 */
+	public boolean isVMIdle();
 }

--- a/jcl/src/com.ibm.management/share/classes/com/ibm/lang/management/internal/ExtendedRuntimeMXBeanImpl.java
+++ b/jcl/src/com.ibm.management/share/classes/com/ibm/lang/management/internal/ExtendedRuntimeMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,4 +79,32 @@ public final class ExtendedRuntimeMXBeanImpl extends RuntimeMXBeanImpl implement
 		return os.getSystemLoadAverage() / os.getAvailableProcessors();
 	}
 
+	private native int getVMIdleStateImpl();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public VMIdleStates getVMIdleState() {
+		int vmIdleState = getVMIdleStateImpl();
+
+		for (VMIdleStates idleState : VMIdleStates.values()) {
+			if (vmIdleState == idleState.idleStateValue()) {
+				return idleState;
+			}
+		}
+		/* control never reaches here */
+		return VMIdleStates.INVALID;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isVMIdle() {
+		if (VMIdleStates.IDLE == getVMIdleState()) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/runtime/jcl/common/mgmtruntime.c
+++ b/runtime/jcl/common/mgmtruntime.c
@@ -80,3 +80,14 @@ Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getProcessIDImpl
 	pid =  (jlong) j9sysinfo_get_pid();
 	return pid;
 }
+
+/**
+ * @return vm idle state of the JVM
+ */
+jint JNICALL
+Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getVMIdleStateImpl(JNIEnv *env, jclass clazz)
+{
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
+
+	return (jint)(javaVM->vmRuntimeStateListener.vmRuntimeState); 
+}

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -171,6 +171,7 @@
 	<export name="Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_getUptimeImpl" />
 	<export name="Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_isBootClassPathSupportedImpl" />
 	<export name="Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getProcessIDImpl" />
+	<export name="Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getVMIdleStateImpl" />
 	<export name="Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_findMonitorDeadlockedThreadsImpl" />
 	<export name="Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_getAllThreadIdsImpl" />
 	<export name="Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_getDaemonThreadCountImpl" />

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5005,7 +5005,9 @@ typedef struct J9VMRuntimeStateListener {
 	UDATA idleTuningFlags;
 } J9VMRuntimeStateListener;
 
-/* Values for J9VMRuntimeStateListener.vmRuntimeState */
+/* Values for J9VMRuntimeStateListener.vmRuntimeState
+ * These values are reflected in the Java class library code(RuntimeMXBean)
+ */
 #define J9VM_RUNTIME_STATE_ACTIVE 1
 #define J9VM_RUNTIME_STATE_IDLE 2
 

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -112,6 +112,8 @@ extern J9_CFUNC jobject JNICALL
 Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_getNameImpl (JNIEnv *env, jobject beanInstance);
 extern J9_CFUNC jlong JNICALL
 Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getProcessIDImpl(JNIEnv *env, jclass clazz);
+extern J9_CFUNC jint JNICALL
+Java_com_ibm_lang_management_internal_ExtendedRuntimeMXBeanImpl_getVMIdleStateImpl(JNIEnv *env, jclass clazz);
 
 /* J9SourceManagementOperatingSystem*/
 jdouble JNICALL

--- a/test/JLM_Tests/src/org/openj9/test/java/lang/management/TestRuntimeMXBean.java
+++ b/test/JLM_Tests/src/org/openj9/test/java/lang/management/TestRuntimeMXBean.java
@@ -92,6 +92,8 @@ public class TestRuntimeMXBean {
 		attribs.put("CPULoad", new AttributeData(Double.TYPE.getName(), true, false, false));
 		attribs.put("ProcessID", new AttributeData(Long.TYPE.getName(), true, false, false));
 		attribs.put("VMGeneratedCPULoad", new AttributeData(Double.TYPE.getName(), true, false, false));
+		attribs.put("VMIdleState", new AttributeData(String.class.getName(), true, false, false));
+		attribs.put("VMIdle", new AttributeData(Boolean.TYPE.getName(), true, false, true));
 	}// end static initializer
 
 	private RuntimeMXBean rb;
@@ -617,14 +619,19 @@ public class TestRuntimeMXBean {
 		// Print description and the class name (not necessarily identical).
 		logger.debug("MBean description for " + rb.getClass().getName() + ": " + mbi.getDescription());
 
-		// Sixteen attributes - none writable - and three IBM specific.
+		// Sixteen attributes - none writable - and five IBM specific.
 		MBeanAttributeInfo[] attributes = mbi.getAttributes();
 		AssertJUnit.assertNotNull(attributes);
-		AssertJUnit.assertTrue(attributes.length == 20);
+		AssertJUnit.assertTrue(attributes.length == 22);
 		for (int i = 0; i < attributes.length; i++) {
 			MBeanAttributeInfo info = attributes[i];
 			AssertJUnit.assertNotNull(info);
 			AllManagementTests.validateAttributeInfo(info, TestRuntimeMXBean.ignoredAttributes, attribs);
 		} // end for
+	}
+
+	@Test
+	public final void testVMIdleState() {
+		AssertJUnit.assertTrue(com.ibm.lang.management.RuntimeMXBean.VMIdleStates.INVALID != ((com.ibm.lang.management.RuntimeMXBean)rb).getVMIdleState());
 	}
 }


### PR DESCRIPTION
Runtime state of the JVM could be either active or idle.  This PR exposes the current runtime state through existing RuntimeMXBean.

Closes: #510 
Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>