### PR TITLE
Add Proxy class's package to the defining classloader

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -11,7 +11,7 @@ import sun.reflect.ConstantPool;
 
 
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,4 +144,15 @@ public interface VMLangAccess {
 	 * @return ContanstPool instance
 	 */
 	public ConstantPool getConstantPool(Object internalRamClass);
+
+	/*[IF Sidecar19-SE]*/
+	/**
+	 * Adds a class's package its classloader's package table.
+	 * This is typically used when a class is defined without using ClassLoader.defineClass().
+	 * @param newClass newly defined class
+	 * @param loader classloader used to define the class
+	 */
+	public void addPackageToList(Class<?> newClass, ClassLoader loader);
+	/*[ENDIF] Sidecar19-SE */
+
 }

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -565,9 +565,7 @@ protected final Class<?> defineClass (
 		}
 	}
 	/*[IF Sidecar19-SE]*/
-	synchronized(packages) {
-		packages.computeIfAbsent(answer.getPackageName(), pkgName->new NamedPackage(pkgName, answer.getModule()));
-	}
+	addPackageToList(answer);
 	/*[ENDIF] Sidecar19-SE */
 
 	/*[PR CMVC 89001] Verbose output when loading non-bootstrap classes */
@@ -578,6 +576,18 @@ protected final Class<?> defineClass (
 	}
 	return answer;
 }
+
+/*[IF Sidecar19-SE]*/
+ /**
+  * Add a class's package name to this classloader's list of packages, if not already present.
+ * @param newClass
+ */
+void addPackageToList(Class<?> newClass) {
+	synchronized(packages) {
+		packages.computeIfAbsent(newClass.getPackageName(), pkgName->new NamedPackage(pkgName, newClass.getModule()));
+	}
+}
+/*[ENDIF] Sidecar19-SE */
 
 /*[PR CMVC 89001] Verbose output when loading non-bootstrap classes */ 
 private native boolean isVerboseImpl();

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@ package java.lang;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+import java.util.Objects;
 import java.util.Properties;
 
 /*[IF Sidecar19-SE]*/
@@ -203,4 +204,16 @@ final class VMAccess implements VMLangAccess {
 	public ConstantPool getConstantPool(Object internalRamClass) {
 		return Access.getConstantPool(internalRamClass);
 	}
+	
+	/*[IF Sidecar19-SE]*/
+	@Override
+	public void addPackageToList(java.lang.Class<?> newClass, ClassLoader loader) {
+		java.lang.ClassLoader packageLoader = loader;
+		if (Objects.isNull(packageLoader)) {
+			packageLoader = ClassLoader.getSystemClassLoader();
+		}
+		packageLoader.addPackageToList(newClass);
+	}
+	/*[ENDIF] Sidecar19-SE */
+
 }

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -23,6 +23,7 @@
 package jdk.internal.misc;
 
 import com.ibm.oti.vm.VM;
+import com.ibm.oti.vm.VMLangAccess;
 
 import java.lang.Class;
 import java.lang.ClassLoader;
@@ -1503,7 +1504,10 @@ public final class Unsafe {
 			throw new ArrayIndexOutOfBoundsException();
 		}
 
-		return defineClass0(name, b, offset, bLength, cl, pd);
+		Class<?> result = defineClass0(name, b, offset, bLength, cl, pd);
+		VMLangAccess access = VM.getVMLangAccess();
+		access.addPackageToList(result, cl);
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
j.l.reflect.Proxy bypasses ClassLoader when defining proxy classes.
Add the Proxy class's package to the classloader used to define the class.
If the classloader is null, use the platform (bootstrap) classloader.
