### PR TITLE
Add OpenJDK Git SHA to Version String

### DIFF
--- a/runtime/jcl/cl_se10/module.xml
+++ b/runtime/jcl/cl_se10/module.xml
@@ -105,6 +105,7 @@
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="ifeq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="jclcinit$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
 			<makefilestub data="vm_scar$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
 			<makefilestub data="endif"/>
 		</makefilestubs>

--- a/runtime/jcl/cl_se7_basic/module.xml
+++ b/runtime/jcl/cl_se7_basic/module.xml
@@ -105,6 +105,7 @@
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="ifeq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="jclcinit$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
 			<makefilestub data="vm_scar$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
 			<makefilestub data="endif"/>
 		</makefilestubs>

--- a/runtime/jcl/cl_se9/module.xml
+++ b/runtime/jcl/cl_se9/module.xml
@@ -105,6 +105,7 @@
 			<makefilestub data="UMA_ENABLE_ALL_WARNINGS=1"/>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="ifeq ($(OPENJ9_BUILD),true)"/>
+			<makefilestub data="jclcinit$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
 			<makefilestub data="vm_scar$(UMA_DOT_O) : CFLAGS += -DOPENJ9_BUILD"/>
 			<makefilestub data="endif"/>
 		</makefilestubs>

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -41,6 +41,9 @@
 #include "omrversionstrings.h"
 #include "j9modron.h"
 #include "omr.h"
+#if defined(OPENJ9_BUILD)
+#include "openj9_version_info.h"
+#endif
 #include "vendor_version.h"
 
 /* The vm version which must match the JCL.
@@ -146,6 +149,12 @@ jint computeFullVersionString(J9JavaVM* vm)
 	#define OMR_INFO ""
 #endif /* J9VM_GC_MODRON_GC */
 
+#if defined(OPENJDK_TAG) && defined(OPENJDK_SHA)
+	#define OPENJDK_INFO "\nJCL      - " OPENJDK_SHA " based on " OPENJDK_TAG
+#else
+	#define OPENJDK_INFO ""
+#endif /* OPENJDK_TAG && OPENJDK_SHA */
+
 #if defined(VENDOR_SHORT_NAME) && defined(VENDOR_SHA)
 	#define VENDOR_INFO "\n" VENDOR_SHORT_NAME "      - " VENDOR_SHA
 #else
@@ -153,7 +162,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 #endif /* VENDOR_SHORT_NAME && VENDOR_SHA */
 
 	if (BUFFER_SIZE <= j9str_printf(PORTLIB, fullversion, BUFFER_SIZE + 1,
-			"JRE %s IBM J9 %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO,
+			"JRE %s IBM J9 %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
 			j2se_version_info,
 			EsVersionString,
 			(NULL != osname ? osname : " "),
@@ -166,7 +175,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 	}
 
 	if (BUFFER_SIZE <= j9str_printf(PORTLIB, vminfo, BUFFER_SIZE + 1,
-			"JRE %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO,
+			"JRE %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
 			j2se_version_info,
 			(NULL != osname ? osname : " "),
 			osarch,


### PR DESCRIPTION
Currently, we add the OpenJDK SHA to the version string by
manually appending the SHA to the -version output. 

This code allows us to populate the -version output with 
the OpenJDK SHA, *and* remove the non-closed extensions 
currently used for that purpose.

One step closer to no extensions at all.

depends on
ibmruntimes/openj9-openjdk-jdk8#34
ibmruntimes/openj9-openjdk-jdk9#111

Fixes: #1011

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>