### PR TITLE
Scan JNI Weak Global References as a hard root for CS

### DIFF
--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,7 @@ protected:
 	OMR_VM *_omrVM;
 
 	bool _stringTableAsRoot;  /**< Treat the string table as a hard root */
+	bool _jniWeakGlobalReferencesTableAsRoot;	/**< Treat JNI Weak References Table as a hard root */
 	bool _singleThread;  /**< Should the iterator operate in single threaded mode */
 
 	bool _nurseryReferencesOnly;  /**< Should the iterator only scan structures that currently contain nursery references */
@@ -238,6 +239,7 @@ public:
 		, _clij((MM_CollectorLanguageInterfaceImpl *)_extensions->collectorLanguageInterface)
 		, _omrVM(env->getOmrVM())
 		, _stringTableAsRoot(true)
+		, _jniWeakGlobalReferencesTableAsRoot(false)
 		, _singleThread(singleThread)
 		, _nurseryReferencesOnly(false)
 		, _nurseryReferencesPossibly(false)
@@ -361,7 +363,7 @@ public:
 	virtual void scanOwnableSynchronizerObjects(MM_EnvironmentBase *env);
 	virtual void scanStringTable(MM_EnvironmentBase *env);
 	void scanJNIGlobalReferences(MM_EnvironmentBase *env);
-	void scanJNIWeakGlobalReferences(MM_EnvironmentBase *env);
+	virtual void scanJNIWeakGlobalReferences(MM_EnvironmentBase *env);
 
     virtual void scanMonitorReferences(MM_EnvironmentBase *env);
     virtual CompletePhaseCode scanMonitorReferencesComplete(MM_EnvironmentBase *env);

--- a/runtime/gc_glue_java/ScavengerRootClearer.hpp
+++ b/runtime/gc_glue_java/ScavengerRootClearer.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,6 +61,12 @@ public:
 	{
 		_typeId = __FUNCTION__;
 		setNurseryReferencesOnly(true);
+
+		/*
+		 * JNI Weak Global References table can be skipped in Clearable phase
+		 * if it has been scanned as a hard root for Concurrent Scavenger already
+		 */
+		_jniWeakGlobalReferencesTableAsRoot = _extensions->isConcurrentScavengerEnabled();
 	};
 
 	virtual void
@@ -204,6 +210,23 @@ public:
 		static_cast<J9JavaVM*>(_omrVM->_language_vm)->internalVMFunctions->objectMonitorDestroyComplete(static_cast<J9JavaVM*>(_omrVM->_language_vm), (J9VMThread *)env->getOmrVMThread()->_language_vmthread);
 		reportScanningEnded(RootScannerEntity_MonitorReferenceObjectsComplete);
 		return complete_phase_OK;
+	}
+
+	virtual void
+	scanJNIWeakGlobalReferences(MM_EnvironmentBase *env)
+	{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		/*
+		 * Currently Concurrent Scavenger replaces STW Scavenger, so this check is not necessary
+		 * (Concurrent Scavenger is always in progress)
+		 * However Concurrent Scavenger runs might be interlaced with STW Scavenger time to time
+		 * (for example for reducing amount of floating garbage)
+		 */
+		if (!_scavenger->isConcurrentInProgress())
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+		{
+			MM_RootScanner::scanJNIWeakGlobalReferences(env);
+		}
 	}
 
 	virtual void


### PR DESCRIPTION
JNI Weak Global References table is usually treated as Clearable root.
This means it is scanned at the end of Scavenger cycle. However this a
problem for Concurrent Scavenger because VM code does not call Read
Barrier on dereferencing elements of this table. As a result references
might be not fixed up properly at time of usage and this is a reason for
crashes in JNI support related code (JVMTI implementation for instance).
So each single place in the code where elements of the table are
dereferenced should be wrapped with macro calling Read Barrier. And
there are many of them.
The temporary solution (until all places required modification are
spotted) is treat JNI Weak Global References table as a hard root at the
time when Concurrent Scavenger cycle active. Concurrent Scavenger scans
all hard roots at the time of first increment so references in the table
would be fixed up before mutator threads have access to it.

Signed-off-by: dmitripivkine <Dmitri_Pivkine@ca.ibm.com>