### PR TITLE
Fix MethodHandles jck tests

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1215,7 +1215,7 @@ K0650=The parameter count of the combiner: {0} must be {1} the parameter count o
 K0651=The clause array must be non-null: {0}
 K0652=No clause exists in the clause array: {0}
 K0653=Each clause in the clause array must be non-null: {0}
-K0654=No method handle exists in the clause: {0}
+
 K0655=At most 4 method handles are allowed in each clause: {0}
 K0656=The return type of predicate must be boolean: {0}
 K0657=There must be at least one predicate in the clause array


### PR DESCRIPTION
Fixes the following JCK tests:
CountedLoop3ParamTests - testBodyWithTypeHavingWrongForm
DoWhileLoopTests - testBodyDoesntConstraintExternalParameterList
LoopTests - ignoreAllNullClauses
LoopTypesTests
*Other MethodHandle failures to be addressed in later commit as they require a larger change

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>