### PR TITLE
Add methods inherited from superinterfaces to iTables

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/InterfaceHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/InterfaceHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2009 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,12 +68,13 @@ final class InterfaceHandle extends IndirectHandle {
 	/// {{{ JIT support
 	protected final long vtableOffset(Object receiver) {
 		/*[IF]*/
-		/* Must be 'defc' rather than 'type().parameterType(0)' so that the 
-		 * itable index matches the defining interface, otherwise handles
-		 * on interfaces methods defined in parent interfaces will crash
+		/* Must be 'referenceClass' rather than 'type().parameterType(0)' or
+		 * 'defc' so that the itable index matches the defining interface at
+		 * handle creation time, otherwise handles on interfaces methods defined
+		 * in parent interfaces will crash
 		 */
 		/*[ENDIF]*/
-		Class<?> interfaceClass = defc;
+		Class<?> interfaceClass = referenceClass;
 		if (interfaceClass.isInstance(receiver)) {
 			long interfaceJ9Class = getJ9ClassFromClass(interfaceClass);
 			long receiverJ9Class = getJ9ClassFromClass(receiver.getClass());

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ lookupInterfaceMethod(J9VMThread *currentThread, J9Class *lookupClass, J9UTF8 *n
 			vmFuncs->setCurrentExceptionNLS(currentThread, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9NLS_JCL_PRIVATE_INTERFACE_REQUIRES_INVOKESPECIAL);
 			method = NULL;
 		} else {
-			*methodIndex = vmFuncs->getITableIndexForMethod(method);
+			*methodIndex = getITableIndexForMethod(method, lookupClass);
 			if (*methodIndex == -1) {
 				method = NULL;
 			}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4481,7 +4481,6 @@ typedef struct J9InternalVMFunctions {
 	UDATA  ( *resolveVirtualMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags, struct J9Method **resolvedMethod) ;
 	struct J9Method*  ( *resolveInterfaceMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags) ;
 	UDATA  ( *getVTableIndexForMethod)(struct J9Method * method, struct J9Class *clazz, struct J9VMThread *vmThread) ;
-	UDATA  ( *getITableIndexForMethod)(struct J9Method * method) ;
 	IDATA  ( *checkVisibility)(struct J9VMThread* currentThread, struct J9Class* sourceClass, struct J9Class* destClass, UDATA modifiers, UDATA lookupOptions) ;
 	void  (JNICALL *sendClinit)(struct J9VMThread *vmContext, struct J9Class *clazz, UDATA reserved1, UDATA reserved2, UDATA reserved3) ;
 	void  ( *freeStackWalkCaches)(struct J9VMThread * currentThread, J9StackWalkState * walkState) ;

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1871,6 +1871,18 @@ U_16
 getReturnTypeFromSignature(U_8 * inData, UDATA inLength, U_8 **outData);
 
 /* ---------------- mthutil.c ---------------- */
+
+/**
+ * @brief Retrieve the index of an interface method within the iTable for an interface
+ *        (not necessarily the same interface, as iTables contain methods from all
+ *        extended interfaces as well as the local one).
+ * @param method The interface method
+ * @param targetInterface The interface in whose table to search
+ *                        (NULL to use the declaring class of method)
+ * @return UDATA The iTable index (not including the fixed J9ITable header), or -1 if not found
+ */
+UDATA
+getITableIndexForMethod(J9Method * method, J9Class *targetInterface);
 
 /**
  * Returns the first ROM method following the argument.

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3888,14 +3888,6 @@ fillJITVTableSlot(J9VMThread *vmStruct, UDATA *currentSlot, J9Method *currentMet
 /**
  * @brief
  * @param method
- * @return UDATA
- */
-UDATA
-getITableIndexForMethod(J9Method * method);
-
-/**
- * @brief
- * @param method
  * @param clazz
  * @param vmThread
  * @return UDATA

--- a/runtime/util/mthutil.c
+++ b/runtime/util/mthutil.c
@@ -215,6 +215,47 @@ getCodeTypeAnnotationsDataFromROMMethod(J9ROMMethod *romMethod)
 	return result;
 }
 
+UDATA
+getITableIndexForMethod(J9Method * method, J9Class *targetInterface)
+{
+	J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
+	const UDATA methodCount = methodClass->romClass->romMethodCount;
+	const UDATA methodIndex = method - methodClass->ramMethods;
+	UDATA skip = 0;
+	/* NULL targetInterface implies searching only within methodClass, which may be an obsolete class.
+	 * This works because the methods for the local interface always appear first in the iTable, with
+	 * extended interface methods appearing after.
+	 */
+	if (NULL != targetInterface) {
+		/* Locate methodClass within the extends chain of targetInterface */
+		J9ITable *allInterfaces = (J9ITable*)targetInterface->iTable;
+		for(;;) {
+			J9Class *interfaceClass = allInterfaces->interfaceClass;
+			if (interfaceClass == methodClass) {
+				break;
+			}
+			skip += interfaceClass->romClass->romMethodCount;
+			allInterfaces = allInterfaces->next;
+		}
+	}
+	/* The iTableIndex is the same as the (ram/rom)method index. 
+	 * This includes static and private methods - they just exist 
+	 * as dead entries in the iTable.
+	 * 
+	 * Code below is the equivalent of doing:
+	 *	for (; methodIndex < methodCount; methodIndex++) {
+	 *		if (ramMethod == method) {
+	 *				return methodIndex;
+	 *		}
+	 *		ramMethod++;
+	 *	}
+	 */
+	if (methodIndex < methodCount) {
+		return methodIndex + skip;
+	}
+	return -1;
+}
+
 J9MethodDebugInfo *
 methodDebugInfoFromROMMethod(J9ROMMethod *romMethod)
 {

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -186,13 +186,13 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 			if (NULL != receiver) {
 				_currentThread->sp += 1;
 				J9Class *receiverClazz = J9OBJECT_CLAZZ(_currentThread, receiver);
-				J9Class *interfaceClazz = getPrimitiveHandleDefc(methodHandle);
+				J9Class *interfaceClazz = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, J9VMJAVALANGINVOKEPRIMITIVEHANDLE_REFERENCECLASS(_currentThread, methodHandle));
 				method = convertITableIndexToVirtualMethod(receiverClazz, interfaceClazz, getVMSlot(methodHandle));
 				if (NULL != method) {
 					goto runMethod;
 				}
 				prepareForExceptionThrow(_currentThread);
-				setClassCastException(_currentThread, receiverClazz, interfaceClazz);
+				setCurrentExceptionUTF(_currentThread, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
 				goto throwCurrentException;
 			}
 			nextAction = THROW_NPE;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,7 +113,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	resolveVirtualMethodRef,
 	resolveInterfaceMethodRef,
 	getVTableIndexForMethod,
-	getITableIndexForMethod,
 	checkVisibility,
 	sendClinit,
 	freeStackWalkCaches,

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2110,7 +2110,11 @@ initializeMethodID(J9VMThread * currentThread, J9JNIMethodID * methodID, J9Metho
 		J9Class * declaringClass = J9_CLASS_FROM_METHOD(method);
 
 		if (declaringClass->romClass->modifiers & J9AccInterface) {
-			vTableIndex = getITableIndexForMethod(method) | J9_JNI_MID_INTERFACE;
+			/* Because methodIDs do not store the original lookup class for interface methods,
+			 * always use the declaring class of the interface method.  Pass NULL here to allow
+			 * for methodIDs to be created on obsolete classes for HCR purposes.
+			 */
+			vTableIndex = getITableIndexForMethod(method, NULL) | J9_JNI_MID_INTERFACE;
 		} else {
 			vTableIndex = getVTableIndexForMethod(method, declaringClass, currentThread);
 		}


### PR DESCRIPTION
Modify iTables to contain every method in both the local interface and
any extended interfaces so that the resolved interface class in the RAM
constant pool for interface methods represents the interface that the
receiver class must implement, rather than the class that declared the
resolved interface method.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>