### PR TITLE
Disable Harmony port library for Java 9 and above

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -76,7 +76,7 @@
 
 #ifdef J9VM_OPT_HARMONY
 #include "harmony_vm.h"
-#endif
+#endif /* J9VM_OPT_HARMONY */
 
 #if defined(DEBUG)
 #define DBG_MSG(x) printf x
@@ -1645,6 +1645,7 @@ printVmArgumentsList(J9VMInitArgs *argList)
 	}
 }
 
+#ifdef J9VM_OPT_HARMONY
 static IDATA
 addHarmonyPortLibrary(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA verboseFlags)
 {
@@ -1657,6 +1658,7 @@ addHarmonyPortLibrary(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsL
 	addHarmonyPortLibToVMArgs(portLib, &(optArg->vmOpt), &dummyArgs, &harmonyPortLibrary);
 	return 0;
 }
+#endif /* J9VM_OPT_HARMONY */
 
 static void
 setNLSCatalog(struct J9PortLibrary* portLib, UDATA j2seVersion)
@@ -2143,7 +2145,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 #ifdef J9VM_OPT_HARMONY
 				/* pass in the Harmony library */
 				|| (0 != addHarmonyPortLibrary(&j9portLibrary, &vmArgumentsList, localVerboseLevel))
-#endif
+#endif /* J9VM_OPT_HARMONY */
 				|| (0 != addXserviceArgs(&j9portLibrary, &vmArgumentsList, xServiceBuffer, localVerboseLevel))
 		) {
 			result = JNI_ERR;

--- a/runtime/tests/port/j9sockTest.c
+++ b/runtime/tests/port/j9sockTest.c
@@ -1541,11 +1541,7 @@ j9sock_runTests(struct J9PortLibrary *portLibrary)
 		rc |= j9sock_test5_basic_options(portLibrary);
 		rc |= j9sock_test6_nonblocking_connect(portLibrary);
 		rc |= j9sock_test7_nonblocking_read(portLibrary);
-#if 0
-		/* CMVC 169177, this testcase only applies to functionality required by
-		 * the Harmony Class Library, remove it for now as it causes failures on windows C builds */
-		rc |= j9sock_test8_select_read_closed_socket(portLibrary);
-#endif
+		/* j9sock_test8_select_read_closed_socket doesn't work on Windows and applies only to Harmony port library. */
 		rc |= j9sock_test10_get_addrinfo(portLibrary);
 		rc |= j9sock_test11_getnameinfo(portLibrary);
 	}

--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -803,11 +803,13 @@ jint JNICALL GetEnv(JavaVM *jvm, void **penv, jint version)
 		return rc;
 	}
 
+#ifdef J9VM_OPT_HARMONY
 	/* Allow retrieval of the Harmony VM interface */
 	if (HARMONY_VMI_VERSION_2_0 == version) {
 		*penv = &(vm->harmonyVMInterface);
 		return JNI_OK;
 	}
+#endif /* J9VM_OPT_HARMONY */
 
 	if (version == UTE_VERSION_1_1) {
 		if (vm->j9rasGlobalStorage != NULL) {	

--- a/runtime/vm/vmifunc.c
+++ b/runtime/vm/vmifunc.c
@@ -67,49 +67,48 @@ struct VMInterfaceFunctions_ J9VMInterfaceFunctions = {
 /* Initialization function */
 vmiError J9VMI_Initialize(J9JavaVM* vm)
 {
-	J9VMInterface* j9VMI;
-	VMInterface* vmi;
-	HarmonyVMInterface* harmonyVMI;
-	JavaVMInitArgs* vmInitArgs;
-
-	j9VMI = &vm->vmInterface;
+	J9VMInterface* j9VMI = &vm->vmInterface;
 	j9VMI->functions = GLOBAL_TABLE(J9VMInterfaceFunctions);
 	j9VMI->javaVM = vm;
 	j9VMI->portLibrary = vm->portLibrary;
-
-	/* Initialize the Harmony copy of the VMI */
-	harmonyVMI = &vm->harmonyVMInterface;
-	harmonyVMI->functions = GLOBAL_TABLE(J9VMInterfaceFunctions);
-	harmonyVMI->javaVM = vm;
-	harmonyVMI->portLibrary = NULL;
 
 	/* load the zlib */
 	if (0 != initZipLibrary(vm->portLibrary, vm->j2seRootDirectory)) {
 		return VMI_ERROR_INITIALIZATION_FAILED;
 	}
 
-#if defined(J9VM_OPT_HARMONY)
 	/* Acquire the initArgs via VMI */
-	vmi = (VMInterface*)j9VMI;
-	vmInitArgs = (*vmi)->GetInitArgs(vmi);
+#if defined(J9VM_OPT_HARMONY)
+	{ /* Introduce a new scope to keep older compilers happy */
+		JavaVMInitArgs* vmInitArgs = NULL;
+		VMInterface* vmi = NULL;
+		/* Initialize the Harmony copy of the VMI */
+		HarmonyVMInterface *harmonyVMI = &vm->harmonyVMInterface;
+		harmonyVMI->functions = GLOBAL_TABLE(J9VMInterfaceFunctions);
+		harmonyVMI->javaVM = vm;
+		harmonyVMI->portLibrary = NULL;
 
-	/* Locate the Harmony portlib (if possible) */
-	if (NULL != vmInitArgs) {
+		/* Acquire the initArgs via VMI */
+		vmi = (VMInterface*)j9VMI;
+		vmInitArgs = (*vmi)->GetInitArgs(vmi);
 
-		jint count = vmInitArgs->nOptions;
-		JavaVMOption *option = vmInitArgs->options;
+		/* Locate the Harmony portlib (if possible) */
+		if (NULL != vmInitArgs) {
 
-		while (count) {
-			if (!strcmp(option->optionString,"_org.apache.harmony.vmi.portlib")) {
-				harmonyVMI->portLibrary = (struct HyPortLibrary *)option->extraInfo;
-				return VMI_ERROR_NONE;
+			jint count = vmInitArgs->nOptions;
+			JavaVMOption *option = vmInitArgs->options;
+
+			while (count > 0) {
+				if (!strcmp(option->optionString,"_org.apache.harmony.vmi.portlib")) {
+					harmonyVMI->portLibrary = (struct HyPortLibrary *)option->extraInfo;
+					return VMI_ERROR_NONE;
+				}
+				++option;
+				--count;
 			}
-			++option;
-			--count;
 		}
 	}
-
-#endif
+#endif /* J9VM_OPT_HARMONY */
 	return VMI_ERROR_NONE;
 }
 


### PR DESCRIPTION
This adds missing ifdefs, relocates some Harmony-related code together, and drops a bogus test.
This is in preparation for a change in a separate repo to turn off the Harmony flag in OpenJ9.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>