### PR TITLE
Avoid generating nodes in codegen for PD2I

### DIFF
--- a/runtime/compiler/trj9/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/trj9/optimizer/DataAccessAccelerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1823,7 +1823,8 @@ TR_DataAccessAccelerator::generatePD2IVariableParameter(TR::TreeTop* treeTop, TR
 
    // Create BCDCHK node
    TR::SymbolReference*  bcdChkSymRef = fastNode->getSymbolReference();
-   TR::Node* bcdchkNode = TR::Node::createWithSymRef(TR::BCDCHK, 1, 1, fastNode, bcdChkSymRef);
+   TR::Node* pdAddressNode = constructAddressNode(fastNode, fastNode->getChild(0), fastNode->getChild(1));
+   TR::Node* bcdchkNode = TR::Node::createWithSymRef(TR::BCDCHK, 2, 2, fastNode, pdAddressNode, bcdChkSymRef);
    fastTT->setNode(bcdchkNode);
 
    // TreeTop replaced by BCDCHK, so we lose 1 reference

--- a/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.hpp
@@ -133,7 +133,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *i2pdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2pdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register* pd2lVariableEvaluator(TR::Node* node, TR::CodeGenerator* cg, bool isUseVectorBCD);
-   static TR::Node* constructDAAAddressPointer(TR::Node* callNode, TR::CodeGenerator* cg);
    static TR::Register *generatePackedToBinaryConversion(TR::Node * node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator * cg);
    static TR::Register *generateVectorPackedToBinaryConversion(TR::Node * node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator * cg);
    static TR::Register *generateBinaryToPackedConversion(TR::Node * node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator * cg);


### PR DESCRIPTION
For variable precision pd2i conversions, avoid constructing nodes in the
codegen level by pre-generating the node in the optimizor phase.

Remove the node construction function constructDAAAddressPointer() from
codegen.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>