### PR TITLE
Fix race condition on master lock

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2009, 2010 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Objects;
 
 public abstract class CommonDirectory {
 	private static final String ATTACH_LOCK = "_attachlock"; //$NON-NLS-1$
@@ -43,6 +44,7 @@ public abstract class CommonDirectory {
 	private static File commonDirFile; /* file where all IPC files are held */
 	private static FileLock masterLock;
 	private static String semaphoreId;
+	private static int masterLockCount = 0;
 	/**
 	 * default name of directories where VMs place their advertisements
 	 */
@@ -88,7 +90,7 @@ public abstract class CommonDirectory {
 				(new File(systemTmpDir,".com_ibm_tools_attach")).getPath()); //$NON-NLS-1$
 		/*[PR CMVC 165300 restriction on embedded blanks was unnecessary. Also, trailing separators were redundant. ]*/
 		if (IPC.loggingEnabled ) {
-			IPC.logMessage("IPC Directory", ipcDirProperty); //$NON-NLS-1$
+			IPC.logMessage("IPC Directory=", ipcDirProperty); //$NON-NLS-1$
 		}
 		File cd = new File(ipcDirProperty);
 		setCommonDirFileObject(cd);
@@ -126,32 +128,65 @@ public abstract class CommonDirectory {
 	 * Lock the master lock file. Create the lockfile if necessary.
 	 * @throws IOException if the file is already locked.
 	 */
-	/*[PR Jazz 30075] obtainMasterLock(File commonDirectory) is never used. */		
 	public static void obtainMasterLock() throws IOException {
-		getMasterLock().lockFile(true);
+		FileLock masterLockCopy = null;
+		synchronized (accessorMutex) {
+			++masterLockCount;
+			if (1 == masterLockCount) {
+				masterLockCopy = getMasterLock();
+			}
+		}
+		if (null != masterLockCopy) { /* first entry */
+			masterLockCopy.lockFile(true);
+		}
 	}
 
 	/**
-	 * non-blocking lock the master lockfile. Create the lockfile if necessary.
+	 * non-blocking lock the master lockfile. 
+	 * Create the lockfile if necessary.
 	 * @return true if lock obtained
-	 * @throws IOException if file already locked
 	 */
-	static boolean tryObtainMasterLock() throws IOException {
-		return getMasterLock().lockFile(false);
+	static boolean tryObtainMasterLock() {
+		boolean masterLockEntered = true;
+		synchronized (accessorMutex) {
+			++masterLockCount; /* optimistically assume we enter the lock */
+			if (1 == masterLockCount) { /* first time in */
+				try {
+					masterLockEntered = getMasterLock().lockFile(false);
+					if (!masterLockEntered) { /* lock failed, so revert */
+						--masterLockCount;
+					}
+				} catch (IOException e) { /* this shouldn't happen */
+					masterLockEntered = false;
+					IPC.logMessage("IOException in tryObtainMasterLock," //$NON-NLS-1$
+							+ " masterLockCount=" +masterLockCount, e); //$NON-NLS-1$
+				}
+			}
+			return masterLockEntered;		
+		}
 	}
 
 	/**
 	 * Release the lock on the master lock file
 	 */
 	public static void releaseMasterLock() {
-		getMasterLock().unlockFile();		
+		synchronized (accessorMutex) {
+			if (masterLockCount <= 0) {
+				IPC.logMessage("releaseMasterLock: Illegal value for masterLockCount", masterLockCount); //$NON-NLS-1$
+				return;
+			}
+			--masterLockCount;
+			if (Objects.nonNull(masterLock) && (0 == masterLockCount)) {
+				masterLock.unlockFile();
+				masterLock = null;
+			}
+		}
 	}
 
 	/**
 	 * Lock the attach lockfile. Create the lockfile if necessary.
 	 * @throws IOException if file already locked
 	 */
-	/*[PR Jazz 30075] obtainAttachLock(File commonDirectory) is never used.. */
 	 
 	public static void obtainAttachLock() throws IOException {
 		getAttachLock().lockFile(true);
@@ -269,7 +304,7 @@ public abstract class CommonDirectory {
 			return 0;
 		} else {
 			int count = 0;
-			for (int i=0; i < vmDirs.length; ++i) {
+			for (int i = 0; i < vmDirs.length; ++i) {
 				String dirMemberName = vmDirs[i].getName();
 				if (dirMemberName.startsWith(TRASH_PREFIX) || isCommonControlFile(dirMemberName)) {
 					continue;
@@ -417,14 +452,16 @@ public abstract class CommonDirectory {
 		return attachLock;
 	}
 	
+	/**
+	 * Returns a FileLock object, creating it if necessary.
+	 * @return FileLock object
+	 * @note this is not thread safe.  This should be called while holding accessorMutex.
+	 */
 	private static FileLock getMasterLock() {
-		synchronized (accessorMutex) {
-			if (null == masterLock) {
-				/*[PR Jazz 30075] inlined function which was called only from this method */
-				File commonDirFileObject = new File(getCommonDirFileObject(), MASTER_LOCKFILE);
-				String commonDirPath = commonDirFileObject.getAbsolutePath();
-				masterLock = new FileLock(commonDirPath, COMMON_LOCK_FILE_PERMISSIONS);
-			}
+		if (null == masterLock) {
+			File commonDirFileObject = new File(getCommonDirFileObject(), MASTER_LOCKFILE);
+			String commonDirPath = commonDirFileObject.getAbsolutePath();
+			masterLock = new FileLock(commonDirPath, COMMON_LOCK_FILE_PERMISSIONS);
 		}
 		return masterLock;
 	}

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/FileLock.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/FileLock.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 2010, 2010 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,9 +118,10 @@ public final class FileLock {
 
 		return locked;
 	}
-
-	/*[PR Jazz 30075] inlined createFileLockWatchdogTimer which is called once and has obligations on its caller */
 	
+	/**
+	 * Release the lock on a file.
+	 */
 	public void unlockFile() {
 		if (IPC.loggingEnabled ) {
 			IPC.logMessage("unlocking file ", lockFilepath);  //$NON-NLS-1$
@@ -132,9 +133,8 @@ public final class FileLock {
 				lockObjectCopy.release();
 				lockFileRAF.close();
 			} catch (IOException e) {
-				IPC.logMessage("IOException unlocking file"); //$NON-NLS-1$
+				IPC.logMessage("IOException unlocking file "+lockFilepath, e); //$NON-NLS-1$
 			}
-			lockObjectCopy = null;
 		}
 		if (locked && (fileDescriptor >= 0)) {
 			unlockFileImpl(fileDescriptor);

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -2,7 +2,7 @@
 package com.ibm.tools.attach.target;
 
 /*******************************************************************************
- * Copyright (c) 2009, 2015 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -285,10 +285,33 @@ public class IPC {
 		}
 	}
 
+	/**
+	 * Print the information about a throwable, including the exact class,
+	 * message, and stack strace.
+	 * @param msg User supplied message
+	 * @param thrown throwable
+	 */
+	public synchronized static void logMessage(String msg, Throwable thrown) {
+		tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
+		@SuppressWarnings("resource")
+		PrintStream log = getLogStream();
+		printLogMessageHeader(log);
+		log.println(msg);
+		thrown.printStackTrace(log);
+		log.flush();
+	}
+
 	private synchronized static void printLogMessage(final String msg) {
 		tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
-		long currentTime = System.currentTimeMillis();
+		@SuppressWarnings("resource")
 		PrintStream log = getLogStream();
+		printLogMessageHeader(log);
+		log.println(msg);
+		log.flush();
+	}
+
+	private static void printLogMessageHeader(PrintStream log) {
+		long currentTime = System.currentTimeMillis();
 		log.print(currentTime);
 		log.print(" "); //$NON-NLS-1$
 		String id = AttachHandler.getVmId();
@@ -301,8 +324,6 @@ public class IPC {
 		log.print(" ["); //$NON-NLS-1$
 		log.print(Thread.currentThread().getName());
 		log.print("]: "); //$NON-NLS-1$
-		log.println(msg);
-		log.flush();
 	}
 	
 	static final class syncObject {


### PR DESCRIPTION
Make the master lock reentrant to allow simultaneous usage by initialization and shutdown
code.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>