### PR TITLE
Temporarily remap defaultvalue and withfield opcodes

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -1391,6 +1391,15 @@ ClassFileOracle::walkMethodCodeAttributeCode(U_16 methodIndex)
 
 	U_8 *code = codeAttribute->code;
 	for (U_32 codeIndex = 0; codeIndex < codeAttribute->codeLength; codeIndex += step) { /* NOTE codeIndex is modified below for CFR_BC_tableswitch and CFR_BC_lookupswitch */
+
+#if defined(J9VM_OPT_VALHALLA_VALUETYPES)
+		if (204 == code[codeIndex]) { /* TODO: Remap defaultvalue opcode */
+			code[codeIndex] = CFR_BC_vdefault;
+		} else if (203 == code[codeIndex]) { /* TODO: Remap withfield opcode */
+			code[codeIndex] = CFR_BC_vwithfield;
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUETYPES) */
+
 		U_8 sunInstruction = code[codeIndex];
 
 		step = sunJavaInstructionSizeTable[sunInstruction];


### PR DESCRIPTION
Temporary fix in ClassFileOracle.cpp to map defaultvalue and withfield
opcodes to their new L-World values.
    
A proper remap will be done in a subsequent commit.
    
Signed-off-by: Eric Zhang <eric99.zhang@gmail.com>