### PR TITLE
Skip package access check for classes within same module

### DIFF
--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2215,6 +2215,19 @@ fieldIndexTableRemove(J9JavaVM* vm, J9Class *ramClass);
  */
 UDATA   
 packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t protectionDomain, UDATA canRunJavaCode);
+
+/**
+ * Determine if the targetClass is subject to the package access check.
+ * Assuming targetClass is NOT NULL.
+ *
+ * @param *vm[in] the J9JavaVM
+ * @param srcClassLoader[in] Current class loader creating RAM class
+ * @param srcModule[in] The module where current RAM class is loaded from
+ * @param targetClass[in] The RAM class being examined to be determined if a package access check should be performed
+ * @return TRUE if a package access check is required, otherwise FALSE.
+ */
+BOOLEAN
+requirePackageAccessCheck(J9JavaVM *vm, J9ClassLoader *srcClassLoader, J9Module *srcModule, J9Class *targetClass);
 
 /**
  * @brief


### PR DESCRIPTION
Skip package access check for classes within same module

Not perform package access check when resolving classes, loading super/interface classes if current class is in same module as target classes.

closes #859 

Reviewers @pshipton @tajila 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>