### PR TITLE
Accelerate String copies to UTF8

### DIFF
--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -201,7 +201,7 @@ searchClassInModule(J9VMThread * vmThread, J9Module * j9module, U_8 * className,
 {
 	J9JavaVM *javaVM = vmThread->javaVM;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-	char *moduleName = moduleNameBuf;
+	char *moduleName = NULL;
 	BOOLEAN freeModuleName = FALSE;
 	IDATA rc = 1;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -213,7 +213,7 @@ searchClassInModule(J9VMThread * vmThread, J9Module * j9module, U_8 * className,
 		moduleName = JAVA_BASE_MODULE;
 	} else {
 		moduleName = J9_VM_FUNCTION(vmThread, copyStringToUTF8WithMemAlloc)(
-			vmThread, j9module->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			vmThread, j9module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == moduleName) {
 			rc = -1;
 			goto _end;

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -213,7 +213,7 @@ searchClassInModule(J9VMThread * vmThread, J9Module * j9module, U_8 * className,
 		moduleName = JAVA_BASE_MODULE;
 	} else {
 		moduleName = J9_VM_FUNCTION(vmThread, copyStringToUTF8WithMemAlloc)(
-			vmThread, j9module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			vmThread, j9module->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == moduleName) {
 			rc = -1;
 			goto _end;

--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -213,7 +213,7 @@ searchClassInModule(J9VMThread * vmThread, J9Module * j9module, U_8 * className,
 		moduleName = JAVA_BASE_MODULE;
 	} else {
 		moduleName = J9_VM_FUNCTION(vmThread, copyStringToUTF8WithMemAlloc)(
-			vmThread, j9module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			vmThread, j9module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == moduleName) {
 			rc = -1;
 			goto _end;

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5269,7 +5269,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    int32_t len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
    U_8* u8ClassString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString, len + 1, TRUE);
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, u8ClassString, len + 1);
 
    /**
    //fprintf(stderr,"name is (res is %d) classString is %p\n",res, classString); fflush(stderr);
@@ -5300,7 +5300,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), fieldString);
    U_8* u8FieldString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString, len + 1, TRUE);
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NULL_TERMINATE_RESULT, u8FieldString, len + 1);
 
    ListIterator<TR_VMField> itr(fields.getFields()) ;
    TR_VMField* field;
@@ -5426,7 +5426,7 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    {
    TR_ASSERT(haveAccess(), "Must have VM access to call getStringAscii");
 
-   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, (UDATA)bufferSize, TRUE);
+   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NULL_TERMINATE_RESULT, (U_8*)buffer, (UDATA)bufferSize);
 
    return buffer;
    }

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5269,10 +5269,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    int32_t len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
    U_8* u8ClassString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString, len+1))
-      {
-      return 0;
-      }
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString);
 
    /**
    //fprintf(stderr,"name is (res is %d) classString is %p\n",res, classString); fflush(stderr);
@@ -5303,10 +5300,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), fieldString);
    U_8* u8FieldString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString, len + 1))
-      {
-      return 0;
-      }
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString);
 
    ListIterator<TR_VMField> itr(fields.getFields()) ;
    TR_VMField* field;
@@ -5434,10 +5428,7 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    TR_ASSERT(objectPointer && buffer, "assertion failure");
    TR_ASSERT(bufferSize >= 1+getStringUTF8Length(objectPointer), "getStringUTF8 buffer must be large enough");
 
-   if (UDATA_MAX == vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, UDATA_MAX))
-      {
-      buffer = NULL;
-      }
+   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer);
 
    return buffer;
    }

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5433,6 +5433,7 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    TR_ASSERT(haveAccess(), "Must have VM access to call getStringAscii");
    TR_ASSERT(objectPointer && buffer, "assertion failure");
    TR_ASSERT(bufferSize >= 1+getStringUTF8Length(objectPointer), "getStringUTF8 buffer must be large enough");
+
    if (UDATA_MAX == vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, UDATA_MAX))
       {
       buffer = NULL;

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5269,7 +5269,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    int32_t len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
    U_8* u8ClassString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString);
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString, TRUE);
 
    /**
    //fprintf(stderr,"name is (res is %d) classString is %p\n",res, classString); fflush(stderr);
@@ -5300,7 +5300,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), fieldString);
    U_8* u8FieldString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString);
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString, TRUE);
 
    ListIterator<TR_VMField> itr(fields.getFields()) ;
    TR_VMField* field;
@@ -5428,7 +5428,7 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    TR_ASSERT(objectPointer && buffer, "assertion failure");
    TR_ASSERT(bufferSize >= 1+getStringUTF8Length(objectPointer), "getStringUTF8 buffer must be large enough");
 
-   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer);
+   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, TRUE);
 
    return buffer;
    }

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5266,10 +5266,13 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    TR::StaticSymbol* fieldSym = fieldRef->getSymbol()->castToStaticSymbol();
    j9object_t fieldString = (j9object_t)getStaticReferenceFieldAtAddress((uintptrj_t)fieldSym->getStaticAddress());
 
-   int32_t len, res;
-   len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
+   int32_t len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
    U_8* u8ClassString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
-   res = (int32_t)jitConfig->javaVM->internalVMFunctions->copyStringToUTF8(vmThread(), classString, J9_STR_XLAT, u8ClassString, len+1);
+
+   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, TRUE, J9_STR_XLAT, u8ClassString, len+1))
+      {
+      return 0;
+      }
 
    /**
    //fprintf(stderr,"name is (res is %d) classString is %p\n",res, classString); fflush(stderr);
@@ -5280,7 +5283,6 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    fprintf(stderr,"  (len is %d)\n",len);fflush(stderr);
    **/
 
-   if (res) return 0;
    char* classSignature = classNameToSignature((char*)u8ClassString, len, comp);
 
    /**
@@ -5300,7 +5302,11 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
 
    len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), fieldString);
    U_8* u8FieldString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
-   res = (int32_t)jitConfig->javaVM->internalVMFunctions->copyStringToUTF8(vmThread(), fieldString, 0, u8FieldString, len+1);
+
+   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, TRUE, J9_STR_NONE, u8FieldString, len + 1))
+      {
+      return 0;
+      }
 
    ListIterator<TR_VMField> itr(fields.getFields()) ;
    TR_VMField* field;

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5269,7 +5269,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    int32_t len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
    U_8* u8ClassString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString, TRUE);
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString, len + 1, TRUE);
 
    /**
    //fprintf(stderr,"name is (res is %d) classString is %p\n",res, classString); fflush(stderr);
@@ -5300,7 +5300,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), fieldString);
    U_8* u8FieldString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString, TRUE);
+   jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString, len + 1, TRUE);
 
    ListIterator<TR_VMField> itr(fields.getFields()) ;
    TR_VMField* field;
@@ -5425,10 +5425,8 @@ char *
 TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t bufferSize)
    {
    TR_ASSERT(haveAccess(), "Must have VM access to call getStringAscii");
-   TR_ASSERT(objectPointer && buffer, "assertion failure");
-   TR_ASSERT(bufferSize >= 1+getStringUTF8Length(objectPointer), "getStringUTF8 buffer must be large enough");
 
-   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, TRUE);
+   vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, (UDATA)bufferSize, TRUE);
 
    return buffer;
    }

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5433,8 +5433,11 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    TR_ASSERT(haveAccess(), "Must have VM access to call getStringAscii");
    TR_ASSERT(objectPointer && buffer, "assertion failure");
    TR_ASSERT(bufferSize >= 1+getStringUTF8Length(objectPointer), "getStringUTF8 buffer must be large enough");
-   UDATA end = vmThread()->javaVM->internalVMFunctions->copyFromStringIntoUTF8(vmThread(), (j9object_t)objectPointer, buffer);
-   buffer[end] = 0;
+   if (UDATA_MAX == vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, TRUE, J9_STR_NONE, (U_8*)buffer, UDATA_MAX))
+      {
+      buffer = NULL;
+      }
+
    return buffer;
    }
 

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -5269,7 +5269,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    int32_t len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), classString);
    U_8* u8ClassString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, TRUE, J9_STR_XLAT, u8ClassString, len+1))
+   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), classString, J9_STR_XLAT, u8ClassString, len+1))
       {
       return 0;
       }
@@ -5303,7 +5303,7 @@ TR_J9VMBase::getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRe
    len = (int32_t)jitConfig->javaVM->internalVMFunctions->getStringUTF8Length(vmThread(), fieldString);
    U_8* u8FieldString = (U_8*)comp->trMemory()->allocateStackMemory(len + 1);
 
-   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, TRUE, J9_STR_NONE, u8FieldString, len + 1))
+   if (UDATA_MAX == jitConfig->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), fieldString, J9_STR_NONE, u8FieldString, len + 1))
       {
       return 0;
       }
@@ -5433,7 +5433,7 @@ TR_J9VMBase::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
    TR_ASSERT(haveAccess(), "Must have VM access to call getStringAscii");
    TR_ASSERT(objectPointer && buffer, "assertion failure");
    TR_ASSERT(bufferSize >= 1+getStringUTF8Length(objectPointer), "getStringUTF8 buffer must be large enough");
-   if (UDATA_MAX == vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, TRUE, J9_STR_NONE, (U_8*)buffer, UDATA_MAX))
+   if (UDATA_MAX == vmThread()->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread(), (j9object_t)objectPointer, J9_STR_NONE, (U_8*)buffer, UDATA_MAX))
       {
       buffer = NULL;
       }

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2527,6 +2527,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	J9ClassLoader *classLoader = NULL;
 	UDATA retried = FALSE;
 	UDATA utf8Length = 0;
+	char utf8NameStackBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	U_8 *utf8Name = NULL;
 	J9Class *clazz = NULL;
 	jclass result = NULL;
@@ -2553,7 +2554,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (className != NULL) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
-		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", utf8Name, 0, &utf8Length);
+		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
@@ -2643,7 +2644,10 @@ done:
 
 	vmFuncs->internalReleaseVMAccess(currentThread);
 
-	j9mem_free_memory(utf8Name);
+	if (utf8NameStackBuffer != utf8Name) {
+		j9mem_free_memory(utf8Name);
+	}
+
 	return result;
 }
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2551,9 +2551,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
-	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (NULL != className) {
-		/* For now, use malloc, but this should use stack allocation for short class-names */
 		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2554,7 +2554,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (className != NULL) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
-		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2551,19 +2551,11 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
-	if (className == NULL) {
-		utf8Length = 0;
-		utf8Name = NULL;
-	} else {
-		utf8Length = vmFuncs->getStringUTF8Length(currentThread, J9_JNI_UNWRAP_REFERENCE(className));
+	if (className != NULL) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
-		utf8Name = j9mem_allocate_memory(utf8Length+1, J9MEM_CATEGORY_CLASSES);
-		if (utf8Name == NULL) {
+		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", utf8Name, 0, &utf8Length);
+		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
-			goto done;
-		}
-		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, utf8Name, utf8Length + 1)) {
-			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			goto done;
 		}
 	}

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2554,7 +2554,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (NULL != className) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
-		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2552,7 +2552,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
-	if (className != NULL) {
+	if (NULL != className) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
 		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2562,9 +2562,7 @@ jvmDefineClassHelper(JNIEnv *env, jobject classLoaderObject,
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
 		}
-		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(className), TRUE, J9_STR_XLAT, utf8Name, utf8Length + 1)
-		) {
+		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, utf8Name, utf8Length + 1)) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			goto done;
 		}

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2644,7 +2644,7 @@ done:
 
 	vmFuncs->internalReleaseVMAccess(currentThread);
 
-	if (utf8NameStackBuffer != utf8Name) {
+	if ((U_8*)utf8NameStackBuffer != utf8Name) {
 		j9mem_free_memory(utf8Name);
 	}
 

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -409,7 +409,10 @@ trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9o
 		if (moduleNameBuf != moduleNameUTF) {
 			j9mem_free_memory(moduleNameUTF);
 		}
+	} else {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 	}
+
 #if J9VM_JAVA9_BUILD < 156
 	if (packageNameBuf != packageNameUTF) {
 		j9mem_free_memory(packageNameUTF);

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -381,11 +381,11 @@ trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9o
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 #if J9VM_JAVA9_BUILD < 156
 	char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, package, J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, package, J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 #endif /* J9VM_JAVA9_BUILD < 156 */
 
 	if (NULL != moduleNameUTF) {
@@ -627,14 +627,14 @@ trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModul
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all(currentThread, package, fromModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports_to_all(currentThread, packageNameUTF, fromModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -682,14 +682,14 @@ trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fr
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, package, fromModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, packageNameUTF, fromModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -778,16 +778,16 @@ trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, jstr
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char toModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	char *toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, toModule->moduleName, J9_STR_NONE, "", toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, toModule->moduleName, J9_STR_NONE, "", toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if ((NULL != fromModuleNameUTF) && (NULL != toModuleNameUTF)) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports(currentThread, package, fromModuleNameUTF, toModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports(currentThread, packageNameUTF, fromModuleNameUTF, toModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -977,7 +977,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 					char *nameUTF = buf;
 
 					nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-						currentThread, moduleName, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+						currentThread, moduleName, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 					if (NULL == nameUTF) {
 						success = FALSE;
 						goto nativeOOM;
@@ -1154,12 +1154,12 @@ trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char toModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, j9FromMod->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, j9FromMod->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	char *toModuleNameUTF = NULL;
 
 	if (NULL != toModule) {
 		toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, j9ToMod->moduleName, J9_STR_NONE, "", toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			currentThread, j9ToMod->moduleName, J9_STR_NONE, "", toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	} else {
 #define LOOSE_MODULE   "loose "
 		PORT_ACCESS_FROM_VMC(currentThread);
@@ -1321,7 +1321,7 @@ JVM_IsExportedToModule(JNIEnv * env, jobject fromModule, jstring package, jobjec
 		char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *nameUTF = buf;
 		nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, pkgObject, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			currentThread, pkgObject, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == nameUTF) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
@@ -1361,14 +1361,14 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring p
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, j9mod->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, j9mod->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_package(currentThread, package, moduleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_package(currentThread, packageNameUTF, moduleNameUTF);
 			if (packageNameBuf != packageNameUTF) {

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -1708,7 +1708,7 @@ JVM_GetModuleByPackageName(JNIEnv *env, jobject classLoader, jstring packageName
 				goto exit;
 			}
 		}
-		vmFuncs->copyStringToUTF8Helper(currentThread, packageObj, TRUE, J9_STR_NONE, J9UTF8_DATA(packageUTF8), length + 1);
+		vmFuncs->copyStringToUTF8Helper(currentThread, packageObj, J9_STR_NONE, J9UTF8_DATA(packageUTF8), length + 1);
 		J9UTF8_SET_LENGTH(packageUTF8, (U_16) length);
 		if (NULL != strchr((const char*)J9UTF8_DATA(packageUTF8), '.')) {
 			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, "package name contains '.' instead of '/'");

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -381,11 +381,11 @@ trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9o
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 #if J9VM_JAVA9_BUILD < 156
 	char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, package, J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, package, J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 #endif /* J9VM_JAVA9_BUILD < 156 */
 
 	if (NULL != moduleNameUTF) {
@@ -630,14 +630,14 @@ trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModul
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all(currentThread, package, fromModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports_to_all(currentThread, packageNameUTF, fromModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -685,14 +685,14 @@ trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fr
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, package, fromModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, packageNameUTF, fromModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -781,16 +781,16 @@ trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, jstr
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char toModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	char *toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, toModule->moduleName, J9_STR_NONE, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, toModule->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if ((NULL != fromModuleNameUTF) && (NULL != toModuleNameUTF)) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports(currentThread, package, fromModuleNameUTF, toModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports(currentThread, packageNameUTF, fromModuleNameUTF, toModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -980,7 +980,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 					char *nameUTF = buf;
 
 					nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-						currentThread, moduleName, J9_STR_NONE, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+						currentThread, moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 					if (NULL == nameUTF) {
 						success = FALSE;
 						goto nativeOOM;
@@ -1157,12 +1157,12 @@ trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char toModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, j9FromMod->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, j9FromMod->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	char *toModuleNameUTF = NULL;
 
 	if (NULL != toModule) {
 		toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, j9ToMod->moduleName, J9_STR_NONE, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, j9ToMod->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	} else {
 #define LOOSE_MODULE   "loose "
 		PORT_ACCESS_FROM_VMC(currentThread);
@@ -1324,7 +1324,7 @@ JVM_IsExportedToModule(JNIEnv * env, jobject fromModule, jstring package, jobjec
 		char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *nameUTF = NULL;
 		nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, pkgObject, J9_STR_NONE, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, pkgObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == nameUTF) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
@@ -1364,14 +1364,14 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring p
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, j9mod->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, j9mod->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_package(currentThread, package, moduleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NULL_TERMINATE_RESULT, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_package(currentThread, packageNameUTF, moduleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -1701,7 +1701,7 @@ JVM_GetModuleByPackageName(JNIEnv *env, jobject classLoader, jstring packageName
 			thisVMClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, thisClassloader);
 		}
 
-		packageUTF8 = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NONE, "\0\0", sizeof(packageUTF8->length), buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &packageLength);
+		packageUTF8 = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NULL_TERMINATE_RESULT, "\0\0", sizeof(packageUTF8->length), buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &packageLength);
 
 		if (NULL == packageUTF8) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -1319,7 +1319,7 @@ JVM_IsExportedToModule(JNIEnv * env, jobject fromModule, jstring package, jobjec
 #if J9VM_JAVA9_BUILD >= 156
 		PORT_ACCESS_FROM_VMC(currentThread);
 		char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-		char *nameUTF = buf;
+		char *nameUTF = NULL;
 		nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
 			currentThread, pkgObject, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == nameUTF) {

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -1698,7 +1698,7 @@ JVM_GetModuleByPackageName(JNIEnv *env, jobject classLoader, jstring packageName
 			thisVMClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, thisClassloader);
 		}
 
-		packageUTF8 = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NONE, "\0\0", sizeof(packageUTF8->length), buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &packageLength);
+		packageUTF8 = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NONE, "\0\0", sizeof(packageUTF8->length), buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &packageLength);
 
 		if (NULL == packageUTF8) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -381,11 +381,11 @@ trcModulesCreationPackage(J9VMThread * currentThread, J9Module * fromModule, j9o
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 #if J9VM_JAVA9_BUILD < 156
 	char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, package, J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, package, J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 #endif /* J9VM_JAVA9_BUILD < 156 */
 
 	if (NULL != moduleNameUTF) {
@@ -627,14 +627,14 @@ trcModulesAddModuleExportsToAll(J9VMThread * currentThread, J9Module * fromModul
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all(currentThread, package, fromModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports_to_all(currentThread, packageNameUTF, fromModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -682,14 +682,14 @@ trcModulesAddModuleExportsToAllUnnamed(J9VMThread * currentThread, J9Module * fr
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != fromModuleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, package, fromModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports_to_all_unnamed(currentThread, packageNameUTF, fromModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -778,16 +778,16 @@ trcModulesAddModuleExports(J9VMThread *currentThread, J9Module *fromModule, jstr
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char toModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, fromModule->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, fromModule->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	char *toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, toModule->moduleName, J9_STR_NONE, "", toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, toModule->moduleName, J9_STR_NONE, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if ((NULL != fromModuleNameUTF) && (NULL != toModuleNameUTF)) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_exports(currentThread, package, fromModuleNameUTF, toModuleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_exports(currentThread, packageNameUTF, fromModuleNameUTF, toModuleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -977,7 +977,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 					char *nameUTF = buf;
 
 					nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-						currentThread, moduleName, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+						currentThread, moduleName, J9_STR_NONE, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 					if (NULL == nameUTF) {
 						success = FALSE;
 						goto nativeOOM;
@@ -1154,12 +1154,12 @@ trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *
 	char fromModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char toModuleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *fromModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, j9FromMod->moduleName, J9_STR_NONE, "", fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, j9FromMod->moduleName, J9_STR_NONE, "", 0, fromModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	char *toModuleNameUTF = NULL;
 
 	if (NULL != toModule) {
 		toModuleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, j9ToMod->moduleName, J9_STR_NONE, "", toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, j9ToMod->moduleName, J9_STR_NONE, "", 0, toModuleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	} else {
 #define LOOSE_MODULE   "loose "
 		PORT_ACCESS_FROM_VMC(currentThread);
@@ -1321,7 +1321,7 @@ JVM_IsExportedToModule(JNIEnv * env, jobject fromModule, jstring package, jobjec
 		char buf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *nameUTF = NULL;
 		nameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, pkgObject, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, pkgObject, J9_STR_NONE, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL == nameUTF) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
@@ -1361,14 +1361,14 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, jstring p
 	J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-		currentThread, j9mod->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, j9mod->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
 #if J9VM_JAVA9_BUILD >= 156
 		Trc_MODULE_add_module_package(currentThread, package, moduleNameUTF);
 #else
 		char packageNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *packageNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			currentThread, J9_JNI_UNWRAP_REFERENCE(package), J9_STR_NONE, "", 0, packageNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		if (NULL != packageNameUTF) {
 			Trc_MODULE_add_module_package(currentThread, packageNameUTF, moduleNameUTF);
 			if (packageNameBuf != packageNameUTF) {
@@ -1699,7 +1699,7 @@ JVM_GetModuleByPackageName(JNIEnv *env, jobject classLoader, jstring packageName
 			thisVMClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, thisClassloader);
 		}
 
-		packageName = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NONE, "", buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &length);
+		packageName = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NONE, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &length);
 
 		if (NULL == packageName) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -1701,14 +1701,12 @@ JVM_GetModuleByPackageName(JNIEnv *env, jobject classLoader, jstring packageName
 			thisVMClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, thisClassloader);
 		}
 
-		packageUTF8 = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageObj, J9_STR_NULL_TERMINATE_RESULT, "\0\0", sizeof(packageUTF8->length), buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &packageLength);
+		packageUTF8 = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, packageObj, J9_STR_NULL_TERMINATE_RESULT, "", 0, buf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
 
 		if (NULL == packageUTF8) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto exit;
 		}
-
-		J9UTF8_SET_LENGTH(packageUTF8, (U_16)packageLength);
 		
 		if (NULL != strchr((const char*)J9UTF8_DATA(packageUTF8), '.')) {
 			vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, "package name contains '.' instead of '/'");

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -928,7 +928,7 @@ allocateJ9UTF8(JNIEnv *env, jstring name)
 	if (NULL != utf8) {
 		J9UTF8_SET_LENGTH(utf8, (U_16) length);
 		/* Can't fail - just translates String->length into data */
-		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(vmThread, jlString, TRUE, J9_STR_NONE, J9UTF8_DATA(utf8), length + 1)) {
+		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(vmThread, jlString, J9_STR_NONE, J9UTF8_DATA(utf8), length + 1)) {
 			j9mem_free_memory(utf8);
 			vmFuncs->setCurrentException(vmThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			utf8 = NULL;

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -924,11 +924,11 @@ allocateJ9UTF8(JNIEnv *env, jstring name)
 
 	PORT_ACCESS_FROM_ENV(env);
 
-	utf8 = j9mem_allocate_memory(sizeof(U_16) + length, J9MEM_CATEGORY_VM_JCL);
+	utf8 = j9mem_allocate_memory(sizeof(U_16) + length + 1, J9MEM_CATEGORY_VM_JCL);
 	if (NULL != utf8) {
 		J9UTF8_SET_LENGTH(utf8, (U_16) length);
 		/* Can't fail - just translates String->length into data */
-		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(vmThread, jlString, FALSE, J9_STR_NONE, J9UTF8_DATA(utf8), length)) {
+		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(vmThread, jlString, TRUE, J9_STR_NONE, J9UTF8_DATA(utf8), length + 1)) {
 			j9mem_free_memory(utf8);
 			vmFuncs->setCurrentException(vmThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			utf8 = NULL;

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -927,12 +927,7 @@ allocateJ9UTF8(JNIEnv *env, jstring name)
 	utf8 = j9mem_allocate_memory(sizeof(U_16) + length + 1, J9MEM_CATEGORY_VM_JCL);
 	if (NULL != utf8) {
 		J9UTF8_SET_LENGTH(utf8, (U_16) length);
-		/* Can't fail - just translates String->length into data */
-		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(vmThread, jlString, J9_STR_NONE, J9UTF8_DATA(utf8), length + 1)) {
-			j9mem_free_memory(utf8);
-			vmFuncs->setCurrentException(vmThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
-			utf8 = NULL;
-		}
+		vmFuncs->copyStringToUTF8Helper(vmThread, jlString, J9_STR_NONE, J9UTF8_DATA(utf8));
 	} else {
 		vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
 	}

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -920,16 +920,16 @@ allocateJ9UTF8(JNIEnv *env, jstring name)
 	J9InternalVMFunctions *vmFuncs = vmThread->javaVM->internalVMFunctions;
 	J9UTF8 *utf8 = NULL;
 	j9object_t jlString = J9_JNI_UNWRAP_REFERENCE(name);
-	UDATA length = vmFuncs->getStringUTF8Length(vmThread, jlString);
+	UDATA utf8Length = 0;
 
 	PORT_ACCESS_FROM_ENV(env);
 
-	utf8 = j9mem_allocate_memory(sizeof(utf8->length) + length, J9MEM_CATEGORY_VM_JCL);
-	if (NULL != utf8) {
-		J9UTF8_SET_LENGTH(utf8, (U_16) length);
-		vmFuncs->copyStringToUTF8Helper(vmThread, jlString, J9_STR_NONE, J9UTF8_DATA(utf8), FALSE);
-	} else {
+	utf8 = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(vmThread, jlString, J9_STR_NONE, "\0\0", sizeof(utf8->length), NULL, 0, &utf8Length);
+
+	if (NULL == utf8) {
 		vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
+	} else {
+		J9UTF8_SET_LENGTH(utf8, (U_16)utf8Length);
 	}
 
 	return utf8;

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -924,10 +924,10 @@ allocateJ9UTF8(JNIEnv *env, jstring name)
 
 	PORT_ACCESS_FROM_ENV(env);
 
-	utf8 = j9mem_allocate_memory(sizeof(U_16) + length + 1, J9MEM_CATEGORY_VM_JCL);
+	utf8 = j9mem_allocate_memory(sizeof(utf8->length) + length, J9MEM_CATEGORY_VM_JCL);
 	if (NULL != utf8) {
 		J9UTF8_SET_LENGTH(utf8, (U_16) length);
-		vmFuncs->copyStringToUTF8Helper(vmThread, jlString, J9_STR_NONE, J9UTF8_DATA(utf8));
+		vmFuncs->copyStringToUTF8Helper(vmThread, jlString, J9_STR_NONE, J9UTF8_DATA(utf8), FALSE);
 	} else {
 		vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
 	}

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -922,8 +922,6 @@ allocateJ9UTF8(JNIEnv *env, jstring name)
 	j9object_t jlString = J9_JNI_UNWRAP_REFERENCE(name);
 	UDATA utf8Length = 0;
 
-	PORT_ACCESS_FROM_ENV(env);
-
 	utf8 = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(vmThread, jlString, J9_STR_NONE, "\0\0", sizeof(utf8->length), NULL, 0, &utf8Length);
 
 	if (NULL == utf8) {

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -911,25 +911,27 @@ Java_java_lang_Class_getMethodImpl(JNIEnv *env, jobject recv, jobject name, jobj
 
 			J9JNINameAndSignature nameAndSig;
 			char nameBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
+			UDATA nameBufferLength;
 			char signatureBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
+			UDATA signatureLength;
 			nameAndSig.name = nameBuffer;
 			nameAndSig.nameLength = 0;
 			nameAndSig.signature = signatureBuffer;
 			nameAndSig.signatureLength = 0;
 
 			nameAndSig.name = vmFuncs->copyStringToUTF8WithMemAlloc(
-				currentThread, nameObject, J9_STR_NONE, "", nameBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+				currentThread, nameObject, J9_STR_NONE, "", nameBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &nameBufferLength);
 			if (NULL == nameAndSig.name) {
 				goto _done;
 			}
-			nameAndSig.nameLength = (U_32) vmFuncs->getStringUTF8Length(currentThread, nameObject);
+			nameAndSig.nameLength = (U_32)nameBufferLength;
 
 			nameAndSig.signature = vmFuncs->copyStringToUTF8WithMemAlloc(
-				currentThread, signatureObject, J9_STR_XLAT, "", signatureBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+				currentThread, signatureObject, J9_STR_XLAT, "", signatureBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &signatureLength);
 			if (NULL == nameAndSig.signature) {
 				goto _done;
 			}
-			nameAndSig.signatureLength = (U_32) vmFuncs->getStringUTF8Length(currentThread, signatureObject);
+			nameAndSig.signatureLength = (U_32)signatureLength;
 
 			currentMethod = (J9Method *) vmFuncs->javaLookupMethodImpl(currentThread, clazz, ((J9ROMNameAndSignature *) &nameAndSig), NULL, lookupFLags, NULL);
 			if (NULL == currentMethod) { /* by default we look for virtual methods.  Try static methods. */

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -911,9 +911,9 @@ Java_java_lang_Class_getMethodImpl(JNIEnv *env, jobject recv, jobject name, jobj
 
 			J9JNINameAndSignature nameAndSig;
 			char nameBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-			UDATA nameBufferLength;
+			UDATA nameBufferLength = 0;
 			char signatureBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
-			UDATA signatureLength;
+			UDATA signatureLength = 0;
 			nameAndSig.name = nameBuffer;
 			nameAndSig.nameLength = 0;
 			nameAndSig.signature = signatureBuffer;

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -920,14 +920,14 @@ Java_java_lang_Class_getMethodImpl(JNIEnv *env, jobject recv, jobject name, jobj
 			nameAndSig.signatureLength = 0;
 
 			nameAndSig.name = vmFuncs->copyStringToUTF8WithMemAlloc(
-				currentThread, nameObject, J9_STR_NONE, "", nameBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &nameBufferLength);
+				currentThread, nameObject, J9_STR_NONE, "", 0, nameBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &nameBufferLength);
 			if (NULL == nameAndSig.name) {
 				goto _done;
 			}
 			nameAndSig.nameLength = (U_32)nameBufferLength;
 
 			nameAndSig.signature = vmFuncs->copyStringToUTF8WithMemAlloc(
-				currentThread, signatureObject, J9_STR_XLAT, "", signatureBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &signatureLength);
+				currentThread, signatureObject, J9_STR_XLAT, "", 0, signatureBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &signatureLength);
 			if (NULL == nameAndSig.signature) {
 				goto _done;
 			}

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -920,14 +920,14 @@ Java_java_lang_Class_getMethodImpl(JNIEnv *env, jobject recv, jobject name, jobj
 			nameAndSig.signatureLength = 0;
 
 			nameAndSig.name = vmFuncs->copyStringToUTF8WithMemAlloc(
-				currentThread, nameObject, J9_STR_NONE, "", 0, nameBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &nameBufferLength);
+				currentThread, nameObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, nameBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &nameBufferLength);
 			if (NULL == nameAndSig.name) {
 				goto _done;
 			}
 			nameAndSig.nameLength = (U_32)nameBufferLength;
 
 			nameAndSig.signature = vmFuncs->copyStringToUTF8WithMemAlloc(
-				currentThread, signatureObject, J9_STR_XLAT, "", 0, signatureBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &signatureLength);
+				currentThread, signatureObject, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, signatureBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &signatureLength);
 			if (NULL == nameAndSig.signature) {
 				goto _done;
 			}

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,8 @@ accessCheckFieldType(J9VMThread *currentThread, J9Class* lookupClass, J9Class* t
 jlong JNICALL
 Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jclass lookupClass, jstring name, jstring signature, jclass type, jboolean isStatic, jclass accessClass)
 {
-	J9UTF8 *sigUTF = NULL;
+	J9UTF8 *signatureUTF8 = NULL;
+	char signatureUTF8Buffer[256];
 	J9Class *j9LookupClass;			/* J9Class for java.lang.Class lookupClass */
 	J9Class *definingClass = NULL;
 	UDATA field = 0;
@@ -88,23 +89,25 @@ Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jc
 
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 
-	sigUTF = allocateJ9UTF8(env, signature);
-	if (NULL == sigUTF) {
+	signatureUTF8 = vmFuncs->copyStringToJ9UTF8WithMemAlloc(vmThread, J9_JNI_UNWRAP_REFERENCE(signature), J9_STR_NONE, "", 0, signatureUTF8Buffer, sizeof(signatureUTF8Buffer));
+
+	if (signatureUTF8 == NULL) {
+		vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
 		Assert_JCL_notNull(vmThread->currentException);
 		goto _cleanup;
 	}
 
 	j9LookupClass = J9VM_J9CLASS_FROM_JCLASS(vmThread, lookupClass);
 
-	field = lookupField(env, isStatic, j9LookupClass, name, sigUTF, &definingClass, &romField, accessClass);
+	field = lookupField(env, isStatic, j9LookupClass, name, signatureUTF8, &definingClass, &romField, accessClass);
 
 	if (NULL != vmThread->currentException) {
 		goto _cleanup;
 	}
 
 	/* Check signature for classloader visibility */
-	if (!accessCheckFieldType(vmThread, j9LookupClass, J9VM_J9CLASS_FROM_JCLASS(vmThread, type), sigUTF)) {
-		setClassLoadingConstraintLinkageError(vmThread, definingClass, sigUTF);
+	if (!accessCheckFieldType(vmThread, j9LookupClass, J9VM_J9CLASS_FROM_JCLASS(vmThread, type), signatureUTF8)) {
+		setClassLoadingConstraintLinkageError(vmThread, definingClass, signatureUTF8);
 		goto _cleanup;
 	}
 
@@ -112,7 +115,11 @@ Java_java_lang_invoke_FieldVarHandle_lookupField(JNIEnv *env, jobject handle, jc
 
 _cleanup:
 	vmFuncs->internalExitVMToJNI(vmThread);
-	j9mem_free_memory(sigUTF);
+
+	if (signatureUTF8 != (J9UTF8*)signatureUTF8Buffer) {
+		j9mem_free_memory(signatureUTF8);
+	}
+
 	return field;
 }
 

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -91,7 +91,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (className != NULL) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
-		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -99,9 +99,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
 		}
-		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(
-			currentThread, J9_JNI_UNWRAP_REFERENCE(className), TRUE, J9_STR_XLAT, utf8Name, utf8Length + 1)
-		) {
+		if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, utf8Name, utf8Length + 1)) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			goto done;
 		}

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -90,7 +90,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (NULL != className) {
-		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -89,8 +89,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 	}
 
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
-	if (className != NULL) {
-		/* For now, use malloc, but this should use stack allocation for short class-names */
+	if (NULL != className) {
 		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 
 		if (NULL == utf8Name) {

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -91,7 +91,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 	/* Allocate and initialize a UTF8 copy of the Unicode class-name */
 	if (className != NULL) {
 		/* For now, use malloc, but this should use stack allocation for short class-names */
-		utf8Name = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = (U_8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, J9_JNI_UNWRAP_REFERENCE(className), J9_STR_XLAT, "", 0, utf8NameStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 
 		if (NULL == utf8Name) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
@@ -212,7 +212,7 @@ done:
 
 	vmFuncs->internalReleaseVMAccess(currentThread);
 
-	if (utf8NameStackBuffer != utf8Name) {
+	if ((U_8*)utf8NameStackBuffer != utf8Name) {
 		j9mem_free_memory(utf8Name);
 	}
 

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -446,7 +446,7 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 					name = j9mem_allocate_memory(1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
 					name[0] = '\0';
 				} else {
-					name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, threadName, J9_STR_NONE, "", 0, name, 0, NULL);
+					name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, threadName, J9_STR_NULL_TERMINATE_RESULT, "", 0, name, 0, NULL);
 
 					if (NULL == name) {
 						rc = JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -433,16 +433,16 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, FALSE);
 		if (rc == JVMTI_ERROR_NONE) {
 			char* name = NULL;
-			j9object_t threadObject = (thread == NULL) ? targetThread->threadObject : *((j9object_t*) thread);
+			j9object_t threadObject = (NULL == thread) ? targetThread->threadObject : *((j9object_t*) thread);
 			jobject threadGroup = NULL;
 			jobject contextClassLoader;
 
-			if (targetThread == NULL) {
+			if (NULL == targetThread) {
 				/* java.lang.thread may not have a ref to vm thread. for example, after it gets terminated.
 				 * but we still want to return the name, so we retrieve it from the thread object itself. */
 				j9object_t threadName = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
 
-				if (threadName == NULL) {
+				if (NULL == threadName) {
 					name = j9mem_allocate_memory(1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
 					name[0] = '\0';
 				} else {
@@ -460,14 +460,14 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 				/* Be sure to allocate at least one byte for the nul termination */
 
 				name = j9mem_allocate_memory(threadNameLen, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-				if (name == NULL) {
+				if (NULL == name) {
 					/* failed to allocate memory, so release VMTthread and exit */
 					releaseOMRVMThreadName(targetThread->omrVMThread);
 					rc = JVMTI_ERROR_OUT_OF_MEMORY;
 					goto done;
 				}
 
-				if (threadName == NULL) {
+				if (NULL == threadName) {
 					name[0] = '\0';
 				} else {
 					memcpy(name, threadName, threadNameLen);

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -446,7 +446,7 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 					name = j9mem_allocate_memory(1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
 					name[0] = '\0';
 				} else {
-					name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, threadName, J9_STR_NONE, "", name, 0, NULL);
+					name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, threadName, J9_STR_NONE, "", 0, name, 0, NULL);
 
 					if (NULL == name) {
 						rc = JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -432,7 +432,7 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, FALSE);
 		if (rc == JVMTI_ERROR_NONE) {
-			char * name;
+			char* name = NULL;
 			j9object_t threadObject = (thread == NULL) ? targetThread->threadObject : *((j9object_t*) thread);
 			jobject threadGroup = NULL;
 			jobject contextClassLoader;

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -455,7 +455,7 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 				if (threadName == NULL) {
 					name[0] = '\0';
 				} else {
-					if (UDATA_MAX == vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, threadName, TRUE, J9_STR_NONE, (U_8*)name, threadNameLen)) {
+					if (UDATA_MAX == vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, threadName, J9_STR_NONE, (U_8*)name, threadNameLen)) {
 						rc = JVMTI_ERROR_INTERNAL;
 						goto done;
 					}

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -446,7 +446,7 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 					name = j9mem_allocate_memory(1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
 					name[0] = '\0';
 				} else {
-					name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, threadName, J9_STR_NULL_TERMINATE_RESULT, "", 0, name, 0, NULL);
+					name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, threadName, J9_STR_NULL_TERMINATE_RESULT, "", 0, NULL, 0, NULL);
 
 					if (NULL == name) {
 						rc = JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -111,7 +111,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 				info_ptr->max_priority = J9VMJAVALANGTHREADGROUP_MAXPRIORITY(currentThread, threadGroupObject);
 				info_ptr->is_daemon = (jboolean)J9VMJAVALANGTHREADGROUP_ISDAEMON(currentThread, threadGroupObject);
 			}
-
+done:
 			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
 		}
 	}

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -103,16 +103,11 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 			threadGroupObject = *((j9object_t*) group);
 
 			groupName = J9VMJAVALANGTHREADGROUP_NAME(currentThread, threadGroupObject);
-			/* Allocate the maximum possible bytes per UTF8 character (3 bytes), + 1 for '\0' at the end of the string */
-			nameLen = J9VMJAVALANGSTRING_LENGTH(currentThread, groupName) * 3 + 1;
-			name = j9mem_allocate_memory(nameLen, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-			if (name == NULL) {
+			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NONE, "", name, 0, NULL);
+
+			if (NULL == name) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 			} else {
-				if (UDATA_MAX == vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, groupName, J9_STR_NONE, (U_8*)name, nameLen)) {
-					rc = JVMTI_ERROR_INTERNAL;
-					goto done;
-				}
 				info_ptr->name = name;
 				info_ptr->parent = (jthreadGroup) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t)J9VMJAVALANGTHREADGROUP_PARENT(currentThread, threadGroupObject));
 				info_ptr->max_priority = J9VMJAVALANGTHREADGROUP_MAXPRIORITY(currentThread, threadGroupObject);

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -109,7 +109,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 			if (name == NULL) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 			} else {
-				if (UDATA_MAX == vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, groupName, TRUE, J9_STR_NONE, (U_8*)name, nameLen)) {
+				if (UDATA_MAX == vm->internalVMFunctions->copyStringToUTF8Helper(currentThread, groupName, J9_STR_NONE, (U_8*)name, nameLen)) {
 					rc = JVMTI_ERROR_INTERNAL;
 					goto done;
 				}

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -84,14 +84,12 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 	if (JAVAVM_FROM_ENV(env)->jclFlags & J9_JCL_FLAG_THREADGROUPS) {
 		J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 		J9VMThread * currentThread;
-		PORT_ACCESS_FROM_JAVAVM(vm);
 
 		rc = getCurrentVMThread(vm, &currentThread);
 		if (rc == JVMTI_ERROR_NONE) {
 			j9object_t threadGroupObject;
 			j9object_t groupName;
-			char * name;
-			UDATA nameLen = 0;
+			char* name = NULL;
 
 			vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -101,7 +101,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 			threadGroupObject = *((j9object_t*) group);
 
 			groupName = J9VMJAVALANGTHREADGROUP_NAME(currentThread, threadGroupObject);
-			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NONE, "", 0, name, 0, NULL);
+			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NULL_TERMINATE_RESULT, "", 0, name, 0, NULL);
 
 			if (NULL == name) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -101,7 +101,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 			threadGroupObject = *((j9object_t*) group);
 
 			groupName = J9VMJAVALANGTHREADGROUP_NAME(currentThread, threadGroupObject);
-			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NULL_TERMINATE_RESULT, "", 0, name, 0, NULL);
+			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NULL_TERMINATE_RESULT, "", 0, NULL, 0, NULL);
 
 			if (NULL == name) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
@@ -111,7 +111,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 				info_ptr->max_priority = J9VMJAVALANGTHREADGROUP_MAXPRIORITY(currentThread, threadGroupObject);
 				info_ptr->is_daemon = (jboolean)J9VMJAVALANGTHREADGROUP_ISDAEMON(currentThread, threadGroupObject);
 			}
-done:
+
 			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
 		}
 	}

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -103,7 +103,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 			threadGroupObject = *((j9object_t*) group);
 
 			groupName = J9VMJAVALANGTHREADGROUP_NAME(currentThread, threadGroupObject);
-			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NONE, "", name, 0, NULL);
+			name = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, groupName, J9_STR_NONE, "", 0, name, 0, NULL);
 
 			if (NULL == name) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -868,6 +868,30 @@ done:
 		return length;
 	}
 
+	/**
+	 * Encode the Unicode character.
+	 *
+	 * Encodes the input Unicode character and stores it into utfChars.
+	 *
+	 * @param[in] unicode The unicode character
+	 * @param[in,out] utfChars buffer for UTF8 character
+	 *
+	 * @return Size of encoding (1,2,3) on success, 0 on failure
+	 */
+	static VMINLINE UDATA
+	encodeUTF8CharI8(I_8 unicode, U_8 *utfChars)
+	{
+		UDATA length = 1;
+		if ((unicode >= 0x01) && (unicode <= 0x7F)) {
+			utfChars[0] = (U_8)unicode;
+		} else {
+			utfChars[0] = (U_8)(((unicode >>6 ) & 0x1F) | 0xC0);
+			utfChars[1] = (U_8)((unicode & 0x3F) | 0x80);
+			length = 2;
+		}
+		return length;
+	}
+
 	 /**
 	 * Encode the Unicode character.
 	 *

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -605,6 +605,8 @@ extern "C" {
 #define J9_STR_INTERN 0x8
 #define J9_STR_UNICODE 0x10
 #define J9_STR_ANON_CLASS_NAME 0x20
+/* Determines whether a copied string result will be null terminated */
+#define J9_STR_NULL_TERMINATE_RESULT 0x40
 #define J9_STR_COMPRESSION_THRESHOLD 0xFF
 
 #define J9_JCL_FLAG_REFERENCE_OBJECTS 0x1

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4494,6 +4494,7 @@ typedef struct J9InternalVMFunctions {
 	struct J9MemorySegment*  ( *allocateMemorySegment)(struct J9JavaVM *javaVM, UDATA size, UDATA type, U_32 memoryCategory) ;
 	IDATA  ( *javaThreadProc)(void *entryarg) ;
 	char*  ( *copyStringToUTF8WithMemAlloc)(struct J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length) ;
+	J9UTF8* ( *copyStringToJ9UTF8WithMemAlloc)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength) ;
 	void  ( *internalAcquireVMAccess)(struct J9VMThread * currentThread) ;
 	void  ( *internalAcquireVMAccessWithMask)(struct J9VMThread * currentThread, UDATA haltFlags) ;
 	void  ( *internalAcquireVMAccessNoMutexWithMask)(struct J9VMThread * vmThread, UDATA haltFlags) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4669,7 +4669,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, BOOLEAN isNullTerminated);
+	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength, BOOLEAN isNullTerminated);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4669,7 +4669,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA  ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
+	U_8* ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4669,7 +4669,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	U_8* ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
+	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4493,7 +4493,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *deallocateVMThread)(struct J9VMThread * vmThread, UDATA decrementZombieCount, UDATA sendThreadDestroyEvent) ;
 	struct J9MemorySegment*  ( *allocateMemorySegment)(struct J9JavaVM *javaVM, UDATA size, UDATA type, U_32 memoryCategory) ;
 	IDATA  ( *javaThreadProc)(void *entryarg) ;
-	char*  ( *copyStringToUTF8WithMemAlloc)(struct J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength) ;
+	char*  ( *copyStringToUTF8WithMemAlloc)(struct J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength, UDATA *utf8Length) ;
 	void  ( *internalAcquireVMAccess)(struct J9VMThread * currentThread) ;
 	void  ( *internalAcquireVMAccessWithMask)(struct J9VMThread * currentThread, UDATA haltFlags) ;
 	void  ( *internalAcquireVMAccessNoMutexWithMask)(struct J9VMThread * vmThread, UDATA haltFlags) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4493,7 +4493,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *deallocateVMThread)(struct J9VMThread * vmThread, UDATA decrementZombieCount, UDATA sendThreadDestroyEvent) ;
 	struct J9MemorySegment*  ( *allocateMemorySegment)(struct J9JavaVM *javaVM, UDATA size, UDATA type, U_32 memoryCategory) ;
 	IDATA  ( *javaThreadProc)(void *entryarg) ;
-	char*  ( *copyStringToUTF8WithMemAlloc)(struct J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength, UDATA *utf8Length) ;
+	char*  ( *copyStringToUTF8WithMemAlloc)(struct J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length) ;
 	void  ( *internalAcquireVMAccess)(struct J9VMThread * currentThread) ;
 	void  ( *internalAcquireVMAccessWithMask)(struct J9VMThread * currentThread, UDATA haltFlags) ;
 	void  ( *internalAcquireVMAccessNoMutexWithMask)(struct J9VMThread * vmThread, UDATA haltFlags) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4670,7 +4670,6 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA  ( *copyCharsIntoUTF8Helper)(struct J9VMThread *vmThread, BOOLEAN compressed, BOOLEAN nullTermination, UDATA stringFlags, j9object_t unicodeBytes, UDATA unicodeOffset, UDATA unicodeLength, U_8 *utf8Data, UDATA utf8Length) ;
 	UDATA  ( *copyStringToUTF8)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
 	UDATA  ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, BOOLEAN nullTermination, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4669,7 +4669,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
+	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, BOOLEAN isNullTerminated);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4493,7 +4493,6 @@ typedef struct J9InternalVMFunctions {
 	void  ( *deallocateVMThread)(struct J9VMThread * vmThread, UDATA decrementZombieCount, UDATA sendThreadDestroyEvent) ;
 	struct J9MemorySegment*  ( *allocateMemorySegment)(struct J9JavaVM *javaVM, UDATA size, UDATA type, U_32 memoryCategory) ;
 	IDATA  ( *javaThreadProc)(void *entryarg) ;
-	UDATA  ( *copyFromStringIntoUTF8)(struct J9VMThread * vmThread, j9object_t string, char * dest) ;
 	char*  ( *copyStringToUTF8WithMemAlloc)(struct J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength) ;
 	void  ( *internalAcquireVMAccess)(struct J9VMThread * currentThread) ;
 	void  ( *internalAcquireVMAccessWithMask)(struct J9VMThread * currentThread, UDATA haltFlags) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4669,7 +4669,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA  ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, BOOLEAN nullTermination, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
+	UDATA  ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4669,7 +4669,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength, BOOLEAN isNullTerminated);
+	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength);
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4670,7 +4670,6 @@ typedef struct J9InternalVMFunctions {
 	void  ( *prepareForExceptionThrow)(struct J9VMThread * currentThread) ;
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
-	UDATA  ( *copyStringToUTF8)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
 	UDATA  ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, BOOLEAN nullTermination, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length) ;
 	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -927,7 +927,6 @@ void JNICALL Java_java_lang_invoke_ThunkTuple_registerNatives(JNIEnv *env, jclas
 void JNICALL Java_java_lang_invoke_InterfaceHandle_registerNatives(JNIEnv *env, jclass nativeClass);
 jlong JNICALL Java_java_lang_invoke_MethodHandle_vtableOffset(JNIEnv *env, jclass ignored);
 void JNICALL Java_java_lang_invoke_MutableCallSite_freeGlobalRef(JNIEnv *env, jclass mutableCallSite, jlong bypassOffset);
-J9UTF8 *allocateJ9UTF8(JNIEnv *env, jstring name);
 void setClassLoadingConstraintLinkageError(J9VMThread *vmThread, J9Class *methodOrFieldClass, J9UTF8 *signatureUTF8);
 #ifdef J9VM_OPT_PANAMA
 extern J9_CFUNC jlong JNICALL

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2781,26 +2781,6 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
 
 
 /**
- * Copy certain number of Unicode characters from an offset into a Unicode character array to a UTF8 data buffer.
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] compressed if the Unicode character array is compressed
- * @param[in] nullTermination if the utf8 data is going to be NULL terminated
- * @param[in] stringFlags the flag to determine performing '.' --> '/'
- * @param[in] unicodeBytes a Unicode character array
- * @param[in] unicodeOffset an offset into the Unicode character array
- * @param[in] unicodeLength the number of Unicode characters to be copied
- * @param[in] utf8Data a utf8 data buffer
- * @param[in] utf8Length the size of the utf8 data buffer
- *
- * @return UDATA_MAX if a failure occurred, otherwise the number of utf8 data copied excluding null termination
- */
-UDATA
-copyCharsIntoUTF8Helper(
-	J9VMThread *vmThread, BOOLEAN compressed, BOOLEAN nullTermination, UDATA stringFlags, j9object_t unicodeBytes, UDATA unicodeOffset, UDATA unicodeLength, U_8 *utf8Data, UDATA utf8Length);
-
-
-/**
  * Copy a Unicode String to a UTF8 data buffer with NULL termination.
  *
  * @param[in] vmThread the current J9VMThread

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2796,21 +2796,6 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, BOOLEAN nullTerm
 
 
 /**
- * !!! this method is for backwards compatibility with JIT usage !!!
- * Copy a Unicode String to a UTF8 data buffer without NULL termination.
- * dest is assumed to have enough length - the easiest way to ensure this is to pass a buffer with 1.5 * string length in it
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] dest a utf8 data buffer
- *
- * @return UDATA_MAX if a failure occurred, otherwise the number of utf8 data copied excluding null termination
- */
-UDATA
-copyFromStringIntoUTF8(J9VMThread *vmThread, j9object_t string, char * dest);
-
-
-/**
 * @brief
 * @param *vm
 * @param *string

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2797,22 +2797,6 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, BOOLEAN nullTerm
 
 /**
  * !!! this method is for backwards compatibility with JIT usage !!!
- * Copy a Unicode String to a UTF8 data buffer with NULL termination.
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] stringFlags the flag to determine performing '.' --> '/'
- * @param[in] utf8Data a utf8 data buffer
- * @param[in] utf8Length the size of the utf8 data buffer
- *
- * @return 1 if a failure occurred, otherwise 0 for success
- */
-UDATA
-copyStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length);
-
-
-/**
- * !!! this method is for backwards compatibility with JIT usage !!!
  * Copy a Unicode String to a UTF8 data buffer without NULL termination.
  * dest is assumed to have enough length - the easiest way to ensure this is to pass a buffer with 1.5 * string length in it
  *

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2785,18 +2785,19 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
 
 
 /**
- * Copy a Unicode String to a UTF8 data buffer with NULL termination. This function makes an assumption that the
- * caller has guaranteed the buffer is of the appropriate size to fit the encoded UTF8 string.
+ * Copy a Unicode String to a UTF8 data buffer. This function makes an assumption that the caller has guaranteed the
+ * buffer is of the appropriate size to fit the encoded UTF8 string.
  *
  * @param[in] vmThread the current J9VMThread
  * @param[in] string a string object to be copied, it can't be NULL
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
+ * @param[in] isNullTerminated determines whether utf8Data will be null terminated or not
  *
  * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
  */
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, BOOLEAN isNullTerminated);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2783,17 +2783,18 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
 
 
 /**
- * Copy a Unicode String to a UTF8 data buffer with NULL termination.
+ * Copy a Unicode String to a UTF8 data buffer with NULL termination. This function makes an assumption that the
+ * caller has guaranteed the buffer is of the appropriate size to fit the encoded UTF8 string.
  *
  * @param[in] vmThread the current J9VMThread
+ * @param[in] string a string object to be copied, it can't be NULL
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
- * @param[in] utf8Length the size of the utf8 data buffer
  *
- * @return UDATA_MAX if a failure occurred, otherwise the number of utf8 data copied including null termination
+ * @return A pointer to the copied UTF8 bytes.
  */
-UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length);
+U_8*
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2785,19 +2785,19 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
 
 
 /**
- * Copy a Unicode String to a UTF8 data buffer. This function makes an assumption that the caller has guaranteed the
- * buffer is of the appropriate size to fit the encoded UTF8 string.
+ * Copy a Unicode String to a UTF8 data buffer.
  *
  * @param[in] vmThread the current J9VMThread
  * @param[in] string a string object to be copied, it can't be NULL
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
+ * @param[in] utf8DataLength the length of utf8Data in number of bytes
  * @param[in] isNullTerminated determines whether utf8Data will be null terminated or not
  *
  * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
  */
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, BOOLEAN isNullTerminated);
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength, BOOLEAN isNullTerminated);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2770,7 +2770,7 @@ romImageNewSegment(J9JavaVM *vm, J9ROMImageHeader *header, UDATA isBaseType, J9C
  * @param[in] currentThread the current J9VMThread
  * @param[in] string a string object to be copied
  * 				it can't be NULL
- * @param[in] stringFlags the flag to determine performing '.' --> '/'
+ * @param[in] stringFlags the flag to determine performing '.' --> '/' or NULL termination
  * @param[in] prependStr the string to be prepended before the string object to be copied
  * 				it can't be NULL but can be an empty string ""
  * @param[in] prependStrLength The length of prependStr as computed by strlen.
@@ -2781,7 +2781,30 @@ romImageNewSegment(J9JavaVM *vm, J9ROMImageHeader *header, UDATA isBaseType, J9C
  * @return a char pointer to the string
  */
 char*
-copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length);
+copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length);
+
+
+/**
+* Copy a string object to a J9UTF8 data buffer, and optionally prepend a string before it.
+*
+* @note The caller must free the memory from this pointer if the return value is NOT the buffer argument.
+* @note If the buffer is not large enough to encode the string this function will allocate enough memory to encode
+*       the worst-case UTF8 encoding of the supplied UTF16 string (length of string * 3 bytes).
+*
+* @param[in] currentThread the current J9VMThread
+* @param[in] string a string object to be copied
+* 				it can't be NULL
+* @param[in] stringFlags the flag to determine performing '.' --> '/' or NULL termination
+* @param[in] prependStr the string to be prepended before the string object to be copied
+* 				it can't be NULL but can be an empty string ""
+* @param[in] prependStrLength The length of prependStr as computed by strlen.
+* @param[in] buffer the buffer for the string
+* @param[in] bufferLength the buffer length
+*
+* @return a J9UTF8 pointer to the string
+*/
+J9UTF8*
+copyStringToJ9UTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2761,9 +2761,11 @@ romImageNewSegment(J9JavaVM *vm, J9ROMImageHeader *header, UDATA isBaseType, J9C
 
 
 /**
- * Copy a string object to a UTF8 data buffer, optionally to prepend a string before it
+ * Copy a string object to a UTF8 data buffer, and optionally prepend a string before it.
  *
- * ***The caller must free the memory from this pointer if the return value is NOT the buffer argument ***
+ * @note The caller must free the memory from this pointer if the return value is NOT the buffer argument.
+ * @note If the buffer is not large enough to encode the string this function will allocate enough memory to encode
+ *       the worst-case UTF8 encoding of the supplied UTF16 string (length of string * 3 bytes).
  *
  * @param[in] currentThread the current J9VMThread
  * @param[in] string a string object to be copied

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2773,11 +2773,12 @@ romImageNewSegment(J9JavaVM *vm, J9ROMImageHeader *header, UDATA isBaseType, J9C
  * 				it can't be NULL but can be an empty string ""
  * @param[in] buffer the buffer for the string
  * @param[in] bufferLength the buffer length
+ * @param[out] utf8Length If not NULL returns the computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
  *
  * @return a char pointer to the string
  */
 char*
-copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength);
+copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength, UDATA *utf8Length);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2792,12 +2792,11 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
  * @param[in] utf8DataLength the length of utf8Data in number of bytes
- * @param[in] isNullTerminated determines whether utf8Data will be null terminated or not
  *
- * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
+ * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding any NULL terminator.
  */
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength, BOOLEAN isNullTerminated);
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2771,6 +2771,7 @@ romImageNewSegment(J9JavaVM *vm, J9ROMImageHeader *header, UDATA isBaseType, J9C
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] prependStr the string to be prepended before the string object to be copied
  * 				it can't be NULL but can be an empty string ""
+ * @param[in] prependStrLength The length of prependStr as computed by strlen.
  * @param[in] buffer the buffer for the string
  * @param[in] bufferLength the buffer length
  * @param[out] utf8Length If not NULL returns the computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
@@ -2778,7 +2779,7 @@ romImageNewSegment(J9JavaVM *vm, J9ROMImageHeader *header, UDATA isBaseType, J9C
  * @return a char pointer to the string
  */
 char*
-copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength, UDATA *utf8Length);
+copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2784,7 +2784,6 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
  * Copy a Unicode String to a UTF8 data buffer with NULL termination.
  *
  * @param[in] vmThread the current J9VMThread
- * @param[in] nullTermination if the utf8 data is going to be NULL terminated
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
  * @param[in] utf8Length the size of the utf8 data buffer
@@ -2792,7 +2791,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
  * @return UDATA_MAX if a failure occurred, otherwise the number of utf8 data copied including null termination
  */
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, BOOLEAN nullTermination, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length);
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length);
 
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2791,9 +2791,9 @@ copyStringToUTF8WithMemAlloc(J9VMThread *currentThread, j9object_t string, UDATA
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
  *
- * @return A pointer to the copied UTF8 bytes.
+ * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
  */
-U_8*
+UDATA
 copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data);
 
 

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3233,7 +3233,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 			}
 
 			if (buf) {
-				len = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, TRUE, J9_STR_NONE, (U_8*)buf, len);
+				len = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, J9_STR_NONE, (U_8*)buf, len);
 			} else {
 				buf = stackBuffer;
 				len = 0;
@@ -3274,7 +3274,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 				nestedLen = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3 + 1;
 				nestedBuf = (char *)j9mem_allocate_memory(nestedLen, OMRMEM_CATEGORY_VM);
 				if (nestedBuf) {
-					nestedLen = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, TRUE, J9_STR_NONE, (U_8*)nestedBuf, nestedLen);
+					nestedLen = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, J9_STR_NONE, (U_8*)nestedBuf, nestedLen);
 					_OutputStream.writeCharacters(" Detail:  \"");
 					_OutputStream.writeCharacters(nestedBuf, nestedLen);
 					_OutputStream.writeCharacters("\"");

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3226,7 +3226,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 	if (exceptionRef && *exceptionRef) {
 		j9object_t message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *exceptionRef);
 		if (NULL != message) {
-			buf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", 0, stackBuffer, _MaximumExceptionNameLength, &len);
+			buf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NULL_TERMINATE_RESULT, "", 0, stackBuffer, _MaximumExceptionNameLength, &len);
 		}
 
 		if (0 != len) {
@@ -3261,7 +3261,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 
 				message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, nestedException);
 				if (NULL != message) {
-					nestedBuf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", 0, detailMessageStackBuffer, _MaximumExceptionNameLength, &nestedLen);
+					nestedBuf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NULL_TERMINATE_RESULT, "", 0, detailMessageStackBuffer, _MaximumExceptionNameLength, &nestedLen);
 				}
 				
 				if (0 != nestedLen) {

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3226,7 +3226,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 	if (exceptionRef && *exceptionRef) {
 		j9object_t message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *exceptionRef);
 		if (NULL != message) {
-			buf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", stackBuffer, _MaximumExceptionNameLength, &len);
+			buf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", 0, stackBuffer, _MaximumExceptionNameLength, &len);
 		}
 
 		if (0 != len) {
@@ -3261,7 +3261,7 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 
 				message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, nestedException);
 				if (NULL != message) {
-					nestedBuf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", detailMessageStackBuffer, _MaximumExceptionNameLength, &nestedLen);
+					nestedBuf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", 0, detailMessageStackBuffer, _MaximumExceptionNameLength, &nestedLen);
 				}
 				
 				if (0 != nestedLen) {

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3227,13 +3227,13 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 		j9object_t message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *exceptionRef);
 		if (message) {
 			/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-			len = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3;
+			len = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3 + 1;
 			if (len > sizeof(stackBuffer)) {
 				buf = (char *)j9mem_allocate_memory(len, OMRMEM_CATEGORY_VM);
 			}
 
 			if (buf) {
-				len = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, FALSE, J9_STR_NONE, (U_8*)buf, len);
+				len = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, TRUE, J9_STR_NONE, (U_8*)buf, len);
 			} else {
 				buf = stackBuffer;
 				len = 0;
@@ -3271,10 +3271,10 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 
 				message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, nestedException);
 				/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-				nestedLen = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3;
+				nestedLen = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3 + 1;
 				nestedBuf = (char *)j9mem_allocate_memory(nestedLen, OMRMEM_CATEGORY_VM);
 				if (nestedBuf) {
-					nestedLen = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, FALSE, J9_STR_NONE, (U_8*)nestedBuf, nestedLen);
+					nestedLen = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, TRUE, J9_STR_NONE, (U_8*)nestedBuf, nestedLen);
 					_OutputStream.writeCharacters(" Detail:  \"");
 					_OutputStream.writeCharacters(nestedBuf, nestedLen);
 					_OutputStream.writeCharacters("\"");

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -3225,22 +3225,11 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 
 	if (exceptionRef && *exceptionRef) {
 		j9object_t message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *exceptionRef);
-		if (message) {
-			/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-			len = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3 + 1;
-			if (len > sizeof(stackBuffer)) {
-				buf = (char *)j9mem_allocate_memory(len, OMRMEM_CATEGORY_VM);
-			}
-
-			if (buf) {
-				len = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, J9_STR_NONE, (U_8*)buf, len);
-			} else {
-				buf = stackBuffer;
-				len = 0;
-			}
+		if (NULL != message) {
+			buf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", stackBuffer, _MaximumExceptionNameLength, &len);
 		}
 
-		if (len) {
+		if (0 != len) {
 			_OutputStream.writeCharacters(" \"");
 			_OutputStream.writeCharacters(buf, len);
 			_OutputStream.writeCharacters("\"");
@@ -3254,8 +3243,9 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 		eiieClass = _VirtualMachine->internalVMFunctions->internalFindKnownClass(vmThread, J9VMCONSTANTPOOL_JAVALANGEXCEPTIONININITIALIZERERROR, J9_FINDKNOWNCLASS_FLAG_EXISTING_ONLY);
 
 		if (J9OBJECT_CLAZZ(vmThread, *exceptionRef) == eiieClass) {
+			char detailMessageStackBuffer[_MaximumExceptionNameLength];
 			char*                  nestedBuf = NULL;
-			IDATA                  nestedLen = 0;
+			UDATA                  nestedLen = 0;
 			j9object_t             nestedException = NULL;
 			J9UTF8*                nestedExceptionClassName = NULL;
 
@@ -3270,15 +3260,18 @@ JavaCoreDumpWriter::writeExceptionDetail(j9object_t* exceptionRef)
 				}
 
 				message = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, nestedException);
-				/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-				nestedLen = J9VMJAVALANGSTRING_LENGTH(vmThread, message) * 3 + 1;
-				nestedBuf = (char *)j9mem_allocate_memory(nestedLen, OMRMEM_CATEGORY_VM);
-				if (nestedBuf) {
-					nestedLen = _VirtualMachine->internalVMFunctions->copyStringToUTF8Helper(vmThread, message, J9_STR_NONE, (U_8*)nestedBuf, nestedLen);
+				if (NULL != message) {
+					nestedBuf = _VirtualMachine->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, message, J9_STR_NONE, "", detailMessageStackBuffer, _MaximumExceptionNameLength, &nestedLen);
+				}
+				
+				if (0 != nestedLen) {
 					_OutputStream.writeCharacters(" Detail:  \"");
 					_OutputStream.writeCharacters(nestedBuf, nestedLen);
 					_OutputStream.writeCharacters("\"");
-					j9mem_free_memory( nestedBuf );
+				}
+
+				if (nestedBuf != detailMessageStackBuffer) {
+					j9mem_free_memory(nestedBuf);
 				}
 			}
 		}	

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -448,7 +448,7 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 			j9object_t emessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *eventData->exceptionRef);
 
 			if (NULL != emessage) {
-				buf = vmThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, emessage, J9_STR_NONE, "", 0, stackBuffer, 256, &buflen);
+				buf = vmThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, emessage, J9_STR_NULL_TERMINATE_RESULT, "", 0, stackBuffer, 256, &buflen);
 
 				if (NULL != buf) {
 					if (wildcardMatch(matchFlag, needleString, needleLength, buf, buflen)) {

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -456,7 +456,7 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 				}
 
 				if (buf != NULL) {
-					buflen = vmThread->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread, emessage, TRUE, J9_STR_NONE, (U_8*)buf, buflen);
+					buflen = vmThread->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread, emessage, J9_STR_NONE, (U_8*)buf, buflen);
 					if (wildcardMatch(matchFlag, needleString, needleLength, buf, buflen)) {
 						retCode = J9RAS_DUMP_MATCH;
 					} else {

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -450,13 +450,13 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 			buf = stackBuffer;
 			if (emessage) {
 				/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-				buflen = J9VMJAVALANGSTRING_LENGTH(vmThread, emessage) * 3;
+				buflen = J9VMJAVALANGSTRING_LENGTH(vmThread, emessage) * 3 + 1;
 				if (buflen > sizeof(stackBuffer)) {
 					buf = (char *)j9mem_allocate_memory(buflen, OMRMEM_CATEGORY_VM);
 				}
 
 				if (buf != NULL) {
-					buflen = vmThread->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread, emessage, FALSE, J9_STR_NONE, (U_8*)buf, buflen);
+					buflen = vmThread->javaVM->internalVMFunctions->copyStringToUTF8Helper(vmThread, emessage, TRUE, J9_STR_NONE, (U_8*)buf, buflen);
 					if (wildcardMatch(matchFlag, needleString, needleLength, buf, buflen)) {
 						retCode = J9RAS_DUMP_MATCH;
 					} else {

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -448,7 +448,7 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 			j9object_t emessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, *eventData->exceptionRef);
 
 			if (NULL != emessage) {
-				buf = vmThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, emessage, J9_STR_NONE, "", stackBuffer, 256, &buflen);
+				buf = vmThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, emessage, J9_STR_NONE, "", 0, stackBuffer, 256, &buflen);
 
 				if (NULL != buf) {
 					if (wildcardMatch(matchFlag, needleString, needleLength, buf, buflen)) {

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -155,9 +155,7 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 			}
 			strncpy((char *)J9UTF8_DATA(jrtURL), JRT_URL_PROTOCOL, sizeof(JRT_URL_PROTOCOL) - 1);
 			nameLocation = (char *)J9UTF8_DATA(jrtURL) + sizeof(JRT_URL_PROTOCOL) - 1;
-			if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, J9_STR_NONE, (U_8*)nameLocation, jrtURLLen - sizeof(JRT_URL_PROTOCOL) + 2)) {
-				goto _exit;
-			}
+			vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, J9_STR_NONE, (U_8*)nameLocation);
 
 			J9UTF8_SET_LENGTH(jrtURL, (U_16) jrtURLLen);
 #undef JRT_URL_PROTOCOL

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -145,17 +145,11 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 	if (NULL == jrtURL) {
 		if (J9_ARE_ALL_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
 			/* set jrt URL for the module */
-#define JRT_URL_PROTOCOL "jrt:/"
-			UDATA jrtURLLength = 0;
-
-			jrtURL = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "\0\0", sizeof(jrtURL->length), NULL, 0, &jrtURLLength);
+			jrtURL = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, module->moduleName, J9_STR_NONE, "jrt:/", 5, NULL, 0);
 
 			if (NULL == jrtURL) {
 				goto _exit;
 			}
-
-			J9UTF8_SET_LENGTH(jrtURL, (U_16)jrtURLLength);
-#undef JRT_URL_PROTOCOL
 		} else {
 			/* its java.base module */
 #define JRT_JAVA_BASE_URL "jrt:/java.base"

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -149,13 +149,13 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 			char *nameLocation = NULL;
 			UDATA jrtURLLen = vmFuncs->getStringUTF8Length(currentThread, module->moduleName) + sizeof(JRT_URL_PROTOCOL) - 1;
 
-			jrtURL = j9mem_allocate_memory(sizeof(jrtURL->length) + jrtURLLen, OMRMEM_CATEGORY_VM);
+			jrtURL = j9mem_allocate_memory(sizeof(jrtURL->length) + jrtURLLen + 1, OMRMEM_CATEGORY_VM);
 			if (NULL == jrtURL) {
 				goto _exit;
 			}
 			strncpy((char *)J9UTF8_DATA(jrtURL), JRT_URL_PROTOCOL, sizeof(JRT_URL_PROTOCOL) - 1);
 			nameLocation = (char *)J9UTF8_DATA(jrtURL) + sizeof(JRT_URL_PROTOCOL) - 1;
-			if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, FALSE, J9_STR_NONE, (U_8*)nameLocation, jrtURLLen - sizeof(JRT_URL_PROTOCOL) + 1)) {
+			if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, TRUE, J9_STR_NONE, (U_8*)nameLocation, jrtURLLen - sizeof(JRT_URL_PROTOCOL) + 2)) {
 				goto _exit;
 			}
 

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -146,18 +146,15 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 		if (J9_ARE_ALL_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
 			/* set jrt URL for the module */
 #define JRT_URL_PROTOCOL "jrt:/"
-			char *nameLocation = NULL;
-			UDATA jrtURLLen = vmFuncs->getStringUTF8Length(currentThread, module->moduleName) + sizeof(JRT_URL_PROTOCOL) - 1;
+			UDATA jrtURLLength = 0;
 
-			jrtURL = j9mem_allocate_memory(sizeof(jrtURL->length) + jrtURLLen + 1, OMRMEM_CATEGORY_VM);
+			jrtURL = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, module->moduleName, J9_STR_NONE, "\0\0", sizeof(jrtURL->length), NULL, 0, &jrtURLLength);
+
 			if (NULL == jrtURL) {
 				goto _exit;
 			}
-			strncpy((char *)J9UTF8_DATA(jrtURL), JRT_URL_PROTOCOL, sizeof(JRT_URL_PROTOCOL) - 1);
-			nameLocation = (char *)J9UTF8_DATA(jrtURL) + sizeof(JRT_URL_PROTOCOL) - 1;
-			vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, J9_STR_NONE, (U_8*)nameLocation, TRUE);
 
-			J9UTF8_SET_LENGTH(jrtURL, (U_16) jrtURLLen);
+			J9UTF8_SET_LENGTH(jrtURL, (U_16)jrtURLLength);
 #undef JRT_URL_PROTOCOL
 		} else {
 			/* its java.base module */

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -155,7 +155,7 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 			}
 			strncpy((char *)J9UTF8_DATA(jrtURL), JRT_URL_PROTOCOL, sizeof(JRT_URL_PROTOCOL) - 1);
 			nameLocation = (char *)J9UTF8_DATA(jrtURL) + sizeof(JRT_URL_PROTOCOL) - 1;
-			if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, TRUE, J9_STR_NONE, (U_8*)nameLocation, jrtURLLen - sizeof(JRT_URL_PROTOCOL) + 2)) {
+			if (UDATA_MAX == vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, J9_STR_NONE, (U_8*)nameLocation, jrtURLLen - sizeof(JRT_URL_PROTOCOL) + 2)) {
 				goto _exit;
 			}
 

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -155,7 +155,7 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 			}
 			strncpy((char *)J9UTF8_DATA(jrtURL), JRT_URL_PROTOCOL, sizeof(JRT_URL_PROTOCOL) - 1);
 			nameLocation = (char *)J9UTF8_DATA(jrtURL) + sizeof(JRT_URL_PROTOCOL) - 1;
-			vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, J9_STR_NONE, (U_8*)nameLocation);
+			vmFuncs->copyStringToUTF8Helper(currentThread, module->moduleName, J9_STR_NONE, (U_8*)nameLocation, TRUE);
 
 			J9UTF8_SET_LENGTH(jrtURL, (U_16) jrtURLLen);
 #undef JRT_URL_PROTOCOL

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -148,7 +148,7 @@ getModuleJRTURL(J9VMThread *currentThread, J9ClassLoader *classLoader, J9Module 
 #define JRT_URL_PROTOCOL "jrt:/"
 			UDATA jrtURLLength = 0;
 
-			jrtURL = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, module->moduleName, J9_STR_NONE, "\0\0", sizeof(jrtURL->length), NULL, 0, &jrtURLLength);
+			jrtURL = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "\0\0", sizeof(jrtURL->length), NULL, 0, &jrtURLLength);
 
 			if (NULL == jrtURL) {
 				goto _exit;

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -182,7 +182,7 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t 
 	memcpy(J9UTF8_DATA(j9package->packageName), (void *)packageName, length);
 	J9UTF8_DATA(j9package->packageName)[length] = '\0';
 #else /* J9VM_JAVA9_BUILD >= 156 */
-	vmFuncs->copyStringToUTF8Helper(currentThread, packageName, TRUE, J9_STR_NONE, J9UTF8_DATA(j9package->packageName), length + 1);
+	vmFuncs->copyStringToUTF8Helper(currentThread, packageName, J9_STR_NONE, J9UTF8_DATA(j9package->packageName), length + 1);
 #endif /* J9VM_JAVA9_BUILD >= 156 */
 	J9UTF8_SET_LENGTH(j9package->packageName, length);
 	return TRUE;

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -175,9 +175,9 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t 
 	}
 
 	memcpy(J9UTF8_DATA(j9package->packageName), (void *)packageName, packageNameLength);
-	J9UTF8_DATA(j9package->packageName)[length] = '\0';
+	J9UTF8_DATA(j9package->packageName)[packageNameLength] = '\0';
 #else /* J9VM_JAVA9_BUILD >= 156 */
-	j9package->packageName = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageName, J9_STR_NONE, "\0\0", sizeof(j9package->packageName->length), (char*)buf, bufLen, &packageNameLength);
+	j9package->packageName = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageName, J9_STR_NULL_TERMINATE_RESULT, "\0\0", sizeof(j9package->packageName->length), (char*)buf, bufLen, &packageNameLength);
 	if (NULL == j9package->packageName) {
 		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 		return FALSE;

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -176,15 +176,14 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t 
 
 	memcpy(J9UTF8_DATA(j9package->packageName), (void *)packageName, packageNameLength);
 	J9UTF8_DATA(j9package->packageName)[packageNameLength] = '\0';
+	J9UTF8_SET_LENGTH(j9package->packageName, (U_16)packageNameLength);
 #else /* J9VM_JAVA9_BUILD >= 156 */
-	j9package->packageName = (J9UTF8*)vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, packageName, J9_STR_NULL_TERMINATE_RESULT, "\0\0", sizeof(j9package->packageName->length), (char*)buf, bufLen, &packageNameLength);
+	j9package->packageName = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, packageName, J9_STR_NULL_TERMINATE_RESULT, "", 0, (char*)buf, bufLen);
 	if (NULL == j9package->packageName) {
 		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 		return FALSE;
 	}
 #endif /* J9VM_JAVA9_BUILD >= 156 */
-
-	J9UTF8_SET_LENGTH(j9package->packageName, (U_16)packageNameLength);
 
 	return TRUE;
 }

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -182,7 +182,7 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t 
 	memcpy(J9UTF8_DATA(j9package->packageName), (void *)packageName, length);
 	J9UTF8_DATA(j9package->packageName)[length] = '\0';
 #else /* J9VM_JAVA9_BUILD >= 156 */
-	vmFuncs->copyStringToUTF8Helper(currentThread, packageName, J9_STR_NONE, J9UTF8_DATA(j9package->packageName));
+	vmFuncs->copyStringToUTF8Helper(currentThread, packageName, J9_STR_NONE, J9UTF8_DATA(j9package->packageName), TRUE);
 #endif /* J9VM_JAVA9_BUILD >= 156 */
 	J9UTF8_SET_LENGTH(j9package->packageName, length);
 	return TRUE;

--- a/runtime/util/modularityHelper.c
+++ b/runtime/util/modularityHelper.c
@@ -182,7 +182,7 @@ addUTFNameToPackage(J9VMThread *currentThread, J9Package *j9package, j9object_t 
 	memcpy(J9UTF8_DATA(j9package->packageName), (void *)packageName, length);
 	J9UTF8_DATA(j9package->packageName)[length] = '\0';
 #else /* J9VM_JAVA9_BUILD >= 156 */
-	vmFuncs->copyStringToUTF8Helper(currentThread, packageName, J9_STR_NONE, J9UTF8_DATA(j9package->packageName), length + 1);
+	vmFuncs->copyStringToUTF8Helper(currentThread, packageName, J9_STR_NONE, J9UTF8_DATA(j9package->packageName));
 #endif /* J9VM_JAVA9_BUILD >= 156 */
 	J9UTF8_SET_LENGTH(j9package->packageName, length);
 	return TRUE;

--- a/runtime/util/thrname.c
+++ b/runtime/util/thrname.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/util/thrname.c
+++ b/runtime/util/thrname.c
@@ -32,7 +32,7 @@ getVMThreadNameFromString(J9VMThread *vmThread, j9object_t nameObject)
 	J9JavaVM *javaVM = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
-	char* result = javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, nameObject, J9_STR_NONE, "", 0, NULL, 0, NULL);
+	char* result = javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, nameObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, NULL, 0, NULL);
 
 	return result;
 }

--- a/runtime/util/thrname.c
+++ b/runtime/util/thrname.c
@@ -32,13 +32,9 @@ getVMThreadNameFromString(J9VMThread *vmThread, j9object_t nameObject)
 	J9JavaVM *javaVM = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
-	J9InternalVMFunctions* fns = javaVM->internalVMFunctions;
-	UDATA length = fns->getStringUTF8Length(vmThread, nameObject);
-	char *buf = j9mem_allocate_memory(length + 1, OMRMEM_CATEGORY_THREADS);
-	if (buf != NULL) {
-		fns->copyStringToUTF8Helper(vmThread, nameObject, J9_STR_NONE, (U_8 *)buf, length + 1);
-	}
-	return buf;
+	char* result = javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, nameObject, J9_STR_NONE, "", NULL, 0, NULL);
+
+	return result;
 }
 
 /*

--- a/runtime/util/thrname.c
+++ b/runtime/util/thrname.c
@@ -32,7 +32,7 @@ getVMThreadNameFromString(J9VMThread *vmThread, j9object_t nameObject)
 	J9JavaVM *javaVM = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
-	char* result = javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, nameObject, J9_STR_NONE, "", NULL, 0, NULL);
+	char* result = javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(vmThread, nameObject, J9_STR_NONE, "", 0, NULL, 0, NULL);
 
 	return result;
 }

--- a/runtime/util/thrname.c
+++ b/runtime/util/thrname.c
@@ -36,7 +36,7 @@ getVMThreadNameFromString(J9VMThread *vmThread, j9object_t nameObject)
 	UDATA length = fns->getStringUTF8Length(vmThread, nameObject);
 	char *buf = j9mem_allocate_memory(length + 1, OMRMEM_CATEGORY_THREADS);
 	if (buf != NULL) {
-		fns->copyStringToUTF8Helper(vmThread, nameObject, TRUE, J9_STR_NONE, (U_8 *)buf, length + 1);
+		fns->copyStringToUTF8Helper(vmThread, nameObject, J9_STR_NONE, (U_8 *)buf, length + 1);
 	}
 	return buf;
 }

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -113,7 +113,7 @@ public:
 		*typeFFI = NULL;
 		UDATA structSize = UDATA_MAX;
 		char bufOnStackLocal[J9VM_LAYOUT_STRING_ON_STACK_LIMIT];
-		char *layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NONE, "", 0, bufOnStackLocal, J9VM_LAYOUT_STRING_ON_STACK_LIMIT, NULL);
+		char *layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, bufOnStackLocal, J9VM_LAYOUT_STRING_ON_STACK_LIMIT, NULL);
 
 		if (NULL == layout) {
 			goto doneGetCustomFFIType;

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -110,29 +110,20 @@ public:
 	getCustomFFIType(ffi_type** typeFFI, j9object_t layoutStringObject) {
 		PORT_ACCESS_FROM_JAVAVM(_vm);
 
-		UDATA result = 0;
 		*typeFFI = NULL;
 		UDATA structSize = UDATA_MAX;
-		UDATA length = getStringUTF8Length(_currentThread, layoutStringObject);
 		char bufOnStackLocal[J9VM_LAYOUT_STRING_ON_STACK_LIMIT];
-		char *buf = bufOnStackLocal;
-		char *layout = NULL;
-		if (length >= J9VM_LAYOUT_STRING_ON_STACK_LIMIT) {
-			buf = (char *) j9mem_allocate_memory(sizeof(char) * (length + 1), OMRMEM_CATEGORY_VM);
-			if (NULL == buf) {
-				goto doneGetCustomFFIType;
-			}
-		}
-		layout = buf;
-		result = copyStringToUTF8Helper(_currentThread, layoutStringObject, J9_STR_NONE, (U_8*)layout, UDATA_MAX);
-		if (UDATA_MAX == result) {
+		char *layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NONE, "", bufOnStackLocal, J9VM_LAYOUT_STRING_ON_STACK_LIMIT, NULL);
+
+		if (NULL == layout) {
 			goto doneGetCustomFFIType;
 		}
+
 		structSize = getIntFromLayout(&layout);
 		*typeFFI = getStructFFIType(&layout, false);
 doneGetCustomFFIType:
-		if (buf != bufOnStackLocal) {
-			j9mem_free_memory(buf);
+		if (layout != bufOnStackLocal) {
+			j9mem_free_memory(layout);
 		}
 		return structSize;
 	}

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -113,7 +113,7 @@ public:
 		*typeFFI = NULL;
 		UDATA structSize = UDATA_MAX;
 		char bufOnStackLocal[J9VM_LAYOUT_STRING_ON_STACK_LIMIT];
-		char *layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NONE, "", bufOnStackLocal, J9VM_LAYOUT_STRING_ON_STACK_LIMIT, NULL);
+		char *layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NONE, "", 0, bufOnStackLocal, J9VM_LAYOUT_STRING_ON_STACK_LIMIT, NULL);
 
 		if (NULL == layout) {
 			goto doneGetCustomFFIType;

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -124,7 +124,7 @@ public:
 			}
 		}
 		layout = buf;
-		result = copyStringToUTF8Helper(_currentThread, layoutStringObject, TRUE, J9_STR_NONE, (U_8*)layout, UDATA_MAX);
+		result = copyStringToUTF8Helper(_currentThread, layoutStringObject, J9_STR_NONE, (U_8*)layout, UDATA_MAX);
 		if (UDATA_MAX == result) {
 			goto doneGetCustomFFIType;
 		}

--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -124,11 +124,10 @@ public:
 			}
 		}
 		layout = buf;
-		result = copyFromStringIntoUTF8(_currentThread, layoutStringObject, layout);
+		result = copyStringToUTF8Helper(_currentThread, layoutStringObject, TRUE, J9_STR_NONE, (U_8*)layout, UDATA_MAX);
 		if (UDATA_MAX == result) {
 			goto doneGetCustomFFIType;
 		}
-		layout[length] = '\0';
 		structSize = getIntFromLayout(&layout);
 		*typeFFI = getStructFFIType(&layout, false);
 doneGetCustomFFIType:

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -269,7 +269,7 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 			}
 		}
 
-		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", 0, localBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_NULL_TERMINATE_RESULT | J9_STR_XLAT, "", 0, localBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			/* Throw out-of-memory */
 			setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -269,13 +269,12 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 			}
 		}
 
-		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", localBuf, sizeof(localBuf));
+		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", localBuf, sizeof(localBuf), &utf8Length);
 		if (NULL == utf8Name) {
 			/* Throw out-of-memory */
 			setNativeOutOfMemoryError(currentThread, 0, 0);
 			return NULL;
 		}
-		utf8Length = (UDATA)getStringUTF8Length(currentThread, className);
 		result = internalFindClassInModule(currentThread, j9module, (U_8 *)utf8Name, utf8Length, classLoader, options);
 		if (utf8Name != localBuf) {
 			j9mem_free_memory(utf8Name);

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -253,7 +253,7 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 	if (NULL == result) {
 		J9Module **findResult = NULL;
 		J9Module *j9module = NULL;
-		char localBuf[256];
+		char localBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char *utf8Name = NULL;
 		UDATA utf8Length = 0;
 		PORT_ACCESS_FROM_JAVAVM(vm);
@@ -269,7 +269,7 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 			}
 		}
 
-		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", localBuf, sizeof(localBuf), &utf8Length);
+		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", localBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			/* Throw out-of-memory */
 			setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -269,7 +269,7 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 			}
 		}
 
-		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", localBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
+		utf8Name = copyStringToUTF8WithMemAlloc(currentThread, className, J9_STR_XLAT, "", 0, localBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, &utf8Length);
 		if (NULL == utf8Name) {
 			/* Throw out-of-memory */
 			setNativeOutOfMemoryError(currentThread, 0, 0);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1836,7 +1836,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 		moduleNameUTF = moduleNameBuf;
 	} else {
 		moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			vmThread, ramClass->module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			vmThread, ramClass->module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	}
 	j9object_t classLoaderName = NULL;
 	if (NULL != classLoader->classLoaderObject) {
@@ -1844,7 +1844,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 	}
 	if (NULL != classLoaderName) {
 		classLoaderNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			vmThread, classLoaderName, J9_STR_NONE, "", classLoaderNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+			vmThread, classLoaderName, J9_STR_NONE, "", classLoaderNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	} else {
 #define UNNAMED_NAMED_MODULE   "system classloader"
 		memcpy(classLoaderNameBuf, UNNAMED_NAMED_MODULE, sizeof(UNNAMED_NAMED_MODULE));

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1836,7 +1836,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 		moduleNameUTF = moduleNameBuf;
 	} else {
 		moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			vmThread, ramClass->module->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			vmThread, ramClass->module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	}
 	j9object_t classLoaderName = NULL;
 	if (NULL != classLoader->classLoaderObject) {
@@ -1844,7 +1844,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 	}
 	if (NULL != classLoaderName) {
 		classLoaderNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			vmThread, classLoaderName, J9_STR_NONE, "", 0, classLoaderNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			vmThread, classLoaderName, J9_STR_NULL_TERMINATE_RESULT, "", 0, classLoaderNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	} else {
 #define UNNAMED_NAMED_MODULE   "system classloader"
 		memcpy(classLoaderNameBuf, UNNAMED_NAMED_MODULE, sizeof(UNNAMED_NAMED_MODULE));

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1836,7 +1836,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 		moduleNameUTF = moduleNameBuf;
 	} else {
 		moduleNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			vmThread, ramClass->module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			vmThread, ramClass->module->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	}
 	j9object_t classLoaderName = NULL;
 	if (NULL != classLoader->classLoaderObject) {
@@ -1844,7 +1844,7 @@ trcModulesSettingPackage(J9VMThread *vmThread, J9Class *ramClass, J9ClassLoader 
 	}
 	if (NULL != classLoaderName) {
 		classLoaderNameUTF = vmFuncs->copyStringToUTF8WithMemAlloc(
-			vmThread, classLoaderName, J9_STR_NONE, "", classLoaderNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			vmThread, classLoaderName, J9_STR_NONE, "", 0, classLoaderNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	} else {
 #define UNNAMED_NAMED_MODULE   "system classloader"
 		memcpy(classLoaderNameBuf, UNNAMED_NAMED_MODULE, sizeof(UNNAMED_NAMED_MODULE));

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -76,21 +76,11 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 	J9UTF8* exceptionClassName = J9ROMCLASS_CLASSNAME(J9OBJECT_CLAZZ(vmThread, exception)->romClass);
 	j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, exception);
 
-	if (detailMessage) {
-		/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-		length = J9VMJAVALANGSTRING_LENGTH(vmThread, detailMessage) * 3 + 1;
-		if (length > sizeof(stackBuffer)) {
-			buf = j9mem_allocate_memory(length, OMRMEM_CATEGORY_VM);
-		}
-		if (buf) {
-			length = copyStringToUTF8Helper(vmThread, detailMessage, J9_STR_NONE, (U_8 *)buf, length);
-			if (UDATA_MAX == length) {
-				length = 0;
-			}
+	if (NULL != detailMessage) {
+		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NONE, "", stackBuffer, 64, &length);
+
+		if (NULL != buf) {
 			separator = ": ";
-		} else {
-			buf = stackBuffer;
-			length = 0;
 		}
 	}
 

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -66,7 +66,7 @@ printExceptionInThread(J9VMThread* vmThread)
 /* assumes VM access */
 static void
 printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
-	char stackBuffer[64];
+	char stackBuffer[256];
 	char* buf = stackBuffer;
 	UDATA length = 0;
 	const char* separator = "";
@@ -77,7 +77,7 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 	j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, exception);
 
 	if (NULL != detailMessage) {
-		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NONE, "", stackBuffer, 64, &length);
+		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NONE, "", stackBuffer, 256, &length);
 
 		if (NULL != buf) {
 			separator = ": ";

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -77,7 +77,7 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 	j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, exception);
 
 	if (NULL != detailMessage) {
-		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NONE, "", stackBuffer, 256, &length);
+		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NONE, "", 0, stackBuffer, 256, &length);
 
 		if (NULL != buf) {
 			separator = ": ";
@@ -139,13 +139,13 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *rom
 
 				if ((NULL != module) && (module != vm->javaBaseModule)) {
 					moduleNameUTF = copyStringToUTF8WithMemAlloc(
-						vmThread, module->moduleName, J9_STR_NONE, "", nameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+						vmThread, module->moduleName, J9_STR_NONE, "", 0, nameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 					if (nameBuf != moduleNameUTF) {
 						freeModuleName = TRUE;
 					}
 					if (NULL != moduleNameUTF) {
 						moduleVersionUTF = copyStringToUTF8WithMemAlloc(
-							vmThread, module->version, J9_STR_NONE, "", versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+							vmThread, module->version, J9_STR_NONE, "", 0, versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 						if (versionBuf != moduleVersionUTF) {
 							freeModuleVersion = TRUE;
 						}

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -149,13 +149,13 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *rom
 
 				if ((NULL != module) && (module != vm->javaBaseModule)) {
 					moduleNameUTF = copyStringToUTF8WithMemAlloc(
-						vmThread, module->moduleName, J9_STR_NONE, "", nameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+						vmThread, module->moduleName, J9_STR_NONE, "", nameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 					if (nameBuf != moduleNameUTF) {
 						freeModuleName = TRUE;
 					}
 					if (NULL != moduleNameUTF) {
 						moduleVersionUTF = copyStringToUTF8WithMemAlloc(
-							vmThread, module->version, J9_STR_NONE, "", versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+							vmThread, module->version, J9_STR_NONE, "", versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 						if (versionBuf != moduleVersionUTF) {
 							freeModuleVersion = TRUE;
 						}

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -77,7 +77,7 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 	j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(vmThread, exception);
 
 	if (NULL != detailMessage) {
-		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NONE, "", 0, stackBuffer, 256, &length);
+		buf = copyStringToUTF8WithMemAlloc(vmThread, detailMessage, J9_STR_NULL_TERMINATE_RESULT, "", 0, stackBuffer, 256, &length);
 
 		if (NULL != buf) {
 			separator = ": ";
@@ -139,13 +139,13 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, J9ROMClass *rom
 
 				if ((NULL != module) && (module != vm->javaBaseModule)) {
 					moduleNameUTF = copyStringToUTF8WithMemAlloc(
-						vmThread, module->moduleName, J9_STR_NONE, "", 0, nameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+						vmThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, nameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 					if (nameBuf != moduleNameUTF) {
 						freeModuleName = TRUE;
 					}
 					if (NULL != moduleNameUTF) {
 						moduleVersionUTF = copyStringToUTF8WithMemAlloc(
-							vmThread, module->version, J9_STR_NONE, "", 0, versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+							vmThread, module->version, J9_STR_NULL_TERMINATE_RESULT, "", 0, versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 						if (versionBuf != moduleVersionUTF) {
 							freeModuleVersion = TRUE;
 						}

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -78,12 +78,12 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 
 	if (detailMessage) {
 		/* length is in jchars. 3x is enough for worst case UTF8 encoding */
-		length = J9VMJAVALANGSTRING_LENGTH(vmThread, detailMessage) * 3;
+		length = J9VMJAVALANGSTRING_LENGTH(vmThread, detailMessage) * 3 + 1;
 		if (length > sizeof(stackBuffer)) {
 			buf = j9mem_allocate_memory(length, OMRMEM_CATEGORY_VM);
 		}
 		if (buf) {
-			length = copyStringToUTF8Helper(vmThread, detailMessage, FALSE, J9_STR_NONE, (U_8 *)buf, length);
+			length = copyStringToUTF8Helper(vmThread, detailMessage, TRUE, J9_STR_NONE, (U_8 *)buf, length);
 			if (UDATA_MAX == length) {
 				length = 0;
 			}

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -83,7 +83,7 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 			buf = j9mem_allocate_memory(length, OMRMEM_CATEGORY_VM);
 		}
 		if (buf) {
-			length = copyStringToUTF8Helper(vmThread, detailMessage, TRUE, J9_STR_NONE, (U_8 *)buf, length);
+			length = copyStringToUTF8Helper(vmThread, detailMessage, J9_STR_NONE, (U_8 *)buf, length);
 			if (UDATA_MAX == length) {
 				length = 0;
 			}

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -238,7 +238,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	prepareForExceptionThrow,
 	copyUTF8ToUnicode,
 	verifyQualifiedName,
-	copyStringToUTF8,
 	copyStringToUTF8Helper,
 	sendCompleteInitialization,
 	J9RegisterAsyncEvent,

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -238,7 +238,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	prepareForExceptionThrow,
 	copyUTF8ToUnicode,
 	verifyQualifiedName,
-	copyCharsIntoUTF8Helper,
 	copyStringToUTF8,
 	copyStringToUTF8Helper,
 	sendCompleteInitialization,

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -62,6 +62,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	allocateMemorySegment,
 	javaThreadProc,
 	copyStringToUTF8WithMemAlloc,
+	copyStringToJ9UTF8WithMemAlloc,
 	internalAcquireVMAccess,
 	internalAcquireVMAccessWithMask,
 	internalAcquireVMAccessNoMutexWithMask,

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -61,7 +61,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	deallocateVMThread,
 	allocateMemorySegment,
 	javaThreadProc,
-	copyFromStringIntoUTF8,
 	copyStringToUTF8WithMemAlloc,
 	internalAcquireVMAccess,
 	internalAcquireVMAccessWithMask,

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -795,7 +795,7 @@ getStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
 		gpCheckSetNativeOutOfMemoryError(currentThread, 0, 0);
 	} else {
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
-		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars, TRUE);
+		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars, utfLength, TRUE);
 
 		if (NULL != isCopy) {
 			*isCopy = JNI_TRUE;

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -795,7 +795,7 @@ getStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
 		gpCheckSetNativeOutOfMemoryError(currentThread, 0, 0);
 	} else {
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
-		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars);
+		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars, TRUE);
 
 		if (NULL != isCopy) {
 			*isCopy = JNI_TRUE;

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -796,6 +796,10 @@ getStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
 	} else {
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
 		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars);
+
+		if (NULL != isCopy) {
+			*isCopy = JNI_TRUE;
+		}
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -824,7 +824,7 @@ outOfBounds:
 			goto outOfBounds;
 		}
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
-		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, (U_8 *)buf, UDATA_MAX);
+		copyStringToUTF8WithMemAlloc(currentThread, stringObject, J9_STR_NONE, "", buf, UDATA_MAX, NULL);
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -795,7 +795,7 @@ getStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
 		gpCheckSetNativeOutOfMemoryError(currentThread, 0, 0);
 	} else {
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
-		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars, utfLength, TRUE);
+		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NULL_TERMINATE_RESULT, utfChars, utfLength);
 
 		if (NULL != isCopy) {
 			*isCopy = JNI_TRUE;
@@ -824,7 +824,7 @@ outOfBounds:
 			goto outOfBounds;
 		}
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
-		copyStringToUTF8WithMemAlloc(currentThread, stringObject, J9_STR_NONE, "", 0, buf, UDATA_MAX, NULL);
+		copyStringToUTF8WithMemAlloc(currentThread, stringObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, buf, UDATA_MAX, NULL);
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -824,8 +824,7 @@ outOfBounds:
 			goto outOfBounds;
 		}
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
-		copyCharsIntoUTF8Helper(currentThread, IS_STRING_COMPRESSED(currentThread, stringObject), TRUE, J9_STR_NONE,
-			J9VMJAVALANGSTRING_VALUE(currentThread, stringObject), 0, len, (U_8 *)buf, UDATA_MAX);
+		copyStringToUTF8Helper(currentThread, stringObject, TRUE, J9_STR_NONE, (U_8 *)buf, UDATA_MAX);
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -795,7 +795,7 @@ getStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
 		gpCheckSetNativeOutOfMemoryError(currentThread, 0, 0);
 	} else {
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
-		if (UDATA_MAX != copyStringToUTF8Helper(currentThread, stringObject, TRUE, J9_STR_NONE, utfChars, utfLength)) {
+		if (UDATA_MAX != copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars, utfLength)) {
 			if (NULL != isCopy) {
 				*isCopy = JNI_TRUE;
 			}
@@ -824,7 +824,7 @@ outOfBounds:
 			goto outOfBounds;
 		}
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
-		copyStringToUTF8Helper(currentThread, stringObject, TRUE, J9_STR_NONE, (U_8 *)buf, UDATA_MAX);
+		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, (U_8 *)buf, UDATA_MAX);
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -824,7 +824,7 @@ outOfBounds:
 			goto outOfBounds;
 		}
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
-		copyStringToUTF8WithMemAlloc(currentThread, stringObject, J9_STR_NONE, "", buf, UDATA_MAX, NULL);
+		copyStringToUTF8WithMemAlloc(currentThread, stringObject, J9_STR_NONE, "", 0, buf, UDATA_MAX, NULL);
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_REGION, (UDATA)length * sizeof(U_16));
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -795,11 +795,7 @@ getStringUTFChars(JNIEnv *env, jstring string, jboolean *isCopy)
 		gpCheckSetNativeOutOfMemoryError(currentThread, 0, 0);
 	} else {
 		JAVA_OFFLOAD_SWITCH_ON_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
-		if (UDATA_MAX != copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars, utfLength)) {
-			if (NULL != isCopy) {
-				*isCopy = JNI_TRUE;
-			}
-		}
+		copyStringToUTF8Helper(currentThread, stringObject, J9_STR_NONE, utfChars);
 		JAVA_OFFLOAD_SWITCH_OFF_WITH_REASON_IF_LIMIT_EXCEEDED(currentThread, J9_JNI_OFFLOAD_SWITCH_GET_STRING_UTF_CHARS, utfLength);
 	}
 	VM_VMAccess::inlineExitVMToJNI(currentThread);

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -288,7 +288,7 @@ trcModulesFreeJ9ModuleEntry(J9JavaVM *javaVM, J9Module *j9module)
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = copyStringToUTF8WithMemAlloc(
-		currentThread, j9module->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, j9module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
 		Trc_MODULE_freeJ9Module_entry(currentThread, moduleNameUTF);
 		if (moduleNameBuf != moduleNameUTF) {

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -288,7 +288,7 @@ trcModulesFreeJ9ModuleEntry(J9JavaVM *javaVM, J9Module *j9module)
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = copyStringToUTF8WithMemAlloc(
-		currentThread, j9module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+		currentThread, j9module->moduleName, J9_STR_NONE, "", 0, moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
 		Trc_MODULE_freeJ9Module_entry(currentThread, moduleNameUTF);
 		if (moduleNameBuf != moduleNameUTF) {

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -288,7 +288,7 @@ trcModulesFreeJ9ModuleEntry(J9JavaVM *javaVM, J9Module *j9module)
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char moduleNameBuf[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 	char *moduleNameUTF = copyStringToUTF8WithMemAlloc(
-		currentThread, j9module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		currentThread, j9module->moduleName, J9_STR_NONE, "", moduleNameBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 	if (NULL != moduleNameUTF) {
 		Trc_MODULE_freeJ9Module_entry(currentThread, moduleNameUTF);
 		if (moduleNameBuf != moduleNameUTF) {

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -1004,7 +1004,7 @@ getModuleNameUTF(J9VMThread *currentThread, j9object_t	moduleObject, char *buffe
 	} else {
 #define NAMED_MODULE   "module "
 		nameBuffer = copyStringToUTF8WithMemAlloc(
-			currentThread, module->moduleName, J9_STR_NONE, NAMED_MODULE, buffer, bufferLength, NULL);
+			currentThread, module->moduleName, J9_STR_NONE, NAMED_MODULE, strlen(NAMED_MODULE), buffer, bufferLength, NULL);
 #undef	NAMED_MODULE
 	}
 	return nameBuffer;

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -1004,7 +1004,7 @@ getModuleNameUTF(J9VMThread *currentThread, j9object_t	moduleObject, char *buffe
 	} else {
 #define NAMED_MODULE   "module "
 		nameBuffer = copyStringToUTF8WithMemAlloc(
-			currentThread, module->moduleName, J9_STR_NONE, NAMED_MODULE, strlen(NAMED_MODULE), buffer, bufferLength, NULL);
+			currentThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, NAMED_MODULE, strlen(NAMED_MODULE), buffer, bufferLength, NULL);
 #undef	NAMED_MODULE
 	}
 	return nameBuffer;

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -1004,7 +1004,7 @@ getModuleNameUTF(J9VMThread *currentThread, j9object_t	moduleObject, char *buffe
 	} else {
 #define NAMED_MODULE   "module "
 		nameBuffer = copyStringToUTF8WithMemAlloc(
-			currentThread, module->moduleName, J9_STR_NONE, NAMED_MODULE, buffer, bufferLength);
+			currentThread, module->moduleName, J9_STR_NONE, NAMED_MODULE, buffer, bufferLength, NULL);
 #undef	NAMED_MODULE
 	}
 	return nameBuffer;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -267,9 +267,9 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
  *
- * @return A pointer to the copied UTF8 bytes.
+ * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
  */
-U_8*
+UDATA
 copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data)
 {
 	Assert_VM_notNull(string);
@@ -318,7 +318,7 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 
 	*data = '\0';
 
-	return utf8Data;
+	return (UDATA)(data - utf8Data);
 }
 
 
@@ -346,7 +346,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 	Assert_VM_notNull(string);
 
 	char *strUTF = NULL;
-	UDATA stringLen = getStringUTF8Length(vmThread, string);
+	UDATA stringLen = J9VMJAVALANGSTRING_LENGTH(vmThread, string) * 3;
 	UDATA length = stringLen + prependStrLength + 1;
 
 	PORT_ACCESS_FROM_VMC(vmThread);
@@ -361,10 +361,10 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 			memcpy(strUTF, prependStr, prependStrLength);
 		}
 
-		copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength));
+		UDATA computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength));
 
 		if (NULL != utf8Length) {
-			*utf8Length = length - 1;
+			*utf8Length = computedUtf8Length + prependStrLength;
 		}
 	}
 	return strUTF;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -258,17 +258,6 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
 }
 
 #if !defined (J9VM_OUT_OF_PROCESS)
-/**
- * Copy a Unicode String to a UTF8 data buffer with NULL termination. This function makes an assumption that the
- * caller has guaranteed the buffer is of the appropriate size to fit the encoded UTF8 string.
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] stringFlags the flag to determine performing '.' --> '/'
- * @param[in] utf8Data a utf8 data buffer
- *
- * @return The computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
- */
 UDATA
 copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data)
 {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -275,7 +275,7 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 			}
 		} else {
 			for (UDATA i = 0; i < unicodeLength; i++) {
-				UDATA encodedLength = VM_VMHelpers::encodeUTF8Char(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i), data);
+				UDATA encodedLength = VM_VMHelpers::encodeUTF8CharI8(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i), data);
 
 				if ('.' == *data) {
 					*data = '/';
@@ -288,7 +288,7 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 		/* Manually version J9_STR_XLAT flag checking from the loop for performance as the compiler does not do it */
 		if ((stringFlags & J9_STR_XLAT) == 0) {
 			for (UDATA i = 0; i < unicodeLength; i++) {
-				data += VM_VMHelpers::encodeUTF8CharI8(J9JAVAARRAYOFCHAR_LOAD(vmThread, unicodeBytes, i), data);
+				data += VM_VMHelpers::encodeUTF8Char(J9JAVAARRAYOFCHAR_LOAD(vmThread, unicodeBytes, i), data);
 			}
 		} else {
 			for (UDATA i = 0; i < unicodeLength; i++) {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -259,7 +259,7 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
 
 #if !defined (J9VM_OUT_OF_PROCESS)
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength, BOOLEAN isNullTerminated)
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength)
 {
 	Assert_VM_notNull(string);
 
@@ -305,7 +305,7 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 
 	UDATA returnLength = (UDATA)(data - utf8Data);
 
-	if (isNullTerminated) {
+	if ((stringFlags & J9_STR_NULL_TERMINATE_RESULT) != 0) {
 		*data = '\0';
 
 		Assert_VM_true(utf8DataLength >= returnLength + 1);
@@ -324,7 +324,11 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 
 	char *strUTF = NULL;
 	UDATA stringLen = J9VMJAVALANGSTRING_LENGTH(vmThread, string) * 3;
-	UDATA length = stringLen + prependStrLength + 1;
+	UDATA length = stringLen + prependStrLength;
+
+	if ((stringFlags & J9_STR_NULL_TERMINATE_RESULT) != 0) {
+		++length;
+	}
 
 	PORT_ACCESS_FROM_VMC(vmThread);
 
@@ -340,7 +344,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 			memcpy(strUTF, prependStr, prependStrLength);
 		}
 
-		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), length, TRUE);
+		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), length);
 
 		if (NULL != utf8Length) {
 			*utf8Length = computedUtf8Length + prependStrLength;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -322,24 +322,6 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, BOOLEAN nullTerm
 
 
 /**
- * !!! this method is for backwards compatibility with JIT usage !!!
- * Copy a Unicode String to a UTF8 data buffer without NULL termination.
- * dest is assumed to have enough length - the easiest way to ensure this is to pass a buffer with 1.5 * string length in it
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] dest a utf8 data buffer
- *
- * @return UDATA_MAX if a failure occurred, otherwise the number of utf8 data copied excluding null termination
- */
-UDATA
-copyFromStringIntoUTF8(J9VMThread * vmThread, j9object_t string, char * dest)
-{
-	return copyStringToUTF8Helper(vmThread, string, FALSE, J9_STR_NONE, (U_8*)dest, UDATA_MAX);
-}
-
-
-/**
  * Copy a string object to a UTF8 data buffer, optionally to prepend a string before it
  *
  * ***The caller must free the memory from this pointer if the return value is NOT the buffer argument ***

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -332,11 +332,12 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
  * 				it can't be NULL but can be an empty string ""
  * @param[in] buffer the buffer for the string
  * @param[in] bufferLength the buffer length, not expected to larger than 64K
+ * @param[out] utf8Length If not NULL returns the computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
  *
  * @return a char pointer to the string (with NULL termination)
  */
 char*
-copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength)
+copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength, UDATA *utf8Length)
 {
 	Assert_VM_notNull(prependStr);
 	Assert_VM_notNull(string);
@@ -363,6 +364,9 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 				j9mem_free_memory(strUTF);
 			}
 			return NULL;
+		}
+		if (NULL != utf8Length) {
+			*utf8Length = length;
 		}
 	}
 	return strUTF;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -330,6 +330,7 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] prependStr the string to be prepended before the string object to be copied
  * 				it can't be NULL but can be an empty string ""
+ * @param[in] prependStrLength The length of prependStr as computed by strlen.
  * @param[in] buffer the buffer for the string
  * @param[in] bufferLength the buffer length, not expected to larger than 64K
  * @param[out] utf8Length If not NULL returns the computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
@@ -337,15 +338,14 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
  * @return a char pointer to the string (with NULL termination)
  */
 char*
-copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, char *buffer, UDATA bufferLength, UDATA *utf8Length)
+copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length)
 {
 	Assert_VM_notNull(prependStr);
 	Assert_VM_notNull(string);
 
 	char *strUTF = NULL;
 	UDATA stringLen = getStringUTF8Length(vmThread, string);
-	UDATA prependStrLen = strlen(prependStr);
-	UDATA length = stringLen + prependStrLen + 1;
+	UDATA length = stringLen + prependStrLength + 1;
 
 	PORT_ACCESS_FROM_VMC(vmThread);
 
@@ -356,10 +356,10 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 		length = bufferLength;
 	}
 	if (NULL != strUTF) {
-		if (0 < prependStrLen) {
-			memcpy(strUTF, prependStr, prependStrLen);
+		if (0 < prependStrLength) {
+			memcpy(strUTF, prependStr, prependStrLength);
 		}
-		if (UDATA_MAX == copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLen), length - prependStrLen)) {
+		if (UDATA_MAX == copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), length - prependStrLength)) {
 			if (buffer != strUTF) {
 				j9mem_free_memory(strUTF);
 			}

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -263,7 +263,6 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
  *
  * @param[in] vmThread the current J9VMThread
  * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] nullTermination if the utf8 data is going to be NULL terminated
  * @param[in] stringFlags the flag to determine performing '.' --> '/'
  * @param[in] utf8Data a utf8 data buffer
  * @param[in] utf8Length the size of the utf8 data buffer
@@ -271,7 +270,7 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
  * @return UDATA_MAX if a failure occurred, otherwise the number of utf8 data copied excluding null termination
  */
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, BOOLEAN nullTermination, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length)
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length)
 {
 	Assert_VM_notNull(string);
 
@@ -359,9 +358,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 		if (0 < prependStrLen) {
 			memcpy(strUTF, prependStr, prependStrLen);
 		}
-		if (UDATA_MAX == copyStringToUTF8Helper(
-			vmThread, string, TRUE, stringFlags, (U_8 *)(strUTF + prependStrLen), length - prependStrLen)
-		) {
+		if (UDATA_MAX == copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLen), length - prependStrLen)) {
 			if (buffer != strUTF) {
 				j9mem_free_memory(strUTF);
 			}

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -279,12 +279,14 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 	U_8 *data = utf8Data;
 
 	if (IS_STRING_COMPRESSED(vmThread, string)) {
-		for (int i = 0; i < unicodeLength; i++) {
-			data += VM_VMHelpers::encodeUTF8Char(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i), data);
+		for (UDATA i = 0; i < unicodeLength; i++) {
+			data += VM_VMHelpers::encodeUTF8CharI8(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i), data);
 		}
 
 		if (stringFlags & J9_STR_XLAT) {
-			for (int i = 0; i < unicodeLength; i++) {
+			data = utf8Data;
+
+			for (UDATA i = 0; i < unicodeLength; i++) {
 				UDATA encodedLength = VM_VMHelpers::encodedUTF8LengthI8(J9JAVAARRAYOFBYTE_LOAD(vmThread, unicodeBytes, i));
 
 				if ('.' == *data) {
@@ -295,12 +297,14 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 			}
 		}
 	} else {
-		for (int i = 0; i < unicodeLength; i++) {
+		for (UDATA i = 0; i < unicodeLength; i++) {
 			data += VM_VMHelpers::encodeUTF8Char(J9JAVAARRAYOFCHAR_LOAD(vmThread, unicodeBytes, i), data);
 		}
 
 		if (stringFlags & J9_STR_XLAT) {
-			for (int i = 0; i < unicodeLength; i++) {
+			data = utf8Data;
+
+			for (UDATA i = 0; i < unicodeLength; i++) {
 				UDATA encodedLength = VM_VMHelpers::encodedUTF8Length(J9JAVAARRAYOFCHAR_LOAD(vmThread, unicodeBytes, i));
 
 				if ('.' == *data) {
@@ -351,7 +355,6 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 		strUTF = (char *)j9mem_allocate_memory(length, OMRMEM_CATEGORY_VM);
 	} else {
 		strUTF = buffer;
-		length = bufferLength;
 	}
 	if (NULL != strUTF) {
 		if (0 < prependStrLength) {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -338,7 +338,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 		strUTF = buffer;
 	}
 	if (NULL != strUTF) {
-		UDATA computedUtf8Length;
+		UDATA computedUtf8Length = 0;
 
 		if (0 < prependStrLength) {
 			memcpy(strUTF, prependStr, prependStrLength);

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -366,7 +366,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 			return NULL;
 		}
 		if (NULL != utf8Length) {
-			*utf8Length = length;
+			*utf8Length = length - 1;
 		}
 	}
 	return strUTF;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -323,29 +323,6 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, BOOLEAN nullTerm
 
 /**
  * !!! this method is for backwards compatibility with JIT usage !!!
- * Copy a Unicode String to a UTF8 data buffer with NULL termination.
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] stringFlags the flag to determine performing '.' --> '/'
- * @param[in] utf8Data a utf8 data buffer
- * @param[in] utf8Length the size of the utf8 data buffer
- *
- * @return 1 if a failure occurred, otherwise 0 for success
- */
-UDATA
-copyStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8Length)
-{
-	if (UDATA_MAX == copyStringToUTF8Helper(vmThread, string, TRUE, stringFlags, utf8Data, utf8Length)) {
-		return 1;
-	} else {
-		return 0;
-	}
-}
-
-
-/**
- * !!! this method is for backwards compatibility with JIT usage !!!
  * Copy a Unicode String to a UTF8 data buffer without NULL termination.
  * dest is assumed to have enough length - the easiest way to ensure this is to pass a buffer with 1.5 * string length in it
  *

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -259,7 +259,7 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
 
 #if !defined (J9VM_OUT_OF_PROCESS)
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, BOOLEAN isNullTerminated)
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, UDATA utf8DataLength, BOOLEAN isNullTerminated)
 {
 	Assert_VM_notNull(string);
 
@@ -303,11 +303,17 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 		}
 	}
 
+	UDATA returnLength = (UDATA)(data - utf8Data);
+
 	if (isNullTerminated) {
 		*data = '\0';
+
+		Assert_VM_true(utf8DataLength >= returnLength + 1);
+	} else {
+		Assert_VM_true(utf8DataLength >= returnLength);
 	}
 
-	return (UDATA)(data - utf8Data);
+	return returnLength;
 }
 
 char*
@@ -334,7 +340,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 			memcpy(strUTF, prependStr, prependStrLength);
 		}
 
-		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), TRUE);
+		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), length, TRUE);
 
 		if (NULL != utf8Length) {
 			*utf8Length = computedUtf8Length + prependStrLength;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -326,7 +326,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 	UDATA stringLen = J9VMJAVALANGSTRING_LENGTH(vmThread, string) * 3;
 	UDATA length = stringLen + prependStrLength;
 
-	if ((stringFlags & J9_STR_NULL_TERMINATE_RESULT) != 0) {
+	if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_NULL_TERMINATE_RESULT)) {
 		++length;
 	}
 
@@ -344,7 +344,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 			memcpy(strUTF, prependStr, prependStrLength);
 		}
 
-		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), length);
+		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), length - prependStrLength);
 
 		if (NULL != utf8Length) {
 			*utf8Length = computedUtf8Length + prependStrLength;

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -321,24 +321,6 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 	return (UDATA)(data - utf8Data);
 }
 
-
-/**
- * Copy a string object to a UTF8 data buffer, optionally to prepend a string before it
- *
- * ***The caller must free the memory from this pointer if the return value is NOT the buffer argument ***
- *
- * @param[in] vmThread the current J9VMThread
- * @param[in] string a string object to be copied, it can't be NULL
- * @param[in] stringFlags the flag to determine performing '.' --> '/'
- * @param[in] prependStr the string to be prepended before the string object to be copied
- * 				it can't be NULL but can be an empty string ""
- * @param[in] prependStrLength The length of prependStr as computed by strlen.
- * @param[in] buffer the buffer for the string
- * @param[in] bufferLength the buffer length, not expected to larger than 64K
- * @param[out] utf8Length If not NULL returns the computed length (in bytes) of the copied UTF8 string in the buffer excluding the NULL terminator.
- *
- * @return a char pointer to the string (with NULL termination)
- */
 char*
 copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength, UDATA *utf8Length)
 {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -259,7 +259,7 @@ compareStringToUTF8(J9VMThread *vmThread, j9object_t string, UDATA translateDots
 
 #if !defined (J9VM_OUT_OF_PROCESS)
 UDATA
-copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data)
+copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, U_8 *utf8Data, BOOLEAN isNullTerminated)
 {
 	Assert_VM_notNull(string);
 
@@ -303,7 +303,9 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 		}
 	}
 
-	*data = '\0';
+	if (isNullTerminated) {
+		*data = '\0';
+	}
 
 	return (UDATA)(data - utf8Data);
 }
@@ -332,7 +334,7 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 			memcpy(strUTF, prependStr, prependStrLength);
 		}
 
-		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength));
+		computedUtf8Length = copyStringToUTF8Helper(vmThread, string, stringFlags, (U_8 *)(strUTF + prependStrLength), TRUE);
 
 		if (NULL != utf8Length) {
 			*utf8Length = computedUtf8Length + prependStrLength;

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -193,7 +193,7 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 			if (NULL != detail) {
 				detail[0] = ':';
 				detail[1] = ' ';
-				javaVM->internalVMFunctions->copyStringToUTF8Helper(currentThread, detailMessage, TRUE, J9_STR_NONE, (U_8*)detail + 2, buffLen - 2);
+				javaVM->internalVMFunctions->copyStringToUTF8Helper(currentThread, detailMessage, J9_STR_NONE, (U_8*)detail + 2, buffLen - 2);
 			}
 		}
 		swPrintf(walkState, 2, "\tThrowing exception: %.*s%s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className), detail ? detail : "");

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -188,7 +188,7 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 		j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(currentThread, walkState->restartException);
 
 		if (NULL != detailMessage) {
-			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NONE, ": ", detailStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NONE, ": ", 2, detailStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		}
 		swPrintf(walkState, 2, "\tThrowing exception: %.*s%s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className), detail ? detail : "");
 		if (detailStackBuffer != detail) {

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -188,7 +188,7 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 		j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(currentThread, walkState->restartException);
 
 		if (NULL != detailMessage) {
-			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NONE, ": ", 2, detailStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
+			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NULL_TERMINATE_RESULT, ": ", 2, detailStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		}
 		swPrintf(walkState, 2, "\tThrowing exception: %.*s%s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className), detail ? detail : "");
 		if (detailStackBuffer != detail) {

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -184,20 +184,13 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 		PORT_ACCESS_FROM_WALKSTATE(walkState);
 		J9UTF8 * className = J9ROMCLASS_CLASSNAME(((J9Class *) walkState->userData4)->romClass);
 		char * detail = NULL;
-		J9JavaVM *javaVM = walkState->walkThread->javaVM;
 		j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(currentThread, walkState->restartException);
 
-		if (detailMessage) {
-			UDATA buffLen = (J9VMJAVALANGSTRING_LENGTH(currentThread, detailMessage) * 3) + 3;
-			detail = j9mem_allocate_memory(buffLen, OMRMEM_CATEGORY_VM);
-			if (NULL != detail) {
-				detail[0] = ':';
-				detail[1] = ' ';
-				javaVM->internalVMFunctions->copyStringToUTF8Helper(currentThread, detailMessage, J9_STR_NONE, (U_8*)detail + 2, buffLen - 2);
-			}
+		if (NULL != detailMessage) {
+			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NONE, ": ", detail, 0, NULL);
 		}
 		swPrintf(walkState, 2, "\tThrowing exception: %.*s%s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className), detail ? detail : "");
-		if (detail) {
+		if (NULL != detail) {
 			j9mem_free_memory(detail);
 		}
 	}

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -183,14 +183,15 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 	if ((walkState->flags & (J9_STACKWALK_MAINTAIN_REGISTER_MAP | J9_STACKWALK_INCLUDE_CALL_IN_FRAMES)) == (J9_STACKWALK_MAINTAIN_REGISTER_MAP | J9_STACKWALK_INCLUDE_CALL_IN_FRAMES)) {
 		PORT_ACCESS_FROM_WALKSTATE(walkState);
 		J9UTF8 * className = J9ROMCLASS_CLASSNAME(((J9Class *) walkState->userData4)->romClass);
+		char detailStackBuffer[J9VM_PACKAGE_NAME_BUFFER_LENGTH];
 		char * detail = NULL;
 		j9object_t detailMessage = J9VMJAVALANGTHROWABLE_DETAILMESSAGE(currentThread, walkState->restartException);
 
 		if (NULL != detailMessage) {
-			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NONE, ": ", detail, 0, NULL);
+			detail = walkState->walkThread->javaVM->internalVMFunctions->copyStringToUTF8WithMemAlloc(currentThread, detailMessage, J9_STR_NONE, ": ", detailStackBuffer, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 		}
 		swPrintf(walkState, 2, "\tThrowing exception: %.*s%s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className), detail ? detail : "");
-		if (NULL != detail) {
+		if (detailStackBuffer != detail) {
 			j9mem_free_memory(detail);
 		}
 	}

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1883,7 +1883,7 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 		j9object_t unicodeChars = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
 
 		if (NULL != unicodeChars) {
-			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NONE, "", threadName, 0, NULL);
+			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NONE, "", 0, threadName, 0, NULL);
 		}
 	} else {
 		j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1882,7 +1882,7 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 		j9object_t unicodeChars = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
 
 		if (NULL != unicodeChars) {
-			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NONE, "", 0, threadName, 0, NULL);
+			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NULL_TERMINATE_RESULT, "", 0, threadName, 0, NULL);
 		}
 	} else {
 		j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1879,7 +1879,6 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 		
 	threadObject = PEEK_OBJECT_IN_SPECIAL_FRAME(currentThread, 3);
 	if (J2SE_SHAPE(vm) == J2SE_SHAPE_RAW) {
-		PORT_ACCESS_FROM_JAVAVM(vm);
 		j9object_t unicodeChars = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
 
 		if (NULL != unicodeChars) {

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1885,9 +1885,7 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 		threadName = (char*)j9mem_allocate_memory(unicodeLength, OMRMEM_CATEGORY_THREADS);
 		if (NULL != threadName) {
 			memset(threadName, 0, unicodeLength);
-			if (UDATA_MAX == copyStringToUTF8Helper(
-				currentThread, unicodeChars, TRUE, J9_STR_NONE, (U_8 *)threadName, unicodeLength)
-			) {
+			if (UDATA_MAX == copyStringToUTF8Helper(currentThread, unicodeChars, J9_STR_NONE, (U_8 *)threadName, unicodeLength)) {
 				j9mem_free_memory(threadName);
 				threadName = NULL;
 			}

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1834,7 +1834,7 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 	omrthread_t osThread;
 	j9object_t cachedOutOfMemoryError;
 	j9object_t threadObject;
-	char *threadName;
+	char *threadName = NULL;
 	
 	/* Fork the OS thread */
 
@@ -1881,14 +1881,9 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 	if (J2SE_SHAPE(vm) == J2SE_SHAPE_RAW) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		j9object_t unicodeChars = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
-		UDATA unicodeLength = getStringUTF8Length(currentThread, unicodeChars) * 2 + 1;
-		threadName = (char*)j9mem_allocate_memory(unicodeLength, OMRMEM_CATEGORY_THREADS);
-		if (NULL != threadName) {
-			memset(threadName, 0, unicodeLength);
-			if (UDATA_MAX == copyStringToUTF8Helper(currentThread, unicodeChars, J9_STR_NONE, (U_8 *)threadName, unicodeLength)) {
-				j9mem_free_memory(threadName);
-				threadName = NULL;
-			}
+
+		if (NULL != unicodeChars) {
+			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NONE, "", threadName, 0, NULL);
 		}
 	} else {
 		j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1882,13 +1882,13 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 		j9object_t unicodeChars = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
 
 		if (NULL != unicodeChars) {
-			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NULL_TERMINATE_RESULT, "", 0, threadName, 0, NULL);
+			threadName = copyStringToUTF8WithMemAlloc(currentThread, unicodeChars, J9_STR_NULL_TERMINATE_RESULT, "", 0, NULL, 0, NULL);
 		}
 	} else {
 		j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
 		threadName = getVMThreadNameFromString(currentThread, nameObject);
 	}
-	if(threadName == NULL) {
+	if (threadName == NULL) {
 		Trc_VM_startJavaThread_failedVMThreadAlloc(currentThread);
 		omrthread_cancel(osThread);
 		return J9_THREAD_START_FAILED_VMTHREAD_ALLOC;


### PR DESCRIPTION
- Return UTF8 length from copyStringToUTF8Helper
- Provide an I_8 version of encodeUTF8Char
- Remove utf8Len parameter from copyStringToUTF8Helper
- Add prependStrLength parameter to copyStringToUTF8WithMemAlloc
- Use stack allocated buffer for copyStringToUTF8WithMemAlloc if possible
- Replace uses of copyStringToUTF8Helper with copyStringToUTF8WithMemAlloc
- Introduce outgoing utf8Length parameter to copyStringToUTF8WithMemAlloc
- Deprecate null termination parameter in copyStringToUTF8Helper
- Deprecate copyFromStringIntoUTF8
- Force null termination on all calls to copyStringToUTF8Helper
- Deprecate copyStringToUTF8
- Deprecate copyCharsIntoUTF8Helper

Closes: #966