### PR TITLE
Handle IllegalStateException thrown by addShutdownHook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,3 +35,6 @@ com.ibm.jvmti.tests
 
 # Visual Studio
 /.vs
+
+# Default test directory (BUILD_ROOT)
+/jvmtest/

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,9 +30,11 @@ autoGenTest.mk
 TestConfig/jvmTest.mk
 TestConfig/specToPlat.mk
 TestConfig/*.log
+TestConfig/*.tap
+TestConfig/machineConfigure.mk
 TestConfig/tempTestTargetResult
 TestConfig/failedtargets.mk
 .DS_Store
 
-# misc downloaded dependent files
-TestConfig/lib/*.jar
+# directory for misc downloaded dependent files
+TestConfig/lib

--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1531,6 +1531,24 @@
 	$(TEST_STATUS)</command>
 		<tags>
 			<tag>sanity</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>memoryMXBeanShutdownTest</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+			-testnames memoryMXBeanShutdownTest \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)</command>
+		<tags>
+			<tag>extended</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>

--- a/test/Java8andUp/src/org/openj9/test/java/lang/management/MemoryMXBeanShutdownNotification.java
+++ b/test/Java8andUp/src/org/openj9/test/java/lang/management/MemoryMXBeanShutdownNotification.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java.lang.management;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/**
+ * MemoryMXBean is a NotificationEmitter; in OpenJ9 a separate thread sends
+ * those notifications and another thread is used as a shutdown hook to signal
+ * the first thread to terminate. If MemoryMXBean is first used after the VM
+ * has started to shutdown, attempting to register a shutdown hook throws
+ * an IllegalStateException which was not being caught (see [1]). This test
+ * verifies that that IllegalStateException is now caught and the VM shuts
+ * down properly.
+ *
+ * [1] https://github.com/eclipse/openj9/issues/932
+ */
+@Test(groups = { "level.extended" })
+public final class MemoryMXBeanShutdownNotification {
+
+	private static final Logger logger = Logger.getLogger(MemoryMXBeanShutdownNotification.class);
+
+	private static void hookAction() {
+		logger.info("The hook thread is running.");
+
+		try {
+			MemoryMXBean bean = ManagementFactory.getMemoryMXBean();
+
+			logger.info("Bean successfully initialized " + bean.getObjectPendingFinalizationCount());
+		} catch (Exception e) {
+			unexpected(e);
+		}
+	}
+
+	@Test
+	public void testNoExceptions() {
+		// Add a shutdown hook that will be the first use of the MemoryMXBean.
+		Runtime.getRuntime().addShutdownHook(new Thread(MemoryMXBeanShutdownNotification::hookAction));
+
+		// Wait a second, then let shutdown happen naturally.
+		try {
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+			unexpected(e);
+		}
+	}
+
+	private static void unexpected(Exception e) {
+		e.printStackTrace();
+		Assert.fail("Unexpected exception: " + e.getLocalizedMessage(), e);
+	}
+
+}

--- a/test/Java8andUp/testng.xml
+++ b/test/Java8andUp/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,6 +220,11 @@
 		<classes>
 			<class name="org.openj9.test.vmArguments.VmArgumentTests">
 			</class>
+		</classes>
+	</test>
+	<test name="memoryMXBeanShutdownTest">
+		<classes>
+			<class name="org.openj9.test.java.lang.management.MemoryMXBeanShutdownNotification" />
 		</classes>
 	</test>
 	<test name="threadMXBeanTestSuite1">

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2017 IBM Corp. and others
+Copyright (c) 2016, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,13 +23,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 # How-to Run Tests
 Prerequisites:
 
-  * perl 5.10.1 or above with JSON and Text::CSV module installed
-  * make 3.81 or above (recommend make 4.1 or above on windows)
-  * wget 1.14 or above
   * ant 1.7.1 or above with ant-contrib.jar
+  * make 3.81 or above (recommend make 4.1 or above on windows)
+  * perl 5.10.1 or above with JSON and Text::CSV module installed
+  * wget 1.14 or above
 
 Let's create the following scenario:
-For the purpose of this example, we assume you have an OpenJ9 SDK ready for testing. Below are the specific commands you'd run to compile and run tests. Details are explained in *Tasks in OpenJ9 Test* section below.
+For the purpose of this example, we assume you have an OpenJ9 SDK ready
+for testing. Below are the specific commands you'd run to compile and
+run tests. Details are explained in *Tasks in OpenJ9 Test* section below.
 
 ```
 cd openj9/test/TestConfig
@@ -42,143 +44,241 @@ make test
 # Tasks in OpenJ9 Test
 
 1. Configure environment:
-* required environment variables
 
-```
-JAVA_BIN=<path to JDK bin directory that you wish to test>
-SPEC=[linux_x86-64|linux_x86-64_cmprssptrs|...] platform_on_which_to_test
-JAVA_VERSION=[SE80|SE90] (SE90 default value)
-```
+  * required environment variables
+    ```
+    JAVA_BIN=<path to JDK bin directory that you wish to test>
+    SPEC=[linux_x86-64|linux_x86-64_cmprssptrs|...] platform_on_which_to_test
+    JAVA_VERSION=[SE80|SE90] (SE90 default value)
+    ```
+
   * list of dependent jars
 
-	* asm-all-6.0_BETA.jar
-	* commons-cli-1.2.jar
-	* commons-exec-1.1.jar
-	* javassist-3.20.0-GA.jar
-	* junit-4.10.jar
-	* testng-6.10.jar
-	* jcommander-1.48.jar
-	* asmtools-6.0.jar
+    * asm-all-6.0_BETA.jar
+    * asmtools-6.0.jar
+    * commons-cli-1.2.jar
+    * commons-exec-1.1.jar
+    * javassist-3.20.0-GA.jar
+    * jcommander-1.48.jar
+    * junit-4.10.jar
+    * testng-6.10.jar
 
-	To get the above dependent jars, please run `make getdependency` . getdependency target will get called when running make compile or test target.
+    To get the above dependent jars, please run `make getdependency`.
+    getdependency target will get called when running make compile
+    or test target.
 
 2. Compile tests:
+
   * compile and run all tests
+    ```
+    make test
+    ```
 
-            make test
   * only compile but do not run tests
-
-            export BUILD_LIST=comma_separated_projects_to_be_compiled (defaults to all projects)
-            make compile
+    ```
+    export BUILD_LIST=comma_separated_projects_to_be_compiled (defaults to all projects)
+    make compile
+    ```
 
 3. Add more tests:
+
   * for Java8/Java9 functionality
 
-	- If you have added new features to OpenJ9, you will likely need to add new tests. Check out openj9/test/TestExample for the format to use.
+    - If you have added new features to OpenJ9, you will likely
+    need to add new tests. Check out openj9/test/TestExample for
+    the format to use.
 
-	- If you have many new test cases to add, then you may want to copy the TestExample project, change the name,replace the test examples with your own code, update the build.xml and playlist.xml files to match your new Test class names.
+    - If you have many new test cases to add, then you may want to
+    copy the TestExample project, change the name,replace the test
+    examples with your own code, update the build.xml and playlist.xml
+    files to match your new Test class names.
 
-	- Most OpenJ9 FV tests are written with TestNG.  We leverage TestNG groups to create test make targets. This means that minimally your test source code should belong to either level.sanity or level.extended group to be included in main OpenJ9 builds.
+    - Most OpenJ9 FV tests are written with TestNG.  We leverage
+    TestNG groups to create test make targets. This means that
+    minimally your test source code should belong to either
+    level.sanity or level.extended group to be included in main
+    OpenJ9 builds.
 
 4. Run tests:
+
   * all tests
+    ```
+    make test (to compile & run)
+    make runtest (to run all tests without recompiling them)
+    ```
 
-            make test (to compile & run)
-            make runtest (to run all tests without recompiling them)
   * sanity tests
+    ```
+    make sanity
+    ```
 
-            make sanity
   * extended tests
+    ```
+    make extended
+    ```
 
-            make extended
   * external tests
+    ```
+    make external
+    ```
 
-            make external
   * perf tests
+    ```
+    make perf
+    ```
 
-            make perf
   * openjdk tests
+    ```
+    make openjdk
+    ```
 
-            make openjdk
   * a specific individual test
+    ```
+    make _generalExtendedTest_0
+    ```
 
-            make _generalExtendedTest_0
   * a directory of tests
+    ```
+    make test_NameOfTestDir (for example: make test_Jsr292 or make test_cmdLineTests.verbosetest, with nested directories separated by '.')
+    ```
 
-            make test_NameOfTestDir  (for example: make test_Jsr292 or make test_cmdLineTests.verbosetest, where nested directories separated by '.')
   * component specific tests (WIP)
+
   * against an IBM Java8 SDK
 
-	Same general instructions for Configure environment, and make test, but export JAVA_VERSION=SE80 explicitly before run_configure.mk step.
+    Same general instructions for Configure environment, and
+    make test, but export JAVA_VERSION=SE80 explicitly before
+    run_configure.mk step.
+
   * against an OpenJ9 Java 9 SDK
 
-	No special steps to accomplish this, as JAVA_VERSION=SE90 by default, so simply need to Configure environment and run make test.
+    No special steps to accomplish this, as JAVA_VERSION=SE90
+    by default, so simply need to Configure environment and run
+    make test.
+
   * against a Java8 or Java9 OpenJDK/Oracle JDK (WIP)
 
-	We are annotating the OpenJ9 specific tests, so that they will be excluded from compilation and execution against an implementation that they are not intended to test.
-  * rerun the failed tests from the last run
+    We are annotating the OpenJ9 specific tests, so that they will be
+    excluded from compilation and execution against an implementation
+    that they are not intended to test.
 
-            make failed
+  * rerun the failed tests from the last run
+    ```
+    make failed
+    ```
+
   * with a different set of JVM options
 
-	There are 3 ways to add options to your test run:
+    There are 3 ways to add options to your test run:
 
-	- If you simply want to add an option for a one-time run, you can either override the original options by using JVM_OPTIONS="your options".
-	- If you want to append options to the set that are already there, use EXTRA_OPTIONS="your extra options". Below example will append to those options already in the make target.
+    - If you simply want to add an option for a one-time run, you can
+    either override the original options by using JVM_OPTIONS="your options".
 
-            make _jsr292_InDynTest_SE90_0 EXTRA_OPTIONS=-Xint
-	- If you want to change test options, you can update playlist.xml in the corresponding test project.
+    - If you want to append options to the set that are already there,
+    use EXTRA_OPTIONS="your extra options". Below example will append
+    to those options already in the make target.
+    ```
+    make _jsr292_InDynTest_SE90_0 EXTRA_OPTIONS=-Xint
+    ```
+
+    - If you want to change test options, you can update playlist.xml
+    in the corresponding test project.
+
 5. Exclude tests:
+
   * temporarily on all platforms
 
-    Depends on the JAVA_VERSION, add a line in the test/TestConfig/resources/excludes/latest_exclude_$(JAVA_VERSION).txt file. It is the same format that the OpenJDK tests use, name of test, defect number, platforms to exclude.
+    Depends on the JAVA_VERSION, add a line in the
+    test/TestConfig/resources/excludes/latest_exclude_$(JAVA_VERSION).txt
+    file. It is the same format that the OpenJDK tests use, name of test,
+    defect number, platforms to exclude.
 
     To exclude on all platforms, use generic-all.  For example:
+    ```
+    org.openj9.test.java.lang.management.TestOperatingSystemMXBean:testGetProcessCPULoad 121187 generic-all
+    ```
 
-```
-org.openj9.test.java.lang.management.TestOperatingSystemMXBean:testGetProcessCPULoad 121187 generic-all
-```
+Note that we additionally added support to exclude individual methods of a
+test class, by using :methodName behind the class name (OpenJDK does not
+support this currently). In the example, only the testGetProcessCPULoad
+method from that class will be excluded (on all platforms/specs).
 
-Note that we additionally added support to exclude individual methods of a test class, by using :methodName behind the class name (OpenJDK does not support this currently). In the example, only the testGetProcessCPULoad method from that class will be excluded (on all platforms/specs).
   * temporarily on specific platforms or architectures
 
-    Same as excluding on all platforms, you add a line to latest_exclude_$(JAVA_VERSION).txt file, but with specific specs to exclude, for example:
-```
-org.openj9.test.java.lang.management.TestOperatingSystemMXBean 121187 linux_x86-64
-```
-This example would exclude all test methods of the TestOperatingSystemMXBean from running on the linux_x86-64 platform.
-Note: in OpenJ9 the defect numbers would associate with git issue numbers (OpenJDK defect numbers associate with their bug tracking system).
+    Same as excluding on all platforms, you add a line to
+    latest_exclude_$(JAVA_VERSION).txt file, but with specific specs to
+    exclude, for example:
+    ```
+    org.openj9.test.java.lang.management.TestOperatingSystemMXBean 121187 linux_x86-64
+    ```
+
+This example would exclude all test methods of the TestOperatingSystemMXBean
+from running on the linux_x86-64 platform.
+Note: in OpenJ9 the defect numbers would associate with git issue numbers
+(OpenJDK defect numbers associate with their bug tracking system).
+
   * permanently on all or specific platforms/archs
 
-    For tests that should NEVER run on particular platforms or architectures, we should not use the default_exclude.txt file. To disable those tests, we annotate the test class to be disabled. To exclude MyTest from running on the aix platform, for example:
-```
-@Test(groups={ "level.sanity", "component.jit", "disabled.os.aix" })
-	public class MyTest {
-	...
-```
+    For tests that should NEVER run on particular platforms or
+    architectures, we should not use the default_exclude.txt file. To
+    disable those tests, we annotate the test class to be disabled. To
+    exclude MyTest from running on the aix platform, for example:
+    ```
+    @Test(groups={ "level.sanity", "component.jit", "disabled.os.aix" })
+        public class MyTest {
+        ...
+    ```
+
 We currently support the following exclusion groups:
 ```
-disabled.os.<os> (i.e. disabled.os.aix)
-disabled.arch.<arch> (i.e. disabled.arch.ppc)
-disabled.bits.<bits> (i.e. disabled.bits.64)
-disabled.spec.<spec> (i.e. disabled.spec.linux_x86-64)
+disabled.os.<os> (e.g. disabled.os.aix)
+disabled.arch.<arch> (e.g. disabled.arch.ppc)
+disabled.bits.<bits> (e.g. disabled.bits.64)
+disabled.spec.<spec> (e.g. disabled.spec.linux_x86-64)
 ```
+
 6. View results:
+
   * in the console
 
     OpenJ9 tests take advantage of the testNG logger.
-    If you want your test to print output, you are required to use the testng logger (and not System.out.print statements). In this way, we can not only direct that output to console, but also to various other clients (WIP).  At the end of a test run, the results are summarized to show which tests passed / failed / skipped.  This gives you a quick view of the test names and numbers in each category (passed/failed/skipped).  If you've piped the output to a file, or if you like scrolling up, you can search for and find the specific output of the tests that failed (exceptions or any other logging that the test produces).
+    If you want your test to print output, you are required to use the
+    testng logger (and not System.out.print statements). In this way,
+    we can not only direct that output to console, but also to various
+    other clients (WIP).  At the end of a test run, the results are
+    summarized to show which tests passed / failed / skipped.  This gives
+    you a quick view of the test names and numbers in each category
+    (passed/failed/skipped).  If you've piped the output to a file, or
+    if you like scrolling up, you can search for and find the specific
+    output of the tests that failed (exceptions or any other logging
+    that the test produces).
+
   * in html files
 
-    Html (and xml) output from the tests are created and stored in a test_output_xxxtimestamp folder in the TestConfig directory (or from where you ran "make test").  The output is organized by tests, each test having its own set of output.  If you open the index.html file in a web browser, you will be able to see which tests passed, failed or were skipped, along with other information like execution time and error messages, exceptions and logs from the individual test methods.
+    Html (and xml) output from the tests are created and stored in a
+    test_output_xxxtimestamp folder in the TestConfig directory (or from
+    where you ran "make test").  The output is organized by tests, each
+    test having its own set of output.  If you open the index.html file
+    in a web browser, you will be able to see which tests passed, failed
+    or were skipped, along with other information like execution time and
+    error messages, exceptions and logs from the individual test methods.
+
   * in the cloud (WIP)
+
 7. Attach a debugger:
+
   * to a particular test
 
-    The command line that is run for each particular test is echo-ed to the console, so you can easily copy the command that is run.
-    You can then run the command directly (which is a direct call to the java executable, adding any additional options, including those to attach a debugger.
+    The command line that is run for each particular test is echo-ed to
+    the console, so you can easily copy the command that is run.
+    You can then run the command directly (which is a direct call to the
+    java executable, adding any additional options, including those to
+    attach a debugger.
+
 8. Move test into different make targets (layers):
+
   * from extended to sanity (or vice versa)
 
-    Change the group annotated at the top of the test class from "level.extended" to "level.sanity" and the test will be automatically switched from the extended target to the sanity target.
-
+    Change the group annotated at the top of the test class from
+    "level.extended" to "level.sanity" and the test will be automatically
+    switched from the extended target to the sanity target.


### PR DESCRIPTION
It is possible that the VM is in the process of shutting down: we shouldn't start the notification loop in that case because it would never terminate.

Fixes #932.