### PR TITLE
Add Doxygen comments for CodeGenerator function

### DIFF
--- a/runtime/compiler/trj9/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/trj9/codegen/J9CodeGenerator.hpp
@@ -370,6 +370,11 @@ public:
    bool getSupportsMaxPrecisionMilliTime() {return _j9Flags.testAny(SupportsMaxPrecisionMilliTime);}
    void setSupportsMaxPrecisionMilliTime() {_j9Flags.set(SupportsMaxPrecisionMilliTime);}
 
+   /**
+    * \brief
+    *    The number of nodes between a monext and the next monent before
+    *    transforming a monitored region with transactional lock elision.
+    */
    int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; }
 
 private:

--- a/runtime/compiler/trj9/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9CodeGenerator.hpp
@@ -290,6 +290,17 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
     */
    TR::Instruction* generateVMCallHelperPrePrologue(TR::Instruction* cursor);
 
+   /**
+    * \brief
+    *    The number of nodes between a monexit and the next monent before transforming
+    *    a monitored region with transactional lock elision.  On Z, 25-30 cycles are
+    *    required between transactions or else the latter transaction will be aborted
+    *    (with significant penalty).
+    *
+    * \return
+    *    45.  This is an estimate based on CPI of 1.5-2 and an average of 1 instruction
+    *    per node.
+    */
    int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 45; }
    };
 


### PR DESCRIPTION
Commit 1640f0d2281b97208cbb2d70578d5bea4d474709 incorporated code relocated
from OMR, but it missed the function comments.  Convert the documentation
to Doxygen style and contribute it.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>