### PR TITLE
Initial support Java 11

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -528,7 +528,9 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 
 	/* Determine allowed class file version */
 #ifdef J9VM_OPT_SIDECAR
-	if (J2SE_VERSION(vm) >= J2SE_V10) {
+	if (J2SE_VERSION(vm) >= J2SE_V11) {
+		translationFlags |= BCT_Java11MajorVersionShifted;
+	} else if (J2SE_VERSION(vm) >= J2SE_V10) {
 		translationFlags |= BCT_Java10MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_19) {
 		translationFlags |= BCT_Java9MajorVersionShifted;

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2017 IBM Corp. and others
+ * Copyright (c) 2002, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1476,12 +1476,13 @@ bail:
  * "1.8.0_xxx" --- Java 8, 'J2SE_18 | J2SE_SHAPE_SUN_OPENJDK' assuming this is an OpenJ9 Java 8 build;
  * "9"         --- Java 9, 'J2SE_19 | J2SE_SHAPE_B165';
  * "10"        --- Java 10, 'J2SE_V10 | J2SE_SHAPE_V10';
+ * "11"        --- Java 11, 'J2SE_V11 | J2SE_SHAPE_V11';
  * Others      --- Latest Java, 'J2SE_LATEST | J2SE_SHAPE_LATEST'.
- * Note: 'release' file contains JAVA_VERSION="10" for Java 10 at this moment.
  * Otherwise, 0 is returned.
  *
  * @return 'J2SE_18 | J2SE_SHAPE_SUN_OPENJDK', 'J2SE_19 | J2SE_SHAPE_B165',
- *         'J2SE_V10 | J2SE_SHAPE_V10', 'J2SE_LATEST | J2SE_SHAPE_LATEST'
+ *         'J2SE_V10 | J2SE_SHAPE_V10', 'J2SE_V11 | J2SE_SHAPE_V11',
+ *         'J2SE_LATEST | J2SE_SHAPE_LATEST' 
  *         according to the 'JAVA_VERSION' value found in 'release';
  *         or 0 if otherwise.
  */
@@ -1509,6 +1510,8 @@ getVersionFromReleaseFile(void)
 				finalVersion = J2SE_19 | J2SE_SHAPE_B165;
 			} else if (!strcmp(version, "\"10\"")) {
 				finalVersion = J2SE_V10 | J2SE_SHAPE_V10;
+			} else if (!strcmp(version, "\"11\"")) {
+				finalVersion = J2SE_V11 | J2SE_SHAPE_V11;
 			} else {
 				/* Assume latest Java version and shape */
 				finalVersion = J2SE_LATEST | J2SE_SHAPE_LATEST;

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -122,6 +122,13 @@ jint computeFullVersionString(J9JavaVM* vm)
 			j2se_version_info = "10.?";
 		}
 		break;
+	case J2SE_V11:
+		if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V11) {
+			j2se_version_info = "11";
+		} else {
+			j2se_version_info = "11.?";
+		}
+		break;
 	default:
 		j2se_version_info = "?.?.?";
 	}

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,12 +37,15 @@
 #define J2SE_18   0x1800
 #define J2SE_19   0x1900
 #define J2SE_V10  0x1A00            /* This refers Java 10 */
+#define J2SE_V11  0x1B00            /* This refers Java 11 */
 #if JAVA_SPEC_VERSION == 8
 	#define J2SE_LATEST  J2SE_18
 #elif JAVA_SPEC_VERSION == 9
 	#define J2SE_LATEST  J2SE_19
-#else
+#elif JAVA_SPEC_VERSION == 10
 	#define J2SE_LATEST  J2SE_V10
+#else
+	#define J2SE_LATEST  J2SE_V11
 #endif
 
 /**
@@ -66,8 +69,10 @@
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_SUN
 #elif JAVA_SPEC_VERSION == 9
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_B165
-#else
+#elif JAVA_SPEC_VERSION == 10
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V10
+#else
+	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V11
 #endif
 #define J2SE_SHAPE_SUN     		0x10000
 #define J2SE_SHAPE_SUN_OPENJDK	0x20000
@@ -75,6 +80,7 @@
 #define J2SE_SHAPE_B148    		0x50000
 #define J2SE_SHAPE_B165    		0x60000
 #define J2SE_SHAPE_V10			0x70000
+#define J2SE_SHAPE_V11			0x80000
 #define J2SE_SHAPE_RAWPLUSJ9	0x80000
 #define J2SE_SHAPE_RAW	 		0x90000
 #define J2SE_SHAPE_MASK 		0xF0000

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2009,7 +2009,8 @@ typedef struct J9BCTranslationData {
 #define BCT_Java8MajorVersionShifted  0x34000000
 #define BCT_Java9MajorVersionShifted  0x35000000
 #define BCT_Java10MajorVersionShifted 0x36000000
-#define BCT_JavaMaxMajorVersionShifted BCT_Java10MajorVersionShifted
+#define BCT_Java11MajorVersionShifted 0x37000000
+#define BCT_JavaMaxMajorVersionShifted BCT_Java11MajorVersionShifted
 
 #define BCT_ActionUnused  6
 #define BCT_ErrFallOffLastInstruction  8

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,6 +37,7 @@ extern "C" {
 #define J9SH_MODLEVEL_JAVA8  4
 #define J9SH_MODLEVEL_JAVA9  5
 #define J9SH_MODLEVEL_JAVA10 6
+#define J9SH_MODLEVEL_JAVA11 7
 
 /*	JVM feature bit flag(s)	*/
 /*

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -714,6 +714,7 @@ addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2s
 		Assert_Util_unreachable();
 	} 
 	if (J2SE_V10 <= j2seReleaseValue) {
+		/* Java 11 shares same dll with Java 10 for now */
 		dllName = J9_JAVA_SE_10_DLL_NAME;
 		dllNameLength = sizeof(J9_JAVA_SE_10_DLL_NAME);
 	} else if (J2SE_19 <= j2seReleaseValue) {

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -159,6 +159,9 @@ getShcModlevelForJCL(uintptr_t j2seVersion)
 	case J2SE_V10 :
 		modLevel = J9SH_MODLEVEL_JAVA10;
 		break;
+	case J2SE_V11 :
+		modLevel = J9SH_MODLEVEL_JAVA11;
+		break;
 	}
 	return modLevel;
 }
@@ -192,6 +195,9 @@ getJCLForShcModlevel(uintptr_t modlevel)
 		break;
 	case J9SH_MODLEVEL_JAVA10 :
 		j2seVersion = J2SE_V10;
+		break;
+	case J9SH_MODLEVEL_JAVA11 :
+		j2seVersion = J2SE_V11;
 		break;
 	}
 	return j2seVersion;
@@ -254,6 +260,9 @@ getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer)
 		break;
 	case J9SH_MODLEVEL_JAVA10 :
 		strcpy(buffer, "Java10");
+		break;
+	case J9SH_MODLEVEL_JAVA11 :
+		strcpy(buffer, "Java11");
 		break;
 	default :
 		strcpy(buffer, "Unknown");

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -390,6 +390,8 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 		javaVersion = "JRE 9";
 	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V10) {
 		javaVersion = "JRE 10";
+	} else if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) == J2SE_V11) {
+		javaVersion = "JRE 11";
 	} else {
 		javaVersion = "UNKNOWN";
 	}

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -685,25 +685,28 @@ initializeSystemProperties(J9JavaVM * vm)
 	}
 
 	/* Properties that always exist */
+	specificationVendor = "Oracle Corporation";
 	switch (j2seVersion) {
 		case J2SE_18:
 			classVersion = "52.0";
 			specificationVersion = "1.8";
-			specificationVendor = "Oracle Corporation";
 			break;
 
 		case J2SE_19:
 			classVersion = "53.0";
 			specificationVersion = "9";
-			specificationVendor = "Oracle Corporation";
 			break;
 			
 		case J2SE_V10:
-			/* FALLTHROUGH */
-		default:
 			classVersion = "54.0";
 			specificationVersion = "10";
-			specificationVendor = "Oracle Corporation";
+			break;
+			
+		case J2SE_V11:
+			/* FALLTHROUGH */
+		default:
+			classVersion = "55.0";
+			specificationVersion = "11";
 			break;
 	}
 	rc = addSystemProperty(vm, "java.class.version", classVersion, 0);


### PR DESCRIPTION
Initial support `Java 11` 
Added `J2SE_V11` & `J2SE_SHAPE_V11` for `Java 11` version/shape;
Added `BCT_Java11MajorVersionShifted` to support `Java 11` class file;

Note: Current `Java 11 release` still has `JAVA_VERSION="10"`, this need to be changed to `11` to make `-version` work:
````
openjdk version "10-internal" 2018-03-20
OpenJDK Runtime Environment (build 10-internal+0-adhoc.arnold.jdk11tip1)
IBM J9 VM (build 2.9, JRE 11 Linux amd64-64 Compressed References 20180130_377542 (JIT enabled, AOT enabled)
OpenJ9   - d64929a
OMR      - d6659af
IBM      - 2321a81)
````

Reviewer @Peter-Shipton 
FYI: @daniel-heidinga @Tobi-Ajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>