### PR TITLE
Use consistent naming for ROMClassBuilder fields

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -65,7 +65,7 @@ ROMClassBuilder::ROMClassBuilder(J9JavaVM *javaVM, J9PortLibrary *portLibrary, U
 	_classFileBuffer(NULL),
 	_bufferManagerBuffer(NULL),
 	_anonClassNameBuffer(NULL),
-	_anonClassNameBufferLength(0),
+	_anonClassNameBufferSize(0),
 	_stringInternTable(javaVM, portLibrary, maxStringInternTableSize)
 {
 }
@@ -294,14 +294,14 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile)
 	 * [className]/[ROMClassAddress]\0
 	 */
 
-	if (0 == _anonClassNameBufferLength || (newAnonClassNameLength > _anonClassNameBufferLength)) {
+	if ((0 == _anonClassNameBufferSize) || (newAnonClassNameLength > _anonClassNameBufferSize)) {
 		j9mem_free_memory(_anonClassNameBuffer);
 		_anonClassNameBuffer = (U_8 *)j9mem_allocate_memory(newAnonClassNameLength, J9MEM_CATEGORY_CLASSES);
 		if (NULL == _anonClassNameBuffer) {
 			result = OutOfMemory;
 			goto done;
 		}
-		_anonClassNameBufferLength = newAnonClassNameLength;
+		_anonClassNameBufferSize = newAnonClassNameLength;
 	}
 	constantPool[newUtfCPEntry].bytes = _anonClassNameBuffer;
 

--- a/runtime/bcutil/ROMClassBuilder.hpp
+++ b/runtime/bcutil/ROMClassBuilder.hpp
@@ -118,7 +118,7 @@ private:
 	UDATA _bufferManagerSize;
 	U_8 *_classFileBuffer;
 	U_8 *_anonClassNameBuffer;
-	UDATA _anonClassNameBufferLength;
+	UDATA _anonClassNameBufferSize;
 	U_8 *_bufferManagerBuffer;
 	StringInternTable _stringInternTable;
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1559,7 +1559,7 @@ typedef struct J9DbgROMClassBuilder {
 	U_8* classFileBuffer;
 	U_8* bufferManagerBuffer;
 	U_8* anonClassNameBuffer;
-	UDATA anonClassNameBufferLength;
+	UDATA anonClassNameBufferSize;
 	struct J9DbgStringInternTable stringInternTable;
 } J9DbgROMClassBuilder;
 


### PR DESCRIPTION
Use consistent naming for ROMClassBuilder fields

Signed-off-by: tajila <atobia@ca.ibm.com>