### PR TITLE
Exclude j9vm.test.invalidclasspath.SetClasspathTest for windows

### DIFF
--- a/test/VM_Test/j9vm.xml
+++ b/test/VM_Test/j9vm.xml
@@ -94,5 +94,9 @@
 	<exclude id="j9vm.test.romclasscreation.NewROMCreationAfterModifyingExistingClassTest" platform="all">
 		<reason>134161: Java 9 j9vm test: Error: Agent library jvmtitest could not be opened (libjvmtitest.so: cannot open shared object file: No such file or directory)</reason>
 	</exclude>
+
+	<exclude id="j9vm.test.invalidclasspath.SetClasspathTest" platform="win_x86-64_cmprssptrs">
+		<reason>Issue 680: j9vm.test.invalidclasspath.SetClasspathTest segmentation error for OpenJ9 JDK9 windows platform</reason>
+	</exclude>
 </suite>
 


### PR DESCRIPTION
Issue #680 

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>