### PR TITLE
Remove references to verbose in Java9AndUp

### DIFF
--- a/test/Java9andUp/src/org/openj9/test/attachAPI/TestJava9AttachAPI.java
+++ b/test/Java9andUp/src/org/openj9/test/attachAPI/TestJava9AttachAPI.java
@@ -41,7 +41,6 @@ import org.testng.log4testng.Logger;
 @Test(groups = { "level.extended" })
 public class TestJava9AttachAPI  {
 	protected static Logger logger = Logger.getLogger(TestJava9AttachAPI.class);
-	private static boolean verbose = Boolean.getBoolean("org.openj9.test.java9AttachAPI.verbose");
 	/* attach API is disabled by default on z/OS. This enables it in child processes. */
 	static final String ATTACH_ENABLE_PROPERTY = "-Dcom.ibm.tools.attach.enable=yes";
 	static final String ATTACH_SELF_ENABLE_PROPERTY = "-Djdk.attach.allowAttachSelf";
@@ -51,7 +50,6 @@ public class TestJava9AttachAPI  {
 	protected void setUp(Method testMethod) throws Exception {
 		testName = testMethod.getName(); 
 		logger.debug("\n------------------------------------------------------\nstarting " + testName);
-		TargetManager.verbose = verbose;
 	}
 
 	@Test


### PR DESCRIPTION
Pull request https://github.com/eclipse/openj9/pull/841 missed the OpenJ9AndUp project.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>