### PR TITLE
Use unicode escapes to remove non-ascii chars

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/string/StringInterning.java
+++ b/test/Java8andUp/src/org/openj9/test/string/StringInterning.java
@@ -102,7 +102,9 @@ public class StringInterning {
 
 	public void testTwoIdenticalMultibyteStrings() {
 		salt = "testTwoIdenticalMultibyteStrings";
-		String[][] helloWorlds = { { "hello", "world" }, { "안녕하세요", "세계" }, { "Καλημέρα", "κόσμε" } };
+		String[][] helloWorlds = { { "hello", "world" },
+				{ "\uc548\ub155\ud558\uc138\uc694", "\uc138\uacc4" },
+				{ "\u039a\u03b1\u03bb\u03b7\u03bc\u03ad\u03c1\u03b1", "\u03ba\u03cc\u03c3\u03bc\u03b5" } };
 		for (int i = 0; i < helloWorlds.length; ++i) {
 			String[] hw = helloWorlds[i];
 			String hello = hw[0], world = hw[1];


### PR DESCRIPTION
Files containing non-ascii characters are much harder to edit

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>