### PR TITLE
Support different diagnostic level in tap file.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -281,7 +281,21 @@ disabled.spec.<spec> (e.g. disabled.spec.linux_x86-64)
     or were skipped, along with other information like execution time and
     error messages, exceptions and logs from the individual test methods.
 
+  * TAP result files
+
+    TAP files are created. Depending on the requirement there are three
+    different diagnostic levels.
+    
+		* export DIAGNOSTICLEVEL=failure
+			Default level. Log all detailed failure information if test fails
+		* export DIAGNOSTICLEVEL=all
+			Log all detailed information no matter test failures or succeed
+		* export DIAGNOSTICLEVEL=nodetails
+			No need to log any detailed information. Top level TAP test result
+			summary is enough 
+			
   * in the cloud (WIP)
+  
 
 7. Attach a debugger:
 

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -97,16 +97,6 @@ ifeq ($(JAVA_VERSION),SE80)
 JDK_HOME := $(JAVA_BIN_TMP)$(D)..$(D)..
 endif
 
-ifdef JTREG_DIR
-# removing "
-JTREG_DIR := $(subst ",,$(JTREG_DIR))
-endif
-
-ifdef JTREG_TEST_DIR
-# removing "
-JTREG_TEST_DIR := $(subst ",,$(JTREG_TEST_DIR))
-endif
-
 #######################################
 # Set OS, ARCH and BITS based on SPEC
 #######################################
@@ -240,9 +230,13 @@ FAILEDTARGETS = $(TESTOUTPUT)$(D)failedtargets.mk
 TEMPRESULTFILE=$(TESTOUTPUT)$(D)TestTargetResult
 TAPRESULTFILE=$(TESTOUTPUT)$(D)TestTargetResult.tap
 
+ifndef DIAGNOSTICLEVEL
+export DIAGNOSTICLEVEL:=failure
+endif
+
 rmResultFile:
 	@$(RM) $(Q)$(TEMPRESULTFILE)$(Q)
 
 resultsSummary:
-	@perl $(Q)$(TEST_ROOT)$(D)TestConfig$(D)scripts$(D)testKitGen$(D)resultsSummary$(D)resultsSum.pl$(Q) --failuremk=$(Q)$(FAILEDTARGETS)$(Q) --resultFile=$(Q)$(TEMPRESULTFILE)$(Q) --tapFile=$(Q)$(TAPRESULTFILE)$(Q) --diagnostic=failure
+	@perl $(Q)$(TEST_ROOT)$(D)TestConfig$(D)scripts$(D)testKitGen$(D)resultsSummary$(D)resultsSum.pl$(Q) --failuremk=$(Q)$(FAILEDTARGETS)$(Q) --resultFile=$(Q)$(TEMPRESULTFILE)$(Q) --tapFile=$(Q)$(TAPRESULTFILE)$(Q) --diagnostic=$(DIAGNOSTICLEVEL)
 


### PR DESCRIPTION
Support different diagnostic level in tap file. User can decide what
diagnostic information is needed. Values for DIAGNOSTICLEVEL are 'failure', 'all', 'nodetails'.
Also removed unused top level make variables

[ci skip]

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>