### PR TITLE
Refactoring the access check for class/member

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -488,14 +488,23 @@ public class MethodHandles {
 				}
 				
 				int modifiers = targetClass.getModifiers();
-				if (Modifier.isPublic(modifiers)) {
-					/* Already determined that we have more than "no access" (public access) */
-					return;
-				} else if (Modifier.isProtected(modifiers)) {
-					/* Already determined that we have more than "no access" (public access) for a protected nested class */
+				
+				/* A protected class (must be a member class) is compiled to a public class as
+				 * the protected flag of this class doesn't exist on the VM level (there is no 
+				 * access flag in the binary form representing 'protected')
+				 */
+				if (Modifier.isProtected(modifiers)) {
+					/* Interfaces are not classes but types, and should therefore not have access to 
+					 * protected methods in java.lang.Object as subclasses.
+					 */
 					if (!accessClass.isInterface()) {
 						return;
 					}
+				
+				/* The following access checking is for a normal class (non-member class) */
+				} else if (Modifier.isPublic(modifiers)) {
+					/* Already determined that we have more than "no access" (public access) */
+					return;
 				} else {
 					if (((PACKAGE == (accessMode & PACKAGE)) || Modifier.isPrivate(accessMode)) && isSamePackage(accessClass, targetClass)) {
 						return;


### PR DESCRIPTION
The changes to ensure the check for class is completed
via checkClassAccess while the check for class members
(including the member classes) is completed via
checkMemberAccess.

Fix: #636

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>