### PR TITLE
Enable optimizations with JProfiling

### DIFF
--- a/runtime/compiler/trj9/arm/codegen/ARMRecompilation.cpp
+++ b/runtime/compiler/trj9/arm/codegen/ARMRecompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,6 +133,9 @@ TR::Instruction *TR_ARMRecompilation::generatePrologue(TR::Instruction *cursor)
          }
       else
          {
+         // This only applies to JitProfiling, as JProfiling uses sampling
+         TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
+
          cursor = generateSrc1ImmInstruction(cg(), ARMOp_cmp, firstNode, gr4, 0, 0, cursor);
          // this is just padding for consistent code length
          cursor = generateTrg1Src2Instruction(cg(), ARMOp_orr, firstNode, gr5, gr5, gr5, cursor);

--- a/runtime/compiler/trj9/control/CompilationController.cpp
+++ b/runtime/compiler/trj9/control/CompilationController.cpp
@@ -203,7 +203,7 @@ TR_OptimizationPlan *TR::DefaultCompilationStrategy::processEvent(TR_MethodEvent
          // For sync re-compilation we have attached a plan to the persistentBodyInfo
          bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(event->_oldStartPC);
          methodInfo = bodyInfo->getMethodInfo();
-         if (bodyInfo->getUsesJProfiling())
+         if (bodyInfo->getUsesJProfiling() && !bodyInfo->getIsProfilingBody())
             {
             hotnessLevel = bodyInfo->getHotness();
             plan = TR_OptimizationPlan::alloc(hotnessLevel);
@@ -1180,7 +1180,7 @@ TR::DefaultCompilationStrategy::processHWPSample(TR_MethodEvent *event)
 
    methodInfo = bodyInfo->getMethodInfo();
    hotnessLevel = bodyInfo->getHotness();
-   if (bodyInfo->getIsProfilingBody())
+   if (bodyInfo->getIsProfilingBody() && !bodyInfo->getUsesJProfiling())
       {
       // We rely on a count-based recompilation for profiled methods.
       return NULL;

--- a/runtime/compiler/trj9/control/J9Recompilation.cpp
+++ b/runtime/compiler/trj9/control/J9Recompilation.cpp
@@ -201,7 +201,7 @@ J9::Recompilation::beforeOptimization()
    //
    if (self()->isProfilingCompilation()) // this asks the bodyInfo
       {
-      _useSampling = false;
+      _useSampling = _compilation->getProfilingMode() != JitProfiling;
       self()->findOrCreateProfileInfo()->setProfilingCount     (DEFAULT_PROFILING_COUNT);
       self()->findOrCreateProfileInfo()->setProfilingFrequency (DEFAULT_PROFILING_FREQUENCY);
       }
@@ -210,7 +210,9 @@ J9::Recompilation::beforeOptimization()
    //
    if (self()->couldBeCompiledAgain())
       {
-      if (!self()->useSampling())
+      if (_compilation->getProfilingMode() == JProfiling)
+         self()->createProfilers();
+      else if (!self()->useSampling())
          {
          if (_compilation->getMethodHotness() == cold)
             {
@@ -370,7 +372,7 @@ J9::Recompilation::switchToProfiling(uint32_t f, uint32_t c)
       comp()->failCompilation<J9::EnforceProfiling>("Enforcing profiling compilation");
       }
 
-   _useSampling = false;
+   _useSampling = _compilation->getProfilingMode() != JitProfiling;
    self()->findOrCreateProfileInfo()->setProfilingFrequency(f);
    self()->findOrCreateProfileInfo()->setProfilingCount(c);
    self()->createProfilers();

--- a/runtime/compiler/trj9/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/trj9/optimizer/IdiomRecognition.cpp
@@ -2988,7 +2988,7 @@ int32_t TR_CISCTransformer::perform()
    TR::Recompilation *recompInfo = comp()->getRecompilationInfo();
    if (!comp()->mayHaveLoops() ||
        methodHotness < minimumHotnessPrepared ||
-       (recompInfo && !recompInfo->useSampling()) ||    // if this method is now profiled
+       comp()->getProfilingMode() == JitProfiling ||    // if this method is now profiled
        !enable)
       return 0;
 

--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -2818,7 +2818,7 @@ TR_MultipleCallTargetInliner::eliminateTailRecursion(
       TR_ASSERT(block->getLastRealTreeTop() == callNodeTreeTop, "eliminateTailRecursion call isn't last or second last tree in block");
       }
 
-   if (comp()->isProfilingCompilation())
+   if (comp()->getProfilingMode() == JitProfiling)
       {
       TR::Node *asyncNode = TR::Node::createWithSymRef(callNode, TR::asynccheck, 0, comp()->getSymRefTab()->findOrCreateAsyncCheckSymbolRef(comp()->getMethodSymbol()));
       block->prepend(TR::TreeTop::create(comp(), asyncNode));

--- a/runtime/compiler/trj9/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/trj9/optimizer/J9Inliner.cpp
@@ -889,7 +889,7 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
          // if the previous value was from the interpreter profiler
          // don't apply the optimization
          TR_ByteCodeInfo &bcInfo = _bcInfo;  //callNode->getByteCodeInfo();
-         if (valueInfo->getTopProbability() == 1.0f && valueInfo->getProfiler()->getSource() < LastProfiler && !comp()->isProfilingCompilation())
+         if (valueInfo->getTopProbability() == 1.0f && valueInfo->getProfiler()->getSource() < LastProfiler)
             guard->setIsHighProbablityProfiledGuard();
 
          heuristicTrace(inliner->tracer(),"Creating a profiled call. callee Symbol %p frequencyadjustment %f",_initialCalleeSymbol, val);

--- a/runtime/compiler/trj9/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/trj9/optimizer/J9Optimizer.cpp
@@ -333,7 +333,7 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::localValuePropagationGroup                                            },
    { OMR::arraycopyTransformation                                               },
    { OMR::treeSimplification,                        OMR::IfEnabled                  },
-   { OMR::redundantAsyncCheckRemoval,                OMR::IfNotProfiling             },
+   { OMR::redundantAsyncCheckRemoval,                OMR::IfNotJitProfiling          },
    { OMR::localDeadStoreElimination                                             }, // after latest copy propagation
    { OMR::deadTreesElimination                                                  }, // remove dead anchors created by check/store removal
    { OMR::treeSimplification,                        OMR::IfEnabled                  },
@@ -371,7 +371,7 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::compactNullChecks,                         OMR::IfEnabled                  }, // cleanup at the end
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead anchors created by check/store removal
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead RegStores produced by previous deadTrees pass
-   { OMR::compactLocals,                             OMR::IfNotProfiling             }, // analysis results are invalidated by profilingGroup
+   { OMR::compactLocals,                             OMR::IfNotJitProfiling          }, // analysis results are invalidated by profilingGroup
    { OMR::globalLiveVariablesForGC                                              },
    { OMR::profilingGroup,                            OMR::IfProfiling                },
    { OMR::regDepCopyRemoval                                                     },
@@ -421,7 +421,7 @@ const OptimizationStrategy hotStrategyOpts[] =
    { OMR::blockSplitter,                         OMR::IfNews                   }, // treeSimplification + blockSplitter + VP => opportunity for EA
    { OMR::expensiveGlobalValuePropagationGroup                            },
    { OMR::dataAccessAccelerator                                           },
-   { OMR::osrGuardRemoval,                       OMR::IfEnabledAndNotProfiling }, // run after calls/monents/asyncchecks have been removed
+   { OMR::osrGuardRemoval,                       OMR::IfEnabled           }, // run after calls/monents/asyncchecks have been removed
    { OMR::globalDeadStoreGroup,                                           },
    { OMR::idiomRecognition,                      OMR::IfLoopsAndNotProfiling   }, // Early pass of idiomRecognition - Loop Canonicalizer transformations break certain idioms (i.e. arrayTranslateAndTest)
    { OMR::globalCopyPropagation,                 OMR::IfNoLoops       },
@@ -440,7 +440,7 @@ const OptimizationStrategy hotStrategyOpts[] =
    { OMR::generalLoopUnroller,                   OMR::IfLoopsAndNotProfiling   }, // unroll Loops
    { OMR::blockManipulationGroup                                          },
    { OMR::lateLocalGroup                                                  },
-   { OMR::redundantAsyncCheckRemoval,            OMR::IfNotProfiling           }, // optimize async check placement
+   { OMR::redundantAsyncCheckRemoval,            OMR::IfNotJitProfiling        }, // optimize async check placement
    { OMR::recompilationModifier,                 OMR::IfProfiling              }, // do before GRA to avoid commoning of longs afterwards
    { OMR::globalCopyPropagation,                 OMR::IfMoreThanOneBlock       }, // Can produce opportunities for store sinking
    { OMR::generalStoreSinking                                             },
@@ -503,7 +503,7 @@ const OptimizationStrategy scorchingStrategyOpts[] =
    { OMR::arrayPrivatizationGroup,               OMR::IfNews      }, // must preceed escape analysis
    { OMR::veryExpensiveGlobalValuePropagationGroup           },
    { OMR::dataAccessAccelerator                              }, //always run after GVP
-   { OMR::osrGuardRemoval,                       OMR::IfEnabledAndNotProfiling }, // run after calls/monents/asyncchecks have been removed
+   { OMR::osrGuardRemoval,                       OMR::IfEnabled }, // run after calls/monents/asyncchecks have been removed
    { OMR::globalDeadStoreGroup,                              },
    { OMR::idiomRecognition,                      OMR::IfLoopsAndNotProfiling   }, // Early pass of idiomRecognition - Loop Canonicalizer transformations break certain idioms (i.e. arrayTranslateAndTest)
    { OMR::globalCopyPropagation,                 OMR::IfNoLoops       },
@@ -525,7 +525,7 @@ const OptimizationStrategy scorchingStrategyOpts[] =
    { OMR::blockSplitter,                         OMR::MarkLastRun },
    { OMR::blockManipulationGroup                             },
    { OMR::lateLocalGroup                                     },
-   { OMR::redundantAsyncCheckRemoval                                      }, // optimize async check placement
+   { OMR::redundantAsyncCheckRemoval,            OMR::IfNotJitProfiling        }, // optimize async check placement
    { OMR::recompilationModifier,                 OMR::IfProfiling              }, // do before GRA to avoid commoning of longs afterwards
    { OMR::globalCopyPropagation,                 OMR::IfMoreThanOneBlock       }, // Can produce opportunities for store sinking
    { OMR::generalStoreSinking                                             },
@@ -601,7 +601,7 @@ static const OptimizationStrategy AOTStrategyOpts[] =
    { OMR::generalLoopUnroller,                   OMR::IfLoops   }, // unroll Loops
    { OMR::blockManipulationGroup                           },
    { OMR::lateLocalGroup                                   },
-   { OMR::redundantAsyncCheckRemoval                       }, // optimize async check placement
+   { OMR::redundantAsyncCheckRemoval,                OMR::IfNotJitProfiling          }, // optimize async check placement
    { OMR::dynamicLiteralPool,                        OMR::IfNotProfiling             },
    { OMR::localDeadStoreElimination,                 OMR::IfEnabled                  }, //remove the astore if no literal pool is required
    { OMR::localCSE,                              OMR::IfEnabled  },  //common up lit pool refs in the same block
@@ -678,7 +678,7 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::localValuePropagationGroup                                            },
    { OMR::arraycopyTransformation                                               },
    { OMR::treeSimplification,                        OMR::IfEnabled                  },
-   { OMR::asyncCheckInsertion,                       OMR::IfNotProfiling             },
+   { OMR::asyncCheckInsertion,                       OMR::IfNotJitProfiling          },
    { OMR::localCSE                                                              },
    { OMR::treeSimplification,                        OMR::MarkLastRun                },
 #ifdef TR_HOST_S390
@@ -712,7 +712,7 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::compactNullChecks,                         OMR::IfEnabled                  }, // cleanup at the end
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead anchors created by check/store removal
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead RegStores produced by previous deadTrees pass
-   { OMR::compactLocals,                             OMR::IfNotProfiling             }, // analysis results are invalidated by profilingGroup
+   { OMR::compactLocals,                             OMR::IfNotJitProfiling          }, // analysis results are invalidated by profilingGroup
    { OMR::globalLiveVariablesForGC                                              },
    { OMR::profilingGroup,                            OMR::IfProfiling                },
    { OMR::regDepCopyRemoval                                                     },
@@ -729,7 +729,7 @@ static const OptimizationStrategy profilingOpts[] =
 
 static const OptimizationStrategy cheapTacticalGlobalRegisterAllocatorOpts[] =
    {
-   { OMR::redundantGotoElimination,      OMR::IfNotProfiling }, // need to be run before global register allocator
+   { OMR::redundantGotoElimination,        OMR::IfNotJitProfiling }, // need to be run before global register allocator
    { OMR::tacticalGlobalRegisterAllocator, OMR::IfEnabled },
    { OMR::endGroup                        }
    };

--- a/runtime/compiler/trj9/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/trj9/p/codegen/PPCRecompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -166,6 +166,9 @@ TR::Instruction *TR_PPCRecompilation::generatePrologue(TR::Instruction *cursor)
          }
       else
          {
+         // This only applies to JitProfiling, as JProfiling uses sampling
+         TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
+
          cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, firstNode, cr0, gr0,   0, cursor);
          // this is just padding for consistent code length
          cursor = generateTrg1Src2Instruction   (cg(), TR::InstOpCode::OR,    firstNode, gr11,  gr11, gr11, cursor);

--- a/runtime/compiler/trj9/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/trj9/x/codegen/X86Recompilation.cpp
@@ -180,7 +180,11 @@ TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
          if (!isProfilingCompilation())
             cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, SUB4MemImms, mRef, 1, cg());
          else
+            {
+            // This only applies to JitProfiling, as JProfiling uses sampling
+            TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
             cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, CMP4MemImms, mRef, 0, cg());
+            }
 
          TR::Instruction *counterInstruction = cursor;
          TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());


### PR DESCRIPTION
This change enables various optimizations
that were disabled under JitProfiling due
to issues with the duplication it performed.

It also ensures JProfiling bodies are treated
as sampling bodies, that upgrade only through
the recompilation counter they insert.