### PR TITLE
Fix Test_AccessController

### DIFF
--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -714,7 +714,6 @@
 	JCL_TEST_Java-Lang-Invoke,\
 	JCL_TEST_Java-Lang-Ref,\
 	JCL_TEST_Java-Lang-Reflect,\
-	JCL_TEST_Java-Security,\
 	JCL_TEST_Java-Math,\
 	JCL_TEST_Test-RunLast \
 	-groups $(TEST_GROUP) \
@@ -758,7 +757,6 @@
 	JCL_TEST_Java-Lang-Invoke,\
 	JCL_TEST_Java-Lang-Ref,\
 	JCL_TEST_Java-Lang-Reflect,\
-	JCL_TEST_Java-Security,\
 	JCL_TEST_Java-Math,\
 	JCL_TEST_Test-RunLast \
 	-groups $(TEST_GROUP) \
@@ -830,6 +828,78 @@
 		</groups>
 		<subsets>
 			<subset>SE80</subset>
+		</subsets>
+	</test>
+<!--
+	Java 8 specific test case.
+	Java 9 and above require VM options not available in Java 8.
+-->
+	<test>
+		<testCaseName>JCL_TEST_Java-Security_SE80</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace \
+	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)testacc.policy$(Q) \
+	-Xbootclasspath/a:$(TEST_RESROOT)$(D)TestResources.jar \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames JCL_TEST_Java-Security \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^vm.hrt</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+	</test>
+
+<!--
+	Java 9 and above.
+-->
+	<test>
+		<testCaseName>JCL_TEST_Java-Security</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stacktrace \
+	--add-modules java.se.ee,openj9.sharedclasses \
+	--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	--add-opens=java.base/java.security=ALL-UNNAMED \
+	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)testacc.policy$(Q) \
+	-Xbootclasspath/a:$(TEST_RESROOT)$(D)TestResources.jar \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames JCL_TEST_Java-Security \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^vm.hrt</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE90</subset>
 		</subsets>
 	</test>
 

--- a/test/Java8andUp/src/org/openj9/test/java/security/TestURLClassLoader.java
+++ b/test/Java8andUp/src/org/openj9/test/java/security/TestURLClassLoader.java
@@ -1,0 +1,47 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 1998, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Subclass of URLClassLoader which handles the TestNG classes specially.
+ */
+public class TestURLClassLoader extends URLClassLoader {
+
+	public TestURLClassLoader(URL[] urls, ClassLoader parent) {
+		super(urls, parent);
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+		Class<?> result;
+		if (name.startsWith("org.testng")) { //$NON-NLS-1$
+			result = Class.forName(name, true, ClassLoader.getSystemClassLoader());
+		} else {
+			result = super.findClass(name);
+		}
+		return result;
+	}
+}

--- a/test/Java8andUp/testacc.policy
+++ b/test/Java8andUp/testacc.policy
@@ -1,0 +1,26 @@
+//  Copyright (c) 2018, 2018 IBM Corp. and others
+//
+//  This program and the accompanying materials are made available under
+//  the terms of the Eclipse Public License 2.0 which accompanies this
+//  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+//  or the Apache License, Version 2.0 which accompanies this distribution and
+//  is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+//  This Source Code may also be made available under the following
+//  Secondary Licenses when the conditions for such availability set
+//  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+//  General Public License, version 2 with the GNU Classpath
+//  Exception [1] and GNU General Public License, version 2 with the
+//  OpenJDK Assembly Exception [2].
+//
+//  [1] https://www.gnu.org/software/classpath/license.html
+//  [2] http://openjdk.java.net/legal/assembly-exception.html
+//
+//  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+grant {
+	// so we can remove the security manager
+	permission java.lang.RuntimePermission "setSecurityManager";
+	// Allow the test harness to write the log files
+	permission java.io.FilePermission "<<ALL FILES>>", "read,write";
+};

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -28,6 +28,7 @@ org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	BPW-https:/
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking									124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						124199 generic-all
+org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all


### PR DESCRIPTION
Add special cases in custom classloaders, via a common superclass, to load test
harness classes.

Add a new security policy which allows the test harness to read and write the
results directory while the security manager is active.

Improve test progress reporting.

Delete obsolete comments, extract redundant strings to a constant.

Fixes issue #858.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>