### PR TITLE
Resolve recursion in package access check.

### DIFF
--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -175,7 +175,7 @@ extern "C" {
 #define J9_PRIVATE_FLAGS_FINAL_CALL_OUT_OF_MEMORY 0x80000000
 
 #define J9_PRIVATE_FLAGS2_UNUSED_0x1 0x1
-#define J9_PRIVATE_FLAGS2_UNUSED_0x2 0x2
+#define J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS 0x2
 #define J9_PRIVATE_FLAGS2_UNSAFE_HANDLE_SIGBUS 0x4
 
 #define J9_PUBLIC_FLAGS_HALT_THREAD_EXCLUSIVE 0x1

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,7 +110,11 @@ packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t
 	if (NULL == security) {
 		legal = TRUE;
 	} else if (canRunJavaCode) {
-		sendCheckPackageAccess(currentThread, targetClass, protectionDomain, 0, 0);
+		if (J9_ARE_NO_BITS_SET(currentThread->privateFlags2, J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS)) {
+			currentThread->privateFlags2 |= J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS;
+			sendCheckPackageAccess(currentThread, targetClass, protectionDomain, 0, 0);
+			currentThread->privateFlags2 &= ~J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS;
+		}
 		if (J9_ARE_NO_BITS_SET(currentThread->publicFlags, J9_PUBLIC_FLAGS_POP_FRAMES_INTERRUPT) && (NULL == currentThread->currentException)) {
 			legal = TRUE;
 		}


### PR DESCRIPTION
If there is a customSecurityManager, we could do package access check
recursively, resulting in StackOverflowError:

Exception in thread "main" java.lang.StackOverflowError:
customSecurityManager.checkPackageAccess()
java/lang/J9VMInternals$2.run()
java/security/AccessController.doPrivileged()
java/lang/J9VMInternals.checkPackageAccess()
customSecurityManager.checkPackageAccess()
java/lang/J9VMInternals$2.run()
java/security/AccessController.doPrivileged()
java/lang/J9VMInternals.checkPackageAccess()
...

Do not call into sendCheckPackageAccess() again if we are already in
sendCheckPackageAccess()

Signed-off-by: hangshao <hangshao@ca.ibm.com>