### PR TITLE
Fix OpenJ9 Java 8 signature test failures

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1270,7 +1270,7 @@ public abstract class MethodHandle {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
-	protected MethodHandle getTarget() {
+	MethodHandle getTarget() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
@@ -1278,7 +1278,7 @@ public abstract class MethodHandle {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
-	public MethodHandle asTypeUncached(MethodType newType) {
+	MethodHandle asTypeUncached(MethodType newType) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	


### PR DESCRIPTION
Fix OpenJ9 Java 8 signature test failures

Removed protect modifier from method getTarget();
Removed public modifier from asTypeUncached().

Close: #531 

Reviewer @pshipton 
FYI: @DanHeidinga @adamfarley 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>