### PR TITLE
Remove exclusion for org.openj9.test.java.lang.Test_ClassLoader

### DIFF
--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -705,6 +705,7 @@
 	JCL_TEST_Test-Annotation,\
 	JCL_TEST_Test-Annotation-Identity,\
 	JCL_TEST_Test-Annotation-ClassLoader,\
+	JCL_TEST_Java-Lang_ClassLoader,\
 	JCL_TEST_Test-Annotation-Package,\
 	JCL_TEST_Test-Defects,\
 	JCL_TEST_Test-UnsafeFence,\
@@ -748,6 +749,7 @@
 	JCL_TEST_Test-Annotation,\
 	JCL_TEST_Test-Annotation-Identity,\
 	JCL_TEST_Test-Annotation-ClassLoader,\
+	JCL_TEST_Java-Lang_ClassLoader,\
 	JCL_TEST_Test-Annotation-Package,\
 	JCL_TEST_Test-Defects,\
 	JCL_TEST_Test-UnsafeFence,\

--- a/test/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
+++ b/test/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
@@ -1,7 +1,7 @@
 package org.openj9.test.java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/test/Java8andUp/testng.xml
+++ b/test/Java8andUp/testng.xml
@@ -115,6 +115,11 @@
 			<class name="org.openj9.test.annotation.Test_Annotation"/>
 		</classes>
 	</test>
+	<test name="JCL_TEST_Java-Lang_ClassLoader">
+		<classes>
+			<class name="org.openj9.test.java.lang.Test_ClassLoader"/>
+		</classes>
+	</test>
 	<test name="JCL_TEST_Test-Annotation-ClassLoader">
 		<classes>
 			<class name="org.openj9.test.annotationClassLoader.Test_ClassLoader"/>

--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -24,7 +24,6 @@
 
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										858 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						858 generic-all
-org.openj9.test.java.lang.Test_ClassLoader																				995 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -28,7 +28,6 @@ org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	BPW-https:/
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedFrameStackWalking									124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										124199 generic-all
 org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						124199 generic-all
-org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all


### PR DESCRIPTION
This exclusion has no effect.  The purportedly excluded test is in fact running and passing.

Fixes https://github.com/eclipse/openj9/issues/995

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>