### PR TITLE
Remove FrontEnd implementation of reserveNTrampolines

### DIFF
--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5714,66 +5714,6 @@ TR_J9VMBase::indexedTrampolineLookup(int32_t helperIndex, void * callSite)
    return (intptrj_t)tramp;
    }
 
-void
-TR_J9VMBase::reserveNTrampolines(TR::Compilation * comp, int32_t n, bool inBinaryEncoding)
-   {
-#if defined(TR_TARGET_X86) && defined(TR_TARGET_64BIT)
-   // Don't do anything if method trampolines are not needed
-   if (!needsMethodTrampolines())
-      return;
-   bool hadClassUnloadMonitor;
-   bool hadVMAccess = releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(comp, &hadClassUnloadMonitor);
-
-   TR::CodeCache *curCache = comp->getCurrentCodeCache();
-   TR::CodeCache *newCache = curCache;
-   OMR::CodeCacheErrorCode::ErrorCode status = OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS;
-
-   TR_ASSERT(curCache->isReserved(), "assertion failure"); // MCT
-
-   if (!isAOT_DEPRECATED_DO_NOT_USE())
-      {
-      status = curCache->reserveNTrampolines(n);
-      if (status != OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
-         {
-         // Current code cache is no good. Must unreserve
-         curCache->unreserve();
-         newCache = 0;
-         if (!inBinaryEncoding)
-            {
-            newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID());
-            if (newCache)
-               {
-               status = newCache->reserveNTrampolines(n);
-               TR_ASSERT(status == OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS, "Failed to reserve trampolines in fresh code cache.");
-               }
-            }
-         }
-      }
-
-   acquireClassUnloadMonitorAndReleaseVMAccessIfNeeded(comp, hadVMAccess, hadClassUnloadMonitor);
-
-   if (!newCache)
-      {
-      throw J9::TrampolineError();
-      }
-
-   if (newCache != curCache)
-      {
-      // We keep track of number of IPIC trampolines that are present in the current code cache
-      // If the code caches have been switched we have to reset this number, the setCodeCacheSwitched helper called
-      // in switchCodeCache resets the count
-      // If we are in binaryEncoding we will kill this compilation anyway
-      switchCodeCache(comp, curCache, newCache);
-      }
-   else
-      {
-      comp->setNumReservedIPICTrampolines(comp->getNumReservedIPICTrampolines()+n);
-      }
-
-   TR_ASSERT(newCache->isReserved(), "assertion failure");
-#endif
-   }
-
 bool TR_J9VMBase::needsMethodTrampolines()
    {
    TR::CodeCacheConfig &codeCacheConfig = TR::CodeCacheManager::instance()->codeCacheConfig();
@@ -7498,7 +7438,7 @@ TR_J9VM::transformJavaLangClassIsArray(TR::Compilation * comp, TR::Node * callNo
    //   PassThrough
    //     aload <parm 1>         <= jlClass
    // treetop
-   //   iushr 
+   //   iushr
    //    iand
    //     iloadi <classAndDepthFlags>
    //       aloadi <classFromJavaLangClass>
@@ -9434,7 +9374,7 @@ portLibCall_sysinfo_has_resumable_trap_handler()
       #endif
       #if defined(J9ZTPF)
          return false;
-      #else      
+      #else
          return true;
       #endif
    #endif

--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -645,7 +645,7 @@ public:
    virtual int checkInlineableWithoutInitialCalleeSymbol (TR_CallSite* callsite, TR::Compilation* comp);
    virtual int checkInlineableTarget (TR_CallTarget* target, TR_CallSite* callsite, TR::Compilation* comp, bool inJSR292InliningPasses);
 
-#ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION 
+#ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    virtual bool inlineRecognizedCryptoMethod(TR_CallTarget* target, TR::Compilation* comp);
    virtual bool inlineNativeCryptoMethod(TR::Node *callNode, TR::Compilation *comp);
 #endif
@@ -786,7 +786,6 @@ public:
 
    virtual void reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void *callSite);
-   virtual void reserveNTrampolines( TR::Compilation *, int32_t n, bool inBinaryEncoding);
    virtual TR::CodeCache* getResolvedTrampoline( TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) = 0;
    virtual bool needsMethodTrampolines();
 

--- a/runtime/compiler/trj9/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/trj9/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1482,7 +1482,7 @@ void TR::AMD64PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *
    cg()->incPicSlotCountBy(IPicParameters.defaultNumberOfSlots);
    numIPICs = IPicParameters.defaultNumberOfSlots;
 
-   fej9->reserveNTrampolines(comp(), numIPICs, false);
+   cg()->reserveNTrampolines(numIPICs);
    }
 
 void TR::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)

--- a/runtime/compiler/trj9/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/trj9/x/codegen/X86PrivateLinkage.cpp
@@ -2880,7 +2880,7 @@ void TR::X86PrivateLinkage::buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *en
    cg()->addSnippet(snippet);
 
    cg()->incPicSlotCountBy(VPicParameters.defaultNumberOfSlots);
-   fej9->reserveNTrampolines(comp(), VPicParameters.defaultNumberOfSlots, false);
+   cg()->reserveNTrampolines(VPicParameters.defaultNumberOfSlots);
    }
 
 void TR::X86PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86CallSite &site, int32_t numIPicSlots, TR::X86PICSlot &lastPicSlot, TR::Instruction *&slotPatchInstruction, TR::LabelSymbol *doneLabel, TR::LabelSymbol *lookupDispatchSnippetLabel, TR_OpaqueClassBlock *declaringClass, uintptrj_t itableIndex )


### PR DESCRIPTION
Route all existing references to the new CodeGenerator implementation.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>