### PR TITLE
Enable OMRChecker linting for openj9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ cache:
 dist: trusty
 addons:
   apt:
+    sources:
+      - llvm-toolchain-trusty
     packages:
       - autoconf
       - ca-certificates
@@ -58,6 +60,10 @@ addons:
       - unzip
       - wget
       - zip
+      - clang-3.8
+      - llvm-3.8
+      - libclang-3.8-dev
+      - llvm-3.8-dev
 before_install:
   - jdk_switcher use oraclejdk8
 before_script:
@@ -88,5 +94,14 @@ script:
   - make images EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"
   # Minimal sniff test - ensure java -version works.
   - ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -version
+
+  # run the OMRChecker linter
+  - export J9SRC=$PWD/build/linux-x86_64-normal-server-release/vm
+  - export OMRCHECKER_DIR=$J9SRC/omr/tools/compiler/OMRChecker
+  - export LLVM_CONFIG=llvm-config-3.8 CLANG=clang++-3.8 CXX_PATH=clang++-3.8 CXX=clang++-3.8
+  - cd $OMRCHECKER_DIR
+  - sh smartmake.sh
+  - cd $J9SRC/compiler
+  - make -f linter.mk
 after_script:
   - ccache -s

--- a/runtime/compiler/linter.mk
+++ b/runtime/compiler/linter.mk
@@ -47,8 +47,8 @@ endif
 # Personally, I feel it's best to default to out-of-tree build but who knows, there may be
 # differing opinions on that.
 #
-JIT_SRCBASE?=../..
-JIT_OBJBASE?=../objs/compiler_$(BUILD_CONFIG)
+JIT_SRCBASE?=..
+JIT_OBJBASE?=$(J9SRC)/objs/compiler_$(BUILD_CONFIG)
 JIT_DLL_DIR?=$(JIT_OBJBASE)
 
 #
@@ -65,7 +65,7 @@ BUILD_CONFIG?=prod
 # Dirs used internally by the makefiles
 #
 JIT_MAKE_DIR?=$(FIXED_SRCBASE)/compiler/build
-JIT_SCRIPT_DIR?=$(FIXED_SRCBASE)/compiler/build/scripts
+JIT_SCRIPT_DIR?=$(JIT_MAKE_DIR)/scripts
 
 #
 # First we set a bunch of tokens about the platform that the rest of the
@@ -88,6 +88,17 @@ include $(JIT_MAKE_DIR)/files/common.mk
 # That makes sense - You can't expect XLC and GCC to take the same arguments
 #
 include $(JIT_MAKE_DIR)/toolcfg/common.mk
+
+# Add include directories to find j9cfg.h and omrcfg.h if needed.
+#
+# If the linter is being run after a CMake build, it
+# results in j9cfg.h and omrcfg.h to be in a location that
+# is different from an automake build.
+#
+
+ifneq ("$(wildcard $(J9SRC)/build/j9cfg.h)", "")
+CXX_INCLUDES+=$(J9SRC)/build $(J9SRC)/build/omr
+endif
 
 
 #


### PR DESCRIPTION
OMRChecker is a clang plugin designed to look for issues in the
implementation of extensible classes. OMRChecker is already
used to lint in the eclipse/OMR Travis CI build process.

Issue: #729
Depends on #1521 , #2749 

Signed-off-by: Nazim Uddin Bhuiyan <nazim.uddin.bhuiyan@ibm.com>