### PR TITLE
Remove libauxv from longabout since it comes from OMR

### DIFF
--- a/longabout.html
+++ b/longabout.html
@@ -52,8 +52,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 Subject to the following notices:<br />
     1.	Google Test is provided under the Google Test license below.<br />
     2.	Pugixml is provided under the pugixml license below.<br />
-    3.	Libauxv is provided under the libauxv license below.<br />
-    4.	config.sub and config.guess are provided under the GPL v3.0 with the Autoconf exception (see below).<br />
+    3.	config.sub and config.guess are provided under the GPL v3.0 with the Autoconf exception (see below).<br />
 <p>
 You may distribute this program and materials under either the
 Eclipse Public License 2 or the Apache V2.0 License as long as you pass through
@@ -114,36 +113,6 @@ THE SOFTWARE.
 </p>
 <p>
 The source is available at <a href="http://pugixml.org/2014/11/27/pugixml-1.5-release.html">http://pugixml.org/2014/11/27/pugixml-1.5-release.html</a>.
-</p>
-
-<h5>libauxv</h5>
-<p>
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:</p>
-<p class="list">* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.</p>
-<p class="list">* Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.</p>
-<p class="list">* Neither the name of the IBM Corporation nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.</p>
-
-<p>
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL IBM CORPORATION BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-</p>
-<p>
-The source is available at <a href="https://github.com/Libauxv/libauxv">https://github.com/Libauxv/libauxv</a>.
 </p>
 
 <h5>config.sub and config.guess</h5>


### PR DESCRIPTION
Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>