### PR TITLE
Add system properties for the OpenJDK extensions name and version

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -779,6 +779,20 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
+#if defined(J9JDK_EXT_NAME)
+	rc = addSystemProperty(vm, "jdk.extensions.name", J9JDK_EXT_NAME, 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
+#endif
+
+#if defined(J9JDK_EXT_VERSION)
+	rc = addSystemProperty(vm, "jdk.extensions.version", J9JDK_EXT_VERSION, 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
+#endif
+
 	/* Don't know the JIT yet, put in a placeholder and make it writeable for now */
 	rc = addSystemProperty(vm, "java.compiler", "", J9SYSPROP_FLAG_WRITEABLE);
 	if (J9SYSPROP_ERROR_NONE != rc) {


### PR DESCRIPTION
#defines have been added to the OpenJDK extensions project to specify
the name and version. Add system properties jdk.extensions.name and
jdk.extensions.version set to these values so they can be determined at
runtime.

See also #1147

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>