### PR TITLE
Exclude SetClasspathTest and libpathTest for windows

### DIFF
--- a/test/VM_Test/j9vm.xml
+++ b/test/VM_Test/j9vm.xml
@@ -95,7 +95,7 @@
 		<reason>134161: Java 9 j9vm test: Error: Agent library jvmtitest could not be opened (libjvmtitest.so: cannot open shared object file: No such file or directory)</reason>
 	</exclude>
 
-	<exclude id="j9vm.test.invalidclasspath.SetClasspathTest" platform="win_x86-64_cmprssptrs">
+	<exclude id="j9vm.test.invalidclasspath.SetClasspathTest" platform="win_x86-64_cr">
 		<reason>Issue 680: j9vm.test.invalidclasspath.SetClasspathTest segmentation error for OpenJ9 JDK9 windows platform</reason>
 	</exclude>
 </suite>

--- a/test/cmdLineTests/libpathTest/playlist.xml
+++ b/test/cmdLineTests/libpathTest/playlist.xml
@@ -26,11 +26,11 @@
 	<!-- LIBPATH tests intended for PMR56610 (CMVC 201272) -->
 	<test>
 		<testCaseName>cmdLineTester_libpathTestRtf</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DJAVA_HOME=$(JAVA_HOME) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DJAVA_HOME=$(Q)$(JAVA_HOME)$(Q) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \
 	-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)libpathTest.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)libpathRtf.xml$(Q) \
-	-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude_rtf.xml$(Q) \
+	-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>bits.64,vm.cmprssptrs</platformRequirements>

--- a/test/cmdLineTests/loadLibraryTest/playlist.xml
+++ b/test/cmdLineTests/loadLibraryTest/playlist.xml
@@ -26,7 +26,7 @@
 <!-- LoadLibrary test intended for CMVC 201408 -->
 	<test>
 		<testCaseName>cmdLineTester_loadLibraryTests</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DJAVA_HOME=$(JAVA_HOME) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DJAVA_HOME=$(Q)$(JAVA_HOME)$(Q) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \
 	-DPATHSEP=\\\\ -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)loadLibraryTest.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)loadLibraryTest.xml$(Q) \


### PR DESCRIPTION
Exclude libpathTest and SetClasspathTest tests.
Fixed java home path for libpathTest and loadLibraryTest.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>