### PR TITLE
Disable redefinition of remove for z/TPF Platform.

### DIFF
--- a/runtime/compiler/trj9/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/trj9/optimizer/EscapeAnalysis.cpp
@@ -20,6 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
+#ifdef J9ZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
+
 #include "optimizer/EscapeAnalysis.hpp"
 
 #include <algorithm>                           // for std::max, etc

--- a/runtime/compiler/trj9/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/trj9/runtime/J9CodeCache.cpp
@@ -20,6 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
+#ifdef J9ZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
+
 #include <algorithm>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
z/TPF builds runtimes with an intermediary character
translation library which uses intercepting headers
to redefine system functions which require translation
from ascii to ebcdic.  However, for some scenarios
translations is not desired.  The remove member function
is one of those instances.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>