### PR TITLE
Inliner changes for VarHandle performance

### DIFF
--- a/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -993,6 +993,7 @@
    java_lang_invoke_InterfaceHandle_invokeExact,
    java_lang_invoke_MethodHandle_doCustomizationLogic,
    java_lang_invoke_MethodHandle_asType,
+   java_lang_invoke_MethodHandle_asType_instance,
    java_lang_invoke_MethodHandle_invoke,
    java_lang_invoke_MethodHandle_invokeExact,
    java_lang_invoke_MethodHandle_invokeExactTargetAddress,

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -3186,6 +3186,7 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
       // This first if statement controls inlining of a large class of JSR292 methods, which we want to consider ONLY in certain cases in early rounds of inlining...
       if ( resolvedMethod->convertToMethod()->isArchetypeSpecimen() ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact ||
+         resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_asType ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MutableCallSite_getTarget ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_DirectHandle_invokeExact ||
@@ -3195,6 +3196,7 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
          {
          if ( resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MutableCallSite_getTarget ||
+             resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_asType ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_DirectHandle_invokeExact ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_InterfaceHandle_invokeExact ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_VirtualHandle_invokeExact
@@ -3307,6 +3309,7 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
       case TR::com_ibm_jit_JITHelpers_getJ9ClassFromObject64:
       case TR::com_ibm_jit_JITHelpers_getClassInitializeStatus:
       case TR::java_lang_StringUTF16_getChar:
+      case TR::java_lang_invoke_MethodHandle_asType_instance:
             return DontInline_Callee;
       default:
          break;

--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -3713,6 +3713,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {  TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress ,   24, "invokeExactTargetAddress",   (int16_t)-1, "*"},
       {x(TR::java_lang_invoke_MethodHandle_invokeWithArgumentsHelper,   "invokeWithArgumentsHelper",  "(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_lang_invoke_MethodHandle_asType, "asType", "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;")},
+      {x(TR::java_lang_invoke_MethodHandle_asType_instance, "asType", "(Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;")},
       {  TR::unknownMethod}
       };
 
@@ -4504,7 +4505,19 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
          else if ((classNameLen == 29) && !strncmp(className, "java/lang/invoke/MethodHandle", 29))
             {
             if (!strncmp(name, "asType", 6))
-               setRecognizedMethodInfo(TR::java_lang_invoke_MethodHandle_asType);
+               {
+               int32_t instanceAsTypeSigLen = strlen("(Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;");
+               if (sigLen == instanceAsTypeSigLen &&
+                   !strncmp(sig, "(Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;", instanceAsTypeSigLen))
+                  {
+                  setRecognizedMethodInfo(TR::java_lang_invoke_MethodHandle_asType_instance);
+                  }
+               else
+                  {
+                  setRecognizedMethodInfo(TR::java_lang_invoke_MethodHandle_asType);
+                  }
+               }
+
             if (!strncmp(name, "invokeExactTargetAddress",24))
                setRecognizedMethodInfo(TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress);
             }

--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -4923,6 +4923,24 @@ TR_J9InlinerUtil::computePrexInfo(TR_CallTarget *target)
    return argInfo;
    }
 
+bool TR_J9InlinerUtil::needTargetedInlining(TR::ResolvedMethodSymbol *callee)
+   {
+   // Trees from archetype specimens may not match the archetype method's bytecodes,
+   // so there may be some calls things that inliner missed.
+   //
+   // We also inline again if MethodHandle.asType has been inlined because VP might be able to
+   // prove invokeHandleGeneric is invoke exact
+   //
+   // Tactically, we also inline again based on hasMethodHandleInvokes because EstimateCodeSize
+   // doesn't yet cope with invokeHandle, invokeHandleGeneric, and invokeDynamic (but it should).
+   //
+   if (callee->getMethod()->isArchetypeSpecimen() ||
+       callee->hasMethodHandleInvokes() ||
+       callee->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_asType)
+      return true;
+   return false;
+   }
+
 /** Find arguments which refer to constant classes
  If a parameter refers to a constant class, set the known object index in _ecsPrexArgInfo
  of the target.

--- a/runtime/compiler/trj9/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/trj9/optimizer/J9Inliner.hpp
@@ -135,6 +135,7 @@ class TR_J9InlinerUtil: public OMR_InlinerUtil
                    TR::TreeTop *&virtualGuard, TR::Block *block4);
       virtual void refineInliningThresholds(TR::Compilation *comp, int32_t &callerWeightLimit, int32_t &maxRecursiveCallByteCodeSizeEstimate, int32_t &methodByteCodeSizeThreshold, int32_t &methodInWarmBlockByteCodeSizeThreshold, int32_t &methodInColdBlockByteCodeSizeThreshold, int32_t &nodeCountThreshold, int32_t size);
       static void checkForConstClass(TR_CallTarget *target, TR_InlinerTracer *tracer);
+      virtual bool needTargetedInlining(TR::ResolvedMethodSymbol *callee);
    protected:
       virtual bool validateInterfaceImplementation(TR_ResolvedMethod *interfaceMethod);
       virtual void refineColdness (TR::Node* node, bool& isCold);

--- a/runtime/compiler/trj9/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/trj9/optimizer/UnsafeFastPath.cpp
@@ -404,7 +404,7 @@ int32_t TR_UnsafeFastPath::perform()
 
          if (type != TR::NoType && performTransformation(comp(), "%s Found unsafe/JITHelpers calls, turning node [" POINTER_PRINTF_FORMAT "] into a load/store\n", optDetailString(), node))
             {
-            TR::SymbolReference * unsafeSymRef = comp()->getSymRefTab()->findOrCreateUnsafeSymbolRef(type, true, false, isVolatile);
+            TR::SymbolReference * unsafeSymRef = comp()->getSymRefTab()->findOrCreateUnsafeSymbolRef(type, true, isStatic, isVolatile);
 
             // some helpers are special - we know they are accessing an array and we know the kind of that array
             // so use the more helpful symref if we can

--- a/runtime/compiler/trj9/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/trj9/optimizer/VarHandleTransformer.cpp
@@ -351,6 +351,9 @@ int32_t TR_VarHandleTransformer::perform()
                invokeCall->setAndIncChild(child_i, nodeCursor);
                child_i++;
                }
+
+            // Set the flag on the caller symbol to trigger targeted inlining
+            methodSymbol->setHasMethodHandleInvokes(true);
             }
          }
       }


### PR DESCRIPTION
Implement the extension point needTargetedInlining with the Java
specific code from OMR. Other changes will allow targeted inlining
inline the static method MethodHandle.asType as well as triggering
another pass of targeted inlining group if MethodHandle.asType is
inlined.

These are necessary because VarHandle.invoke is implemented with
generic MethodHandle invoke. i.e. calling invokeExact on the result of
MethodHandle.asType. It requires more passes of targeted inlining
group to inline methods, to propagate the type information and
devirtualize calls.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>