### PR TITLE
Compress OSR assumption representation

### DIFF
--- a/runtime/tr.source/trj9/env/CHTable.hpp
+++ b/runtime/tr.source/trj9/env/CHTable.hpp
@@ -155,6 +155,18 @@ class TR_PatchNOPedGuardSiteOnClassRedefinition: public TR::PatchNOPedGuardSite
    void setKey(uintptrj_t newKey) {_key = newKey;}
    };
 
+class TR_PatchMultipleNOPedGuardSitesOnClassRedefinition : public TR::PatchMultipleNOPedGuardSites
+   {
+   protected:
+   TR_PatchMultipleNOPedGuardSitesOnClassRedefinition(TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, TR::PatchSites *sites)
+      : TR::PatchMultipleNOPedGuardSites(pm, (uintptrj_t)clazz, RuntimeAssumptionOnClassRedefinitionNOP, sites) {}
+   public:
+   static TR_PatchMultipleNOPedGuardSitesOnClassRedefinition *make(
+      TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, TR::PatchSites *sites, OMR::RuntimeAssumption **sentinel);
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnClassRedefinitionNOP; }
+   void setKey(uintptrj_t newKey) {_key = newKey;}
+   };
+
 class TR_PatchNOPedGuardSiteOnMutableCallSiteChange : public TR::PatchNOPedGuardSite
    {
    protected:
@@ -201,7 +213,8 @@ class TR_PatchJNICallSite : public OMR::ValueModifyRuntimeAssumption
          TR_PatchJNICallSite *site = other.asPJNICSite();
          return site != 0 && getPc() == site->getPc();
          }
-   virtual uint8_t *getAssumingPC() { return getPc(); }
+   virtual uint8_t *getFirstAssumingPC() { return getPc(); }
+   virtual uint8_t *getLastAssumingPC() { return getPc(); }
 
    virtual TR_PatchJNICallSite *asPJNICSite() { return this; }
    uint8_t *getPc() { return _pc; }
@@ -231,7 +244,8 @@ class TR_PreXRecompile : public OMR::LocationRedirectRuntimeAssumption
          }
 
    virtual TR_PreXRecompile *asPXRecompile() { return this; }
-   virtual uint8_t *getAssumingPC() { return getStartPC(); }
+   virtual uint8_t *getFirstAssumingPC() { return getStartPC(); }
+   virtual uint8_t *getLastAssumingPC() { return getStartPC(); }
    uint8_t *getStartPC()          { return _startPC; }
 
 
@@ -373,6 +387,7 @@ class TR_CHTable
 
    void commitVirtualGuard(TR_VirtualGuard *info, List<TR_VirtualGuardSite> &sites,
                            TR_PersistentCHTable *table, TR::Compilation *comp);
+   void commitOSRVirtualGuards(TR::Compilation *comp, TR::list<TR_VirtualGuard*> &vguards);
 
    TR_Array<TR_OpaqueClassBlock *> *getClasses() { return _classes;}
    TR_Array<TR_OpaqueClassBlock *> *getClassesThatShouldNotBeNewlyExtended() { return _classesThatShouldNotBeNewlyExtended;}

--- a/runtime/tr.source/trj9/runtime/J9RuntimeAssumptions.hpp
+++ b/runtime/tr.source/trj9/runtime/J9RuntimeAssumptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,8 @@ class TR_RedefinedClassPicSite : public OMR::ValueModifyRuntimeAssumption
       TR_RedefinedClassPicSite *o = other.asRCPSite();
       return (o != 0) && o->_picLocation == _picLocation;
       }
-   virtual uint8_t *getAssumingPC() { return getPicLocation(); }
+   virtual uint8_t *getFirstAssumingPC() { return getPicLocation(); }
+   virtual uint8_t *getLastAssumingPC() { return getPicLocation(); }
    virtual TR_RedefinedClassPicSite *asRCPSite() { return this; }
    uint8_t * getPicLocation()    { return _picLocation; }
    void      setPicLocation   (uint8_t *p) { _picLocation = p; }

--- a/runtime/tr.source/trj9/runtime/RuntimeAssumptions.hpp
+++ b/runtime/tr.source/trj9/runtime/RuntimeAssumptions.hpp
@@ -266,7 +266,8 @@ class TR_UnloadedClassPicSite : public OMR::ValueModifyRuntimeAssumption
       TR_UnloadedClassPicSite *o = other.asUCPSite();
       return (o != 0) && o->_picLocation == _picLocation;
       }
-   virtual uint8_t *getAssumingPC() { return getPicLocation(); }
+   virtual uint8_t *getFirstAssumingPC() { return getPicLocation(); }
+   virtual uint8_t *getLastAssumingPC() { return getPicLocation(); }
    virtual TR_UnloadedClassPicSite *asUCPSite() { return this; }
    uint8_t * getPicLocation()    { return _picLocation; }
    void      setPicLocation   (uint8_t *p) { _picLocation = p; }


### PR DESCRIPTION
All OSR guards will be patched in the event an OSR transition
is desired. This was implemented by creating a runtime
assumption for each possible event and each patch point.
This incurred significant overhead due to the number of assumptions.
A new type of runtime assumption has been added capable
of representing several patch points for one event.
This change uses these new assumptions for OSR guards.