### PR TITLE
Add missing JDK10 methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -58,4 +58,14 @@ final class MemberName {
 	public boolean isNative() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+	
+	/*[IF Java18.3]*/
+	public MethodType getMethodType() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	
+	String getMethodDescriptor() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	/*[ENDIF]*/
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1155,6 +1155,16 @@ public final class MethodType implements Serializable {
 	MethodType asCollectorType(Class<?> clz, int num1, int num2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+
+	/*[IF Java18.3]*/
+	/**
+	 * Returns the number of stack slots used by the described args in the MethodType.
+	 * @return The number of stack slots
+	 */
+	int parameterSlotCount() {
+		return argSlots;
+	}
+	/*[ENDIF]*/	
 /*[ELSE]*/
 	MethodType asCollectorType(Class<?> clz, int num1) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();


### PR DESCRIPTION
Adding folllowing missing JDK10 methods
````
java.lang.invoke.MemberName:
	public MethodType getMethodType()
	String getMethodDescriptor()
java.lang.invoke.MethodType:
	int parameterSlotCount()
````
Though @andrew-m-leonard requested `public String getMethodDescriptor()` in issue #651, latest `Java 10 b32` has `String getMethodDescriptor()` instead which only has `package` access.

Manually verified that pConfigs still compile.

closes: #651

Reviewer @DanHeidinga 
FYI @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>