### PR TITLE
Remove unused declaration in EnvironmentDelegate

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -69,7 +69,6 @@ class MM_EnvironmentDelegate
 private:
 	MM_EnvironmentBase *_env;
 	GC_Environment _gcEnv;
-	bool _reacquireJNICriticalAccess;
 protected:
 public:
 
@@ -179,7 +178,6 @@ public:
 
 	MM_EnvironmentDelegate()
 		: _env(NULL)
-		, _reacquireJNICriticalAccess(false)
 	{ }
 };
 


### PR DESCRIPTION
Private field _reacquireJNICriticalAccess in EnvironmentDelegate.hpp is
not required any more. Removing it.

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>