### PR TITLE
Fix DecimalFormat when BigDecimal value is 0

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/jit/DecimalFormatHelper.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/DecimalFormatHelper.java
@@ -11,7 +11,7 @@ import java.lang.StringBuilder;
 import java.lang.String;
 import java.lang.RuntimeException;
 /*******************************************************************************
- * Copyright (c) 2011, 2011 IBM Corp. and others
+ * Copyright (c) 2011, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -454,7 +454,7 @@ public class DecimalFormatHelper {
 						// Determine whether or not there are any printable fractional
 						// digits.  If we've used up the digits we know there aren't.
 						boolean fractionPresent = (minFraDigits > 0) ||
-								(!isInteger && digitIndex < digitList.count);
+								(!isInteger && digitIndex < digitList.count && !digitList.isZero());
 
 						// If there is no fraction present, and we haven't printed any
 						// integer digits, then print a zero.  Otherwise we won't print
@@ -916,7 +916,7 @@ public class DecimalFormatHelper {
 						// Determine whether or not there are any printable fractional
 						// digits.  If we've used up the digits we know there aren't.
 						boolean fractionPresent = (minFraDigits > 0) ||
-								(!isInteger && digitIndex < digitList.count);
+								(!isInteger && digitIndex < digitList.count && !digitList.isZero());
 
 						// If there is no fraction present, and we haven't printed any
 						// integer digits, then print a zero.  Otherwise we won't print

--- a/test/JIT_Test/playlist.xml
+++ b/test/JIT_Test/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -218,6 +218,29 @@
 	NewInstanceTest,\
 	signExtensionATest,\
 	VPTypeTest \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<tags>
+			<tag>sanity</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>StringPeepholeTest</testCaseName>
+		<variations>
+			<variation>-XX:-EnableHCR -Xjit:count=0,optLevel=hot</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS)\
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	StringPeepholeTest \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>

--- a/test/JIT_Test/src/jit/test/tr/stringPeephole/BigDecimalToStringTest.java
+++ b/test/JIT_Test/src/jit/test/tr/stringPeephole/BigDecimalToStringTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package jit.test.tr.stringPeephole;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.text.DecimalFormat;
+
+@Test(groups = { "level.sanity","component.jit" })
+
+public class BigDecimalToStringTest{
+
+      private static Logger logger = Logger.getLogger(BigDecimalToStringTest.class);
+
+      @Test
+      public void testBigDecimal0ToString() {
+         NumberFormat format = new DecimalFormat("###,###,##0");
+         BigDecimal bigDecimalValue = new BigDecimal(new Double(0.000));
+         String s = bigDecimalToString(format, bigDecimalValue);
+         logger.debug("Converting BigDecimal with value 0 to string ...");
+         Assert.assertEquals(s, "0");
+      }
+
+      private String bigDecimalToString(NumberFormat format, BigDecimal bigDecimalValue){
+         String str = format.format(bigDecimalValue.doubleValue());
+         return str;
+      }
+   }

--- a/test/JIT_Test/testng.xml
+++ b/test/JIT_Test/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -427,6 +427,11 @@
   <test name="signExtensionATest">
     <classes>
       <class name="jit.test.tr.signExtensionA.SignExtElimTest" />
+    </classes>
+  </test>
+  <test name="StringPeepholeTest">
+    <classes>
+      <class name="jit.test.tr.stringPeephole.BigDecimalToStringTest" />
     </classes>
   </test>
   <test name="VPTypeTest">


### PR DESCRIPTION
The code deciding whether to print out the decimal separator
doesn't work with 0. This changeset fixes this problem so that
the result string won't contain a redundant decimal separator.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>