### PR TITLE
Relocate ValuePropagation getParmValues to OpenJ9

### DIFF
--- a/runtime/compiler/trj9/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/trj9/optimizer/J9ValuePropagation.hpp
@@ -56,6 +56,8 @@ class ValuePropagation : public OMR::ValuePropagation
    bool isKnownStringObject(TR::VPConstraint *constraint);
    TR_YesNoMaybe isStringObject(TR::VPConstraint *constraint);
 
+   virtual void getParmValues();
+
    private:
 
    struct TreeIntResultPair {


### PR DESCRIPTION
The implementation is OpenJ9-specific.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>