### PR TITLE
Move infra-style jobs to run on worker

### DIFF
--- a/buildenv/jenkins/copyrightCheck
+++ b/buildenv/jenkins/copyrightCheck
@@ -26,7 +26,7 @@ def BAD_FILES = []
 String HASHES = '###################################'
 
 stage('Copyright Check') {
-    node ('master') {
+    node ('worker') {
         timestamps {
             git url: SRC_REPO
             sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"

--- a/buildenv/jenkins/lineEndingsCheck
+++ b/buildenv/jenkins/lineEndingsCheck
@@ -26,7 +26,7 @@ def BAD_FILES = []
 String HASHES = '###################################'
 
 stage('Line Endings Check') {
-    node ('master') {
+    node ('worker') {
         timestamps {
             git url: SRC_REPO
             sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"

--- a/buildenv/jenkins/omrMirror
+++ b/buildenv/jenkins/omrMirror
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
  *******************************************************************************/
 
 pipeline {
-    agent {label 'master'}
+    agent {label 'worker'}
 
     environment {
         HTTP         = 'https://'


### PR DESCRIPTION
- Move Copyright, Line-Endings and OMR Mirror
- Move from Master to 'worker' node(s)

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>