### PR TITLE
Clean up queries related to SIMDStringCaseConv

### DIFF
--- a/runtime/compiler/trj9/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/trj9/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -369,6 +369,15 @@ public:
    // Determines whether high-resolution timer can be used to implement java/lang/System.currentTimeMillis()
    bool getSupportsMaxPrecisionMilliTime() {return _j9Flags.testAny(SupportsMaxPrecisionMilliTime);}
    void setSupportsMaxPrecisionMilliTime() {_j9Flags.set(SupportsMaxPrecisionMilliTime);}
+   
+   /** \brief
+    *    Determines whether the code generator supports inlining of java/lang/String.toUpperCase() and toLowerCase()
+    */
+   bool getSupportsInlineStringCaseConversion() { return _j9Flags.testAny(SupportsInlineStringCaseConversion);}
+   /** \brief
+    *    The code generator supports inlining of java/lang/String.toUpperCase() and toLowerCase()
+    */
+   void setSupportsInlineStringCaseConversion() { return _j9Flags.set(SupportsInlineStringCaseConversion);}
 
    /**
     * \brief
@@ -381,8 +390,9 @@ private:
 
    enum // Flags
       {
-      HasFixedFrameC_CallingConvention = 0x00000001,
-      SupportsMaxPrecisionMilliTime    = 0x00000002
+      HasFixedFrameC_CallingConvention    = 0x00000001,
+      SupportsMaxPrecisionMilliTime       = 0x00000002,
+      SupportsInlineStringCaseConversion  = 0x00000004 /*! codegen inlining of Java string case conversion */ 
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/trj9/env/VMJ9.cpp
+++ b/runtime/compiler/trj9/env/VMJ9.cpp
@@ -3110,7 +3110,7 @@ bool TR_J9VMBase::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, 
          case TR::java_lang_String_toLowerHWOptimizedDecompressed:
          case TR::java_lang_String_toUpperHWOptimized:
          case TR::java_lang_String_toLowerHWOptimized:
-            if(comp->cg()->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringCaseConv))
+            if(comp->cg()->getSupportsInlineStringCaseConversion())
                {
                dontInlineRecognizedMethod = true;
                break;

--- a/runtime/compiler/trj9/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/trj9/ilgen/IlGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1483,11 +1483,7 @@ TR_J9ByteCodeIlGenerator::genHWOptimizedStrProcessingAvailable()
    setIsGenerated(_bcIndex);
    if (constToLoad == -1)
       {
-      bool disable = comp()->getOption(TR_DisableSIMDStringCaseConv);
-      bool platformSupported = TR::Compiler->target.cpu.isZ();
-      bool vecInstrAvailable = cg()->getSupportsVectorRegisters();
-
-      if (platformSupported && vecInstrAvailable && !disable)
+      if (cg()->getSupportsInlineStringCaseConversion())
          constToLoad = 1;
       else
          constToLoad = 0;

--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -5215,32 +5215,26 @@ break
          }
       }
 
-   if (!comp()->getOption(TR_DisableSIMDStringCaseConv))
+   if(symbol->getRecognizedMethod() == TR::java_lang_String_StrHWAvailable)
       {
-      bool platformSupported = TR::Compiler->target.cpu.isZ();
-      bool vecInstrAvailable = cg()->getSupportsVectorRegisters();
+      if (cg()->getSupportsInlineStringCaseConversion())
+         constToLoad = 1;
+      else
+         constToLoad  = 0; // should already be 0 but just incase..
 
-      if(symbol->getRecognizedMethod() == TR::java_lang_String_StrHWAvailable)
-         {
-         if (platformSupported && vecInstrAvailable)
-            constToLoad = 1;
-         else
-            constToLoad  = 0; // should already be 0 but just incase..
+      loadConstant(TR::iconst, constToLoad);
+      return NULL;
+      }
 
-         loadConstant(TR::iconst, constToLoad);
-         return NULL;
-         }
-
-      if (platformSupported && vecInstrAvailable &&
-            (symbol->getRecognizedMethod() == TR::java_lang_String_toUpperHWOptimizedCompressed ||
-             symbol->getRecognizedMethod() == TR::java_lang_String_toLowerHWOptimizedCompressed ||
-             symbol->getRecognizedMethod() == TR::java_lang_String_toUpperHWOptimizedDecompressed ||
-             symbol->getRecognizedMethod() == TR::java_lang_String_toLowerHWOptimizedDecompressed ||
-             symbol->getRecognizedMethod() == TR::java_lang_String_toUpperHWOptimized ||
-             symbol->getRecognizedMethod() == TR::java_lang_String_toLowerHWOptimized))
-         {
-         isDirectCall = true;
-         }
+   if (cg()->getSupportsInlineStringCaseConversion() &&
+         (symbol->getRecognizedMethod() == TR::java_lang_String_toUpperHWOptimizedCompressed ||
+            symbol->getRecognizedMethod() == TR::java_lang_String_toLowerHWOptimizedCompressed ||
+            symbol->getRecognizedMethod() == TR::java_lang_String_toUpperHWOptimizedDecompressed ||
+            symbol->getRecognizedMethod() == TR::java_lang_String_toLowerHWOptimizedDecompressed ||
+            symbol->getRecognizedMethod() == TR::java_lang_String_toUpperHWOptimized ||
+            symbol->getRecognizedMethod() == TR::java_lang_String_toLowerHWOptimized))
+      {
+      isDirectCall = true;
       }
 
    if (!comp()->getOption(TR_DisableSIMDDoubleMaxMin))

--- a/runtime/compiler/trj9/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/z/codegen/J9CodeGenerator.cpp
@@ -104,6 +104,9 @@ J9::Z::CodeGenerator::CodeGenerator() :
    if (!comp->getOption(TR_FullSpeedDebug))
       cg->setSupportsDirectJNICalls();
 
+   if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringCaseConv))
+      cg->setSupportsInlineStringCaseConversion();
+
    // Let's turn this on.  There is more work needed in the opt
    // to catch the case where the BNDSCHK is inserted after
    //

--- a/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -12477,7 +12477,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       }
 #endif
 
-   if (!comp->getOption(TR_DisableSIMDStringCaseConv) && cg->getSupportsVectorRegisters())
+   if (cg->getSupportsInlineStringCaseConversion())
       {
       switch (methodSymbol->getRecognizedMethod())
          {


### PR DESCRIPTION
Clean up the queries to check supports of SIMDStringCaseConv
to make it easier to extend to platforms other than Z.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>