### PR TITLE
Remove SPP Step from AIX Builds

### DIFF
--- a/runtime/tr.source/trj9/build/rules/aix-xlc/filetypes.mk
+++ b/runtime/tr.source/trj9/build/rules/aix-xlc/filetypes.mk
@@ -103,8 +103,10 @@ endef # DEF_RULE.ipp
 
 RULE.ipp=$(eval $(DEF_RULE.ipp))
 
-# Compile .aspp file into .ipp file
-define DEF_RULE.aspp
+#
+# Compile .spp file into .o file
+#
+define DEF_RULE.spp
 $(1).ipp: $(2) | jit_createdirs
 	$$(ASPP_CMD) $$(ASPP_FLAGS) $$(patsubst %,-D%,$$(ASPP_DEFINES)) $$(patsubst %,-I'%',$$(ASPP_INCLUDES)) -E $$< > $$@
 
@@ -114,23 +116,6 @@ jit_cleanobjs::
 	rm -f $(1).ipp
 
 $(call RULE.ipp,$(1),$(1).ipp)
-endef
-
-RULE.aspp=$(eval $(DEF_RULE.aspp))
-
-#
-# Compile .spp file into .o file
-#
-define DEF_RULE.spp
-$(1).aspp: $(2) | jit_createdirs
-	$$(SPP_CMD) $$(SPP_FLAGS) $$< $$@
-
-JIT_DIR_LIST+=$(dir $(1))
-
-jit_cleanobjs::
-	rm -f $(1).aspp
-
-$(call RULE.aspp,$(1),$(1).aspp)
 endef # DEF_RULE.spp
 
 RULE.spp=$(eval $(DEF_RULE.spp))

--- a/runtime/tr.source/trj9/build/toolcfg/aix-xlc/common.mk
+++ b/runtime/tr.source/trj9/build/toolcfg/aix-xlc/common.mk
@@ -187,9 +187,6 @@ endif
 
 IPP_FLAGS+=$(IPP_FLAGS_EXTRA)
 
-# Now setup SPP
-SPP_CMD?=$(ASPP_PATH)
-
 #
 # Finally setup the linker
 #


### PR DESCRIPTION
Removing SPP/ASPP Processing from AIX Builds since ASPP is an internal tool that is not shipped with OpenJ9. 

Signed-off-by: Alen Badel alen.badel@ibm.com
