### PR TITLE
Allow jlink module info extension to be undone

### DIFF
--- a/jcl/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
+++ b/jcl/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
@@ -20,3 +20,44 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package jdk.tools.jlink.internal.plugins;
+
+import jdk.tools.jlink.plugin.Plugin;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * We override the default GenerateJLIClassesPlugin with this
+ * one because the default relies on Hotspot-specific code.
+ * Removing this class entirely causes the build to fail when
+ * using the default module-info.java file for the jlink module.
+ * So we create the class, but include no code that affects any 
+ * change.
+ */
+public class GenerateJLIClassesPlugin implements Plugin
+{
+ /**
+   * This method makes a copy of the ResourcePool.
+   * Since this plugin is intended to have no effect,
+   * it lacks any transformational logic.
+   * @param rp            Pool of resources
+   * @param rpb           Builder to create a copy of the pool of resources.
+   * @return ResourcePool Built copy of the pool of resources.
+   */
+   public ResourcePool transform(ResourcePool rp, ResourcePoolBuilder rpb){
+      return null;
+   }
+   
+  /**
+   * This method tells the caller that this plugin is disabled,
+   * and should not be used.
+   * @return Set<State> State of the Plugin.
+   */
+   @Override
+   public Set<State> getState() {
+       return EnumSet.of(State.DISABLED, State.FUNCTIONAL);
+   }
+}
+


### PR DESCRIPTION
In the Extensions for OpenJDK9 for OpenJ9, there is a change 
to the jlink module-info.java file which excludes the use of 
a Plugin that OpenJ9 doesn't support. 

Since undoing the module-info.java extension will require the 
existence of this class, I've implemented the only method in 
the Plugin abstract class that we need to implement, in a way 
that doesn't change anything (so the plugin is used, but should 
do nothing).

Fixes #911

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>