### PR TITLE
Compile OpenJ9 build on zOS

### DIFF
--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -201,7 +201,6 @@
 		<flag id="module_ddr" value="true"/>
 		<flag id="module_gc_modron_eprof" value="true"/>
 		<flag id="module_gptest" value="true"/>
-		<flag id="module_ifa" value="true"/>
 		<flag id="module_j9vm" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jcl.profile_scar" value="true"/>
@@ -243,7 +242,6 @@
 		<flag id="opt_icbuilderSupport" value="true"/>
 		<flag id="opt_infoServer" value="true"/>
 		<flag id="opt_invariantInterning" value="true"/>
-		<flag id="opt_javaOffloadSupport" value="true"/>
 		<flag id="opt_jvmti" value="true"/>
 		<flag id="opt_jxeLoadSupport" value="true"/>
 		<flag id="opt_memoryCheckSupport" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -201,7 +201,6 @@
 		<flag id="module_ddr" value="true"/>
 		<flag id="module_gc_modron_eprof" value="true"/>
 		<flag id="module_gptest" value="true"/>
-		<flag id="module_ifa" value="true"/>
 		<flag id="module_j9vm" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jcl.profile_scar" value="true"/>
@@ -243,7 +242,6 @@
 		<flag id="opt_icbuilderSupport" value="true"/>
 		<flag id="opt_infoServer" value="true"/>
 		<flag id="opt_invariantInterning" value="true"/>
-		<flag id="opt_javaOffloadSupport" value="true"/>
 		<flag id="opt_jvmti" value="true"/>
 		<flag id="opt_jxeLoadSupport" value="true"/>
 		<flag id="opt_memoryCheckSupport" value="true"/>

--- a/buildspecs/zos_390.spec
+++ b/buildspecs/zos_390.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -199,7 +199,6 @@
 		<flag id="module_ddr" value="true"/>
 		<flag id="module_gc_modron_eprof" value="true"/>
 		<flag id="module_gptest" value="true"/>
-		<flag id="module_ifa" value="true"/>
 		<flag id="module_j9vm" value="true"/>
 		<flag id="module_j9vmtest" value="true"/>
 		<flag id="module_jcl.profile_scar" value="true"/>
@@ -241,7 +240,6 @@
 		<flag id="opt_icbuilderSupport" value="true"/>
 		<flag id="opt_infoServer" value="true"/>
 		<flag id="opt_invariantInterning" value="true"/>
-		<flag id="opt_javaOffloadSupport" value="true"/>
 		<flag id="opt_jvmti" value="true"/>
 		<flag id="opt_jxeLoadSupport" value="true"/>
 		<flag id="opt_memoryCheckSupport" value="true"/>

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -118,6 +118,7 @@ all: $(TARGETS)
 <#elseif uma.spec.type.osx>
 <#include "targets.mk.osx.inc.ftl">
 </#if>
+<#include "targets.mk.vendor.inc.ftl">
 
 # Add OMR include paths
 #  Note assumptions about the directory layout of the OMR project.
@@ -310,7 +311,7 @@ LIBCDEFS := $(wildcard /ztpf/$(UMA_ZTPF_ROOT)/base/lib/libCDEFSFORASM.so)
 # compilation rule for metal-C files.
 %$(UMA_DOT_O): %.mc
 	cp $< $*.c
-	xlc $(MCFLAGS) -qmetal -qlongname -S -o $*.s $*.c > $*.asmlist
+	xlc $(MCFLAGS) -qnosearch  -I /usr/include/metal/ -qmetal -qlongname -S -o $*.s $*.c > $*.asmlist
 	rm -f $*.c
 	as -mgoff $(UMA_MCASM_INCLUDES) $*.s
 	rm -f $*.s

--- a/runtime/makelib/targets.mk.vendor.inc.ftl
+++ b/runtime/makelib/targets.mk.vendor.inc.ftl
@@ -1,0 +1,22 @@
+<#-- 
+	Copyright (c) 2018, 2018 IBM Corp. and others
+	
+	This program and the accompanying materials are made available under
+	the terms of the Eclipse Public License 2.0 which accompanies this
+	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+	or the Apache License, Version 2.0 which accompanies this distribution and
+	is available at https://www.apache.org/licenses/LICENSE-2.0.
+	
+	This Source Code may also be made available under the following
+	Secondary Licenses when the conditions for such availability set
+	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+	General Public License, version 2 with the GNU Classpath
+	Exception [1] and GNU General Public License, version 2 with the
+	OpenJDK Assembly Exception [2].
+	
+	[1] https://www.gnu.org/software/classpath/license.html
+	[2] http://openjdk.java.net/legal/assembly-exception.html
+
+	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+

--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-   Copyright (c) 2006, 2017 IBM Corp. and others
+   Copyright (c) 2006, 2018 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,14 @@
 			<xi:include href="vendor_port_default.xml"></xi:include>
 		</xi:fallback>
 	</xi:include>
-
+	
+	<!-- ri_support.xml can contain the RI support on z/OS-->
+	<xi:include href="ri_support.xml">
+		<xi:fallback>
+			<xi:include href="ri_support_default.xml"></xi:include>
+		</xi:fallback>
+	</xi:include>
+	
 	<objects group="all">
 		<object name="j9gp" />
 
@@ -81,11 +88,8 @@
 		<object name="j9port" />
 		<object name="j9process" />
 		<object name="j9gs"/>
-		<object name="j9gs_authorize_64">
-			<include-if condition="spec.zos_390.* and spec.flags.J9VM_ENV_DATA64"/>
-		</object>
-		<object name="j9gs_authorize_31">
-			<include-if condition="spec.zos_390.* and not spec.flags.J9VM_ENV_DATA64"/>
+		<object name="j9guardedstorage">
+			<include-if condition="spec.zos_390.*"/>
 		</object>
 		<object name="j9gs_get_supported">
 			<include-if condition="spec.zos_390.*"/>
@@ -108,35 +112,11 @@
 			<include-if condition="spec.linux_ztpf.*"/>
 			<exclude-if condition="spec.linux_x86.*"/>
 			<exclude-if condition="spec.win_x86.*"/>
-		</object>	
+		</object>
 		<object name="j9ri">
 			<include-if condition="spec.flags.port_runtimeInstrumentation"/>
 		</object>
-		<object name="j9ri_authorize_31">
-			<include-if condition="spec.zos_390.* and not spec.flags.J9VM_ENV_DATA64 and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_authorize_64">
-			<include-if condition="spec.zos_390.* and spec.flags.J9VM_ENV_DATA64 and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_get_supported">
-			<include-if condition="spec.zos_390.* and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_mric">
-			<include-if condition="spec.zos_390.* and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_rioff">
-			<include-if condition="spec.zos_390.* and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_rion">
-			<include-if condition="spec.zos_390.* and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_stric">
-			<include-if condition="spec.zos_390.* and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-		<object name="j9ri_tric">
-			<include-if condition="spec.zos_390.* and spec.flags.port_runtimeInstrumentation"/>
-		</object>
-
+		
 		<object name="j9sharedhelper">
 			<exclude-if condition="spec.win_x86.*"/>
 		</object>
@@ -163,7 +143,7 @@
 		</object>
 		<object name="ut_j9prt" />
 	</objects>
-
+	
 	<!-- vendor_port_flags.xml can contain vendor specific configuration -->
 	<xi:include href="vendor_port_flags.xml">
 		<xi:fallback>
@@ -362,6 +342,7 @@
 
 		<objects>
 			<group name="all"/>
+			<group name="ri_support"/>
 			<group name="vendor_port"/>
 		</objects>
 

--- a/runtime/port/ri_support_default.xml
+++ b/runtime/port/ri_support_default.xml
@@ -1,0 +1,27 @@
+<!--
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+-->
+
+<!-- This xml file contains the configuration to provide RI (Runtime Instrumentation) support on z/OS -->
+<objects group="ri_support">
+</objects>

--- a/runtime/port/zos390/j9guardedstorage.mc
+++ b/runtime/port/zos390/j9guardedstorage.mc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
The changes includes minor code changes
plus a few adjustments in compilation setting
to get source compiled on the zOS platform.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>