### PR TITLE
Suppress unguarded trace messages in compiler log

### DIFF
--- a/runtime/compiler/trj9/codegen/CodeGenGC.cpp
+++ b/runtime/compiler/trj9/codegen/CodeGenGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -470,7 +470,7 @@ J9::CodeGenerator::createStackAtlas()
    atlas->setInternalPointerMap(0);
    atlas->setNumberOfPendingPushSlots(numberOfPendingPushSlots);
    atlas->setNumberOfPaddingSlots(numberOfPaddingSlots);
-   traceMsg(comp, "numberOfSlots is %d, numberOfPaddingSlots is %d\n", numberOfSlots, numberOfPaddingSlots);
+   if (comp->getOption(TR_TraceCG)) traceMsg(comp, "numberOfSlots is %d, numberOfPaddingSlots is %d\n", numberOfSlots, numberOfPaddingSlots);
    self()->setStackAtlas(atlas);
 
    }

--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2081,7 +2081,10 @@ TR_J9ByteCodeIlGenerator::genUnary(TR::ILOpCodes unaryOp, bool isForArrayAccess)
    TR::Node *node = TR::Node::create(unaryOp, 1, pop());
    if(isForArrayAccess)
       {
-      traceMsg(comp(), "setting i2l node %p n%dn nonegative because it's for array access\n");
+      if (comp()->getOption(TR_TraceILGen))
+         {
+         traceMsg(comp(), "setting i2l node %p n%dn non-negative because it's for array access\n");
+         }
       node->setIsNonNegative(true);
       }
    push(node);
@@ -2172,9 +2175,9 @@ TR_J9ByteCodeIlGenerator::genTreeTop(TR::Node * n)
         }
 
       if ((comp()->getOption(TR_MimicInterpreterFrameShape) ||
-            comp()->getOption(TR_FullSpeedDebug) || 
+            comp()->getOption(TR_FullSpeedDebug) ||
             comp()->getHCRMode() == TR::osr ||
-            ((n->getNumChildren() > 0) && n->getFirstChild()->getOpCode().isCall() && !OSRTooExpensive && comp()->getOption(TR_EnableOSR))) 
+            ((n->getNumChildren() > 0) && n->getFirstChild()->getOpCode().isCall() && !OSRTooExpensive && comp()->getOption(TR_EnableOSR)))
             && !comp()->isPeekingMethod())
          {
          if (comp()->isOSRTransitionTarget(TR::postExecutionOSR))
@@ -2583,7 +2586,7 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
 
    if (comp()->isPeekingMethod()
        || !comp()->getOption(TR_EnableOSR)
-       || _cannotAttemptOSR 
+       || _cannotAttemptOSR
        || !comp()->isOSRTransitionTarget(TR::postExecutionOSR))
       return;
 
@@ -2625,7 +2628,7 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
 
    TR::MethodSymbol *symbol = symRef->getSymbol()->castToMethodSymbol();
    int32_t numArgs = symbol->getMethod()->numberOfExplicitParameters() + (symbol->isStatic() ? 0 : 1);
-   
+
    TR_OSRMethodData *osrMethodData =
       comp()->getOSRCompilationData()->findOrCreateOSRMethodData(comp()->getCurrentInlinedSiteIndex(), _methodSymbol);
    osrMethodData->ensureArgInfoAt(_bcIndex, numArgs);
@@ -2637,13 +2640,13 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
    for (int32_t i = 0; i < _stack->size(); ++i)
       {
       TR::Node * n = _stack->element(i);
-      if (_stack->size() - numArgs <= i) 
+      if (_stack->size() - numArgs <= i)
          {
          TR::SymbolReference * symRef = symRefTab()->findOrCreatePendingPushTemporary(_methodSymbol, slot, getDataType(n));
          osrMethodData->addArgInfo(_bcIndex, arg, symRef->getReferenceNumber());
          arg++;
          }
-      slot += n->getNumberOfSlots(); 
+      slot += n->getNumberOfSlots();
       }
    }
 
@@ -4296,7 +4299,7 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
       }
 
 #if !defined(TR_HOST_ARM)
-   
+
    if (comp()->supportsQuadOptimization())
       {
       // Under DLT, the Quad opts don't work because the interpreted Quad
@@ -6863,7 +6866,7 @@ TR_J9ByteCodeIlGenerator::genNew(TR::ILOpCodes opCode)
           ((len == 68) && strncmp(sig, "Ljava/util/concurrent/locks/ReentrantReadWriteLock$Sync$HoldCounter;", 68) == 0) ||
           ((len == 25) && strncmp(sig, "Ljava/util/PriorityQueue;", 25) == 0) ||
           ((len == 42) && strncmp(sig, "Ljava/util/concurrent/locks/ReentrantLock;", 42) == 0) ||
-          ((len == 54) && strncmp(sig, "Ljava/util/concurrent/locks/ReentrantLock$NonfairSync;", 54) == 0) 
+          ((len == 54) && strncmp(sig, "Ljava/util/concurrent/locks/ReentrantLock$NonfairSync;", 54) == 0)
          )
          {
          skipFlush = true;
@@ -7062,7 +7065,7 @@ TR_J9ByteCodeIlGenerator::genReturn(TR::ILOpCodes nodeop, bool monitorExit)
    static const char* disableMethodHookForCallees = feGetEnv("TR_DisableMethodHookForCallees");
    if ((fej9()->isMethodExitTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
         TR::Compiler->vm.canMethodExitEventBeHooked(comp()))
-         && (isOutermostMethod() || !disableMethodHookForCallees)) 
+         && (isOutermostMethod() || !disableMethodHookForCallees))
       {
       TR::SymbolReference * methodExitSymRef = symRefTab()->findOrCreateReportMethodExitSymbolRef(_methodSymbol);
 

--- a/runtime/compiler/trj9/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/trj9/optimizer/EscapeAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1323,7 +1323,7 @@ void TR_EscapeAnalysis::findCandidates()
          //
          _dememoizationSymRef = node->getSymbolReference();
 
-         traceMsg(comp(), "Attempt dememoize on %p\n", node);
+         if (trace()) traceMsg(comp(), "Attempt dememoize on %p\n", node);
          TR_OpaqueMethodBlock *constructor = comp()->getOption(TR_DisableDememoization)? NULL : comp()->fej9()->getMethodFromName("java/lang/Integer", "<init>", "(I)V");
          if (  constructor
             && performTransformation(comp(), "%sTry dememoizing %p\n", OPT_DETAILS, node))
@@ -5911,14 +5911,14 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
       // the collectable slots (in addition to their initialization at method entry)
       //
       initTree = candidate->_treeTop;
-      
+
       if (candidate->_kind == TR::newarray)
          {
-         // TODO (Task 118458): We need to investigate the effect of using arrayset on small number of elements. This involves verifying the instruction 
+         // TODO (Task 118458): We need to investigate the effect of using arrayset on small number of elements. This involves verifying the instruction
          // sequences each induvidual codegen will generate and only if the codegens can handle arraysets of small number of elements in a performant manner
          // can we enable this optimization.
          const bool enableNewArrayArraySetPendingInvestigation = false;
-         
+
          // Non-collectable slots should be initialized with arrayset since they do not have field symrefs
          if (enableNewArrayArraySetPendingInvestigation && tryToZeroInitializeUsingArrayset(candidate, initTree))
             {
@@ -5927,7 +5927,7 @@ void TR_EscapeAnalysis::makeContiguousLocalAllocation(Candidate *candidate)
             return;
             }
          }
-      
+
       int32_t headerSize = (candidate->_kind == TR::New) ?
          comp()->fej9()->getObjectHeaderSizeInBytes() :
          TR::Compiler->om.contiguousArrayHeaderSizeInBytes();

--- a/runtime/compiler/trj9/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/trj9/optimizer/IdiomRecognition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3220,7 +3220,7 @@ int32_t TR_CISCTransformer::perform()
          graph = makeCISCGraph(&bblistPred, &bblistBody, &bblistSucc);
          if (!graph)
             {
-            traceMsg(comp(), "Loop %d.  Failed to make CISC Graph.\n", nextLoop->getNumber());
+            if (trace()) traceMsg(comp(), "Loop %d.  Failed to make CISC Graph.\n", nextLoop->getNumber());
             restoreBitsKeepAliveCalls();
             continue;
             }

--- a/runtime/compiler/trj9/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/trj9/optimizer/IdiomTransformations.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -520,7 +520,7 @@ reorderTargetNodesInBB(TR_CISCTransformer *trans)
                   {
                   T->duplicateListsDuplicator();
                   // OK, we can move the node t!
-                  traceMsg(comp,"We can move the node %d to %p(%d)\n",tID,tgt,tgt->getID());
+                  if (disptrace) traceMsg(comp,"We can move the node %d to %p(%d)\n",tID,tgt,tgt->getID());
                   anyChanged = changed = true;
 
                   trans->moveCISCNodes(t, t, tgt, "reorderTargetNodesInBB");

--- a/runtime/compiler/trj9/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/trj9/optimizer/J9TransformUtil.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -402,7 +402,7 @@ static bool foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32
       return true; // We can ONLY do this opt to fields that are never victimized by setAccessible
    else if (classNameLength >= 30 && !strncmp(className, "java/lang/String$UnsafeHelpers", 30))
       return true;
-   
+
    // Fold static final fields in java/lang/String* for string compression flag
    else if (classNameLength >= 16 && !strncmp(className, "java/lang/String", 16))
       return true;
@@ -1002,7 +1002,7 @@ J9::TransformUtil::transformDirectLoad(TR::Compilation *comp, TR::Node *node)
             TR_ASSERT(node->getDataType() == TR::Int32, "Java_lang_String_enableCompression must be Int32");
             bool fieldValue = *(int32_t*)sym->castToStaticSymbol()->getStaticAddress() != 0;
             bool compressionEnabled = IS_STRING_COMPRESSION_ENABLED_VM(static_cast<TR_J9VMBase *>(comp->fe())->getJ9JITConfig()->javaVM);
-            TR_ASSERT((fieldValue && compressionEnabled) || (!fieldValue && !compressionEnabled), 
+            TR_ASSERT((fieldValue && compressionEnabled) || (!fieldValue && !compressionEnabled),
                "java/lang/String.enableCompression and javaVM->strCompEnabled must be in sync");
             if (fieldValue)
                aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_StringCompressionEnabled;
@@ -1267,7 +1267,10 @@ J9::TransformUtil::transformIndirectLoadChainImpl(TR::Compilation *comp, TR::Nod
 
    if (!fej9->canDereferenceAtCompileTime(symRef, comp))
       {
-      traceMsg(comp, "Abort transformIndirectLoadChain - cannot dereference at compile time!\n");
+      if (comp->getOption(TR_TraceOptDetails))
+         {
+         traceMsg(comp, "Abort transformIndirectLoadChain - cannot dereference at compile time!\n");
+         }
       return false;
       }
 
@@ -1275,7 +1278,10 @@ J9::TransformUtil::transformIndirectLoadChainImpl(TR::Compilation *comp, TR::Nod
    void *fieldAddress = dereferenceStructPointerChain(baseAddress, baseExpression, node, comp);
    if (!fieldAddress)
       {
-      traceMsg(comp, "Abort transformIndirectLoadChain - cannot verify/dereference field access to %s in %p!\n", symRef->getName(comp->getDebug()), baseAddress);
+      if (comp->getOption(TR_TraceOptDetails))
+         {
+         traceMsg(comp, "Abort transformIndirectLoadChain - cannot verify/dereference field access to %s in %p!\n", symRef->getName(comp->getDebug()), baseAddress);
+         }
       return false;
       }
 

--- a/runtime/compiler/trj9/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/trj9/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1492,7 +1492,10 @@ void TR::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, 
       generateLabelInstruction(LABEL, site.getCallNode(), entryLabel, cg());
 
    TR::SymbolReference *methodSymRef = site.getSymbolReference();
-   traceMsg(comp(), "buildVirtualOrComputedCall(%p), isComputed=%d\n", site.getCallNode(), methodSymRef->getSymbol()->castToMethodSymbol()->isComputed());
+   if (comp()->getOption(TR_TraceCG))
+      {
+      traceMsg(comp(), "buildVirtualOrComputedCall(%p), isComputed=%d\n", site.getCallNode(), methodSymRef->getSymbol()->castToMethodSymbol()->isComputed());
+      }
    bool evaluateVftEarly = methodSymRef->isUnresolved() || fej9->forceUnresolvedDispatch();
 
    if (methodSymRef->getSymbol()->castToMethodSymbol()->isComputed())

--- a/runtime/compiler/trj9/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/x/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3353,7 +3353,11 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGe
    if (node->hasFoldedImplicitNULLCHK())
       {
       TR::Instruction *faultingInstruction = cg->getImplicitExceptionPoint();
-      traceMsg(comp,"Node %p has foldedimplicitNULLCHK, and a faulting instruction of %p\n",node,faultingInstruction);
+      if (comp->getOption(TR_TraceCG))
+         {
+         traceMsg(comp,"Node %p has foldedimplicitNULLCHK, and a faulting instruction of %p\n",node,faultingInstruction);
+         }
+
       if (faultingInstruction)
          {
          faultingInstruction->setNeedsGCMap(0xFF00FFFF);
@@ -15869,7 +15873,7 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
 
    // Call was not inlined.  Delegate to the parent directCallEvaluator.
    //
-   return J9::TreeEvaluator::directCallEvaluator(node, cg); 
+   return J9::TreeEvaluator::directCallEvaluator(node, cg);
    }
 
 

--- a/runtime/compiler/trj9/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/trj9/x/codegen/X86PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1338,7 +1338,10 @@ void TR::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    if (cg()->getStackFramePaddingSizeInBytes())
       {
       deallocateSize += cg()->getStackFramePaddingSizeInBytes();
-      traceMsg(comp(), "Bytes of stack frame padding to be dealloated %d\n", cg()->getStackFramePaddingSizeInBytes());
+      if (comp()->getOption(TR_TraceCG))
+         {
+         traceMsg(comp(), "Bytes of stack frame padding to be deallocated %d\n", cg()->getStackFramePaddingSizeInBytes());
+         }
       }
 
    if (deallocateSize)


### PR DESCRIPTION
Place appropriate guards around trace messages to prevent unwanted
messages in the compiler log file.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>