### PR TITLE
avoid the potential case causes GMP is running back to back

### DIFF
--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1228,6 +1228,11 @@ MM_IncrementalGenerationalGC::partialGarbageCollect(MM_EnvironmentVLHGC *env, MM
 
 		double optimalEmptinessRegionThreshold = _reclaimDelegate.calculateOptimalEmptinessRegionThreshold(env, regionConsumptionRate, avgSurvivorRegions, avgCopyForwardRate, scanTimeCostPerGMP);
 		_schedulingDelegate.setAutomaticDefragmentEmptinessThreshold(optimalEmptinessRegionThreshold);
+
+		/* recalculate ratios due to sweep */
+		_schedulingDelegate.calculatePGCCompactionRate(env, _schedulingDelegate.getCurrentEdenSizeInRegions(env) * _regionManager->getRegionSize());
+		_schedulingDelegate.calculateHeapOccupancyTrend(env);
+		_schedulingDelegate.calculateScannableBytesRatio(env);
 	}
 
 	if (env->_cycleState->_shouldRunCopyForward) {

--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -290,14 +290,6 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 
 	estimateMacroDefragmentationWork(env);
 	
-	if (isFirstPGCAfterGMP()) {
-		calculatePGCCompactionRate(env, edenCountBeforeCollect * _regionManager->getRegionSize());
-		calculateHeapOccupancyTrend(env);
-		calculateScannableBytesRatio(env);
-
-		firstPGCAfterGMPCompleted();
-	}
-	
 	/* Calculate the time spent in the current Partial GC */
 	U_64 partialGcEndTime = j9time_hires_clock();
 	U_64 pgcTime = j9time_hires_delta(_partialGcStartTime, partialGcEndTime, J9PORT_TIME_DELTA_IN_MILLISECONDS);
@@ -786,6 +778,7 @@ MM_SchedulingDelegate::getDesiredCompactWork()
 	return desiredCompactWork;
 }
 
+/*
 bool
 MM_SchedulingDelegate::isFirstPGCAfterGMP()
 {
@@ -797,6 +790,7 @@ MM_SchedulingDelegate::firstPGCAfterGMPCompleted()
 {
 	_didGMPCompleteSinceLastReclaim = false;
 }
+*/
 
 void
 MM_SchedulingDelegate::copyForwardCompleted(MM_EnvironmentVLHGC *env)

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -337,15 +337,6 @@ public:
 	 * @return desired bytes to be compacted
 	 */
 	UDATA getDesiredCompactWork();
-
-	/**
-	 * @return true if it is first PGC after GMP completed (so we can calculate compact-bytes/free-bytes ratio, etc.)
-	 */
-	bool isFirstPGCAfterGMP();
-	/**
-	 * clear the flag that indicate this was the first PGC after GMP completed
-	 */
-	void firstPGCAfterGMPCompleted();
 
 	/**
 	 * return whether the following PGC is required to do global sweep (typically, first PGC after GMP completed)


### PR DESCRIPTION
move recalculating ratios (PGCCompactionRate,HeapOccupancyTrend,
ScannableBytesRatio) right after the sweep from the end of PGC

Fixes: #721

Signed-off-by: Lin Hu <linhu@ca.ibm.com>