### PR TITLE
Rename draft 'MemberOfNest' to final 'NestHost'

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,7 +153,7 @@ ClassFileOracle::ClassFileOracle(BufferManager *bufferManager, J9CfrClassFile *c
 	_innerClassCount(0),
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	_nestMembersCount(0),
-	_memberOfNest(0),
+	_nestHost(0),
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	_maxBranchCount(1), /* This is required to support buffer size calculations for stackmap support code */
 	_outerClassNameIndex(0),
@@ -503,10 +503,10 @@ ClassFileOracle::walkAttributes()
 			}
 			break;
 
-		case CFR_ATTRIBUTE_MemberOfNest: {
-			U_16 hostClassIndex = ((J9CfrAttributeMemberOfNest *)attrib)->hostClassIndex;
-			_memberOfNest = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, hostClassIndex);
-			markConstantUTF8AsReferenced(_memberOfNest);
+		case CFR_ATTRIBUTE_NestHost: {
+			U_16 hostClassIndex = ((J9CfrAttributeNestHost *)attrib)->hostClassIndex;
+			_nestHost = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, hostClassIndex);
+			markConstantUTF8AsReferenced(_nestHost);
 			break;
 		}
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -853,7 +853,7 @@ class NameAndTypeIterator
 	U_16 getInnerClassCount() const { return _innerClassCount; }
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	U_16 getNestMembersCount() const { return _nestMembersCount; }
-	U_16 getNestTopNameIndex() const { return _memberOfNest; }
+	U_16 getNestHostNameIndex() const { return _nestHost; }
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	U_16 getMajorVersion() const { return _classFile->majorVersion; }
 	U_16 getMinorVersion() const { return _classFile->minorVersion; }
@@ -961,7 +961,7 @@ private:
 	U_16 _innerClassCount;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	U_16 _nestMembersCount;
-	U_16 _memberOfNest;
+	U_16 _nestHost;
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	U_32 _maxBranchCount;
 	U_16 _outerClassNameIndex;

--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,7 @@ DECLARE_UTF8_ATTRIBUTE_NAME(ANNOTATION_DEFAULT, "AnnotationDefault");
 DECLARE_UTF8_ATTRIBUTE_NAME(BOOTSTRAP_METHODS, "BootstrapMethods");
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 DECLARE_UTF8_ATTRIBUTE_NAME(NEST_MEMBERS, "NestMembers");
-DECLARE_UTF8_ATTRIBUTE_NAME(MEMBER_OF_NEST, "MemberOfNest");
+DECLARE_UTF8_ATTRIBUTE_NAME(NEST_HOST, "NestHost");
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
 void
@@ -97,7 +97,7 @@ ClassFileWriter::analyzeROMClass()
 	J9UTF8 * outerClassName = J9ROMCLASS_OUTERCLASSNAME(_romClass);
 	J9UTF8 * simpleName = getSimpleNameForROMClass(_javaVM, NULL, _romClass);
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	J9UTF8 *nestTop = J9ROMCLASS_NESTTOPNAME(_romClass);
+	J9UTF8 *nestHost = J9ROMCLASS_NESTHOSTNAME(_romClass);
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
 	/* For a local class only InnerClasses.class[i].inner_name_index is preserved as simpleName in its J9ROMClass */
@@ -120,7 +120,7 @@ ClassFileWriter::analyzeROMClass()
 	}
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	/* Class can not have both a nest members and member of nest attribute */
+	/* Class can not have both a nest members and nest host attribute */
 	if (0 != _romClass->nestMemberCount) {
 		U_16 nestMemberCount = _romClass->nestMemberCount;
 		J9SRP *nestMembers = (J9SRP *) J9ROMCLASS_NESTMEMBERS(_romClass);
@@ -130,9 +130,9 @@ ClassFileWriter::analyzeROMClass()
 			J9UTF8 * className = NNSRP_GET(nestMembers[i], J9UTF8 *);
 			addClassEntry(className, 0);
 		}
-	} else if (NULL != nestTop) {
-		addEntry((void *) &MEMBER_OF_NEST, 0, CFR_CONSTANT_Utf8);
-		addClassEntry(nestTop, 0);
+	} else if (NULL != nestHost) {
+		addEntry((void *) &NEST_HOST, 0, CFR_CONSTANT_Utf8);
+		addClassEntry(nestHost, 0);
 	}
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
@@ -878,7 +878,7 @@ ClassFileWriter::writeAttributes()
 	U_32 * annotationsData = getClassAnnotationsDataForROMClass(_romClass);
 	U_32 * typeAnnotationsData = getClassTypeAnnotationsDataForROMClass(_romClass);
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	J9UTF8 *nestTop = J9ROMCLASS_NESTTOPNAME(_romClass);
+	J9UTF8 *nestHost = J9ROMCLASS_NESTHOSTNAME(_romClass);
 	U_16 nestMemberCount = _romClass->nestMemberCount;
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
@@ -908,7 +908,7 @@ ClassFileWriter::writeAttributes()
 	}
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	/* Class can not have both a nest members and member of nest attribute */
-	if ((0 != _romClass->nestMemberCount) || (NULL != nestTop)) {
+	if ((0 != _romClass->nestMemberCount) || (NULL != nestHost)) {
 		attributesCount += 1;
 	}
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
@@ -966,9 +966,9 @@ ClassFileWriter::writeAttributes()
 			writeU16(indexForClass(nestMemberName));
 			nestMembers += 1;
 		}
-	} else if (NULL != nestTop) {
-		writeAttributeHeader((J9UTF8 *) &MEMBER_OF_NEST, 2);
-		writeU16(indexForUTF8(nestTop));
+	} else if (NULL != nestHost) {
+		writeAttributeHeader((J9UTF8 *) &NEST_HOST, 2);
+		writeU16(indexForUTF8(nestHost));
 	}
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -383,7 +383,7 @@ ROMClassWriter::writeROMClass(Cursor *cursor,
 		cursor->writeU32(_classFileOracle->getInnerClassCount(), Cursor::GENERIC);
 		cursor->writeSRP(_innerClassesSRPKey, Cursor::SRP_TO_GENERIC);
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-		cursor->writeSRP(_srpKeyProducer->mapCfrConstantPoolIndexToKey(_classFileOracle->getNestTopNameIndex()), Cursor::SRP_TO_UTF8);
+		cursor->writeSRP(_srpKeyProducer->mapCfrConstantPoolIndexToKey(_classFileOracle->getNestHostNameIndex()), Cursor::SRP_TO_UTF8);
 		cursor->writeU16(_classFileOracle->getNestMembersCount(), Cursor::GENERIC);
 		cursor->writeU16(0, Cursor::GENERIC); /* padding */
 		cursor->writeSRP(_nestMembersSRPKey, Cursor::SRP_TO_GENERIC);

--- a/runtime/bcutil/attrlookup.gperf
+++ b/runtime/bcutil/attrlookup.gperf
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,4 +69,4 @@ RuntimeVisibleParameterAnnotations, CFR_ATTRIBUTE_RuntimeVisibleParameterAnnotat
 RuntimeInvisibleParameterAnnotations, CFR_ATTRIBUTE_RuntimeInvisibleParameterAnnotations, CFR_ATTRIBUTE_RuntimeInvisibleParameterAnnotations
 MethodParameters, CFR_ATTRIBUTE_MethodParameters, CFR_ATTRIBUTE_MethodParameters
 NestMembers, CFR_ATTRIBUTE_NestMembers, CFR_ATTRIBUTE_NestMembers
-MemberOfNest, CFR_ATTRIBUTE_MemberOfNest, CFR_ATTRIBUTE_MemberOfNest
+NestHost, CFR_ATTRIBUTE_NestHost, CFR_ATTRIBUTE_NestHost

--- a/runtime/bcutil/attrlookup.h
+++ b/runtime/bcutil/attrlookup.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,12 +163,12 @@ lookupKnownAttribute (register const char *str, register unsigned int len)
       {"Exceptions", CFR_ATTRIBUTE_Exceptions, CFR_ATTRIBUTE_Exceptions},
 #line 69 "attrlookup.gperf"
       {"RuntimeInvisibleParameterAnnotations", CFR_ATTRIBUTE_RuntimeInvisibleParameterAnnotations, CFR_ATTRIBUTE_RuntimeInvisibleParameterAnnotations},
+#line 72 "attrlookup.gperf"
+      {"NestHost", CFR_ATTRIBUTE_NestHost, CFR_ATTRIBUTE_NestHost},
 #line 51 "attrlookup.gperf"
       {"Deprecated", CFR_ATTRIBUTE_Deprecated, CFR_ATTRIBUTE_Deprecated},
 #line 71 "attrlookup.gperf"
       {"NestMembers", CFR_ATTRIBUTE_NestMembers, CFR_ATTRIBUTE_NestMembers},
-#line 72 "attrlookup.gperf"
-      {"MemberOfNest", CFR_ATTRIBUTE_MemberOfNest, CFR_ATTRIBUTE_MemberOfNest},
 #line 70 "attrlookup.gperf"
       {"MethodParameters", CFR_ATTRIBUTE_MethodParameters, CFR_ATTRIBUTE_MethodParameters}
     };
@@ -177,8 +177,8 @@ lookupKnownAttribute (register const char *str, register unsigned int len)
     {
       -1, -1, -1, -1,  0, -1, -1, -1, -1,  1,  2, -1,  3,  4,
       -1,  5,  6,  7,  8, -1,  9, -1, 10, 11, 12, 13, -1, 14,
-      15, 16, 17, 18, -1, -1, 19, 20, 21, -1, -1, -1, 22, 23,
-      24, -1, -1, -1, 25
+      15, 16, 17, 18, -1, -1, 19, 20, 21, -1, 22, -1, 23, 24,
+      -1, -1, -1, -1, 25
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -143,7 +143,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 	J9CfrAttributeStackMap *stackMap;
 	J9CfrAttributeBootstrapMethods *bootstrapMethods;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	J9CfrAttributeMemberOfNest *memberOfNest;
+	J9CfrAttributeNestHost *nestHost;
 	J9CfrAttributeNestMembers *nestMembers;
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 	U_32 name, length;
@@ -753,21 +753,21 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 			
 			break;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-		case CFR_ATTRIBUTE_MemberOfNest:
+		case CFR_ATTRIBUTE_NestHost:
 			if (nestAttributeRead) {
 				errorCode = J9NLS_CFR_ERR_MULTIPLE_NEST_ATTRIBUTES__ID;
 				offset = address;
 				goto _errorFound;
 			}
 
-			if (!ALLOC(memberOfNest, J9CfrAttributeMemberOfNest)) {
+			if (!ALLOC(nestHost, J9CfrAttributeNestHost)) {
 				return -2;
 			}
 			nestAttributeRead = TRUE;
-			attrib = (J9CfrAttribute*)memberOfNest;
+			attrib = (J9CfrAttribute*)nestHost;
 
 			CHECK_EOF(2);
-			NEXT_U16(memberOfNest->hostClassIndex, index);
+			NEXT_U16(nestHost->hostClassIndex, index);
 			break;
 
 		case CFR_ATTRIBUTE_NestMembers: {
@@ -2050,14 +2050,14 @@ checkAttributes(J9CfrClassFile* classfile, J9CfrAttribute** attributes, U_32 att
 			break;
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-		case CFR_ATTRIBUTE_MemberOfNest:
-			value = ((J9CfrAttributeMemberOfNest*)attrib)->hostClassIndex;
+		case CFR_ATTRIBUTE_NestHost:
+			value = ((J9CfrAttributeNestHost*)attrib)->hostClassIndex;
 			if ((!value) || (value > cpCount)) {
 				errorCode = J9NLS_CFR_ERR_BAD_INDEX__ID;
 				goto _errorFound;
 			}
 			if (CFR_CONSTANT_Class != cpBase[value].tag) {
-				errorCode = J9NLS_CFR_ERR_BAD_NEST_TOP_INDEX__ID;
+				errorCode = J9NLS_CFR_ERR_BAD_NEST_HOST_INDEX__ID;
 				goto _errorFound;
 			}
 			break;

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -673,8 +673,8 @@ static void dumpAttribute(J9CfrClassFile* classfile, J9CfrAttribute* attrib, U_3
 			break;
 		}
 
-		case CFR_ATTRIBUTE_MemberOfNest: {
-			index = ((J9CfrAttributeMemberOfNest*)attrib)->hostClassIndex;
+		case CFR_ATTRIBUTE_NestHost: {
+			index = ((J9CfrAttributeNestHost*)attrib)->hostClassIndex;
 			for(i = 0; i < tabLevel + 1; i++) j9tty_printf( PORTLIB, "  ");
 			j9tty_printf( PORTLIB, "%i -> %s\n", index, classfile->constantPool[classfile->constantPool[index].slot1].bytes);
 			break;

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1774,8 +1774,8 @@ Java_java_lang_Class_getNestHostImpl(JNIEnv *env, jobject recv)
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
 	J9Class *clazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9_JNI_UNWRAP_REFERENCE(recv));
-	J9Class *nestTop = clazz->memberOfNest;
-	j9object_t resultObject = J9VM_J9CLASS_TO_HEAPCLASS(nestTop);
+	J9Class *nestHost = clazz->nestHost;
+	j9object_t resultObject = J9VM_J9CLASS_TO_HEAPCLASS(nestHost);
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
 
 	if (NULL == result) {

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1280,7 +1280,7 @@ J9NLS_CFR_ERR_MULTIPLE_NEST_ATTRIBUTES.user_response=Contact the provider of the
 # END NON-TRANSLATABLE
 
 #Nest members attribute name is not a utf8
-J9NLS_CFR_ERR_NEST_MEMBERS_NAME_NOT_CONSTANT_CLASS=Member of nest attribute's nest top must be a constant class
+J9NLS_CFR_ERR_NEST_MEMBERS_NAME_NOT_CONSTANT_CLASS=Member of nest attribute's nest host must be a constant class
 # START NON-TRANSLATABLE
 J9NLS_CFR_ERR_NEST_MEMBERS_NAME_NOT_CONSTANT_CLASS.explanation=Member of nest attribute must be a constant class
 J9NLS_CFR_ERR_NEST_MEMBERS_NAME_NOT_CONSTANT_CLASS.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
@@ -1288,12 +1288,12 @@ J9NLS_CFR_ERR_NEST_MEMBERS_NAME_NOT_CONSTANT_CLASS.user_response=Contact the pro
 
 # END NON-TRANSLATABLE
 
-# Member of nest attribute is not a constant class 
-J9NLS_CFR_ERR_BAD_NEST_TOP_INDEX=Nest top must be a constant class
+# Nest host attribute is not a constant class 
+J9NLS_CFR_ERR_BAD_NEST_HOST_INDEX=Nest host must be a constant class
 # START NON-TRANSLATABLE
-J9NLS_CFR_ERR_BAD_NEST_TOP_INDEX.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
-J9NLS_CFR_ERR_BAD_NEST_TOP_INDEX.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
-J9NLS_CFR_ERR_BAD_NEST_TOP_INDEX.user_response=Contact the provider of the classfile for a corrected version.
+J9NLS_CFR_ERR_BAD_NEST_HOST_INDEX.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
+J9NLS_CFR_ERR_BAD_NEST_HOST_INDEX.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_BAD_NEST_HOST_INDEX.user_response=Contact the provider of the classfile for a corrected version.
 
 # END NON-TRANSLATABLE
 

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1705,35 +1705,35 @@ J9NLS_VM_ILLEGAL_ACCESS_NONSTATIC_FINAL.user_response=Modify source code to avoi
 
 # First argument is class name length
 # Second argument is class name
-# Third argument is nest top name length
-# Fourth argument is nest top name
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_CLASSLOADER=Class %2$.*1$s and its nest top %4$.*3$s must have the same classloader.
+# Third argument is nest host name length
+# Fourth argument is nest host name
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_CLASSLOADER=Class %2$.*1$s and its nest host %4$.*3$s must have the same classloader.
 # START NON-TRANSLATABLE
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_CLASSLOADER.explanation=Class and nest top class were loaded with different class loaders.
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_CLASSLOADER.system_action=The JVM will throw a java/lang/VerifyError
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_CLASSLOADER.user_response=Load class and nest top class with same classloader.
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_CLASSLOADER.explanation=Class and nest host class were loaded with different class loaders.
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_CLASSLOADER.system_action=The JVM will throw a java/lang/VerifyError
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_CLASSLOADER.user_response=Load class and nest host class with same classloader.
 # END NON-TRANSLATABLE
 
 # First argument is class name length
 # Second argument is class name
-# Third argument is nest top name length
-# Fourth argument is nest top name
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_PACKAGE=Class %2$.*1$s and its nest top %4$.*3$s must have the same package.
+# Third argument is nest host name length
+# Fourth argument is nest host name
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_PACKAGE=Class %2$.*1$s and its nest host %4$.*3$s must have the same package.
 # START NON-TRANSLATABLE
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_PACKAGE.explanation=Class and nest top class were loaded with different class loaders.
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_PACKAGE.system_action=The JVM will throw a java/lang/VerifyError
-J9NLS_VM_NEST_TOP_HAS_DIFFERENT_PACKAGE.user_response=Load class and nest top class with same classloader.
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_PACKAGE.explanation=Class and nest host class were loaded with different class loaders.
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_PACKAGE.system_action=The JVM will throw a java/lang/VerifyError
+J9NLS_VM_NEST_HOST_HAS_DIFFERENT_PACKAGE.user_response=Load class and nest host class with same classloader.
 # END NON-TRANSLATABLE
 
 # First argument is class name length
 # Second argument is class name
-# Third argument is nest top name length
-# Fourth argument is nest top name
-J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP=Class %2$.*1$s must be claimed by its nest top %4$.*1$s.
+# Third argument is nest host name length
+# Fourth argument is nest host name
+J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST=Class %2$.*1$s must be claimed by its nest host %4$.*1$s.
 # START NON-TRANSLATABLE
-J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP.explanation=Class was not claimed by its nest top class.
-J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP.system_action=The JVM will throw a java/lang/VerifyError
-J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP.user_response=Contact the provider of the classfile for a corrected version.
+J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST.explanation=Class was not claimed by its nest host class.
+J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST.system_action=The JVM will throw a java/lang/VerifyError
+J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
 
 # First argument is the library name

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -232,7 +232,7 @@ typedef struct J9CfrAttribute {
 #define CFR_ATTRIBUTE_RuntimeInvisibleTypeAnnotations  23
 #define CFR_ATTRIBUTE_MethodParameters 24
 #define CFR_ATTRIBUTE_NestMembers 25
-#define CFR_ATTRIBUTE_MemberOfNest 26
+#define CFR_ATTRIBUTE_NestHost 26
 #define CFR_ATTRIBUTE_StrippedLocalVariableTypeTable  122
 #define CFR_ATTRIBUTE_StrippedSourceDebugExtension  123
 #define CFR_ATTRIBUTE_StrippedInnerClasses  124
@@ -479,13 +479,13 @@ typedef struct J9CfrAttributeSynthetic {
 } J9CfrAttributeSynthetic;
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-typedef struct J9CfrAttributeMemberOfNest {
+typedef struct J9CfrAttributeNestHost {
 	U_8 tag;
 	U_16 nameIndex;
 	U_32 length;
 	UDATA romAddress;
 	U_16 hostClassIndex;
-} J9CfrAttributeMemberOfNest;
+} J9CfrAttributeNestHost;
 
 typedef struct J9CfrAttributeNestMembers {
 	U_8 tag;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2966,7 +2966,7 @@ typedef struct J9Class {
 	struct J9Class* derivedValueType;
 #endif /* defined(J9VM_OPT_VALHALLA_MVT) */
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	struct J9Class* memberOfNest;
+	struct J9Class* nestHost;
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 } J9Class;
 
@@ -3017,7 +3017,7 @@ typedef struct J9ArrayClass {
 	struct J9JITExceptionTable* jitMetaDataList;
 	struct J9Class* gcLink;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	struct J9Class* memberOfNest;
+	struct J9Class* nestHost;
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 } J9ArrayClass;
 
@@ -3110,7 +3110,7 @@ typedef struct J9ROMClass {
 	U_32 innerClassCount;
 	J9SRP innerClasses;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	J9SRP memberOfNest;
+	J9SRP nestHost;
 	U_16 nestMemberCount;
 	U_16 unused;
 	J9SRP nestMembers;
@@ -3153,7 +3153,7 @@ typedef struct J9ROMClass {
 #define J9ROMCLASS_OUTERCLASSNAME(base) SRP_GET((base)->outerClassName, struct J9UTF8*)
 #define J9ROMCLASS_INNERCLASSES(base) NNSRP_GET((base)->innerClasses, J9SRP*)
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-#define J9ROMCLASS_NESTTOPNAME(base) SRP_GET((base)->memberOfNest, struct J9UTF8*)
+#define J9ROMCLASS_NESTHOSTNAME(base) SRP_GET((base)->nestHost, struct J9UTF8*)
 #define J9ROMCLASS_NESTMEMBERS(base) SRP_GET((base)->nestMembers, J9SRP*)
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 #define J9ROMCLASS_OPTIONALINFO(base) SRP_GET((base)->optionalInfo, U_32*)
@@ -3187,7 +3187,7 @@ typedef struct J9ROMArrayClass {
 	U_32 innerClassCount;
 	J9SRP innerClasses;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	J9SRP memberOfNest;
+	J9SRP nestHost;
 	U_16 nestMemberCount;
 	U_16 unused;
 	J9SRP nestMembers;
@@ -3259,7 +3259,7 @@ typedef struct J9ROMReflectClass {
 	U_32 innerClassCount;
 	J9SRP innerClasses;
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	J9SRP memberOfNest;
+	J9SRP nestHost;
 	U_16 nestMemberCount;
 	U_16 unused;
 	J9SRP nestMembers;

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -181,7 +181,7 @@ IDATA j9bcutil_dumpRomClass( J9ROMClass *romClass, J9PortLibrary *portLib, J9Tra
 	}
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	/* dump the nest members or nest top, if defined */
+	/* dump the nest members or nest host, if defined */
 	dumpNest(portLib, romClass, flags);
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
@@ -827,7 +827,7 @@ dumpNest(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 	U_16 nestMemberCount = romClass->nestMemberCount;
-	J9UTF8 *nestTopName = J9ROMCLASS_NESTTOPNAME(romClass);
+	J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
 
 	if (0 != nestMemberCount) {
 		/* The class has a "nest members" attribute (non-zero nestMemberCount) */
@@ -840,9 +840,9 @@ dumpNest(J9PortLibrary *portLib, J9ROMClass *romClass, U_32 flags)
 		}
 	}
 
-	if (NULL != nestTopName) {
-		/* The class has a "member of nest" attribute (non-NULL nest top name) */
-		j9tty_printf(PORTLIB, "Nest top class: %.*s\n", J9UTF8_LENGTH(nestTopName), J9UTF8_DATA(nestTopName));
+	if (NULL != nestHostName) {
+		/* The class has a "member of nest" attribute (non-NULL nest host name) */
+		j9tty_printf(PORTLIB, "Nest host class: %.*s\n", J9UTF8_LENGTH(nestHostName), J9UTF8_DATA(nestHostName));
 	}
 	return BCT_ERR_NO_ERROR;
 }

--- a/runtime/util/romclasswalk.c
+++ b/runtime/util/romclasswalk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,7 +137,7 @@ void allSlotsInROMClassDo(J9ROMClass* romClass,
 	SLOT_CALLBACK(romClass, J9ROM_U32,  romClass, innerClassCount);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, innerClasses);
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, memberOfNest);
+	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, nestHost);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, nestMemberCount);
 	SLOT_CALLBACK(romClass, J9ROM_U16,  romClass, unused);
 	SLOT_CALLBACK(romClass, J9ROM_SRP,  romClass, nestMembers);

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ static char const *statusNames[] = {
 static j9object_t setInitStatus(J9VMThread *currentThread, J9Class *clazz, UDATA status, j9object_t initializationLock);
 static void classInitStateMachine(J9VMThread *currentThread, J9Class *clazz, J9ClassInitState desiredState);
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-static bool verifyNestTop(J9Class *clazz, J9VMThread *vmThread);
+static bool verifyNestHost(J9Class *clazz, J9VMThread *vmThread);
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
 void
@@ -176,7 +176,7 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 					goto done;
 				}
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-				if (false == verifyNestTop(clazz, currentThread)) {
+				if (false == verifyNestHost(clazz, currentThread)) {
 					goto done;
 				}
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
@@ -622,13 +622,13 @@ done:
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 static bool
-verifyNestTop(J9Class *clazz, J9VMThread *vmThread)
+verifyNestHost(J9Class *clazz, J9VMThread *vmThread)
 {
-	J9Class *nestTop = clazz->memberOfNest;
+	J9Class *nestHost = clazz->nestHost;
 	bool verified = false;
 
-	/* Verification only needed if class's nest top is not itself */
-	if (clazz == nestTop) {
+	/* Verification only needed if class's nest host is not itself */
+	if (clazz == nestHost) {
 		verified = true;
 	} else {
 		J9ROMClass *romClass = clazz->romClass;
@@ -636,19 +636,19 @@ verifyNestTop(J9Class *clazz, J9VMThread *vmThread)
 		U_32 moduleName = 0;
 		U_32 nlsNumber = 0;
 
-		/* Nest top must have same classloader & package */
-		if (clazz->classLoader != nestTop->classLoader) {
-			Trc_VM_CreateRAMClassFromROMClass_nestTopNotSameClassLoader(vmThread, nestTop, nestTop->classLoader, clazz->classLoader);
-			moduleName = J9NLS_VM_NEST_TOP_HAS_DIFFERENT_CLASSLOADER__MODULE;
-			nlsNumber = J9NLS_VM_NEST_TOP_HAS_DIFFERENT_CLASSLOADER__ID;
-		} else if (clazz->packageID != nestTop->packageID) {
-			Trc_VM_CreateRAMClassFromROMClass_nestTopNotSamePackage(vmThread, nestTop, nestTop->classLoader, clazz->classLoader);
-			moduleName = J9NLS_VM_NEST_TOP_HAS_DIFFERENT_PACKAGE__MODULE;
-			nlsNumber = J9NLS_VM_NEST_TOP_HAS_DIFFERENT_PACKAGE__ID;
+		/* Nest host must have same classloader & package */
+		if (clazz->classLoader != nestHost->classLoader) {
+			Trc_VM_CreateRAMClassFromROMClass_nestHostNotSameClassLoader(vmThread, nestHost, nestHost->classLoader, clazz->classLoader);
+			moduleName = J9NLS_VM_NEST_HOST_HAS_DIFFERENT_CLASSLOADER__MODULE;
+			nlsNumber = J9NLS_VM_NEST_HOST_HAS_DIFFERENT_CLASSLOADER__ID;
+		} else if (clazz->packageID != nestHost->packageID) {
+			Trc_VM_CreateRAMClassFromROMClass_nestHostNotSamePackage(vmThread, nestHost, nestHost->classLoader, clazz->classLoader);
+			moduleName = J9NLS_VM_NEST_HOST_HAS_DIFFERENT_PACKAGE__MODULE;
+			nlsNumber = J9NLS_VM_NEST_HOST_HAS_DIFFERENT_PACKAGE__ID;
 		} else {
-			/* The nest top must have a nestmembers attribute that includes this class. */
-			J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(nestTop->romClass);
-			U_16 nestMemberCount = nestTop->romClass->nestMemberCount;
+			/* The nest host must have a nestmembers attribute that includes this class. */
+			J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(nestHost->romClass);
+			U_16 nestMemberCount = nestHost->romClass->nestMemberCount;
 			for (U_16 i = 0; i < nestMemberCount; i++) {
 				J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
 				if (J9UTF8_EQUALS(className, nestMemberName)) {
@@ -657,19 +657,19 @@ verifyNestTop(J9Class *clazz, J9VMThread *vmThread)
 				}
 			}
 			if (!verified) {
-				Trc_VM_CreateRAMClassFromROMClass_nestTopNotVerified(vmThread, nestTop, nestTop->classLoader, clazz->classLoader, className);
-				moduleName = J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP__MODULE;
-				nlsNumber = J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_TOP__ID;
+				Trc_VM_CreateRAMClassFromROMClass_nestHostNotVerified(vmThread, nestHost, nestHost->classLoader, clazz->classLoader, className);
+				moduleName = J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST__MODULE;
+				nlsNumber = J9NLS_VM_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST__ID;
 			}
 		}
 
 		if (!verified) {
-			J9UTF8 *nestTopName = J9ROMCLASS_NESTTOPNAME(romClass);
+			J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
 			setCurrentExceptionNLSWithArgs(vmThread,
 					moduleName, nlsNumber,
 					J9VMCONSTANTPOOL_JAVALANGVERIFYERROR,
 					J9UTF8_LENGTH(className),J9UTF8_DATA(className),
-					J9UTF8_LENGTH(nestTopName), J9UTF8_DATA(className));
+					J9UTF8_LENGTH(nestHostName), J9UTF8_DATA(className));
 		}
 	}
 	return verified;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,7 +144,7 @@ static BOOLEAN verifyClassLoadingStack(J9VMThread *vmThread, J9ClassLoader *clas
 static void popFromClassLoadingStack(J9VMThread *vmThread);
 static VMINLINE BOOLEAN loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9ROMClass *romClass, J9Class *elementClass, UDATA packageID, BOOLEAN hotswapping, UDATA classPreloadFlags, J9Class **superclassOut);
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-static J9Class *loadNestTop(J9VMThread *vmThread, J9ClassLoader *classLoader, J9UTF8 *nestTopName, UDATA classPreloadFlags);
+static J9Class *loadNestHost(J9VMThread *vmThread, J9ClassLoader *classLoader, J9UTF8 *nestHostName, UDATA classPreloadFlags);
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 static J9Class* internalCreateRAMClassDropAndReturn(J9VMThread *vmThread, J9ROMClass *romClass, J9CreateRAMClassState *state);
 static J9Class* internalCreateRAMClassDoneNoMutex(J9VMThread *vmThread, J9ROMClass *romClass, UDATA options, J9CreateRAMClassState *state);
@@ -1606,11 +1606,11 @@ loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 static J9Class *
-loadNestTop(J9VMThread *vmThread, J9ClassLoader *classLoader, J9UTF8 *nestTopName, UDATA classPreloadFlags)
+loadNestHost(J9VMThread *vmThread, J9ClassLoader *classLoader, J9UTF8 *nestHostName, UDATA classPreloadFlags)
 {
-	J9Class *nestTop = internalFindClassUTF8(vmThread, J9UTF8_DATA(nestTopName), J9UTF8_LENGTH(nestTopName), classLoader, classPreloadFlags);
-	Trc_VM_CreateRAMClassFromROMClass_nestTopLoaded(vmThread, J9UTF8_LENGTH(nestTopName), J9UTF8_DATA(nestTopName), nestTop);
-	return nestTop;
+	J9Class *nestHost = internalFindClassUTF8(vmThread, J9UTF8_DATA(nestHostName), J9UTF8_LENGTH(nestHostName), classLoader, classPreloadFlags);
+	Trc_VM_CreateRAMClassFromROMClass_nestHostLoaded(vmThread, J9UTF8_LENGTH(nestHostName), J9UTF8_DATA(nestHostName), nestHost);
+	return nestHost;
 }
 #endif
 
@@ -2339,29 +2339,29 @@ fail:
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 			{
-				J9Class *nestTop = NULL;
-				J9UTF8 *nestTopName = J9ROMCLASS_NESTTOPNAME(romClass);
+				J9Class *nestHost = NULL;
+				J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
 
-				/* If no nest top is named, class is own nest top */
-				if (NULL == nestTopName) {
-					nestTop = ramClass;
+				/* If no nest host is named, class is own nest host */
+				if (NULL == nestHostName) {
+					nestHost = ramClass;
 				} else {
-					UDATA nestTopClassPreloadFlags = 0;
+					UDATA nestHostClassPreloadFlags = 0;
 					if (hotswapping) {
-						nestTopClassPreloadFlags = J9_FINDCLASS_FLAG_EXISTING_ONLY;
+						nestHostClassPreloadFlags = J9_FINDCLASS_FLAG_EXISTING_ONLY;
 					} else {
-						nestTopClassPreloadFlags = J9_FINDCLASS_FLAG_THROW_ON_FAIL;
+						nestHostClassPreloadFlags = J9_FINDCLASS_FLAG_THROW_ON_FAIL;
 						if (classLoader != javaVM->systemClassLoader) {
-							nestTopClassPreloadFlags |= J9_FINDCLASS_FLAG_CHECK_PKG_ACCESS;
+							nestHostClassPreloadFlags |= J9_FINDCLASS_FLAG_CHECK_PKG_ACCESS;
 						}
 					}
-					nestTop = loadNestTop(vmThread, hostClassLoader, nestTopName, nestTopClassPreloadFlags);
+					nestHost = loadNestHost(vmThread, hostClassLoader, nestHostName, nestHostClassPreloadFlags);
 				}
-				/* If nest top loading failed, an exception has been set; end loading early */
-				if (NULL == nestTop) {
+				/* If nest host loading failed, an exception has been set; end loading early */
+				if (NULL == nestHost) {
 					return internalCreateRAMClassDone(vmThread, classLoader, romClass, options, elementClass, className, state);
 				}
-				ramClass->memberOfNest = nestTop;
+				ramClass->nestHost = nestHost;
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2017 IBM Corp. and others
+// Copyright (c) 2006, 2018 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -755,10 +755,10 @@ TraceAssert=Assert_VM_Null noEnv Overhead=1 Level=1 Assert="(P1) == NULL"
 TraceEntry=Trc_VM_resolveStaticFieldRef_Entry Overhead=1 Level=3 Template="resolveStaticFieldRef(method=%p, ramCP=%p, cpIndex=%zu, flags=%zx, returnAddress=%p)"
 TraceEntry=Trc_VM_resolveInstanceFieldRef_Entry Overhead=1 Level=3 Template="resolveInstanceFieldRef(method=%p, ramCP=%p, cpIndex=%zu, flags=%zx, returnAddress=%p)"
 
-TraceEvent=Trc_VM_CreateRAMClassFromROMClass_nestTopLoaded Overhead=1 Level=3 Template="Loaded the nest top %.*s (RAM class=%p)"
-TraceException=Trc_VM_CreateRAMClassFromROMClass_nestTopNotSamePackage Overhead=1 Level=1 Template="The nest top class (RAM class=%p, class loader=%p, this class loader=%p) is not in the same package."
-TraceException=Trc_VM_CreateRAMClassFromROMClass_nestTopNotSameClassLoader Overhead=1 Level=1 Template="The nest top class (RAM class=%p, class loader=%p, this class loader=%p) has not been loaded by the same class loader."
-TraceException=Trc_VM_CreateRAMClassFromROMClass_nestTopNotVerified Overhead=1 Level=1 Template="The nest top (nest top class=%p, class loader=%p, this class loader=%p) does not claim the nest member (nest member=%p)."
+TraceEvent=Trc_VM_CreateRAMClassFromROMClass_nestHostLoaded Overhead=1 Level=3 Template="Loaded the nest host %.*s (RAM class=%p)"
+TraceException=Trc_VM_CreateRAMClassFromROMClass_nestHostNotSamePackage Overhead=1 Level=1 Template="The nest host class (RAM class=%p, class loader=%p, this class loader=%p) is not in the same package."
+TraceException=Trc_VM_CreateRAMClassFromROMClass_nestHostNotSameClassLoader Overhead=1 Level=1 Template="The nest host class (RAM class=%p, class loader=%p, this class loader=%p) has not been loaded by the same class loader."
+TraceException=Trc_VM_CreateRAMClassFromROMClass_nestHostNotVerified Overhead=1 Level=1 Template="The nest host (nest host class=%p, class loader=%p, this class loader=%p) does not claim the nest member (nest member=%p)."
 
 TraceEntry=Trc_VM_sendResolveMethodTypeRefInto_Entry Overhead=1 Level=5 Template="sendResolveMethodTypeRefInto ramCP=%p cpIndex=%zu resolveFlags=%zu"
 TraceException=Trc_VM_sendResolveMethodTypeRefInto_Exception Overhead=1 Level=1 Template="Sender class=%p cannot access receiver class=%p, errorCode=%zi."

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -102,7 +102,7 @@ checkVisibility(J9VMThread *currentThread, J9Class* sourceClass, J9Class* destCl
 			/* Private */
 			if ((sourceClass != destClass)
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-					&& (sourceClass->memberOfNest != destClass->memberOfNest)
+					&& (sourceClass->nestHost != destClass->nestHost)
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 			) {
 				result = J9_VISIBILITY_NON_MODULE_ACCESS_ERROR;

--- a/test/Valhalla/README.md
+++ b/test/Valhalla/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,4 +21,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 -->
 
 # Valhalla Test
-- Contains [tests](src/org/openj9/test/valhalla/) for nest mates attributes
+- Contains [tests](src/org/openj9/test/valhalla/) for nest host & nest members attributes

--- a/test/Valhalla/src/org/openj9/test/valhalla/ClassGenerator.java
+++ b/test/Valhalla/src/org/openj9/test/valhalla/ClassGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,7 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("FieldAccess$Inner");
+			NestHostAttribute attr = new NestHostAttribute("FieldAccess$Inner");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -117,7 +117,7 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{  /* Nestmates attribute(s) */
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("MethodAccess$Inner");
+			NestHostAttribute attr = new NestHostAttribute("MethodAccess$Inner");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -205,7 +205,7 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("MultipleNestMembers");
+			NestHostAttribute attr = new NestHostAttribute("MultipleNestMembers");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -235,7 +235,7 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("MultipleNestMembers");
+			NestHostAttribute attr = new NestHostAttribute("MultipleNestMembers");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -257,7 +257,7 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("MultipleNestMembers");
+			NestHostAttribute attr = new NestHostAttribute("MultipleNestMembers");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -291,10 +291,10 @@ public class ClassGenerator implements Opcodes {
 		return cw.toByteArray();
 	}
 
-	public static byte[] MultipleMemberOfNestAttributesdump () throws Exception {
+	public static byte[] MultipleNestHostAttributesdump () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleMemberOfNestAttributes", null, "java/lang/Object", null);
+		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestHostAttributes", null, "java/lang/Object", null);
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -312,11 +312,11 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("clazzname");
+			NestHostAttribute attr = new NestHostAttribute("clazzname");
 			cw.visitAttribute(attr);
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("clazzname");
+			NestHostAttribute attr = new NestHostAttribute("clazzname");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -342,7 +342,7 @@ public class ClassGenerator implements Opcodes {
 			cw.visitAttribute(attr);
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("clazzname");
+			NestHostAttribute attr = new NestHostAttribute("clazzname");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
@@ -395,7 +395,7 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			MemberOfNestAttribute attr = new MemberOfNestAttribute("TestClass");
+			NestHostAttribute attr = new NestHostAttribute("TestClass");
 			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();

--- a/test/Valhalla/src/org/openj9/test/valhalla/NestAttributeTest.java
+++ b/test/Valhalla/src/org/openj9/test/valhalla/NestAttributeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ public class NestAttributeTest {
 	
 	@Test(expectedExceptions = java.lang.ClassFormatError.class)
 	static public void testMultipleMemberOfNestAttributes() throws Exception {
-		byte[] bytes = ClassGenerator.MultipleMemberOfNestAttributesdump();
+		byte[] bytes = ClassGenerator.MultipleNestHostAttributesdump();
 		Class<?> clazz = classloader.getClass("MultipleMemberOfNestAttributes", bytes);
 		Object instance = clazz.getDeclaredConstructor().newInstance();
 	}

--- a/test/Valhalla/src/org/openj9/test/valhalla/NestHostAttribute.java
+++ b/test/Valhalla/src/org/openj9/test/valhalla/NestHostAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,16 +27,16 @@ import org.objectweb.asm.ByteVector;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 
-final class MemberOfNestAttribute extends Attribute {
-	private String nestTop;
+final class NestHostAttribute extends Attribute {
+	private String nestHost;
 
 	public Label[] getLabels(){
 		return null;
 	}
 	
-	public MemberOfNestAttribute(String nestTop){
-		super("MemberOfNest");
-		this.nestTop = nestTop;
+	public NestHostAttribute(String nestTop){
+		super("NestHost");
+		this.nestHost = nestHost;
 	}
 	
 	public boolean isCodeAttribute(){
@@ -51,7 +51,7 @@ final class MemberOfNestAttribute extends Attribute {
 			byte[] code, 	int len,
 			int maxStack, 	int maxLocals){
 
-		int topclass_index = cw.newClass(nestTop);		
+		int topclass_index = cw.newClass(nestHost);		
 		ByteVector b = new ByteVector();
 		b.putShort(topclass_index);
 		return b;


### PR DESCRIPTION
Drafted specification for 'JEP 181: Support Nestmate Access Control in
the JVM' used attribute name 'MemberOfNest.' Final specification uses
attribute name 'NestHost.' This commit brings parser & internal variable
names up to date.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>