### PR TITLE
Replaced hard-coded values with defined VM constants

### DIFF
--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -609,7 +609,7 @@ static void allSlotsInCPShapeDescriptionDo(J9ROMClass* romClass, J9ROMClassWalkC
 	U_32 *cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
 	BOOLEAN rangeValid;
 
-	count = (romClass->romConstantPoolCount + (sizeof(U_32) * 2) - 1) / (sizeof(U_32) * 2);
+	count = (romClass->romConstantPoolCount + J9_CP_DESCRIPTIONS_PER_U32 - 1) / J9_CP_DESCRIPTIONS_PER_U32;
 
 	rangeValid = callbacks->validateRangeCallback(romClass, cpShapeDescription, count * sizeof(U_32), userData);
 	if (rangeValid) {

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -1478,8 +1478,8 @@ contendedLoadTableRemoveThread(J9VMThread* vmThread, J9ContendedLoadTableEntry *
 void
 fixCPShapeDescription(J9Class * clazz, UDATA cpIndex)
 {
-	UDATA wordIndex = (UDATA) (cpIndex / (sizeof(U_32)*2));
-	UDATA shiftAmount = (UDATA) ((cpIndex % (sizeof(U_32)*2)) * 4);
+	UDATA wordIndex = (UDATA) (cpIndex / J9_CP_DESCRIPTIONS_PER_U32);
+	UDATA shiftAmount = (UDATA) ((cpIndex % J9_CP_DESCRIPTIONS_PER_U32) * J9_CP_BITS_PER_DESCRIPTION);
 	U_32 * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(clazz->romClass);
 
 	cpShapeDescription[wordIndex] = (cpShapeDescription[wordIndex] & ~(J9_CP_DESCRIPTION_MASK << shiftAmount)) | (J9CPTYPE_INSTANCE_METHOD << shiftAmount);


### PR DESCRIPTION
Use the J9_CP_DESCRIPTION_PER_U32 macro to calculate block size
instead of assuming each byte contains exectly two CP description
entry (4 bits) and hard code it as (sizeof(U_32) * 2)

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>