### PR TITLE
Renaming Java 18.3 to Java 10

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -299,9 +299,9 @@
 	</configuration>
 
 	<configuration
-		  label="JAVA18.3"
-		  outputpath="JAVA18.3/src"
-		  flags="Java18.3"
+		  label="JAVA10"
+		  outputpath="JAVA10/src"
+		  flags="Java10"
 		  dependencies="SIDECAR19-SE-B175"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -257,11 +257,11 @@ public abstract class ClassLoader {
 		
 		/*[IF Sidecar19-SE]*/
 		jdk.internal.misc.VM.initLevel(1);
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		try {
 		/*[ENDIF]*/
 			System.bootLayer = jdk.internal.module.ModuleBootstrap.boot();
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -72,7 +72,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	static final boolean enableCompression = com.ibm.oti.vm.VM.J9_STRING_COMPRESSION_ENABLED;
 	
 	/*[IF Sidecar19-SE]*/
-	/*[IF Java18.3]*/
+	/*[IF Java10]*/
 	private final byte coder;
 	/*[ENDIF]*/
 	static final byte LATIN1 = 0;
@@ -422,7 +422,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value = byteArray;
 			count = byteArray.length / 2;
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		this.coder = coder();
 		/*[ENDIF]*/
 	}
@@ -446,7 +446,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	public String() {
 		value = emptyValue;
 		count = 0;
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -575,7 +575,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -660,7 +660,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -744,7 +744,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -839,7 +839,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			value[slen] = c;
 			/*[ENDIF]*/
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -903,7 +903,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(data, 0, value, 0, data.length);
 			/*[ENDIF]*/
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -967,7 +967,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1089,7 +1089,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				}
 			}
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1207,7 +1207,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				}
 			}
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1222,7 +1222,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		value = string.value;
 		count = string.count;
 		hashCode = string.hashCode;
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1249,7 +1249,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			/*[ENDIF]*/
 			count = numChars;
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1283,7 +1283,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				count = buffer.length();
 			}
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1363,7 +1363,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(s2.value, 0, value, s1len, s2len);
 			/*[ENDIF]*/
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1463,7 +1463,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(s3.value, 0, value, (s1len + s2len), s3len);
 			/*[ENDIF]*/
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1606,7 +1606,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			System.arraycopy(s1.value, 0, value, 0, s1len);
 			/*[ENDIF]*/
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -1907,7 +1907,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				/*[ENDIF]*/
 			}
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -4641,7 +4641,7 @@ written authorization of the copyright holder.
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -4675,7 +4675,7 @@ written authorization of the copyright holder.
 			value = chars;
 			count = builder.lengthInternal();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}
@@ -5150,7 +5150,7 @@ written authorization of the copyright holder.
 		} else {
 			throw new StringIndexOutOfBoundsException();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		coder = coder();
 		/*[ENDIF]*/
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DelegatingMethodHandle.java
@@ -50,7 +50,7 @@ abstract class DelegatingMethodHandle extends MethodHandle {
 	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, String str, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[IF Java18.3]*/
+	/*[IF Java10]*/
 	static LambdaForm makeReinvokerForm(MethodHandle mh, int num, Object obj, boolean flag, LambdaForm.NamedFunction nf1, LambdaForm.NamedFunction nf2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -41,7 +41,7 @@ class LambdaForm {
 	LambdaForm(String str, int num, Name[] names, boolean flag) {
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
-	/*[IF Java18.3]*/
+	/*[IF Java10]*/
 	LambdaForm(int a, Name[] b, int c) {
 		OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
@@ -87,7 +87,7 @@ class LambdaForm {
 		NamedFunction(Method m) {
 			OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
-		/*[IF Java18.3]*/
+		/*[IF Java10]*/
 		NamedFunction(MethodHandle a, MethodHandleImpl.Intrinsic b){
 			OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
@@ -114,7 +114,7 @@ class LambdaForm {
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 	}
-	/*[IF Java18.3]*/
+	/*[IF Java10]*/
 	enum Kind {
 		CONVERT,
 		SPREAD,

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -59,7 +59,7 @@ final class MemberName {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 	
-	/*[IF Java18.3]*/
+	/*[IF Java10]*/
 	public MethodType getMethodType() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1203,7 +1203,7 @@ public final class MethodType implements Serializable {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 
-	/*[IF Java18.3]*/
+	/*[IF Java10]*/
 	/**
 	 * Returns the number of stack slots used by the described args in the MethodType.
 	 * @return The number of stack slots

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1322,7 +1322,7 @@ VersionSetting SHAPE_SETTINGS[] = {
 		{"b135", J2SE_SHAPE_B136},
 		{"b148", J2SE_SHAPE_B148},
 		{"b165", J2SE_SHAPE_B165},
-		{"b1803", J2SE_SHAPE_B1803},
+		{"b1000", J2SE_SHAPE_V10},
 };
 #define NUM_SHAPE_SETTINGS (sizeof(SHAPE_SETTINGS) / sizeof(VersionSetting))
 
@@ -1462,13 +1462,13 @@ bail:
  * If the file is found, 'JAVA_VERSION' value is retrieved and decoded as following:
  * "1.8.0_xxx" --- Java 8, 'J2SE_18 | J2SE_SHAPE_SUN';
  * "9"         --- Java 9, 'J2SE_19 | J2SE_SHAPE_B165';
- * "10"        --- Java 18.3, 'J2SE_2018_3 | J2SE_SHAPE_B1803';
+ * "10"        --- Java 10, 'J2SE_V10 | J2SE_SHAPE_V10';
  * Others      --- Latest Java, 'J2SE_LATEST | J2SE_SHAPE_LATEST'.
- * Note: 'release' file contains JAVA_VERSION="10" for Java 18.3 at this moment.
+ * Note: 'release' file contains JAVA_VERSION="10" for Java 10 at this moment.
  * Otherwise, 0 is returned.
  *
  * @return 'J2SE_18 | J2SE_SHAPE_SUN', 'J2SE_19 | J2SE_SHAPE_B165',
- *         'J2SE_2018_3 | J2SE_SHAPE_B1803', 'J2SE_LATEST | J2SE_SHAPE_LATEST'
+ *         'J2SE_V10 | J2SE_SHAPE_V10', 'J2SE_LATEST | J2SE_SHAPE_LATEST'
  *         according to the 'JAVA_VERSION' value found in 'release';
  *         or 0 if otherwise.
  */
@@ -1495,7 +1495,7 @@ getVersionFromReleaseFile(void)
 			} else if (!strcmp(version, "\"9\"")) {
 				finalVersion = J2SE_19 | J2SE_SHAPE_B165;
 			} else if (!strcmp(version, "\"10\"")) {
-				finalVersion = J2SE_2018_3 | J2SE_SHAPE_B1803;
+				finalVersion = J2SE_V10 | J2SE_SHAPE_V10;
 			} else {
 				/* Assume latest Java version and shape */
 				finalVersion = J2SE_LATEST | J2SE_SHAPE_LATEST;

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -714,7 +714,7 @@ Java_jdk_internal_misc_Unsafe_objectFieldOffset1(JNIEnv *env, jobject receiver, 
 	return offset;
 }
 
-/* register jdk.internal.misc.Unsafe natives common to Java 9, 18.3 and beyond */
+/* register jdk.internal.misc.Unsafe natives common to Java 9, 10 and beyond */
 static void
 registerJdkInternalMiscUnsafeNativesCommon(JNIEnv *env, jclass clazz) {
 	/* clazz can't be null */
@@ -818,9 +818,9 @@ registerJdkInternalMiscUnsafeNativesCommon(JNIEnv *env, jclass clazz) {
 	env->RegisterNatives(clazz, natives, sizeof(natives)/sizeof(JNINativeMethod));
 }
 
-/* register jdk.internal.misc.Unsafe natives for Java 18.3 */
+/* register jdk.internal.misc.Unsafe natives for Java 10 */
 static void
-registerJdkInternalMiscUnsafeNativesJava18_3(JNIEnv *env, jclass clazz) {
+registerJdkInternalMiscUnsafeNativesJava10(JNIEnv *env, jclass clazz) {
 	/* clazz can't be null */
 	JNINativeMethod natives[] = {
 		{
@@ -840,8 +840,8 @@ Java_jdk_internal_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 
 	Java_sun_misc_Unsafe_registerNatives(env, clazz);
 	registerJdkInternalMiscUnsafeNativesCommon(env, clazz);
-	if (J2SE_SHAPE(currentThread->javaVM) >= J2SE_SHAPE_B1803) {
-		registerJdkInternalMiscUnsafeNativesJava18_3(env, clazz);
+	if (J2SE_SHAPE(currentThread->javaVM) >= J2SE_SHAPE_V10) {
+		registerJdkInternalMiscUnsafeNativesJava10(env, clazz);
 	}
 }
 

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -31,18 +31,18 @@
  *       This allows JVM operates with latest version when neither classlib.properties
  *       nor release file presents.
  */
-#define J2SE_15  0x1500
-#define J2SE_16  0x1600
-#define J2SE_17  0x1700
-#define J2SE_18  0x1800
-#define J2SE_19  0x1900
-#define J2SE_2018_3  0xB700            /* 0xB7 is 183 which refers to Java 18.3 */
+#define J2SE_15   0x1500
+#define J2SE_16   0x1600
+#define J2SE_17   0x1700
+#define J2SE_18   0x1800
+#define J2SE_19   0x1900
+#define J2SE_V10  0x1A00            /* This refers Java 10 */
 #if JAVA_SPEC_VERSION == 8
 	#define J2SE_LATEST  J2SE_18
 #elif JAVA_SPEC_VERSION == 9
 	#define J2SE_LATEST  J2SE_19
 #else
-	#define J2SE_LATEST  J2SE_2018_3
+	#define J2SE_LATEST  J2SE_V10
 #endif
 
 /**
@@ -67,13 +67,13 @@
 #elif JAVA_SPEC_VERSION == 9
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_B165
 #else
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_B1803
+	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V10
 #endif
 #define J2SE_SHAPE_SUN     		0x10000
 #define J2SE_SHAPE_B136    		0x40000
 #define J2SE_SHAPE_B148    		0x50000
 #define J2SE_SHAPE_B165    		0x60000
-#define J2SE_SHAPE_B1803		0x70000
+#define J2SE_SHAPE_V10			0x70000
 #define J2SE_SHAPE_RAWPLUSJ9	0x80000
 #define J2SE_SHAPE_RAW	 		0x90000
 #define J2SE_SHAPE_MASK 		0xF0000


### PR DESCRIPTION
Renaming `Java 18.3` to `Java 10`

Updated `JPP` tags accordingly;
Updated `J2SE_` Java version and build shape as well. 

Reviewer @Peter-Shipton @Tobi-Ajila 
FYI: @daniel-heidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>