### PR TITLE
(ebb.spp) fix Compatability for AS 2.28

### DIFF
--- a/runtime/compiler/trj9/p/runtime/ebb.spp
+++ b/runtime/compiler/trj9/p/runtime/ebb.spp
@@ -376,7 +376,7 @@ FUNCTION_START(ebbHandler)
 .LreturnEBBHanlder:
    ! If the main event handler returns non-zero, something went wrong and we`ll leave
    ! the PMU frozen and disable EBBs
-   cmpli        cr0, r3, 0
+   cmplwi        cr0, r3, 0
 
    ! Grab our TR_PPCHWProfilerEBBContext
    laddr        r3, TCB_EBB_CONTEXT(TCB)


### PR DESCRIPTION
Recently,

Builds have been broken on adoptOpenJDK on Linux PPCLE64.

See Issue: #769

The "as" complains with:
... runtime/ebb.o.s: Assembler messages:
... runtime/ebb.o.s:337: Error: operand out of range (3 is not between 0 and 1)
... runtime/ebb.o.s:337: Error: missing operand

It was complaining on the following instruction in ebb.o.s
cmpli 0, 3, 0

or in ebb.spp
cmpli cr0, r3, 0

The version of the assembler we are using internally will not complain when a 32-bit context is assumed (usually an extra bit is used tell). This should be processed as a cmplwi.

The fix should be changing the cmpli cr0, r3, 0 with cmplwi cr0,r3,0 in ebb.spp.

Signed-off-by: Alen Badel Alen.Badel@ibm.com