### PR TITLE
Enable IdleTuning feature on zOS

### DIFF
--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -131,6 +131,7 @@
 		<flag id="env_hasFPU" value="true"/>
 		<flag id="gc_batchClearTLH" value="true"/>
 		<flag id="gc_debugAsserts" value="true"/>
+		<flag id="gc_idleHeapManager" value="true"/>
 		<flag id="gc_inlinedAllocFields" value="true"/>
 		<flag id="gc_minimumObjectSize" value="true"/>
 		<flag id="gc_subpoolsAlias" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -130,6 +130,7 @@
 		<flag id="env_hasFPU" value="true"/>
 		<flag id="gc_batchClearTLH" value="true"/>
 		<flag id="gc_debugAsserts" value="true"/>
+		<flag id="gc_idleHeapManager" value="true"/>
 		<flag id="gc_inlinedAllocFields" value="true"/>
 		<flag id="gc_minimumObjectSize" value="true"/>
 		<flag id="gc_subpoolsAlias" value="true"/>

--- a/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
+++ b/runtime/gc_glue_java/configure_includes/configure_zos_390.mk.ftl
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@ ifeq (zos_390-64_cmprssptrs, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
+		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
@@ -62,6 +63,7 @@ ifeq (zos_390-64, $(SPEC))
 		--enable-OMR_ARCH_S390 \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_CONCURRENT_SCAVENGER \
+		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 endif
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1935,7 +1935,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			 */
 			if (J9_ARE_ANY_BITS_SET(vm->vmRuntimeStateListener.idleTuningFlags, J9_IDLE_TUNING_GC_ON_IDLE | J9_IDLE_TUNING_COMPACT_ON_IDLE)) {
 				BOOLEAN idleGCTuningSupported = FALSE;
-#if defined(LINUX) && (defined(J9HAMMER) || defined(J9X86))
+#if (defined(LINUX) && (defined(J9HAMMER) || defined(J9X86))) || defined(J9ZOS39064)
 				/* & only for gencon GC policy */
 				if (J9_GC_POLICY_GENCON == ((OMR_VM *)vm->omrVM)->gcPolicy) {
 					idleGCTuningSupported = TRUE;


### PR DESCRIPTION
Defines/Enables the compilation flags which make the IdleTuning
is available on zOS.

Refer OMR issue #1069 for more details on IdleTuning. 

Signed-off-by: Parameswaran Selvam <parselva@in.ibm.com>