### PR TITLE
Correct Xtrace:what behaviour with Xtrace:none

### DIFF
--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -1142,6 +1142,15 @@ printTraceWhat(J9PortLibrary* portLibrary)
 	j9tty_err_printf(PORTLIB, "Trace engine configuration\n");
 	j9tty_err_printf(PORTLIB, "--------------------------\n");
 	if( NULL != option) {
+		while ( NULL != *cursor ) {
+			option = walkTraceConfig(cursor);
+			if (0 == strcmp (option,"none")) break;
+		}
+		if (0 != strcmp (option,"none")) {
+			cursor_ptr = NULL;
+			cursor = &cursor_ptr;
+			option = walkTraceConfig(cursor);
+		}
 		j9tty_err_printf(PORTLIB, "-Xtrace:%s\n", option);
 		while ( NULL != *cursor ) {
 			option = walkTraceConfig(cursor);


### PR DESCRIPTION
This fix changes behaviour of -Xtrace:what while used together with
-Xtrace:none. When -Xtrace:what comes after -Xtrace:none in the JVM
commandline sequence, it will display only the trace options that
comes after, and including -Xtrace:none and not display the
default options.

Fixes: #179
Signed-off-by: Kabir Islam <kaislam1@in.ibm.com>