### PR TITLE
Re-exclude Test_ClassLoader for Java8

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -25,3 +25,4 @@
 org.openj9.test.java.lang.Test_J9VMInternals:test_checkPackageAccess													BPW-https://github.ibm.com/runtimes/test/issues/59 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						124199 generic-all
+org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all


### PR DESCRIPTION
This entry is still required due to some internal Test_ClassLoader tests running.

Signed-off-by: smlambert <slambert@gmail.com>