### PR TITLE
Add stddef.h from musl and fix GCC commands

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -577,4 +577,26 @@ be misrepresented as being the original software.
 3. This notice may not be removed or altered from any source
 distribution.
 
+H. musl
+Copyright © 2005-2014 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 END OF TERMS AND CONDITIONS

--- a/longabout.html
+++ b/longabout.html
@@ -234,5 +234,30 @@ be misrepresented as being the original software.
 <p>
 3. This notice may not be removed or altered from any source
 distribution.
+<h4>
+musl 1.1.4
+</h4>
+c<p>
+Copyright © 2005-2014 Rich Felker, et al.
+</p><p>
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+</p><p>
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+</p><p>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</p>
 </body>
 </html>

--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -1,4 +1,4 @@
-# Copyright (c) 1998, 2017 IBM Corp. and others
+# Copyright (c) 1998, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -495,7 +495,7 @@ endif
 	-mv -f $*.asm $*.hold
 
 ifdef USE_MINGW
-MINGW_CXXFLAGS+=-mdll -mwin32 -mthreads -fno-rtti -fno-threadsafe-statics -fno-strict-aliasing -fno-exceptions -fno-use-linker-plugin
+MINGW_CXXFLAGS+=-mdll -mwin32 -mthreads -fno-rtti -fno-threadsafe-statics -fno-strict-aliasing -fno-exceptions -fno-use-linker-plugin -fno-asynchronous-unwind-tables
 ifdef VS12AndHigher
 MINGW_CXXFLAGS+=-std=c++0x -D_CRT_SUPPRESS_RESTRICT -DVS12AndHigher
 <#if uma.spec.processor.x86>

--- a/runtime/oti/mingw/about.html
+++ b/runtime/oti/mingw/about.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p><em>January 15, 2018</em></p>
+<h3>License</h3>
+
+<p>This program and the accompanying materials are made available under the terms of the
+Eclipse Public License 2 which accompanies this distribution and is available at
+<a href="https://eclipse.org/legal/epl-2.0">https://eclipse.org/legal/epl-2.0</a> or the
+Apache License, Version 2.0 which accompanies this distribution and is available at
+<a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>.</p>
+
+<p>This Source Code may also be made available under the following Secondary Licenses when
+the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are
+satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and
+GNU General Public License, version 2 with the OpenJDK Assembly Exception [2].</p>
+
+<p>
+[1] <a href="https://www.gnu.org/software/classpath/license.html">https://www.gnu.org/software/classpath/license.html</a><br>
+[2] <a href="http://openjdk.java.net/legal/assembly-exception.html">http://openjdk.java.net/legal/assembly-exception.html</a><br><br>
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is being redistributed by
+another party ("Redistributor") and different terms and conditions may apply to your use of any object code in
+the Content. Check the Redistributor's license that was provided with the Content. If no such license exists,
+contact the Redistributor. Unless otherwise indicated below, the terms and conditions of the EPL and Apache
+License 2.0 still apply to any source code in the Content and such source code may be obtained at
+<a href="https://www.eclipse.org/">https://www.eclipse.org</a>.</p>
+
+
+<h3>Third Party Content</h3>
+
+<p>The Content includes items that have been sourced from third parties as set out below. If you did not receive this
+Content directly from the Eclipse Foundation, the following is provided for informational purposes only, and you
+should look to the Redistributor's license for terms and conditions of use.</p>
+<p> 
+----------------------------------------------------------------------
+</p>
+<h3>musl 1.1.4</h3>
+
+<p>An MIT-licensed
+implementation of the standard C library targetting the Linux syscall
+API, obtained from  <a href="http://www.musl-libc.org/">http://www.musl-libc.org/</a>.
+<p>
+<p>The software included here is a subset of the original project 
+and the source file(s) is/are modified from the original version(s).
+</p>
+<p>
+<p>musl as a whole is licensed under the following standard MIT license:</p>
+<p>Copyright (c) 2005-2014 Rich Felker, et al.</p>
+<p>
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+</p>
+<p> 
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+</p>
+<p> 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</p>
+<p> 
+----------------------------------------------------------------------
+</p>
+<p> 
+Authors/contributors include:
+<ul>
+<li>Anthony G. Basile</li>
+<li>Arvid Picciani</li>
+<li>Bobby Bingham</li>
+<li>Boris Brezillon</li>
+<li>Brent Cook</li>
+<li>Chris Spiegel</li>
+<li>Cl&eacute;ment Vasseur</li>
+<li>Emil Renner Berthing</li>
+<li>Hiltjo Posthuma</li>
+<li>Isaac Dunham</li>
+<li>Jens Gustedt</li>
+<li>Jeremy Huntwork</li>
+<li>John Spencer</li>
+<li>Justin Cormack</li>
+<li>Luca Barbato</li>
+<li>Luka Perkov</li>
+<li>M Farkas-Dyck (Strake)</li>
+<li>Michael Forney</li>
+<li>Nicholas J. Kain</li>
+<li>orc</li>
+<li>Pascal Cuoq</li>
+<li>Pierre Carrier</li>
+<li>Rich Felker</li>
+<li>Richard Pennington</li>
+<li>sin</li>
+<li>Solar Designer</li>
+<li>Stefan Kristiansson</li>
+<li>Szabolcs Nagy</li>
+<li>Timo Ter&auml;s</li>
+<li>Valentin Ochs</li>
+<li>William Haddon</li>
+</ul>
+<p>Portions of this software are derived from third-party works licensed
+under terms compatible with the above MIT license:</p>
+<p> 
+(deleted terms related to files not included in this content).
+</p>
+<p> 
+All other files which have no copyright comments are original works
+produced specifically for use as part of this library, written either
+by Rich Felker, the main author of the library, or by one or more
+contibutors listed above. Details on authorship of individual files
+can be found in the git version control history of the project. The
+omission of copyright and license comments in each file is in the
+interest of source tree size.
+</p>
+<p> 
+All public header files (include/* and arch/*/bits/*) should be
+treated as Public Domain as they intentionally contain no content
+which can be covered by copyright. Some source modules may fall in
+this category as well. If you believe that a file is so trivial that
+it should be in the Public Domain, please contact the authors and
+request an explicit statement releasing it from copyright.
+</p>
+<p> 
+The following files are trivial, believed not to be copyrightable in
+the first place, and hereby explicitly released to the Public Domain:
+<ul>
+<li>All public headers: include/*, arch/*/bits/*</li>
+<li>Startup files: crt/*</li>
+</ul>
+</body></html>

--- a/runtime/oti/mingw/stddef.h
+++ b/runtime/oti/mingw/stddef.h
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ *
+ * This file is derived from the musl libc (http://www.musl-libc.org) version 1.1.4.
+ * Original file https://github.com/cloudius-systems/musl/blob/master/include/stddef.h
+ * The copyright (https://github.com/cloudius-systems/musl/blob/master/COPYRIGHT) states:
+ * 		All public header files (include/<star> and arch/<star>/bits/<star>) should be
+ *		treated as Public Domain as they intentionally contain no content
+ *		which can be covered by copyright. Some source modules may fall in
+ *		this category as well. If you believe that a file is so trivial that
+ *		it should be in the Public Domain, please contact the authors and
+ *		request an explicit statement releasing it from copyright.
+ *
+ *		The following files are trivial, believed not to be copyrightable in
+ *		the first place, and hereby explicitly released to the Public Domain:
+ *
+ *		All public headers: include/<star>, arch/<star>/bits/<star>
+ *		Startup files: crt/*
+ */
+
+#ifndef _STDDEF_H
+#define _STDDEF_H
+
+#if __GNUC__ > 3
+#define offsetof(type, member) __builtin_offsetof(type, member)
+#else
+#define offsetof(type, member) ((size_t)( (char *)&(((type *)0)->member) - (char *)0 ))
+#endif
+
+#endif


### PR DESCRIPTION
Use an open-source friendly copy of stddef.h.  Update GCC options so object
files are compatible with GCC linker.

Part of #727

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>