### PR TITLE
Updates valhalla nestmates test to match spec update

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -67,6 +67,12 @@ make test
     To get the above dependent jars, please run `make getdependency`.
     getdependency target will get called when running make compile
     or test target.
+    
+    Valhalla tests currently make use of the nestmates capabilities
+    which are available starting in asm version 7. In order to run
+    the Valhalla nestmates on a local machine, you must manually get
+    the asm-7.0.jar and put it in TestConfig/lib/. Avoid using asm 7
+    in other tests as this is a temporary solution.
 
 2. Compile tests:
 

--- a/test/Valhalla/build.xml
+++ b/test/Valhalla/build.xml
@@ -57,7 +57,7 @@
 			<classpath>
 				<pathelement location="../TestConfig/lib/testng.jar"/>
 				<pathelement location="../TestConfig/lib/jcommander.jar"/>
-				<pathelement location="../TestConfig/lib/asm-all.jar"/>
+				<pathelement location="../TestConfig/lib/asm-7.0.jar"/>
 			</classpath>
 		</javac>
 	</target>

--- a/test/Valhalla/playlist.xml
+++ b/test/Valhalla/playlist.xml
@@ -25,7 +25,7 @@
 	<test>
 		<testCaseName>NestAttributeTest</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+	-cp $(Q)$(LIB_DIR)$(D)asm-7.0.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames NestAttributeTest \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \

--- a/test/Valhalla/src/org/openj9/test/valhalla/ClassGenerator.java
+++ b/test/Valhalla/src/org/openj9/test/valhalla/ClassGenerator.java
@@ -25,11 +25,41 @@ import org.objectweb.asm.*;
 
 public class ClassGenerator implements Opcodes {
 
-	public static byte[] fieldAccessDump () throws Exception {
+	public static byte[] MultipleNestMembersAttributesdump () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
-		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE + ACC_STATIC);
+		
+		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestMembersAttributes", null, "java/lang/Object", null);
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		/* Classwriter will automatically correct the existence of two nest members
+		 * attributes, so they are generated separately  */
+		{
+			String[] nestmems = {};
+			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
+			cw.visitAttribute(attr);
+		}
+		{
+			String[] nestmems = {};
+			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
+			cw.visitAttribute(attr);
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static byte[] MultipleNestHostAttributesdump () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+		
+		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestHostAttributes", null, "java/lang/Object", null);
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -40,20 +70,109 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "foo", "()I", null, null);
+			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "main", "([Ljava/lang/String;)V", null, new String[] { "java/lang/Exception" });
+			mv.visitCode();
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(0, 1);
+			mv.visitEnd();
+		}
+		/* Classwriter will automatically correct the existence of two nest host
+		 * attributes, so they are generated separately  */
+		{
+			NestHostAttribute attr = new NestHostAttribute("clazzname");
+			cw.visitAttribute(attr);
+		}
+		{
+			NestHostAttribute attr = new NestHostAttribute("clazzname");
+			cw.visitAttribute(attr);
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static byte[] MultipleNestAttributesdump () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+		
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "MultipleNestAttributes", null, "java/lang/Object", null);
+		cw.visitNestMember("DoesNotExist");
+		cw.visitNestHost("DoesNotExist");
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static byte[] ClassIsOwnNestHostdump () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+		
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "ClassIsOwnNestHost", null, "java/lang/Object", null);
+		cw.visitNestHost("ClassIsOwnNestHost");
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static byte[] NestMemberIsItselfdump () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+		
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "NestMemberIsItself", null, "java/lang/Object", null);
+		cw.visitNestMember("NestMemberIsItself");
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}	
+
+	public static byte[] fieldAccessDump () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+		
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
+		cw.visitNestMember("FieldAccess$Inner");
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "foo", "()I", null, null);
 			mv.visitCode();
 			mv.visitFieldInsn(GETSTATIC, "FieldAccess$Inner", "f", "I");
 			mv.visitInsn(IRETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
 		}
-		{
-			String[] nestmems = {"FieldAccess$Inner"};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
 		cw.visitEnd();
-
 		return cw.toByteArray();
 	}
 
@@ -61,10 +180,12 @@ public class ClassGenerator implements Opcodes {
 		ClassWriter cw = new ClassWriter(0);
 		FieldVisitor fv;
 		MethodVisitor mv;
-		cw.visit(52, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
-		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE + ACC_STATIC);
+		
+		cw.visit(V1_8, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
+		cw.visitNestHost("FieldAccess");
+		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
-			fv = cw.visitField(ACC_PRIVATE + ACC_STATIC, "f", "I", null, null);
+			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
 			fv.visitEnd();
 		}
 		{
@@ -85,20 +206,17 @@ public class ClassGenerator implements Opcodes {
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
 		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("FieldAccess$Inner");
-			cw.visitAttribute(attr);
-		}
 		cw.visitEnd();
-
 		return cw.toByteArray();
 	}
 
 	public static byte[] methodAccessDump () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MethodAccess", null, "java/lang/Object", null);
-		cw.visitInnerClass("MethodAccess$Inner", "MethodAccess", "Inner", ACC_PRIVATE + ACC_STATIC);
+		
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "MethodAccess", null, "java/lang/Object", null);
+		cw.visitNestMember("MethodAccess$Inner");
+		cw.visitInnerClass("MethodAccess$Inner", "MethodAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -109,27 +227,24 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "bar", "()I", null, null);
+			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "bar", "()I", null, null);
 			mv.visitCode();
 			mv.visitMethodInsn(INVOKESTATIC, "MethodAccess$Inner", "foo", "()I", false);
 			mv.visitInsn(IRETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
 		}
-		{  /* Nestmates attribute(s) */
-			NestHostAttribute attr = new NestHostAttribute("MethodAccess$Inner");
-			cw.visitAttribute(attr);
-		}
 		cw.visitEnd();
-
 		return cw.toByteArray();
 	}
 
 	public static byte[] methodAcccess$InnerDump () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
-		cw.visit(52, ACC_SUPER, "MethodAccess$Inner", null, "java/lang/Object", null);
-		cw.visitInnerClass("MethodAccess$Inner", "MethodAccess", "Inner", ACC_PRIVATE + ACC_STATIC);
+		
+		cw.visit(V1_8, ACC_SUPER, "MethodAccess$Inner", null, "java/lang/Object", null);
+		cw.visitNestHost("MethodAccess");
+		cw.visitInnerClass("MethodAccess$Inner", "MethodAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			mv = cw.visitMethod(ACC_PRIVATE, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -140,30 +255,24 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC, "foo", "()I", null, null);
+			mv = cw.visitMethod(ACC_PRIVATE | ACC_STATIC, "foo", "()I", null, null);
 			mv.visitCode();
 			mv.visitInsn(ICONST_3);
 			mv.visitInsn(IRETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
 		}
-		{
-			String[] nestmems = {"MethodAccess"};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
 		cw.visitEnd();
-
 		return cw.toByteArray();
 	}
 
-	public static byte[] multipleNestMembersDump () throws Exception {
+	public static byte[] fieldAccessDump_different_package () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestMembers", null, "java/lang/Object", null);
-		cw.visitInnerClass("MultipleNestMembers$c", "MultipleNestMembers", "c", ACC_PRIVATE + ACC_STATIC);
-		cw.visitInnerClass("MultipleNestMembers$b", "MultipleNestMembers", "b", ACC_PRIVATE);
-		cw.visitInnerClass("MultipleNestMembers$a", "MultipleNestMembers", "a", ACC_PUBLIC);
+		
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visitInnerClass("pkg/FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
+		cw.visitNestMember("pkg/FieldAccess$Inner");
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -174,272 +283,27 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			String[] nestmems = {"MethodAccess$a", "MethodAccess$b", "MethodAccess$c"};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] multipleNestMembers$aDump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		FieldVisitor fv;
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestMembers$a", null, "java/lang/Object", null);
-		cw.visitInnerClass("MultipleNestMembers$a", "MultipleNestMembers", "a", ACC_PUBLIC);
-		{
-			fv = cw.visitField(ACC_FINAL + ACC_SYNTHETIC, "this$0", "LMultipleNestMembers;", null, null);
-			fv.visitEnd();
-		}
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "(LMultipleNestMembers;)V", null, null);
+			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "foo", "()I", null, null);
 			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitVarInsn(ALOAD, 1);
-			mv.visitFieldInsn(PUTFIELD, "MultipleNestMembers$a", "this$0", "LMultipleNestMembers;");
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(2, 2);
-			mv.visitEnd();
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("MultipleNestMembers");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] multipleNestMembers$bDump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		FieldVisitor fv;
-		MethodVisitor mv;
-		cw.visit(52, ACC_SUPER, "MultipleNestMembers$b", null, "java/lang/Object", null);
-		cw.visitInnerClass("MultipleNestMembers$b", "MultipleNestMembers", "b", ACC_PRIVATE);
-		{
-			fv = cw.visitField(ACC_FINAL + ACC_SYNTHETIC, "this$0", "LMultipleNestMembers;", null, null);
-			fv.visitEnd();
-		}
-		{
-			mv = cw.visitMethod(ACC_PRIVATE, "<init>", "(LMultipleNestMembers;)V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitVarInsn(ALOAD, 1);
-			mv.visitFieldInsn(PUTFIELD, "MultipleNestMembers$b", "this$0", "LMultipleNestMembers;");
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(2, 2);
-			mv.visitEnd();
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("MultipleNestMembers");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] multipleNestMembers$cDump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		cw.visit(52, ACC_SUPER, "MultipleNestMembers$c", null, "java/lang/Object", null);
-		cw.visitInnerClass("MultipleNestMembers$c", "MultipleNestMembers", "c", ACC_PRIVATE + ACC_STATIC);
-		{
-			mv = cw.visitMethod(ACC_PRIVATE, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("MultipleNestMembers");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] MultipleNestMembersAttributesdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestMembersAttributes", null, "java/lang/Object", null);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			String[] nestmems = {};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		{
-			String[] nestmems = {};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] MultipleNestHostAttributesdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestHostAttributes", null, "java/lang/Object", null);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "main", "([Ljava/lang/String;)V", null, new String[] { "java/lang/Exception" });
-			mv.visitCode();
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(0, 1);
-			mv.visitEnd();
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("clazzname");
-			cw.visitAttribute(attr);
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("clazzname");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] MultipleNestAttributesdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestAttributes", null, "java/lang/Object", null);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			String[] nestmems = {};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("clazzname");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] DifferentPackagedump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "TestClass", null, "java/lang/Object", null);
-		cw.visitInnerClass("TestClass$Inner", "TestClass", "Inner", ACC_PUBLIC);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			String[] nestmems = {"p/TestClass$Inner"};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] DifferentPackage$Innerdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		FieldVisitor fv;
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "p/TestClass$Inner", null, "java/lang/Object", null);
-		cw.visitInnerClass("p/TestClass$Inner", "p/TestClass", "Inner", ACC_PUBLIC);
-		{
-			fv = cw.visitField(ACC_FINAL + ACC_SYNTHETIC, "this$0", "Lp/TestClass;", null, null);
-			fv.visitEnd();
-		}
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "(Lp/TestClass;)V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitVarInsn(ALOAD, 1);
-			mv.visitFieldInsn(PUTFIELD, "p/TestClass$Inner", "this$0", "Lp/TestClass;");
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(2, 2);
-			mv.visitEnd();
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("TestClass");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
-	}
-
-	public static byte[] nestTopNotClaimedDump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "NestTopNotClaimed", null, "java/lang/Object", null);
-		cw.visitInnerClass("NestTopNotClaimed$Inner", "NestTopNotClaimed", "Inner", ACC_PRIVATE + ACC_STATIC);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "bar", "()I", null, null);
-			mv.visitCode();
-			mv.visitFieldInsn(GETSTATIC, "NestTopNotClaimed$Inner", "f", "I");			mv.visitInsn(IRETURN);
+			mv.visitFieldInsn(GETSTATIC, "pkg/FieldAccess$Inner", "f", "I");
+			mv.visitInsn(IRETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
 		}
-		{  /* NestMembers attribute */
-			String[] nestmems = {"NestTopNotClaimed$Inner"};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
 
-	public static byte[] nestTopNotClaimed$InnerDump () throws Exception {
+	public static byte[] fieldAccess$InnerDump_different_package () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		FieldVisitor fv;
 		MethodVisitor mv;
-		cw.visit(52, ACC_SUPER, "NestTopNotClaimed$Inner", null, "java/lang/Object", null);
-		cw.visitInnerClass("NestTopNotClaimed$Inner", "NestTopNotClaimed", "Inner", ACC_PRIVATE + ACC_STATIC);
+
+		cw.visit(V1_8, ACC_SUPER, "pkg/FieldAccess$Inner", null, "java/lang/Object", null);
+		cw.visitNestHost("FieldAccess");
+		cw.visitInnerClass("pkg/FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
-			fv = cw.visitField(ACC_PRIVATE + ACC_STATIC, "f", "I", null, null);
+			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
 			fv.visitEnd();
 		}
 		{
@@ -455,7 +319,7 @@ public class ClassGenerator implements Opcodes {
 			mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
 			mv.visitCode();
 			mv.visitInsn(ICONST_3);
-			mv.visitFieldInsn(PUTSTATIC, "NestTopNotClaimed$Inner", "f", "I");
+			mv.visitFieldInsn(PUTSTATIC, "pkg/FieldAccess$Inner", "f", "I");
 			mv.visitInsn(RETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
@@ -464,11 +328,12 @@ public class ClassGenerator implements Opcodes {
 		return cw.toByteArray();
 	}
 
-	public static byte[] nestMemberNotClaimedDump () throws Exception {
+	public static byte[] fieldAccessDump_nest_member_not_verified () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "NestMemberNotClaimed", null, "java/lang/Object", null);
-		cw.visitInnerClass("NestMemberNotClaimed$Inner", "NestMemberNotClaimed", "Inner", ACC_PRIVATE + ACC_STATIC);
+
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -479,30 +344,27 @@ public class ClassGenerator implements Opcodes {
 			mv.visitEnd();
 		}
 		{
-			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "bar", "()I", null, null);
+			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "foo", "()I", null, null);
 			mv.visitCode();
-			mv.visitFieldInsn(GETSTATIC, "NestMemberNotClaimed$Inner", "f", "I");			
+			mv.visitFieldInsn(GETSTATIC, "FieldAccess$Inner", "f", "I");
 			mv.visitInsn(IRETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();
-		}
-		{  /* NestMembers attribute */
-			String[] nestmems = {"NestMemberNotClaimed$Inner"};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
 		}
 		cw.visitEnd();
 		return cw.toByteArray();
 	}
 
-	public static byte[] nestMemberNotClaimed$InnerDump () throws Exception {
+	public static byte[] fieldAccess$InnerDump_nest_member_not_verified () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		FieldVisitor fv;
 		MethodVisitor mv;
-		cw.visit(52, ACC_SUPER, "NestMemberNotClaimed$Inner", null, "java/lang/Object", null);
-		cw.visitInnerClass("NestMemberNotClaimed$Inner", "NestMemberNotClaimed", "Inner", ACC_PRIVATE + ACC_STATIC);
+
+		cw.visit(V1_8, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
+		cw.visitNestHost("FieldAccess");
+		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
-			fv = cw.visitField(ACC_PRIVATE + ACC_STATIC, "f", "I", null, null);
+			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
 			fv.visitEnd();
 		}
 		{
@@ -518,7 +380,68 @@ public class ClassGenerator implements Opcodes {
 			mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
 			mv.visitCode();
 			mv.visitInsn(ICONST_3);
-			mv.visitFieldInsn(PUTSTATIC, "NestMemberNotClaimed$Inner", "f", "I");
+			mv.visitFieldInsn(PUTSTATIC, "FieldAccess$Inner", "f", "I");
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 0);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static byte[] fieldAccessDump_nest_host_not_claimed () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		MethodVisitor mv;
+
+		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
+		cw.visitNestMember("FieldAccess$Inner");
+		{
+			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "foo", "()I", null, null);
+			mv.visitCode();
+			mv.visitFieldInsn(GETSTATIC, "FieldAccess$Inner", "f", "I");
+			mv.visitInsn(IRETURN);
+			mv.visitMaxs(1, 0);
+			mv.visitEnd();
+		}
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static byte[] fieldAccess$InnerDump_nest_host_not_claimed () throws Exception {
+		ClassWriter cw = new ClassWriter(0);
+		FieldVisitor fv;
+		MethodVisitor mv;
+
+		cw.visit(V1_8, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
+		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
+		{
+			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
+			fv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_PRIVATE, "<init>", "()V", null, null);
+			mv.visitCode();
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+			mv.visitInsn(RETURN);
+			mv.visitMaxs(1, 1);
+			mv.visitEnd();
+		}
+		{
+			mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+			mv.visitCode();
+			mv.visitInsn(ICONST_3);
+			mv.visitFieldInsn(PUTSTATIC, "FieldAccess$Inner", "f", "I");
 			mv.visitInsn(RETURN);
 			mv.visitMaxs(1, 0);
 			mv.visitEnd();

--- a/test/Valhalla/src/org/openj9/test/valhalla/NestHostAttribute.java
+++ b/test/Valhalla/src/org/openj9/test/valhalla/NestHostAttribute.java
@@ -36,7 +36,7 @@ final class NestHostAttribute extends Attribute {
 	
 	public NestHostAttribute(String nestTop){
 		super("NestHost");
-		this.nestHost = nestHost;
+		this.nestHost = nestTop;
 	}
 	
 	public boolean isCodeAttribute(){


### PR DESCRIPTION
Valhalla nestmates introduces the concept of a 'nest' of classes which share access between eachothers private members. This nest is defined by a 'nest host' which claims a list of 'nest members' and by the nest members which link back to the nest host.

An earlier spec draft loaded the nest host during class loading. A newer spec puts off nest host loading and verification until required for an access check.  Exceptions and errors that arise within class loading and access checking have therefore changed and the tests must change in order to remain up-to-date.

Current spec draft here: cr.openjdk.java.net/~dlsmith/nestmates.html

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>