### PR TITLE
Remove JVM version 2.9

### DIFF
--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -1855,7 +1855,7 @@ static void dumpHelpText( J9PortLibrary *portLib, int argc, char **argv)
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	vmDetailString(portLib, detailString, 1024);
-	j9file_printf( PORTLIB, J9PORT_TTY_OUT, "\nOpenJ9 Java(TM) Class File Reader, Version " EsVersionString);
+	j9file_printf( PORTLIB, J9PORT_TTY_OUT, "\nOpenJ9 Java(TM) Class File Reader, Version " J9JVM_VERSION_STRING);
 	j9file_printf( PORTLIB, J9PORT_TTY_OUT, "\n" J9_COPYRIGHT_STRING);
 	j9file_printf( PORTLIB, J9PORT_TTY_OUT, "\nTarget: %s\n", detailString);
 	j9file_printf( PORTLIB, J9PORT_TTY_OUT, "\nJava and all Java-based marks and logos are trademarks or registered");

--- a/runtime/gc_check/CheckCycle.cpp
+++ b/runtime/gc_check/CheckCycle.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,7 +80,7 @@ GC_CheckCycle::printHelp(J9PortLibrary *portLib)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	j9tty_printf(PORTLIB, "gcchk for J9, Version " EsVersionString "\n");
+	j9tty_printf(PORTLIB, "gcchk for J9, Version " J9JVM_VERSION_STRING "\n");
 	j9tty_printf(PORTLIB, J9_COPYRIGHT_STRING "\n\n");
 	j9tty_printf(PORTLIB, "Usage: -Xcheck:gc[:scanOption,...][:verifyOption,...][:miscOption,...]\n");
 	j9tty_printf(PORTLIB, "scan options (default is all):\n");

--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,8 @@ extern "C" {
 #endif
 
 #include "omrcfg.h"
+#include "openj9_version_info.h"
+#include "vendor_version.h"
 
 #define J9_COPYRIGHT_STRING "(c) Copyright 1991, ${uma.year} IBM Corp. and others."
 
@@ -42,7 +44,6 @@ extern "C" {
 #undef EsVersionMinor
 #define EsVersionMinor ${uma.buildinfo.version.minor}0
 
-#define EsVersionString "${uma.buildinfo.version.major}.${uma.buildinfo.version.minor}"
 #define EsExtraVersionString ""
 
 /*  Note: The following defines record flags used to build VM.  */

--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/* Example usage for inclusion of a vendor name and repository sha.  These values
+/* This file provides a means to supply vendor specific version info such as 
+ * short name, SHA, and version string.
+ * These vendor version info can be defined either in this file or other places.
+ * 
+ * Example usage for inclusion of a vendor name and repository sha.  These values
  * will be inserted into the java.fullversion and java.vm.info system properties
  * and in a generated javacore file.
  *
@@ -31,4 +35,8 @@
  *
  * #define VENDOR_SHORT_NAME "ABC"
  * #define VENDOR_SHA "1a2b3c4"
+ *
+ * Example usage for inclusion of a vendor version string.
+ * This value will be stored in the system property java.vm.version.
+ * #define J9JVM_VERSION_STRING "0.8.1"
  */

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -980,7 +980,7 @@ jniVerboseGetID(const char *function, JNIEnv *env, jclass classRef, const char *
 static void printJnichkHelp(J9PortLibrary* portLib) {
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	j9file_printf(PORTLIB, J9PORT_TTY_OUT, j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_JNICHK_HELP_1, NULL), EsVersionString);
+	j9file_printf(PORTLIB, J9PORT_TTY_OUT, j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_JNICHK_HELP_1, NULL), J9JVM_VERSION_STRING);
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, J9_COPYRIGHT_STRING "\n\n");
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_JNICHK_HELP_2, NULL));
 	j9file_printf(PORTLIB, J9PORT_TTY_OUT, "\n");

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -761,7 +761,7 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
-	rc = addSystemProperty(vm, "java.vm.version", EsVersionString, 0);
+	rc = addSystemProperty(vm, "java.vm.version", J9JVM_VERSION_STRING, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {
 		goto fail;
 	}

--- a/runtime/vmchk/vmcheck.c
+++ b/runtime/vmchk/vmcheck.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,7 +174,7 @@ vmchkPrintf(J9JavaVM *javaVM, const char *format, ...)
 static void
 printVMCheckHelp(J9JavaVM *vm)
 {
-	vmchkPrintf(vm, "vmchk VM Check utility for J9, Version " EsVersionString "\n");
+	vmchkPrintf(vm, "vmchk VM Check utility for J9, Version " J9JVM_VERSION_STRING "\n");
 	vmchkPrintf(vm, J9_COPYRIGHT_STRING "\n\n");
 	vmchkPrintf(vm, "  help              print this screen\n");
 	vmchkPrintf(vm, "  all               all checks\n");


### PR DESCRIPTION
Remove JVM version `2.9`

Added a vendor specific define

This PR meets the minimum requirement to remove JVM version `2.9` from system properties, and replace it with `OpenJ9 JVM_VERSION_STRING`.
There are other internal references to JVM version such as `kca_offsets_generator.cpp` and `share classes`, which use this version as their support levels. Will address that in a separated PR instead.

Related to #1020, #1096

Related PRs:
https://github.com/ibmruntimes/openj9-openjdk-jdk9/pull/121
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/36

Reviewer @pshipton 
FYI @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>