### PR TITLE
Remove unused import

### DIFF
--- a/test/Java8andUp/src/org/openj9/test/java/lang/management/MemoryMXBeanShutdownNotification.java
+++ b/test/Java8andUp/src/org/openj9/test/java/lang/management/MemoryMXBeanShutdownNotification.java
@@ -25,7 +25,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 
 import org.testng.Assert;
-import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
 


### PR DESCRIPTION
As @smlambert pointed out, `org.testng.AssertJUnit` is imported but not used.