### PR TITLE
Scan RS concurrently

### DIFF
--- a/runtime/gc_glue_java/ScavengerRootScanner.cpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@
 
 #if defined(J9VM_GC_FINALIZATION)
 void
-MM_ScavengerRootScanner::startUnfinalizedProcessing(MM_EnvironmentStandard *env)
+MM_ScavengerRootScanner::startUnfinalizedProcessing(MM_EnvironmentBase *env)
 {
 	if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 		_clij->scavenger_setShouldScavengeUnfinalizedObjects(false);

--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,7 +66,7 @@ public:
 	 */
 private:
 #if defined(J9VM_GC_FINALIZATION)
-	void startUnfinalizedProcessing(MM_EnvironmentStandard *env);
+	void startUnfinalizedProcessing(MM_EnvironmentBase *env);
 	void scavengeFinalizableObjects(MM_EnvironmentStandard *env);
 #endif /* defined(J9VM_GC_FINALIZATION) */
 
@@ -191,6 +191,13 @@ public:
 			MM_RootScanner::scanJNIWeakGlobalReferences(env);
 		}
 	}
+	
+	virtual void scanRoots(MM_EnvironmentBase *env) 
+	{
+		MM_RootScanner::scanRoots(env);
+		
+		startUnfinalizedProcessing(env);
+	}
 
 	void
 	scavengeRememberedSet(MM_EnvironmentStandard *env)
@@ -198,7 +205,6 @@ public:
 		reportScanningStarted(RootScannerEntity_ScavengeRememberedSet);
 		_scavenger->scavengeRememberedSet(env);
 		reportScanningEnded(RootScannerEntity_ScavengeRememberedSet);
-		startUnfinalizedProcessing(env);
 	}
 
 	void

--- a/runtime/gc_trace/TgcRootScanner.cpp
+++ b/runtime/gc_trace/TgcRootScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@
 #include "VMThreadListIterator.hpp"
 
 static void printRootScannerStats(OMR_VMThread *omrVMThread);
-static void tgcHookGlobalGcCycleEnd(J9HookInterface** hook, UDATA eventNumber, void* eventData, void* userData);
+static void tgcHookGCEnd(J9HookInterface** hook, UDATA eventNumber, void* eventData, void* userData);
 
 /**
  * XML attribute names corresponding to entities in the root scanner enumeration.
@@ -83,7 +83,8 @@ tgcRootScannerInitialize(J9JavaVM *javaVM)
 		extensions->rootScannerStatsEnabled = true;
 
 		J9HookInterface** mmOmrHooks = J9_HOOK_INTERFACE(extensions->omrHookInterface);
-		(*mmOmrHooks)->J9HookRegisterWithCallSite(mmOmrHooks, J9HOOK_MM_OMR_GC_CYCLE_END, tgcHookGlobalGcCycleEnd, OMR_GET_CALLSITE(), NULL);
+		(*mmOmrHooks)->J9HookRegisterWithCallSite(mmOmrHooks, J9HOOK_MM_OMR_LOCAL_GC_END, tgcHookGCEnd, OMR_GET_CALLSITE(), NULL);
+		(*mmOmrHooks)->J9HookRegisterWithCallSite(mmOmrHooks, J9HOOK_MM_OMR_GLOBAL_GC_END, tgcHookGCEnd, OMR_GET_CALLSITE(), NULL);
 	}
 	
 	return true;
@@ -149,7 +150,7 @@ printRootScannerStats(OMR_VMThread *omrVMThread)
 }
 
 static void
-tgcHookGlobalGcCycleEnd(J9HookInterface** hook, UDATA eventNumber, void* eventData, void* userData)
+tgcHookGCEnd(J9HookInterface** hook, UDATA eventNumber, void* eventData, void* userData)
 {
 	MM_GCCycleEndEvent* event = (MM_GCCycleEndEvent*) eventData;
 	


### PR DESCRIPTION
This is just a preparation change for (it's not dependent on):
eclipse/omr#2302

- move the pre-processing pass for Unfinalized from RS Scavneger
RootScanner wrapper to main roots wrapper. This is cleaner, and more
importantly needed for Concurrent Scavenger to avoid calling this
pre-processing pass twice, since CS will have two RS root scan
passes

- report TGC scan roots stats for both STW pauses of a CS cycle, by
hooking into to local-end instead of cycle-end event

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>