### PR TITLE
Implement software read barrier for concurrent scavenger testing

### DIFF
--- a/runtime/compiler/trj9/env/J9ObjectModel.cpp
+++ b/runtime/compiler/trj9/env/J9ObjectModel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,7 @@ J9::ObjectModel::initialize()
       }
 
    _shouldGenerateReadBarriersForFieldLoads = mmf->j9gc_concurrent_scavenger_enabled(vm);
+   _shouldReplaceGuardedLoadWithSoftwareReadBarrier = mmf->j9gc_software_read_barrier_enabled(vm);
    }
 
 
@@ -456,6 +457,12 @@ bool
 J9::ObjectModel::shouldGenerateReadBarriersForFieldLoads()
    {
    return _shouldGenerateReadBarriersForFieldLoads;
+   }
+
+bool
+J9::ObjectModel::shouldReplaceGuardedLoadWithSoftwareReadBarrier()
+   {
+   return _shouldReplaceGuardedLoadWithSoftwareReadBarrier;
    }
 
 bool

--- a/runtime/compiler/trj9/env/J9ObjectModel.hpp
+++ b/runtime/compiler/trj9/env/J9ObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,12 +118,21 @@ public:
    */
    bool shouldGenerateReadBarriersForFieldLoads();
 
+   /**
+    * \brief Determine whether to replace guarded loads with software read barrier sequence
+    *
+    * \return
+    *     true if debug gc option -XXgc:softwareEvacuateReadBarrier is used
+    */
+   bool shouldReplaceGuardedLoadWithSoftwareReadBarrier();
+
 private:
 
    bool _usesDiscontiguousArraylets;
    int32_t _arrayLetLeafSize;
    int32_t _arrayLetLeafLogSize;
    bool _shouldGenerateReadBarriersForFieldLoads;
+   bool _shouldReplaceGuardedLoadWithSoftwareReadBarrier;
    };
 
 }

--- a/runtime/compiler/trj9/env/J9VMEnv.cpp
+++ b/runtime/compiler/trj9/env/J9VMEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -446,11 +446,46 @@ J9::VMEnv::ensureOSRBufferSize(TR::Compilation *comp, uintptrj_t osrFrameSizeInB
    return comp->fej9()->ensureOSRBufferSize(osrFrameSizeInBytes, osrScratchBufferSizeInBytes, osrStackFrameSizeInBytes);
    }
 
-
 uintptrj_t
 J9::VMEnv::thisThreadGetOSRReturnAddressOffset(TR::Compilation *comp)
    {
    return comp->fej9()->thisThreadGetOSRReturnAddressOffset();
+   }
+
+uintptrj_t
+J9::VMEnv::thisThreadGetGSIntermediateResultOffset(TR::Compilation *comp)
+   {
+   return comp->fej9()->thisThreadGetGSIntermediateResultOffset();
+   }
+
+uintptrj_t
+J9::VMEnv::thisThreadGetConcurrentScavengeActiveByteAddressOffset(TR::Compilation *comp)
+   {
+   return comp->fej9()->thisThreadGetConcurrentScavengeActiveByteAddressOffset();
+   }
+
+uintptrj_t
+J9::VMEnv::thisThreadGetEvacuateBaseAddressOffset(TR::Compilation *comp)
+   {
+   return comp->fej9()->thisThreadGetEvacuateBaseAddressOffset();
+   }
+
+uintptrj_t
+J9::VMEnv::thisThreadGetEvacuateTopAddressOffset(TR::Compilation *comp)
+   {
+   return comp->fej9()->thisThreadGetEvacuateTopAddressOffset();
+   }
+
+uintptrj_t
+J9::VMEnv::thisThreadGetGSOperandAddressOffset(TR::Compilation *comp)
+   {
+   return comp->fej9()->thisThreadGetGSOperandAddressOffset();
+   }
+
+uintptrj_t
+J9::VMEnv::thisThreadGetGSHandlerAddressOffset(TR::Compilation *comp)
+   {
+   return comp->fej9()->thisThreadGetGSHandlerAddressOffset();
    }
 
 /*

--- a/runtime/compiler/trj9/env/J9VMEnv.hpp
+++ b/runtime/compiler/trj9/env/J9VMEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,6 +110,13 @@ public:
    uintptrj_t OSRFrameSizeInBytes(TR::Compilation *comp, TR_OpaqueMethodBlock* method);
    bool ensureOSRBufferSize(TR::Compilation *comp, uintptrj_t osrFrameSizeInBytes, uintptrj_t osrScratchBufferSizeInBytes, uintptrj_t osrStackFrameSizeInBytes);
    uintptrj_t thisThreadGetOSRReturnAddressOffset(TR::Compilation *comp);
+
+   uintptrj_t thisThreadGetGSIntermediateResultOffset(TR::Compilation *comp);
+   uintptrj_t thisThreadGetConcurrentScavengeActiveByteAddressOffset(TR::Compilation *comp);
+   uintptrj_t thisThreadGetEvacuateBaseAddressOffset(TR::Compilation *comp);
+   uintptrj_t thisThreadGetEvacuateTopAddressOffset(TR::Compilation *comp);
+   uintptrj_t thisThreadGetGSOperandAddressOffset(TR::Compilation *comp);
+   uintptrj_t thisThreadGetGSHandlerAddressOffset(TR::Compilation *comp);
 
    };
 

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1953,6 +1953,83 @@ UDATA TR_J9VMBase::thisThreadGetOSRReturnAddressOffset()
    return offsetof(J9VMThread, osrReturnAddress);
    }
 
+/**
+ * @brief Returns offset from the current thread to the intermediate result field.
+ * The field contains intermediate result from the latest guarded load during concurrent scavenge.
+ */
+UDATA TR_J9VMBase::thisThreadGetGSIntermediateResultOffset()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   return offsetof(J9VMThread, gsParameters.intermediateResult);
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   TR_ASSERT(0,"Field gsParameters.intermediateResult does not exists in J9VMThread.");
+   return 0;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }
+
+/**
+ * @brief Returns offset from the current thread to the flags to check if concurrent scavenge is active
+ */
+UDATA TR_J9VMBase::thisThreadGetConcurrentScavengeActiveByteAddressOffset()
+   {
+   TR_ASSERT_FATAL(J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE == 0x20000,
+              "GSCS: The check weither concurrent scavenge is active is dependant on the flag being 0x20000");
+   int32_t privateFlagsConcurrentScavengerActiveByteOffset = 5;
+   return offsetof(J9VMThread, privateFlags) + privateFlagsConcurrentScavengerActiveByteOffset;
+   }
+
+/**
+ * @brief Returns offset from the current thread to the field with the base address of the evacuate memory region
+ */
+UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   return offsetof(J9VMThread, evacuateBase);
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   TR_ASSERT(0,"Field evacuateBase does not exists in J9VMThread.");
+   return 0;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }
+
+/**
+  * @brief Returns offset from the current thread to the field with the top address of the evacuate memory region
+  */
+UDATA TR_J9VMBase::thisThreadGetEvacuateTopAddressOffset()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   return offsetof(J9VMThread, evacuateTop);
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   TR_ASSERT(0,"Field evacuateTop does not exists in J9VMThread.");
+   return 0;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }
+
+/**
+ * @brief Returns offset from the current thread to the operand address field.
+ * It contains data from the most recent guarded load during concurrent scavenge
+ */
+UDATA TR_J9VMBase::thisThreadGetGSOperandAddressOffset()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   return offsetof(J9VMThread, gsParameters.operandAddr);
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   TR_ASSERT(0,"Field gsParameters.operandAddr does not exists in J9VMThread.");
+   return 0;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }
+
+/**
+ * @brief Returns offset from the current thread to the filed with the read barrier handler address
+ */
+UDATA TR_J9VMBase::thisThreadGetGSHandlerAddressOffset()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+   return offsetof(J9VMThread, gsParameters.handlerAddr);
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   TR_ASSERT(0,"Field gsParameters.handlerAddr does not exists in J9VMThread.");
+   return 0;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }
 
 // This query answers whether or not the commandline option -XCEEHDLR was passed in.
 //

--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -611,6 +611,14 @@ public:
    virtual uintptrj_t         thisThreadGetOSRScratchBufferOffset();
    virtual uintptrj_t         thisThreadGetOSRFrameIndexOffset();
    virtual uintptrj_t         thisThreadGetOSRReturnAddressOffset();
+
+
+   virtual uintptrj_t         thisThreadGetGSIntermediateResultOffset();
+   virtual uintptrj_t         thisThreadGetConcurrentScavengeActiveByteAddressOffset();
+   virtual uintptrj_t         thisThreadGetEvacuateBaseAddressOffset();
+   virtual uintptrj_t         thisThreadGetEvacuateTopAddressOffset();
+   virtual uintptrj_t         thisThreadGetGSOperandAddressOffset();
+   virtual uintptrj_t         thisThreadGetGSHandlerAddressOffset();
 
    virtual int32_t            getArraySpineShift(int32_t);
    virtual int32_t            getArrayletMask(int32_t);

--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	getStaticObjectAllocateFlags,
 	j9gc_scavenger_enabled,
 	j9gc_concurrent_scavenger_enabled,
+	j9gc_software_read_barrier_enabled,
 #if defined(J9VM_GC_HEAP_CARD_TABLE)
 	j9gc_concurrent_getCardSize,
 	j9gc_concurrent_getHeapBase,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,6 +92,7 @@ extern J9_CFUNC void J9WriteBarrierJ9ClassBatchStore(J9VMThread *vmThread, J9Cla
 extern J9_CFUNC UDATA mergeMemorySpaces(J9VMThread *vmThread, void *destinationMemorySpace, void *sourceMemorySpace);
 extern J9_CFUNC UDATA j9gc_scavenger_enabled(J9JavaVM *javaVM);
 extern J9_CFUNC UDATA j9gc_concurrent_scavenger_enabled(J9JavaVM *javaVM);
+extern J9_CFUNC UDATA j9gc_software_read_barrier_enabled(J9JavaVM *javaVM);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreAddress(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_cloneObject(J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject);

--- a/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.cpp
+++ b/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -678,7 +678,8 @@ MM_CollectorLanguageInterfaceImpl::scavenger_switchConcurrentForThread(MM_Enviro
 			j9tty_printf(PORTLIB, "%p: Nursery [%p,%p] Evacuate [%p,%p] GS [%p,%p] Section size 0x%zx, sections %lu bit offset %lu bit mask 0x%zx\n",
 					vmThread, nurseryBase, nurseryTop, gsBase, gsTop, pageBase, pageTop, _extensions->getConcurrentScavengerPageSectionSize() , sectionCount, startOffsetInBits, bitMask);
 		}
-
+		vmThread->evacuateBase = gsBase;
+		vmThread->evacuateTop = gsTop;
 		vmThread->privateFlags |= J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE;
 		j9gs_enable(&vmThread->gsParameters, _extensions->getConcurrentScavengerPageStartAddress(), _extensions->getConcurrentScavengerPageSectionSize(), bitMask);
     } else {

--- a/runtime/gc_modron_startup/mmhelpers.cpp
+++ b/runtime/gc_modron_startup/mmhelpers.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,6 +137,12 @@ UDATA
 j9gc_concurrent_scavenger_enabled(J9JavaVM *javaVM)
 {
 	return MM_GCExtensions::getExtensions(javaVM)->isConcurrentScavengerEnabled() ? 1 : 0;
+}
+
+UDATA
+j9gc_software_read_barrier_enabled(J9JavaVM *javaVM)
+{
+	return MM_GCExtensions::getExtensions(javaVM)->isSoftwareEvacuateReadBarrierEnabled() ? 1 : 0;
 }
 
 /**

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2717,7 +2717,9 @@ gcInitializeDefaults(J9JavaVM* vm)
 			/* If running jitted, it must be on supported h/w */
 			J9ProcessorDesc  processorDesc;
 			j9sysinfo_get_processor_description(&processorDesc);
-			if (j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE) && j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_SIDE_EFFECT_ACCESS)) {
+			if ((j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE) &&
+					j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_SIDE_EFFECT_ACCESS))
+					|| (extensions->softwareEvacuateReadBarrier)) {
 				extensions->concurrentScavenger = true;
 			}
 		} else {

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -770,6 +770,13 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		if (try_scan(&scan_start, "debugConcurrentScavengerPageAlignment")) {
 			extensions->setDebugConcurrentScavengerPageAlignment(true);
+			continue;
+		}
+		if(try_scan(&scan_start, "softwareEvacuateReadBarrier")) {
+			/* Software read barriers are only implemented on s390 for now */
+#if defined(S390) || defined(J9ZOS390)
+			extensions->softwareEvacuateReadBarrier = true;
+#endif /* defined(S390) || defined(J9ZOS390) */
 			continue;
 		}
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4210,6 +4210,7 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA  ( *getStaticObjectAllocateFlags)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_scavenger_enabled)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_concurrent_scavenger_enabled)(struct J9JavaVM *javaVM) ;
+	UDATA  ( *j9gc_software_read_barrier_enabled)(struct J9JavaVM *javaVM) ;
 #if defined(J9VM_GC_HEAP_CARD_TABLE)
 	UDATA  ( *j9gc_concurrent_getCardSize)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_concurrent_getHeapBase)(struct J9JavaVM *javaVM) ;
@@ -4933,6 +4934,8 @@ typedef struct J9VMThread {
 #endif /* J9VM_JIT_TRANSACTION_DIAGNOSTIC_THREAD_BLOCK */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	struct J9GSParameters gsParameters;
+	void* evacuateBase;
+	void* evacuateTop;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	UDATA safePointCount;
 } J9VMThread;

--- a/runtime/vm/guardedstorage.c
+++ b/runtime/vm/guardedstorage.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 
+J9_EXTERN_BUILDER_SYMBOL(handleReadBarrier);
 J9_EXTERN_BUILDER_SYMBOL(handleGuardedStorageEvent);
 
 void
@@ -48,6 +49,14 @@ j9gs_initializeThread(J9VMThread *vmThread)
 	if (IS_THREAD_GS_INITIALIZED(vmThread)) {
 		success = 1;
 	} else {
+		BOOLEAN supportsGuardedStorageFacility = FALSE;
+		J9ProcessorDesc  processorDesc;
+		j9sysinfo_get_processor_description(&processorDesc);
+		if (j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE) &&
+				j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_SIDE_EFFECT_ACCESS)) {
+			supportsGuardedStorageFacility = TRUE;
+		}
+
 		/* Allocate the control block */
 		J9GSControlBlock *gsControlBlock = (J9GSControlBlock *)j9mem_allocate_memory(sizeof(J9GSControlBlock), J9MEM_CATEGORY_VM);
 		if (NULL != gsControlBlock) {
@@ -60,13 +69,22 @@ j9gs_initializeThread(J9VMThread *vmThread)
 			gsControlBlock->designationRegister = 0;
 			gsControlBlock->sectionMask = 0;
 			gsControlBlock->paramListAddr = (uint64_t) &vmThread->gsParameters;
-			vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleGuardedStorageEvent);
-		
+			if (1 == supportsGuardedStorageFacility) {
+				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleGuardedStorageEvent);
+			} else {
+				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleReadBarrier);
+			}
+
 			/* Initialize the parameters */
 			j9gs_params_init(&vmThread->gsParameters, gsControlBlock);
 		
 			/* Initialize the current thread */
-			success = j9gs_initialize(&vmThread->gsParameters, compressedRefShift);
+
+			if (TRUE == supportsGuardedStorageFacility) {
+				success = j9gs_initialize(&vmThread->gsParameters, compressedRefShift);
+			} else {
+				success = 1;
+			}
 		
 			/* Check to see if initialization was a success */
 			if (0 == success) {
@@ -84,6 +102,13 @@ j9gs_deinitializeThread(J9VMThread *vmThread)
 {
 	PORT_ACCESS_FROM_VMC(vmThread);
 	int32_t success = 0;
+	BOOLEAN supportsGuardedStorageFacility = FALSE;
+	J9ProcessorDesc  processorDesc;
+	j9sysinfo_get_processor_description(&processorDesc);
+	if (j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_GUARDED_STORAGE) &&
+			j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_SIDE_EFFECT_ACCESS)) {
+		supportsGuardedStorageFacility = TRUE;
+	}
 
 	/* Check if thread is already deinitialized */
 	if (!IS_THREAD_GS_INITIALIZED(vmThread)) {
@@ -92,8 +117,11 @@ j9gs_deinitializeThread(J9VMThread *vmThread)
 		J9GSControlBlock *gsControlBlock = (J9GSControlBlock*)((vmThread->gsParameters).controlBlock);
 		if (NULL != gsControlBlock) {
 			/* Deinitialize the current thread */
-			success = j9gs_deinitialize(&vmThread->gsParameters);
-		
+			if (TRUE == supportsGuardedStorageFacility) {
+				success = j9gs_deinitialize(&vmThread->gsParameters);
+			} else {
+				success = 1;
+			}
 			/* Free the Control Block */
 			j9mem_free_memory(gsControlBlock);
 			(vmThread->gsParameters).controlBlock = NULL;

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -348,6 +348,14 @@ initializeROMClasses(J9JavaVM *vm);
  * The trap handler that gets invoked when a H/W Read Barrier is triggered
  */
 J9_EXTERN_BUILDER_SYMBOL(handleGuardedStorageEvent);
+
+/**
+ * Software Read Barrier Handler
+ *
+ * The handler that gets invoked by JIT before loads when running concurrent scavenger on hardware
+ * that doesn't support guarded storage facility for object that are being evacuated
+ */
+J9_EXTERN_BUILDER_SYMBOL(handleReadBarrier);
 
 /**
  * Handle a Guarded Storage Event

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2017, 2017 IBM Corp. and others
+dnl Copyright (c) 2017, 2018 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,10 +153,12 @@ END_CURRENT
 })
 
 ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
-dnl Handler for guarded storage events. 
+dnl Helper to handle guarded storage events and
+dnl software read barriers. 
 dnl When event occurs, hardware populates return address in
 dnl vmThread->gsParameters.returnAddr
-define({HANDLE_GS_EVENT},{
+dnl For software read barriers gsParameters.returnAddr is set by JIT
+define({HANDLE_GS_EVENT_HELPER},{
 BEGIN_HELPER($1)
     SAVE_ALL_REGS($1)
     ST_GPR J9SP,J9TR_VMThread_sp(J9VMTHREAD)
@@ -194,6 +196,10 @@ ifdef({ASM_J9VM_ENV_DATA64},{
        .short 0x0000
     })
 })
+})
+
+define({HANDLE_GS_EVENT},{
+    HANDLE_GS_EVENT_HELPER($1)
 
 dnl Branch back to the instruction that triggered guarded storage event.
 BRANCH_INDIRECT_ON_CONDITION(15,J9TR_VMThread_gsParameters_returnAddr,0,J9VMTHREAD)
@@ -201,7 +207,15 @@ BRANCH_INDIRECT_ON_CONDITION(15,J9TR_VMThread_gsParameters_returnAddr,0,J9VMTHRE
 END_CURRENT
 })
 
+define({HANDLE_SW_READ_BARRIER},{
+    HANDLE_GS_EVENT_HELPER($1)
+dnl Branch back to the instruction that called software read barrier hanlder.
+    BR r14
+END_CURRENT
+})
+
 HANDLE_GS_EVENT(handleGuardedStorageEvent)
+HANDLE_SW_READ_BARRIER(handleReadBarrier)
 
 })
 


### PR DESCRIPTION
Add ability to run concurrent scavenger with JIT enabled on s390
hardware that doesn't support guarded storage.

Signed-off-by: Evgenia Badyanova evgeniab@ca.ibm.com