### PR TITLE
Adding -Xdump:none to JCL_TEST

### DIFF
--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -733,6 +733,46 @@
 	</test>
 
 	<test>
+		<testCaseName>JCL_Test_OutOfMemoryError_SE90+</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>-XX:RecreateClassfileOnload</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump:none -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
+	--add-modules java.se.ee,openj9.sharedclasses \
+	--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.util=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED \
+	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	--add-opens=java.base/java.security=ALL-UNNAMED \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	JCL_TEST_Java-Lang_OutOfMemoryError \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^vm.hrt</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+		</subsets>
+	</test>
+
+	<test>
 		<testCaseName>JCL_Test_SE80</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
@@ -760,6 +800,35 @@
 	JCL_TEST_Java-Lang-Reflect,\
 	JCL_TEST_Java-Math,\
 	JCL_TEST_Test-RunLast \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^vm.hrt</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>JCL_Test_OutOfMemoryError_SE80</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>-XX:RecreateClassfileOnload</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump:none -verbose:stacktrace -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	-Drowset.provider.classname=org.openj9.resources.classloader.CustomSyncProvider \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	JCL_TEST_Java-Lang_OutOfMemoryError \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>

--- a/test/Java8andUp/testng.xml
+++ b/test/Java8andUp/testng.xml
@@ -144,7 +144,6 @@
 			<class name="org.openj9.test.java.lang.Test_InstantiationError"/>
 			<class name="org.openj9.test.java.lang.Test_InstantiationException"/>
 			<class name="org.openj9.test.java.lang.Test_Object"/>
-			<class name="org.openj9.test.java.lang.Test_OutOfMemoryError"/>
 			<class name="org.openj9.test.java.lang.Test_RuntimePermission"/>
 			<class name="org.openj9.test.java.lang.Test_String"/>
 			<class name="org.openj9.test.java.lang.Test_StringBuffer"/>
@@ -154,6 +153,11 @@
 			<class name="org.openj9.test.java.lang.Test_ThreadGroup"/>
 			<class name="org.openj9.test.java.lang.Test_Throwable"/>
 			<class name="org.openj9.test.java.lang.Test_VMAccess"/>
+		</classes>
+	</test>
+	<test name="JCL_TEST_Java-Lang_OutOfMemoryError">
+		<classes>
+			<class name="org.openj9.test.java.lang.Test_OutOfMemoryError"/>
 		</classes>
 	</test>
 	<test name="JCL_TEST_Java-Internals">


### PR DESCRIPTION
- Separate OutOfMemoryErrorTest from JCL_Test.
- Add -Xdump:none to OutOfMemoryErrorTest

Fixes: #981

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>