### PR TITLE
Improve JVMTRCE003E message for invalid filename

### DIFF
--- a/runtime/rastrace/trcoptions.c
+++ b/runtime/rastrace/trcoptions.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 IBM Corp. and others
+ * Copyright (c) 1998, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -651,7 +651,8 @@ setOutput(UtThreadData **thr, const char *value, BOOLEAN atRuntime)
 				} else {
 					if ((UT_GLOBAL(generationChar) =
 						strchr(UT_GLOBAL(traceFilename), '#')) == NULL) {
-						reportCommandLineError(atRuntime, "Invalid filename for generation mode");
+						reportCommandLineError(atRuntime, "Invalid filename for generation mode," 
+								" the filename must contain a \"#\"");
 						rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 					}
 				}


### PR DESCRIPTION
This fix modifies the JVMTRCE003E error message in case the output
filename in Xtrace option does not contain a '#' to provide more clarity
why the error is thrown.

Fixes: #637
Signed-off-by: Kabir Islam <kaislam1@in.ibm.com>