### PR TITLE
Update buildspec to use updated Fips libraries

### DIFF
--- a/buildspecs/j9.build-info
+++ b/buildspecs/j9.build-info
@@ -34,7 +34,7 @@
 	<sourceControl>
 		<repositoryBranch id="fips.repo" name="git@github.ibm.com:runtimes/fips.git"/>
 		<repositoryBranch id="fips.branch" name="master"/>
-		<repositoryBranch id="fips.sha" name="4b5341b"/>
+		<repositoryBranch id="fips.sha" name="edbc462"/>
 		<repositoryBranch id="jit_release" name="tr.dev"/>
 		<repositoryBranch id="rtc_product_stream" name="jvm.29"/>
 		<repositoryBranch id="san_hursley" name="foreman@java-bin.hursley.ibm.com"/>


### PR DESCRIPTION
A new version of FIPS binaries are uploaded in runtimes/fips repo.

Signed-off-by: Hadi Jooybar <hjooybar@ca.ibm.com>