### PR TITLE
Fix and re-enable sub-tests in URLStaleClassPathEntryTest

### DIFF
--- a/test/cmdLineTests/shareClassTests/URLHelperTests/StaleClassPathEntryTests/props_unix/Test4.props
+++ b/test/cmdLineTests/shareClassTests/URLHelperTests/StaleClassPathEntryTests/props_unix/Test4.props
@@ -4,5 +4,5 @@ NumberOfClassesToLoad0=2
 LoadClasses0=B,E
 NumberOfClassesToFind0=2
 FindClasses0=B,E
-Results0=true,true
+Results0=false,false
 BatchFileToRun=/bin/sh ./batchfiles/StaleClassPathTest5.sh

--- a/test/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests.xml
+++ b/test/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests.xml
@@ -63,6 +63,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -81,6 +82,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -98,6 +100,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -116,6 +119,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -134,6 +138,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -152,6 +157,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -169,6 +175,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -186,6 +193,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -204,6 +212,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -221,6 +230,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -238,6 +248,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -255,6 +266,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>

--- a/test/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests_80.xml
+++ b/test/cmdLineTests/shareClassTests/URLHelperTests/URLHelperTests_80.xml
@@ -63,6 +63,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -81,6 +82,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -98,6 +100,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -116,6 +119,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -134,6 +138,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -152,6 +157,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -169,6 +175,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -186,6 +193,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -221,6 +229,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -238,6 +247,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>
@@ -255,6 +265,7 @@
 	
 	<test id="destroy cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error:</output>

--- a/test/cmdLineTests/shareClassTests/URLHelperTests/exclude.xml
+++ b/test/cmdLineTests/shareClassTests/URLHelperTests/exclude.xml
@@ -27,15 +27,11 @@
 <suite id="URLHelper Excluded Test Case List">
 <!-- PR 117232 Java 9 modularity share class test failures-->
 	<platform id="all"/>
-	<exclude id="APITests.URLStoreFindTest" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="APITests.URLGetDifferentHelperTest" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLClassPathMatchingTest 1" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLClassPathMatchingTest 2" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLClassPathMatchingTest 3" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLStaleClassPathEntryTest 1" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLStaleClassPathEntryTest 2" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLStaleClassPathEntryTest 3" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="destroy cache" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLStaleClassPathEntryTest 4" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="PartitioningTest 1" platform="all"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="APITests.URLStoreFindTest" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="APITests.URLGetDifferentHelperTest" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="URLClassPathMatchingTest 1" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="URLClassPathMatchingTest 2" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="URLClassPathMatchingTest 3" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="URLStaleClassPathEntryTest 4" platform="SE80"><reason>Shouldn't find class B and E from shared cache as Alphabet.jar is updated. Should be re-enabled when openj9-openjdk8 is enabled in the builds</reason></exclude>
+	<exclude id="PartitioningTest 1" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
 </suite>

--- a/test/cmdLineTests/shareClassTests/URLHelperTests/playlist.xml
+++ b/test/cmdLineTests/shareClassTests/URLHelperTests/playlist.xml
@@ -36,7 +36,7 @@
 	$(CONVERT_TO_EBCDIC_CMD) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_HOME='$(JDK_HOME)' -DPATHSEP=$(Q)$(D)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DPROPS_DIR=$(PROPS_DIR) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) -DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DCPDL=$(Q)$(P)$(Q) -DSCMODE=210 -DTEST_JVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)URLHelperTests_80.xml$(Q) \
+	-config $(Q)$(TEST_RESROOT)$(D)URLHelperTests_80.xml$(Q) -xids all,$(PLATFORM),$(JAVA_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>
@@ -60,7 +60,7 @@
 	$(CONVERT_TO_EBCDIC_CMD) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_HOME='$(JDK_HOME)' -DPATHSEP=$(Q)$(D)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DPROPS_DIR=$(PROPS_DIR) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) -DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DCPDL=$(Q)$(P)$(Q) -DSCMODE=210 -DTEST_JVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)URLHelperTests.xml$(Q) -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-config $(Q)$(TEST_RESROOT)$(D)URLHelperTests.xml$(Q) -xids all,$(PLATFORM),$(JAVA_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>


### PR DESCRIPTION
1. Re-enable URLStaleClassPathEntryTest 1-4 on Java 9
2. Jar file has been updated after classes are stored to the shared
cache, we should not be able to find the classes from the shared cache.
So the expected test results of URLStaleClassPathEntryTest 4 in Test4.props
should be modified. 
3. Add "cache does not exist" to the successful conditions in
URLHelperTests.xml when cleaning up the shared cache from the previous
tests. We do not need to care about the destroy message as long as the
shared cache is deleted.

Fixes #470

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>