### PR TITLE
DirectByteBufferTest fails with NullPointerException on openjdk8_openj9

### DIFF
--- a/runtime/jcl/uma/se829_exports.xml
+++ b/runtime/jcl/uma/se829_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2016, 2017 IBM Corp. and others
+	Copyright (c) 2016, 2018 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,4 +33,5 @@
 	<export name="Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getSharedClassCacheSoftmxUnstoredBytesImpl" />
 	<export name="Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getSharedClassCacheMaxAotUnstoredBytesImpl" />
 	<export name="Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getSharedClassCacheMaxJitDataUnstoredBytesImpl" />
+	<export name="Java_java_lang_ref_Reference_waitForReferenceProcessingImpl" />
 </exports>

--- a/runtime/jcl/uma/se9_exports.xml
+++ b/runtime/jcl/uma/se9_exports.xml
@@ -53,7 +53,6 @@
 	<export name="Java_java_lang_System_startSNMPAgent" />
 	<export name="Java_java_lang_StackWalker_walkWrapperImpl" />
 	<export name="Java_java_lang_StackWalker_getImpl" />
-	<export name="Java_java_lang_ref_Reference_waitForReferenceProcessingImpl" />
 	<export name="Java_java_lang_invoke_MethodHandles_findNativeAddress">
 		<include-if condition="spec.flags.opt_panama" />
 	</export>


### PR DESCRIPTION
 - implement JavaLangRefAccess.tryHandlePendingReference() for
Java8-OpenJ9
 - back port native function waitForReferenceProcessingImpl() for
  matching JavaLangRefAccess.tryHandlePendingReference() feature. 

Fixes #1077

Signed-off-by: Lin Hu <linhu@ca.ibm.com>