### PR TITLE
WIP: Update test_indyn_invalid_bootstrap_method and add API for Java version

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/util/JavaVersion.java
+++ b/test/Java8andUp/src/org/openj9/test/util/JavaVersion.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.openj9.test.util;
+
+public class JavaVersion {
+	private static final String JAVA_VERSION = System.getProperty("java.version");
+	
+	/* Return true if Java 8 is used; otherwise, return false. */
+	public static boolean isJava8() {
+		return JAVA_VERSION.startsWith("1.8.0");
+	}
+	
+	/* Return true if Java 9 is used; otherwise, return false. */
+	public static boolean isJava9() {
+		return JAVA_VERSION.startsWith("1.9.0") || JAVA_VERSION.startsWith("9");
+	}
+	
+	/* Return String value of "java.version" property. */
+	public static String getJavaVersion() {
+		return JAVA_VERSION;
+	}
+}

--- a/test/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
+++ b/test/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.openj9.test.util.JavaVersion;
 import org.openj9.test.util.StringPrintStream;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -144,9 +145,9 @@ public class VmArgumentTests {
 						"-Djava.class.path",
 						"-Dsun.java.command",
 						"-Dsun.java.launcher"
-		};	
-		JAVA_VERSION=System.getProperty("java.version");
-		isJava8 = JAVA_VERSION.startsWith("1.8.0");
+		};
+		JAVA_VERSION = JavaVersion.getJavaVersion();
+		isJava8 = JavaVersion.isJava8();
 		vmargsJarFilename = isJava8? "vmargs_SE80.jar": "vmargs_SE90.jar";
 	}
 

--- a/test/Java8andUp/src_80/org/openj9/test/java/lang/Test_System.java
+++ b/test/Java8andUp/src_80/org/openj9/test/java/lang/Test_System.java
@@ -25,8 +25,10 @@ package org.openj9.test.java.lang;
 import org.testng.annotations.Test;
 import org.testng.annotations.BeforeMethod;
 import org.openj9.test.support.Support_Exec;
+import org.openj9.test.util.JavaVersion;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -42,7 +44,8 @@ import java.util.Properties;
 
 @Test(groups = { "level.sanity" })
 public class Test_System {
-
+	public static final String javaVersion = JavaVersion.getJavaVersion();
+	
 	// Properties orgProps = System.getProperties();
 	static boolean flag = false;
 	static boolean ranFinalize = false;
@@ -142,9 +145,8 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperties() {
-		Properties p = System.getProperties();
- 		AssertJUnit.assertTrue("Incorrect properties returned", p.getProperty(
- 				"java.version").indexOf("1.", 0) >= 0);
+ 		AssertJUnit.assertTrue("Incorrect properties returned",
+ 				javaVersion.indexOf("1.", 0) >= 0);
 
 		// ensure spec'ed properties are non-null. See System.getProperties()
 		// spec.
@@ -165,7 +167,7 @@ public class Test_System {
 		 * This test should only run for Java 1.8.0 and above. For Java 1.9.0
 		 * and above, we do not support java.ext.dirs property.
 		 */
-		if (p.getProperty("java.version").startsWith("1.8.0")) {
+		if (JavaVersion.isJava8()) {
 			String javaExtDirs = "java.ext.dirs";
 			AssertJUnit.assertTrue(javaExtDirs, System.getProperty(javaExtDirs) != null);
 		}
@@ -176,8 +178,8 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperty() {
- 		AssertJUnit.assertTrue("Incorrect properties returned", System.getProperty(
- 				"java.version").indexOf("1.", 0) >= 0);
+ 		AssertJUnit.assertTrue("Incorrect properties returned",
+ 				javaVersion.indexOf("1.", 0) >= 0);
 
 		boolean is8859_1 = true;
 		String encoding = System.getProperty("file.encoding");
@@ -215,12 +217,12 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperty2() {
-		AssertJUnit.assertTrue("Failed to return correct property value: "
-				+ System.getProperty("java.version", "99999"), System
-				.getProperty("java.version", "99999").indexOf("1.", 0) >= 0);
+		String javaVersionOrDefault = System.getProperty("java.version", "99999");
+		AssertJUnit.assertTrue("Failed to return correct property value: " + javaVersionOrDefault, 
+				javaVersionOrDefault.indexOf("1.", 0) >= 0);
 
-		AssertJUnit.assertTrue("Failed to return correct property value", System
-				.getProperty("bogus.prop", "bogus").equals("bogus"));
+		AssertJUnit.assertTrue("Failed to return correct property value", 
+				System.getProperty("bogus.prop", "bogus").equals("bogus"));
 	}
 
 	/**

--- a/test/Java8andUp/src_90/org/openj9/test/java/lang/Test_System.java
+++ b/test/Java8andUp/src_90/org/openj9/test/java/lang/Test_System.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 import org.testng.annotations.BeforeMethod;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -39,12 +40,13 @@ import java.security.Permission;
 import java.util.Enumeration;
 import java.util.Properties;
 
-
 import org.openj9.test.support.Support_Exec;
+import org.openj9.test.util.JavaVersion;
 
 @Test(groups = { "level.sanity" })
 public class Test_System {
-
+	public static final String javaVersion = JavaVersion.getJavaVersion();
+	
 	// Properties orgProps = System.getProperties();
 	static boolean flag = false;
 	static boolean ranFinalize = false;
@@ -144,9 +146,8 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperties() {
-		Properties p = System.getProperties();
- 		AssertJUnit.assertTrue("Incorrect properties returned", p.getProperty(
- 				"java.version").indexOf("9", 0) == 0);
+ 		AssertJUnit.assertTrue("Incorrect properties returned", 
+ 				javaVersion.indexOf("9", 0) == 0);
 
 		// ensure spec'ed properties are non-null. See System.getProperties()
 		// spec.
@@ -167,7 +168,7 @@ public class Test_System {
 		 * This test should only run for Java 1.8.0 and above. For Java 1.9.0
 		 * and above, we do not support java.ext.dirs property.
 		 */
-		if (p.getProperty("java.version").startsWith("1.8.0")) {
+		if (JavaVersion.isJava8()) {
 			String javaExtDirs = "java.ext.dirs";
 			AssertJUnit.assertTrue(javaExtDirs, System.getProperty(javaExtDirs) != null);
 		}
@@ -178,8 +179,8 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperty() {
- 		AssertJUnit.assertTrue("Incorrect properties returned", System.getProperty(
- 				"java.version").indexOf("9", 0) == 0);
+ 		AssertJUnit.assertTrue("Incorrect properties returned", 
+ 				javaVersion.indexOf("9", 0) == 0);
 
 		boolean is8859_1 = true;
 		String encoding = System.getProperty("file.encoding");
@@ -217,12 +218,12 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperty2() {
- 		AssertJUnit.assertTrue("Failed to return correct property value: "
- 				+ System.getProperty("java.version", "99999"), System
- 				.getProperty("java.version", "99999").indexOf("9", 0) >= 0);
+		String javaVersionOrDefault = System.getProperty("java.version", "99999");
+ 		AssertJUnit.assertTrue("Failed to return correct property value: " + javaVersionOrDefault, 
+ 				javaVersionOrDefault.indexOf("9", 0) >= 0);
 
-		AssertJUnit.assertTrue("Failed to return correct property value", System
-				.getProperty("bogus.prop", "bogus").equals("bogus"));
+		AssertJUnit.assertTrue("Failed to return correct property value",
+				System.getProperty("bogus.prop", "bogus").equals("bogus"));
 	}
 
 	/**

--- a/test/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
+++ b/test/Jsr292/src/com/ibm/j9/jsr292/indyn/IndyTest.java
@@ -24,6 +24,7 @@ package com.ibm.j9.jsr292.indyn;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+import org.openj9.test.util.JavaVersion;
 import static org.objectweb.asm.Opcodes.ARETURN;
 
 import java.lang.invoke.MethodHandle;
@@ -211,18 +212,20 @@ public class IndyTest {
 	//Negative test : invalid bootstrap method
 	@Test(groups = { "level.extended" })
 	public void test_indyn_invalid_bootstrap_method() {
-		
-		boolean bootstrapMethodError = false;
-		
 		try {
 			String s = com.ibm.j9.jsr292.indyn.GenIndyn.invalid_bootstrap(new Object());
-		} catch ( BootstrapMethodError e ) {
-			bootstrapMethodError = true;
+		} catch (BootstrapMethodError e) {
+			if (!JavaVersion.isJava8()) {
+				Assert.fail("[Java 9+] NoSuchMethodError not thrown when a non-existent bootstrap method is used");
+			}
+			return;
+		} catch (NoSuchMethodError e) {
+			if (JavaVersion.isJava8()) {
+				Assert.fail("[Java 8] BootstrapMethodError not thrown when invalid bootstrap method is used");
+			}
+			return;
 		}
-		
-		if ( bootstrapMethodError == false ) {
-			Assert.fail("BootstrapMethodError not thrown when invalid bootstrap method is used");
-		}
+		Assert.fail("BootstrapMethodError (in Java 8) or NoSuchMethodError (Java 9+) should have been thrown");
 	}
 	
 	//Test creating an Object#toString() method using LDC


### PR DESCRIPTION
JVM behavior has changed between Java 8 and Java 9. In Java 8,
BootstrapMethodError is thrown for non-existent bootstrap
method is used. In Java 9, NoSuchMethodError is thrown for non-existent
bootstrap method is used. Test, IndyTest.test_indyn_invalid_bootstrap_method, has been
updated to account for change in JVM behavior.

Added an API for Java version: JavaVersion.isJava8(),
JavaVersion.isJava9() and JavaVersion.getJavaVersion(). Updated tests to
utilize the new API.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>