### PR TITLE
Fix VarHandleUtilTests extended test failures

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -325,14 +325,13 @@ public abstract class VarHandle extends VarHandleInternal {
 	}
 	
 	/**
-	 * Not all AccessMode are supported for all {@link VarHandle} instances, e.g. 
-	 * because of the field type and/or field modifiers. This method indicates whether 
-	 * a specific {@link AccessMode} is supported by by this {@link VarHandle} instance.
+	 * This is a helper method to allow sub-class ViewVarHandle provide its own implementation
+	 * while making isAccessModeSupported(accessMode) final to satisfy signature tests.
 	 * 
 	 * @param accessMode The {@link AccessMode} to check support for.
 	 * @return A boolean value indicating whether the {@link AccessMode} is supported.
 	 */
-	public final boolean isAccessModeSupported(AccessMode accessMode) {
+	boolean isAccessModeSupportedHelper(AccessMode accessMode) {
 		switch (accessMode) {
 		case GET:
 		case GET_VOLATILE:
@@ -372,6 +371,18 @@ public abstract class VarHandle extends VarHandleInternal {
 		default:
 			throw new InternalError("Invalid AccessMode"); //$NON-NLS-1$
 		}
+	}
+	
+	/**
+	 * Not all AccessMode are supported for all {@link VarHandle} instances, e.g. 
+	 * because of the field type and/or field modifiers. This method indicates whether 
+	 * a specific {@link AccessMode} is supported by by this {@link VarHandle} instance.
+	 * 
+	 * @param accessMode The {@link AccessMode} to check support for.
+	 * @return A boolean value indicating whether the {@link AccessMode} is supported.
+	 */
+	public final boolean isAccessModeSupported(AccessMode accessMode) {
+		return isAccessModeSupportedHelper(accessMode);
 	}
 	
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ViewVarHandle.java
@@ -27,6 +27,48 @@ abstract class ViewVarHandle extends VarHandle {
 		super(fieldType, coordinateTypes, handleTable, modifiers);
 	}
 	
+	@Override
+	final boolean isAccessModeSupportedHelper(AccessMode accessMode) {
+		switch (accessMode) {
+		case GET:
+		case GET_VOLATILE:
+		case GET_OPAQUE:
+		case GET_ACQUIRE:
+		case SET:
+		case SET_VOLATILE:
+		case SET_OPAQUE:
+		case SET_RELEASE:
+			return true;
+		case COMPARE_AND_SET:
+		case COMPARE_AND_EXCHANGE_ACQUIRE:
+		case COMPARE_AND_EXCHANGE_RELEASE:
+		case COMPARE_AND_EXCHANGE:
+		case WEAK_COMPARE_AND_SET:
+		case WEAK_COMPARE_AND_SET_ACQUIRE:
+		case WEAK_COMPARE_AND_SET_RELEASE:
+		case WEAK_COMPARE_AND_SET_PLAIN:
+		case GET_AND_SET:
+		case GET_AND_SET_ACQUIRE:
+		case GET_AND_SET_RELEASE:
+			return ((char.class != fieldType) && (short.class != fieldType));
+		case GET_AND_ADD:
+		case GET_AND_ADD_ACQUIRE:
+		case GET_AND_ADD_RELEASE:
+		case GET_AND_BITWISE_AND:
+		case GET_AND_BITWISE_AND_ACQUIRE:
+		case GET_AND_BITWISE_AND_RELEASE:
+		case GET_AND_BITWISE_OR:
+		case GET_AND_BITWISE_OR_ACQUIRE:
+		case GET_AND_BITWISE_OR_RELEASE:
+		case GET_AND_BITWISE_XOR:
+		case GET_AND_BITWISE_XOR_ACQUIRE:
+		case GET_AND_BITWISE_XOR_RELEASE:
+			return ((int.class == fieldType) || (long.class == fieldType));
+		default:
+			throw new InternalError("Invalid AccessMode"); //$NON-NLS-1$
+		}
+	}
+	
 	static class ViewVarHandleOperations extends VarHandleOperations {
 		static final char convertEndian(char value) {
 			return Character.reverseBytes(value);


### PR DESCRIPTION
Fix `VarHandleUtilTests` extended test failures

Introducing helper method `isAccessModeSupportedHelper(accessMode)` to allow `VarHandle` and sub-class `ViewVarHandle` keep existing implementation while making method `isAccessModeSupported(accessMode)` final to satisfy signature tests.

closes: #646 

Reviewer @DanHeidinga 
FYI: @smlambert @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>