### PR TITLE
Removing ASPP Step from AIX Build

### DIFF
--- a/runtime/compiler/trj9/build/rules/aix-xlc/filetypes.mk
+++ b/runtime/compiler/trj9/build/rules/aix-xlc/filetypes.mk
@@ -103,10 +103,12 @@ endef # DEF_RULE.ipp
 
 RULE.ipp=$(eval $(DEF_RULE.ipp))
 
-# Compile .aspp file into .ipp file
-define DEF_RULE.aspp
+#
+# Compile .spp file into .o file
+#
+define DEF_RULE.spp
 $(1).ipp: $(2) | jit_createdirs
-	$$(ASPP_CMD) $$(ASPP_FLAGS) $$(patsubst %,-D%,$$(ASPP_DEFINES)) $$(patsubst %,-I'%',$$(ASPP_INCLUDES)) -E $$< > $$@
+	$$(SPP_CMD) $$(SPP_FLAGS) $$(patsubst %,-D%,$$(SPP_DEFINES)) $$(patsubst %,-I'%',$$(SPP_INCLUDES)) -E $$< > $$@
 
 JIT_DIR_LIST+=$(dir $(1))
 
@@ -114,23 +116,6 @@ jit_cleanobjs::
 	rm -f $(1).ipp
 
 $(call RULE.ipp,$(1),$(1).ipp)
-endef
-
-RULE.aspp=$(eval $(DEF_RULE.aspp))
-
-#
-# Compile .spp file into .o file
-#
-define DEF_RULE.spp
-$(1).aspp: $(2) | jit_createdirs
-	$$(SPP_CMD) $$(SPP_FLAGS) $$< $$@
-
-JIT_DIR_LIST+=$(dir $(1))
-
-jit_cleanobjs::
-	rm -f $(1).aspp
-
-$(call RULE.aspp,$(1),$(1).aspp)
 endef # DEF_RULE.spp
 
 RULE.spp=$(eval $(DEF_RULE.spp))

--- a/runtime/compiler/trj9/build/toolcfg/aix-xlc/common.mk
+++ b/runtime/compiler/trj9/build/toolcfg/aix-xlc/common.mk
@@ -43,7 +43,6 @@ DEPSUFF=.depend.mk
 AS_PATH?=as
 CC_PATH?=xlc_r
 CXX_PATH?=xlC_r
-ASPP_PATH?=cp
 SED_PATH?=sed
 PERL_PATH?=perl
 SHAREDLIB_PATH?=makeC++SharedLib_r
@@ -147,13 +146,13 @@ endif
 S_FLAGS+=$(S_FLAGS_EXTRA)
 
 #
-# Now setup ASPP
+# Now setup SPP
 #
-ASPP_CMD?=$(CC_PATH)
+SPP_CMD?=$(CC_PATH)
 
-ASPP_INCLUDES=$(PRODUCT_INCLUDES)
+SPP_INCLUDES=$(PRODUCT_INCLUDES)
 
-ASPP_DEFINES+=\
+SPP_DEFINES+=\
     $(PRODUCT_DEFINES) \
     $(HOST_DEFINES) \
     $(TARGET_DEFINES) \
@@ -162,17 +161,17 @@ ASPP_DEFINES+=\
     _XOPEN_SOURCE_EXTENDED=1 \
     _ALL_SOURCE \
     SUPPORTS_THREAD_LOCAL \
-    $(ASPP_DEFINES_EXTRA)
+    $(SPP_DEFINES_EXTRA)
 
 ifeq ($(BUILD_CONFIG),debug)
-    ASPP_FLAGS+=$(ASPP_FLAGS_DEBUG)
+    SPP_FLAGS+=$(SPP_FLAGS_DEBUG)
 endif
 
 ifeq ($(BUILD_CONFIG),prod)
-    ASPP_FLAGS+=$(ASPP_FLAGS_PROD)
+    SPP_FLAGS+=$(SPP_FLAGS_PROD)
 endif
     
-ASPP_FLAGS+=$(ASPP_FLAGS_EXTRA)
+SPP_FLAGS+=$(SPP_FLAGS_EXTRA)
 
 # Now setup IPP
 IPP_CMD?=$(SED_PATH)
@@ -186,9 +185,6 @@ ifeq ($(BUILD_CONFIG),prod)
 endif
 
 IPP_FLAGS+=$(IPP_FLAGS_EXTRA)
-
-# Now setup SPP
-SPP_CMD?=$(ASPP_PATH)
 
 #
 # Finally setup the linker


### PR DESCRIPTION
Removing ASPP Build Stage during AIX Compiles

Currently we compile with a step called ASPP. This step adds some spacing, formatting and generates an intermediate file that can be used in the ASPP tool in order to debug SPP file compiles. Since launching open source, we don't ship with this tool as this tool is strictly internal. This needs to be removed as it is not used anymore, and the debugging tool is not accessible by the general public. 

This change would alter the compile process of spp files. Below is the before and after workflow for the compile process: 

Before:
.SPP --(ASPP Compile)--> .ASPP --(XLC Pre-processing)--> .IPP

After:
.SPP --(XLC Preprocessing)--> .IPP

Earlier, in the compile process we would use the ASPP tool to compile the .ASPP file. The resulting .ASPP file is then fed into XLC and pre-processing is done which is then imported into an .IPP file. 

Since the ASPP tool is not shipped now, the .SPP file is directly fed into XLC Pre-processing stage to create the .IPP output. 

Signed-off-by: Alen Badel <Alen.Badel@ibm.com>