### PR TITLE
String.regionMatches optimizations

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -2273,7 +2273,14 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				return false;
 			}
 
-			if (s1.value == s2.value) {
+			/*[IF Sidecar19-SE]*/
+			byte[] s1Value = s1.value;
+			byte[] s2Value = s2.value;
+			/*[ELSE]*/
+			char[] s1Value = s1.value;
+			char[] s2Value = s2.value;
+			/*[ENDIF]*/
+			if (s1Value == s2Value) {
 				return true;
 			}
 
@@ -2285,10 +2292,8 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (s1hash != 0 && s2hash != 0 && s1hash != s2hash) {
 				return false;
 			}
-			
-			boolean matches = regionMatches(0, s2, 0, s1len);
-			
-			if (!matches) {
+
+			if (!regionMatchesInternal(s1, s2, s1Value, s2Value, 0, 0, s1len)) {
 				return false;
 			}
 
@@ -3199,49 +3204,41 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			return false;
 		}
 
+		return regionMatchesInternal(s1, s2, s1.value, s2.value, thisStart, start, length);
+	}
+
+	/*[IF Sidecar19-SE]*/
+	private static boolean regionMatchesInternal(String s1, String s2, byte[] s1Value, byte[] s2Value, int s1Start, int s2Start, int length)
+	/*[ELSE]*/
+	private static boolean regionMatchesInternal(String s1, String s2, char[] s1Value, char[] s2Value, int s1Start, int s2Start, int length)
+	/*[ENDIF]*/
+	{
 		if (length <= 0) {
 			return true;
 		}
-
-		int o1 = thisStart;
-		int o2 = start;
-
 		// Index of the last char to compare
 		int end = length - 1;
-
-		/*[IF Sidecar19-SE]*/
-		byte[] s1Value = s1.value;
-		byte[] s2Value = s2.value;
-		/*[ELSE]*/
-		char[] s1Value = s1.value;
-		char[] s2Value = s2.value;
-		/*[ENDIF]*/
-
-		s1Value.getClass(); // Implicit null check
-		s2Value.getClass(); // Implicit null check
-
 		if (enableCompression && ((compressionFlag == null) || ((s1.count | s2.count) >= 0))) {
-			if (helpers.getByteFromArrayByIndex(s1Value, o1 + end) != helpers.getByteFromArrayByIndex(s2Value, o2 + end)) {
+			if (helpers.getByteFromArrayByIndex(s1Value, s1Start + end) != helpers.getByteFromArrayByIndex(s2Value, s2Start + end)) {
 				return false;
 			} else {
 				for (int i = 0; i < end; ++i) {
-					if (helpers.getByteFromArrayByIndex(s1Value, o1 + i) != helpers.getByteFromArrayByIndex(s2Value, o2 + i)) {
+					if (helpers.getByteFromArrayByIndex(s1Value, s1Start + i) != helpers.getByteFromArrayByIndex(s2Value, s2Start + i)) {
 						return false;
 					}
 				}
 			}
 		} else {
-			if (s1.charAtInternal(o1 + end, s1Value) != s2.charAtInternal(o2 + end, s2Value)) {
+			if (s1.charAtInternal(s1Start + end, s1Value) != s2.charAtInternal(s2Start + end, s2Value)) {
 				return false;
 			} else {
 				for (int i = 0; i < end; ++i) {
-					if (s1.charAtInternal(o1 + i, s1Value) != s2.charAtInternal(o2 + i, s2Value)) {
+					if (s1.charAtInternal(s1Start + i, s1Value) != s2.charAtInternal(s2Start + i, s2Value)) {
 						return false;
 					}
 				}
 			}
 		}
-
 		return true;
 	}
 

--- a/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -189,6 +189,7 @@
    java_lang_String_toCharArray,
    java_lang_String_regionMatches,
    java_lang_String_regionMatches_bool,
+   java_lang_String_regionMatchesInternal,
    java_lang_String_equalsIgnoreCase,
    java_lang_String_compareToIgnoreCase,
    java_lang_String_compress,

--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -841,7 +841,7 @@ TR_ResolvedJ9MethodBase::owningMethodDoesntMatter()
          case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress: // This is just a getter that's practically always inlined
             return true;
          default:
-         	break;
+            break;
          }
       }
    else if (!strncmp((char*)J9UTF8_DATA(className), "java/lang/invoke/ILGenMacros", J9UTF8_LENGTH(className)))
@@ -2969,6 +2969,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {x(TR::java_lang_String_toCharArray,         "toCharArray",         "(Ljava/util/Locale;)Ljava/lang/String;")},
       {x(TR::java_lang_String_regionMatches,       "regionMatches",       "(ILjava/lang/String;II)Z")},
       {x(TR::java_lang_String_regionMatches_bool,  "regionMatches",       "(ZILjava/lang/String;II)Z")},
+      {  TR::java_lang_String_regionMatchesInternal, 21, "regionMatchesInternal", (int16_t)-1, "*"},
       {x(TR::java_lang_String_equalsIgnoreCase,    "equalsIgnoreCase",    "(Ljava/lang/String;)Z")},
       {x(TR::java_lang_String_compareToIgnoreCase, "compareToIgnoreCase", "(Ljava/lang/String;)I")},
       {x(TR::java_lang_String_compress,            "compress",            "([C[BII)I")},
@@ -3803,8 +3804,8 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {
       {x(TR::java_lang_invoke_CollectHandle_numArgsToPassThrough,          "numArgsToPassThrough",        "()I")},
       {x(TR::java_lang_invoke_CollectHandle_numArgsToCollect,              "numArgsToCollect",            "()I")},
-	  {x(TR::java_lang_invoke_CollectHandle_collectionStart,     	       "collectionStart",             "()I")},
-	  {x(TR::java_lang_invoke_CollectHandle_numArgsAfterCollectArray,      "numArgsAfterCollectArray",    "()I")},
+      {x(TR::java_lang_invoke_CollectHandle_collectionStart,     	       "collectionStart",             "()I")},
+      {x(TR::java_lang_invoke_CollectHandle_numArgsAfterCollectArray,      "numArgsAfterCollectArray",    "()I")},
       {  TR::unknownMethod}
       };
 
@@ -4853,7 +4854,7 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
      //SYM     564  0.02    TR::sun_misc_Unsafe_putLong(__complex __complex)
                setRecognizedMethod(rm);
             default:
-            	break;
+               break;
             } // ens case
          }
       else
@@ -5321,7 +5322,7 @@ TR_J9MethodBase::isUnsafeWithObjectArg(TR::Compilation * c)
       case TR::sun_misc_Unsafe_putObjectOrdered_jlObjectJjlObject_V:
          return true;
       default:
-      	return false;
+         return false;
       }
 
    return false;
@@ -6982,13 +6983,11 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             TR::VMAccessCriticalSection invokeCollectHandleNumArgsToCollect(fej9);
             methodHandle = *thunkDetails->getHandleRef();
             collectArraySize = fej9->getInt32Field(methodHandle, "collectArraySize");
-            if ((symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() ==
-            		TR::java_lang_invoke_CollectHandle_collectionStart)
-            || (symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() ==
-            		TR::java_lang_invoke_CollectHandle_numArgsAfterCollectArray)
-			) {
-            	collectionStart = fej9->getInt32Field(methodHandle, "collectPosition");
-            }
+            if ((symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_CollectHandle_collectionStart)
+             || (symRef->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod() == TR::java_lang_invoke_CollectHandle_numArgsAfterCollectArray))
+               {
+               collectionStart = fej9->getInt32Field(methodHandle, "collectPosition");
+               }
             arguments = fej9->getReferenceField(fej9->getReferenceField(methodHandle, "type", "Ljava/lang/invoke/MethodType;"), "arguments", "[Ljava/lang/Class;");
             numArguments = (int32_t)fej9->getArrayLengthInElements(arguments);
             }
@@ -7008,7 +7007,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                loadConstant(TR::iconst, numArguments - collectionStart - collectArraySize);
                break;
             default:
-            	break;
+                break;
             }
          return true;
          }
@@ -7449,7 +7448,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                loadConstant(TR::iconst, numValues);
                break;
             default:
-            	break;
+               break;
             }
          }
          return true;
@@ -7593,7 +7592,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                   }
                break;
             default:
-            	break;
+               break;
             }
          push(result);
          }
@@ -7723,7 +7722,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                loadConstant(TR::iconst, numArguments - 1 - spreadStart);
                break;
             default:
-            	break;
+               break;
             }
          return true;
          }
@@ -7894,7 +7893,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                loadConstant(TR::iconst, numFilters);
                break;
             default:
-            	break;
+               break;
             }
          return true;
          }

--- a/runtime/compiler/trj9/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/compiler/trj9/il/symbol/J9MethodSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -269,7 +269,7 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
    TR::java_lang_String_toUpperCaseCore,
    TR::java_lang_String_regionMatches,
    TR::java_lang_String_regionMatches_bool,
-   TR::java_lang_String_regionMatches,
+   TR::java_lang_String_regionMatchesInternal,
    TR::java_lang_String_equalsIgnoreCase,
    TR::java_lang_String_compareToIgnoreCase,
    TR::java_lang_String_hashCodeImplCompressed,

--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -381,6 +381,7 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       {
       case TR::java_lang_J9VMInternals_fastIdentityHashCode:
       case TR::java_lang_Class_getSuperclass:
+      case TR::java_lang_String_regionMatchesInternal:
       case TR::java_lang_String_regionMatches:
       case TR::java_lang_Class_newInstance:
       // we rely on inlining compareAndSwap so we see the inner native call and can special case it


### PR DESCRIPTION
The loop to verify content of two strings are separated, which
allows Optimizer better see through the inlined body and hence
better remove unnecessary checks.

Issue #1179

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>