### PR TITLE
Remove java.logging requires from java.management

### DIFF
--- a/jcl/j9modules.txt
+++ b/jcl/j9modules.txt
@@ -32,6 +32,7 @@ openj9.sharedclasses
 openj9.traceformat
 jdk.attach
 openj9.jvm
+java.management
 
 # requires openj9.cuda
 openj9.gpu
@@ -39,7 +40,6 @@ openj9.gpu
 # requires java.logging
 openj9.dtfj
 openj9.dtfjview
-java.management
 
 # requires java.management
 jdk.management

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,14 +23,25 @@
 package com.ibm.java.lang.management.internal;
 
 import java.lang.management.PlatformLoggingMXBean;
+/*[IF Sidecar19-SE]*/
+/*[IF Sidecar19-SE-B165]*/
+import java.lang.Module;
+import java.lang.ModuleLayer;
+/*[ELSE]
+import java.lang.reflect.Module;
+import java.lang.reflect.Layer;
+/*[ENDIF]*/
+/*[ENDIF]*/
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+/*[IF !Sidecar19-SE]
+import java.util.logging.LoggingMXBean;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
-/*[IF !Sidecar19-SE]
-import java.util.logging.LoggingMXBean;
 /*[ENDIF]*/
 
 import javax.management.ObjectName;
@@ -49,8 +60,53 @@ public final class LoggingMXBeanImpl
 /*[ENDIF]*/
 			PlatformLoggingMXBean {
 
-	private static final LoggingMXBeanImpl instance = new LoggingMXBeanImpl();
+	private static final LoggingMXBeanImpl instance;
 
+/*[IF Sidecar19-SE]*/
+	private static final Method logManager_getLogManager;
+	private static final Method logManager_getLogger;
+	private static final Method logManager_getLoggerNames;
+	private static final Method logger_getLevel;
+	private static final Method logger_getParent;
+	private static final Method logger_getName;
+	private static final Method logger_setLevel;
+	private static final Method level_getName;
+	private static final Method level_parse;
+	private static final String logManager_LOGGING_MXBEAN_NAME;
+/*[ENDIF]*/	
+
+	static {
+/*[IF Sidecar19-SE]*/
+		try {
+
+/*[IF Sidecar19-SE-B165]*/
+			Module java_logging = ModuleLayer.boot().findModule("java.logging").get(); //$NON-NLS-1$
+/*[ELSE]
+			Module java_logging = Layer.boot().findModule("java.logging").get(); //$NON-NLS-1$
+/*[ENDIF]*/			
+			Class<?> logManagerClass = Class.forName(java_logging, "java.util.logging.LogManager"); //$NON-NLS-1$
+			Class<?> loggerClass = Class.forName(java_logging, "java.util.logging.Logger"); //$NON-NLS-1$
+			Class<?> levelClass = Class.forName(java_logging, "java.util.logging.Level"); //$NON-NLS-1$
+			logManager_getLogManager = logManagerClass.getMethod("getLogManager"); //$NON-NLS-1$
+			logManager_getLogger = logManagerClass.getMethod("getLogger", String.class); //$NON-NLS-1$
+			logManager_getLoggerNames = logManagerClass.getMethod("getLoggerNames"); //$NON-NLS-1$
+			logger_getLevel = loggerClass.getMethod("getLevel"); //$NON-NLS-1$
+			logger_getParent = loggerClass.getMethod("getParent"); //$NON-NLS-1$
+			logger_getName = loggerClass.getMethod("getName"); //$NON-NLS-1$
+			logger_setLevel = loggerClass.getMethod("setLevel", levelClass); //$NON-NLS-1$
+			level_getName = levelClass.getMethod("getName"); //$NON-NLS-1$
+			level_parse = levelClass.getMethod("parse", String.class); //$NON-NLS-1$
+			logManager_LOGGING_MXBEAN_NAME = logManagerClass.getField("LOGGING_MXBEAN_NAME").get(null).toString(); //$NON-NLS-1$
+
+		} catch (Exception e) {
+			throw handleError(e);
+		}
+/*[ENDIF]*/		
+		
+		/* Initialize class */
+		instance = new LoggingMXBeanImpl();
+	}
+	
 	/**
 	 * the object name
 	 */
@@ -62,7 +118,11 @@ public final class LoggingMXBeanImpl
 	 */
 	private LoggingMXBeanImpl() {
 		super(PlatformLoggingMXBean.class, true);
+/*[IF Sidecar19-SE]*/
+		objectName = ManagementUtils.createObjectName(logManager_LOGGING_MXBEAN_NAME);
+/*[ELSE]		
 		objectName = ManagementUtils.createObjectName(LogManager.LOGGING_MXBEAN_NAME);
+/*[ENDIF]*/
 	}
 
 	/**
@@ -88,20 +148,40 @@ public final class LoggingMXBeanImpl
 	@Override
 	public String getLoggerLevel(String loggerName) {
 		String result = null;
-		Logger logger = LogManager.getLogManager().getLogger(loggerName);
 
-		if (logger != null) {
-			// The named Logger exists. Now attempt to obtain its log level.
-			Level level = logger.getLevel();
-			if (level != null) {
-				result = level.getName();
-			} else {
-				// A null return from getLevel() means that the Logger
-				// is inheriting its log level from an ancestor. Return an
-				// empty string to the caller.
-				result = ""; //$NON-NLS-1$
+/*[IF Sidecar19-SE]*/
+		try {
+			Object logger = getLoggerFromName(loggerName);
+/*[ELSE]	
+			Logger logger = LogManager.getLogManager().getLogger(loggerName);
+/*[ENDIF]*/			
+			
+			if (logger != null) {
+				// The named Logger exists. Now attempt to obtain its log level.
+/*[IF Sidecar19-SE]*/
+				Object level = logger_getLevel.invoke(logger);
+/*[ELSE]					
+				Level level = logger.getLevel();
+/*[ENDIF]*/					
+				if (level != null) {
+/*[IF Sidecar19-SE]*/
+					result = (String)level_getName.invoke(level);
+/*[ELSE]	
+					result = level.getName();
+/*[ENDIF]*/	
+				} else {
+					// A null return from getLevel() means that the Logger
+					// is inheriting its log level from an ancestor. Return an
+					// empty string to the caller.
+					result = ""; //$NON-NLS-1$
+				}
 			}
+/*[IF Sidecar19-SE]*/
+		} catch (Exception e) {
+			throw handleError(e);
 		}
+/*[ENDIF]*/
+		
 		return result;
 	}
 
@@ -112,11 +192,21 @@ public final class LoggingMXBeanImpl
 	public List<String> getLoggerNames() {
 		// By default, return an empty list to caller
 		List<String> result = new ArrayList<>();
-		Enumeration<String> enumeration = LogManager.getLogManager().getLoggerNames();
+		Enumeration<?> enumeration;
 
+/*[IF Sidecar19-SE]*/
+		try {
+			Object logManagerInstance = logManager_getLogManager.invoke(null);
+			enumeration = (Enumeration<?>) logManager_getLoggerNames.invoke(logManagerInstance);
+		} catch (Exception e) {
+			throw handleError(e);
+		}
+/*[ELSE]	
+		enumeration = LogManager.getLogManager().getLoggerNames();
+/*[ENDIF]*/	
 		if (enumeration != null) {
 			while (enumeration.hasMoreElements()) {
-				result.add(enumeration.nextElement());
+				result.add((String)enumeration.nextElement());
 			}
 		}
 
@@ -129,20 +219,38 @@ public final class LoggingMXBeanImpl
 	@Override
 	public String getParentLoggerName(String loggerName) {
 		String result = null;
-		Logger logger = LogManager.getLogManager().getLogger(loggerName);
 
-		if (logger != null) {
-			// The named Logger exists. Now attempt to obtain its parent.
-			Logger parent = logger.getParent();
-			if (parent != null) {
-				// There is a parent
-				result = parent.getName();
-			} else {
-				// logger must be the root Logger
-				result = ""; //$NON-NLS-1$
+/*[IF Sidecar19-SE]*/
+		try {
+			Object logger = getLoggerFromName(loggerName);
+/*[ELSE]		
+			Logger logger = LogManager.getLogManager().getLogger(loggerName);
+/*[ENDIF]*/
+			if (logger != null) {
+				// The named Logger exists. Now attempt to obtain its parent.
+/*[IF Sidecar19-SE]*/
+				Object parent = logger_getParent.invoke(logger);
+/*[ELSE]	
+				Logger parent = logger.getParent();
+/*[ENDIF]*/
+				if (parent != null) {
+					// There is a parent
+/*[IF Sidecar19-SE]*/
+					result = (String)logger_getName.invoke(parent);
+/*[ELSE]	
+					result = parent.getName();
+/*[ENDIF]*/
+				} else {
+					// logger must be the root Logger
+					result = ""; //$NON-NLS-1$
+				}
 			}
+/*[IF Sidecar19-SE]*/
+		} catch (Exception e) {
+			throw handleError(e);
 		}
-
+/*[ENDIF]*/
+		
 		return result;
 	}
 
@@ -151,15 +259,34 @@ public final class LoggingMXBeanImpl
 	 */
 	@Override
 	public void setLoggerLevel(String loggerName, String levelName) {
+/*[IF Sidecar19-SE]*/
+		final Object logger;
+		try {
+			logger = getLoggerFromName(loggerName);
+		} catch (Exception e) {
+			throw handleError(e);
+		}
+/*[ELSE]	
 		final Logger logger = LogManager.getLogManager().getLogger(loggerName);
-
+/*[ENDIF]*/	
+		
 		if (logger != null) {
 			// The named Logger exists. Now attempt to set its level. The
 			// below attempt to parse a Level from the supplied levelName
 			// will throw an IllegalArgumentException if levelName is not
 			// a valid level name.
+/*[IF Sidecar19-SE]*/
+			try {
+				Object newLevel = level_parse.invoke(null, levelName);
+				logger_setLevel.invoke(logger, newLevel);
+			} catch (Exception e) {
+				throw handleError(e);
+			}
+/*[ELSE]	
 			Level newLevel = Level.parse(levelName);
 			logger.setLevel(newLevel);
+/*[ENDIF]*/
+			
 		} else {
 			// Named Logger does not exist.
 			/*[MSG "K05E7", "Unable to find Logger with name {0}."]*/
@@ -167,4 +294,34 @@ public final class LoggingMXBeanImpl
 		}
 	}
 
+/*[IF Sidecar19-SE]*/
+	private static Object getLoggerFromName(String loggerName) throws Exception {
+		Object logManagerInstance = logManager_getLogManager.invoke(null);
+		return logManager_getLogger.invoke(logManagerInstance, loggerName);
+	}
+	
+	/* Handle error thrown by method invoke as internal error */
+	private static InternalError handleError(Exception cause) {
+		handleInvocationTargetException(cause);
+		
+		InternalError err = new InternalError(cause.toString());
+		err.initCause(cause);
+		throw err;
+	}
+	
+	/* invoke throws InvocationTargetException if the method it is invoking
+	 * throws an error. This method unwraps that error for this class to maintain
+	 * its specification.
+	 */
+	private static void handleInvocationTargetException(Exception cause) {
+		if (cause instanceof InvocationTargetException) {
+			Throwable wrappedCause = cause.getCause();
+			if (wrappedCause instanceof Error) {
+				throw (Error)wrappedCause;
+			} else if (wrappedCause instanceof RuntimeException) {
+				throw (RuntimeException)wrappedCause;
+			}
+		}
+	}
+/*[ENDIF]*/
 }

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 package java.lang.management;
+
+/*[IF Sidecar19-SE-B165]*/
+import java.lang.ModuleLayer;
+/*[ELSE]
+import java.lang.reflect.Layer;
+/*[ENDIF]*/
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,9 +67,19 @@ final class DefaultPlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.addInterface(java.lang.management.OperatingSystemMXBean.class)
 			.register(allComponents);
 
-		ComponentBuilder.create(LoggingMXBeanImpl.getInstance())
-			.addInterface(java.lang.management.PlatformLoggingMXBean.class)
-			.register(allComponents);
+		/* LoggingMXBeanImpl depends on java.logging. If java.logging is not 
+		 * available exclude this component.
+		 */
+/*[IF Sidecar19-SE-B165]*/
+		if (ModuleLayer.boot().findModule("java.logging").isPresent()) //$NON-NLS-1$
+/*[ELSE]
+		if (Layer.boot().findModule("java.logging").isPresent()) //$NON-NLS-1$
+/*[ENDIF]*/
+		{
+			ComponentBuilder.create(LoggingMXBeanImpl.getInstance())
+				.addInterface(java.lang.management.PlatformLoggingMXBean.class)
+				.register(allComponents);
+		}
 
 		ComponentBuilder.create(RuntimeMXBeanImpl.getInstance())
 			.addInterface(java.lang.management.RuntimeMXBean.class)

--- a/jcl/src/java.management/share/classes/module-info.java.extra
+++ b/jcl/src/java.management/share/classes/module-info.java.extra
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 module java.management {
-	requires java.logging;
 	exports com.ibm.java.lang.management.internal to jdk.management;
 	uses com.ibm.sharedclasses.spi.SharedClassProvider;
 }


### PR DESCRIPTION
Use reflection instead of module-info export.

Fixes: #786

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>

Reviewers: @tajila @DanHeidinga 