### PR TITLE
Fix HelperCompatabilityTest 9 and 11

### DIFF
--- a/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/HelperCompatabilityTests_SE80.xml
+++ b/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/HelperCompatabilityTests_SE80.xml
@@ -198,7 +198,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
-	<test id="destroy cache" timeout="600" runPath=".">
+	<test id="destroy cache 9" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
@@ -232,7 +232,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
-	<test id="destroy cache" timeout="600" runPath=".">
+	<test id="destroy cache 11" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xshareclasses:destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
 		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>

--- a/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/exclude.xml
+++ b/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/exclude.xml
@@ -25,16 +25,16 @@
 <!DOCTYPE suite SYSTEM "excludes.dtd">
 <?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
 <suite id="HelperCompatabilityTest Excluded Test Case List">
-	<exclude id="HelperCompatabilityTest 9" platform="SE90" shouldFix="true">
-			<reason>133325: Revisit HelperCompatabilityTest</reason>
+	<exclude id="HelperCompatabilityTest 9" platform="current" shouldFix="true">
+			<reason>The result on IBM SDK is incorrect due to JCL patch of zip Hook, we should not find classes from SCC after jar are updated. See StaleClassPathTest5.sh</reason>
 	</exclude>
-	<exclude id="destroy cache 9" platform="SE90" shouldFix="true">
-			<reason>133325: Revisit HelperCompatabilityTest</reason>
+	<exclude id="destroy cache 9" platform="current" shouldFix="true">
+			<reason>The result on IBM SDK is incorrect due to JCL patch of zip Hook, we should not find classes from SCC after jar are updated</reason>
 	</exclude>
-	<exclude id="HelperCompatabilityTest 11" platform="SE90" shouldFix="true">
-			<reason>133325: Revisit HelperCompatabilityTest</reason>
+	<exclude id="HelperCompatabilityTest 11" platform="current" shouldFix="true">
+			<reason>The result on IBM SDK is incorrect due to JCL patch of zip Hook, we should not find classes from SCC after jar are updated. See StaleClassPathTest5.sh</reason>
 	</exclude>
-	<exclude id="destroy cache 11" platform="SE90" shouldFix="true">
-			<reason>133325: Revisit HelperCompatabilityTest</reason>
+	<exclude id="destroy cache 11" platform="current" shouldFix="true">
+			<reason>The result on IBM SDK is incorrect due to JCL patch of zip Hook, we should not find classes from SCC after jar are updated</reason>
 	</exclude>
 </suite>

--- a/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/playlist.xml
+++ b/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/playlist.xml
@@ -63,7 +63,7 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DJDK_HOME=$(Q)$(JDK_HOME)$(Q) -DCPDL=$(Q)$(P)$(Q) -DPROPS_DIR=$(Q)$(TEST_RESROOT)$(D)props_unix$(Q) -DSCMODE=204 \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)HelperCompatabilityTests_$(JAVA_VERSION).xml$(Q) \
-	-xids all,$(JAVA_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-xids all,$(JAVA_VERSION),$(JCL_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>

--- a/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/props_unix/Test10.props
+++ b/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/props_unix/Test10.props
@@ -11,6 +11,6 @@ LoadClasses2=A,E,I,O
 Classpath=./AlphabetJar/Alphabet.jar;./Pets;./Vowels;
 NumberOfClassesToFind=8
 FindClasses=A,E,F,Cat,Dog,Hamster,I,O
-Results=true,true,true,true,true,true,true,true
+Results=false,false,false,true,true,true,true,true
 FoundAt=Vowels,AlphabetJar,AlphabetJar,Pets,Pets,Pets,Vowels,Vowels
 BatchFileToRun=/bin/sh ./batchfiles/StaleClassPathTest5.sh

--- a/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/props_unix/Test8.props
+++ b/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/props_unix/Test8.props
@@ -5,5 +5,5 @@ NumberOfUrls=1
 Url0=./AlphabetJar/Alphabet.jar;
 NumberOfClassesToFind0=3
 FindClasses0=D,E,F
-Results0=true,true,true
+Results0=false,false,false
 BatchFileToRun=/bin/sh ./batchfiles/StaleClassPathTest5.sh


### PR DESCRIPTION
We shouldn't return the classes from the shared cache after Alphabet.jar
is already modified. Expected result of Test8.props and Test10.props
should be changed. 

Excluded HelperCompatabilityTest 9/11 on IBK SDK8 and 9

Fixes #469

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>