### PR TITLE
Start Java 9 SNMP agent via jdk.internal.agent.Agent

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -476,8 +476,12 @@ Java_java_lang_System_startSNMPAgent(JNIEnv *env, jclass jlClass)
 	if (J9_ARE_ALL_BITS_SET(vm->jclFlags, J9_JCL_FLAG_COM_SUN_MANAGEMENT_PROP)) {
 		jclass smAClass = NULL;
 		jmethodID startAgent = NULL;
-
-		smAClass = (*env)->FindClass(env, "sun/management/Agent");
+		
+		if ((J2SE_VERSION(vm) >= J2SE_19) && (J2SE_SHAPE(vm) >= J2SE_SHAPE_B165)) {
+			smAClass = (*env)->FindClass(env, "jdk/internal/agent/Agent");
+		} else {
+			smAClass = (*env)->FindClass(env, "sun/management/Agent");
+		}
 		if (NULL != smAClass) {
 			startAgent = (*env)->GetStaticMethodID(env, smAClass, "startAgent", "()V");
 			if (NULL != startAgent) {


### PR DESCRIPTION
Start `Java 9 SNMP` agent via jdk.internal.agent.Agent

`SNMP` agent class has been changed to `jdk.internal.agent.Agent` from
`sun.management.Agent` since Java 9 b165.

Close: #301 

Reviewer @DanHeidinga
FYI: @pshipton  

Signed-off-by: Jason Feng <fengj@ca.ibm.com>