### PR TITLE
Allow opt level downgrades during grace period

### DIFF
--- a/runtime/compiler/trj9/control/CompilationThread.cpp
+++ b/runtime/compiler/trj9/control/CompilationThread.cpp
@@ -474,17 +474,12 @@ bool TR::CompilationInfo::shouldDowngradeCompReq(TR_MethodToBeCompiled *entry)
          }
       else
          {
-         // Is it grace-period?
-         if (persistentInfo->getElapsedTime() < (uint64_t)persistentInfo->getClassLoadingPhaseGracePeriod())
+         // We may skip downgrading during grace period
+         if (TR::Options::getCmdLineOptions()->getOption(TR_DontDowgradeToColdDuringGracePeriod) &&
+             persistentInfo->getElapsedTime() < (uint64_t)persistentInfo->getClassLoadingPhaseGracePeriod())
             {
-            // During grace period only downgrade non-bootstrap methods
-            //TR_J9VMBase *fe = TR_J9VMBase::get(_jitConfig, NULL);
-            //if (fe && !fe->isClassLibraryMethod(method))
-            //   {
-            //   doDowngrade = true;
-            //   }
             }
-         else // no grace period here
+         else 
             {
             // Downgrade during CLP when queue grows too large
             if ((persistentInfo->isClassLoadingPhase() && getNumQueuedFirstTimeCompilations() > TR::Options::_qsziThresholdToDowngradeDuringCLP) ||


### PR DESCRIPTION
This commit changes the existing heuristics for when the optimization level
of compilations is changed from 'warm' to 'cold'. Previously, such downgrades
were not allowed during the "grace period" (first second) to preserve behavior
of short running benchmarks. Recent experiments showed that we could further
improve startup of applications if we lift that restriction.
The new heuristic can be disabled with a new option:
  -Xjit:dontDowngradeToColdDuringGracePeriod

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>