### PR TITLE
Update commandline java -version related tests match pattern

### DIFF
--- a/test/cmdLineTests/ignoreUnrecognizedVMOptions/ignoreunrecognizedvmoptions.xml
+++ b/test/cmdLineTests/ignoreUnrecognizedVMOptions/ignoreunrecognizedvmoptions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,50 +34,50 @@
 
  <test id="test -XX:+IgnoreUnrecognizedVMOptions, bad option: --abc=def.ghi">
   <command>$EXE$ $IGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION1$ -version</command>
-  <output type="success" caseSensitive="no" regex="no">version</output>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
   <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
  </test>
  
  <test id="test -XX:+IgnoreUnrecognizedVMOptions, bad option: -Xtr:minimizeUserCPU,what">
   <command>$EXE$ $IGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION2$ -version</command>
-  <output type="success" caseSensitive="no" regex="no">version</output>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
   <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
  </test>
  
  <test id="test -XX:-IgnoreUnrecognizedVMOptions, bad option: --abc=def.ghi">
   <command>$EXE$ $NOIGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION1$ -version</command>
   <output type="success" caseSensitive="no" regex="no">Command-line option unrecognised</output>
-  <output type="failure" caseSensitive="no" regex="no">version</output>
+  <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
  </test>
  
  <test id="test -XX:-IgnoreUnrecognizedVMOptions, bad option: -Xtr:minimizeUserCPU,what">
   <command>$EXE$ $NOIGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION2$ -version</command>
   <output type="success" caseSensitive="no" regex="no">Command-line option unrecognised</output>
-  <output type="failure" caseSensitive="no" regex="no">version</output>
+  <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
  </test>
  
   <test id="test -XX:-IgnoreUnrecognizedVMOptions -XX:+IgnoreUnrecognizedVMOptions, bad option: --abc=def.ghi">
   <command>$EXE$ $NOIGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION1$ $IGNOREUNRECOGNIZEDVMOPTIONS$ -version</command>
-  <output type="success" caseSensitive="no" regex="no">version</output>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
   <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
  </test>
  
  <test id="test -XX:-IgnoreUnrecognizedVMOptions -XX:+IgnoreUnrecognizedVMOptions, bad option: -Xtr:minimizeUserCPU,what">
   <command>$EXE$ $NOIGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION2$ $IGNOREUNRECOGNIZEDVMOPTIONS$ -version</command>
-  <output type="success" caseSensitive="no" regex="no">version</output>
+  <output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
   <output type="failure" caseSensitive="no" regex="no">Command-line option unrecognised</output>
  </test>
  
  <test id="test -XX:+IgnoreUnrecognizedVMOptions -XX:-IgnoreUnrecognizedVMOptions, bad option: --abc=def.ghi">
   <command>$EXE$ $IGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION1$ $NOIGNOREUNRECOGNIZEDVMOPTIONS$ -version</command>
   <output type="success" caseSensitive="no" regex="no">Command-line option unrecognised</output>
-  <output type="failure" caseSensitive="no" regex="no">version</output>
+  <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
  </test>
  
  <test id="test -XX:+IgnoreUnrecognizedVMOptions -XX:-IgnoreUnrecognizedVMOptions, bad option: -Xtr:minimizeUserCPU,what">
   <command>$EXE$ $IGNOREUNRECOGNIZEDVMOPTIONS$ $BADOPTION2$ $NOIGNOREUNRECOGNIZEDVMOPTIONS$ -version</command>
   <output type="success" caseSensitive="no" regex="no">Command-line option unrecognised</output>
-  <output type="failure" caseSensitive="no" regex="no">version</output>
+  <output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
  </test>
 
 </suite>

--- a/test/cmdLineTests/shareClassTests/ListAllCachesTests/expireAndListAllCachesTests.xml
+++ b/test/cmdLineTests/shareClassTests/ListAllCachesTests/expireAndListAllCachesTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2010, 2017 IBM Corp. and others
+  Copyright (c) 2010, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,35 +57,35 @@
 	
 	<test id="Expire & List 1: Create nonpersistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$NP,nonpersistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
 	<test id="Expire & List 2: Create Java 6 nonpersistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA6_EXE$ $currentMode$NP,nonpersistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
 	<test id="Expire & List 3: Create Java 6 persistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA6_EXE$ $currentMode$P,persistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no"  javaUtilRegex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
 	<test id="Expire & List 4: Create persistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$P,persistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 
 	<test id="Expire & List 5: expire persistent cache." timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$P,persistent,expire=0 -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>

--- a/test/cmdLineTests/shareClassTests/ListAllCachesTests/listAllCachesTests.xml
+++ b/test/cmdLineTests/shareClassTests/ListAllCachesTests/listAllCachesTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2010, 2017 IBM Corp. and others
+  Copyright (c) 2010, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,21 +53,21 @@
 	
 	<test id="ListAllCaches 2: Make sure Java 6 is present" timeout="600" runPath=".">
 		<command>$JAVA6_EXE$ -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
 	<test id="ListAllCaches 3: Create Java 6 nonpersistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA6_EXE$ $currentMode$NP,nonpersistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 	
 	<test id="ListAllCaches 4: Create Java 6 persistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA6_EXE$ $currentMode$P,persistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no"  javaUtilRegex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="no"  javaUtilregex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
@@ -92,14 +92,14 @@
 
 	<test id="ListAllCaches 7: Create a nonpersistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$NP,nonpersistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>
 		
 	<test id="ListAllCaches 8: Create a persistent shared cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$P,persistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 	</test>

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2012, 2017 IBM Corp. and others
+  Copyright (c) 2012, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,7 +114,7 @@
 	
 	<test id="Test 1: Create a cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,reset -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -125,7 +125,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xnolinenumbers[\s]*= false</output>
 		<output type="required" caseSensitive="yes" regex="no">Cache contains only classes with line numbers</output>
-		<output type="failure" caseSensitive="yes" regex="no">version</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -144,7 +144,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xnolinenumbers[\s]*= false</output>
 		<output type="required" caseSensitive="yes" regex="no">Cache contains classes with line numbers and classes without line numbers</output>
-		<output type="failure" caseSensitive="yes" regex="no">version</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -153,7 +153,7 @@
 	
 	<test id="Test 3: Build a new cache with -Xnolinenumbers" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xnolinenumbers $currentMode$,reset -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -164,7 +164,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xnolinenumbers[\s]*= true</output>
 		<output type="required" caseSensitive="yes" regex="no">Cache contains only classes without line numbers</output>
-		<output type="failure" caseSensitive="yes" regex="no">version</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -184,7 +184,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xnolinenumbers[\s]*= true</output>
 		<output type="required" caseSensitive="yes" regex="no">Cache contains classes with line numbers and classes without line numbers</output>
-		<output type="failure" caseSensitive="yes" regex="no">version</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -193,7 +193,7 @@
 
 	<test id="Test 4 - d: Build a new cache with -Xnolinenumbers and mprotect=all" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xnolinenumbers $currentMode$,reset,mprotect=all -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -204,7 +204,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xnolinenumbers[\s]*= true</output>
 		<output type="required" caseSensitive="yes" regex="no">Cache contains only classes without line numbers</output>
-		<output type="failure" caseSensitive="yes" regex="no">version</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -224,7 +224,7 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xnolinenumbers[\s]*= true</output>
 		<output type="required" caseSensitive="yes" regex="no">Cache contains classes with line numbers and classes without line numbers</output>
-		<output type="failure" caseSensitive="yes" regex="no">version</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -235,7 +235,7 @@
 		
 	<test id="Test 5: Create a cache with 500K memory and ensure vm starts successfully" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xscmx500k $currentMode$,reset -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -254,7 +254,7 @@
 
 	<test id="Test 6: ensure vm starts with the option -Xshareclasses:readonly" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,readonly -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -481,7 +481,7 @@
 	
 	<test id="Test 26: CMVC 168131 : Create a non persistent cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -500,7 +500,7 @@
 	
 	<test id="Test 28: CMVC 168131 : Re-create by failing buildid match" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,testBadBuildId -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -529,7 +529,7 @@
 	
 	<test id="Test 31: CMVC 168131 : Create a non persistent cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xscmx32m $currentMode$,nonpersistent -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -547,7 +547,7 @@
 	
 	<test id="Test 33: CMVC 168131 : Re-create by failing buildid match" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,testBadBuildId -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -577,7 +577,7 @@
 	
 	<test id="Test 36: LIR 1445.1 : Debug Area PrintStats Test : Create a test cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -614,7 +614,7 @@
 	
 	<test id="Test 39: LIR 1445.1 : Debug Area PrintStats Test : Create a test cache with -Xscdmx0m" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xscdmx0m $currentMode$ -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/cmdLineTests/xxargtest/XXArgumentTesting.xml
+++ b/test/cmdLineTests/xxargtest/XXArgumentTesting.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2011, 2017 IBM Corp. and others
+  Copyright (c) 2011, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 
 	<test id="Ensure -XXnosuballoc32bitmem is recognized on all platforms">
 		<command>$EXE$ -Xcompressedrefs -XXnosuballoc32bitmem -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output regex="no" type="failure">Command-line option unrecognised</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -38,7 +38,7 @@
 
 	<test id="Generate a javacore without -XXnosuballoc32bitmem">
 		<command>$EXE$ -Xcompressedrefs -Xdump:java:events=vmstop,file=testjavacore.txt -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output regex="no" type="failure">Command-line option unrecognised</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
@@ -53,7 +53,7 @@
 	
 	<test id="Generate a javacore with -XXnosuballoc32bitmem">
 		<command>$EXE$ -Xcompressedrefs -XXnosuballoc32bitmem -Xdump:java:events=vmstop,file=testjavacore.txt -version</command>
-		<output type="success" caseSensitive="yes" regex="no">version</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
 		<output regex="no" type="failure">Command-line option unrecognised</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>


### PR DESCRIPTION
Update commandline java -version tests match pattern from "version"
without regex to "(java|openjdk) version" with regex

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>