### PR TITLE
Use OMR implementation of omrfile_chown()

### DIFF
--- a/runtime/port/sysvipc/j9sharedhelper.c
+++ b/runtime/port/sysvipc/j9sharedhelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -460,7 +460,7 @@ ControlFileOpenWithWriteLock(struct J9PortLibrary* portLibrary, intptr_t * fd, B
 
 			*fd = omrfile_open(filename, exclcreateflags, mode);
 			if (*fd != -1) {		
-				if (chown(filename, -1, getegid()) == -1) {
+				if (omrfile_chown(filename, OMRPORT_FILE_IGNORE_ID, getegid()) == -1) {
 					/*If this fails it is not fatal ... but we may have problems later ...*/
 					Trc_PRT_shared_ControlFileFDWithWriteLock_Message("Info: could not chown file.");
 				}

--- a/runtime/port/sysvipc/j9shsem.c
+++ b/runtime/port/sysvipc/j9shsem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -382,7 +382,7 @@ j9shsem_destroy (struct J9PortLibrary *portLibrary, struct j9shsem_handle **hand
 			 ours to delete. However, given the dir permissions, we can still unlink it. Therefore, try an operation for which we need
 			 to own the file. If it succeeds, that means we own it and can go ahead and unlink it. */
 			Trc_PRT_shsem_j9shsem_destroy_Debug2((*handle)->semid, myerrno);
-			rc = chown((*handle)->baseFile, -1, getegid()); /* Completely benign - done anyway when the file is created */
+			rc = omrfile_chown((*handle)->baseFile, OMRPORT_FILE_IGNORE_ID, getegid()); /* Completely benign - done anyway when the file is created */
 		} else {
 			Trc_PRT_shsem_j9shsem_destroy_Debug2((*handle)->semid, myerrno);
 			rc = -1;
@@ -475,7 +475,7 @@ ensureBaseFile(struct J9PortLibrary *portLibrary, char *filename)
 	omrfile_close(fd);
 
 	Trc_PRT_shsem_createbaseFile_Event1(filename, gid);
-	rc = chown(filename, -1, gid);
+	rc = omrfile_chown(filename, OMRPORT_FILE_IGNORE_ID, gid);
 	Trc_PRT_shsem_createbaseFile_Event2(rc, errno);
 
 	Trc_PRT_shsem_createbaseFile_Exit();

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -24,7 +24,7 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<!-- Test 200-a to Test 206-aa: 81 tests -->
+<!-- Test 200-a to Test 207 cleanup: 83 tests -->
 
 <suite id="Shared Classes CommandLineOptionTests Suite">
 
@@ -911,6 +911,29 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 	</test>
 	
+	<test id="Test 207: Create a non-persistent cache" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -Xtrace:print=j9prt.700 $currentMode$,nonpersistent -version</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
+
+		<!-- Check for non-fatal message in ControlFileOpenWithWriteLock() -->
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes">j9prt.700.*ControlFileFDWithWriteLock(Info:</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 207 cleanup: destroy non-persistent cache" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="failure" caseSensitive="no"  regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
 	<test id="At end destroy cache for cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>


### PR DESCRIPTION
1. Use OMR version of file_chown().
2. Add a test case for setting groupID of shared cache control file.

Signed-off-by: hangshao <hangshao@ca.ibm.com>