### PR TITLE
Disable support for hypervisor in JIT

### DIFF
--- a/runtime/tr.source/trj9/env/CpuUtilization.hpp
+++ b/runtime/tr.source/trj9/env/CpuUtilization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -189,7 +189,15 @@ public:
    // sure te portlib is up and running
    void init(J9JITConfig *jitConfig)
       {
-      _hypervisorPresent = TR_maybe;
+      /* Couple of issues were discovered when the support for hypervisor was enabled.
+       * When JVM ran on VMWare, then the port library loaded libvmGuestLib.so which
+       * interferes with implementation of some of j.l.Math methods.
+       * The library also causes JVM to core dump when an application is using libjsig.so
+       * for signal chaining.
+       * For these reasons, support for hypervisor is being disabled until the issues with
+       * VMWare library are resolved.
+       */
+      _hypervisorPresent = TR_no;
       _jitConfig = jitConfig;
       computeAndCacheCpuEntitlement();
       }


### PR DESCRIPTION
Disable support for hypervisor in JIT as it results in
some java.lang.Math tests to fail when JVM is running on
VMWare hypervisor.
It also causes JVM to core dump when an application is
using libjsig.so (for signal chaining) and is running on
VMWare hypervisor.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>