### PR TITLE
Prevent division by zero in IProfiler

### DIFF
--- a/runtime/tr.source/trj9/runtime/IProfiler.cpp
+++ b/runtime/tr.source/trj9/runtime/IProfiler.cpp
@@ -2875,8 +2875,8 @@ TR_IPBCDataCallGraph::getData(TR::Compilation *comp)
       {
       traceMsg(comp, "\nMax weight %d, current sum weight %d\n", maxWeight, sumWeight);
       }
-
-   if (((float)maxWeight/(float)sumWeight)<0.1f)
+   // prevent potential division by zero
+   if (sumWeight && ((float)maxWeight/(float)sumWeight) < 0.1f)
       {
 //#ifdef VERBOSE_INLINING_PROFILING
       TR_IProfiler::_STATS_weakProfilingRatio ++;


### PR DESCRIPTION
A crash is possible on some platforms due to a hardware exception
caused by division by zero. Therefore we need to prevent that
possibility.

Signed-off-by: Simon Hirst <shirst@ca.ibm.com>