### PR TITLE
Attach API test cleanup

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/attachAPI/AttachAPIStress.java
+++ b/test/Java8andUp/src/org/openj9/test/attachAPI/AttachAPIStress.java
@@ -72,7 +72,6 @@ public class AttachAPIStress extends AttachApiTest {
 			return;
 		}
 		logger.debug("starting " + testName);
-		TargetManager.setVerbose(false);
 		for (int i = 0; i < SEQ_ITERATIONS; ++i) {
 			launchAndTestTargets(1);
 			logger.debug("waiting");
@@ -87,7 +86,6 @@ public class AttachAPIStress extends AttachApiTest {
 			return;
 		}
 		logger.debug("starting " + testName);
-		TargetManager.setVerbose(false);
 		for (int i = 0; i < MULT_ITERATIONS; ++i) {
 			launchAndTestTargets(i, MULT_ATTACHES);
 			logger.debug("waiting");
@@ -103,7 +101,6 @@ public class AttachAPIStress extends AttachApiTest {
 		}
 
 		logger.debug("starting " + testName);
-		TargetManager.setVerbose(false);
 		setVmOptions("-Xmx16M");
 		setVmOptions("-Xms16M");
 		int instances = PAR_INSTANCES;


### PR DESCRIPTION
Replace direct console output with logger calls.

Tested manually.  Note that this has no effect on normal test runs (which have the debug logger level disabled).

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>