### PR TITLE
Print total number of tests before test execution

### DIFF
--- a/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
+++ b/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
@@ -57,7 +57,7 @@ sub resultReporter {
 	my $numOfTotal = 0;
 	my @passed;
 	my @failed;
-	my @skipped;
+	my @capSkipped;
 	my $tapString = '';
 	my $fhIn;
 
@@ -96,7 +96,12 @@ sub resultReporter {
 						last;
 					} elsif ($result =~ /(capabilities \(.*?\))\s*=>\s*${testName}_SKIPPED\n/) {
 						my $capabilities = $1;
-						push (@skipped, "$testName - $capabilities");
+						push (@capSkipped, "$testName - $capabilities");
+						$numOfSkipped++;
+						$numOfTotal++;
+						$tapString .= "ok " . $numOfTotal . " - " . $testName . " # skip\n";
+						last;
+					} elsif ($result =~ /(jvm options|platform requirements).*=>\s*${testName}_SKIPPED\n/) {
 						$numOfSkipped++;
 						$numOfTotal++;
 						$tapString .= "ok " . $numOfTotal . " - " . $testName . " # skip\n";
@@ -127,8 +132,9 @@ sub resultReporter {
 		print "\n";
 	}
 
-	if ($numOfSkipped != 0) {
-		printTests(\@skipped, "SKIPPED test targets due to capabilities");
+	# only print out skipped due to capabilities in console
+	if (@capSkipped) {
+		printTests(\@capSkipped, "SKIPPED test targets due to capabilities");
 		print "\n";
 	}
 

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -40,6 +40,8 @@ Q="
 P=:
 PROPS_DIR=props_unix
 
+include $(TEST_ROOT)$(D)TestConfig$(D)utils.mk
+
 ifndef JAVA_BIN
 $(error Please provide JAVA_BIN value.)
 else
@@ -232,7 +234,10 @@ setup_%:
 	@$(ECHO) set JCL_VERSION to $(JCL_VERSION)
 	@$(ECHO) set JAVA_BIN to $(JAVA_BIN)
 	@$(ECHO) set SPEC to $(SPEC)
-	@$(ECHO) Running $(TESTTARGET)
+	@$(ECHO) Running $(TESTTARGET) ...
+	@if [ $(TOTALCOUNT) -ne 0 ]; then \
+		$(ECHO) There are $(TOTALCOUNT) test targets in $(TESTTARGET).; \
+	fi
 	$(JAVA_COMMAND) -version
 
 ifndef JCL_VERSION


### PR DESCRIPTION
- testKitGen calculates number of tests contained in different groups.
- All numbers are saved into util.mk.
- The number of corresponding group is printed out based on target name.
- Match total number before and after test run.

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>