### PR TITLE
Adding package access API j.l.String.value().

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -5307,4 +5307,29 @@ written authorization of the copyright holder.
 		return CharSequence.super.codePoints();
 	}
 /*[ENDIF]*/	
+
+/*[IF Java10]*/
+	/*
+	 * Internal API, assuming no modification to the byte array returned.
+	 * In case of enableSharingInSubstringWhenOffsetIsZero is set to true (by default), the actual bytes will be 
+	 * copied to a new array, and replace the original byte array value via Unsafe.
+	 * The value is returned.
+	 */
+	byte[] value() {
+		int validLen;
+		if (enableCompression) {
+			if ((null == compressionFlag) || (count >= 0)) {
+				validLen = count;
+			} else {
+				validLen = (count & ~uncompressedBit) * 2;
+			}
+		} else {
+			validLen = count * 2;
+		}
+		if (validLen < value.length) {
+			helpers.putObjectInObject(this, UnsafeHelpers.valueFieldOffset, java.util.Arrays.copyOf(value, validLen));
+		}
+		return value;
+	}
+/*[ENDIF] Java10 */	
 }


### PR DESCRIPTION
Adding package access API `j.l.String.value()`

Assuming no modification to the byte array returned.
In case of `enableSharingInSubstringWhenOffsetIsZero` is set to true (by default), the actual bytes will be copied to a new array, and replace the original byte array `value` via `Unsafe`. The `value` is returned.

Verified manually that `Java 10` pConfig still compiles and `Java 10` build with the extension repo provided by JCL team works as well.
Since this PR only affects `Java 10`, there is no need for a PR build verification.  

closes: #912 

Reviewer @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>