### PR TITLE
Relocate reserveNTrampolines to x86 CodeGenerator

### DIFF
--- a/runtime/tr.source/trj9/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/tr.source/trj9/x/codegen/J9CodeGenerator.hpp
@@ -67,6 +67,18 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
+   /*
+    * \brief Reserve space in the code cache for a specified number of trampolines.
+    *        This is useful for inline caches where the methods are not yet known at
+    *        compile-time but for which trampolines may be required for compiled
+    *        bodies in the future.
+    *
+    * \param[in] numTrampolines : number of trampolines to reserve
+    *
+    * \return : none
+    */
+   void reserveNTrampolines(int32_t numTrampolines);
+
    };
 
 }


### PR DESCRIPTION
Move the `reserveNTrampolines()` implementation from the FrontEnd to
the x86 CodeGenerator where it more naturally belongs.  The API is
also simplified to only accept the number of trampolines to reserve.
The rest of the original API can be derived from other queries
on the `TR::CodeGenerator` object.

Nothing uses this function yet.  A subsequent commit will delete the
implementation in the FrontEnd and re-route all references to the
version in CodeGenerator.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>