### PR TITLE
Remove java.version check in getProperty tests for jdk9+

### DIFF
--- a/test/Java8andUp/build.xml
+++ b/test/Java8andUp/build.xml
@@ -65,11 +65,10 @@
 		</if>
 		<!-- Compile the fake string impl and AppLoader caller with it -->
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
 				<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
 				debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<compilerarg line ="${compilerargline}" />
 					<classpath>
 						<pathelement location="../TestConfig/lib/asm-all.jar" />
 						<pathelement location="../TestConfig/lib/testng.jar" />
@@ -80,6 +79,7 @@
 			<else>
 				<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
 				debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<compilerarg line ="${compilerargline}" />
 					<classpath>
 						<pathelement location="../TestConfig/lib/asm-all.jar" />
 						<pathelement location="../TestConfig/lib/testng.jar" />
@@ -127,18 +127,31 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${src_80}" />
+					<src path="${TestUtilities}" />
+					<src path="${transformerListener}" />
+					<exclude name="**/Cmvc194280.java" />
+					<exclude name="**/resources/**"/>
+					<exclude name="**/gpu/**"/>
+					<!-- requires special compilation methods -->
+					<exclude name="**/NoSuchMethod/**" />
+					<classpath>
+						<pathelement location="../TestConfig/lib/asm-all.jar" />
+						<pathelement location="../TestConfig/lib/testng.jar" />
+						<pathelement location="../TestConfig/lib/jcommander.jar" />
+						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
+						<pathelement location="../TestConfig/lib/commons-cli.jar" />
+						<pathelement location="../TestConfig/lib/javassist.jar" />
+					</classpath>
+				</javac>
+			</then>
+			<else>
 				<property name="addModules" value="--add-modules java.se.ee,openj9.sharedclasses" />
-				<if>
-					<equals arg1="${JCL_VERSION}" arg2="latest"/>
-					<then>
-						<property name="addExports" value="--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind.annotation=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind=ALL-UNNAMED" />
-					</then>
-					<else>
-						<property name="addExports" value="--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind.annotation=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind=ALL-UNNAMED" />
-					</else>
-				</if>
+				<property name="addExports" value="--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind.annotation=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind=ALL-UNNAMED" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${src_90}" />
@@ -161,27 +174,6 @@
 						<pathelement location="../TestConfig/lib/javassist.jar" />
 					</classpath>
 				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_80}" />
-					<src path="${TestUtilities}" />
-					<src path="${transformerListener}" />
-					<exclude name="**/Cmvc194280.java" />
-					<exclude name="**/resources/**"/>
-					<exclude name="**/gpu/**"/>
-					<!-- requires special compilation methods -->
-					<exclude name="**/NoSuchMethod/**" />
-					<classpath>
-						<pathelement location="../TestConfig/lib/asm-all.jar" />
-						<pathelement location="../TestConfig/lib/testng.jar" />
-						<pathelement location="../TestConfig/lib/jcommander.jar" />
-						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
-						<pathelement location="../TestConfig/lib/commons-cli.jar" />
-						<pathelement location="../TestConfig/lib/javassist.jar" />
-					</classpath>
-				</javac>
 			</else>
 		</if>
 	</target>
@@ -200,12 +192,12 @@
 	<!-- This target is used to prepare test resource which is located in org/openj9/resources-->
 	<target name="pack_resources" depends="compileNoSuchMethod" description="prepare JCL test resources">
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
-				<property name="addModules" value="--add-modules java.se.ee" />
+				<property name="addModules" value="" />
 			</then>
 			<else>
-				<property name="addModules" value="" />
+				<property name="addModules" value="--add-modules java.se.ee" />
 			</else>
 		</if>
 		<!-- compile java files within resources dir without '-parameter' flag in javac command line, README in '${src}/org/openj9/resources/methodparameters/README'-->

--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -679,7 +679,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JCL_Test_SE90</testCaseName>
+		<testCaseName>JCL_Test_SE90+</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
@@ -728,6 +728,7 @@
 		</groups>
 		<subsets>
 			<subset>SE90</subset>
+			<subset>SE100</subset>
 		</subsets>
 	</test>
 

--- a/test/Java8andUp/src_90/org/openj9/test/java/lang/Test_System.java
+++ b/test/Java8andUp/src_90/org/openj9/test/java/lang/Test_System.java
@@ -144,10 +144,6 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperties() {
-		Properties p = System.getProperties();
- 		AssertJUnit.assertTrue("Incorrect properties returned", p.getProperty(
- 				"java.version").indexOf("9", 0) == 0);
-
 		// ensure spec'ed properties are non-null. See System.getProperties()
 		// spec.
 		String[] props = { "java.version", "java.vendor", "java.vendor.url",
@@ -162,15 +158,6 @@ public class Test_System {
 		for (int i = 0; i < props.length; i++) {
 			AssertJUnit.assertTrue(props[i], System.getProperty(props[i]) != null);
 		}
-
-		/*
-		 * This test should only run for Java 1.8.0 and above. For Java 1.9.0
-		 * and above, we do not support java.ext.dirs property.
-		 */
-		if (p.getProperty("java.version").startsWith("1.8.0")) {
-			String javaExtDirs = "java.ext.dirs";
-			AssertJUnit.assertTrue(javaExtDirs, System.getProperty(javaExtDirs) != null);
-		}
 	}
 
 	/**
@@ -178,9 +165,6 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperty() {
- 		AssertJUnit.assertTrue("Incorrect properties returned", System.getProperty(
- 				"java.version").indexOf("9", 0) == 0);
-
 		boolean is8859_1 = true;
 		String encoding = System.getProperty("file.encoding");
 		byte[] bytes = new byte[128];
@@ -217,10 +201,6 @@ public class Test_System {
 	 */
 	@Test
 	public void test_getProperty2() {
- 		AssertJUnit.assertTrue("Failed to return correct property value: "
- 				+ System.getProperty("java.version", "99999"), System
- 				.getProperty("java.version", "99999").indexOf("9", 0) >= 0);
-
 		AssertJUnit.assertTrue("Failed to return correct property value", System
 				.getProperty("bogus.prop", "bogus").equals("bogus"));
 	}


### PR DESCRIPTION
The java.version system property is set by OpenJDK code so it can be
assumed to be correct. The hard coded value in these tests would need to
be updated every 6 months for each Java version as well.
Therefore, the java.version check will be removed from the getProperty
tests.
Also changes the order of java version conditionals in build.xml so
future version of Java use the Java 9 compile path with modules.

Closes #303 

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Reviewers: @pshipton @llxia 