### PR TITLE
Enable legacy security by default

### DIFF
--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
@@ -2,7 +2,7 @@
 package com.ibm.jvm;
 
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corp. and others
+ * Copyright (c) 2006, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -507,8 +507,8 @@ public class Dump {
     }
     
     private static void checkLegacySecurityPermssion() throws SecurityException {
-    	if ("true".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
-    		.internalGetProperties().getProperty(LEGACY_DUMP_PERMISSION_PROPERTY)))	{
+    	if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
+    		.internalGetProperties().getProperty(LEGACY_DUMP_PERMISSION_PROPERTY)))) {
     		checkDumpSecurityPermssion();
     	}
     }

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Log.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Log.java
@@ -2,7 +2,7 @@
 package com.ibm.jvm;
 
 /*******************************************************************************
- * Copyright (c) 2006, 2016 IBM Corp. and others
+ * Copyright (c) 2006, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,8 +69,8 @@ public class Log {
 	 * @throws SecurityException
 	 */
     private static void checkLegacySecurityPermssion() throws SecurityException {
-    	if ("true".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
-    		.internalGetProperties().getProperty(LEGACY_LOG_PERMISSION_PROPERTY)))	{	
+    	if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
+    		.internalGetProperties().getProperty(LEGACY_LOG_PERMISSION_PROPERTY)))) {
     		checkLogSecurityPermssion();
     	}
     }

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Trace.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Trace.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -283,8 +283,8 @@ public final class Trace {
 	 * @throws SecurityException
 	 */
     private static void checkLegacySecurityPermssion() throws SecurityException {
-    	if ("true".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
-    		.internalGetProperties().getProperty(LEGACY_TRACE_PERMISSION_PROPERTY)))	{	
+    	if (!("false".equalsIgnoreCase(com.ibm.oti.vm.VM.getVMLangAccess()	//$NON-NLS-1$
+    		.internalGetProperties().getProperty(LEGACY_TRACE_PERMISSION_PROPERTY)))) {
     		checkTraceSecurityPermssion();
     	}
     }


### PR DESCRIPTION
Perform security check by default and skip security check only when the
following system properties are set to false

com.ibm.jvm.enableLegacyTraceSecurity
com.ibm.jvm.enableLegacyDumpSecurity
com.ibm.jvm.enableLegacyLogSecurity

Signed-off-by: hangshao <hangshao@ca.ibm.com>