### PR TITLE
Comment out the report function to avoid causing lock failure

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1373,6 +1373,7 @@ exit:
 	static VMINLINE void
 	reportFinalFieldModified(J9VMThread* currentThread, J9Class* fieldClass)
 	{
+#if 0
 		if (J9_ARE_NO_BITS_SET(fieldClass->classFlags, J9ClassHasIllegalFinalFieldModifications)) {
 			J9JavaVM* vm = currentThread->javaVM;
 			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_OSR_SAFE_POINT)) {
@@ -1391,6 +1392,7 @@ exit:
 				vmFuncs->releaseSafePointVMAccess(currentThread);
 			}
 		}
+#endif
 	}
 };
 


### PR DESCRIPTION
The reporter function is causing intermittent hangs during testing,
Removing this until hanging issue is fixed

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>