### PR TITLE
fix openj9 access tests

### DIFF
--- a/test/Java9andUp/playlist.xml
+++ b/test/Java9andUp/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -232,7 +232,7 @@
 	</test>
 	<test>
 		<testCaseName>StaticAccessChecks-IllegalAccessPermit</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --illegal-access=permit\
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --illegal-access=permit \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames AccessUnRestrictedClass \
@@ -249,7 +249,7 @@
 	</test>
 	<test>
 		<testCaseName>StaticAccessChecks-IllegalAccessDeny</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --illegal-access=deny\
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --illegal-access=deny \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames AccessRestrictedClass \

--- a/test/Java9andUp/src/org/openj9/test/access/staticAccessChecks/DenyAccess.java
+++ b/test/Java9andUp/src/org/openj9/test/access/staticAccessChecks/DenyAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,13 +50,13 @@ public class DenyAccess {
 			Field f = Unsafe.class.getDeclaredField("theUnsafe");
 			f.setAccessible(true);
 			Unsafe unsafe = (Unsafe) f.get(null);
-		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException e) {
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 			e.printStackTrace();
-		} catch (IllegalAccessException e) {
+		} catch (IllegalAccessError e) {
 			threwIAE = true;
 		}
 		
-		Assert.assertTrue(threwIAE, "Expected IllegalAccessException not thrown");
+		Assert.assertTrue(threwIAE, "Expected IllegalAccessError not thrown");
 	}
 	
 }

--- a/test/Java9andUp/src/org/openj9/test/access/staticAccessChecks/PermitAccess.java
+++ b/test/Java9andUp/src/org/openj9/test/access/staticAccessChecks/PermitAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,12 +48,12 @@ public class PermitAccess {
 			Field f = Unsafe.class.getDeclaredField("theUnsafe");
 			f.setAccessible(true);
 			Unsafe unsafe = (Unsafe) f.get(null);
-		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException e) {
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 			e.printStackTrace();
-		} catch (IllegalAccessException e) {
+		} catch (IllegalAccessError e) {
 			threwIAE = true;
 		}
 		
-		Assert.assertTrue(threwIAE, "Expected IllegalAccessException not thrown");
+		Assert.assertTrue(threwIAE, "Expected IllegalAccessError not thrown");
 	}
 }


### PR DESCRIPTION
fix openj9 access tests

Fix the test command for the openJ9 tests. Also, detect
IllegalAccessError instead of IllegalAccessException for the 
failure cases.

Closes: #152

Signed-off-by: tajila <atobia@ca.ibm.com>

Reviewers: @llxia @pshipton 
  