### PR TITLE
Fix Java 9 signature test failures

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2032,7 +2032,7 @@ public native boolean isPrimitive();
  */
 @CallerSensitive
 /*[IF Sidecar19-SE]*/
-@Deprecated(forRemoval=false, since="1.1")
+@Deprecated(forRemoval=false, since="9")
 /*[ENDIF]*/
 public T newInstance() throws IllegalAccessException, InstantiationException {
 	SecurityManager security = System.getSecurityManager();

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -939,7 +939,7 @@ public InputStream getResourceAsStream (String resName) {
  *
  * @throws IOException
  */
-protected InputStream getResourceAsStream(String moduleName, String name) throws IOException
+InputStream getResourceAsStream(String moduleName, String name) throws IOException
 {
 	return null;
 }

--- a/jcl/src/java.base/share/classes/java/lang/Compiler.java
+++ b/jcl/src/java.base/share/classes/java/lang/Compiler.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2010 IBM Corp. and others
+ * Copyright (c) 1998, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,9 @@ package java.lang;
  *
  * @see			Cloneable
  */
+/*[IF Sidecar19-SE]*/
+@Deprecated(forRemoval=true, since="9")
+/*[ENDIF]*/
 public final class Compiler {
 
 private Compiler() {}

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -37,6 +37,7 @@ import java.util.StringJoiner;
 import java.util.Iterator;
 /*[IF Sidecar19-SE]*/
 import jdk.internal.misc.Unsafe;
+import java.util.stream.IntStream;
 /*[ELSE]*/
 import sun.misc.Unsafe;
 /*[ENDIF]*/
@@ -5281,6 +5282,18 @@ written authorization of the copyright holder.
 			return;
 		}
 		throw newStringIndexOutOfBoundsException(begin, end, length);
+	}
+	
+	@Override
+	public IntStream chars() {
+		/* Following generic CharSequence method invoking need to be updated with optimized implementation specifically for this class */
+		return CharSequence.super.chars();
+	}
+	
+	@Override
+	public IntStream codePoints() {
+		/* Following generic CharSequence method invoking need to be updated with optimized implementation specifically for this class */
+		return CharSequence.super.codePoints();
 	}
 /*[ENDIF]*/	
 }

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -32,6 +32,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.InvalidObjectException;
 
+/*[IF Sidecar19-SE]*/
+import java.util.stream.IntStream;
+/*[ENDIF]*/
+
 /**
  * StringBuffer is a variable size contiguous indexable array of characters.
  * The length of the StringBuffer is the number of characters it contains.
@@ -3398,4 +3402,19 @@ char[] getValue() {
 /*[ENDIF]*/
 	return value;
 }
+
+/*[IF Sidecar19-SE]*/
+	@Override
+	public IntStream chars() {
+		/* Following generic CharSequence method invoking need to be updated with optimized implementation specifically for this class */
+		return CharSequence.super.chars();
+	}
+	
+	@Override
+	public IntStream codePoints() {
+		/* Following generic CharSequence method invoking need to be updated with optimized implementation specifically for this class */
+		return CharSequence.super.codePoints();
+	}
+/*[ENDIF]*/
+
 }

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -32,6 +32,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.InvalidObjectException;
 
+/*[IF Sidecar19-SE]*/
+import java.util.stream.IntStream;
+/*[ENDIF]*/
+
 /**
  * StringBuilder is not thread safe. For a synchronized implementation, use
  * StringBuffer.
@@ -3431,4 +3435,19 @@ char[] getValue() {
 /*[ENDIF]*/
 	return value;
 }
+
+/*[IF Sidecar19-SE]*/
+	@Override
+	public IntStream chars() {
+		/* Following generic CharSequence method invoking need to be updated with optimized implementation specifically for this class */
+		return CharSequence.super.chars();
+	}
+	
+	@Override
+	public IntStream codePoints() {
+		/* Following generic CharSequence method invoking need to be updated with optimized implementation specifically for this class */
+		return CharSequence.super.codePoints();
+	}
+/*[ENDIF]*/
+
 }

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -690,7 +690,7 @@ public static void runFinalization() {
  * @deprecated 	This method is unsafe.
  */
 /*[IF Sidecar19-SE]*/
-@Deprecated(forRemoval=false, since="1.2")
+@Deprecated(forRemoval=true, since="1.2")
 /*[ELSE]
 @Deprecated
 /*[ENDIF]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2938,7 +2938,7 @@ public class MethodHandles {
 	 * @param location the (zero-indexed) location of the first argument to be removed
 	 * @return a MethodHandle representing a transformed handle as described above
 	 */
-	public static final  MethodHandle dropArgumentsToMatch(MethodHandle originalHandle, int skippedArgumentCount, List<Class<?>> valueTypes, int location) {
+	public static MethodHandle dropArgumentsToMatch(MethodHandle originalHandle, int skippedArgumentCount, List<Class<?>> valueTypes, int location) {
 		/* implicit null checks */
 		MethodType originalType = originalHandle.type;
 		Class<?>[] valueTypesCopy = valueTypes.toArray(new Class<?>[valueTypes.size()]);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -301,7 +301,7 @@ public abstract class VarHandle extends VarHandleInternal {
 	 * 
 	 * @return The parameters required to access the field.
 	 */
-	public List<Class<?>> coordinateTypes() {
+	public final List<Class<?>> coordinateTypes() {
 		return Collections.unmodifiableList(Arrays.<Class<?>>asList(coordinateTypes));
 	}
 	
@@ -332,7 +332,7 @@ public abstract class VarHandle extends VarHandleInternal {
 	 * @param accessMode The {@link AccessMode} to check support for.
 	 * @return A boolean value indicating whether the {@link AccessMode} is supported.
 	 */
-	public boolean isAccessModeSupported(AccessMode accessMode) {
+	public final boolean isAccessModeSupported(AccessMode accessMode) {
 		switch (accessMode) {
 		case GET:
 		case GET_VOLATILE:

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -27,48 +27,6 @@ abstract class ViewVarHandle extends VarHandle {
 		super(fieldType, coordinateTypes, handleTable, modifiers);
 	}
 	
-	@Override
-	public boolean isAccessModeSupported(AccessMode accessMode) {
-		switch (accessMode) {
-		case GET:
-		case GET_VOLATILE:
-		case GET_OPAQUE:
-		case GET_ACQUIRE:
-		case SET:
-		case SET_VOLATILE:
-		case SET_OPAQUE:
-		case SET_RELEASE:
-			return true;
-		case COMPARE_AND_SET:
-		case COMPARE_AND_EXCHANGE_ACQUIRE:
-		case COMPARE_AND_EXCHANGE_RELEASE:
-		case COMPARE_AND_EXCHANGE:
-		case WEAK_COMPARE_AND_SET:
-		case WEAK_COMPARE_AND_SET_ACQUIRE:
-		case WEAK_COMPARE_AND_SET_RELEASE:
-		case WEAK_COMPARE_AND_SET_PLAIN:
-		case GET_AND_SET:
-		case GET_AND_SET_ACQUIRE:
-		case GET_AND_SET_RELEASE:
-			return ((char.class != fieldType) && (short.class != fieldType));
-		case GET_AND_ADD:
-		case GET_AND_ADD_ACQUIRE:
-		case GET_AND_ADD_RELEASE:
-		case GET_AND_BITWISE_AND:
-		case GET_AND_BITWISE_AND_ACQUIRE:
-		case GET_AND_BITWISE_AND_RELEASE:
-		case GET_AND_BITWISE_OR:
-		case GET_AND_BITWISE_OR_ACQUIRE:
-		case GET_AND_BITWISE_OR_RELEASE:
-		case GET_AND_BITWISE_XOR:
-		case GET_AND_BITWISE_XOR_ACQUIRE:
-		case GET_AND_BITWISE_XOR_RELEASE:
-			return ((int.class == fieldType) || (long.class == fieldType));
-		default:
-			throw new InternalError("Invalid AccessMode"); //$NON-NLS-1$
-		}
-	}
-	
 	static class ViewVarHandleOperations extends VarHandleOperations {
 		static final char convertEndian(char value) {
 			return Character.reverseBytes(value);


### PR DESCRIPTION
Fix `Java 9` signature test failures

- Fixed annotation for `j.l.Class.newInstance, j.l.Compiler` and `j.l.System.runFinalizersOnExit`;
- Changed method `j.l.ClassLoader.getResourceAsStream(moduleName, name)` access level to package access;
- Provided public access method implementation `chars()/codePoints()` for  classes`j.l.String`, `j.l.StringBuffer`, and `j.l.StringBuilder`;
- Removed `final` from method `j.l.i.MethodHandles.dropArgumentsToMatch`;
- Added `final` for methods `j.l.i.VarHandle.coordinateTypes/isAccessModeSupported`, also removed the override method `j.l.i.ViewVarHandle.isAccessModeSupported`.

Closes #548 

Reviewers: @pshipton @tajila 
FYI @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>