### PR TITLE
Reduce redundant testcases

### DIFF
--- a/test/cmdLineTests/shareClassTests/DataHelperTests/playlist.xml
+++ b/test/cmdLineTests/shareClassTests/DataHelperTests/playlist.xml
@@ -24,7 +24,7 @@
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>cmdLineTester_DataHelperTests_win</testCaseName>
+		<testCaseName>cmdLineTester_DataHelperTests</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>	
@@ -32,42 +32,10 @@
 		<command>$(MKTREE) $(REPORTDIR); \
 	$(CD) $(REPORTDIR); \
 	cp $(Q)$(TEST_RESROOT)$(D)DataHelperTests.jar$(Q) .; \
-	$(Q)$(JDK_HOME)$(D)bin$(D)jar.exe$(Q) xf DataHelperTests.jar; \
-	$(CD) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)dataone.contents$(Q); $(Q)$(JDK_HOME)$(D)bin$(D)jar.exe$(Q) cf dataone.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
-	$(CD) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)datatwo.contents$(Q); $(Q)$(JDK_HOME)$(D)bin$(D)jar.exe$(Q) cf datatwo.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
-	mv $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)dataone.contents$(D)dataone.jar$(Q) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(Q); \
-	mv $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)datatwo.contents$(D)datatwo.jar$(Q) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(Q); \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DCPDL=$(Q)$(P)$(Q) -DSCMODE=204 -DTEST_JVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)DataHelperTests_$(JAVA_VERSION).xml$(Q) -xids all,$(JAVA_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
-	-nonZeroExitWhenError \
-	-outputLimit 300; \
-	$(TEST_STATUS)</command>
-		<platformRequirements>os.win</platformRequirements>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-		</subsets>
-	</test>
-	<test>
-	<testCaseName>cmdLineTester_DataHelperTests_unix</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>	
-		</variations>
-		<command>$(MKTREE) $(REPORTDIR); \
-	$(CD) $(REPORTDIR); \
-	cp $(Q)$(TEST_RESROOT)$(D)DataHelperTests.jar$(Q) .; \
-	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(Q) xf DataHelperTests.jar; \
+	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf DataHelperTests.jar; \
 	$(CONVERT_TO_EBCDIC_CMD) \
-	$(CD) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)dataone.contents$(Q); $(Q)$(JDK_HOME)$(D)bin$(D)jar$(Q) cf dataone.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
-	$(CD) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)datatwo.contents$(Q); $(Q)$(JDK_HOME)$(D)bin$(D)jar$(Q) cf datatwo.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
+	$(CD) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)dataone.contents$(Q); $(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) cf dataone.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
+	$(CD) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)datatwo.contents$(Q); $(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) cf datatwo.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
 	mv $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)dataone.contents$(D)dataone.jar$(Q) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(Q); \
 	mv $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(D)datatwo.contents$(D)datatwo.jar$(Q) $(Q)$(TESTOUTPUT)$(D)$@$(D)datacaching$(Q); \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DCPDL=$(Q)$(P)$(Q) -DSCMODE=204 -DTEST_JVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
@@ -76,7 +44,6 @@
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Combine cmdLineTester_DataHelperTests_win and
cmdLineTester_DataHelperTests_unix to cmdLineTester_DataHelperTests

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>