### PR TITLE
Simplify testKitGen

### DIFF
--- a/test/Panama/build.xml
+++ b/test/Panama/build.xml
@@ -80,7 +80,7 @@
 
 	<target name="build" >
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="Panama"/>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/TestConfig/makefile
+++ b/test/TestConfig/makefile
@@ -239,7 +239,7 @@ endif
 
 .PHONY: test_$(DIRTARGET)
 $(DIRTARGET): JVM_TEST_ROOT := $(BUILD_ROOT)
-test_$(DIRTARGET): setup_$(DIRTARGET) rmResultFile $(DIRTARGET)_$(JAVA_VERSION) resultsSummary
+test_$(DIRTARGET): setup_$(DIRTARGET) rmResultFile $(DIRTARGET) resultsSummary
 
 test: compile runtest
 	@$(ECHO) "All Tests Completed"
@@ -249,7 +249,7 @@ export JCL_VERSION:=latest
 else
 export JCL_VERSION:=$(JCL_VERSION)
 endif
-$(info set JAVA_VERSION to $(JAVA_VERSION))
+$(info set JCL_VERSION to $(JCL_VERSION))
 
 # Define the EXCLUDE_FILE to be used for temporarily excluding failed tests.
 # This macro is used in /test/Utils/src/org/openj9/test/util/IncludeExcludeTestAnnotationTransformer
@@ -280,25 +280,7 @@ rmResultFile:
 resultsSummary:
 	@perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)testKitGen$(D)resultsSummary$(D)resultsSum.pl --failuremk=$(Q)$(FAILEDTAGETS)$(Q) --resultFile=$(Q)$(TEMPRESULTFILE)$(Q) --tapFile=$(Q)$(TAPRESULTFILE)$(Q) --diagnostic=failure
 
-sanity: JVM_TEST_ROOT := $(BUILD_ROOT)
-sanity: setup_sanity rmResultFile sanity_$(JAVA_VERSION) resultsSummary
-
-extended: JVM_TEST_ROOT := $(BUILD_ROOT)
-extended: setup_extended rmResultFile extended_$(JAVA_VERSION) resultsSummary
-
-openjdk: JVM_TEST_ROOT := $(BUILD_ROOT)
-openjdk: setup_openjdk rmResultFile openjdk_$(JAVA_VERSION) resultsSummary
-
-external: JVM_TEST_ROOT := $(BUILD_ROOT)
-external: setup_external rmResultFile external_$(JAVA_VERSION) resultsSummary
-
-perf: JVM_TEST_ROOT := $(BUILD_ROOT)
-perf: setup_perf rmResultFile perf_$(JAVA_VERSION) resultsSummary
-
-jck: JVM_TEST_ROOT := $(BUILD_ROOT)
-jck: setup_jck rmResultFile jck_$(JAVA_VERSION) resultsSummary
-
-runtest: setup_runtest rmResultFile sanity_$(JAVA_VERSION) extended_$(JAVA_VERSION) openjdk_$(JAVA_VERSION) external_$(JAVA_VERSION) perf_$(JAVA_VERSION) jck_$(JAVA_VERSION) resultsSummary
+runtest: setup_runtest rmResultFile sanity extended openjdk external perf jck resultsSummary
 .NOTPARALLEL: extended sanity openjdk external perf jck runtest rmResultFile resultsSummary
 
 # cleanup

--- a/test/TestConfig/run_configure.mk
+++ b/test/TestConfig/run_configure.mk
@@ -39,17 +39,19 @@ endif
 
 ifndef SPEC
 $(error Please provide SPEC that matches the current platform (e.g. SPEC=linux_x86-64))
-else
-export SPEC:=$(SPEC)
-$(info set SPEC to $(SPEC))
 endif
+
+ifndef JAVA_VERSION
+export JAVA_VERSION:=SE90
+endif
+
 
 autoconfig:
 	perl configure.pl
 
 autogen: autoconfig
 	cd $(CURRENT_DIR)$(D)scripts$(D)testKitGen; \
-	perl testKitGen.pl --graphSpecs=$(SPEC) $(OPTS); \
+	perl testKitGen.pl --graphSpecs=$(SPEC) --javaVersion=$(JAVA_VERSION) $(OPTS); \
 	cd $(CURRENT_DIR);
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)

--- a/test/TestConfig/scripts/build_test.xml
+++ b/test/TestConfig/scripts/build_test.xml
@@ -34,7 +34,11 @@
 	<property name="JAVA_BIN" value="${JAVA_BIN}" />
 	<echo> JAVA_BIN is ${JAVA_BIN} </echo>
 	<if>
-		<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+		<or>
+			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="Panama"/>
+			<equals arg1="${JAVA_VERSION}" arg2="Valhalla"/>
+		</or>
 		<then>
 			<property name="JAVAC" value="${JAVA_BIN}/javac" />
 		</then>
@@ -69,38 +73,20 @@
 
 	<target name="build" depends="stage_test_material" description="using ${JAVA_VERSION} compile the source ">
 		<if>
-			<equals arg1="${JCL_VERSION}" arg2="latest"/>
+			<equals arg1="${JAVA_VERSION}" arg2="Panama"/>
 			<then>
 				<subant target="">
 					<property name="build.dir" value="subant1.build" />
 					<property name="not.overloaded" value="not.overloaded" />
 					<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
 					<property name="compiler.javac" value="${JAVAC}" />
-					<fileset dir="../../" includes="${build.list}" >
-						<exclude name="TEST_*/build.xml" />
-						<exclude name="NativeTest/build.xml" />
-						<exclude name="SharedCPEntryInvokerTests/build.xml" />
-						<exclude name="Valhalla/build.xml" />
-						<exclude name="Panama/build.xml" />
+					<fileset dir="../../">
+						<include name="Panama/build.xml" />
 					</fileset>
 				</subant>
 			</then>
 			<elseif>
-				<equals arg1="${JCL_VERSION}" arg2="Panama"/>
-				<then>
-					<subant target="">
-						<property name="build.dir" value="subant1.build" />
-						<property name="not.overloaded" value="not.overloaded" />
-						<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
-						<property name="compiler.javac" value="${JAVAC}" />
-						<fileset dir="../../">
-							<include name="Panama/build.xml" />
-						</fileset>
-					</subant>
-				</then>
-			</elseif>
-			<elseif>
-				<equals arg1="${JCL_VERSION}" arg2="Valhalla"/>
+				<equals arg1="${JAVA_VERSION}" arg2="Valhalla"/>
 				<then>
 					<subant target="">
 						<property name="build.dir" value="subant1.build" />
@@ -113,19 +99,78 @@
 					</subant>
 				</then>
 			</elseif>
-			<else>
-				<subant target="">
-					<property name="build.dir" value="subant1.build" />
-					<property name="not.overloaded" value="not.overloaded" />
-					<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
-					<property name="compiler.javac" value="${JAVAC}" />
-					<fileset dir="../../" includes="${build.list}" >
-						<exclude name="TEST_*/build.xml" />
-						<exclude name="Panama/build.xml" />
-						<exclude name="OpenJ9_Jsr_292_API/build.xml" />
-					</fileset>
-				</subant>
-			</else>
+			<elseif>
+				<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+				<then>
+					<if>
+						<equals arg1="${JCL_VERSION}" arg2="latest"/>
+						<then>
+							<subant target="">
+								<property name="build.dir" value="subant1.build" />
+								<property name="not.overloaded" value="not.overloaded" />
+								<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
+								<property name="compiler.javac" value="${JAVAC}" />
+								<fileset dir="../../" includes="${build.list}" >
+									<exclude name="TEST_*/build.xml" />
+									<exclude name="NativeTest/build.xml" />
+									<exclude name="SharedCPEntryInvokerTests/build.xml" />
+									<exclude name="Valhalla/build.xml" />
+									<exclude name="Panama/build.xml" />
+								</fileset>
+							</subant>
+						</then>
+						<else>
+							<subant target="">
+								<property name="build.dir" value="subant1.build" />
+								<property name="not.overloaded" value="not.overloaded" />
+								<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
+								<property name="compiler.javac" value="${JAVAC}" />
+								<fileset dir="../../" includes="${build.list}" >
+									<exclude name="TEST_*/build.xml" />
+									<exclude name="Panama/build.xml" />
+									<exclude name="Valhalla/build.xml" />
+									<exclude name="OpenJ9_Jsr_292_API/build.xml" />
+								</fileset>
+							</subant>
+						</else>
+					</if>
+				</then>
+			</elseif>
+			<elseif>
+				<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+				<then>
+					<if>
+						<equals arg1="${JCL_VERSION}" arg2="latest"/>
+						<then>
+							<subant target="">
+								<property name="build.dir" value="subant1.build" />
+								<property name="not.overloaded" value="not.overloaded" />
+								<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
+								<property name="compiler.javac" value="${JAVAC}" />
+								<fileset dir="../../" includes="${build.list}" >
+									<exclude name="TEST_*/build.xml" />
+									<exclude name="NativeTest/build.xml" />
+									<exclude name="Valhalla/build.xml" />
+									<exclude name="Panama/build.xml" />
+								</fileset>
+							</subant>
+						</then>
+						<else>
+							<subant target="">
+								<property name="build.dir" value="subant1.build" />
+								<property name="not.overloaded" value="not.overloaded" />
+								<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
+								<property name="compiler.javac" value="${JAVAC}" />
+								<fileset dir="../../" includes="${build.list}" >
+									<exclude name="TEST_*/build.xml" />
+									<exclude name="Panama/build.xml" />
+									<exclude name="Valhalla/build.xml" />
+								</fileset>
+							</subant>
+						</else>
+					</if>
+				</then>
+			</elseif>
 		</if>
 	</target>
 

--- a/test/TestConfig/scripts/testKitGen/testKitGen.pl
+++ b/test/TestConfig/scripts/testKitGen/testKitGen.pl
@@ -35,12 +35,16 @@ my $projectRootDir = '';
 my $modesxml       = "../../resources/modes.xml";
 my $ottawacsv      = "../../resources/ottawa.csv";
 my $graphSpecs     = '';
+my $javaVersion    = '';
 my $output         = '';
 my @allSubsets = ( "SE80", "SE90", "Panama", "Valhalla" );
 
 foreach my $argv (@ARGV) {
 	if ( $argv =~ /^\-\-graphSpecs=/ ) {
 		($graphSpecs) = $argv =~ /^\-\-graphSpecs=(.*)/;
+	}
+	elsif ( $argv =~ /^\-\-javaVersion=/ ) {
+		($javaVersion) = $argv =~ /^\-\-javaVersion=(.*)/;
 	}
 	elsif ( $argv =~ /^\-\-projectRootDir=/ ) {
 		($projectRootDir) = $argv =~ /^\-\-projectRootDir=(.*)/;
@@ -61,12 +65,13 @@ foreach my $argv (@ARGV) {
 		  . "jvmTest.mk and specToPlat.mk - under TestConfig\n";
 		print "Options:\n"
 		  . "--graphSpecs=<specs>    Comma separated specs that the build will run on.\n"
+		  . "--javaVersion=<version> Java version that the build will run on.\n"
 		  . "--output=<path>         Path to output makefiles.\n"
 		  . "--projectRootDir=<path> Root path for searching playlist.xml.\n"
 		  . "--modesXml=<path>       Path to modes.xml file.\n"
 		  . "                        If the modesXml is not provided, the program will try to find modes.xml under projectRootDir/TestConfig/resources.\n"
 		  . "--ottawaCsv=<path>      Path to ottawa.csv file.\n"
-  		  . "                        If the ottawaCsv is not provided, the program will try to find ottawa.csv under projectRootDir/TestConfig/resources.\n";
+		  . "                        If the ottawaCsv is not provided, the program will try to find ottawa.csv under projectRootDir/TestConfig/resources.\n";
 		die "Please specify valid options!";
 	}
 }
@@ -87,7 +92,10 @@ if ( !$graphSpecs ) {
 	die "Please provide graphSpecs!"
 }
 
+if ( !$javaVersion ) {
+	die "Please provide javaVersion!"
+}
 # run make file generator
-my $tests = runmkgen( $projectRootDir, \@allSubsets, $output, $graphSpecs, $modesxml, $ottawacsv );
+my $tests = runmkgen( $projectRootDir, \@allSubsets, $output, $graphSpecs, $javaVersion, $modesxml, $ottawacsv );
 
 print "\nTEST AUTO GEN SUCCESSFUL\n";

--- a/test/Valhalla/build.xml
+++ b/test/Valhalla/build.xml
@@ -76,7 +76,7 @@
 
 	<target name="build" >
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="Valhalla"/>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>


### PR DESCRIPTION
- only generate targets that match JAVA_VERSION
- remove JAVA_VERSION suffix from internal target
- run_configure.mk requires JAVA_VERSION
- define Panama/Valhalla with JAVA_VERSION instead of JCL_VERSION
- use JAVA_VERSION to separate build process in build_test.xml

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>