### PR TITLE
Relocate OMR CodeGenerator function to OpenJ9

### DIFF
--- a/runtime/compiler/trj9/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/trj9/codegen/J9CodeGenerator.hpp
@@ -370,6 +370,8 @@ public:
    bool getSupportsMaxPrecisionMilliTime() {return _j9Flags.testAny(SupportsMaxPrecisionMilliTime);}
    void setSupportsMaxPrecisionMilliTime() {_j9Flags.set(SupportsMaxPrecisionMilliTime);}
 
+   int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; }
+
 private:
 
    enum // Flags

--- a/runtime/compiler/trj9/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9CodeGenerator.hpp
@@ -289,6 +289,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     *     The last generated instruction.
     */
    TR::Instruction* generateVMCallHelperPrePrologue(TR::Instruction* cursor);
+
+   int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 45; }
    };
 
 }


### PR DESCRIPTION
Relocate `OMR::CodeGenerator` function
`getMinimumNumberOfNodesBetweenMonitorsForTLE` to the OpenJ9
project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>