### PR TITLE
Delete JSR292 SE90 tests which only applies to b148 but failed on b181

### DIFF
--- a/test/Jsr292/testngSE90.xml
+++ b/test/Jsr292/testngSE90.xml
@@ -30,7 +30,6 @@
 	<test name="jsr292Test">
 		<classes>
 			<class name="com.ibm.j9.jsr292.AdaptorTests"/>
-			<class name="com.ibm.j9.jsr292.LookupInTests"/>
 			<class name="com.ibm.j9.jsr292.LookupAPITests_Find"/>
 			<class name="com.ibm.j9.jsr292.LookupAPITests_Unreflect"/>
 			<class name="com.ibm.j9.jsr292.Crash"/>

--- a/test/TestConfig/resources/excludes/openj9_exclude.txt
+++ b/test/TestConfig/resources/excludes/openj9_exclude.txt
@@ -46,4 +46,4 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generi
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
-
+com.ibm.j9.jsr292.indyn.IndyTest:test_indyn_invalid_bootstrap_method													600 generic-all

--- a/test/TestConfig/scripts/build_test.xml
+++ b/test/TestConfig/scripts/build_test.xml
@@ -78,7 +78,6 @@
 					<property name="compiler.javac" value="${JAVAC}" />
 					<fileset dir="../../" includes="${build.list}" >
 						<exclude name="TEST_*/build.xml" />
-						<exclude name="Jsr292/build.xml" />
 						<exclude name="NativeTest/build.xml" />
 						<exclude name="SharedCPEntryInvokerTests/build.xml" />
 						<exclude name="Valhalla/build.xml" />

--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -109,7 +109,7 @@ sub generateOnDir {
 	while ( my $entry = readdir $dir ) {
 		next if $entry eq '.' or $entry eq '..';
 		# temporarily exclude projects for CCM build (i.e., when JCL_VERSION is latest)
-		my $latestDisabledDir = "jvmtitests proxyFieldAccess classesdbgddrext dumpromtests jep178staticLinkingTest getCallerClassTests pltest Jsr292 Panama NativeTest SharedCPEntryInvokerTests gcCheck classvertest";
+		my $latestDisabledDir = "jvmtitests proxyFieldAccess classesdbgddrext dumpromtests jep178staticLinkingTest getCallerClassTests pltest Panama NativeTest SharedCPEntryInvokerTests gcCheck classvertest";
 		# Temporarily exclude SVT_Modularity tests from integration build where we are still using b148 JCL level
 		my $currentDisableDir= "SVT_Modularity OpenJ9_Jsr_292_API";
 		if ((($JCL_VERSION eq "latest") and ($latestDisabledDir !~ $entry )) or (($JCL_VERSION eq "current") and ($currentDisableDir !~ $entry ))) {


### PR DESCRIPTION
* Tests in LookupInTests.java in Jsr292 are obsolete for Openj9
* new tests are updated in OpenJ9_Jsr_292_API project
* delete the test exection from testngSE90.xml
* wait for another PR, then merge Jsr292 and OpenJ9_Jsr_292_API together

fixes : #481 
Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>