### PR TITLE
Adjust preprocessor conditions

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/ClosingFileReader.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/ClosingFileReader.java
@@ -159,7 +159,7 @@ public class ClosingFileReader extends ImageInputStreamImpl implements ResourceR
 		}
 	}
 
-	/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE]*/
+	/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 	/**
 	 * z/OS native implementation of IRandomAccessFile - wrappers com.ibm.recordio.RandomAccessRecordFile
 	 */
@@ -265,12 +265,12 @@ public class ClosingFileReader extends ImageInputStreamImpl implements ResourceR
 			_seekOffset = pos%_recordLength;
 		}
 	}
-	/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE]*/
+	/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 
 	public ClosingFileReader(File file) throws IOException
 	{
 		_fileRef = file;
-		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE]*/
+		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 		try {
 			_file = new BaseRandomAccessFile(_fileRef, "r");
 		} catch (FileNotFoundException e1) {
@@ -287,9 +287,9 @@ public class ClosingFileReader extends ImageInputStreamImpl implements ResourceR
 				throw e;
 			}
 		}
-		/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE*/
+		/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )*/
 		_file = new BaseRandomAccessFile(_fileRef, "r");
-		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE*/
+		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )*/
 	}
 	
 	/**
@@ -561,7 +561,7 @@ public class ClosingFileReader extends ImageInputStreamImpl implements ResourceR
 	
 	public boolean isMVSFile()
 	{
-		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE]*/
+		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 		return _file instanceof ZosRandomAccessFile;
 		/*[ELSE]
 		return false;

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/FileManager.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/FileManager.java
@@ -86,7 +86,7 @@ public abstract class FileManager {
 			// found it in HFS on z/OS or normally on other platforms so return true
 			return true;
 		}
-		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE]*/
+		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 		String os = System.getProperty("os.name"); //$NON-NLS-1$
 		if (os == null) {
 			// cannot perform the check so default to true to allow processing to continue blind
@@ -108,7 +108,7 @@ public abstract class FileManager {
 				// ignore
 			}
 		}
-		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE*/
+		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )*/
 		return false;
 	}
 	

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/MVSImageInputStream.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/MVSImageInputStream.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE & (PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE)]*/
+/*[INCLUDE-IF PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 /*******************************************************************************
  * Copyright (c) 2012, 2017 IBM Corp. and others
  *

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/SimpleFileManager.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/SimpleFileManager.java
@@ -122,7 +122,7 @@ public class SimpleFileManager extends FileManager {
 			filesize = managedFile.length();
 			return new FileImageInputStream(managedFile);
 		}
-		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE]*/
+		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )]*/
 		String os = System.getProperty("os.name"); //$NON-NLS-1$
 		if (os == null) {
 			throw new IOException("Cannot determine the system type from os.name"); //$NON-NLS-1$
@@ -138,7 +138,7 @@ public class SimpleFileManager extends FileManager {
 				// drop through to throw FileNotFoundException below (with absolute path)
 			}
 		}
-		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! Sidecar19-SE*/
+		/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 | ! ( Sidecar18-SE-OpenJ9 | Sidecar19-SE )*/
 		throw new FileNotFoundException("The specified file " + managedFile.getAbsolutePath() + " was not found");
 	}
 }


### PR DESCRIPTION
We need to omit code specific to zOS for open builds of Java 8.

The preprocessor conditions were written at a time before OpenJ9 worked with openjdk-jdk8 and needed to be adjusted for that world.