### PR TITLE
Zero out dead slots at OSR transition for FSD

### DIFF
--- a/runtime/compiler/trj9/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/trj9/codegen/J9CodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,8 @@ J9::CodeGenPhase::performInsertEpilogueYieldPointsPhase(TR::CodeGenerator * cg, 
    //
    if ((comp->getCurrentMethod()->maxBytecodeIndex() >= BYTECODESIZE_THRESHOLD_FOR_ASYNCCHECKS) &&
        !comp->mayHaveLoops() &&
-       comp->getCurrentMethod()->convertToMethod()->methodType() == TR_Method::J9) // FIXME: enable for ruby and python
+       comp->getCurrentMethod()->convertToMethod()->methodType() == TR_Method::J9 &&  // FIXME: enable for ruby and python
+       comp->getOSRMode() != TR::involuntaryOSR) 
       {
       cg->insertEpilogueYieldPoints();
       }

--- a/runtime/compiler/trj9/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/codegen/J9CodeGenerator.cpp
@@ -2391,6 +2391,13 @@ J9::CodeGenerator::populateOSRBuffer()
             }
          }
 
+      /*
+       * dead slots are bookkept together with shared slots under involuntary OSR
+       * increase this number to indicate the existence of entries for dead slots
+       */
+      if (osrMethodData->hasSlotSharingOrDeadSlotsInfo() && numOfSymsThatShareSlot == 0) 
+         numOfSymsThatShareSlot++;
+
       osrMethodData->setNumOfSymsThatShareSlot(numOfSymsThatShareSlot);
       maxScratchBufferSize = (maxScratchBufferSize > scratchBufferOffset) ? maxScratchBufferSize : scratchBufferOffset;
 
@@ -2405,6 +2412,7 @@ J9::CodeGenerator::populateOSRBuffer()
       //The OSR helper call will print the contents of the OSR buffer (if trace option is on)
       //and populate the OSR buffer with the correct values of the shared slots (if there is any)
       bool emitCall = false;
+
       if ((numOfSymsThatShareSlot > 0) ||
           self()->comp()->getOption(TR_EnablePrepareForOSREvenIfThatDoesNothing))
          emitCall = true;
@@ -2445,6 +2453,7 @@ J9::CodeGenerator::populateOSRBuffer()
          );
       insertionPoint->insertTreeTopsAfterMe(osrFrameIndexAdvanceTreeTop);
       }
+
 
    for (int32_t i = 0; i < methodDataArray.size(); i++)
       {

--- a/runtime/compiler/trj9/compile/J9Compilation.cpp
+++ b/runtime/compiler/trj9/compile/J9Compilation.cpp
@@ -1186,7 +1186,9 @@ bool
 J9::Compilation::pendingPushLivenessDuringIlgen()
    {
    static bool enabled = (feGetEnv("TR_DisablePendingPushLivenessDuringIlGen") == NULL);
-   return enabled;
+   if (self()->getOSRMode() == TR::involuntaryOSR)
+      return false;
+   else return enabled;
    }
 
 bool

--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -2231,11 +2231,7 @@ TR_J9ByteCodeIlGenerator::genTreeTop(TR::Node * n)
             // part of decompilation
             //
             saveStack(-1);
-
-            // Currently, livenss will not run under involuntary OSR, so stashing
-            // the pending push liveness is only necessary in the voluntary case
-            if (comp()->getOSRMode() == TR::voluntaryOSR)
-               stashPendingPushLivenessForOSR();
+            stashPendingPushLivenessForOSR();
             }
          }
       }

--- a/runtime/compiler/trj9/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/trj9/runtime/CRuntimeImpl.cpp
@@ -141,6 +141,15 @@ void _prepareForOSR(uintptrj_t vmThreadArg, int32_t currentInlinedSiteIndex, int
                  jitPCOffset, metaData->startPC);
 
          osrMetaData = previousMapping;
+         //In debugging mode, meta data keeps both slots sharing and dead slots info. There are cases where dead slots
+         //don't exist in certain bci but do exist in another bci. This is not possible under other OSR modes where only
+         //slots sharing info are kept.
+         if (!osrMetaData)
+            {
+            TR_ASSERT(TR::Options::getCmdLineOptions()->getOption(TR_FullSpeedDebug), "it's only possible to not to find");
+            return;
+            }
+
          int32_t numSymbols = *osrMetaData; osrMetaData++;
          int32_t numSymbolsForThisCallerIndex = 0;
 
@@ -156,9 +165,9 @@ void _prepareForOSR(uintptrj_t vmThreadArg, int32_t currentInlinedSiteIndex, int
             if (inlinedSiteIndex != currentInlinedSiteIndex) continue;
 
 
-            numSymbolsForThisCallerIndex++;
             if (scratchBufferOffset != -1)
                {
+               numSymbolsForThisCallerIndex++;
                uint8_t* dataAtScrBuffer = (uint8_t*)vmThread->osrScratchBuffer + scratchBufferOffset;
                if (details)
                   {
@@ -197,7 +206,7 @@ void _prepareForOSR(uintptrj_t vmThreadArg, int32_t currentInlinedSiteIndex, int
                }
             }
          TR_ASSERT(numSymbolsForThisCallerIndex <= numSymsThatShareSlot,
-                 "the number of symbols we are going to write (%d) is more than the number of symbols that share slots (%d)\n",
+                 "the number of live symbols we are going to write (%d) is more than the number of symbols that share slots (%d)\n",
                  numSymbolsForThisCallerIndex, numSymsThatShareSlot);
          }
       }


### PR DESCRIPTION
In debugging mode, the debugger may dereference an object slot even
after it's gone dead and we must make sure such dead slots are zeroed
out at OSR transition to avoid program crashing.

VoluntaryOSR could zero out the dead slots at induceOSR in trees
because there is one induceOSR for each osrPoint. However, under
involuntarOSR, which debbuging mode runs with, multiple osrPoints
would transit to the same code block and therefore the zero stores
can not be expressed in trees shared between all the different
osrPoints.

This changeset is the openj9 part of the infrastructure to bookkeep
deadslots while compiling the Java code.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>