### PR TITLE
Remove references to J2SE_17 level

### DIFF
--- a/runtime/compiler/trj9/control/J9Options.cpp
+++ b/runtime/compiler/trj9/control/J9Options.cpp
@@ -1057,8 +1057,7 @@ J9::Options::fePreProcess(void * base)
       self()->setOption(TR_DisableTraps);
    #endif
 
-   if (self()->getOption(TR_AggressiveOpts) &&
-       (J2SE_VERSION(jitConfig->javaVM) & J2SE_RELEASE_MASK) >= J2SE_17)
+   if (self()->getOption(TR_AggressiveOpts))
       self()->setOption(TR_DontDowngradeToCold, true);
 
    if (forceSuffixLogs)
@@ -1736,15 +1735,11 @@ J9::Options::fePreProcess(void * base)
                UDATA hugePreferredPageSize = 0;
    #if defined(TR_TARGET_POWER)
                preferredPageSize = 65536;
-   #else
-               if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) >= J2SE_17) {
-   #if (defined(LINUX) && defined(TR_TARGET_X86))
-                  preferredPageSize = 2097152;
-                  hugePreferredPageSize = 0x40000000;
+   #elif (defined(LINUX) && defined(TR_TARGET_X86))
+               preferredPageSize = 2097152;
+               hugePreferredPageSize = 0x40000000;
    #elif (defined(TR_TARGET_S390))
-                  preferredPageSize = 1048576;
-   #endif
-               }
+               preferredPageSize = 1048576;
    #endif
                if (0 != preferredPageSize)
                   {

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -98,13 +98,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
 	switch(J2SE_VERSION(vm) & J2SE_VERSION_MASK) {
-	case J2SE_17:
-		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_17) {
-			j2se_version_info = "1.7.0";
-		} else {
-			j2se_version_info = "1.7.?";
-		}
-		break;
 	case J2SE_18:
 		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_18) {
 			j2se_version_info = "1.8.0";

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -235,7 +235,7 @@ jint standardInit( J9JavaVM *vm, char* dllName)
 		vm->jlrMethodInvoke = ((J9JNIMethodID *) invokeMethod)->method;
 		(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
 		
-		if (J2SE_VERSION(vm) >= J2SE_17 && (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW)) {
+		if (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW) {
 			/* JSR 292-related class */
 			clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "com/ibm/oti/lang/ArgumentHelper");
 			if (!clazz) goto _fail;

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -302,9 +302,6 @@ scarInit(J9JavaVM * vm)
 
 #if defined(WIN32) && !defined(OPENJ9_BUILD)
 	switch (jclVersion) {
-	case J2SE_17:
-		dbgwrapperStr = "dbgwrapper70";
-		break;
 	case J2SE_18:
 	case J2SE_19:	/* This will need to be modified when the JCL team provides a dbgwrapper90 */
 		dbgwrapperStr = "dbgwrapper80";

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -399,7 +399,6 @@ enum INIT_STAGE {
 #define VMOPT_XLP_CODECACHE "-Xlp:codecache:"
 #define VMOPT_XTLHPREFETCH "-XtlhPrefetch"
 
-#define VMOPT_XDBG_COLON "-Xdbg:"
 #define VMOPT_XDIAGNOSTICSCOLLECTOR "-Xdiagnosticscollector"
 
 #define VMOPT_XXALLOWNONVIRTUALCALLS "-XX:+AllowNonVirtualCalls"

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -398,7 +398,7 @@ initializeReflectionGlobals(JNIEnv * env,BOOLEAN includeAccessors) {
 	}
 
 #if defined(J9VM_OPT_METHOD_HANDLE)
-	if ((J2SE_VERSION(vm) >= J2SE_17) && (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW)) {
+	if (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW) {
 		clazz = (*env)->FindClass(env, "java/lang/invoke/MethodHandles$Lookup");
 		if (NULL == clazz) {
 			return JNI_ERR;
@@ -573,7 +573,7 @@ getClassContextIterator(J9VMThread * currentThread, J9StackWalkState * walkState
 			if (walkState->userData2 != NULL) {
 				j9object_t classObject = J9VM_J9CLASS_TO_HEAPCLASS(currentClass);
 #if defined(J9VM_OPT_METHOD_HANDLE)
-				if ((J2SE_VERSION(vm) >= J2SE_17) && (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW)) {
+				if (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW) {
 					/* check for non-static MethodHandles$Lookup methods */
 					if (walkState->method == ((J9JNIMethodID*)VM.jliMethodHandles_Lookup_checkSecurity)->method) {
 						walkState->userData3 = (void*)(n + 2);

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -140,10 +140,8 @@ retry:
 		}
 	}
 
-	if ((J2SE_VERSION(javaVM) & J2SE_VERSION_MASK) >= J2SE_17) {
-		if (J9VMJAVALANGCLASSLOADER_ISPARALLELCAPABLE(vmThread, classLoaderObject)) {
-			classLoader->flags |= J9CLASSLOADER_PARALLEL_CAPABLE;
-		}
+	if (J9VMJAVALANGCLASSLOADER_ISPARALLELCAPABLE(vmThread, classLoaderObject)) {
+		classLoader->flags |= J9CLASSLOADER_PARALLEL_CAPABLE;
 	}
 	J9CLASSLOADER_SET_CLASSLOADEROBJECT(vmThread, classLoader, classLoaderObject);
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3768,12 +3768,6 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XSHARE_AUTO, MAPOPT_XSHARECLASSES_NONFATAL, EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
-	/* Map the old-style -Xdbg: to -agentlib:jdwp= in releases before Java 7 */
-	if ((J2SE_VERSION(vm) & J2SE_VERSION_MASK) < J2SE_17) {
-		if (RC_FAILED == registerCmdLineMapping(vm, VMOPT_XDBG_COLON, MAPOPT_AGENTLIB_JDWP_EQUALS, MAP_WITH_INCLUSIVE_OPTIONS)) {
-			return RC_FAILED;
-		}
-	}
 
 	return 0;
 }

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -384,16 +384,12 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 	char *serviceLevel = NULL;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_16) {
-		javaVersion = "JRE 1.6.0";
-	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_17) {
-		javaVersion = "JRE 1.7.0";
-	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_18) {
+	if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_18) {
 		javaVersion = "JRE 1.8.0";
 	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_19) {
 		javaVersion = "JRE 9";
 	} else {
-		javaVersion = "J2ME";
+		javaVersion = "UNKNOWN";
 	}
 
 	if ((NULL == runtimeVersion) || ('\0' == *runtimeVersion)) {

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -686,18 +686,6 @@ initializeSystemProperties(J9JavaVM * vm)
 
 	/* Properties that always exist */
 	switch (j2seVersion) {
-		case J2SE_16:
-			classVersion = "50.0";
-			specificationVersion = "1.0";
-			specificationVendor = "Sun Microsystems Inc.";
-			break;
-
-		case J2SE_17:
-			classVersion = "51.0";
-			specificationVersion = "1.7";
-			specificationVendor = "Oracle Corporation";
-			break;
-
 		case J2SE_18:
 			classVersion = "52.0";
 			specificationVersion = "1.8";


### PR DESCRIPTION
There are references to J2SE_16 & J2SE_17 throughout the code that no longer apply.  The OpenJ9 code base doesn't support any JDK level older than JDK 8 so these references can be removed.

This is a minor code cleanup item.