### PR TITLE
Adding a build spec to compile OpenJ9 Java 10

### DIFF
--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -169,6 +169,10 @@
 		<description>Buildspec compiles sources with openjdk-jdk8.</description>
 		<ifRemoved>OpenJ9 compile job, sanity and extended tests no longer run on this buildspec.</ifRemoved>
 	</flag>
+	<flag id="build_openj9JDK10">
+		<description>Buildspec compiles sources with openjdk Java 10 extension.</description>
+		<ifRemoved>OpenJ9 compile job no longer run on this buildspec.</ifRemoved>
+	</flag>
 	<flag id="build_ouncemake">
 		<description>Buildspec compiles source using ouncemake for appscan.</description>
 		<ifRemoved>Ouncemake compile jobs will no longer run on this buildspec.</ifRemoved>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -130,6 +130,7 @@
 		<flag id="build_java9" value="true"/>
 		<flag id="build_openj9" value="true"/>
 		<flag id="build_openj9JDK8" value="true"/>
+		<flag id="build_openj9JDK10" value="true"/>
 		<flag id="build_product" value="true"/>
 		<flag id="build_vmContinuous" value="true"/>
 		<flag id="env_hasFPU" value="true"/>


### PR DESCRIPTION
Adding a build spec to compile `OpenJ9 Java 10` for `linux_x86-64_cmprssptrs`


Reviewers @pshipton @AdamBrousseau 
FYI: @DanHeidinga @jdekonin 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>