### PR TITLE
Cache actual size of non-persistent shared cache to a local variable

### DIFF
--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -187,6 +187,7 @@ private:
 	IDATA _attach_count;
 	UDATA _totalNumSems;
 	UDATA _userSemCntr;
+	U_32 _actualCacheSize;
 
 	char* _shmFileName;
 	char* _semFileName;


### PR DESCRIPTION
SH_CompositeCacheImpl::allocate() calls into
SH_OSCachesysv::getTotalSize() every time allocation happens.
The size of shared cache does not change, so we can cache this size
instead of calling into j9shmem_stat() from allocate() each time.

Signed-off-by: hangshao <hangshao@ca.ibm.com>