### PR TITLE
Improve String getChars methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -383,7 +383,8 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			helpers.putCharInArrayByIndex(array2, start2 + i, helpers.getCharFromArrayByIndex(array1, start1 + i));
 		}
 	}
-	
+	/*[ENDIF]*/	
+
 	static void decompressedArrayCopy(char[] array1, int start1, char[] array2, int start2, int length) {
 		if (array1 == array2 && start1 < start2) {
 			for (int i = length - 1; i >= 0; --i) {
@@ -395,7 +396,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			}
 		}
 	}
-	/*[ENDIF]*/
 	
 	boolean isCompressed() {
 		// Check if the String is compressed
@@ -2585,32 +2585,40 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public void getChars(int start, int end, char[] data, int index) {
 		if (0 <= start && start <= end && end <= lengthInternal()) {
-			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
-				decompress(value, start, data, index, end - start);
-			} else {
-				/*[IF Sidecar19-SE]*/
-				decompressedArrayCopy(value, start, data, index, end - start);
-				/*[ELSE]*/
-				System.arraycopy(value, start, data, index, end - start);
-				/*[ENDIF]*/
-			}
+			getCharsNoBoundChecks(start, end, data, index);
 		} else {
 			throw new StringIndexOutOfBoundsException();
+		}
+	}
+
+	// This is a package protected method that performs the getChars operation without explicit bound checks.
+	// Caller of this method must validate bound safety for String indexing and array copying.
+	void getCharsNoBoundChecks(int start, int end, char[] data, int index) {
+		// Check if the String is compressed
+		if (enableCompression && (null == compressionFlag || count >= 0)) {
+			decompress(value, start, data, index, end - start);
+		} else {
+			decompressedArrayCopy(value, start, data, index, end - start);
 		}
 	}
 
 	/*[IF Sidecar19-SE]*/
 	void getChars(int start, int end, byte[] data, int index) {
 		if (0 <= start && start <= end && end <= lengthInternal()) {
-			// Check if the String is compressed
-			if (enableCompression && (null == compressionFlag || count >= 0)) {
-				decompress(value, start, data, index, end - start);
-			} else {
-				decompressedArrayCopy(value, start, data, index, end - start);
-			}
+			getCharsNoBoundChecks(start, end, data, index);
 		} else {
 			throw new StringIndexOutOfBoundsException();
+		}
+	}
+
+	// This is a package protected method that performs the getChars operation without explicit bound checks.
+	// Caller of this method must validate bound safety for String indexing and array copying.
+	void getCharsNoBoundChecks(int start, int end, byte[] data, int index) {
+		// Check if the String is compressed
+		if (enableCompression && (null == compressionFlag || count >= 0)) {
+			decompress(value, start, data, index, end - start);
+		} else {
+			decompressedArrayCopy(value, start, data, index, end - start);
 		}
 	}
 	/*[ENDIF]*/

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -655,7 +655,7 @@ public StringBuilder append (String string) {
 				ensureCapacityImpl(newLength);
 			}
 			
-			string.getChars(0, stringLength, value, currentLength);
+			string.getCharsNoBoundChecks(0, stringLength, value, currentLength);
 			
 			count = newLength | uncompressedBit;
 		}
@@ -664,7 +664,7 @@ public StringBuilder append (String string) {
 			ensureCapacityImpl(newLength);
 		}
 		
-		string.getChars(0, stringLength, value, currentLength);
+		string.getCharsNoBoundChecks(0, stringLength, value, currentLength);
 		
 		count = newLength;
 	}
@@ -914,14 +914,11 @@ private void ensureCapacityImpl(int min) {
 	} else {
 		/*[IF Sidecar19-SE]*/
 		byte[] newData = new byte[newLength * 2];
-		
-		String.decompressedArrayCopy(value, 0, newData, 0, currentLength);
 		/*[ELSE]*/
 		char[] newData = new char[newLength];
-		
-		System.arraycopy(value, 0, newData, 0, currentLength);
 		/*[ENDIF]*/
 		
+		String.decompressedArrayCopy(value, 0, newData, 0, currentLength);
 		value = newData;
 	}
 	

--- a/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -196,6 +196,8 @@
    java_lang_String_compressNoCheck,
    java_lang_String_unsafeCharAt,
    java_lang_String_split_str_int,
+   java_lang_String_getChars_charArray,
+   java_lang_String_getChars_byteArray,
 
    java_lang_StringUTF16_getChar,
 

--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -2970,6 +2970,8 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {x(TR::java_lang_String_StrHWAvailable,      "StrHWAvailable", "()Z")},
       {x(TR::java_lang_String_unsafeCharAt,        "unsafeCharAt",        "(I)C")},
       {x(TR::java_lang_String_split_str_int,       "split",               "(Ljava/lang/String;I)[Ljava/lang/String;")},
+      {x(TR::java_lang_String_getChars_charArray,  "getChars",            "(II[CI)V")},
+      {x(TR::java_lang_String_getChars_byteArray,  "getChars",            "(II[BI)V")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -401,6 +401,8 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_StringBuilder_lengthInternal:
       case TR::java_util_HashMap_get:
       case TR::java_util_HashMap_getNode:
+      case TR::java_lang_String_getChars_charArray:
+      case TR::java_lang_String_getChars_byteArray:
          return true;
          
       // In Java9 the following enum values match both sun.misc.Unsafe and


### PR DESCRIPTION
Refactor String getChars into fast getCharsImpl methods that do not
include bound checks. StringBuilder append(String) method which already
ensures array bound safety will call the fast version.

Also use the JIT recognized fast decompressedArrayCopy which does not
generate arrayCopyBoundChecks instead of System.arrayCopy to perform
the actual copy.

Signed-off-by: Yan Luo <yan_luo@ca.ibm.com>