### PR TITLE
Remove excludes for Windows tests that pass now

### DIFF
--- a/test/VM_Test/j9vm.xml
+++ b/test/VM_Test/j9vm.xml
@@ -4,7 +4,7 @@
 
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,10 +93,6 @@
 
 	<exclude id="j9vm.test.romclasscreation.NewROMCreationAfterModifyingExistingClassTest" platform="all">
 		<reason>134161: Java 9 j9vm test: Error: Agent library jvmtitest could not be opened (libjvmtitest.so: cannot open shared object file: No such file or directory)</reason>
-	</exclude>
-
-	<exclude id="j9vm.test.invalidclasspath.SetClasspathTest" platform="win_x86-64_cr">
-		<reason>Issue 680: j9vm.test.invalidclasspath.SetClasspathTest segmentation error for OpenJ9 JDK9 windows platform</reason>
 	</exclude>
 </suite>
 

--- a/test/cmdLineTests/libpathTest/exclude.xml
+++ b/test/cmdLineTests/libpathTest/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,4 @@
 <!DOCTYPE suite SYSTEM "excludes.dtd">
 <?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
 <suite id="LIBPATH Rtf test intended for PMR56610 (CMVC 201272)">
-	<exclude id="PMR testcase with Rtf/RtfChild involved" platform="win_x86-64_cr" shouldFix="true">
-		<reason>Issue 681: cmdLineTester_libpathTestRtfChild_0 segmentation fault on OpenJ9 JDK9 windows platform</reason>
-	</exclude>
 </suite>

--- a/test/cmdLineTests/libpathTest/exclude_rtfchild.xml
+++ b/test/cmdLineTests/libpathTest/exclude_rtfchild.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,5 @@
 <!DOCTYPE suite SYSTEM "excludes.dtd">
 <?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
 <suite id="LIBPATH RtfChild test intended for PMR56610 (CMVC 201272)">
-	<exclude id="RtfChild testcase" platform="win_x86-64_cr" shouldFix="true">
-		<reason>Issue 681: cmdLineTester_libpathTestRtfChild_0 segmentation fault on OpenJ9 JDK9 windows platform</reason>
-	</exclude>
 </suite>
 	


### PR DESCRIPTION
[ci skip]

cmdLineTester_libpathTestRtfChild_0
j9vm.test.invalidclasspath.SetClasspathTest

Fixed by the mingw change for #727

Closes: #680
Closes: #681

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>