### PR TITLE
update getDependency script to grab asmtools.jar directly.

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -92,8 +92,8 @@ my %jcommander = (
 	sha1 => 'bfcb96281ea3b59d626704f74bc6d625ff51cbce'
 );
 my %asmtools = (
-	url => 'https://ci.adoptopenjdk.net/view/Dependencies/job/asmtools/lastSuccessfulBuild/artifact/asmtools-6.0.tar.gz',
-	fname => 'asmtools-6.0.tar.gz',
+	url => 'https://ci.adoptopenjdk.net/view/Dependencies/job/asmtools/lastSuccessfulBuild/artifact/asmtools.jar',
+	fname => 'asmtools.jar',
 	sha1 => 'd57dfcdd591635d31372cfcc18474a8ca6442171'
 );
 
@@ -138,19 +138,9 @@ if ( $task eq "default" ) {
 
 		# TODO check asmtools.jar file
 		if (index($jars_info[$i]{fname}, "asmtools") != -1) {
-			if (! -e "$path/asmtools.jar"){
-				my $untar = `tar -zxvf $path/asmtools-6.0.tar.gz -C $path`;
-				if ($? != 0 ) {
-					die;
-				}
-				my $unzip = `unzip -o $path/asmtools-6.0.zip -d $path`;
-				if ($? != 0 ) {
-					die;
-				}
-				copy("$path/asmtools-6.0/lib/asmtools.jar", $path) or die "Copy failed: $!";
-			}
 			next;
 		}
+		
 		# validate dependencies sha1 sum
 		$sha->addfile($filename);
 		$digest = $sha->hexdigest ;


### PR DESCRIPTION
* update getDependency script to grab asmtools.jar directly.
* Server builds should provide the asmtools.jar from its stage job.

[ci skip]
Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>