### PR TITLE
Use J9 option instead of TR_DisableCCR

### DIFF
--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -2383,8 +2383,7 @@ TR_J9VMBase::getCodeCacheTop(TR::CodeCache * codeCache)
 void
 TR_J9VMBase::releaseCodeMemory(void *startPC, uint8_t bytesToSaveAtStart)
    {
-   static char *disableCCR = feGetEnv("TR_DisableCCR");
-   if (!disableCCR)
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableCodeCacheReclamation))
       {
       TR::VMAccessCriticalSection releaseCodeMemory(this);
       J9JavaVM            *vm        = jitConfig->javaVM;


### PR DESCRIPTION
Environment variable TR_DisableCCR sets the TR_DisableCodeCacheReclamation
option during option processing.
Internally, the JIT no longer needs to check TR_DisableCCR environment
variable.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>