### PR TITLE
Add build instructions for OpenJDK8 Windows 64-bit

### DIFF
--- a/buildenv/Build_Instructions_V8.md
+++ b/buildenv/Build_Instructions_V8.md
@@ -310,7 +310,8 @@ The following instructions guide you through the process of building a Windows 6
 :ledger:
 You must install a number of software dependencies to create a suitable build environment on your system:
 
-- [Cygwin for 64-bit versions of Windows](https://cygwin.com/install.html), which provides a Unix-style command line interface. Install all packages in the `Devel` category. In the `Archive` category, install the packages `zip`, `unzip`, and `cpio`. Install any further package dependencies that are identified by the installer. More information about using Cygwin can be found [here](https://cygwin.com/docs.html).
+- [Cygwin for 64-bit versions of Windows](https://cygwin.com/install.html), which provides a Unix-style command line interface. Install all packages in the `Devel` category, which includes `mingw`, a minimalist subset of GNU tools for Microsoft Windows. 
+OpenJ9 uses the mingw/GCC compiler during the build process. In the `Archive` category, install the packages `zip`, `unzip`, and `cpio`. Install any further package dependencies that are identified by the installer. More information about using Cygwin can be found [here](https://cygwin.com/docs.html).
 - [Windows JDK 7](http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html), which is used as the boot JDK.
 - [Windows SDK 7 Debugging tools](https://www.microsoft.com/download/confirmation.aspx?id=8279).
 - [Microsoft Visual Studio Professional 2010](https://www.visualstudio.com/vs/older-downloads/).
@@ -321,8 +322,8 @@ You must install a number of software dependencies to create a suitable build en
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
 
 ```
-set INCLUDE ="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc";%INCLUDE%
-set LIB="C:\Program Files\Debugging Tools for Windows (x64)\sdk\lib";%LIB%;
+set INCLUDE =C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;%INCLUDE%
+set LIB=C:\Program Files\Debugging Tools for Windows (x64)\sdk\lib;%LIB%;
 ```
 
 You can download Freemarker and Freetype manually or obtain them using the [wget](http://www.gnu.org/software/wget/faq.html#download) utility. If you choose to use `wget`, follow these steps:

--- a/buildenv/Build_Instructions_V8.md
+++ b/buildenv/Build_Instructions_V8.md
@@ -322,7 +322,7 @@ OpenJ9 uses the mingw/GCC compiler during the build process. In the `Archive` ca
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
 
 ```
-set INCLUDE =C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;%INCLUDE%
+set INCLUDE=C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;%INCLUDE%
 set LIB=C:\Program Files\Debugging Tools for Windows (x64)\sdk\lib;%LIB%;
 ```
 

--- a/buildenv/Build_Instructions_V8.md
+++ b/buildenv/Build_Instructions_V8.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -17,7 +17,7 @@ OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html
 [2] http://openjdk.java.net/legal/assembly-exception.html
 
-SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
 Building OpenJDK Version 8 with OpenJ9
@@ -167,19 +167,19 @@ make all
 :warning: If you just type `make`, rather than `make all` your build will fail, because the default `make` target is `exploded-image`. If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script. For more information, read this [issue](https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/34).
 
 Two Java builds are produced: a full developer kit (jdk) and a runtime environment (jre)
-- **build/linux-x86_64-normal-server-release/images/jdk**
-- **build/linux-x86_64-normal-server-release/images/jre**
+- **build/linux-x86_64-normal-server-release/images/j2sdk-image**
+- **build/linux-x86_64-normal-server-release/images/j2re-image**
 
     :whale: If you built your binaries in a Docker container, copy the binaries to the containers **/root/hostdir** directory so that you can access them on your local system. You'll find them in the directory you set for `<host_directory>` when you started your Docker container. See [Setting up your build environment with Docker](#setting-up-your-build-environment-with-docker).
 
-    :pencil: On other architectures the **/jdk** and **/jre** directories are in **build/linux-ppc64le-normal-server-release/images** (Linux on 64-bit Power systems) and **build/linux-s390x-normal-server-release/images** (Linux on 64-bit z Systems)
+    :pencil: On other architectures the **/j2sdk-image** and **/j2re-image** directories are in **build/linux-ppc64le-normal-server-release/images** (Linux on 64-bit Power systems) and **build/linux-s390x-normal-server-release/images** (Linux on 64-bit z Systems)
 
 ### 5. Test
 :penguin:
 For a simple test, try running the `java -version` command.
-Change to the /jre directory:
+Change to the **/j2re-image** directory:
 ```
-cd build/linux-x86_64-normal-server-release/images/jre
+cd build/linux-x86_64-normal-server-release/images/j2re-image
 ```
 Run:
 ```
@@ -270,8 +270,8 @@ make all
 :warning: If you just type `make`, rather than `make all` your build will fail, because the default `make` target is `exploded-image`. If you want to specify `make` instead of `make all`, you must add `--default-make-target=images` when you run the configure script. For more information, read this [issue](https://github.com/ibmruntimes/openj9-openjdk-jdk9/issues/34).
 
 Two Java builds are produced: a full developer kit (jdk) and a runtime environment (jre)
-- **build/aix-ppc64-normal-server-release/images/jdk**
-- **build/aix-ppc64-normal-server-release/images/jre**
+- **build/aix-ppc64-normal-server-release/images/j2sdk-image**
+- **build/aix-ppc64-normal-server-release/images/j2re-image**
 
     :pencil: A JRE binary is not currently generated due to an OpenJDK bug.
 
@@ -279,9 +279,9 @@ Two Java builds are produced: a full developer kit (jdk) and a runtime environme
 ### 5. Test
 :blue_book:
 For a simple test, try running the `java -version` command.
-Change to the /jdk directory:
+Change to the **/j2sdk-image** directory:
 ```
-cd build/aix-ppc64-normal-server-release/images/jdk
+cd build/aix-ppc64-normal-server-release/images/j2sdk-image
 ```
 Run:
 ```
@@ -304,9 +304,114 @@ OpenJDK  - 27f5b8f based on jdk8u152-b03)
 
 ## Windows
 :ledger:
+The following instructions guide you through the process of building a Windows 64-bit OpenJDK V8 binary that contains Eclipse OpenJ9. This process can be used to build binaries for Windows 7, 8, and 10.
 
-:construction:
-We haven't created a full build process for Windows yet? Watch this space!
+### 1. Prepare your system
+:ledger:
+You must install a number of software dependencies to create a suitable build environment on your system:
+
+- [Cygwin for 64-bit versions of Windows](https://cygwin.com/install.html), which provides a Unix-style command line interface. Install all packages in the `Devel` category. In the `Archive` category, install the packages `zip`, `unzip`, and `cpio`. Install any further package dependencies that are identified by the installer. More information about using Cygwin can be found [here](https://cygwin.com/docs.html).
+- [Windows JDK 7](http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html), which is used as the boot JDK.
+- [Windows SDK 7 Debugging tools](https://www.microsoft.com/download/confirmation.aspx?id=8279).
+- [Microsoft Visual Studio Professional 2010](https://www.visualstudio.com/vs/older-downloads/).
+- [Microsoft Visual Studio 2010 Service Pack 1](https://support.microsoft.com/en-us/help/983509/description-of-visual-studio-2010-service-pack-1)
+- [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download)
+- [Freetype2 V2.3 or newer](https://www.freetype.org/download.html)
+
+Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
+
+```
+set INCLUDE ="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc";%INCLUDE%
+set LIB="C:\Program Files\Debugging Tools for Windows (x64)\sdk\lib";%LIB%;
+```
+
+You can download Freemarker and Freetype manually or obtain them using the [wget](http://www.gnu.org/software/wget/faq.html#download) utility. If you choose to use `wget`, follow these steps:
+
+- Open a cygwin64 terminal and change to the `/temp` directory:
+```
+cd /cygdrive/c/temp
+```
+
+- Run the following commands:
+```
+wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz
+wget http://download.savannah.gnu.org/releases/freetype/freetype-2.5.3.tar.gz
+```
+
+- To unpack the Freemarker and Freetype compressed files, run:
+```
+tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2
+tar --one-top-level=/cygdrive/c/temp/freetype --strip-components=1 -xzf freetype-2.5.3.tar.gz
+```
+
+- To build the Freetype dynamic and static libraries, open the Visual Studio Command Prompt (VS2010) (see C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Microsoft Visual Studio 2010\Visual Studio Tools) and run:
+```
+cd c:\temp
+msbuild.exe C:/temp/freetype/builds/windows/vc2010/freetype.vcxproj  /p:PlatformToolset=v100  /p:Configuration="Release Multithreaded"  /p:Platform=x64  /p:ConfigurationType=DynamicLibrary  /p:TargetName=freetype  /p:OutDir="C:/temp/freetype/lib64/"  /p:IntDir="C:/temp/freetype/obj64/" > freetype.log
+msbuild.exe C:/temp/freetype/builds/windows/vc2010/freetype.vcxproj  /p:PlatformToolset=v100  /p:Configuration="Release Multithreaded"  /p:Platform=x64  /p:ConfigurationType=StaticLibrary  /p:TargetName=freetype  /p:OutDir="C:/temp/freetype/lib64/"  /p:IntDir="C:/temp/freetype/obj64/" >> freetype.log
+```
+:pencil: Check the `freetype.log` for errors.
+
+### 2. Get the source
+:ledger:
+First you need to clone the Extensions for OpenJDK for OpenJ9 project. This repository is a git mirror of OpenJDK without the HotSpot JVM, but with an **openj9** branch that contains a few necessary patches.
+
+Run the following command in the Cygwin terminal:
+```
+git clone https://github.com/ibmruntimes/openj9-openjdk-jdk8
+```
+Cloning this repository can take a while because OpenJDK is a large project! When the process is complete, change directory into the cloned repository:
+```
+cd openj9-openjdk-jdk8
+```
+Now fetch additional sources from the Eclipse OpenJ9 project and its clone of Eclipse OMR:
+
+```
+bash ./get_source.sh
+```
+### 3. Configure
+:ledger:
+When you have all the source files that you need, run the configure script, which detects how to build in the current build environment.
+```
+bash configure --disable-ccache --with-boot-jdk=/cygdrive/c/temp/jdk7 --with-freemarker-jar=/cygdrive/c/temp/freemarker.jar --with-freetype-include=/cygdrive/c/temp/freetype/include --with-freetype-lib=/cygdrive/c/temp/freetype/lib64
+```
+
+:pencil: Modify the paths for freemarker and freetype if you manually downloaded and unpacked these dependencies into different directories.
+
+### 4. build
+:ledger:
+Now you're ready to build OpenJDK with OpenJ9:
+```
+make all
+```
+
+Two Java builds are produced: a full developer kit (jdk) and a runtime environment (jre)
+- **build/windows-x86_64-normal-server-release/images/j2sdk-image**
+- **build/windows-x86_64-normal-server-release/images/j2re-image**
+
+### 5. Test
+:ledger:
+For a simple test, try running the `java -version` command.
+Change to the **/j2sdk-image** directory:
+```
+cd build/windows-x86_64-normal-server-release/images/j2sdk-image
+```
+Run:
+```
+./bin/java -version
+```
+
+Here is some sample output:
+
+```
+OpenJDK Runtime Environment (build 1.8.0-internal-Administrator_2017_12_14_15_20-b00)
+Eclipse OpenJ9 VM (build 2.9, JRE 1.8.0 Windows 10 amd64-64 Compressed References 20171214_000000 (JIT enabled, AOT enabled)
+OpenJ9   - b8ac7e1747
+OMR      - 101e793f
+OpenJDK  - 2597cd5c6f based on jdk8u152-b16)
+```
+
+:ledger: *Congratulations!* :tada:
 
 ----------------------------------
 


### PR DESCRIPTION
Add section to existing detailed build instructions
to cover building a Windows 64-bit binary. See
issue #845.

[ci skip]

Closes #845

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>