### PR TITLE
 Fix Java 10 extension compilation

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BoundMethodHandle.java
@@ -70,6 +70,12 @@ abstract class BoundMethodHandle extends MethodHandle {
 		LambdaForm.NamedFunction getterFunction(int num) {
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
+		
+		/*[IF Java10]*/
+		MethodHandle factory() {
+			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		}
+		/*[ENDIF]*/
 	}
 	
 	abstract BoundMethodHandle copyWithExtendL(MethodType mt, LambdaForm lf, Object obj);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -1,0 +1,23 @@
+/*[INCLUDE-IF Java10]*/
+
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -67,5 +67,8 @@ final class MemberName {
 	String getMethodDescriptor() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+	public Class<?> getDeclaringClass() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
 	/*[ENDIF]*/
 }


### PR DESCRIPTION
Fix `Java 10` extension compilation

1. Added a `J9 java.lang.invoke.ClassSpecializer.java` (empty) to overlay
`OpenJDK` version;
2. Added a stub method `java.lang.invoke.BoundMethodHandle$SpeciesData.factory()`;
3. Added a stub method `java.lang.invoke.MemberName.getDeclaringClass()`.

closes: #824 #826 #840

Reviewer @pshipton 
FYI @DanHeidinga @yongja79

Signed-off-by: Jason Feng <fengj@ca.ibm.com>