### PR TITLE
Updates method handles to use newer java.lang.Class API

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -397,7 +397,7 @@ public class MethodHandles {
 			} else if (Modifier.isPrivate(memberModifiers)) {
 				if (Modifier.isPrivate(accessMode) && ((targetClass == accessClass)
 /*[IF Valhalla-NestMates]*/
-						|| targetClass.isInSameNest(accessClass)
+						|| targetClass.isNestmateOf(accessClass)
 /*[ENDIF] Valhalla-NestMates*/	
 				)) {
 					return;


### PR DESCRIPTION
Earlier draft for nestmates changes to java.lang.Class defined new
method:
> public boolean isNestmateOf(Class<?> c)

Newer draft for nestmates changes to java.lang.Class defines new method:
> public boolean isInSameNest(Class<?> c)

This commit updates method handles to make use of the newer
java.lang.Class method definition.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>