### PR TITLE
Update deprecated ArraySetToZero check to ArraySet

### DIFF
--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6936,7 +6936,7 @@ TR_J9ByteCodeIlGenerator::genNewArray(int32_t typeIndex)
    if (!comp()->getOption(TR_DisableSeparateInitFromAlloc) &&
        !node->canSkipZeroInitialization() &&
        !generateArraylets && separateInitializationFromAllocation &&
-       (comp()->cg()->getSupportsArraySet() || comp()->cg()->getSupportsArraySetToZero()))
+       comp()->cg()->getSupportsArraySet())
       {
       node->setCanSkipZeroInitialization(true);
 

--- a/runtime/compiler/trj9/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/trj9/optimizer/EscapeAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5771,7 +5771,7 @@ void TR_EscapeAnalysis::avoidStringCopyAllocation(Candidate *candidate)
  */
 bool TR_EscapeAnalysis::tryToZeroInitializeUsingArrayset(Candidate* candidate, TR::TreeTop* precedingTreeTop)
    {
-   if (cg()->getSupportsArraySetToZero())
+   if (cg()->getSupportsArraySet())
       {
       int32_t candidateHeaderSizeInBytes = candidate->_origKind == TR::New ? comp()->fej9()->getObjectHeaderSizeInBytes() : TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
 

--- a/runtime/compiler/trj9/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/trj9/optimizer/IdiomRecognition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1041,9 +1041,7 @@ TR_CISCGraph::makePreparedCISCGraphs(TR::Compilation *c)
    bool genTROT = c->cg()->getSupportsArrayTranslateTROT();
    bool genTRT =  c->cg()->getSupportsArrayTranslateAndTest();
    bool genMemcpy = c->cg()->getSupportsReferenceArrayCopy() || c->cg()->getSupportsPrimitiveArrayCopy();
-   static const bool allowZeroOnlyMemset = feGetEnv("TR_disableZeroOnlyMemsetIdiom") == NULL;
-   bool genMemset = c->cg()->getSupportsArraySet()
-      || (allowZeroOnlyMemset && c->cg()->getSupportsArraySetToZero());
+   bool genMemset = c->cg()->getSupportsArraySet();
    bool genMemcmp = c->cg()->getSupportsArrayCmp();
    bool genIDiv2Mul = c->cg()->getSupportsLoweringConstIDiv();
    bool genLDiv2Mul = c->cg()->getSupportsLoweringConstLDiv();


### PR DESCRIPTION
ArraySetToZero has been deprecated for long time. Updating them to generic ArraySet.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>