### PR TITLE
Relocate notYetRunMeansCold to OpenJ9 from OMR

### DIFF
--- a/runtime/compiler/trj9/compile/J9Compilation.hpp
+++ b/runtime/compiler/trj9/compile/J9Compilation.hpp
@@ -203,6 +203,17 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    CompilationPhase saveCompilationPhase();
    void restoreCompilationPhase(CompilationPhase phase);
 
+   /**
+    * \brief
+    *    Answers whether the fact that a method has not been executed yet implies
+    *    that the method is cold.
+    *
+    * \return
+    *    true if the fact that a method has not been executed implies it is cold;
+    *    false otherwise
+    */
+   bool notYetRunMeansCold();
+
    // --------------------------------------------------------------------------
    // Hardware profiling
    //


### PR DESCRIPTION
The majority of the body of this function only applies to OpenJ9.  Move
the function in preparation for providing a simpler version in OMR.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>