### PR TITLE
Fix JVM_LatestUserDefinedLoader

### DIFF
--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -90,7 +90,15 @@ latestUserDefinedLoaderIterator(J9VMThread * currentThread, J9StackWalkState * w
 	J9Class * currentClass = J9_CLASS_FROM_CP(walkState->constantPool);
 	J9ClassLoader * classLoader = currentClass->classLoader;
 
-	if (classLoader != vm->systemClassLoader) {
+	/* Ignore jdk/internal/loader/ClassLoaders$PlatformClassLoader (Java 9+).
+	 * In Java 9+, vm->extensionClassLoader is the PlatformClassLoader.
+	 */
+	BOOLEAN isPlatformClassLoader = FALSE;
+	if ((J2SE_VERSION(vm) >= J2SE_19) && (classLoader == vm->extensionClassLoader)) {
+		isPlatformClassLoader = TRUE;
+	}
+
+	if ((classLoader != vm->systemClassLoader) && !isPlatformClassLoader) {
 		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
 		Assert_SunVMI_mustHaveVMAccess(currentThread);

--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -667,6 +667,7 @@
 			<variation>-XX:RecreateClassfileOnload</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	--add-modules java.se.ee,openj9.sharedclasses \
 	--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
@@ -718,6 +719,7 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames \
 	JCL_TEST_Test-TypeAnnotation,\

--- a/test/Java8andUp/src/org/openj9/resources/classloader/CustomSyncProvider.java
+++ b/test/Java8andUp/src/org/openj9/resources/classloader/CustomSyncProvider.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+package org.openj9.resources.classloader;
+
+import java.io.Serializable;
+
+import javax.sql.RowSetReader;
+import javax.sql.RowSetWriter;
+import javax.sql.rowset.spi.SyncProvider;
+import javax.sql.rowset.spi.SyncProviderException;
+
+/* CustomSyncProvider is loaded by the Application ClassLoader.
+ * CustomSyncProvider is used to verify that JVM_LatestUserDefinedLoader returns
+ * a valid Application ClassLoader in Java 9+.
+ */
+public class CustomSyncProvider extends SyncProvider implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public String getProviderID() {
+		return null;
+	}
+
+	@Override
+	public RowSetReader getRowSetReader() {
+		return null;
+	}
+
+	@Override
+	public RowSetWriter getRowSetWriter() {
+		return null;
+	}
+
+	@Override
+	public int getProviderGrade() {
+		return 0;
+	}
+
+	@Override
+	public void setDataSourceLock(int datasource_lock) throws SyncProviderException {
+		/* Empty */
+	}
+
+	@Override
+	public int getDataSourceLock() throws SyncProviderException {
+		return 0;
+	}
+
+	@Override
+	public int supportsUpdatableView() {
+		return 0;
+	}
+
+	@Override
+	public String getVersion() {
+		return null;
+	}
+
+	@Override
+	public String getVendor() {
+		return null;
+	}
+}

--- a/test/Java8andUp/src/org/openj9/test/annotationClassLoader/Test_ClassLoader.java
+++ b/test/Java8andUp/src/org/openj9/test/annotationClassLoader/Test_ClassLoader.java
@@ -21,10 +21,16 @@ package org.openj9.test.annotationClassLoader;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
+import org.openj9.resources.classloader.CustomSyncProvider;
 import org.testng.annotations.Test;
 import org.testng.Assert;
+
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.sql.SQLException;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.spi.SyncProvider;
 
 @Test(groups = { "level.sanity" })
 public class Test_ClassLoader {
@@ -70,4 +76,68 @@ public class Test_ClassLoader {
 		}
 	}
 
+	@Test
+	public void test_latestUserDefinedLoader() throws Exception {
+		String customSyncProviderClassName = CustomSyncProvider.class.getName();
+		CachedRowSet crs = (CachedRowSet)Class.forName("com.sun.rowset.CachedRowSetImpl").newInstance();
+		crs.setSyncProvider(customSyncProviderClassName);
+		SyncProvider syncProvider = crs.getSyncProvider();
+	
+		if (syncProvider instanceof CustomSyncProvider) {
+			/* Call to CachedRowSetImpl.createCopy results in the following Java stack:
+			 * 
+			 *  [1] jdk.internal.loader.BuiltinClassLoader.loadClass [Bootstrap ClassLoader]
+			 *  [2] java.lang.ClassLoader.loadClass [Bootstrap ClassLoader]
+			 *  [3] java.lang.Class.forNameImpl [Bootstrap ClassLoader]
+			 *  [4] java.lang.Class.forName [Bootstrap ClassLoader]
+			 *  [5] java.io.ClassCache$FutureValue.get [Bootstrap ClassLoader]
+			 *  [6] java.io.ClassCache.get [Bootstrap ClassLoader]
+			 *  [7] java.io.ObjectInputStream.resolveClass [Bootstrap ClassLoader]
+			 *  [8] java.io.ObjectInputStream.readNonProxyDesc [Bootstrap ClassLoader]
+			 *  [9] java.io.ObjectInputStream.readClassDesc [Bootstrap ClassLoader]
+			 *  [10] java.io.ObjectInputStream.readOrdinaryObject [Bootstrap ClassLoader]
+			 *  [11] java.io.ObjectInputStream.readObject0 [Bootstrap ClassLoader]
+			 *  [12] java.io.ObjectInputStream.defaultReadFields [Bootstrap ClassLoader]
+			 *  [13] java.io.ObjectInputStream.defaultReadObject [Bootstrap ClassLoader]
+			 *  [14] com.sun.rowset.CachedRowSetImpl.readObject [Platform ClassLoader]
+			 *  [15] jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 [Bootstrap ClassLoader]
+			 *  [16] jdk.internal.reflect.NativeMethodAccessorImpl.invoke [Bootstrap ClassLoader]
+			 *  [17] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke [Bootstrap ClassLoader]
+			 *  [18] java.lang.reflect.Method.invoke [Bootstrap ClassLoader]
+			 *  [19] java.io.ObjectStreamClass.invokeReadObject [Bootstrap ClassLoader]
+			 *  [20] java.io.ObjectInputStream.readSerialData [Bootstrap ClassLoader]
+			 *  [21] java.io.ObjectInputStream.readOrdinaryObject [Bootstrap ClassLoader]
+			 *  [22] java.io.ObjectInputStream.readObject0 [Bootstrap ClassLoader]
+			 *  [23] java.io.ObjectInputStream.readObjectImpl [Bootstrap ClassLoader]
+			 *  [24] java.io.ObjectInputStream.readObject [Bootstrap ClassLoader]
+			 *  [25] com.sun.rowset.CachedRowSetImpl.createCopy [Platform ClassLoader]
+			 *  [26] .... [Application ClassLoader]
+			 *  
+			 * ObjectInputStream.resolveClass makes a call to JVM_LatestUserDefinedLoader.
+			 * ClassLoader returned from JVM_LatestUserDefinedLoader is passed to Class.forName.
+			 *  
+			 * CustomSyncProvider is loaded by the Application ClassLoader. CachedRowSetImpl.createCopy
+			 * will try to search for CustomSyncProvider using the ClassLoader returned by
+			 * JVM_LatestUserDefinedLoader. If JVM_LatestUserDefinedLoader returns a Bootstrap
+			 * or Platform ClassLoader, then CustomSyncProvider won't be found.
+			 * CachedRowSetImpl.createCopy will catch the ClassNotFoundException and throw
+			 * a SQLException.
+			 *  
+			 * The purpose of this test is to verify that JVM_LatestUserDefinedLoader returns
+			 * a valid Application ClassLoader. If a Bootstrap or a Platform ClassLoader is
+			 * returned, then SQLException will be thrown by CachedRowSetImpl.createCopy
+			 * since CustomSyncProvider won't be found.
+			 *  
+			 * CachedRowSetImpl.createCopy may also throw SQLException for other reasons.
+			 * Use a debugger to confirm if SQLException is a result of ClassNotFoundException
+			 * or something else.
+			 */
+			CachedRowSet crsCopy = crs.createCopy();
+		} else {
+			Assert.fail("Wrong SyncProvider.\n"
+					+ "Failed to use " + customSyncProviderClassName + ".\n"
+					+ "Instead " + syncProvider + " is used.\n"
+					+ "Check if cmdline option -Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider is set.");
+		}
+	}
 }


### PR DESCRIPTION
For Java 9 and onwards, ignore instances of PlatformClassLoader when
finding the latest user defined class loader.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>