### PR TITLE
Use host class loader for anon class constraint checks

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2021,7 +2021,7 @@ fail:
 		} else {
 			interfaceHead = markInterfaces(romClass, superclass, hostClassLoader, &foundCloneable, &interfaceCount, &inheritedInterfaceCount, &maxInterfaceDepth);
 			/* Compute the number of slots required for the interpreter and jit (if enabled) vTables. */
-			vTable = computeVTable(vmThread, classLoader, superclass, romClass, packageID, methodRemapArray, interfaceHead, &defaultConflictCount, interfaceCount, inheritedInterfaceCount, &errorData);
+			vTable = computeVTable(vmThread, hostClassLoader, superclass, romClass, packageID, methodRemapArray, interfaceHead, &defaultConflictCount, interfaceCount, inheritedInterfaceCount, &errorData);
 			if (vTable == NULL) {
 				unmarkInterfaces(interfaceHead);
 				popFromClassLoadingStack(vmThread);


### PR DESCRIPTION
When performing class loading constraint checks, use the host class
loader rather than the internal anon loader (of which there is only
one).

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>