### PR TITLE
z/TPF update to build cnathelp.

### DIFF
--- a/runtime/codert_vm/module.xml
+++ b/runtime/codert_vm/module.xml
@@ -80,7 +80,7 @@
 				<exclude-if condition="spec.flags.arch_arm"/>
 			</makefilestub>
 			<makefilestub data="UMA_OBJECTS:=$(filter-out znathelp%,$(UMA_OBJECTS))\n">
-				<exclude-if condition="spec.flags.arch_s390 and not spec.linux_ztpf_390-64.*"/>
+				<exclude-if condition="spec.flags.arch_s390"/>
 			</makefilestub>
 		</makefilestubs>
 


### PR DESCRIPTION
Remove filter for z/TPF in order to build cnathelp.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>