### PR TITLE
Remove some obsolete jcl preprocessor configurations

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -164,118 +164,10 @@
 	</configuration>
 
 	<configuration
-		  label="SIDECAR19-SE-B165"
-		  outputpath="SIDECAR19-SE-B165/src"
-		  flags="Sidecar19-SE-B165"
-		  dependencies="SIDECAR19-SE-B148"
-		  jdkcompliance="1.8">
-		<classpathentry kind="src" path="src/java.base/share/classes"/>
-		<classpathentry kind="src" path="src/java.management/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
-		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190b165.jar"/>
-		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
-		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
-		<parameter name="jxerules:outputdir" value="java/lang"/>
-	</configuration>
-
-	<configuration
-		  label="SIDECAR19-SE-B169"
-		  outputpath="SIDECAR19-SE-B169/src"
-		  flags="Sidecar19-SE-B169"
-		  dependencies="SIDECAR19-SE-B165"
-		  jdkcompliance="1.8">
-		<classpathentry kind="src" path="src/java.base/share/classes"/>
-		<classpathentry kind="src" path="src/java.management/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
-		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190b165.jar"/>
-		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
-		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
-		<parameter name="jxerules:outputdir" value="java/lang"/>
-	</configuration>
-
-	<configuration
-		  label="SIDECAR19-SE-B174"
-		  outputpath="SIDECAR19-SE-B174/src"
-		  flags="Sidecar19-SE-B174"
-		  dependencies="SIDECAR19-SE-B169"
-		  jdkcompliance="1.8">
-		<classpathentry kind="src" path="src/java.base/share/classes"/>
-		<classpathentry kind="src" path="src/java.management/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
-		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190b174.jar"/>
-		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
-		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
-		<parameter name="jxerules:outputdir" value="java/lang"/>
-	</configuration>
-
-	<configuration
 		  label="SIDECAR19-SE-OPENJ9"
 		  outputpath="SIDECAR19-SE-OpenJ9/src"
 		  flags="Sidecar18-SE-OpenJ9,Sidecar19-SE-OpenJ9"
-		  dependencies="SIDECAR19-SE-B174"
-		  jdkcompliance="1.8">
-		<classpathentry kind="src" path="src/java.base/share/classes"/>
-		<classpathentry kind="src" path="src/java.management/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
-		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190b174.jar"/>
-		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
-		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
-		<parameter name="jxerules:outputdir" value="java/lang"/>
-	</configuration>
-
-	<configuration
-		  label="SIDECAR19-SE-B175"
-		  outputpath="SIDECAR19-SE-B175/src"
-		  flags="Sidecar19-SE-B175"
-		  dependencies="SIDECAR19-SE-OPENJ9"
+		  dependencies="SIDECAR19-SE-B148"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
@@ -302,7 +194,7 @@
 		  label="JAVA10"
 		  outputpath="JAVA10/src"
 		  flags="Java10"
-		  dependencies="SIDECAR19-SE-B175"
+		  dependencies="SIDECAR19-SE-OPENJ9"
 		  jdkcompliance="1.8">
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>

--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -3,7 +3,7 @@
 package com.ibm.jit;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -222,7 +222,7 @@ public final class JITHelpers {
 	}
 
 	public boolean compareAndSwapIntInObject(Object obj, long offset, int expected, int value) {
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 		return unsafe.compareAndSetInt(obj, offset, expected, value);
 /*[ELSE]
 		return unsafe.compareAndSwapInt(obj, offset, expected, value);
@@ -230,7 +230,7 @@ public final class JITHelpers {
 	}
 
 	public boolean compareAndSwapLongInObject(Object obj, long offset, long expected, long value) {
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 		return unsafe.compareAndSetLong(obj, offset, expected, value);
 /*[ELSE]
 		return unsafe.compareAndSwapLong(obj, offset, expected, value);
@@ -238,7 +238,7 @@ public final class JITHelpers {
 	}
 
 	public boolean compareAndSwapObjectInObject(Object obj, long offset, Object expected, Object value) {
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 		return unsafe.compareAndSetObject(obj, offset, expected, value);
 /*[ELSE]
 		return unsafe.compareAndSwapObject(obj, offset, expected, value);
@@ -326,7 +326,7 @@ public final class JITHelpers {
 	}
 
 	public boolean compareAndSwapIntInArray(Object obj, long offset, int expected, int value) {
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 		return unsafe.compareAndSetInt(obj, offset, expected, value);
 /*[ELSE]
 		return unsafe.compareAndSwapInt(obj, offset, expected, value);
@@ -334,7 +334,7 @@ public final class JITHelpers {
 	}
 
 	public boolean compareAndSwapLongInArray(Object obj, long offset, long expected, long value) {
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 		return unsafe.compareAndSetLong(obj, offset, expected, value);
 /*[ELSE]
 		return unsafe.compareAndSwapLong(obj, offset, expected, value);
@@ -342,7 +342,7 @@ public final class JITHelpers {
 	}
 
 	public boolean compareAndSwapObjectInArray(Object obj, long offset, Object expected, Object value) {
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 		return unsafe.compareAndSetObject(obj, offset, expected, value);
 /*[ELSE]
 		return unsafe.compareAndSwapObject(obj, offset, expected, value);

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/MsgHelp.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/MsgHelp.java
@@ -3,7 +3,7 @@
 package com.ibm.oti.vm;
 
 /*******************************************************************************
- * Copyright (c) 2003, 2017 IBM Corp. and others
+ * Copyright (c) 2003, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /*[IF Sidecar19-SE]
-/*[IF Sidecar19-SE-B165]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
 /*[ELSE]
 import java.lang.reflect.Module;

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,17 +70,17 @@ final class Attachment extends Thread implements Response {
 				Class<?> agentClass;
 				Class<?> startRemoteArgumentType;
 				try {
-					/*[IF Sidecar19-SE-B165]*/
+					/*[IF Sidecar19-SE-OpenJ9]*/
 					agentClass = Class.forName("jdk.internal.agent.Agent"); //$NON-NLS-1$
-					/*[ELSE] Sidecar19-SE-B165 */
+					/*[ELSE] Sidecar19-SE-OpenJ9 */
 					agentClass = Class.forName("sun.management.Agent"); //$NON-NLS-1$
-					/*[ENDIF] Sidecar19-SE-B165 */
+					/*[ENDIF] Sidecar19-SE-OpenJ9 */
 					
-					/*[IF Sidecar19-SE-B165 | Sidecar18-SE-OpenJ9]*/
+					/*[IF Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9]*/
 					startRemoteArgumentType = String.class;
-					/*[ELSE] Sidecar19-SE-B165 | Sidecar18-SE-OpenJ9 */
+					/*[ELSE] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
 					startRemoteArgumentType = Properties.class;
-					/*[ENDIF] Sidecar19-SE-B165 | Sidecar18-SE-OpenJ9 */
+					/*[ENDIF] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
 					startLocalManagementAgentMethod = agentClass.getDeclaredMethod(START_LOCAL_MANAGEMENT_AGENT);
 					startRemoteManagementAgentMethod = agentClass.getDeclaredMethod(START_REMOTE_MANAGEMENT_AGENT, startRemoteArgumentType);
 					startLocalManagementAgentMethod.setAccessible(true);
@@ -374,13 +374,13 @@ final class Attachment extends Thread implements Response {
 			IPC.logMessage("startAgent"); //$NON-NLS-1$
 			if (null != MethodRefsHolder.startRemoteManagementAgentMethod) {
 				Object startArgument;
-				/*[IF Sidecar19-SE-B165 | Sidecar18-SE-OpenJ9]*/
+				/*[IF Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9]*/
 				startArgument = agentProperties.entrySet().stream()
 						.map(entry -> entry.getKey() + "=" + entry.getValue()) //$NON-NLS-1$
 						.collect(java.util.stream.Collectors.joining(",")); //$NON-NLS-1$
-				/*[ELSE] Sidecar19-SE-B165 | Sidecar18-SE-OpenJ9 */
+				/*[ELSE] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
 				startArgument = agentProperties;
-				/*[ENDIF] Sidecar19-SE-B165 | Sidecar18-SE-OpenJ9 */
+				/*[ENDIF] Sidecar19-SE-OpenJ9 | Sidecar18-SE-OpenJ9 */
 				MethodRefsHolder.startRemoteManagementAgentMethod.invoke(null, startArgument);
 				return true;
 			}

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -44,7 +44,7 @@ import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
 
 /*[IF Sidecar19-SE]
-/*[IF Sidecar19-SE-B165]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
 import java.util.Iterator;
 import java.util.List;
@@ -215,7 +215,7 @@ final class Access implements JavaLangAccess {
 	 }
 	
 	public 
-/*[IF Sidecar19-SE-B165]	
+/*[IF Sidecar19-SE-OpenJ9]	
 	java.lang.ModuleLayer
 /*[ELSE]*/
 	java.lang.reflect.Layer
@@ -284,7 +284,7 @@ final class Access implements JavaLangAccess {
 		return targetClassLoader.defineClass(className, classRep, 0, classRep.length, protectionDomain);
 	}
 
-/*[IF Sidecar19-SE-B165]*/	
+/*[IF Sidecar19-SE-OpenJ9]*/	
 	public Stream<ModuleLayer> layers(ModuleLayer ml) {
 		return ml.layers();
 	}
@@ -323,13 +323,13 @@ final class Access implements JavaLangAccess {
 		return ml.getServicesCatalog();
 	}
 
-/*[IF Sidecar19-SE-B169]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 	public void addNonExportedPackages(ModuleLayer ml) {
 		SecurityManager.addNonExportedPackages(ml);
 	}
 /*[ENDIF]*/
 	 
-/*[IF Sidecar19-SE-B175]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 	public List<Method> getDeclaredPublicMethods(Class<?> clz, String name, Class<?>... types) {
 		return clz.getDeclaredPublicMethods(name, types);
 	}
@@ -347,7 +347,7 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF]*/	
 	 
-/*[ENDIF] Sidecar19-SE-B165 */
+/*[ENDIF] Sidecar19-SE-OpenJ9 */
 
 /*[IF Java10]*/
 	public String newStringUTF8NoRepl(byte[] bytes, int offset, int length) {

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -364,7 +364,7 @@ boolean casAnnotationType(AnnotationType oldType, AnnotationType newType) {
 		localTypeOffset = getUnsafe().objectFieldOffset(field);
 		AnnotationVars.annotationTypeOffset = localTypeOffset;
 	}
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 	return getUnsafe().compareAndSetObject(localAnnotationVars, localTypeOffset, oldType, newType);
 /*[ELSE]
 	return getUnsafe().compareAndSwapObject(localAnnotationVars, localTypeOffset, oldType, newType);
@@ -3818,7 +3818,7 @@ private ReflectCache acquireReflectCache() {
 		ReflectCache newCache = new ReflectCache(this);
 		do {
 			// Some thread will insert this new cache making it available to all.
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 			if (theUnsafe.compareAndSetObject(this, cacheOffset, null, newCache)) {
 /*[ELSE]
 			if (theUnsafe.compareAndSwapObject(this, cacheOffset, null, newCache)) {

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -42,7 +42,7 @@ import sun.reflect.CallerSensitive;
 /*[ENDIF]*/
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -399,7 +399,7 @@ protected ClassLoader(ClassLoader parentLoader) {
 			com.ibm.oti.vm.VM.initializeClassLoader(this, false, isParallelCapable);
 		}
 /*[IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE-B165]
+/*[IF Sidecar19-SE-OpenJ9]
 		unnamedModule = new Module(this);
 /*[ELSE]*/
 		unnamedModule = SharedSecrets.getJavaLangReflectModuleAccess().defineUnnamedModule(this);

--- a/jcl/src/java.base/share/classes/java/lang/LiveStackFrame.java
+++ b/jcl/src/java.base/share/classes/java/lang/LiveStackFrame.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/LiveStackFrameInfo.java
+++ b/jcl/src/java.base/share/classes/java/lang/LiveStackFrameInfo.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/StackFrameInfo.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackFrameInfo.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -27,7 +27,7 @@ import java.lang.invoke.MethodType;
 /*[ENDIF]*/
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Version;
-/*[IF Sidecar19-SE-B165]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.IllegalCallerException;
 import java.lang.Module;
 /*[ELSE]
@@ -185,7 +185,7 @@ public final class StackWalker {
 				s -> s.limit(2).collect(Collectors.toList()));
 		if (result.size() < 2) {
 			/*[MSG "K0640", "getCallerClass() called from method with no caller"]*/
-			/*[IF Sidecar19-SE-B165]
+			/*[IF Sidecar19-SE-OpenJ9]
 			throw new IllegalCallerException(com.ibm.oti.util.Msg.getString("K0640")); //$NON-NLS-1$
 			/*[ELSE]*/
 			throw new IllegalStateException(com.ibm.oti.util.Msg.getString("K0640")); //$NON-NLS-1$

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -511,7 +511,7 @@ public StringBuffer append (float value) {
  */
 public synchronized StringBuffer append(int value) {
 	/*[IF Sidecar19-SE]*/
-	/*[IF Sidecar19-SE-B174]*/
+	/*[IF Sidecar19-SE-OpenJ9]*/
 	int currentLength = lengthInternalUnsynchronized();
 	int currentCapacity = capacityInternal();
 
@@ -588,7 +588,7 @@ public synchronized StringBuffer append(int value) {
  */
 public synchronized StringBuffer append(long value) {
 	/*[IF Sidecar19-SE]*/
-	/*[IF Sidecar19-SE-B174]*/
+	/*[IF Sidecar19-SE-OpenJ9]*/
 	int currentLength = lengthInternalUnsynchronized();
 	int currentCapacity = capacityInternal();
 

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -502,7 +502,7 @@ public StringBuilder append (float value) {
 public StringBuilder append(int value) {
 	/*[PR JAZZ103 69835] This implementation is optimized for the JIT */
 	/*[IF Sidecar19-SE]*/
-	/*[IF Sidecar19-SE-B174]*/
+	/*[IF Sidecar19-SE-OpenJ9]*/
 	int currentLength = lengthInternal();
 	int currentCapacity = capacityInternal();
 
@@ -580,7 +580,7 @@ public StringBuilder append(int value) {
 public StringBuilder append(long value) {
 	/*[PR JAZZ103 69835] This implementation is optimized for the JIT */
 	/*[IF Sidecar19-SE]*/
-	/*[IF Sidecar19-SE-B174]*/
+	/*[IF Sidecar19-SE-OpenJ9]*/
 	int currentLength = lengthInternal();
 	int currentCapacity = capacityInternal();
 

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.SharedSecrets;
 import jdk.internal.misc.VM;
 import java.lang.StackWalker.Option;
-/*[IF Sidecar19-SE-B165]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
 /*[ELSE]
 import java.lang.reflect.Module;
@@ -102,7 +102,7 @@ public final class System {
 	private static String osEncoding;
 
 /*[IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE-B165]
+/*[IF Sidecar19-SE-OpenJ9]
 	static java.lang.ModuleLayer	bootLayer;
 /*[ELSE]*/
 	static java.lang.reflect.Layer	bootLayer;

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -195,7 +195,7 @@ final class ArrayVarHandle extends VarHandle {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetObject(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapObject(receiver, computeOffset(index), testValue, newValue);
@@ -206,7 +206,7 @@ final class ArrayVarHandle extends VarHandle {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeObject(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeObjectVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -231,7 +231,7 @@ final class ArrayVarHandle extends VarHandle {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObject(receiver, computeOffset(index), testValue, newValue);
@@ -242,7 +242,7 @@ final class ArrayVarHandle extends VarHandle {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetObjectAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObjectAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -253,7 +253,7 @@ final class ArrayVarHandle extends VarHandle {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObjectRelease(receiver, computeOffset(index), testValue, newValue);
@@ -264,7 +264,7 @@ final class ArrayVarHandle extends VarHandle {
 				receiver.getClass();
 				boundsCheck(((Object[])receiver).length, index);
 				storeCheck(newValue, receiver.getClass().getComponentType());
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObject(receiver, computeOffset(index), testValue, newValue);
@@ -400,7 +400,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetByte(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapByte(receiver, computeOffset(index), testValue, newValue);
@@ -410,7 +410,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final byte compareAndExchange(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeByte(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeByteVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -432,7 +432,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetBytePlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapByte(receiver, computeOffset(index), testValue, newValue);
@@ -442,7 +442,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetByteAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapByteAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -452,7 +452,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetByteRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapByteRelease(receiver, computeOffset(index), testValue, newValue);
@@ -462,7 +462,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((byte[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetBytePlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapByte(receiver, computeOffset(index), testValue, newValue);
@@ -619,7 +619,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetChar(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapChar(receiver, computeOffset(index), testValue, newValue);
@@ -629,7 +629,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final char compareAndExchange(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeChar(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeCharVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -651,7 +651,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetCharPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapChar(receiver, computeOffset(index), testValue, newValue);
@@ -661,7 +661,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetCharAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapCharAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -671,7 +671,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetCharRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapCharRelease(receiver, computeOffset(index), testValue, newValue);
@@ -681,7 +681,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((char[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetCharPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapChar(receiver, computeOffset(index), testValue, newValue);
@@ -838,7 +838,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(receiver, computeOffset(index), testValue, newValue);
@@ -848,7 +848,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final double compareAndExchange(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.compareAndExchangeDouble(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeDoubleVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -870,7 +870,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, computeOffset(index), testValue, newValue);
@@ -880,7 +880,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -890,7 +890,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(receiver, computeOffset(index), testValue, newValue);
@@ -900,7 +900,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((double[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, computeOffset(index), testValue, newValue);
@@ -1039,7 +1039,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(receiver, computeOffset(index), testValue, newValue);				
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(receiver, computeOffset(index), testValue, newValue);
@@ -1049,7 +1049,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final float compareAndExchange(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeFloat(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeFloatVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -1071,7 +1071,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, computeOffset(index), testValue, newValue);
@@ -1081,7 +1081,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -1091,7 +1091,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(receiver, computeOffset(index), testValue, newValue);
@@ -1101,7 +1101,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((float[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, computeOffset(index), testValue, newValue);
@@ -1240,7 +1240,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, computeOffset(index), testValue, newValue);
@@ -1250,7 +1250,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final int compareAndExchange(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeInt(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeIntVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -1272,7 +1272,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, computeOffset(index), testValue, newValue);
@@ -1282,7 +1282,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -1292,7 +1292,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, computeOffset(index), testValue, newValue);
@@ -1302,7 +1302,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((int[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, computeOffset(index), testValue, newValue);
@@ -1459,7 +1459,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(receiver, computeOffset(index), testValue, newValue);
@@ -1469,7 +1469,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final long compareAndExchange(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeLong(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeLongVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -1491,7 +1491,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, computeOffset(index), testValue, newValue);
@@ -1501,7 +1501,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -1511,7 +1511,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(receiver, computeOffset(index), testValue, newValue);
@@ -1521,7 +1521,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((long[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, computeOffset(index), testValue, newValue);
@@ -1678,7 +1678,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetShort(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapShort(receiver, computeOffset(index), testValue, newValue);
@@ -1688,7 +1688,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final short compareAndExchange(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeShort(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeShortVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -1710,7 +1710,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetShortPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapShort(receiver, computeOffset(index), testValue, newValue);
@@ -1720,7 +1720,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetShortAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapShortAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -1730,7 +1730,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetShortRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapShortRelease(receiver, computeOffset(index), testValue, newValue);
@@ -1740,7 +1740,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((short[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetShortPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapShort(receiver, computeOffset(index), testValue, newValue);
@@ -1897,7 +1897,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndSet(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetBoolean(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapBoolean(receiver, computeOffset(index), testValue, newValue);
@@ -1907,7 +1907,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean compareAndExchange(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeBoolean(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeBooleanVolatile(receiver, computeOffset(index), testValue, newValue);
@@ -1929,7 +1929,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSet(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetBooleanPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapBoolean(receiver, computeOffset(index), testValue, newValue);
@@ -1939,7 +1939,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetBooleanAcquire(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapBooleanAcquire(receiver, computeOffset(index), testValue, newValue);
@@ -1949,7 +1949,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetRelease(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetBooleanRelease(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapBooleanRelease(receiver, computeOffset(index), testValue, newValue);
@@ -1959,7 +1959,7 @@ final class ArrayVarHandle extends VarHandle {
 			private static final boolean weakCompareAndSetPlain(Object receiver, int index, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
 				boundsCheck(((boolean[])receiver).length, index);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetBooleanPlain(receiver, computeOffset(index), testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapBoolean(receiver, computeOffset(index), testValue, newValue);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ByteArrayViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ByteArrayViewVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -279,7 +279,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(receiver, offset, testValue, newValue);
@@ -288,7 +288,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final double compareAndExchange(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeDouble(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeDoubleVolatile(receiver, offset, testValue, newValue);
@@ -307,7 +307,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, offset, testValue, newValue);
@@ -316,7 +316,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(receiver, offset, testValue, newValue);
@@ -325,7 +325,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(receiver, offset, testValue, newValue);
@@ -334,7 +334,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, offset, testValue, newValue);
@@ -450,7 +450,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(receiver, offset, testValue, newValue);
@@ -459,7 +459,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final float compareAndExchange(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeFloat(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeFloatVolatile(receiver, offset, testValue, newValue);
@@ -478,7 +478,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, offset, testValue, newValue);
@@ -487,7 +487,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(receiver, offset, testValue, newValue);
@@ -496,7 +496,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetFloatRelease(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(receiver, offset, testValue, newValue);
@@ -505,7 +505,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, offset, testValue, newValue);
@@ -621,7 +621,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, offset, testValue, newValue);
@@ -630,7 +630,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final int compareAndExchange(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeInt(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeIntVolatile(receiver, offset, testValue, newValue);
@@ -649,7 +649,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, offset, testValue, newValue);
@@ -658,7 +658,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, offset, testValue, newValue);
@@ -667,7 +667,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, offset, testValue, newValue);
@@ -676,7 +676,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, offset, testValue, newValue);
@@ -804,7 +804,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(receiver, offset, testValue, newValue);
@@ -813,7 +813,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final long compareAndExchange(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeLong(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeLongVolatile(receiver, offset, testValue, newValue);
@@ -832,7 +832,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, offset, testValue, newValue);
@@ -841,7 +841,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(receiver, offset, testValue, newValue);
@@ -850,7 +850,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(receiver, offset, testValue, newValue);
@@ -859,7 +859,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, offset, testValue, newValue);
@@ -1267,7 +1267,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean compareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1276,7 +1276,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final double compareAndExchange(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				double result = _unsafe.compareAndExchangeDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				double result = _unsafe.compareAndExchangeDoubleVolatile(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1298,7 +1298,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1307,7 +1307,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1316,7 +1316,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1325,7 +1325,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1448,7 +1448,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean compareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1457,7 +1457,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final float compareAndExchange(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				float result = _unsafe.compareAndExchangeFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				float result = _unsafe.compareAndExchangeFloatVolatile(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1479,7 +1479,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1488,7 +1488,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1497,7 +1497,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetFloatRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1506,7 +1506,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1629,7 +1629,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean compareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1638,7 +1638,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final int compareAndExchange(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				int result = _unsafe.compareAndExchangeInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				int result = _unsafe.compareAndExchangeIntVolatile(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1660,7 +1660,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1669,7 +1669,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1678,7 +1678,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1687,7 +1687,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetIntPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1834,7 +1834,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean compareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1843,7 +1843,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final long compareAndExchange(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				long result = _unsafe.compareAndExchangeLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				long result = _unsafe.compareAndExchangeLongVolatile(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1865,7 +1865,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSet(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1874,7 +1874,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetAcquire(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1883,7 +1883,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetRelease(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(receiver, offset, convertEndian(testValue), convertEndian(newValue));
@@ -1892,7 +1892,7 @@ final class ByteArrayViewVarHandle extends ViewVarHandle {
 		
 			private static final boolean weakCompareAndSetPlain(byte[] receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				long offset = checkAndComputeOffset(receiver, BYTES, index, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, offset, convertEndian(testValue), convertEndian(newValue));

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ByteBufferViewVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ByteBufferViewVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -353,7 +353,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(be.base, be.offset, testValue, newValue);	
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(be.base, be.offset, testValue, newValue);
@@ -362,7 +362,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final double compareAndExchange(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeDouble(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeDoubleVolatile(be.base, be.offset, testValue, newValue);
@@ -381,7 +381,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(be.base, be.offset, testValue, newValue);
@@ -390,7 +390,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(be.base, be.offset, testValue, newValue);
@@ -399,7 +399,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(be.base, be.offset, testValue, newValue);
@@ -408,7 +408,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(be.base, be.offset, testValue, newValue);
@@ -524,7 +524,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(be.base, be.offset, testValue, newValue);
@@ -533,7 +533,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final float compareAndExchange(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeFloat(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeFloatVolatile(be.base, be.offset, testValue, newValue);
@@ -552,7 +552,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(be.base, be.offset, testValue, newValue);
@@ -561,7 +561,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(be.base, be.offset, testValue, newValue);
@@ -570,7 +570,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(be.base, be.offset, testValue, newValue);
@@ -579,7 +579,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(be.base, be.offset, testValue, newValue);
@@ -695,7 +695,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(be.base, be.offset, testValue, newValue);
@@ -704,7 +704,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final int compareAndExchange(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeInt(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeIntVolatile(be.base, be.offset, testValue, newValue);
@@ -723,7 +723,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(be.base, be.offset, testValue, newValue);
@@ -732,7 +732,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(be.base, be.offset, testValue, newValue);
@@ -741,7 +741,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(be.base, be.offset, testValue, newValue);
@@ -750,7 +750,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(be.base, be.offset, testValue, newValue);
@@ -878,7 +878,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(be.base, be.offset, testValue, newValue);
@@ -887,7 +887,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final long compareAndExchange(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeLong(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeLongVolatile(be.base, be.offset, testValue, newValue);
@@ -906,7 +906,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(be.base, be.offset, testValue, newValue);
@@ -915,7 +915,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(be.base, be.offset, testValue, newValue);
@@ -924,7 +924,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(be.base, be.offset, testValue, newValue);
@@ -933,7 +933,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(be.base, be.offset, testValue, newValue);
@@ -1341,7 +1341,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1350,7 +1350,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final double compareAndExchange(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				double result = _unsafe.compareAndExchangeDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				double result = _unsafe.compareAndExchangeDoubleVolatile(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1372,7 +1372,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1381,7 +1381,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1390,7 +1390,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1399,7 +1399,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, double testValue, double newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1522,7 +1522,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1531,7 +1531,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final float compareAndExchange(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				float result = _unsafe.compareAndExchangeFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				float result = _unsafe.compareAndExchangeFloatVolatile(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1553,7 +1553,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1562,7 +1562,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1571,7 +1571,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1580,7 +1580,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, float testValue, float newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetFloatPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1703,7 +1703,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1712,7 +1712,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final int compareAndExchange(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				int result = _unsafe.compareAndExchangeInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				int result = _unsafe.compareAndExchangeIntVolatile(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1734,7 +1734,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1743,7 +1743,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1752,7 +1752,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1761,7 +1761,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, int testValue, int newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetIntPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1908,7 +1908,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean compareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1917,7 +1917,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final long compareAndExchange(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				long result = _unsafe.compareAndExchangeLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				long result = _unsafe.compareAndExchangeLongVolatile(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1939,7 +1939,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSet(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1948,7 +1948,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1957,7 +1957,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
@@ -1966,7 +1966,7 @@ final class ByteBufferViewVarHandle extends ViewVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(ByteBuffer receiver, int index, long testValue, long newValue, VarHandle varHandle) {
 				BufferElement be = checkAndGetBufferElement(receiver, BYTES, index, false, false);
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetLongPlain(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(be.base, be.offset, convertEndian(testValue), convertEndian(newValue));

--- a/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/InstanceFieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InstanceFieldVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,7 +153,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -162,7 +162,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final Object compareAndExchange(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeObjectVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -181,7 +181,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -190,7 +190,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObjectAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -199,7 +199,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObjectRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -208,7 +208,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, Object testValue, Object newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObject(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -322,7 +322,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -331,7 +331,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final byte compareAndExchange(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return (byte)_unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return (byte)_unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -350,7 +350,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -359,7 +359,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -368,7 +368,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -377,7 +377,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, byte testValue, byte newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -503,7 +503,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -512,7 +512,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final char compareAndExchange(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return (char)_unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return (char)_unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -531,7 +531,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -540,7 +540,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -549,7 +549,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -558,7 +558,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, char testValue, char newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -684,7 +684,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -693,7 +693,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final double compareAndExchange(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeDoubleVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -712,7 +712,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -721,7 +721,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -730,7 +730,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -739,7 +739,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, double testValue, double newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoublePlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -856,7 +856,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -865,7 +865,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final float compareAndExchange(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeFloatVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -884,7 +884,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -893,7 +893,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -902,7 +902,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -911,7 +911,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, float testValue, float newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1028,7 +1028,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1037,7 +1037,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final int compareAndExchange(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1056,7 +1056,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1065,7 +1065,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1074,7 +1074,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1083,7 +1083,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, int testValue, int newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1209,7 +1209,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1218,7 +1218,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final long compareAndExchange(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeLongVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1237,7 +1237,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1246,7 +1246,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1255,7 +1255,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1264,7 +1264,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, long testValue, long newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1390,7 +1390,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1399,7 +1399,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final short compareAndExchange(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return (short)_unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return (short)_unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1418,7 +1418,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1427,7 +1427,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1436,7 +1436,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1445,7 +1445,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, short testValue, short newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue, newValue);
@@ -1571,7 +1571,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndSet(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
@@ -1580,7 +1580,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndExchange(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return (0 != _unsafe.compareAndExchangeInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0));
 /*[ELSE]
 				return (0 != _unsafe.compareAndExchangeIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0));
@@ -1599,7 +1599,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntVolatile(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
@@ -1608,7 +1608,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
@@ -1617,7 +1617,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
@@ -1626,7 +1626,7 @@ final class InstanceFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(Object receiver, boolean testValue, boolean newValue, VarHandle varHandle) {
 				receiver.getClass();
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(receiver, ((FieldVarHandle)varHandle).vmslot, testValue ? 1: 0, newValue ? 1 : 0);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/LambdaFormBuffer.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE-OpenJ9|Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar18-SE-OpenJ9]*/
 
 /*******************************************************************************
  * Copyright (c) 2017, 2018 IBM Corp. and others

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -53,13 +53,13 @@ import java.util.Iterator;
 import java.util.ArrayList;
 import java.nio.ByteOrder;
 import jdk.internal.reflect.CallerSensitive;
-/*[IF Sidecar19-SE-B175]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
 import jdk.internal.misc.SharedSecrets;
 import jdk.internal.misc.JavaLangAccess;
 import java.security.ProtectionDomain;
 import jdk.internal.org.objectweb.asm.ClassReader;
-/*[ENDIF] Sidecar19-SE-B175*/
+/*[ENDIF] Sidecar19-SE-OpenJ9*/
 /*[ELSE]*/
 import sun.reflect.CallerSensitive;
 /*[ENDIF]*/
@@ -147,11 +147,11 @@ public class MethodHandles {
 		
 		static final int INTERNAL_PRIVILEGED = 0x40;
 
-		/*[IF Sidecar19-SE-B175]
+		/*[IF Sidecar19-SE-OpenJ9]
 		private static final int FULL_ACCESS_MASK = PUBLIC | PRIVATE | PROTECTED | PACKAGE | MODULE;
 		/*[ELSE]*/
 		private static final int FULL_ACCESS_MASK = PUBLIC | PRIVATE | PROTECTED | PACKAGE;
-		/*[ENDIF] Sidecar19-SE-B175*/
+		/*[ENDIF] Sidecar19-SE-OpenJ9*/
 		
 		private static final int NO_ACCESS = 0;
 		
@@ -160,11 +160,11 @@ public class MethodHandles {
 		static final int VARARGS = 0x80;
 		
 		/* single cached value of public Lookup object */
-		/*[IF Sidecar19-SE-B175]
+		/*[IF Sidecar19-SE-OpenJ9]
 		static Lookup PUBLIC_LOOKUP = new Lookup(Object.class, Lookup.PUBLIC | Lookup.UNCONDITIONAL);
 		/*[ELSE]*/
 		static Lookup PUBLIC_LOOKUP = new Lookup(Object.class, Lookup.PUBLIC);
-		/*[ENDIF] Sidecar19-SE-B175*/
+		/*[ENDIF] Sidecar19-SE-OpenJ9*/
 		
 		/* single cached internal privileged lookup */
 		static Lookup internalPrivilegedLookup = new Lookup(MethodHandle.class, Lookup.INTERNAL_PRIVILEGED);
@@ -937,7 +937,7 @@ public class MethodHandles {
 			/*[IF ]*/
 			/* If the new lookup class differs from the old one, protected members will not be accessible by virtue of inheritance. (Protected members may continue to be accessible because of package sharing.) */
 			/*[ENDIF]*/
-			/*[IF !Sidecar19-SE-B175]
+			/*[IF !Sidecar19-SE-OpenJ9]
 			int newAccessMode = accessMode & ~PROTECTED;
 			/*[ELSE]*/
 			/* The UNCONDITIONAL bit is discarded if the new lookup class differs from the old one in Java 9 */
@@ -969,7 +969,7 @@ public class MethodHandles {
 					newAccessMode &= ~MODULE;
 				}
 			}
-			/*[ENDIF] Sidecar19-SE-B175*/
+			/*[ENDIF] Sidecar19-SE-OpenJ9*/
 			
 			/*[IF ]*/
 			/* If the new lookup class is in a different package than the old one, protected and default (package) members will not be accessible. */
@@ -982,13 +982,13 @@ public class MethodHandles {
 				Class<?> a = getUltimateEnclosingClassOrSelf(accessClass);
 				Class<?> l = getUltimateEnclosingClassOrSelf(lookupClass);
 				if (a != l) {
-				/*[IF Sidecar19-SE-B175]
+				/*[IF Sidecar19-SE-OpenJ9]
 				/* If the new lookup class is not within the same package member as the old one, private and protected members will not be accessible. */
 					newAccessMode &= ~(PRIVATE | PROTECTED);
 				/*[ELSE]*/
 				/* If the new lookup class is not within the same package member as the old one, private members will not be accessible. */
 					newAccessMode &= ~PRIVATE;
-				/*[ENDIF] Sidecar19-SE-B175*/
+				/*[ENDIF] Sidecar19-SE-OpenJ9*/
 				}
 			}
 			
@@ -1417,7 +1417,7 @@ public class MethodHandles {
 			case PUBLIC:
 				toString += "/public"; //$NON-NLS-1$
 				break;
-			/*[IF Sidecar19-SE-B175]
+			/*[IF Sidecar19-SE-OpenJ9]
 			case PUBLIC | UNCONDITIONAL:
 				toString += "/publicLookup"; //$NON-NLS-1$
 				break;
@@ -1437,7 +1437,7 @@ public class MethodHandles {
 			case PUBLIC | PACKAGE | PRIVATE:
 				toString += "/private"; //$NON-NLS-1$
 				break;
-			/*[ENDIF] Sidecar19-SE-B175*/
+			/*[ENDIF] Sidecar19-SE-OpenJ9*/
 			}
 			return toString;
 		}
@@ -1648,7 +1648,7 @@ public class MethodHandles {
 			return targetClass;
 		}
 		
-		/*[IF Sidecar19-SE-B175]*/
+		/*[IF Sidecar19-SE-OpenJ9]*/
 		/**
 		 * Return a class object with the same class loader, the same package and
 		 * the same protection domain as the lookup's lookup class.
@@ -1709,7 +1709,7 @@ public class MethodHandles {
 			
 			return targetClass;
 		}
-		/*[ENDIF] Sidecar19-SE-B175*/
+		/*[ENDIF] Sidecar19-SE-OpenJ9*/
 		
 		/**
 		 * Return a MethodHandles.Lookup object without the requested lookup mode.
@@ -1801,7 +1801,7 @@ public class MethodHandles {
 		return Lookup.PUBLIC_LOOKUP;
 	}
 	
-	/*[IF Sidecar19-SE-B175]*/
+	/*[IF Sidecar19-SE-OpenJ9]*/
 	/**
 	 * Return a MethodHandles.Lookup object with full capabilities including the access 
 	 * to the <code>private</code> members in the requested class
@@ -1858,7 +1858,7 @@ public class MethodHandles {
 		
 		return new Lookup(targetClass);
 	}
-	/*[ENDIF] Sidecar19-SE-B175*/
+	/*[ENDIF] Sidecar19-SE-OpenJ9*/
 	
 	/**
 	 * Gets the underlying Member of the provided <code>target</code> MethodHandle. This is done through an unchecked crack of the MethodHandle.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MutableCallSite.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MutableCallSite.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -159,7 +159,7 @@ public class MutableCallSite extends CallSite {
 				if (StructuralComparator.get().handlesAreEquivalent(oldTarget, newTarget)) {
 					// Equivalence check saved us a thaw, so it's worth doing them every time.
 					equivalenceInterval = 1;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 					MethodHandle.UNSAFE.compareAndSetObject(this, targetFieldOffset, oldTarget, newTarget);
 /*[ELSE]
 					MethodHandle.UNSAFE.compareAndSwapObject(this, targetFieldOffset, oldTarget, newTarget);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/StaticFieldVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -160,7 +160,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(Object testValue, Object newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -169,7 +169,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final Object compareAndExchange(Object testValue, Object newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeObjectVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -188,7 +188,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(Object testValue, Object newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -197,7 +197,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(Object testValue, Object newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObjectAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -206,7 +206,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(Object testValue, Object newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObjectRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -215,7 +215,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(Object testValue, Object newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetObjectPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapObject(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -341,7 +341,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(byte testValue, byte newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -350,7 +350,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final byte compareAndExchange(byte testValue, byte newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return (byte)_unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return (byte)_unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -369,7 +369,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(byte testValue, byte newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -378,7 +378,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(byte testValue, byte newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -387,7 +387,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(byte testValue, byte newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -396,7 +396,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(byte testValue, byte newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -522,7 +522,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(char testValue, char newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -531,7 +531,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final char compareAndExchange(char testValue, char newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return (char)_unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return (char)_unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -550,7 +550,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(char testValue, char newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -559,7 +559,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(char testValue, char newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -568,7 +568,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(char testValue, char newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -577,7 +577,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(char testValue, char newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -703,7 +703,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(double testValue, double newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -712,7 +712,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final double compareAndExchange(double testValue, double newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeDoubleVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -731,7 +731,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(double testValue, double newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetDoublePlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -740,7 +740,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(double testValue, double newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -749,7 +749,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(double testValue, double newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapDoubleRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -758,7 +758,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(double testValue, double newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapDouble(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -884,7 +884,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(float testValue, float newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -893,7 +893,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final float compareAndExchange(float testValue, float newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeFloatVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -912,7 +912,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(float testValue, float newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -921,7 +921,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(float testValue, float newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -930,7 +930,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(float testValue, float newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapFloatRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -939,7 +939,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(float testValue, float newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapFloat(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1065,7 +1065,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(int testValue, int newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1074,7 +1074,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final int compareAndExchange(int testValue, int newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1093,7 +1093,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(int testValue, int newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1102,7 +1102,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(int testValue, int newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1111,7 +1111,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(int testValue, int newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1120,7 +1120,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(int testValue, int newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1246,7 +1246,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(long testValue, long newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1255,7 +1255,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final long compareAndExchange(long testValue, long newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.compareAndExchangeLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndExchangeLongVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1274,7 +1274,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSet(long testValue, long newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetLongPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1283,7 +1283,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetAcquire(long testValue, long newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1292,7 +1292,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetRelease(long testValue, long newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapLongRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1301,7 +1301,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean weakCompareAndSetPlain(long testValue, long newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);	
 /*[ELSE]
 				return _unsafe.compareAndSwapLong(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1427,7 +1427,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(short testValue, short newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1451,7 +1451,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(short testValue, short newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1460,7 +1460,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(short testValue, short newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1469,7 +1469,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(short testValue, short newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1478,7 +1478,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(short testValue, short newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue, newValue);
@@ -1604,7 +1604,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 			
 			private static final boolean compareAndSet(boolean testValue, boolean newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
@@ -1613,7 +1613,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean compareAndExchange(boolean testValue, boolean newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return (0 != _unsafe.compareAndExchangeInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
 /*[ELSE]
 				return (0 != _unsafe.compareAndExchangeIntVolatile(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0));
@@ -1632,7 +1632,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSet(boolean testValue, boolean newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 				return _unsafe.weakCompareAndSetIntPlain(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
@@ -1641,7 +1641,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetAcquire(boolean testValue, boolean newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntAcquire(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
@@ -1650,7 +1650,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetRelease(boolean testValue, boolean newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.weakCompareAndSetIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.weakCompareAndSwapIntRelease(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
@@ -1659,7 +1659,7 @@ final class StaticFieldVarHandle extends FieldVarHandle {
 
 			private static final boolean weakCompareAndSetPlain(boolean testValue, boolean newValue, VarHandle varHandle) {
 				FieldVarHandle fieldVarHandle = (FieldVarHandle)varHandle;
-/*[IF Sidecar19-SE-B174]*/				
+/*[IF Sidecar19-SE-OpenJ9]*/				
 				return _unsafe.compareAndSetInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);
 /*[ELSE]
 				return _unsafe.compareAndSwapInt(fieldVarHandle.definingClass, fieldVarHandle.vmslot, testValue ? 1 : 0, newValue ? 1 : 0);

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleByteArrayBase.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleByteArrayBase.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -24,7 +24,7 @@ package com.ibm.java.lang.management.internal;
 
 import java.lang.management.PlatformLoggingMXBean;
 /*[IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE-B165]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.Module;
 import java.lang.ModuleLayer;
 /*[ELSE]
@@ -79,7 +79,7 @@ public final class LoggingMXBeanImpl
 /*[IF Sidecar19-SE]*/
 		try {
 
-/*[IF Sidecar19-SE-B165]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 			Module java_logging = ModuleLayer.boot().findModule("java.logging").get(); //$NON-NLS-1$
 /*[ELSE]
 			Module java_logging = Layer.boot().findModule("java.logging").get(); //$NON-NLS-1$

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -22,7 +22,7 @@
  *******************************************************************************/
 package java.lang.management;
 
-/*[IF Sidecar19-SE-B165]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.ModuleLayer;
 /*[ELSE]
 import java.lang.reflect.Layer;
@@ -70,7 +70,7 @@ final class DefaultPlatformMBeanProvider extends sun.management.spi.PlatformMBea
 		/* LoggingMXBeanImpl depends on java.logging. If java.logging is not 
 		 * available exclude this component.
 		 */
-/*[IF Sidecar19-SE-B165]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 		if (ModuleLayer.boot().findModule("java.logging").isPresent()) //$NON-NLS-1$
 /*[ELSE]
 		if (Layer.boot().findModule("java.logging").isPresent()) //$NON-NLS-1$

--- a/jcl/src/java.management/share/classes/sun/management/BaseOperatingSystemImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/BaseOperatingSystemImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/ClassLoadingImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/ClassLoadingImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/CompilationImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/CompilationImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/CompilerThreadStat.java
+++ b/jcl/src/java.management/share/classes/sun/management/CompilerThreadStat.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/GarbageCollectorImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/GarbageCollectorImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotClassLoading.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotClassLoading.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotClassLoadingMBean.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotClassLoadingMBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotCompilation.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotCompilation.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotCompilationMBean.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotCompilationMBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotInternal.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotInternal.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotInternalMBean.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotInternalMBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotMemory.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotMemory.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotMemoryMBean.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotMemoryMBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotRuntime.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotRuntime.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotRuntimeMBean.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotRuntimeMBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotThread.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotThread.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/HotspotThreadMBean.java
+++ b/jcl/src/java.management/share/classes/sun/management/HotspotThreadMBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/LazyCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/LazyCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/LockInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/LockInfoCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/ManagementFactoryHelper.java
+++ b/jcl/src/java.management/share/classes/sun/management/ManagementFactoryHelper.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MappedMXBeanType.java
+++ b/jcl/src/java.management/share/classes/sun/management/MappedMXBeanType.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MemoryImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MemoryManagerImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryManagerImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MemoryNotifInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryNotifInfoCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MemoryPoolImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryPoolImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MemoryUsageCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/MemoryUsageCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MethodInfo.java
+++ b/jcl/src/java.management/share/classes/sun/management/MethodInfo.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/MonitorInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/MonitorInfoCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/NotificationEmitterSupport.java
+++ b/jcl/src/java.management/share/classes/sun/management/NotificationEmitterSupport.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/RuntimeImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/RuntimeImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/Sensor.java
+++ b/jcl/src/java.management/share/classes/sun/management/Sensor.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/StackTraceElementCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/StackTraceElementCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/ThreadInfoCompositeData.java
+++ b/jcl/src/java.management/share/classes/sun/management/ThreadInfoCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/TypeVersionMapper.java
+++ b/jcl/src/java.management/share/classes/sun/management/TypeVersionMapper.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/VMManagement.java
+++ b/jcl/src/java.management/share/classes/sun/management/VMManagement.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.management/share/classes/sun/management/VMManagementImpl.java
+++ b/jcl/src/java.management/share/classes/sun/management/VMManagementImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/VMOption.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/VMOption.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandArgumentInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandArgumentInfo.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandInfo.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandInfo.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/Flag.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/Flag.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotifInfoCompositeData.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotifInfoCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectorExtImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectorExtImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/GcInfoBuilder.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/GcInfoBuilder.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotThreadImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotThreadImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/VMOptionCompositeData.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/VMOptionCompositeData.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/jcl/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/jdk.management/windows/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/jcl/src/jdk.management/windows/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -1,7 +1,7 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE]*/
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this


### PR DESCRIPTION
Removed
  SIDECAR19-SE-B165
  SIDECAR19-SE-B169
  SIDECAR19-SE-B174
  SIDECAR19-SE-B175

Depends on ibmruntimes/openj9-openjdk-jdk9#127

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>