### PR TITLE
Throw IllegalArgumentException from Unsafe.defineAnonymousClass

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@
 #include "bcutil_api.h"
 #include "bcutil_internal.h"
 #include "SCQueryFunctions.h"
+#include "j9jclnls.h"
 
 #if (defined(J9VM_OPT_DYNAMIC_LOAD_SUPPORT))  /* File Level Build Flags */
 
@@ -42,6 +43,11 @@ static void throwNoClassDefFoundError (J9VMThread* vmThread, J9LoadROMClassData 
 static void reportROMClassLoadEvents (J9VMThread* vmThread, J9ROMClass* romClass, J9ClassLoader* classLoader);
 static J9Class* checkForExistingClass (J9VMThread* vmThread, J9LoadROMClassData * loadData);
 static UDATA callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediateClassData, UDATA intermediateClassDataLength, UDATA translationFlags, UDATA classFileBytesReplacedByRIA, UDATA classFileBytesReplacedByRCA, J9TranslationLocalBuffer *localBuffer);
+
+static BOOLEAN hasSamePackageName(J9ROMClass *anonROMClass, J9ROMClass *hostROMClass);
+static char* createErrorMessage(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *hostROMClass, const char* errorMsg);
+static void setIllegalArgumentExceptionHostClassAnonClassHaveDifferentPackages(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *hostROMClass);
+static void freeAnonROMClass(J9JavaVM *vm, J9ROMClass *romClass);
 
 #define GET_CLASS_LOADER_FROM_ID(vm, classLoader) ((classLoader) != NULL ? (classLoader) : (vm)->systemClassLoader)
 
@@ -67,7 +73,8 @@ internalDefineClass(
 	J9ROMClass* orphanROMClass = NULL;
 	J9ROMClass* romClass = NULL;
 	J9Class* result = NULL;
-	J9LoadROMClassData loadData;
+	J9LoadROMClassData loadData = {0};
+	BOOLEAN isAnonFlagSet = J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_ANON);
 
 	/* This trace point is obsolete. It is retained only because j9vm test depends on it.
 	 * Once j9vm tests are fixed, it would be marked as Obsolete in j9bcu.tdf
@@ -99,7 +106,7 @@ internalDefineClass(
 	loadData.freeFunction = NULL;
 	loadData.romClass = existingROMClass;
 
-	if (0 == (options & J9_FINDCLASS_FLAG_NO_CHECK_FOR_EXISTING_CLASS)) {
+	if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NO_CHECK_FOR_EXISTING_CLASS)) {
 		/* For non-bootstrap classes, this check is done in jcldefine.c:defineClassCommon(). */
 		if (checkForExistingClass(vmThread, &loadData) != NULL) {
 			Trc_BCU_internalDefineClass_Exit(vmThread, className, NULL);
@@ -107,7 +114,7 @@ internalDefineClass(
 		}
 	}
 
-	if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_ANON)) {
+	if (!isAnonFlagSet) {
 		/* See if there's already an orphan romClass available */
 		if (NULL != classLoader->romClassOrphansHashTable) {
 			orphanROMClass = romClassHashTableFind(classLoader->romClassOrphansHashTable, className, classNameLength);
@@ -134,6 +141,22 @@ internalDefineClass(
 		romClass = createROMClassFromClassFile(vmThread, &loadData, localBuffer);
 	}
 	if (romClass) {
+		/* Host class can only be set for anonymous classes, which are defined by Unsafe.defineAnonymousClass.
+		 * For other cases, host class is set to NULL.
+		 */
+		if ((NULL != hostClass) && (J2SE_VERSION(vm) >= J2SE_19)) {
+			J9ROMClass *hostROMClass = hostClass->romClass;
+			/* This error-check should only be done for anonymous classes. */
+			Trc_BCU_Assert_True(isAnonFlagSet);
+			/* From Java 9 and onwards, set IllegalArgumentException when host class and anonymous class have different packages. */
+			if (!hasSamePackageName(romClass, hostROMClass)) {
+				omrthread_monitor_exit(vm->classTableMutex);
+				setIllegalArgumentExceptionHostClassAnonClassHaveDifferentPackages(vmThread, romClass, hostROMClass);
+				freeAnonROMClass(vm, romClass);
+				goto done;
+			}
+		}
+
 		/* report the ROM load events */
 		reportROMClassLoadEvents(vmThread, romClass, classLoader);
 
@@ -171,6 +194,7 @@ internalDefineClass(
 		}
 	}
 
+done:
 	Trc_BCU_internalDefineClass_Exit(vmThread, className, result);
 
 	return result;
@@ -859,6 +883,122 @@ classCouldPossiblyBeShared(J9VMThread * vmThread, J9LoadROMClassData * loadData)
 {
 	J9JavaVM * vm = vmThread->javaVM;
 	return ((0 != (loadData->classLoader->flags & J9CLASSLOADER_SHARED_CLASSES_ENABLED)) && !j9shr_Query_IsCacheFull(vm));
+}
+
+/* Return TRUE if anonClass and hostClass have the same package name.
+ * If anonymous class has no package name, then consider it to be part
+ * of host class's package. Return TRUE if anonymous class has no
+ * package name. Otherwise, return FALSE.
+ */
+static BOOLEAN
+hasSamePackageName(J9ROMClass *anonROMClass, J9ROMClass *hostROMClass) {
+	BOOLEAN rc = FALSE;
+	const UDATA anonClassPackageNameLength = packageNameLength(anonROMClass);
+
+	if (0 == anonClassPackageNameLength) {
+		rc = TRUE;
+	} else {
+		const U_8 *anonClassName = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(anonROMClass));
+		const U_8 *hostClassName = J9UTF8_DATA(J9ROMCLASS_CLASSNAME(hostROMClass));
+		const UDATA hostClassPackageNameLength = packageNameLength(hostROMClass);
+		if (J9UTF8_DATA_EQUALS(anonClassName, anonClassPackageNameLength, hostClassName, hostClassPackageNameLength)) {
+			rc = TRUE;
+		}
+	}
+
+	return rc;
+}
+
+/* Create error message with host class and anonymous class. */
+static char*
+createErrorMessage(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *hostROMClass, const char* errorMsg) {
+	PORT_ACCESS_FROM_VMC(vmStruct);
+	char *buf = NULL;
+
+	if (NULL != errorMsg) {
+		UDATA bufLen = 0;
+		const J9UTF8 *anonClassName = J9ROMCLASS_CLASSNAME(anonROMClass);
+		const J9UTF8 *hostClassName = J9ROMCLASS_CLASSNAME(hostROMClass);
+		const U_8 *hostClassNameData = J9UTF8_DATA(hostClassName);
+		const U_8 *anonClassNameData = J9UTF8_DATA(anonClassName);
+		const UDATA hostClassNameLength = J9UTF8_LENGTH(hostClassName);
+
+		/* Anonymous class name has trailing digits. Example - "test/DummyClass/00000000442F098".
+		 * The code below removes the trailing digits, "/00000000442F098", from the anonymous class name.
+		 */
+		UDATA anonClassNameLength = J9UTF8_LENGTH(anonClassName) - 1;
+		for (; anonClassNameLength >= 0; anonClassNameLength--) {
+			if (anonClassNameData[anonClassNameLength] == '/') {
+				break;
+			}
+		}
+
+		bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+						hostClassNameLength, hostClassNameData,
+						anonClassNameLength, anonClassNameData);
+		if (bufLen > 0) {
+			buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
+			if (NULL != buf) {
+				j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+						hostClassNameLength, hostClassNameData,
+						anonClassNameLength, anonClassNameData);
+			}
+		}
+	}
+
+	return buf;
+}
+
+/* From Java 9 and onwards, set IllegalArgumentException when host class and anonymous class have different packages. */
+static void
+setIllegalArgumentExceptionHostClassAnonClassHaveDifferentPackages(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *hostROMClass) {
+	PORT_ACCESS_FROM_VMC(vmStruct);
+	const J9JavaVM *vm = vmStruct->javaVM;
+	const J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	/* Construct error string */
+	const char *errorMsg = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES, NULL);
+	char *buf = createErrorMessage(vmStruct, anonROMClass, hostROMClass, errorMsg);
+	vmFuncs->setCurrentExceptionUTF(vmStruct, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, buf);
+	j9mem_free_memory(buf);
+}
+
+/* Free the memory segment corresponding to the anonymous ROM class. */
+static void
+freeAnonROMClass(J9JavaVM *vm, J9ROMClass *romClass) {
+	if (NULL != romClass) {
+		omrthread_monitor_t segmentMutex = vm->classMemorySegments->segmentMutex;
+		omrthread_monitor_enter(segmentMutex);
+		{
+			J9MemorySegment **previousSegmentPointerROM = &vm->anonClassLoader->classSegments;
+			J9MemorySegment *segmentROM = *previousSegmentPointerROM;
+			BOOLEAN foundMemorySegment = FALSE;
+
+			/* Walk all anonymous classloader's ROM memory segments. If ROM class
+			 * is allocated there it would be one per segment.
+			 */
+			while (NULL != segmentROM) {
+				J9MemorySegment *nextSegmentROM = segmentROM->nextSegmentInClassLoader;
+				if (J9_ARE_ALL_BITS_SET(segmentROM->type, MEMORY_TYPE_ROM_CLASS)
+					&& ((J9ROMClass *)segmentROM->heapBase == romClass)
+				) {
+					foundMemorySegment = TRUE;
+					/* Found memory segment corresponding to the ROM class. Remove
+					 * this memory segment from the list.
+					 */
+					*previousSegmentPointerROM = nextSegmentROM;
+					/* Free memory segment corresponding to the ROM class. */
+					vm->internalVMFunctions->freeMemorySegment(vm, segmentROM, 1);
+					break;
+				}
+				previousSegmentPointerROM = &segmentROM->nextSegmentInClassLoader;
+				segmentROM = nextSegmentROM;
+			}
+			/* Memory segment should always be found if the ROM class exists. */
+			Trc_BCU_Assert_True(foundMemorySegment);
+		}
+		omrthread_monitor_exit(segmentMutex);
+	}
 }
 
 #endif /* J9VM_OPT_DYNAMIC_LOAD_SUPPORT */ /* End File Level Build Flags */

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -406,4 +406,19 @@ J9NLS_JCL_OOM_NEW_GLOBAL_REF=Unable to allocate memory for new JNI global refere
 J9NLS_JCL_OOM_NEW_GLOBAL_REF.explanation=The JVM was not able to allocate the native memory required to create a new JNI global reference.
 J9NLS_JCL_OOM_NEW_GLOBAL_REF.system_action=The JVM will exit unless the OutOfMemoryError is caught and recovered from.
 J9NLS_JCL_OOM_NEW_GLOBAL_REF.user_response=Ensure the process has enough native memory to run.
+# END NON-TRANSLATABLE
+
+# Message for IllegalArgumentException if host class and anonymous class are in different packages
+# argument 1 is the host class
+# argument 2 is the anonymous class
+
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES=Host class %2$.*1$s and anonymous class %4$.*3$s are in different packages
+# START NON-TRANSLATABLE
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.sample_input_1=Foo
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.sample_input_2=3
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.sample_input_3=Bar
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.sample_input_4=3
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.explanation=NOTAG
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.system_action=
+J9NLS_JCL_HOSTCLASS_ANONCLASS_DIFFERENT_PACKAGES.user_response=
 # END NON-TRANSLATABLE

--- a/test/UnsafeTest/build.xml
+++ b/test/UnsafeTest/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,7 +57,7 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src_90}" />
 					<src path="${transformerListener}" />
-					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
 					<classpath>
 						<pathelement location="../TestConfig/lib/testng.jar" />
 					</classpath>

--- a/test/UnsafeTest/playlist.xml
+++ b/test/UnsafeTest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,8 +55,9 @@
 			<variation>-DScenario=Regular</variation>
 			<variation>-DScenario=Compiled</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
- 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-opens java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames UnsafeTests \
 	-groups $(TEST_GROUP) \

--- a/test/UnsafeTest/src_90/org/openj9/test/unsafe/TestUnsafeAccess.java
+++ b/test/UnsafeTest/src_90/org/openj9/test/unsafe/TestUnsafeAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2012 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@ package org.openj9.test.unsafe;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
+import org.testng.Assert;
 
 @Test(groups = { "level.sanity" })
 public class TestUnsafeAccess extends UnsafeTestBase {
@@ -298,5 +299,35 @@ public class TestUnsafeAccess extends UnsafeTestBase {
 	
 	public void testStaticGetBoolean() throws Exception {
 		testGetBoolean(BooleanData.class, DEFAULT);
+	}
+	
+	/* Test behavior of jdk.internal.misc.Unsafe.defineAnonymousClass */
+	public void testDefineAnonymousClass() throws Exception {
+		/* Anonymous Class = DummyClass; Host Class = java/lang/Object 
+		 * No exception should be thrown since anonymous class has no
+		 * package name. Anonymous classes with no package name are
+		 * considered part of host class's package.
+		 */
+		byte[] bytes = createDummyClass(null);
+		Class<?> anon = myUnsafe.defineAnonymousClass(Object.class, bytes, null);
+		
+		/* Anonymous Class = java/lang/DummyClass; Host Class = java/lang/Object 
+		 * No execption should be thrown since anonymous class and host class
+		 * are in the same package.
+		 */
+		bytes = createDummyClass("java/lang");
+		anon = myUnsafe.defineAnonymousClass(Object.class, bytes, null);
+		
+		/* Anonymous Class = test/DummyClass; Host Class = java/lang/Object 
+		 * IllegalArgumentException should be thrown since anonymous class
+		 * and host class are in different packages.
+		 */
+		try {
+			bytes = createDummyClass("test");
+			anon = myUnsafe.defineAnonymousClass(Object.class, bytes, null);
+			Assert.fail("IllegalArgumentException expected since host class and anonymous class are in different packages.");
+		} catch (IllegalArgumentException e) {
+			/* Correct Behavior. */
+		}
 	}
 }


### PR DESCRIPTION
From Java 9 and onwards, Unsafe.defineAnonymousClass should throw IllegalArgumentException when host class and anonymous class have different packages. If anonymous class has no package name, then it is considered to be part of host class's package.

Also, a test case has been added to verify the above behavior.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>