### PR TITLE
Fix comment for getProcessCpuTimeImpl() to specify 1 ns units

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -305,7 +305,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 	 * executed so far in both kernel and user modes. Returns -1 if the
 	 * value is unavailable on this platform or in the case of an error.
 	 * 
-	 * @return process cpu ime in 100 ns units
+	 * @return process cpu ime in 1 ns units
 	 * @see #getProcessCpuTime()
 	 */
 	private native long getProcessCpuTimeImpl();


### PR DESCRIPTION
[ci skip]

The comment for
ExtendedOperatingSystemMXBeanImpl.getProcessCpuTimeImpl() wasn't updated
to specify the correct units.

Fixes: #707

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>