### PR TITLE
Remove unnecessary files for building JitBuilder

### DIFF
--- a/runtime/compiler/trj9/build/files/common.mk
+++ b/runtime/compiler/trj9/build/files/common.mk
@@ -179,7 +179,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/OMRLinkage.cpp \
     omr/compiler/codegen/LiveRegister.cpp \
     omr/compiler/codegen/OutOfLineCodeSection.cpp \
-    omr/compiler/codegen/OMRRegisterDependency.cpp \
     omr/compiler/codegen/Relocation.cpp \
     omr/compiler/codegen/ScratchRegisterManager.cpp \
     omr/compiler/codegen/StorageInfo.cpp \

--- a/runtime/compiler/trj9/build/files/target/x.mk
+++ b/runtime/compiler/trj9/build/files/target/x.mk
@@ -39,7 +39,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/OutlinedInstructions.cpp \
     omr/compiler/x/codegen/RegisterRematerialization.cpp \
     omr/compiler/x/codegen/SubtractAnalyser.cpp \
-    omr/compiler/x/codegen/Trampoline.cpp \
     omr/compiler/x/codegen/OMRTreeEvaluator.cpp \
     omr/compiler/x/codegen/UnaryEvaluator.cpp \
     omr/compiler/x/codegen/X86BinaryEncoding.cpp \


### PR DESCRIPTION
While building JitBuilder on OS/X, the archiver warns about
files which it believes to be responsible for generating empty
objects.

Upon closer inspection, that indeed seems to be the case.

The actual files are being removed in https://github.com/eclipse/omr/pull/1740
This commit acts as a paired dependency change on the OpenJ9 side.

Signed-off-by: Rwitaban (Ray) Banerjee <rayb@ca.ibm.com>