### PR TITLE
Move createParameterSymbol to OpenJ9

### DIFF
--- a/runtime/compiler/trj9/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/trj9/compile/J9SymbolReferenceTable.cpp
@@ -1978,3 +1978,27 @@ J9::SymbolReferenceTable::findOrCreateArrayComponentTypeSymbolRef()
       }
    return element(componentClassSymbol);
    }
+
+
+TR::ParameterSymbol *
+J9::SymbolReferenceTable::createParameterSymbol(
+      TR::ResolvedMethodSymbol *owningMethodSymbol,
+      int32_t slot,
+      TR::DataType type,
+      bool isUnsigned)
+   {
+   TR::ParameterSymbol * sym = TR::ParameterSymbol::create(trHeapMemory(),type,isUnsigned,slot);
+
+   if (comp()->getOption(TR_MimicInterpreterFrameShape))
+      {
+      int32_t parameterSlots = owningMethodSymbol->getNumParameterSlots();
+      sym->setGCMapIndex(-slot + parameterSlots - sym->getNumberOfSlots());
+      }
+
+   TR::SymbolReference *symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), slot);
+   owningMethodSymbol->setParmSymRef(slot, symRef);
+   if (!parmSlotCameFromExpandingAnArchetypeArgPlaceholder(slot, owningMethodSymbol, trMemory()))
+      owningMethodSymbol->getAutoSymRefs(slot).add(symRef);
+
+   return sym;
+   }

--- a/runtime/compiler/trj9/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/trj9/compile/J9SymbolReferenceTable.hpp
@@ -215,6 +215,28 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    TR::SymbolReference * findOrCreateCheckCastForArrayStoreSymbolRef(TR::ResolvedMethodSymbol *owningMethodSymbol);
 
+   /**
+    * \brief
+    *    Creates a new symbol for a parameter within the supplied owning method of the
+    *    specified type and slot index.
+    *
+    * \param owningMethodSymbol
+    *    Resolved method symbol for which this parameter is created.
+    *
+    * \param slot
+    *    Slot index for this parameter.
+    *
+    * \param type
+    *    TR::DataType of the parameter.
+    *
+    * \param isUnsigned
+    *    Unused and deprecated.
+    *
+    * \return
+    *    The created TR::ParameterSymbol
+    */
+   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, bool isUnsigned);
+
    void initShadowSymbol(TR_ResolvedMethod *, TR::SymbolReference *, bool, TR::DataType, uint32_t, bool);
 
    List<TR::SymbolReference> *dynamicMethodSymrefsByCallSiteIndex(int32_t index);


### PR DESCRIPTION
Move the `OMR::SymbolReferenceTable::createParameterSymbol` implementation
to OpenJ9 to isolate the OpenJ9 specializations therein.  The version in OMR
will be simplified.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>