### PR TITLE
WIP Fixed BUILD_ROOT incorrectly set to jvmtest

### DIFF
--- a/test/TestConfig/makefile
+++ b/test/TestConfig/makefile
@@ -100,7 +100,7 @@ endif
 $(info set SRC_ROOT to $(SRC_ROOT))
 
 ifndef BUILD_ROOT
-BUILD_ROOT := $(SRC_ROOT)$(D)..$(D)jvmtest
+BUILD_ROOT := $(SRC_ROOT)$(D)..$(D)test
 BUILD_ROOT := $(subst \,/,$(BUILD_ROOT))
 endif
 $(info set BUILD_ROOT to $(BUILD_ROOT))


### PR DESCRIPTION
Tests failed to run due to incorrect path constructed from bad BUILD_ROOT
assignment of `jvmtest`.

Changed the value to `test`, fixing many failing tests.

Fixes: #665
Signed-off-by: Scott Young <Scott.Young@unb.ca>