### PR TITLE
Fix timing hole releasing safe point VM access

### DIFF
--- a/runtime/vm/VMAccess.cpp
+++ b/runtime/vm/VMAccess.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1003,11 +1003,11 @@ releaseSafePointVMAccess(J9VMThread * vmThread)
 		do {
 			VM_VMAccess::clearPublicFlags(currentThread, J9_PUBLIC_FLAGS_HALTED_AT_SAFE_POINT, true);
 		} while ((currentThread = currentThread->linkNext) != vmThread);
-		omrthread_monitor_exit(vm->vmThreadListMutex);
 		omrthread_monitor_enter(vm->exclusiveAccessMutex);
 		vm->safePointState = J9_XACCESS_NONE;
 		omrthread_monitor_notify_all(vm->exclusiveAccessMutex);
 		omrthread_monitor_exit(vm->exclusiveAccessMutex);
+		omrthread_monitor_exit(vm->vmThreadListMutex);
 	}
 	Assert_VM_mustHaveVMAccess(vmThread);
 }


### PR DESCRIPTION
When releasing safe point VM access, the vmThreadListMutex must be
released after resetting the VM safePointState in order to prevent
newly-created threads from incorrectly setting the halted at safe point
bit.

The vmThreadListMutex is held for the entirety of the safe point, and it
is also required while creating a new thread, so new threads will not be
created during the safe point.  Releasing the vmThreadListMutex early
allows the thread creation code to proceed, where it examines the
safePointState and incorrectly set the halt bit which will never be
cleared, causing VM access acquisition to block forever.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>