### PR TITLE
Remove reference of evaluateNodeInRegPair

### DIFF
--- a/runtime/compiler/trj9/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/z/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1978,7 +1978,7 @@ J9::Z::CodeGenerator::evaluateAggregateToGPR(size_t destSize, TR::Node *srcNode,
       }
    else if (destSize > 4)
       {
-      if (is64BitTarget && !cg->evaluateNodeInRegPair(srcNode))
+      if (is64BitTarget)
          targetReg = cg->allocateRegister(TR_GPR64);
       else
          targetReg = cg->allocateConsecutiveRegisterPair();


### PR DESCRIPTION
evaluateNodeInRegPair function was removed as a part of clean up work in
OMR project (https://github.com/eclipse/omr/pull/2247). We need to remove
all references of the same in openj9 project as well.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>