### PR TITLE
Enable OpenJ9 build for windows platform

### DIFF
--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -136,6 +136,7 @@
 		<flag id="build_java8" value="true"/>
 		<flag id="build_java9" value="true"/>
 		<flag id="build_newCompiler" value="true"/>
+		<flag id="build_openj9" value="true"/>
 		<flag id="build_ouncemake" value="true"/>
 		<flag id="build_product" value="true"/>
 		<flag id="env_littleEndian" value="true"/>

--- a/test/TestConfig/makefile
+++ b/test/TestConfig/makefile
@@ -176,7 +176,10 @@ CMDLINETESTER_RESJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdline_options_testresources$(D)cm
 # testng report dir
 #######################################
 TIMESTAMP := $(shell perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)testKitGen$(D)resultsSummary$(D)getTimeStamp.pl -v)
-TESTOUTPUT = $(shell $(PWD))$(D)test_output_$(TIMESTAMP)
+TESTOUTPUT := $(shell $(PWD))$(D)test_output_$(TIMESTAMP)
+ifeq ($(CYGWIN),1)
+	TESTOUTPUT := $(subst \,/,$(shell cygpath -w $(TESTOUTPUT)))
+endif
 REPORTDIR = $(Q)$(TESTOUTPUT)$(D)$@$(Q)
 
 #######################################


### PR DESCRIPTION
Enable build_openj9 flag in win_x86-64_cmprssptrs.spec.
Convert test output unix path to windows in cygwin environment.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>