### PR TITLE
Initialize StringCompressionFlag when loading

### DIFF
--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -646,6 +646,10 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32) unicodeLength);
 			} else {
 				if (J9VMJAVALANGSTRING_COMPRESSIONFLAG(vmThread, stringClass) == 0) {
+					/*
+					 * jitHookClassPreinitialize will process initialization events for String compression sideEffectGuards
+					 * so we must initialize the class if this is the first time we are loading it
+					 */
 			 		J9Class* flagClass = vm->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
 
 					if (flagClass == NULL) {
@@ -923,6 +927,10 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32) unicodeLength);
 		} else {
 		 	if (J9VMJAVALANGSTRING_COMPRESSIONFLAG(vmThread, stringClass) == 0) {
+				/*
+				 * jitHookClassPreinitialize will process initialization events for String compression sideEffectGuards
+				 * so we must initialize the class if this is the first time we are loading it
+				 */
 		 		J9Class* flagClass = vm->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
 
 				if (flagClass == NULL) {

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -646,7 +646,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 				J9VMJAVALANGSTRING_SET_COUNT(vmThread, result, (I_32) unicodeLength);
 			} else {
 				if (J9VMJAVALANGSTRING_COMPRESSIONFLAG(vmThread, stringClass) == 0) {
-			 		J9Class* flagClass = vm->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, 0);
+			 		J9Class* flagClass = vm->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
 
 					if (flagClass == NULL) {
 						goto nomem;
@@ -923,7 +923,7 @@ j9gc_allocStringWithSharedCharData(J9VMThread *vmThread, U_8 *data, UDATA length
 			J9VMJAVALANGSTRING_SET_COUNT(vmThread, string, (I_32) unicodeLength);
 		} else {
 		 	if (J9VMJAVALANGSTRING_COMPRESSIONFLAG(vmThread, stringClass) == 0) {
-		 		J9Class* flagClass = vm->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, 0);
+		 		J9Class* flagClass = vm->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGSTRINGSTRINGCOMPRESSIONFLAG, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
 
 				if (flagClass == NULL) {
 					goto nomem;


### PR DESCRIPTION
When loading the StringCompressionFlag class initialize it as well as
the JIT depends on the initialization hook in jitHookClassPreinitialize
to capture the event and update its class hierarchy table.

When this table is updated all known assumptions made for this class
load will trigger and the corresponding side effect guards will be
patched at runtime. An example of this is the NOP side effect guards
placed for String compression.

Closes: #784
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>