### PR TITLE
Support the boolean array type in DDR code

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1189,7 +1189,8 @@ public class J9BCUtil {
 				"J",
 				"S",
 				"B",
-				"C" };
+				"C",
+				"Z" };
 
 		out.print("(");
 


### PR DESCRIPTION
The change is to ensure the boolean array type is
correctly displayed in DDR output as we already
changed the code in verifier to differentiate the
boolean arrays from the byte arrays.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>