### PR TITLE
Improve GC pause times by removing assumptions in one pass

### DIFF
--- a/runtime/compiler/trj9/control/HookedByTheJit.cpp
+++ b/runtime/compiler/trj9/control/HookedByTheJit.cpp
@@ -6915,6 +6915,7 @@ static void jitHookReleaseCodeGlobalGCEnd(J9HookInterface **hook, UDATA eventNum
    MM_GlobalGCEndEvent *event = (MM_GlobalGCEndEvent *)eventData;
    J9VMThread  *vmThread  = (J9VMThread*)event->currentThread->_language_vmthread;
    jitReleaseCodeStackWalk(vmThread->omrVMThread);
+   jitReclaimMarkedAssumptions();
    }
 
 static void jitHookReleaseCodeGCCycleEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData)
@@ -6926,12 +6927,14 @@ static void jitHookReleaseCodeGCCycleEnd(J9HookInterface **hook, UDATA eventNum,
       condYield = event->condYieldFromGCFunction;
 
    jitReleaseCodeStackWalk(omrVMThread,condYield);
+   jitReclaimMarkedAssumptions();
    }
 
 static void jitHookReleaseCodeLocalGCEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData)
    {
    MM_LocalGCEndEvent *event = (MM_LocalGCEndEvent *)eventData;
    jitReleaseCodeStackWalk(event->currentThread);
+   jitReclaimMarkedAssumptions();
    }
 
 

--- a/runtime/compiler/trj9/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/trj9/env/RuntimeAssumptionTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,7 @@ char const * const runtimeAssumptionKindNames[LastAssumptionKind] =
 struct TR_RatHT
    {
    OMR::RuntimeAssumption ** _htSpineArray;
+   uint32_t              * _markedforDetachCount;
    size_t                  _spineArraySize;
    };
 
@@ -111,15 +112,21 @@ class TR_RuntimeAssumptionTable
    void incReclaimedAssumptionCount(int32_t tableId) { reclaimedAssumptionCount[tableId]++; }
    void detachFromRAT(OMR::RuntimeAssumption *assumption);
 
+   void markAssumptionsAndDetach(void *reclaimedMetaData, bool reclaimPrePrologueAssumptions = false);
+   void reclaimMarkedAssumptionsFromRAT();
+
    int32_t countRatAssumptions();
 
    private:
    friend class OMR::RuntimeAssumption;
    void addAssumption(OMR::RuntimeAssumption *a, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption **sentinel);
    int32_t reclaimAssumptions(void *md, OMR::RuntimeAssumption **hashTable, OMR::RuntimeAssumption **possiblyRelevantHashTable);
+   void markForDetachFromRAT(OMR::RuntimeAssumption *assumption);
 
    // My table of hash tables; init() allocate memory and populate it
    TR_RatHT _tables[LastAssumptionKind];
+   bool     _detachPending[LastAssumptionKind]; // Marks tables that have assumptions waiting to be removed
+   uint32_t _marked;                            // Counts the number of assumptions waiting to be removed
    int32_t assumptionCount[LastAssumptionKind]; // this never gets decremented
    int32_t reclaimedAssumptionCount[LastAssumptionKind];
    };

--- a/runtime/compiler/trj9/runtime/HookHelpers.hpp
+++ b/runtime/compiler/trj9/runtime/HookHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ struct J9VMThread;
 
 void jitReleaseCodeCollectMetaData(J9JITConfig *jitConfig, J9VMThread *vmThread, J9JITExceptionTable *metaData, OMR::FaintCacheBlock* = 0);
 void jitRemoveAllMetaDataForClassLoader(J9VMThread * vmThread, J9ClassLoader * classLoader);
+void jitReclaimMarkedAssumptions();
 void vlogReclamation(const char *prefix, J9JITExceptionTable *metaData, size_t bytesToSaveAtStart);
 
 // Defined in Runtime.cpp


### PR DESCRIPTION
Use a mark and sweep approach to removing runtime assumptions
from the Runtime Assumption Table (RAT) in places where we are
doing assumption clean up during a GC pause time. This will
significantly reduce the GC pause times in cases were we have
a large number of assumptions and the GC is unloading classes.

Signed-off-by: Kevin Langman langman@ca.ibm.com