### PR TITLE
Clean up test exclude files

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2016, 2017 IBM Corp. and others
+#  Copyright (c) 2016, 2018 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,27 +22,6 @@
 
 # Exclude tests temporarily
 
-org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	                 AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
-org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														JTC-JAT-133182 generic-all
-org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	BPW-https://github.ibm.com/runtimes/test/issues/109 generic-all
 org.openj9.test.java.lang.Test_J9VMInternals:test_checkPackageAccess													BPW-https://github.ibm.com/runtimes/test/issues/59 generic-all
-org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking									124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher1															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher2															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher3															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_ECC1																124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_ECC2																124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_NIST_AES															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_NIST_SHA															124199 generic-all
-vich.bench.CurrentTimeMillis:testCurrentTimeMillis																		158622 generic-all
-org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
-org.openj9.test.java.lang.management.TestMonitorInfo:testFrom_WithCDContainingNullStackFrame							000000 generic-all
-org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
-org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all
-org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all
-org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all
-org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
-org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
-j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2016, 2017 IBM Corp. and others
+#  Copyright (c) 2016, 2018 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,24 +22,15 @@
 
 # Exclude tests temporarily
 
-org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	                 AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
+org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN												                    AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
 org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														JTC-JAT-133182 generic-all
 org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	BPW-https://github.ibm.com/runtimes/test/issues/109 generic-all
 org.openj9.test.java.lang.Test_J9VMInternals:test_checkPackageAccess													BPW-https://github.ibm.com/runtimes/test/issues/59 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking									124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher1															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher2															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher3															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_ECC1																124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_ECC2																124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_NIST_AES															124199 generic-all
-org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_NIST_SHA															124199 generic-all
-vich.bench.CurrentTimeMillis:testCurrentTimeMillis																		158622 generic-all
-org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
-org.openj9.test.java.lang.management.TestMonitorInfo:testFrom_WithCDContainingNullStackFrame							000000 generic-all
 org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
+org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all


### PR DESCRIPTION
Fixes: #737 
Removes entries from the test exclude files for entries whose issues either indicate they have been fixed or that should not be excluded for a particular Java version.
