### PR TITLE
Remove FrontEnd function needsMethodTrampolines()

### DIFF
--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5715,13 +5715,6 @@ TR_J9VMBase::indexedTrampolineLookup(int32_t helperIndex, void * callSite)
    return (intptrj_t)tramp;
    }
 
-bool TR_J9VMBase::needsMethodTrampolines()
-   {
-   TR::CodeCacheConfig &codeCacheConfig = TR::CodeCacheManager::instance()->codeCacheConfig();
-   return codeCacheConfig.needsMethodTrampolines();
-   }
-
-
 // interpreter profiling support
 TR_IProfiler *
 TR_J9VMBase::getIProfiler()

--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -787,7 +787,6 @@ public:
    virtual void reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void *callSite);
    virtual TR::CodeCache* getResolvedTrampoline( TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) = 0;
-   virtual bool needsMethodTrampolines();
 
    // Interpreter profiling support
    virtual TR_IProfiler  *getIProfiler();

--- a/runtime/compiler/trj9/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/trj9/runtime/RelocationRuntime.cpp
@@ -45,6 +45,7 @@
 #include "runtime/MethodMetaData.h"
 #include "runtime/Runtime.hpp"
 #include "runtime/CodeCache.hpp"
+#include "runtime/CodeCacheConfig.hpp"
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/ArtifactManager.hpp"
 #include "runtime/DataCache.hpp"
@@ -1261,7 +1262,7 @@ TR_SharedCacheRelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
    if (TR::Options::getCmdLineOptions()->getOption(TR_TLHPrefetch))
       featureFlags |= TR_FeatureFlag_TLHPrefetch;
 
-   if (fe->needsMethodTrampolines())
+   if (TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines())
       featureFlags |= TR_FeatureFlag_MethodTrampolines;
 
    if (TR::Options::getCmdLineOptions()->getOption(TR_EnableHCR))

--- a/runtime/compiler/trj9/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/trj9/x/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,8 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "il/SymbolReference.hpp"
+#include "runtime/CodeCacheConfig.hpp"
+#include "runtime/CodeCacheManager.hpp"
 
 #define NON_HELPER   0x00
 
@@ -44,7 +46,9 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
    // calculate the amount of memory needed to hold the relocation data
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
 
-   if (TR::Compiler->target.is64Bit() && fej9->needsMethodTrampolines() && _cg->getPicSlotCount())
+   if (TR::Compiler->target.is64Bit()
+       && TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines()
+       && _cg->getPicSlotCount())
       {
       _cg->addAOTRelocation(new (_cg->trHeapMemory()) TR::ExternalRelocation(NULL,
                                                                                  (uint8_t *)_cg->getPicSlotCount(),

--- a/runtime/compiler/trj9/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/x/codegen/J9CodeGenerator.cpp
@@ -37,6 +37,7 @@
 #include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
 #include "runtime/CodeCache.hpp"
+#include "runtime/CodeCacheConfig.hpp"
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/CodeCacheTypes.hpp"
 #include "runtime/Runtime.hpp"
@@ -408,8 +409,7 @@ J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
    TR::Compilation *comp = self()->comp();
 
-   // Don't do anything if method trampolines are not needed
-   if (!fej9->needsMethodTrampolines())
+   if (!TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines())
       return;
 
    bool hadClassUnloadMonitor;


### PR DESCRIPTION
This function simply asks the CodeCacheConfig whether trampolines are required.  Eliminate
the FrontEnd function and ask the CodeCacheConfig directly.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>