### PR TITLE
Update release process to change tag and branch names

### DIFF
--- a/doc/processes/release_process.md
+++ b/doc/processes/release_process.md
@@ -101,8 +101,8 @@ candidate SHA should be taken from within that range.
 1. Branch the `openj9` & `openj9-omr` repos at the specified level.  Branch names
 should be of the form: `v#releaseNumber#-release`.  Immediately
 tag the newly created branch with a tag of the following form: 
-`openj9-#releaseNumber#-rc#candidatenumber#`.  For the `0.8` release, this would 
-result in a `v0.0-release` branch with a `openj9-0.8-rc1` tag.  These branches 
+`openj9-#releaseNumber#-rc#candidatenumber#`.  For the `0.8.0` release, this would 
+result in a `v0.8.0-release` branch with a `openj9-0.8.0-rc1` tag.  These branches 
 are not intended as development branches and no continued support will be done on 
 them.  They are merely points in time.
 1. The Extensions repos should have been branched for each of the releases.
@@ -116,17 +116,20 @@ determination can be made to either:
 	* Apply a targetted fix to the release branch and retag, or
 	* Rebase the release branch on the master branch if the 
 	changes that have gone in between the initial RC tag and now are safe.
-1. Retag the `-rcX` level as `openj9-#releaseNumber#`.  For the `0.8` release this 
-will be `openj9-0.8`.
+1. Retag the `-rcX` level as `openj9-#releaseNumber#`.  For the `0.8.0` release this 
+will be `openj9-0.8.0`.
 1. Create the [github release](https://help.github.com/articles/creating-releases/)
 corresponding to the tagged level.  The release should link to the Eclipse Release 
 document, the release issue, and the AdoptOpenJDK download links.
 1. Open an Eclipse Bugzilla requesting the branch be marked `protected` to prevent 
 commits after the release is complete.
 
+For a milestone release, the tag will be of the form: `openj9-0.8.0-m1`.
+
 Note, use annotated tags (`git tag -a <tag name>`) as they are treated specially by
 git compared to simple tags.
 
-The `java -version` should now show the tagged level and the javacore will also show
-the tag.
+The `java -version` should now show the tagged level due to the `${java.vm.version}`
+property being set to the tag.  Javacores will also display the tag if the build has
+been tagged.
 

--- a/doc/processes/release_process.md
+++ b/doc/processes/release_process.md
@@ -99,12 +99,12 @@ should be a level that has successfully passed the nightly testing builds at
 both OpenJ9 and AdoptOpenJDK. Given these builds may target a range of SHAs, a
 candidate SHA should be taken from within that range.
 1. Branch the `openj9` & `openj9-omr` repos at the specified level.  Branch names
-should be of the form: `openj9-#releaseNumber#`.  Immediately
+should be of the form: `v#releaseNumber#-release`.  Immediately
 tag the newly created branch with a tag of the following form: 
-`openj9-#releaseNumber#RC#candidatenumber#`.  For the `0.8` release, this would 
-result in a `openj9-0.8RC1` tag.  These branches are not intended as development
-branches and no continued support will be done on them.  They are merely points
-in time.
+`openj9-#releaseNumber#-rc#candidatenumber#`.  For the `0.8` release, this would 
+result in a `v0.0-release` branch with a `openj9-0.8-rc1` tag.  These branches 
+are not intended as development branches and no continued support will be done on 
+them.  They are merely points in time.
 1. The Extensions repos should have been branched for each of the releases.
 Update the Extensions branches to pull the tagged levels from the `openj9` 
 & `openj9-omr` release branches.
@@ -116,7 +116,7 @@ determination can be made to either:
 	* Apply a targetted fix to the release branch and retag, or
 	* Rebase the release branch on the master branch if the 
 	changes that have gone in between the initial RC tag and now are safe.
-1. Retag the `RCx` level as `openj9-#releaseNumber#`.  For the `0.8` release this 
+1. Retag the `-rcX` level as `openj9-#releaseNumber#`.  For the `0.8` release this 
 will be `openj9-0.8`.
 1. Create the [github release](https://help.github.com/articles/creating-releases/)
 corresponding to the tagged level.  The release should link to the Eclipse Release 
@@ -124,5 +124,9 @@ document, the release issue, and the AdoptOpenJDK download links.
 1. Open an Eclipse Bugzilla requesting the branch be marked `protected` to prevent 
 commits after the release is complete.
 
-The `java -version` should now show the tagged level.
+Note, use annotated tags (`git tag -a <tag name>`) as they are treated specially by
+git compared to simple tags.
+
+The `java -version` should now show the tagged level and the javacore will also show
+the tag.
 


### PR DESCRIPTION
Using the same value for tags and branches is difficult in
git and requires being explicit about refs to branch vs tag.
This is unnecessary compilications.

Adapted the tag format to `openj9-0.0-rc1` and `openj9-0.0`
Adapted branch format to `v0.0-release`

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>