### PR TITLE
Revert "Enable OpenJ9 OpenJDK8 build flag"

### DIFF
--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2018 IBM Corp. and others
+  Copyright (c) 2006, 2017 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -136,7 +136,6 @@
 		<flag id="build_java9" value="true"/>
 		<flag id="build_newCompiler" value="true"/>
 		<flag id="build_openj9" value="true"/>
-		<flag id="build_openj9JDK8" value="true"/>
 		<flag id="build_ouncemake" value="true"/>
 		<flag id="build_product" value="true"/>
 		<flag id="env_littleEndian" value="true"/>


### PR DESCRIPTION
Reverts eclipse/openj9#915, which is specific to IBM's internal builds, due to #938 until machines are fixed to have Visual Studio 10 SP1