### PR TITLE
Remove spurious directories from mingw include path

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -197,8 +197,11 @@ UMA_LINK_PATH+=-L/ztpf/$(UMA_ZTPF_ROOT)/base/oco/stdlib
 <#if uma.spec.type.windows>
 ifdef USE_MINGW
   MINGW_CXXFLAGS+=$(UMA_C_INCLUDES)
-  MINGW_INCLUDES:="$(subst ;," -I",$(INCLUDE))"
-  MINGW_CXXFLAGS+=-I../oti/mingw $(UMA_C_INCLUDE_PREFIX)$(MINGW_INCLUDES)
+  MINGW_CXXFLAGS+=-I../oti/mingw
+  ifneq ($(OPENJ9_BUILD),true)
+    MINGW_INCLUDES:="$(subst ;," -I",$(INCLUDE))"
+    MINGW_CXXFLAGS+=$(UMA_C_INCLUDE_PREFIX)$(MINGW_INCLUDES)
+  endif # OPENJ9_BUILD
 endif
 </#if>
 <#if uma.spec.processor.ppc>


### PR DESCRIPTION
Remove the INCLUDE environment variable from the mingw include path.  The build
system may set this variable to the MSVC include path.  The result is double
definitions of certain types and hence compilation failures.

The mingw include path is sufficient without the INCLUDE variable.

See also ibmruntimes/openj9-openjdk-jdk9#116

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>