### PR TITLE
Rename new encodedUTF8Length overload to fix DDR failures

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -834,7 +834,7 @@ done:
 	 * @returns the number of bytes required to encode the character as UTF8
 	 */
 	static VMINLINE UDATA
-	encodedUTF8Length(I_8 unicode)
+	encodedUTF8LengthI8(I_8 unicode)
 	{
 		return (unicode >= 0x01) && (unicode <= 0x7F) ? 1 : 2;
 	}

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -447,7 +447,7 @@ getStringUTF8Length(J9VMThread *vmThread, j9object_t string)
 
 	if (IS_STRING_COMPRESSED(vmThread, string)) {
 		for (i = 0; i < unicodeLength; i++) {
-			utf8Length += VM_VMHelpers::encodedUTF8Length(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i));
+			utf8Length += VM_VMHelpers::encodedUTF8LengthI8(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i));
 		}
 	} else {
 		for (i = 0; i < unicodeLength; i++) {


### PR DESCRIPTION
DDR does not seem to like overloaded functions with parameter types.
Rename the newly added encodedUTF8Length function to fix this problem
until the new DDR solution is rolled in.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>