### PR TITLE
Throw NoClassDefFoundError instead of TypeNotPresentException

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -333,8 +333,7 @@
 	<staticmethodref class="java/lang/J9VMInternals" name="threadCleanup" signature="(Ljava/lang/Thread;)V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="newInstanceImpl" signature="(Ljava/lang/Class;)Ljava/lang/Object;" flags="jit_newInstancePrototype"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="formatNoSuchMethod" signature="(Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/String;"/>
-	<staticmethodref class="java/lang/invoke/MethodType" name="fromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
-	<staticmethodref class="java/lang/invoke/MethodType" name="fromMethodDescriptorStringAppendArg" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
+	<staticmethodref class="java/lang/invoke/MethodType" name="vmResolveFromMethodDescriptorString" signature="(Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Class;)Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="sendResolveMethodHandle" signature="(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="resolveInvokeDynamic" signature="(JLjava/lang/String;Ljava/lang/String;J)Ljava/lang/invoke/MethodHandle;" flags="opt_methodHandle"/> 
 	<staticmethodref class="java/lang/invoke/MethodHandle" name="invokeWithArgumentsHelper" signature="(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;" flags="opt_methodHandle"/> 

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -874,14 +874,9 @@ sendFromMethodDescriptorString(J9VMThread *currentThread, J9UTF8 *descriptor, J9
 			/* Run the method */
 			*--currentThread->sp = (UDATA)descriptorString;
 			*--currentThread->sp = (UDATA)classLoader->classLoaderObject;
+			*--currentThread->sp = (UDATA)J9VM_J9CLASS_TO_HEAPCLASS(appendArgType);
 			currentThread->returnValue = J9_BCLOOP_RUN_METHOD;
-			if (NULL == appendArgType) {
-				currentThread->returnValue2 = (UDATA)J9VMJAVALANGINVOKEMETHODTYPE_FROMMETHODDESCRIPTORSTRING_METHOD(vm);
-			} else {
-				/* If an appendArgType has been provided, push it on the stack and call a different MethodType factory method. */
-				*--currentThread->sp = (UDATA)J9VM_J9CLASS_TO_HEAPCLASS(appendArgType);
-				currentThread->returnValue2 = (UDATA)J9VMJAVALANGINVOKEMETHODTYPE_FROMMETHODDESCRIPTORSTRINGAPPENDARG_METHOD(vm);
-			}
+			currentThread->returnValue2 = (UDATA)J9VMJAVALANGINVOKEMETHODTYPE_VMRESOLVEFROMMETHODDESCRIPTORSTRING_METHOD(vm);
 			c_cInterpreter(currentThread);
 		}
 		restoreCallInFrame(currentThread);

--- a/test/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
+++ b/test/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
@@ -333,27 +333,14 @@ public class IndyTest {
 		}
 	}
 	
-	//Negative test : Creating an invalid MethodType using LDC
+	//Negative test : Creating a MethodType with a non-existent class using LDC
 	@Test(groups = { "level.extended" })
-	public void test_indyn_ldc_invalid_type() {
-		
-		boolean typeNotPresentExceptionThrown = false;
-		
+	public void test_indyn_ldc_non_existent_class_methodtype() {
 		try {
 			MethodType mtToString = com.ibm.j9.jsr292.indyn.GenIndyn.ldc_invalid_type();
-		} catch ( java.lang.TypeNotPresentException e ) {
-			typeNotPresentExceptionThrown = true;
-		}
-		
-		//Call it again
-		try {
-			MethodType mtToString = com.ibm.j9.jsr292.indyn.GenIndyn.ldc_invalid_type();
-		} catch ( java.lang.TypeNotPresentException e ) {
-			typeNotPresentExceptionThrown = true;
-		}
-		
-		if ( typeNotPresentExceptionThrown == false ) {
-			Assert.fail("TypeNotPresentException not thrown when invalid type descriptor is used to create MethodType via LDC");
+			Assert.fail("NoClassDefFoundError not thrown when non-existent class is used to create MethodType via LDC");
+		} catch (NoClassDefFoundError e) {
+			/* Expected behavior */
 		}
 	}
 	


### PR DESCRIPTION
Change 1:

When the VM is resolving a `MethodType`, `NoClassDefFoundError` should be thrown instead of `TypeNotPresentException`.


Change 2:

Renamed `test_indyn_ldc_invalid_type` to `test_indyn_ldc_non_existent_class_methodtype`. Updated test to check for `NoClassDefFoundError` instead of `TypeNotPresentException`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>
