### PR TITLE
Re-enable excluded sub-tests in URLHelperTests

### DIFF
--- a/test/cmdLineTests/shareClassTests/URLHelperTests/exclude.xml
+++ b/test/cmdLineTests/shareClassTests/URLHelperTests/exclude.xml
@@ -27,11 +27,6 @@
 <suite id="URLHelper Excluded Test Case List">
 <!-- PR 117232 Java 9 modularity share class test failures-->
 	<platform id="all"/>
-	<exclude id="APITests.URLStoreFindTest" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="APITests.URLGetDifferentHelperTest" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLClassPathMatchingTest 1" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLClassPathMatchingTest 2" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
-	<exclude id="URLClassPathMatchingTest 3" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
+	<exclude id="APITests.URLGetDifferentHelperTest" platform="SE90"><reason>A classloader can have more than 1 helpers in Java 9</reason></exclude>
 	<exclude id="URLStaleClassPathEntryTest 4" platform="SE80"><reason>Shouldn't find class B and E from shared cache as Alphabet.jar is updated. Should be re-enabled when openj9-openjdk8 is enabled in the builds</reason></exclude>
-	<exclude id="PartitioningTest 1" platform="SE90"><reason>Java 9 modularity share class test failures</reason></exclude>
 </suite>


### PR DESCRIPTION
Signed-off-by: Hang Shao <hangshao@ca.ibm.com>