### PR TITLE
Bring up rawbuild Java 10 b35

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -184,6 +184,7 @@ final class Access implements JavaLangAccess {
 		return result;
 	}
 
+	/*[IF !Java10]*/
 	/**
 	 * Return a newly created String that uses the passed in char[]
 	 * without copying.  The array must not be modified after creating
@@ -197,6 +198,7 @@ final class Access implements JavaLangAccess {
 	public java.lang.String newStringUnsafe(char[] data) {
 		return new String(data, true /*ignored*/);
 	}
+	/*[ENDIF]*/
 
 	@Override
 	public void invokeFinalize(java.lang.Object arg0)

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -488,10 +488,10 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 	}
 
 	/* Determine allowed class file version */
-
 #ifdef J9VM_OPT_SIDECAR
-	/* Jazz 107424: update the max class version number on 2.9 to v53.0 class files */
-	if (J2SE_VERSION(vm) >= J2SE_19) {
+	if (J2SE_VERSION(vm) >= J2SE_V10) {
+		translationFlags |= BCT_Java10MajorVersionShifted;
+	} else if (J2SE_VERSION(vm) >= J2SE_19) {
 		translationFlags |= BCT_Java9MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_18) {
 		translationFlags |= BCT_Java8MajorVersionShifted;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2017,6 +2017,7 @@ typedef struct J9BCTranslationData {
 #define BCT_InitInstanceFields  19
 #define BCT_ErrConstantPoolMapTooSmall  14
 #define BCT_InitCopyDoubles  5
+#define BCT_Java10MajorVersionShifted 0x36000000
 #define BCT_Java9MajorVersionShifted  0x35000000
 #define BCT_Java8MajorVersionShifted  0x34000000
 #define BCT_ActionUnused  6


### PR DESCRIPTION
Bring up rawbuild `Java 10 b35`

1. Removed method `java.lang.Access.newStringUnsafe()` which is removed from `jdk.internal.misc.JavaLangAccess` since `b35`;
2. Added support for `Java 10` class version `54`

closes #762 

Reviewers @pshipton @tajila 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>