### PR TITLE
Fix interpreter performance regression in char[]-to-char[] decompressed array copy

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -386,15 +386,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	/*[ENDIF]*/	
 
 	static void decompressedArrayCopy(char[] array1, int start1, char[] array2, int start2, int length) {
-		if (array1 == array2 && start1 < start2) {
-			for (int i = length - 1; i >= 0; --i) {
-				helpers.putCharInArrayByIndex(array2, start2 + i, helpers.getCharFromArrayByIndex(array1, start1 + i));
-			}
-		} else {
-			for (int i = 0; i < length; ++i) {
-				helpers.putCharInArrayByIndex(array2, start2 + i, helpers.getCharFromArrayByIndex(array1, start1 + i));
-			}
-		}
+		System.arraycopy(array1, start1, array2, start2, length);
 	}
 	
 	boolean isCompressed() {


### PR DESCRIPTION
Fix interpreter performance regression in char[]-to-char[] decompressed array copy

As a performance optimization we directly call char[]-to-char[]
decompressedArrayCopy in a few places, as the method is JIT-recognized
and no bound checks are generated. However the interpreter implementation
of it is very slow compared to System.arraycopy, we need to implement native(s) 
similar to System.arraycopy for all variants of String (de)compressedArrayCopy. 
As a stop-gap, for now in Java 8, for char[]-to-char[] decompressedArrayCopy 
we call System.arraycopy to address the -Xint DT startup regression.

Signed-off-by: Yan Luo <yan_luo@ca.ibm.com>