### PR TITLE
Re-exclude SE80 j9vm.test.softmx.SoftmxRemoteTest which fails in setup

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -30,3 +30,4 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generi
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
+j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all


### PR DESCRIPTION
Issue #480 covers fixing the test

Closes #1110

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>