### PR TITLE
Allow jlink module info extension to be undone

### DIFF
--- a/jcl/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
+++ b/jcl/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
@@ -20,3 +20,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package jdk.tools.jlink.internal.plugins;
+
+import jdk.tools.jlink.plugin.Plugin;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
+import java.util.function.Function;
+
+public class GenerateJLIClassesPlugin implements Plugin
+{
+   public ResourcePool transform( ResourcePool a, ResourcePoolBuilder b ){
+      Function<ResourcePoolEntry, ResourcePoolEntry> functhisnoise = (c) -> {
+         return c;
+      };
+      a.transformAndCopy(functhisnoise,b);
+      return b.build();
+   }
+}


### PR DESCRIPTION
In the Extensions for OpenJDK9 for OpenJ9, there is a change 
to the jlink module-info.java file which excludes the use of 
a Plugin that OpenJ9 doesn't support. 

Since undoing the module-info.java extension will require the 
existence of this class, I've implemented the only method in 
the Plugin abstract class that we need to implement, in a way 
that doesn't change anything (so the plugin is used, but should 
do nothing).

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>