### PR TITLE
Remove 2.9 and "IBM J9" from java.fullversion system property

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -77,7 +77,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 #define BUFFER_SIZE 512
 
 	/* The actual allowed BUFFER_SIZE is 512, the extra 1 char is added to check for overflow */
-	char fullversion[BUFFER_SIZE + 1];
 	char vminfo[BUFFER_SIZE + 1];
 
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)
@@ -168,19 +167,6 @@ jint computeFullVersionString(J9JavaVM* vm)
 	#define VENDOR_INFO ""
 #endif /* VENDOR_SHORT_NAME && VENDOR_SHA */
 
-	if (BUFFER_SIZE <= j9str_printf(PORTLIB, fullversion, BUFFER_SIZE + 1,
-			"JRE %s IBM J9 %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
-			j2se_version_info,
-			EsVersionString,
-			(NULL != osname ? osname : " "),
-			osarch,
-			EsBuildVersionString,
-			jitEnabled,
-			aotEnabled)) {
-		j9tty_err_printf(PORTLIB, "\n%s - %d: %s: Error: Java full version string exceeds buffer size\n", __FILE__, __LINE__, __FUNCTION__);
-		return JNI_ERR;
-	}
-
 	if (BUFFER_SIZE <= j9str_printf(PORTLIB, vminfo, BUFFER_SIZE + 1,
 			"JRE %s %s %s" MEM_INFO "%s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
 			j2se_version_info,
@@ -200,8 +186,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 #undef VENDOR_INFO
 
 	(*VMI)->SetSystemProperty(VMI, "java.vm.info", vminfo);
-	/*[PR 114306] System property java.fullversion is not initialized properly */
-	(*VMI)->SetSystemProperty(VMI, "java.fullversion", fullversion);
+	(*VMI)->SetSystemProperty(VMI, "java.fullversion", vminfo);
 	return JNI_OK;
 }
 

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
@@ -288,7 +288,7 @@
 	
  	<test id="Test 9-a: create a new cache" timeout="600" runPath=".">
  		<command>$JAVA_EXE$ $currentMode$,reset $PROGRAM$</command>
-  		<output type="success" caseSensitive="yes" regex="no">IBM J9</output>
+  		<output type="success" caseSensitive="yes" regex="no">java.runtime.version</output>
   		
   		<output type="failure" caseSensitive="no" regex="no">error</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
@@ -301,7 +301,7 @@
  	
  	<test id="Test 9-b: Mark previous class entry as stale" timeout="600" runPath=".">
  		<command>$JAVA_EXE$ $currentMode$ $PROGRAM$</command>
-  		<output type="success" caseSensitive="yes" regex="no">IBM J9</output>
+  		<output type="success" caseSensitive="yes" regex="no">java.runtime.version</output>
   		
   		<output type="failure" caseSensitive="no" regex="no">error</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>


### PR DESCRIPTION
Partly addresses Issue #1020, as "2.9" is removed from the
java.fullversion system property.

The change makes the internal computation of local variables
vminfo and fullversion the same, so fullversion is removed. Note, at
runtime the system property java.fullversion is currently prepended with
additional build information.

Fixes: #1012

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>