### PR TITLE
enable test_indyn_invalid_bootstrap_method in IndyTest

### DIFF
--- a/test/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
+++ b/test/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
@@ -211,17 +211,19 @@ public class IndyTest {
 	//Negative test : invalid bootstrap method
 	@Test(groups = { "level.extended" })
 	public void test_indyn_invalid_bootstrap_method() {
-		
-		boolean bootstrapMethodError = false;
-		
 		try {
 			String s = com.ibm.j9.jsr292.indyn.GenIndyn.invalid_bootstrap(new Object());
-		} catch ( BootstrapMethodError e ) {
-			bootstrapMethodError = true;
-		}
-		
-		if ( bootstrapMethodError == false ) {
-			Assert.fail("BootstrapMethodError not thrown when invalid bootstrap method is used");
+			Assert.fail("BootstrapMethodError (in Java 8) or NoSuchMethodError (Java 9+) should have been thrown");
+		} catch (BootstrapMethodError e) {
+			//BootstrapMethodError should only apply to Java8
+			if (false == "1.8".equals(System.getProperty("java.specification.version"))) {
+				Assert.fail("[Java 9+] NoSuchMethodError not thrown when a non-existent bootstrap method is used ", e);
+			}
+		} catch (NoSuchMethodError e) {
+			//Java9 and up throws NoSuchMethodError
+			if ("1.8".equals(System.getProperty("java.specification.version"))) {
+				Assert.fail("[Java 8] BootstrapMethodError not thrown when invalid bootstrap method is used ", e);
+			}
 		}
 	}
 	

--- a/test/TestConfig/resources/excludes/openj9_exclude.txt
+++ b/test/TestConfig/resources/excludes/openj9_exclude.txt
@@ -46,4 +46,3 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generi
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
-com.ibm.j9.jsr292.indyn.IndyTest:test_indyn_invalid_bootstrap_method													600 generic-all


### PR DESCRIPTION
* 8 wrap an exception in BootStrapMethodError
* 9 allows Error subclasses to be passed through
* update test case to suit both Java versions

Fixes : #600
Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>