### PR TITLE
Add missing -f option to the Docker build instructions

### DIFF
--- a/buildenv/Build_Instructions_V8.md
+++ b/buildenv/Build_Instructions_V8.md
@@ -78,7 +78,7 @@ wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk
 
 3. Next, run the following command to build a Docker image, called **openj9**:
 ```
-docker build -t openj9 Dockerfile .
+docker build -t openj9 -f Dockerfile .
 ```
 
 4. Start a Docker container from the **openj9** image with the following command, where `-v` maps any directory, `<host_directory>`,

--- a/buildenv/Build_Instructions_V9.md
+++ b/buildenv/Build_Instructions_V9.md
@@ -78,7 +78,7 @@ wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/jdk
 
 3. Next, run the following command to build a Docker image, called **openj9**:
 ```
-docker build -t openj9 Dockerfile .
+docker build -t openj9 -f Dockerfile .
 ```
 
 4. Start a Docker container from the **openj9** image with the following command, where `-v` maps any directory, `<host_directory>`,


### PR DESCRIPTION
[ci skip] Build doc isn't compiled / tested
Fixes: #684

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>