### PR TITLE
Initialize java/lang/String.coder

### DIFF
--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -165,7 +165,7 @@ uma : buildtools copya2e
 
 # process constant pool definition file to generate jcl constant pool definitions and header file
 CONSTANTPOOL_TOOL    := $(JAVA) -cp "sourcetools/lib/om.jar$(PATHSEP)sourcetools/lib/j9vmcp.jar" com.ibm.oti.VMCPTool.Main
-CONSTANTPOOL_OPTIONS := -rootDir . -buildSpecId $(SPEC) -configDir $(SPEC_DIR) -jcls se7_basic,se9_before_b165,se9
+CONSTANTPOOL_OPTIONS := -rootDir . -buildSpecId $(SPEC) -configDir $(SPEC_DIR) -jcls se7_basic,se9_before_b165,se9,se10
 constantpool : buildtools
 	$(CONSTANTPOOL_TOOL) $(CONSTANTPOOL_OPTIONS)
 

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "hashtable_api.h"
+#include "j2sever.h"
 #include "j9consts.h"
 #include "j9protos.h"
 #include "objhelp.h"
@@ -669,6 +670,13 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 			}
 		} else {
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32) unicodeLength);
+			if (J2SE_VERSION(vm) >= J2SE_V10) {
+				/* Setting java/lang/String.coder to 1 (UTF16)
+				 * which can be removed if this field can be removed by
+				 * https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/91
+				 */
+				J9VMJAVALANGSTRING_SET_CODER(vmThread, result, 1);
+			}
 		}
 
 		MM_AtomicOperations::writeBarrier();

--- a/runtime/jcl/cl_se10/module.xml
+++ b/runtime/jcl/cl_se10/module.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+	Copyright (c) 2017, 2017 IBM Corp. and others
+	
+	This program and the accompanying materials are made available under
+	the terms of the Eclipse Public License 2.0 which accompanies this
+	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+	or the Apache License, Version 2.0 which accompanies this distribution and
+	is available at https://www.apache.org/licenses/LICENSE-2.0.
+	
+	This Source Code may also be made available under the following
+	Secondary Licenses when the conditions for such availability set
+	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+	General Public License, version 2 with the GNU Classpath
+	Exception [1] and GNU General Public License, version 2 with the
+	OpenJDK Assembly Exception [2].
+	
+	[1] https://www.gnu.org/software/classpath/license.html
+	[2] http://openjdk.java.net/legal/assembly-exception.html
+
+	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+<module xmlns:xi="http://www.w3.org/2001/XInclude">
+
+	<xi:include href="../uma/sun_misc_Unsafe_exports.xml"></xi:include>
+	<xi:include href="../uma/unsafemem_inl_exports.xml"></xi:include>
+	<xi:include href="../uma/se6_vm-side_natives_exports.xml"></xi:include>
+	<xi:include href="../uma/se6_vm-side_lifecycle_exports.xml"></xi:include>
+	<xi:include href="../uma/attach_exports.xml"></xi:include>
+	<xi:include href="../uma/se7_exports.xml"></xi:include>
+	<xi:include href="../uma/se626_orb_ludcl_exports.xml"></xi:include>
+	<xi:include href="../uma/jithelpers_jni_exports.xml"></xi:include>
+	<xi:include href="../uma/rcm_exports.xml"></xi:include>
+	<xi:include href="../uma/se8_exports.xml"></xi:include>
+	<xi:include href="../uma/se829_exports.xml"></xi:include>
+	<xi:include href="../uma/se9_exports.xml"></xi:include>
+
+	<xi:include href="../uma/vendor_jcl_exports.xml">
+		<xi:fallback/>
+	</xi:include>
+
+	<xi:include href="../uma/sun_misc_Unsafe_objects.xml"></xi:include>	
+	<xi:include href="../uma/se6_vm-side_natives_objects.xml"></xi:include>
+	<xi:include href="../uma/se6_vm-side_lifecycle_objects.xml"></xi:include>
+	<xi:include href="../uma/attach_objects.xml"></xi:include>
+	<xi:include href="../uma/se7_objects.xml"></xi:include>
+	<xi:include href="../uma/se626_orb_ludcl_objects.xml"></xi:include>
+	<xi:include href="../uma/jithelpers_objects.xml"></xi:include>
+	<xi:include href="../uma/rcm_objects.xml"></xi:include>
+	<xi:include href="../uma/se8_objects.xml"></xi:include>
+	<xi:include href="../uma/se9_objects.xml"></xi:include>
+
+	<!-- vendor_jcl.xml can contain vendor specific configuration -->
+	<xi:include href="../uma/vendor_jcl.xml">
+		<xi:fallback>
+			<xi:include href="../uma/vendor_jcl_default.xml"></xi:include>
+		</xi:fallback>
+	</xi:include>
+
+	<artifact type="shared" name="jclse10_" bundle="jvm" loadgroup="jcl">
+		<include-if condition="spec.flags.build_java7"/>
+		<options>
+			<option name="isRequired">
+				<include-if condition="spec.jcl.Sidecar"/>
+			</option>
+			<option name="requiresPrimitiveTable"/>
+			<option name="prototypeHeaderFileNames" data="j9protos.h jclprots.h"/>
+			<option name="requiresLockFixups386"/>
+			<option name="dllDescription" data="Java SE 10"/>
+		</options>
+		<phase>core j2se</phase>
+		
+		<exports>
+			<group name="se6_vm-side_lifecycle"/>
+			<group name="se6_vm-side_natives"/>
+			<group name="jithelpers"/>
+			<group name="sun_misc_Unsafe"/>
+			<group name="sun_misc_Unsafe_inl"/>
+			<group name="attach">
+				<include-if condition="spec.flags.opt_sidecar"/>
+			</group>
+			<group name="se7"/>
+			<group name="se626_orb_ludcl"/>
+			<group name="se8"/>
+			<group name="se829"/>
+			<group name="se9" />
+		</exports>
+		
+		<flags>
+			<flag name="J9VM_JCL_SE10"/>
+		</flags>
+		
+		<includes>
+			<include path="j9include"/>
+			<include path="j9oti"/>
+			<include path="j9zlib"/>
+			<include path="j9util"/>
+			<include path="j9gcinclude"/>
+			<include path="$(OMR_DIR)/gc/include" type="relativepath"/>
+			<include path="j9gcgluejava"/>
+			<include path="jvm"/>
+			<include path="j9shr_include"/>
+		</includes>
+
+		<makefilestubs>
+			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
+			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="ifeq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="vm_scar$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
+			<makefilestub data="endif"/>
+		</makefilestubs>
+
+		<vpaths>
+			<vpath pattern="%" path="../unix" augmentIncludes="true" type="relativepath">
+				<exclude-if condition="spec.win_x86.*"/>
+			</vpath>
+			<vpath pattern="%" path="../win32" augmentIncludes="true" type="relativepath">
+				<include-if condition="spec.win_x86.*"/>
+			</vpath>
+			<vpath pattern="%" path="../crypto" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="%" path="../filerms" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="%" path="../filesys" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="%" path="../common" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="%" path="../inl" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="%" path="../." augmentIncludes="true" type="relativepath"/>
+		</vpaths>
+		
+		<objects>
+			<group name="se6_vm-side_lifecycle"/>
+			<group name="se6_vm-side_natives"/>
+			<group name="jithelpers"/>
+			<group name="sun_misc_Unsafe"/>
+			<group name="attach">
+				<include-if condition="spec.flags.opt_sidecar"/>
+			</group>
+			<group name="se7"/>
+			<group name="se626_orb_ludcl"/>
+
+			<group name="se8"/>
+			<group name="se9"/>
+			
+			<group name="vendor_jcl"/>
+			
+			<!-- Groups must be before Objects -->
+			<object name="j9vmconstantpool_se10" />
+		</objects>
+
+		<libraries>
+			<library name="omrsig">
+				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
+			</library>
+			<library name="pthread" type="system">
+				<include-if condition="spec.aix_.*"/>
+			</library>
+			<library name="psapi.lib" type="system" delayload="true">
+				<include-if condition="spec.win_.*"/>
+			</library>
+			<library name="pdh.lib" type="system" delayload="true">
+				<include-if condition="spec.win_.*"/>
+			</library>
+			<library name="j9hookable"/>
+			<library name="j9zlib"/>
+			<library name="j9util"/>
+			<library name="j9utilcore"/>
+			<library name="j9avl" type="external"/>
+			<library name="j9hashtable" type="external"/>
+			<library name="j9pool" type="external"/>
+			<library name="j9thr"/>
+			<library name="j9vmi"/>
+			<library name="socket" type="macro"/>
+			<library name="sunvmi"/>
+		</libraries>
+	</artifact>
+</module>

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -55,6 +55,8 @@
 #define J9_DLL_NAME J9_JAVA_SE_7_BASIC_DLL_NAME
 #elif defined(J9VM_JCL_SE9)
 #define J9_DLL_NAME J9_JAVA_SE_9_DLL_NAME
+#elif defined(J9VM_JCL_SE10)
+#define J9_DLL_NAME J9_JAVA_SE_10_DLL_NAME
 #else
 #error Unknown J9VM_JCL_SE
 #endif

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -125,17 +125,17 @@
 	<classref name="com/ibm/oti/vm/VM"/> 
 	<classref name="java/lang/System"/> 
 	<classref name="java/lang/reflect/Module" jcl="se9_before_b165" flags="opt_module"/>
-	<classref name="java/lang/Module" jcl="se9" flags="opt_module"/>
-	<classref name="java/lang/invoke/VarHandle" jcl="se9_before_b165,se9"/>
-	<classref name="java/lang/invoke/VarHandleInvokeHandle" jcl="se9_before_b165,se9"/>
+	<classref name="java/lang/Module" jcl="se9,se10" flags="opt_module"/>
+	<classref name="java/lang/invoke/VarHandle" jcl="se9_before_b165,se9,se10"/>
+	<classref name="java/lang/invoke/VarHandleInvokeHandle" jcl="se9_before_b165,se9,se10"/>
 
 	<fieldref class="java/lang/ClassLoader" name="parent" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/ClassLoader" name="vmRef" signature="J" cast="struct J9ClassLoader *"/>
 	<fieldref class="java/lang/ClassLoader" name="isParallelCapable" signature="Z"/>
 	<fieldref class="java/lang/ClassLoader" name="unnamedModule" signature="Ljava/lang/reflect/Module;" flags="opt_module" jcl="se9_before_b165">
-		<fieldalias name="unnamedModule" signature="Ljava/lang/Module;" flags="opt_module" jcl="se9" />
+		<fieldalias name="unnamedModule" signature="Ljava/lang/Module;" flags="opt_module" jcl="se9,se10" />
 	</fieldref> 
-	<fieldref class="java/lang/ClassLoader" name="classLoaderName" signature="Ljava/lang/String;" flags="opt_module" jcl="se9_before_b165,se9" />
+	<fieldref class="java/lang/ClassLoader" name="classLoaderName" signature="Ljava/lang/String;" flags="opt_module" jcl="se9_before_b165,se9,se10" />
 	<fieldref class="java/lang/Class" name="reflectCache" signature="Ljava/lang/Class$ReflectCache;"/>
 	<fieldref class="java/lang/Class" name="classLoader" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/Class" name="vmRef" signature="J" cast="struct J9Class *"/>
@@ -144,20 +144,21 @@
 	<fieldref class="java/lang/Class" name="classNameString" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/Class" name="annotationCache" signature="Ljava/lang/Class$AnnotationCache;"/>
 	<fieldref class="java/lang/Class" name="module" signature="Ljava/lang/reflect/Module;" flags="opt_module" jcl="se9_before_b165">
-		<fieldalias name="module" signature="Ljava/lang/Module;" flags="opt_module" jcl="se9" />
+		<fieldalias name="module" signature="Ljava/lang/Module;" flags="opt_module" jcl="se9,se10" />
 	</fieldref> 
 	<fieldref class="java/lang/Class" name="methodHandleCache" signature="Ljava/lang/Object;" flags="opt_methodHandle"/>
 	
 	<staticfieldref class="java/lang/String" name="compressionFlag" signature="Ljava/lang/String$StringCompressionFlag;"/>
-	<fieldref class="java/lang/String" name="value" signature="[B" jcl="se9_before_b165,se9">
+	<fieldref class="java/lang/String" name="value" signature="[B" jcl="se9_before_b165,se9,se10">
 		<fieldalias name="value" signature="[C" jcl="se7_basic" />
 	</fieldref> 
 	<fieldref class="java/lang/String" name="count" signature="I"/>
 	<fieldref class="java/lang/String" name="hashCode" signature="I"/>
-	<fieldref class="java/lang/StackTraceElement" name="moduleName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9" flags="opt_module"/>
-	<fieldref class="java/lang/StackTraceElement" name="moduleVersion" signature="Ljava/lang/String;" jcl="se9_before_b165,se9" flags="opt_module"/>
+	<fieldref class="java/lang/String" name="coder" signature="B" jcl="se10"/>
+	<fieldref class="java/lang/StackTraceElement" name="moduleName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9,se10" flags="opt_module"/>
+	<fieldref class="java/lang/StackTraceElement" name="moduleVersion" signature="Ljava/lang/String;" jcl="se9_before_b165,se9,se10" flags="opt_module"/>
 	<fieldref class="java/lang/StackTraceElement" name="declaringClass" signature="Ljava/lang/String;"/>
-	<fieldref class="java/lang/StackTraceElement" name="classLoaderName" signature="Ljava/lang/String;" flags="opt_module" jcl="se9_before_b165,se9" />
+	<fieldref class="java/lang/StackTraceElement" name="classLoaderName" signature="Ljava/lang/String;" flags="opt_module" jcl="se9_before_b165,se9,se10" />
 	<fieldref class="java/lang/StackTraceElement" name="methodName" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/StackTraceElement" name="fileName" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/StackTraceElement" name="lineNumber" signature="I"/>
@@ -168,16 +169,16 @@
 	<fieldref class="java/lang/Thread" name="started" signature="Z"/>
 	<fieldref class="java/lang/Thread" name="name" signature="Ljava/lang/String;"/>
 	
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="declaringClass" signature="Ljava/lang/Class;" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="callerSensitive" signature="Z" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="fileName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="bytecodeIndex" signature="I" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="className" signature="Ljava/lang/String;" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="classLoaderName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="lineNumber" signature="I" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="declaringClass" signature="Ljava/lang/Class;" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="callerSensitive" signature="Z" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="fileName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="bytecodeIndex" signature="I" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="className" signature="Ljava/lang/String;" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="classLoaderName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="lineNumber" signature="I" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="methodName" signature="Ljava/lang/String;" jcl="se9_before_b165,se9,se10"/>
 	<fieldref class="java/lang/StackWalker$StackFrameImpl" name="frameModule" signature="Ljava/lang/reflect/Module;" jcl="se9_before_b165">
-		<fieldalias name="frameModule" signature="Ljava/lang/Module;" jcl="se9" />
+		<fieldalias name="frameModule" signature="Ljava/lang/Module;" jcl="se9,se10" />
 	</fieldref> 
 	
 	<fieldref class="java/lang/Thread" name="priority" signature="I"/>
@@ -311,22 +312,22 @@
 	<fieldref class="java/lang/invoke/ConstantLongHandle" name="value" signature="J" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/ConstantDoubleHandle" name="value" signature="D" cast="U_64" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/InvokeGenericHandle" name="castType" signature="Ljava/lang/invoke/MethodType;" flags="opt_methodHandle"/>
-	<fieldref class="java/lang/invoke/VarHandle" name="handleTable" signature="[Ljava/lang/invoke/MethodHandle;" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/invoke/VarHandle" name="modifiers" signature="I" jcl="se9_before_b165,se9"/>
+	<fieldref class="java/lang/invoke/VarHandle" name="handleTable" signature="[Ljava/lang/invoke/MethodHandle;" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/invoke/VarHandle" name="modifiers" signature="I" jcl="se9_before_b165,se9,se10"/>
 	<fieldref class="java/lang/invoke/FoldHandle" name="foldPosition" signature="I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/FoldHandle" name="argumentIndices" signature="[I" flags="opt_methodHandle"/>
 	<fieldref class="java/lang/invoke/MethodHandleCache" name="directHandlesHead" signature="Lcom/ibm/oti/util/WeakReferenceNode;" flags="opt_methodHandle"/>	
-	<fieldref class="java/lang/invoke/VarHandleInvokeHandle" name="operation" signature="I" jcl="se9_before_b165,se9"/>
-	<fieldref class="java/lang/invoke/VarHandleInvokeHandle" name="accessModeType" signature="Ljava/lang/invoke/MethodType;" jcl="se9_before_b165,se9"/>
+	<fieldref class="java/lang/invoke/VarHandleInvokeHandle" name="operation" signature="I" jcl="se9_before_b165,se9,se10"/>
+	<fieldref class="java/lang/invoke/VarHandleInvokeHandle" name="accessModeType" signature="Ljava/lang/invoke/MethodType;" jcl="se9_before_b165,se9,se10"/>
 
 	<fieldref class="java/lang/reflect/Module" name="loader" signature="Ljava/lang/ClassLoader;" jcl="se9_before_b165" flags="opt_module"/>
-	<fieldref class="java/lang/Module" name="loader" signature="Ljava/lang/ClassLoader;" jcl="se9" flags="opt_module"/>
+	<fieldref class="java/lang/Module" name="loader" signature="Ljava/lang/ClassLoader;" jcl="se9,se10" flags="opt_module"/>
 	<fieldref class="java/lang/reflect/Module" name="name" signature="Ljava/lang/String;" jcl="se9_before_b165" flags="opt_module"/>
-	<fieldref class="java/lang/Module" name="name" signature="Ljava/lang/String;" jcl="se9" flags="opt_module"/>
+	<fieldref class="java/lang/Module" name="name" signature="Ljava/lang/String;" jcl="se9,se10" flags="opt_module"/>
 	
 	<fieldref class="java/lang/InternalRamClass" name="vmref" signature="J" cast="struct J9Class *"/>
 	
-	<fieldref class="com/ibm/oti/util/WeakReferenceNode" name="next" signature="Lcom/ibm/oti/util/WeakReferenceNode;" jcl="se7_basic,se9" flags="opt_methodHandle"/>
+	<fieldref class="com/ibm/oti/util/WeakReferenceNode" name="next" signature="Lcom/ibm/oti/util/WeakReferenceNode;" jcl="se7_basic,se9,se10" flags="opt_methodHandle"/>
 
 	<staticmethodref class="java/lang/J9VMInternals" name="completeInitialization" signature="()V"/>
 	<staticmethodref class="java/lang/J9VMInternals" name="checkPackageAccess" signature="(Ljava/lang/Class;Ljava/security/ProtectionDomain;)V"/>

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -706,29 +706,22 @@ addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2s
 	size_t dllNameLength = -1;
 	size_t argumentLength = -1;
 	char *argString = NULL;
+	UDATA j2seReleaseValue = j2seVersion & J2SE_RELEASE_MASK;
 	J9JavaVMArgInfo *optArg = NULL;
+	
 	PORT_ACCESS_FROM_PORT(portLib);
-
-	if (J2SE_19 <= (j2seVersion & J2SE_RELEASE_MASK)) {
-		switch (j2seVersion & J2SE_SHAPE_MASK) {
-		case J2SE_SHAPE_RAW:
-			Assert_Util_unreachable();
-			break;
-		default:
-			dllName = J9_JAVA_SE_9_DLL_NAME;
-			dllNameLength = sizeof(J9_JAVA_SE_9_DLL_NAME);
-			break;
-		}
-	} else if (J2SE_17 <= (j2seVersion & J2SE_RELEASE_MASK)) {
-		switch (j2seVersion & J2SE_SHAPE_MASK) {
-		case J2SE_SHAPE_RAW:
-			Assert_Util_unreachable();
-			break;
-		default:
-			dllName = J9_JAVA_SE_7_BASIC_DLL_NAME;
-			dllNameLength = sizeof(J9_JAVA_SE_7_BASIC_DLL_NAME);
-			break;
-		}
+	if (J2SE_SHAPE_RAW == (j2seVersion & J2SE_SHAPE_MASK)) {
+		Assert_Util_unreachable();
+	} 
+	if (J2SE_V10 <= j2seReleaseValue) {
+		dllName = J9_JAVA_SE_10_DLL_NAME;
+		dllNameLength = sizeof(J9_JAVA_SE_10_DLL_NAME);
+	} else if (J2SE_19 <= j2seReleaseValue) {
+		dllName = J9_JAVA_SE_9_DLL_NAME;
+		dllNameLength = sizeof(J9_JAVA_SE_9_DLL_NAME);
+	} else if (J2SE_17 <= j2seReleaseValue) {
+		dllName = J9_JAVA_SE_7_BASIC_DLL_NAME;
+		dllNameLength = sizeof(J9_JAVA_SE_7_BASIC_DLL_NAME);
 	} else { /* Java 6 */
 		Assert_Util_unreachable();
 	}

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -50,7 +50,8 @@ static J9JCLConfigurationInfo jclConfigs[] = {
 	{ "scar" },
 	{ "se7b" },
 	{ "se7r" },
-	{ "se9" }
+	{ "se9" },
+	{ "se10" }
 };
 
 #define NUM_JCL_CONFIGS (sizeof(jclConfigs) / sizeof(J9JCLConfigurationInfo))


### PR DESCRIPTION
Initialize `java/lang/String.coder`

1. Initialize the field `java/lang/String.coder` to `1` for `Java 10` when string compression is not enabled (default behavior now). 
Note: these code could be removed if this field `java/lang/String.coder` can be removed via https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/91
2. Added `java/lang/String.coder` within `vmconstantpool.xml` for `Java 10` only;
3. Added `scar se10` accordingly.

closes: #655 

Reviewer @pshipton @dmitripivkine 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>