### PR TITLE
Fix field init bug in TR_ValueProfiler

### DIFF
--- a/runtime/compiler/trj9/runtime/J9Profiler.hpp
+++ b/runtime/compiler/trj9/runtime/J9Profiler.hpp
@@ -316,8 +316,12 @@ class TR_BlockFrequencyProfiler : public TR_RecompilationProfiler
 class TR_ValueProfiler : public TR_RecompilationProfiler
    {
    public:
-   TR_ValueProfiler(TR::Compilation  * c, TR::Recompilation * r, TR_ValueInfoSource profiler = LinkedListProfiler)
-       : TR_RecompilationProfiler(c, r, initialCompilation), _defaultProfiler(profiler), _postLowering(false)
+   TR_ValueProfiler(TR::Compilation  * c, TR::Recompilation * r, TR_ValueInfoSource profiler = LinkedListProfiler) :
+      TR_RecompilationProfiler(c, r, initialCompilation),
+      _bdClass(NULL),
+      _stringClass(NULL),
+      _defaultProfiler(profiler),
+      _postLowering(false)
       {
       }
 


### PR DESCRIPTION
TR_ValueProfiler will cache certain classes to
avoid compile time overhead. In recent changes
to JitProfiling, the initialization of these
fields was accidentally removed.