### PR TITLE
Stop allocating memory from already released segments

### DIFF
--- a/runtime/compiler/trj9/env/SystemSegmentProvider.hpp
+++ b/runtime/compiler/trj9/env/SystemSegmentProvider.hpp
@@ -47,14 +47,16 @@ public:
    size_t bytesAllocated() const throw();
    size_t allocationLimit() const throw();
    void setAllocationLimit(size_t allocationLimit);
+   bool isLargeSegment(size_t segmentSize);
 
 private:
    size_t round(size_t requestedSize);
    ptrdiff_t remaining(const J9MemorySegment &memorySegment);
-   TR::MemorySegment &allocateNewSegment(size_t size);
+   TR::MemorySegment &allocateNewSegment(size_t size, TR::reference_wrapper<J9MemorySegment> systemSegment);
    TR::MemorySegment &createSegmentFromArea(size_t size, void * segmentArea);
 
-   size_t const _systemSegmentSize;
+   // _systemSegmentSize is only to be written once in the constructor
+   size_t _systemSegmentSize;
    size_t _allocationLimit;
    size_t _systemBytesAllocated;
    size_t _regionBytesAllocated;
@@ -91,6 +93,10 @@ private:
       FreeSegmentDequeAllocator
       > _freeSegments;
 
+   // Current active System segment from where memory might be allocated.
+   // A segment with space larger than _systemSegmentSize is used for only one request,
+   // and is to be released when the release method is invoked, e.g. when a TR::Region
+   // goes out of scope. Thus _currentSystemSegment is not allowed to hold such segment.
    TR::reference_wrapper<J9MemorySegment> _currentSystemSegment;
 
    };


### PR DESCRIPTION
A large system segment, one that's larger than a specific size, is
used by only one region and is to be release once that region is out
of scope.

A field in J9::SystemSegmentProvider named _currentSystemSegment keeps
track of current active segment from where allocation can be made.
This field will point to a large system segment if one is created.
When this segment is released, this field is not updated, resulting
potential allocations from such segment, then causing segmentation
errors due to read/write to inaccessible addresses. The inaccessible
address usually appears to be a seemingly valid one.

This change stops _currentSystemSegment holding onto such segment.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>