### PR TITLE
fix IllegalArgumentException committed value cannot be larger than max

### DIFF
--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1668,6 +1668,9 @@ MM_IncrementalGenerationalGC::setRegionAgesToMax(MM_EnvironmentVLHGC *env)
 				region->_allocateData._owningContext = commonContext;
 				owner->migrateRegionToAllocationContext(region, commonContext);
 			}
+		} else if (region->isArrayletLeaf()) {
+			/* adjust age for arraylet leaves */
+			region->setAge(_extensions->tarokMaximumAgeInBytes, _extensions->tarokRegionMaxAge);
 		}
 	}
 }


### PR DESCRIPTION

set arraylet regions to old region after system gc
for avioding to count the arraylet regions as eden region(which might
caause the committed size for Eden is bigger than maximum Eden size in
both verbosegc and GCNotificationInfo)

Signed-off-by: Lin Hu <linhu@ca.ibm.com>