### PR TITLE
Ensure primitive types are assigned to java.base

### DIFF
--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1013,6 +1013,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 
 						clazz = vmFuncs->allClassesStartDo(&classWalkState, vm, vm->systemClassLoader);
 						while (NULL != clazz) {
+							Assert_SC_true(clazz->module == vm->javaBaseModule);
 							J9VMJAVALANGCLASS_SET_MODULE(currentThread, clazz->classObject, modObj);
 							clazz = vmFuncs->allClassesNextDo(&classWalkState);
 						}

--- a/test/Java9andUp/playlist.xml
+++ b/test/Java9andUp/playlist.xml
@@ -274,7 +274,6 @@
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)
 		</command>
-		<disabled>ISSUE#1086</disabled>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Ensure primitive types are assigned to java.base

Java primitive types are currently loaded under unnamedmodules. This
patch fixes this and correctly loads them under java.base.

Fixes: #1086

Signed-off-by: tajila <atobia@ca.ibm.com>