### PR TITLE
Add TestUtilities to the source paths of test projects

### DIFF
--- a/test/Java8andUp/.classpath
+++ b/test/Java8andUp/.classpath
@@ -9,5 +9,6 @@
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/pConfig SIDECAR18-SE"/>
 	<classpathentry kind="lib" path="/VM_Test/VM/lib/tools.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/TestUtilities"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/test/Java9andUp/.classpath
+++ b/test/Java9andUp/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="lib" path="/TestConfig/lib/testng.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/pConfig SIDECAR19-SE"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/TestUtilities"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
This is useful when building the projects within Eclipse.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>