### PR TITLE
Add JProfiling Thread

### DIFF
--- a/doc/compiler/JProfiling.md
+++ b/doc/compiler/JProfiling.md
@@ -1,0 +1,84 @@
+<!--
+Copyright (c) 2017, 2017 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+-->
+
+# Persistent Profile Info
+
+Persistent profile info holds profiling information between compilations. It holds both
+meta data and the actual profiling information. For example, when a compilation decides
+to include profiling instrumentation, it will create a `TR_PersistentProfileInfo` and
+add call site information as well as the frequency with which profiling should be collected.
+Depending on what instrumentation is then added, it may create value profiling and/or
+block frequency counters and their respective persistent data structures. These data structures
+are used by jitted code to record values/frequencies that are seen.
+
+Later compiles, either of the same method or others with similar inlining, will attempt to
+access this information to inform optimizations. Its possible that there could have been
+several compiles of the particular method, all with profiling data. To simplify the situation
+and ensure a recent compile doesn't reduce the quality of profiling information, the
+best and most recent profiling information are tracked on the method info. A request for a method's
+persistent profile information will evaluate whether the most recent has superceeded the best.
+If so, the most recent now becomes best and is returned. Otherwise, the best is returned.
+Only these two have to be compared as there will typically only be one compilation of a method
+collecting information at a time.
+
+## Reference Counts
+
+As accesses to profiling information can exceed the lifetime of the body for which they were
+created and they can incur significant memory overhead, its necessary to deallocate when
+they can no longer be accessed. This is achieved through reference counting. There is an implicit
+reference count on each persistent profile info, to represent the reference from its body info.
+Other sources of references include the best and recent pointers on the method info. Methods wrapping
+these two references will manage reference counts as necessary. Each compilation has a `TR_AccessedProfileInfo`
+which manages the reference counts for accesses from within a compilation, extending the duration of the
+reference until the end of the compile. Through this, most uses of profile information don't have
+to be concerned with reference counts.
+
+To reduce synchronization overhead, accesses to profiling information through the body info
+will not modify reference counts as its assumed these uses will all be within the lifetime of the body
+info, such as during its compilation or commit.
+
+Once the reference count reaches zero, it will be deallocated, either immediately or after a short
+duration in a separate cleanup process. It cannot be incremented after reaching zero.
+
+## JProfiling Thread
+
+The JProfiling thread maintains a linked list of all persistent profile info, which it traverses
+at runtime to detect profiling information that should be reset. This is done for value profile
+info, as it will select the first N distinct values it sees for profiling. Due to this, these values
+may not be the most frequenct, as indicated by the relative frequencies of the selected values and
+the other counter. If this is determined to be the case, the thread will clear the selected values
+and allow them to repopulate. As it is only logical to carry out this step when repopulation is still
+possible, the thread will only inspect information that is being activey updated, as indicated by the active
+flag on the persistent profile info. This flag is set when the corresponding jitted body is
+about to be committed and cleared when it becomes a stub. This reduces the thread's overhead.
+
+To simplify the process of maintaining the linked list of profile info along with any reference counts,
+the deallocation of persistent profile information is deferred to this thread. When it traverses the list,
+it will check the reference count and deallocate if it finds one that has reached zero. With this design,
+compilations add new persistent profile information to the linked list as soon as they create it and the
+thread removes them when possible. These constraits simplify the synchronization required on the linked
+list significantly, as it only has to be singly linked for O(1) removal and only the single thread can remove.
+Due to this, the linked list updates are lockless.
+
+There should only be one of these threads for entire execution, similar to the IProfiler and Sampler threads.
+It can be disabled using `TR_DisableJProfilerThread` and details about its execution can be inspected using
+the verbose option `profiling`.

--- a/runtime/compiler/trj9/control/CompilationRuntime.hpp
+++ b/runtime/compiler/trj9/control/CompilationRuntime.hpp
@@ -830,6 +830,8 @@ public:
 
    TR_LMGuardedStorage *getLMGuardedStorage() const;
 
+   TR_JProfilerThread *getJProfilerThread() const;
+
    int32_t calculateCodeSize(TR_MethodMetaData *metaData);
    void increaseUnstoredBytes(U_32 aotBytes, U_32 jitBytes);
 

--- a/runtime/compiler/trj9/control/HookedByTheJit.cpp
+++ b/runtime/compiler/trj9/control/HookedByTheJit.cpp
@@ -4771,6 +4771,10 @@ void JitShutdown(J9JITConfig * jitConfig)
       shutdownJITRuntimeInstrumentation(javaVM);
 #endif
 
+   TR_JProfilerThread *jProfiler = ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->jProfiler;
+   if (jProfiler != NULL)
+      jProfiler->stop(javaVM);
+
    {
    TR::RawAllocator rawAllocator(jitConfig->javaVM);
    J9::SegmentAllocator segmentAllocator(MEMORY_TYPE_JIT_SCRATCH_SPACE | MEMORY_TYPE_VIRTUAL, *jitConfig->javaVM);
@@ -7079,6 +7083,12 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
             TR_HWProfiler *hwProfiler = ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->hwProfiler;
             hwProfiler->startHWProfilerThread(javaVM);
             }
+         }
+
+      if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableJProfilerThread))
+         {
+         TR_JProfilerThread *jProfiler = ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->jProfiler;
+         jProfiler->start(javaVM);
          }
       }
 

--- a/runtime/compiler/trj9/control/J9Recompilation.cpp
+++ b/runtime/compiler/trj9/control/J9Recompilation.cpp
@@ -22,6 +22,7 @@
 
 #include "AtomicSupport.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "control/CompilationRuntime.hpp"   // for TR::CompilationInfo
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "compile/Compilation.hpp"
@@ -30,7 +31,6 @@
 #include "env/VMJ9.h"
 #include "runtime/J9Profiler.hpp"
 #include "exceptions/RuntimeFailure.hpp"    // for J9::EnforceProfiling
-
 
 bool J9::Recompilation::_countingSupported = false;
 
@@ -173,6 +173,12 @@ J9::Recompilation::findOrCreateProfileInfo()
       profileInfo = new (PERSISTENT_NEW) TR_PersistentProfileInfo(DEFAULT_PROFILING_FREQUENCY, DEFAULT_PROFILING_COUNT);
       _methodInfo->setRecentProfileInfo(profileInfo);
       _bodyInfo->setProfileInfo(profileInfo);
+
+      // If running with the profiling thread, add to its list
+      if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableJProfilerThread))
+         {
+         TR::CompilationInfo::get(NULL)->getJProfilerThread()->addProfileInfo(profileInfo);
+         }
       }
    return profileInfo;
    }

--- a/runtime/compiler/trj9/control/rossa.cpp
+++ b/runtime/compiler/trj9/control/rossa.cpp
@@ -1473,6 +1473,19 @@ onLoadInternal(
       ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->iProfiler = NULL;
       }
 
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableJProfilerThread))
+      {
+      ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->jProfiler = TR_JProfilerThread::allocate();
+      if (!(((TR_JitPrivateConfig*)(jitConfig->privateConfig))->jProfiler))
+         {
+         TR::Options::getCmdLineOptions()->setOption(TR_DisableJProfilerThread); 
+         }
+      }
+   else
+      {
+      ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->jProfiler = NULL;
+      }
+
    vpMonitor = TR::Monitor::create("ValueProfilingMutex");
 
    // initialize the HWProfiler

--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -50,6 +50,7 @@ namespace TR { class CompilationInfo; }
 namespace TR { class CompilationInfoPerThread; }
 class TR_IProfiler;
 class TR_HWProfiler;
+class TR_JProfilerThread;
 class TR_LMGuardedStorage;
 class TR_Debug;
 class TR_OptimizationPlan;
@@ -135,6 +136,7 @@ typedef struct TR_JitPrivateConfig
    char          *itraceFileNamePrefix;
    TR_IProfiler  *iProfiler;
    TR_HWProfiler *hwProfiler;
+   TR_JProfilerThread  *jProfiler;
    TR_LMGuardedStorage *lmGuardedStorage;
    TR::CodeCacheManager *codeCacheManager; // reachable from JitPrivateConfig for kca's benefit
    TR_DataCacheManager *dcManager;  // reachable from JitPrivateConfig for kca's benefit

--- a/runtime/compiler/trj9/runtime/HookHelpers.cpp
+++ b/runtime/compiler/trj9/runtime/HookHelpers.cpp
@@ -273,6 +273,7 @@ void jitReleaseCodeCollectMetaData(J9JITConfig *jitConfig, J9VMThread *vmThread,
       TR_PersistentJittedBodyInfo *bodyInfo = metaData->bodyInfo ? (TR_PersistentJittedBodyInfo *) metaData->bodyInfo : NULL;
       if (bodyInfo && bodyInfo->getProfileInfo())
          {
+         bodyInfo->getProfileInfo()->setActive(false);
          TR_PersistentProfileInfo::decRefCount(bodyInfo->getProfileInfo());
          bodyInfo->setProfileInfo(NULL);
          }

--- a/runtime/compiler/trj9/runtime/J9Profiler.cpp
+++ b/runtime/compiler/trj9/runtime/J9Profiler.cpp
@@ -1604,6 +1604,32 @@ TR_ValueProfileInfo::getOrCreateProfilerInfo(
    return profilerInfo;
    }
 
+/**
+ * Run through all hash tables and determine if their contents should be cleared out.
+ * Only supports resetting on hash tables.
+ *
+ * \param profileLog Dump all the tables that have been inspected, as well as a log of any that were cleared. NULL will disable tracing.
+ */
+void
+TR_ValueProfileInfo::resetLowFreqValues(TR::FILE *profileLog)
+   {
+   for (TR_AbstractProfilerInfo *valueInfo = _values[HashTableProfiler]; valueInfo; valueInfo = valueInfo->getNext())
+      {
+      TR_AbstractHashTableProfilerInfo *hashTable = static_cast<TR_AbstractHashTableProfilerInfo*>(valueInfo);
+      if (profileLog)
+         hashTable->dumpInfo(profileLog);
+      if (!hashTable->isFull())
+         continue;
+      if (hashTable->resetLowFreqKeys())
+         {
+         if (profileLog)
+            J9::IO::fprintf(profileLog, "Resetting info 0x%p\n", hashTable);
+         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseProfiling))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Resetting info 0x%p.", hashTable);
+         }
+      }
+   }
+
 int32_t TR_BlockFrequencyInfo::_enableJProfilingRecompilation = -1;
 
 TR_BlockFrequencyInfo::TR_BlockFrequencyInfo(TR_CallSiteInfo *callSiteInfo, int32_t numBlocks, TR_ByteCodeInfo *blocks, int32_t *frequencies) :
@@ -2280,7 +2306,23 @@ TR_CallSiteInfo::hasSamePartialBytecodeInfo(
 
 TR_PersistentProfileInfo::~TR_PersistentProfileInfo()
    {
-   clearProfilingInfo();
+   if (_catchBlockProfileInfo)
+      {
+      jitPersistentFree(_catchBlockProfileInfo);
+      _catchBlockProfileInfo = NULL;
+      }
+   if (_valueProfileInfo)
+      {
+      _valueProfileInfo->~TR_ValueProfileInfo();
+      jitPersistentFree(_valueProfileInfo);
+      _valueProfileInfo = NULL;
+      }
+   if (_blockFrequencyInfo)
+      {
+      _blockFrequencyInfo->~TR_BlockFrequencyInfo();
+      jitPersistentFree(_blockFrequencyInfo);
+      _blockFrequencyInfo = NULL;
+      }
    if (_callSiteInfo)
       {
       _callSiteInfo->~TR_CallSiteInfo();
@@ -2319,31 +2361,6 @@ TR_PersistentProfileInfo::prepareForProfiling(TR::Compilation *comp)
       TR_CallSiteInfo * const updatedCallSiteInfo = new ((void*)originalCallSiteInfo) TR_CallSiteInfo(comp, persistentAlloc);
       }
    }
-
-/**
- * Remove all existing profiling information.
- */
-void
-TR_PersistentProfileInfo::clearProfilingInfo()
-   {
-   if (_catchBlockProfileInfo)
-      {
-      jitPersistentFree(_catchBlockProfileInfo);
-      _catchBlockProfileInfo = NULL;
-      }
-   if (_valueProfileInfo)
-      {
-      _valueProfileInfo->~TR_ValueProfileInfo();
-      jitPersistentFree(_valueProfileInfo);
-      _valueProfileInfo = NULL;
-      }
-   if (_blockFrequencyInfo)
-      {
-      _blockFrequencyInfo->~TR_BlockFrequencyInfo();
-      jitPersistentFree(_blockFrequencyInfo);
-      _blockFrequencyInfo = NULL;
-      }
-   } 
 
 /**
  * Returns the best available profiling information for the current
@@ -2398,15 +2415,14 @@ TR_PersistentProfileInfo::getCurrent(TR::Compilation *comp)
 void
 TR_PersistentProfileInfo::incRefCount(TR_PersistentProfileInfo *info)
    {
+   TR_ASSERT_FATAL(info->_refCount > 0, "Increment called on profile info with no references");
    VM_AtomicSupport::add((uintptr_t*) &(info->_refCount), 1);
-   TR_ASSERT_FATAL(info->_refCount, "Increment resulted in reference count of 0");
+   TR_ASSERT_FATAL(info->_refCount >= 0, "Increment resulted in negative reference count");
    }
 
 /**
  * Decrement reference count for persistent profile info.
  * Will perform an atomic decrement.
- * If the reference count reaches 0, the persistent profile
- * info will be freed.
  *
  * \param info Persistent profile info to manipulate and potentially free.
  */
@@ -2415,10 +2431,15 @@ TR_PersistentProfileInfo::decRefCount(TR_PersistentProfileInfo *info)
    {
    VM_AtomicSupport::subtract((uintptr_t*) &(info->_refCount), 1);
    TR_ASSERT_FATAL(info->_refCount >= 0, "Decrement resulted in negative reference count");
-   if (info->_refCount == 0 && !TR::Options::getCmdLineOptions()->getOption(TR_DisableProfilingDataReclamation))
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableJProfilerThread))
+      {
+      if (info->_refCount == 0 && TR::Options::isAnyVerboseOptionSet(TR_VerboseProfiling, TR_VerboseReclamation))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_RECLAMATION, "PersistentProfileInfo 0x%p queued for reclamation.", info);
+      }
+   else if (info->_refCount == 0 && !TR::Options::getCmdLineOptions()->getOption(TR_DisableProfilingDataReclamation))
       {
       if (TR::Options::getVerboseOption(TR_VerboseReclamation))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_RECLAMATION, "Reclaiming PersistentProfileInfo 0x%p.", info);
+         TR_VerboseLog::writeLineLocked(TR_Vlog_RECLAMATION, "Reclaiming PersistentProfileInfo immediately 0x%p.", info);
       info->~TR_PersistentProfileInfo();
       TR_Memory::jitPersistentFree(info);
       }
@@ -2601,4 +2622,238 @@ TR_PersistentProfileInfo *TR_AccessedProfileInfo::get(TR_ResolvedMethod *vmMetho
    TR_PersistentMethodInfo *methodInfo = TR_PersistentMethodInfo::get(vmMethod);
    _usedInfo[vmMethod] = compare(methodInfo);
    return _usedInfo[vmMethod];
+   }
+
+/**
+ * JProfiler thread function.
+ * Real work is carried out by processWorkingQueue
+ */
+static int32_t
+J9THREAD_PROC jProfilerThreadProc(void * entryarg)
+   {
+   J9JITConfig *jitConfig  = (J9JITConfig *) entryarg;
+   J9JavaVM *vm            = jitConfig->javaVM;
+   TR_JProfilerThread *jProfiler = ((TR_JitPrivateConfig*)(jitConfig->privateConfig))->jProfiler;
+   J9VMThread *jProfilerThread = NULL;
+   PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+
+   // Starting
+   int rc = vm->internalVMFunctions->internalAttachCurrentThread(vm, &jProfilerThread, NULL,
+                                  J9_PRIVATE_FLAGS_DAEMON_THREAD | J9_PRIVATE_FLAGS_NO_OBJECT |
+                                  J9_PRIVATE_FLAGS_SYSTEM_THREAD | J9_PRIVATE_FLAGS_ATTACHED_THREAD,
+                                  jProfiler->getJProfilerOSThread());
+
+   jProfiler->getJProfilerMonitor()->enter();
+   jProfiler->setAttachAttempted();
+   if (rc == JNI_OK)
+      jProfiler->setJProfilerThread(jProfilerThread);
+   jProfiler->getJProfilerMonitor()->notifyAll();
+   jProfiler->getJProfilerMonitor()->exit();
+   if (rc != JNI_OK)
+      return JNI_ERR;
+
+   j9thread_set_name(j9thread_self(), "JIT JProfiler");
+
+   // Process JProfiling data
+   jProfiler->processWorkingQueue();
+
+   // Stopping
+   vm->internalVMFunctions->DetachCurrentThread((JavaVM *) vm);
+   jProfiler->getJProfilerMonitor()->enter();
+   jProfiler->setJProfilerThread(NULL);
+   jProfiler->getJProfilerMonitor()->notifyAll();
+   j9thread_exit((J9ThreadMonitor*)jProfiler->getJProfilerMonitor()->getVMMonitor());
+   return 0;
+   }
+
+TR_JProfilerThread *
+TR_JProfilerThread::allocate()
+   {
+   TR_JProfilerThread * profiler = new (PERSISTENT_NEW) TR_JProfilerThread();
+   return profiler;
+   }
+
+/**
+ * Start the profiler thread.
+ */
+void
+TR_JProfilerThread::start(J9JavaVM *javaVM)
+   {
+   PORT_ACCESS_FROM_JAVAVM(javaVM);
+   UDATA priority;
+
+   priority = J9THREAD_PRIORITY_NORMAL;
+
+   if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Starting jProfiler thread");
+
+   _jProfilerMonitor = TR::Monitor::create("JIT-jProfilerMonitor");
+   _state = Initial;
+   if (_jProfilerMonitor)
+      {
+      // Try to create thread
+      if (javaVM->internalVMFunctions->createThreadWithCategory(&_jProfilerOSThread,
+                                                                TR::Options::_profilerStackSize << 10,
+                                                                priority, 0,
+                                                                &jProfilerThreadProc,
+                                                                javaVM->jitConfig,
+                                                                J9THREAD_CATEGORY_SYSTEM_JIT_THREAD))
+         {
+         if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Failed to start jProfiler thread");
+
+         // Thread creation failed, don't try again
+         TR::Options::getCmdLineOptions()->setOption(TR_DisableJProfilerThread);
+         _jProfilerMonitor = NULL;
+         }
+      else
+         {
+         // Wait until creation completes
+         _jProfilerMonitor->enter();
+         while (_state == Initial)
+            _jProfilerMonitor->wait();
+         _jProfilerMonitor->exit();
+
+         if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Started jProfiler thread");
+         }
+      }
+   else
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Failed to create JIT-jProfilerMonitor");
+      }
+   }
+
+/**
+ * Stop the profiler thread.
+ * This will set the state to Stop and wait.
+ */
+void
+TR_JProfilerThread::stop(J9JavaVM *javaVM)
+   {
+   PORT_ACCESS_FROM_JAVAVM(javaVM);
+   if (!_jProfilerMonitor)
+      return;
+
+   // Check the thread actually started
+   _jProfilerMonitor->enter();
+   if (!getJProfilerThread())
+      {
+      _jProfilerMonitor->exit();
+      return;
+      }
+
+   if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Stopping jProfiler thread");
+
+   // Set state and wait for it to stop
+   _state = Stop;
+   while (getJProfilerThread())
+      {
+      _jProfilerMonitor->notifyAll();
+      _jProfilerMonitor->wait();
+      }
+
+   if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Stopped jProfiler thread");
+
+   _jProfilerMonitor->exit();
+   }
+
+/**
+ * Process the persistent profile info.
+ * Should only be called in the profiler thread.
+ */
+void
+TR_JProfilerThread::processWorkingQueue()
+   {
+   while (_state == Run)
+      {
+      _jProfilerMonitor->enter();
+
+      _jProfilerMonitor->wait_timed(_waitMillis, 0);
+      if (_state == Stop)
+         {
+         _jProfilerMonitor->exit();
+         break;
+         }
+
+      _jProfilerMonitor->exit();
+
+      TR_PersistentProfileInfo **prevPtr = &_listHead;
+      TR_PersistentProfileInfo *cur = _listHead;
+
+      size_t index = 0;
+      while (cur && _state == Run)
+         {
+         if (cur->_refCount == 0)
+            {
+            // Clear out entries that are no longer referenced
+            cur = deleteProfileInfo(prevPtr, cur);
+            continue;
+            }
+         else if (cur->isActive() && cur->getValueProfileInfo())
+            {
+            // Inspect value profile info
+            cur->getValueProfileInfo()->resetLowFreqValues(NULL);
+            }
+
+         prevPtr = &cur->_next;
+         cur = *prevPtr;
+         }
+      }
+   }
+
+/**
+ * Add a new entry at the start of the linked list.
+ * Can be called by compilation threads concurrently.
+ *
+ * \param newHead Info to add to the list.
+ */
+void
+TR_JProfilerThread::addProfileInfo(TR_PersistentProfileInfo *newHead)
+   {
+   TR_PersistentProfileInfo *oldHead;
+   uintptr_t oldPtr;
+
+   // Atomic update for list head
+   do {
+      oldHead = _listHead;
+      oldPtr = (uintptr_t)oldHead;
+      newHead->_next = oldHead;
+      }
+   while (oldPtr != VM_AtomicSupport::lockCompareExchange((uintptr_t*)&_listHead, oldPtr, (uintptr_t)newHead));
+
+   VM_AtomicSupport::add(&_footprint, 1);
+   }
+
+/**
+ * Remove an arbitrary entry from the linked list.
+ * Should only be called by the thread, as it does not support concurrent removals.
+ *
+ * \param prevNext Pointer to previous info's next pointer.
+ * \param info Info to remove.
+ * \return The next TR_PersistentProfileInfo after the removed info.
+ */
+TR_PersistentProfileInfo *
+TR_JProfilerThread::deleteProfileInfo(TR_PersistentProfileInfo **prevNext, TR_PersistentProfileInfo *info)
+   {
+   TR_PersistentProfileInfo *next = info->_next;
+   uintptr_t oldPtr = (uintptr_t)info;
+
+   if (oldPtr != VM_AtomicSupport::lockCompareExchange((uintptr_t*)prevNext, oldPtr, (uintptr_t)next))
+      return next;
+
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableProfilingDataReclamation))
+      {
+      VM_AtomicSupport::subtract(&_footprint, 1);
+      if (TR::Options::isAnyVerboseOptionSet(TR_VerboseProfiling, TR_VerboseReclamation))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_RECLAMATION, "Reclaiming PersistentProfileInfo 0x%p.", info);
+      // Deallocate info
+      info->~TR_PersistentProfileInfo();
+      TR_Memory::jitPersistentFree(info);
+      }
+
+   return next;
    }


### PR DESCRIPTION
This change adds a JProfiling thread, capable of
improving the accuracy of profiled information.
It will inspect profiled information at runtime
and clear entries that it decides are not
sufficiently frequent. The task of deallocating
TR_PersistentProfileInfo has also been shifted
to it.