### PR TITLE
Correct Java 9 parsing for -enableassertion like options

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2106,7 +2106,11 @@ boolean getDefaultAssertionStatus() {
  */
 private void initializeClassLoaderAssertStatus() {
 	/*[PR CMVC 130382] Optimize checking ClassLoader assertion status */
+	/*[IF Sidecar19-SE]*/
+	boolean bootLoader = bootstrapClassLoader == this;
+	/*[ELSE]
 	boolean bootLoader = bootstrapClassLoader == null;
+	/*[ENDIF]*/
 
 	if (!bootLoader && !checkAssertionOptions) {
 		// if the bootLoader didn't find any assertion options, other


### PR DESCRIPTION
The check for the boot loader in
ClassLoader.initializeClassLoaderAssertStatus() is different for Java 9
and later.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>