### PR TITLE
clear reference before explicit enqueue

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/java/lang/ref/Test_Reference.java
+++ b/test/Java8andUp/src/org/openj9/test/java/lang/ref/Test_Reference.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,9 @@ import java.lang.ref.WeakReference;
 public class Test_Reference {
 	Object tmpA, tmpB, obj;
 	volatile WeakReference wr;
+	final boolean isJava8 = System.getProperty("java.specification.version").equals("1.8");
+	final boolean disableClearBeforeEnqueue =
+            Boolean.getBoolean("jdk.lang.ref.disableClearBeforeEnqueue");
 
 	protected void doneSuite() {
 		tmpA = tmpB = obj = null;
@@ -64,7 +67,12 @@ public class Test_Reference {
 		obj = new Object();
 		Reference ref = new SoftReference(obj, rq);
 		AssertJUnit.assertTrue("Enqueue failed.", (!ref.isEnqueued()) && ((ref.enqueue()) && (ref.isEnqueued())));
-		AssertJUnit.assertTrue("Not properly enqueued.", rq.poll().get() == obj);
+		if (isJava8 || disableClearBeforeEnqueue) {
+			AssertJUnit.assertTrue("Not properly enqueued.", rq.poll().get() == obj);
+		} else {
+			AssertJUnit.assertTrue("Not properly enqueued.", rq.poll().get() == null);
+		}
+		
 		AssertJUnit.assertTrue("Should remain enqueued.", !ref.isEnqueued()); //This fails.
 		AssertJUnit.assertTrue("Can not enqueue twice.", (!ref.enqueue()) && (rq.poll() == null));
 
@@ -72,7 +80,11 @@ public class Test_Reference {
 		obj = new Object();
 		ref = new WeakReference(obj, rq);
 		AssertJUnit.assertTrue("Enqueue failed2.", (!ref.isEnqueued()) && ((ref.enqueue()) && (ref.isEnqueued())));
-		AssertJUnit.assertTrue("Not properly enqueued2.", rq.poll().get() == obj);
+		if (isJava8 || disableClearBeforeEnqueue) {
+			AssertJUnit.assertTrue("Not properly enqueued2.", rq.poll().get() == obj);
+		} else {
+			AssertJUnit.assertTrue("Not properly enqueued2.", rq.poll().get() == null);
+		}
 		AssertJUnit.assertTrue("Should remain enqueued2.", !ref.isEnqueued()); //This fails.
 		AssertJUnit.assertTrue("Can not enqueue twice2.", (!ref.enqueue()) && (rq.poll() == null));
 	}

--- a/test/Java8andUp/src/org/openj9/test/java/lang/ref/Test_ReferenceQueue.java
+++ b/test/Java8andUp/src/org/openj9/test/java/lang/ref/Test_ReferenceQueue.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang.ref;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,9 @@ import java.lang.ref.SoftReference;
 public class Test_ReferenceQueue {
 	static Boolean b;
 	static Integer integer;
+	final boolean isJava8 = System.getProperty("java.specification.version").equals("1.8");
+	final boolean disableClearBeforeEnqueue =
+            Boolean.getBoolean("jdk.lang.ref.disableClearBeforeEnqueue");
 
 	protected void doneSuite() {
 		b = null;
@@ -76,7 +79,11 @@ public class Test_ReferenceQueue {
 		SoftReference sr = new SoftReference(b, rq);
 		sr.enqueue();
 		try {
-			AssertJUnit.assertTrue("Remove failed.", ((Boolean)rq.poll().get()).booleanValue());
+			if (isJava8 || disableClearBeforeEnqueue) {
+				AssertJUnit.assertTrue("Poll failed.", ((Boolean)rq.poll().get()).booleanValue());
+			} else {
+				AssertJUnit.assertTrue("Poll failed.", (rq.poll().get() == null));
+			}
 		} catch (Exception e) {
 			AssertJUnit.assertTrue("Exception during the test.", false);
 		}
@@ -94,7 +101,11 @@ public class Test_ReferenceQueue {
 		SoftReference sr = new SoftReference(b, rq);
 		sr.enqueue();
 		try {
-			AssertJUnit.assertTrue("Remove failed.", ((Boolean)rq.remove().get()).booleanValue());
+			if (isJava8 || disableClearBeforeEnqueue) {
+				AssertJUnit.assertTrue("Remove failed.", ((Boolean)rq.remove().get()).booleanValue());
+			} else {
+				AssertJUnit.assertTrue("Remove failed.", (rq.remove().get() == null));
+			}
 		} catch (Exception e) {
 			AssertJUnit.assertTrue("Exception during the test.", false);
 		}


### PR DESCRIPTION
	
	- base on new Java9 spec, clear reference before 
	explicit enqueue
	- jdk.lang.ref.disableClearBeforeEnqueue system property for
	reverting to the old behavior
	- update related test codes for new behavior

Signed-off-by: Lin Hu <linhu@ca.ibm.com>