### PR TITLE
Add permission checking to shared cache utilities

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassUtilities.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassUtilities.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.shared;
 
 /*******************************************************************************
- * Copyright (c) 2010, 2017 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@ package com.ibm.oti.shared;
  *******************************************************************************/
 
 import java.util.*;
+import com.ibm.oti.shared.SharedClassesNamedPermission.SharedPermissions;
 
 /**
  * SharedClassUtilities provides APIs to get information about all shared class caches in a directory and
@@ -107,8 +108,16 @@ public class SharedClassUtilities {
 	 * 					If shared classes is disabled for this JVM (that is -Xshareclasses:none is present).
 	 * @throws		IllegalArgumentException
 	 * 					If <code>flags</code> is not a valid value.
+	 * @throws		SecurityException
+	 * 					If a security manager is enabled and the calling thread does not
+	 * 					have SharedClassesNamedPermission("getSharedCacheInfo")
 	 */
 	static public List<SharedClassCacheInfo> getSharedCacheInfo(String cacheDir, int flags, boolean useCommandLineValues) {
+		SecurityManager sm = System.getSecurityManager();
+		if (sm != null) {
+			sm.checkPermission(SharedPermissions.getSharedCacheInfo);
+		}
+		
 		int retVal;
 		/*[MSG "K0553", "parameter {0} has invalid value"]*/
 		if (flags != NO_FLAGS) {
@@ -169,8 +178,16 @@ public class SharedClassUtilities {
 	 * 					If shared classes is disabled for this JVM (that is -Xshareclasses:none is present).
 	 * @throws		IllegalArgumentException
 	 * 					If <code>cacheType<code> is not a valid value.
+	 * @throws		SecurityException
+	 * 					If a security manager is enabled and the calling thread does not
+	 * 					have SharedClassesNamedPermission("destroySharedCache")
 	 */
 	static public int destroySharedCache(String cacheDir, int cacheType, String cacheName, boolean useCommandLineValues) {
+		SecurityManager sm = System.getSecurityManager();
+		if (sm != null) {
+			sm.checkPermission(SharedPermissions.destroySharedCache);
+		}
+
 		int retVal = -1;
 		
 		/*

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassesNamedPermission.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassesNamedPermission.java
@@ -1,0 +1,90 @@
+/*[INCLUDE-IF SharedClasses]*/
+package com.ibm.oti.shared;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.security.BasicPermission;
+
+/**
+ * This class defines shared cache permissions as described in the table below.
+ *
+ * <table border=1 cellpadding=5>
+ * <caption>Shared Cache Permissions</caption>
+ * <tr>
+ * <th align='left'>Permission Name</th>
+ * <th align='left'>Allowed Action</th>
+ * </tr>
+ * <tr>
+ * <td>getSharedCacheInfo</td>
+ * <td>Obtaining available shared cache information.
+ *     See {@link SharedClassUtilities#getSharedCacheInfo(String, int, boolean)}.</td>
+ * </tr>
+ * <tr>
+ * <td>destroySharedCache</td>
+ * <td>Destroying a shared cache.
+ *     See {@link SharedClassUtilities#destroySharedCache(String, int, String, boolean)}.</td>
+ * </tr>
+ * </table>
+ */
+public final class SharedClassesNamedPermission extends BasicPermission {
+	
+	private static final long serialVersionUID = -4800623387760880313L;
+
+	/*
+	 * Helper class to avoid creating permission objects unless needed at runtime.
+	 */
+	static final class SharedPermissions {
+		public static final SharedClassesNamedPermission getSharedCacheInfo = new SharedClassesNamedPermission("getSharedCacheInfo"); //$NON-NLS-1$
+		public static final SharedClassesNamedPermission destroySharedCache = new SharedClassesNamedPermission("destroySharedCache"); //$NON-NLS-1$
+	}
+	
+	/**
+	 * Create a representation of the named permissions.
+	 *
+	 * @param name
+	 *          name of the permission
+	 */
+	public SharedClassesNamedPermission(String name) {
+		super(name);
+	}
+
+	/**
+	 * Create a representation of the named permissions.
+	 *
+	 * @param name
+	 *          name of the permission
+	 * @param actions
+	 *          not used, must be null or an empty string
+	 * @throws IllegalArgumentException
+	 *          if actions is not null or an empty string
+	 */
+	public SharedClassesNamedPermission(String name, String actions) {
+		super(name, actions);
+
+		// ensure that actions is null or an empty string
+		if (!((null == actions) || actions.isEmpty())) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+}


### PR DESCRIPTION
In Java 9 and later, com.ibm.oti. is not a restricted package. The
shared cache utilities need to check permissions to avoid untrusted
callers when the security manager is enabled.

Fixes: #1015

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>