### PR TITLE
Fix atomic free JNI compile and runtime errors

### DIFF
--- a/runtime/compiler/trj9/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/trj9/p/codegen/PPCJNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -743,7 +743,7 @@ void TR::PPCJNILinkage::releaseVMAccessAtomicFree(TR::Node* callNode, TR::Regist
       }
 
    TR::SymbolReference *jitReleaseVMAccessSymRef = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getJittedMethodSymbol());
-   OMR::LabelSymbol *releaseVMAcessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitReleaseVMAccessSymRef);
+   TR::LabelSymbol *releaseVMAcessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitReleaseVMAccessSymRef);
    if (!releaseVMAcessSnippetLabel)
       {
       releaseVMAcessSnippetLabel = generateLabelSymbol(cg());
@@ -777,7 +777,7 @@ void TR::PPCJNILinkage::acquireVMAccessAtomicFree(TR::Node* callNode, TR::Regist
       }
 
    TR::SymbolReference *jitAcquireVMAccessSymRef = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getJittedMethodSymbol());
-   OMR::LabelSymbol *acquireVMAcessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitAcquireVMAccessSymRef);
+   TR::LabelSymbol *acquireVMAcessSnippetLabel = cg()->lookUpSnippet(TR::Snippet::IsHelperCall, jitAcquireVMAccessSymRef);
    if (!acquireVMAcessSnippetLabel)
       {
       acquireVMAcessSnippetLabel = generateLabelSymbol(cg());

--- a/runtime/compiler/trj9/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/trj9/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1111,8 +1111,8 @@ void TR::AMD64JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode)
                              generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
                              cg());
 
-   OMR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
-   OMR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
 
    if (J9_PUBLIC_FLAGS_HALT_THREAD_ANY > 0x7fffffff && TR::Compiler->target.is64Bit())
       {
@@ -1179,8 +1179,8 @@ void TR::AMD64JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode)
                              generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
                              cg());
 
-   OMR::LabelSymbol *longAcquireSnippetLabel = generateLabelSymbol(cg());
-   OMR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol *longAcquireSnippetLabel = generateLabelSymbol(cg());
+   TR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
 
    if (J9_PUBLIC_FLAGS_VM_ACCESS > 0x7fffffff && TR::Compiler->target.is64Bit())
       {

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -265,7 +265,9 @@ jint standardInit( J9JavaVM *vm, char* dllName)
 	 * We need to initialize the methodID caches for String.<init> and String.getBytes(String) while we are still in single threaded cade.
 	 * The JCL natives that initialize this are not thread safe and we run the risk of invoking these methods with a NULL methodID.
 	 * This code is a work around that forces the methodID cache initialization code to be run.
+	 * Ensure VM access is released when calling registerBootstrapLibrary.
 	 */
+	vmFuncs->internalReleaseVMAccessInJNI(vmThread);
 	if (0 == vmFuncs->registerBootstrapLibrary(vmThread, "java", &javaLibHandle, 0)) {
 		jstring (JNICALL *nativeFuncAddr)(JNIEnv *env, const char *str) = NULL;
 		PORT_ACCESS_FROM_JAVAVM(vm);

--- a/runtime/vm/VMAccess.cpp
+++ b/runtime/vm/VMAccess.cpp
@@ -951,7 +951,15 @@ acquireSafePointVMAccess(J9VMThread * vmThread)
 			VM_VMAccess::setPublicFlags(currentThread, J9_PUBLIC_FLAGS_REQUEST_SAFE_POINT, true);
 			VM_AtomicSupport::writeBarrier(); // necessary?
 			if (J9_ARE_ANY_BITS_SET(currentThread->publicFlags, J9_PUBLIC_FLAGS_NOT_AT_SAFE_POINT | J9_PUBLIC_FLAGS_VM_ACCESS)) {
-				responsesExpected++;
+				VM_AtomicSupport::readBarrier(); // necessary?
+				if (currentThread->inNative) {
+					Assert_VM_false(J9_ARE_ANY_BITS_SET(currentThread->publicFlags, J9_PUBLIC_FLAGS_NOT_AT_SAFE_POINT));
+					VM_VMAccess::setPublicFlags(currentThread, J9_PUBLIC_FLAGS_HALTED_AT_SAFE_POINT, true);				
+					VM_AtomicSupport::writeBarrier(); // necessary?
+					VM_VMAccess::clearPublicFlags(currentThread, J9_PUBLIC_FLAGS_REQUEST_SAFE_POINT, true);
+				} else {
+					responsesExpected++;
+				}
 			} else {
 				VM_VMAccess::setPublicFlags(currentThread, J9_PUBLIC_FLAGS_HALTED_AT_SAFE_POINT, true);				
 				VM_AtomicSupport::writeBarrier(); // necessary?


### PR DESCRIPTION
Fix compile errors and an assertion on VM startup related to the
experimental atomic-free JNI feature.  Implement basic support in safe
point exclusive VM access.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>