### PR TITLE
Skip dbgwrapper load on windows for OpenJ9 OpenJDK8 builds

### DIFF
--- a/runtime/jcl/cl_se7_basic/module.xml
+++ b/runtime/jcl/cl_se7_basic/module.xml
@@ -109,6 +109,9 @@
 		<makefilestubs>
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
+			<makefilestub data="ifeq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="vm_scar$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
+			<makefilestub data="endif"/>
 		</makefilestubs>
 
 		<vpaths>


### PR DESCRIPTION
Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>