### PR TITLE
Add stub classes to support Java 11 builds

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -326,6 +326,33 @@
 	</configuration>
 
 	<configuration
+		  label="JAVA11"
+		  outputpath="JAVA11/src"
+		  flags="Java11"
+		  dependencies="JAVA10"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava10.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
+	
+	<configuration
 		  label="PANAMA"
 		  outputpath="PANAMA/src"
 		  flags="Panama"

--- a/jcl/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Java11]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,19 +21,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-/*[IF Java11]*/
-
 package java.lang.invoke;
 
 /*
  * Stub class for compilation
  */
 
-class MethodHandleNatives {
+class BootstrapMethodInvoker {
 
-	static LinkageError mapLookupExceptionToError(ReflectiveOperationException roe) {
+	static <T> T invoke(Class<T> clz1, MethodHandle mh, String str, Object obj1, Object obj2, Class<?> clz2) {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 }
-
-/*[ENDIF]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,5 +70,10 @@ final class MemberName {
 	public Class<?> getDeclaringClass() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
+	/*[IF Java11]*/
+	public boolean isFinal() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+	/*[ENDIF]*/
 	/*[ENDIF]*/
 }


### PR DESCRIPTION
Add stub classes to support `Java 11` builds

* Added pConfig JAVA11
* Added stub class `java.lang.invoke.BootstrapMethodInvoker`;
* Added stub class `java.lang.invoke.MethodHandleNatives`;
* Added stub method `java.lang.invoke.MemberName.isFinal()`.

Closes #1153 

With this PR, `java -version` output is as following:
```
Exception in thread "(unnamed thread)" java/lang/ExceptionInInitializerError
java/lang/NullPointerException
```
This is same as raw build result discovered earlier which appears due to `NULL helpers` within `java.lang.String`
```  
private static final com.ibm.jit.JITHelpers helpers = com.ibm.jit.JITHelpers.getHelpers();
```
This `NPE` is still under investigation but not related to the compilation error reported in the issue specified.

Reviewer @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>