### PR TITLE
Improve locking

### DIFF
--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -487,24 +487,20 @@ spinOnTryEnter(J9VMThread *currentThread, J9ObjectMonitor *objectMonitor, j9obje
 	}
 #endif /* OMR_THR_JLM */
 
-#if defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL)
-	bool tryEnterSpin = true;
-	if (monitor->spinThreads < lib->maxSpinThreads) {
-		VM_AtomicSupport::add(&monitor->spinThreads, 1);
-	} else {
-		tryEnterSpinCount1 = 1;
-		tryEnterSpinCount2 = 1;
-		tryEnterYieldCount = 1;
-		tryEnterSpin = false;
-	}
-#endif /* defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL) */
-
 	/* Need to store the original value of tryEnterSpinCount2 since it gets overridden during non-nested spinning */
 	UDATA tryEnterSpinCount2Init = tryEnterSpinCount2;
-	
+
 	UDATA _tryEnterYieldCount = tryEnterYieldCount;
 	UDATA _tryEnterSpinCount2 = tryEnterSpinCount2;
 
+#if defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL)
+	if (monitor->spinThreads < lib->maxSpinThreads) {
+		VM_AtomicSupport::add(&monitor->spinThreads, 1);
+	} else {
+		goto exit;
+	}
+#endif /* defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL) */
+	
 	/* we have the monitor object from the lock word so prime the cache with the monitor so we do not later look it up from the monitor table */
 #if defined(J9VM_THR_LOCK_NURSERY)
 	cacheObjectMonitorForLookup(vm, currentThread, objectMonitor);
@@ -596,11 +592,10 @@ update_jlm:
 #endif /* OMR_THR_JLM */
 
 #if defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL)
-	if (tryEnterSpin) {
-		VM_AtomicSupport::subtract(&monitor->spinThreads, 1);
-	}
-#endif /* defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL) */
+	VM_AtomicSupport::subtract(&monitor->spinThreads, 1);
 
+exit:
+#endif /* defined(OMR_THR_THREE_TIER_LOCKING) && defined(OMR_THR_SPIN_WAKE_CONTROL) */
 	return rc;
 }
 


### PR DESCRIPTION
Change 1:
```
Currently, there is a limit (spin_thread_limit) on how many threads can
spin at a time on a monitor/lock. Over this spin_thread_limit, threads
don't spin but try to acquire the lock once before waiting. This can
cause high CPU utilization if there are large number of threads that try
to acquire a monitor/lock.

Now onwards, threads over the spin_thread_limit will immediately wait
instead of trying to acquire the monitor/lock once. This will help avoid
high CPU utilization.
```
Change 2:
```
High CPU utilization is seen for micro-contended locks; locks with small
critical-section/hold-time. Depending upon available CPUs,
maxSpinThreads is scaled down to reduce high CPU utilization.

For 1-4 CPU machines, maxSpinThreads is set to (available_CPUs).
For 5-16 CPU machines, maxSpinThreads is set to (available_CPUs/2).
For 17-64 CPU machines, maxSpinThreads is set to (available_CPUs/3).
For greater than 64 CPU machines, maxSpinThreads is set to
(available_CPUs/4).
```
These changes depend on eclipse/omr#1979.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>