### PR TITLE
Add RuntimeMXBean.getPid() to jdk10

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,8 @@
  *******************************************************************************/
 package java.lang.management;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Map;
 
@@ -129,6 +131,24 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * @return the name of this running virtual machine.
 	 */
 	public String getName();
+
+	/*[IF Java10]*/
+	/**
+	 * Returns the process ID (PID) of the current running Java virtual machine.
+	 * 
+	 * @return the process ID of the current running JVM
+	 * 
+	 * @since 10
+	 */
+	@SuppressWarnings("boxing")
+	default long getPid() {
+		return AccessController.doPrivileged(new PrivilegedAction<Long>() {
+			public Long run() {
+				return ProcessHandle.current().pid();
+			}
+		});
+	}
+	/*[ENDIF]*/
 
 	/**
 	 * Returns the name of the Java virtual machine specification followed by

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/RuntimeMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/RuntimeMXBean.java
@@ -83,7 +83,15 @@ public interface RuntimeMXBean extends java.lang.management.RuntimeMXBean {
 	 * 
 	 * @return A long representing the process ID (pid) on the underlying 
 	 * operating system.
+	/*[IF Java10]
+	 * 
+	 * @deprecated As of Java 10. Use 
+	 * {@link java.lang.management.RuntimeMXBean#getPid() getPid()} instead.
 	 */
+	@Deprecated(forRemoval=true, since="10")
+	/*[ELSE]
+	 */
+	/*[ENDIF]*/
 	public long getProcessID();
 
 	/**

--- a/test/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/cmdLineTests/runtimemxbeanTests/build.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<project name="runtimemxbeanTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests_runtimemxbeanTests
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/cmdLineTests/runtimemxbeanTests" />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/runtimemxbeanTests.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="./" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml,*.mk,*.pl" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+		<delete>
+			<fileset dir=".">
+				<include name="*.class"/>
+			</fileset>
+		</delete>
+	</target>
+
+	<target name="build">
+		<if>
+			<equals arg1="${JAVA_VERSION}" arg2="SE100"/>
+			<then>
+				<antcall target="clean" inheritall="true" />
+			</then>
+		</if>
+	</target>
+</project>

--- a/test/cmdLineTests/runtimemxbeanTests/getPidTest.pl
+++ b/test/cmdLineTests/runtimemxbeanTests/getPidTest.pl
@@ -1,0 +1,42 @@
+#!/usr/bin/perl
+
+##############################################################################
+#  Copyright (c) 2017, 2017 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
+
+use strict;
+use warnings;
+use IPC::Open3;
+
+my $javaCmd = join(' ', @ARGV);
+
+my ($in, $out, $err);
+
+my $perlPid = open3($in, $out, $err, $javaCmd);
+
+my $javaPid = <$out>;
+
+if ($perlPid == $javaPid) {
+	print "PASS: RuntimeMXBean.getPid() returned correct PID.";
+}
+else {
+	print "FAIL: RuntimeMXBean.getPID() returned ${javaPid} instead of ${perlPid}";
+}

--- a/test/cmdLineTests/runtimemxbeanTests/getPidTest.xml
+++ b/test/cmdLineTests/runtimemxbeanTests/getPidTest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+ 
+<suite id="getPid test" timeout="600">
+
+	<test id="Compare RuntimeMXBean.getPid() with getting PID from system">
+		<command>perl $TESTDIR$/getPidTest.pl $EXE$ -cp $TESTSJARPATH$ GetPid</command>
+		<output type="success" caseSensitive="yes" regex="no">PASS</output>
+		<output type="failure" caseSensitive="yes" regex="no">FAIL</output>
+	</test>
+
+</suite>

--- a/test/cmdLineTests/runtimemxbeanTests/playlist.xml
+++ b/test/cmdLineTests/runtimemxbeanTests/playlist.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2017, 2017 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_getPid</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)runtimemxbeanTests.jar$(Q) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)getPidTest.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>sanity</tag>
+		</tags>
+		<subsets>
+			<subset>SE100</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/test/cmdLineTests/runtimemxbeanTests/src/GetPid.java
+++ b/test/cmdLineTests/runtimemxbeanTests/src/GetPid.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ManagementFactory;
+
+class GetPid {
+
+	public static void main(String[] args) {
+		RuntimeMXBean mb = ManagementFactory.getRuntimeMXBean();
+		long id = mb.getPid();
+		System.out.println(id);
+	}
+
+}


### PR DESCRIPTION
Adds getPid() method to RuntimeMXBean to match jdk10 specs.

Deprecates getProcessId() in RuntimeMXBean in jdk.management module
since getPid() does the same thing.

Adds a cmdlinetest for the new method. The new test will not be compiled or run until Java 10 builds are available.

Resolves #717

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>