### PR TITLE
Adding Java 10 support continued

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -119,6 +119,13 @@ jint computeFullVersionString(J9JavaVM* vm)
 			j2se_version_info = "9.?";
 		}
 		break;
+	case J2SE_V10:
+		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V10) {
+			j2se_version_info = "10";
+		} else {
+			j2se_version_info = "10.?";
+		}
+		break;
 	default:
 		j2se_version_info = "?.?.?";
 	}

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -31,11 +31,12 @@
 extern "C" {
 #endif
 
-#define J9SH_MODLEVEL_JAVA5 1
-#define J9SH_MODLEVEL_JAVA6 2
-#define J9SH_MODLEVEL_JAVA7 3
-#define J9SH_MODLEVEL_JAVA8 4
-#define J9SH_MODLEVEL_JAVA9 5
+#define J9SH_MODLEVEL_JAVA5  1
+#define J9SH_MODLEVEL_JAVA6  2
+#define J9SH_MODLEVEL_JAVA7  3
+#define J9SH_MODLEVEL_JAVA8  4
+#define J9SH_MODLEVEL_JAVA9  5
+#define J9SH_MODLEVEL_JAVA10 6
 
 /*	JVM feature bit flag(s)	*/
 /*

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,24 +139,28 @@ getGenerationFromName(const char* cacheNameWithVGen)
 uint32_t
 getShcModlevelForJCL(uintptr_t j2seVersion)
 {
+	uint32_t modLevel = 0;
 	switch (j2seVersion) {
 	case J2SE_15 :
-		return J9SH_MODLEVEL_JAVA5;
+		modLevel = J9SH_MODLEVEL_JAVA5;
 		break;
 	case J2SE_16 :
-		return J9SH_MODLEVEL_JAVA6;
+		modLevel = J9SH_MODLEVEL_JAVA6;
 		break;
 	case J2SE_17 :
-		return J9SH_MODLEVEL_JAVA7;
+		modLevel = J9SH_MODLEVEL_JAVA7;
 		break;
 	case J2SE_18 :
-		return J9SH_MODLEVEL_JAVA8;
+		modLevel = J9SH_MODLEVEL_JAVA8;
 		break;
 	case J2SE_19 :
-		return J9SH_MODLEVEL_JAVA9;
+		modLevel = J9SH_MODLEVEL_JAVA9;
+		break;
+	case J2SE_V10 :
+		modLevel = J9SH_MODLEVEL_JAVA10;
 		break;
 	}
-	return 0;
+	return modLevel;
 }
 
 /**
@@ -169,24 +173,28 @@ getShcModlevelForJCL(uintptr_t j2seVersion)
 uint32_t
 getJCLForShcModlevel(uintptr_t modlevel)
 {
+	uint32_t j2seVersion = 0;
 	switch (modlevel) {
 	case J9SH_MODLEVEL_JAVA5 :
-		return J2SE_15;
+		j2seVersion = J2SE_15;
 		break;
 	case J9SH_MODLEVEL_JAVA6 :
-		return J2SE_16;
+		j2seVersion = J2SE_16;
 		break;
 	case J9SH_MODLEVEL_JAVA7 :
-		return J2SE_17;
+		j2seVersion = J2SE_17;
 		break;
 	case J9SH_MODLEVEL_JAVA8 :
-		return J2SE_18;
+		j2seVersion = J2SE_18;
 		break;
 	case J9SH_MODLEVEL_JAVA9 :
-		return J2SE_19;
+		j2seVersion = J2SE_19;
+		break;
+	case J9SH_MODLEVEL_JAVA10 :
+		j2seVersion = J2SE_V10;
 		break;
 	}
-	return 0;
+	return j2seVersion;
 }
 
 /**
@@ -243,6 +251,9 @@ getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer)
 		break;
 	case J9SH_MODLEVEL_JAVA9 :
 		strcpy(buffer, "Java9");
+		break;
+	case J9SH_MODLEVEL_JAVA10 :
+		strcpy(buffer, "Java10");
 		break;
 	default :
 		strcpy(buffer, "Unknown");

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -392,6 +392,8 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 		javaVersion = "JRE 1.8.0";
 	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_19) {
 		javaVersion = "JRE 9";
+	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V10) {
+		javaVersion = "JRE 10";
 	} else {
 		javaVersion = "J2ME";
 	}

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -705,9 +705,16 @@ initializeSystemProperties(J9JavaVM * vm)
 			break;
 
 		case J2SE_19:
-		default:
-			classVersion = "52.0";
+			classVersion = "53.0";
 			specificationVersion = "9";
+			specificationVendor = "Oracle Corporation";
+			break;
+			
+		case J2SE_V10:
+			/* FALLTHROUGH */
+		default:
+			classVersion = "54.0";
+			specificationVersion = "10";
 			specificationVendor = "Oracle Corporation";
 			break;
 	}


### PR DESCRIPTION
Adding `Java 10` support continued

1. Computed `Java 10` full version string;
2. Added `J9SH_MODLEVEL_JAVA10` to match `Java 10` SE version, and refactored a bit for `getShcModlevelForJCL()` and `getJCLForShcModlevel()`;
3. Set `Java 10` RAS service level;
4. Initialized system property `java.class.version` for `Java 10`, also fix it for `Java 9`.

Reviewer @pshipton @tajila 
FYI @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>