### PR TITLE
Fix hash table collision bug in Class.getMethods()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -3484,8 +3484,9 @@ private class MethodInfo {
 		if (!that.getClass().equals(this.getClass())) {
 			return false;
 		}
+		@SuppressWarnings("unchecked")
 		MethodInfo otherMethod = (MethodInfo) that;
-		if (!otherMethod.methodName.equals(otherMethod.methodName)) {
+		if (!methodName.equals(otherMethod.methodName)) {
 			return false;
 		}
 		if (null == returnType) {

--- a/test/Java8andUp/src/org/openj9/test/reflect/ExampleClass.java
+++ b/test/Java8andUp/src/org/openj9/test/reflect/ExampleClass.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * firstary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+/**
+ * Test methods which 
+ * - have the same name but different arguments and return types
+ * - have the same arguments and return types but different name
+ * 
+ * Use contrived method names which have the same hashcode.
+ *
+ */
+public class ExampleClass {
+
+	public boolean methodName21() {
+		return false;
+	}
+
+	public void methodName21(@SuppressWarnings("unused") Integer arg) {
+		return;
+	}
+
+	public boolean methodName21(@SuppressWarnings("unused") String arg) {
+		return false;
+	}
+
+	public boolean methodName1P() {
+		return false;
+	}
+
+	public void methodName1P(@SuppressWarnings("unused") Integer arg) {
+		return;
+	}
+
+	public boolean methodName1P(@SuppressWarnings("unused") String arg) {
+		return false;
+	}
+}

--- a/test/Java8andUp/src/org/openj9/test/reflect/GetMethodsTests.java
+++ b/test/Java8andUp/src/org/openj9/test/reflect/GetMethodsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,6 +37,11 @@ import java.util.Iterator;
 import java.util.List;
 
 public class GetMethodsTests {
+	/* contrived method names which have the same String.hashCode(). */
+	private static final String METHOD_NAME21 = "methodName21"; //$NON-NLS-1$
+	private static final String METHOD_NAME1P = "methodName1P"; //$NON-NLS-1$	
+	private static final String EXAMPLE_CLASS = "org.openj9.test.reflect.ExampleClass."; //$NON-NLS-1$
+	
 	public static final Logger logger = Logger.getLogger(GetMethodsTests.class);
 	private final static boolean isJava8 = System.getProperty("java.specification.version").equals("1.8");  //$NON-NLS-1$//$NON-NLS-2$
 
@@ -289,6 +294,16 @@ public class GetMethodsTests {
 				"org.openj9.test.reflect.J.m()void" }));
 		methodLists.put("org.openj9.test.reflect.I", new String[] { "org.openj9.test.reflect.I.m()void" });
 		methodLists.put("org.openj9.test.reflect.J", new String[] { "org.openj9.test.reflect.J.m()void" });
+		methodLists.put("org.openj9.test.reflect.ExampleClass",  //$NON-NLS-1$
+				concatenateObjectMethods(new String[] {
+				EXAMPLE_CLASS+METHOD_NAME1P+"()boolean", //$NON-NLS-1$
+				EXAMPLE_CLASS+METHOD_NAME1P+"(java.lang.String)boolean", //$NON-NLS-1$
+				EXAMPLE_CLASS+METHOD_NAME21+"()boolean", //$NON-NLS-1$
+				EXAMPLE_CLASS+METHOD_NAME21+"(java.lang.String)boolean", //$NON-NLS-1$
+				EXAMPLE_CLASS+METHOD_NAME1P+"(java.lang.Integer)void", //$NON-NLS-1$
+				EXAMPLE_CLASS+METHOD_NAME21+"(java.lang.Integer)void" //$NON-NLS-1$
+		}));
+
 		return methodLists;
 	}
 


### PR DESCRIPTION
MethodInfo.equals() did not distinguish methods with the same name, causing
them to be dropped in the case of a hash table collision.

Add a specific test case.

Fix the equals() method.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>