### PR TITLE
Remove deprecated isUnsigned parameter from createParameterSymbol

### DIFF
--- a/runtime/compiler/trj9/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/trj9/codegen/CodeGenGPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3468,87 +3468,87 @@ J9::CodeGenerator::generateGPU()
       TR::ParameterSymbol *parmSymbol;
       int slot = 0;
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(0);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(1);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(2);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(3);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setLinkageRegisterIndex(4);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(5);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(6);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setLinkageRegisterIndex(7);
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Int32);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setTypeSignature("", 0);
       la.add(parmSymbol);
 
-      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address, false);
+      parmSymbol = method->comp()->getSymRefTab()->createParameterSymbol(method, slot, TR::Address);
       parmSymbol->setOrdinal(slot++);
       parmSymbol->setReferencedParameter();
       parmSymbol->setTypeSignature("", 0);

--- a/runtime/compiler/trj9/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/trj9/compile/J9SymbolReferenceTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1984,10 +1984,9 @@ TR::ParameterSymbol *
 J9::SymbolReferenceTable::createParameterSymbol(
       TR::ResolvedMethodSymbol *owningMethodSymbol,
       int32_t slot,
-      TR::DataType type,
-      bool isUnsigned)
+      TR::DataType type)
    {
-   TR::ParameterSymbol * sym = TR::ParameterSymbol::create(trHeapMemory(),type,isUnsigned,slot);
+   TR::ParameterSymbol * sym = TR::ParameterSymbol::create(trHeapMemory(),type,slot);
 
    if (comp()->getOption(TR_MimicInterpreterFrameShape))
       {

--- a/runtime/compiler/trj9/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/trj9/compile/J9SymbolReferenceTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -229,13 +229,10 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
     * \param type
     *    TR::DataType of the parameter.
     *
-    * \param isUnsigned
-    *    Unused and deprecated.
-    *
     * \return
     *    The created TR::ParameterSymbol
     */
-   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, bool isUnsigned);
+   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type);
 
    void initShadowSymbol(TR_ResolvedMethod *, TR::SymbolReference *, bool, TR::DataType, uint32_t, bool);
 


### PR DESCRIPTION
OMR has removed this deprecated parameter from the API via
eclipse/omr#2253.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>