### PR TITLE
Add build_openj9JDK8 flag to linux compressed refs specs

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -165,6 +165,10 @@
 		<description>Buildspec compiles sources with openjdk.</description>
 		<ifRemoved>Openj9 clone,make jobs longer run on this buildspec.</ifRemoved>
 	</flag>
+	<flag id="build_openj9JDK8">
+		<description>Buildspec compiles sources with openjdk-jdk8.</description>
+		<ifRemoved>OpenJ9 compile job, sanity and extended tests no longer run on this buildspec.</ifRemoved>
+	</flag>
 	<flag id="build_ouncemake">
 		<description>Buildspec compiles source using ouncemake for appscan.</description>
 		<ifRemoved>Ouncemake compile jobs will no longer run on this buildspec.</ifRemoved>

--- a/buildspecs/linux_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_390-64_cmprssptrs.spec
@@ -130,6 +130,7 @@
 		<flag id="build_java9" value="true"/>
 		<flag id="build_product" value="true"/>
 		<flag id="build_openj9" value="true"/>
+		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="env_hasFPU" value="true"/>
 		<flag id="env_sharedLibsCalleeGlobalTableSetup" value="true"/>
 		<flag id="env_sharedLibsUseGlobalTable" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
@@ -130,6 +130,7 @@
 		<flag id="build_java9" value="false"/>
 		<flag id="build_product" value="false"/>
 		<flag id="build_openj9" value="true"/>
+		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_stage_toronto_lab" value="true"/>
 		<flag id="env_gcc" value="true"/>
 		<flag id="env_hasFPU" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -130,6 +130,7 @@
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="true"/>
 		<flag id="build_openj9" value="true"/>
+		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_product" value="true"/>
 		<flag id="build_vmContinuous" value="true"/>
 		<flag id="env_hasFPU" value="true"/>


### PR DESCRIPTION
This flag is used by the axxon graph tools.
When this flag is enabled the tool would include jobs that
compile OpenJ9 OpenJDK8 and run sanity and extended tests.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>