### PR TITLE
Modify JVM_SocketAvailable() return values to match JCL natives

### DIFF
--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -323,6 +323,7 @@ TraceAssert=Assert_SC_false noEnv Overhead=1 Level=1 Assert="!(P1)"
 TraceAssert=Assert_SC_notNull noEnv Overhead=1 Level=1 Assert="(P1) != NULL"
 TraceAssert=Assert_SC_mustHaveVMAccess noEnv overhead=1 Level=1 Assert="(P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS"
 TraceAssert=Assert_SC_mustNotHaveVMAccess noEnv overhead=1 Level=1 Assert="0 == ((P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)"
+TraceAssert=Assert_SC_unreachable noEnv Overhead=1 Level=1 Assert="(0 /* unreachable */)"
 
 // if (defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390))
 TraceExit-Exception=Trc_SC_Available_poll_failed NoEnv Overhead=1 Level=1 Template="poll failed for descriptor: %d. errno %i, Returning: 0"

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -57,6 +57,9 @@
 		</includes>
 		<makefilestubs>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="ifeq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="jvm$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
+			<makefilestub data="endif"/>
 		</makefilestubs>
 		<vpaths>
 			<vpath path="harmony_jvm" pattern="%.c" augmentIncludes="true">

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -70,6 +70,7 @@
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V10
 #endif
 #define J2SE_SHAPE_SUN     		0x10000
+#define J2SE_SHAPE_SUN_OPENJDK	0x20000
 #define J2SE_SHAPE_B136    		0x40000
 #define J2SE_SHAPE_B148    		0x50000
 #define J2SE_SHAPE_B165    		0x60000


### PR DESCRIPTION
Modify `JVM_SocketAvailable()` return values to match `JCL` natives

1. Added a new shape `sun_openjdk` which refers `OpenJDK JCL` while `IBM Java 8` with a `JCL` patch has shape value `sun`;
2. Added compilation flag `OPENJ9_BUILD` to allow `JVM_SocketAvailable()` returns values expected by `OpenJ9 Java 8 JCL`;
3. When the compilation flag `OPENJ9_BUILD` is not enabled, `J2SE_SHAPE` will be checked, if it is `J2SE_SHAPE_SUN_OPENJDK`, `JVM_SocketAvailable()` also returns values expected by `OpenJ9 Java 8 JCL`, otherwise, returns values expected by `IBM Java 8 JCL` as existing implementation;
4. Windows platform seems not invoke `JVM_SocketAvailable()`, replaced the method with `Assert_SC_unreachable()`;
5. Note the compilation flag and handling of two shape values for Java 8 can be removed when `IBM JCL` patch is removed;
6. Additional note: the change to `module.xml` includes converting line delimiters to `UNIX` style. In addition I didn't attempt to match the alignment within `j2servr.h` due to mixing usage of space and tab in existing code.

closes: #523

Reviewer @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>