### PR TITLE
Reformat Jenkins files to use configuration settings

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -34,88 +34,31 @@ def get_source() {
             git_clean()
 
             // Setup REPO variables
-            script {
-                try {
-                    if ( OPENJDK_REPO == "" ) {
-                        error("Must specify the OpenJDK Repo")
-                    }
-                } catch(ex) {
-                    error("Must specify the OpenJDK Repo")
-                }
-                try {
-                    if ( OPENJDK_BRANCH == "" ) {
-                       OPENJDK_BRANCH = DEFAULT_OPENJDK_BRANCH
-                    }
-                } catch(ex) {
-                    OPENJDK_BRANCH = 'openj9'
-                }
-                try {
-                    if ( OPENJDK_SHA == "" ) {
-                        OPENJDK_SHA = ''
-                    }
-                } catch(ex) {
-                    OPENJDK_SHA = ''
-                }
-                try {
-                    if ( OPENJ9_REPO != "" ) {
-                        OPENJ9_REPO_OPTION = "-openj9-repo=${OPENJ9_REPO}"
-                    } else {
-                        OPENJ9_REPO_OPTION = ''
-                    }
-                } catch(ex) {
-                    OPENJ9_REPO_OPTION = ''
-                }
-                try {
-                    if ( OPENJ9_BRANCH != "" ) {
-                        OPENJ9_BRANCH_OPTION = "-openj9-branch=${OPENJ9_BRANCH}"
-                    } else {
-                        OPENJ9_BRANCH_OPTION = ''
-                    }
-                } catch(ex) {
-                    OPENJ9_BRANCH_OPTION = ''
-                }
-                try {
-                    if ( OPENJ9_SHA != "" ) {
-                        OPENJ9_SHA_OPTION = "-openj9-sha=${OPENJ9_SHA}"
-                    } else {
-                        OPENJ9_SHA_OPTION = ''
-                    }
-                } catch (ex) {
-                    OPENJ9_SHA_OPTION = ''
-                }
-                try {
-                    if ( OMR_REPO != "" ) {
-                        OMR_REPO_OPTION = "-omr-repo=${OMR_REPO}"
-                    } else {
-                        OMR_REPO_OPTION = ''
-                    }
-                } catch(ex) {
-                    OMR_REPO_OPTION = ''
-                }
-                try {
-                    if ( OMR_BRANCH != "" ) {
-                        OMR_BRANCH_OPTION = "-omr-branch=${OMR_BRANCH}"
-                    } else {
-                        OMR_BRANCH_OPTION = ''
-                    }
-                } catch(ex) {
-                    OMR_BRANCH_OPTION = ''
-                }
-                try {
-                    if ( OMR_SHA != "" ) {
-                        OMR_SHA_OPTION = "-omr-sha=${OMR_SHA}"
-                    } else {
-                        OMR_SHA_OPTION = ''
-                    }
-                } catch(ex) {
-                    OMR_SHA_OPTION = ''
-                }
-            }
+            OPENJ9_REPO_OPTION = (OPENJ9_REPO != "") ? "-openj9-repo=${OPENJ9_REPO}" : ""
+            OPENJ9_BRANCH_OPTION = (OPENJ9_BRANCH != "") ? "-openj9-branch=${OPENJ9_BRANCH}" : ""
+            OPENJ9_SHA_OPTION = (OPENJ9_SHA != "") ? "-openj9-sha=${OPENJ9_SHA}" : ""
+            OMR_REPO_OPTION = (OMR_REPO != "") ? "-omr-repo=${OMR_REPO}" : ""
+            OMR_BRANCH_OPTION = (OMR_BRANCH != "")? "-omr-branch=${OMR_BRANCH}" : ""
+            OMR_SHA_OPTION = (OMR_SHA != "") ? "-omr-sha=${OMR_SHA}" : ""
 
-            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: "${OPENJDK_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false, timeout: 30]], submoduleCfg: [], userRemoteConfigs: [[url: "${OPENJDK_REPO}"]]]
-            sh "git checkout ${OPENJDK_SHA}"
-            sh "bash ./get_source.sh ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${OMR_REPO_OPTION} ${OMR_BRANCH_OPTION} ${OMR_SHA_OPTION}"
+            if (USER_CREDENTIALS_ID != '') {
+                get_sources_with_authentication()
+            } else {
+                get_sources()
+            }
         }
+    }
+}
+
+def get_sources() {
+    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: "${OPENJDK_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false, timeout: 30]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: "${USER_CREDENTIALS_ID}", url: "${OPENJDK_REPO}"]]]
+    sh "git checkout ${OPENJDK_SHA}"
+    sh "bash ./get_source.sh ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${OMR_REPO_OPTION} ${OMR_BRANCH_OPTION} ${OMR_SHA_OPTION}"
+}
+
+def get_sources_with_authentication() {
+    sshagent(credentials:["${USER_CREDENTIALS_ID}"]) {
+        get_sources()
     }
 }
 

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -23,15 +23,28 @@
  def get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH) {
     // Get a set of SHAs for a standard OpenJ9 build
     def SHAS = [:]
+
+    // check if the SHAs are set as build parameters
+    // if not set, sniff the remote repositories references
+
     stage ('Sniff Repos') {
         dir('openjdk') {
-            SHAS['OPENJDK'] = get_sha(OPENJDK_REPO, OPENJDK_BRANCH)
+            SHAS['OPENJDK'] = OPENJDK_SHA
+            if (SHAS['OPENJDK'] == '') {
+                SHAS['OPENJDK'] = get_repository_sha(OPENJDK_REPO, OPENJDK_BRANCH)
+            }
         }
         dir('openj9') {
-            SHAS['OPENJ9'] = get_sha(OPENJ9_REPO, OPENJ9_BRANCH)
+            SHAS['OPENJ9'] = OPENJ9_SHA
+            if ((SHAS['OPENJ9'] == '') && ((OPENJ9_REPO != '') && (OPENJ9_BRANCH != ''))) {
+                SHAS['OPENJ9'] = get_repository_sha(OPENJ9_REPO, OPENJ9_BRANCH)
+            }
         }
         dir('omr') {
-            SHAS['OMR'] = get_sha(OMR_REPO, OMR_BRANCH)
+            SHAS['OMR'] = OMR_SHA
+            if ((SHAS['OMR'] == '') && ((OMR_REPO != '') && (OMR_BRANCH != ''))){
+                SHAS['OMR'] = get_repository_sha(OMR_REPO, OMR_BRANCH)
+            }
         }
         // Write the SHAs to the Build Description
         echo "OPENJDK_SHA:${SHAS['OPENJDK']}"
@@ -40,6 +53,17 @@
         currentBuild.description = "OpenJ9: ${SHAS['OPENJ9']}<br/>OMR: ${SHAS['OMR']}<br/>OpenJDK: ${SHAS['OPENJDK']}"
         return SHAS
     }
+}
+
+def get_repository_sha(REPO, BRANCH) {
+   // use ssh-agent to avoid permission denied on private repositories
+    if (USER_CREDENTIALS_ID != '') {
+        return sshagent(credentials:["${USER_CREDENTIALS_ID}"]) {
+            get_sha(REPO, BRANCH)
+        }
+    }
+
+    return get_sha(REPO, BRANCH)
 }
 
 def get_sha(REPO, BRANCH) {
@@ -52,16 +76,16 @@ def get_sha(REPO, BRANCH) {
         ).trim()
 }
 
-def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA) {
+def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE) {
     stage ('Build') {
-        JOB = build job: BUILD_JOB_NAME, parameters: [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO), string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH), string(name: 'OPENJDK_SHA', value: OPENJDK_SHA), string(name: 'OPENJ9_REPO', value: OPENJ9_REPO), string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH), string(name: 'OPENJ9_SHA', value: OPENJ9_SHA), string(name: 'OMR_REPO', value: OMR_REPO), string(name: 'OMR_BRANCH', value: OMR_BRANCH), string(name: 'OMR_SHA', value: OMR_SHA)]
+        JOB = build job: BUILD_JOB_NAME, parameters: [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO), string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH), string(name: 'OPENJDK_SHA', value: OPENJDK_SHA), string(name: 'OPENJ9_REPO', value: OPENJ9_REPO), string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH), string(name: 'OPENJ9_SHA', value: OPENJ9_SHA), string(name: 'OMR_REPO', value: OMR_REPO), string(name: 'OMR_BRANCH', value: OMR_BRANCH), string(name: 'OMR_SHA', value: OMR_SHA), string(name: 'VARIABLE_FILE', value: VARIABLE_FILE)]
         return JOB
     }
 }
 
-def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER) {
+def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, VARIABLE_FILE) {
     stage ("${JOB_NAME}") {
-        JOB = build job: JOB_NAME, parameters: [string(name: 'UPSTREAM_JOB_NAME', value: UPSTREAM_JOB_NAME), string(name: 'UPSTREAM_JOB_NUMBER', value: "${UPSTREAM_JOB_NUMBER}")]
+        JOB = build job: JOB_NAME, parameters: [string(name: 'UPSTREAM_JOB_NAME', value: UPSTREAM_JOB_NAME), string(name: 'UPSTREAM_JOB_NUMBER', value: "${UPSTREAM_JOB_NUMBER}"), string(name: 'VARIABLE_FILE', value: VARIABLE_FILE)]
         return JOB
     }
 }

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -20,6 +20,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+// Set JAVA_BIN here not in the variables-functions.set_job_variables() function
+// to ensure a correct JAVA_BIN path. JAVA_BIN should be available on the
+// machine the tests run.
+// set_job_variables() is usually called on the master not on the node (where
+// the tests run) and the master's WORKSPACE is different than the node's WORKSPACE
+JRE_FOLDER = (SDK_VERSION == '8') ? '/jre' : ''
+JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}${JRE_FOLDER}/bin"
+
 def fetch_artifacts(){
     stage('Fetch Artifacts') {
         timestamps {
@@ -49,7 +57,7 @@ def configure() {
 def get_dependencies() {
     stage('Get Test Dependencies') {
         timestamps {
-            copyArtifacts fingerprintArtifacts: true, projectName: 'test.getDependency', selector: lastSuccessful(), target: 'openj9/test/TestConfig/lib'
+            copyArtifacts fingerprintArtifacts: true, projectName: "${TEST_DEPENDENCIES_JOB_NAME}", selector: lastSuccessful(), target: 'openj9/test/TestConfig/lib'
         }
     }
 }
@@ -99,5 +107,6 @@ def test_all() {
 def test_all_with_fetch() {
     fetch_artifacts()
     test_all()
+    cleanWs()
 }
 return this

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -1,0 +1,249 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+def VARIABLES
+
+/*
+* Parses the Jenkins job variables file and populates the VARIABLES collection.
+* If a variables file is not set, parse the default variables file.
+* The variables file is in YAML format and contains configuration settings
+* required to compile and test the OpenJ9 extensions for OpenJDK on multiple
+* platforms.
+*/
+def parse_variables_file(){
+    DEFAULT_VARIABLE_FILE = "buildenv/jenkins/variables/defaults.yml"
+
+    // check if a variable file is passed as a Jenkins build parameter
+    // if not use default configuration settings
+    VARIABLE_FILE = params.VARIABLE_FILE
+    if ((VARIABLE_FILE == null) || (VARIABLE_FILE == '')) {
+        VARIABLE_FILE = "${DEFAULT_VARIABLE_FILE}"
+    }
+
+    if (!fileExists("${VARIABLE_FILE}")) {
+        error("Missing variable file: ${VARIABLE_FILE}")
+    }
+
+    echo "Using variables file: ${VARIABLE_FILE}"
+    VARIABLES = readYaml file: "${VARIABLE_FILE}"
+}
+
+/*
+* Sets the Git repository URLs and branches for all sources required to build
+* the OpenJ9 extensions for OpenJDK.
+* Initializes variables to the value passed as build parameters.
+* When no values are available as build parameters set them to the values
+* available with the variable file otherwise set them to empty strings.
+*/
+def set_repos_variables() {
+    // check if passed as Jenkins build parameters
+    // if not set as params, check the variables file
+
+    OPENJDK_REPO = params.OPENJDK_REPO
+    if ((OPENJDK_REPO == null) || (OPENJDK_REPO == '')) {
+        OPENJDK_REPO = get_value(VARIABLES.openjdk_repo, SDK_VERSION)
+    }
+
+    if ( OPENJDK_REPO == "" ) {
+        error("Must specify the OpenJDK repository")
+    }
+
+    OPENJDK_BRANCH = params.OPENJDK_BRANCH
+    if ((OPENJDK_BRANCH == null) || (OPENJDK_BRANCH == '')) {
+        OPENJDK_BRANCH = VARIABLES.openjdk_branch
+    }
+
+    if ( OPENJDK_BRANCH == "" ) {
+        error("Must specify the OpenJDK branch")
+    }
+
+    OPENJDK_SHA = (params.OPENJDK_SHA != null) ? params.OPENJDK_SHA : ''
+
+    if ((params.OPENJ9_REPO != null) && (params.OPENJ9_REPO != '')) {
+        //set it to the value passed as build parameter
+         OPENJ9_REPO = params.OPENJ9_REPO
+    } else if (VARIABLES.openj9_repo != null) {
+        // set it to the value set into the variable file
+         OPENJ9_REPO = VARIABLES.openj9_repo
+    } else {
+        OPENJ9_REPO = ''
+    }
+
+    if ((params.OPENJ9_BRANCH != null) && (params.OPENJ9_BRANCH != null)) {
+        OPENJ9_BRANCH = params.OPENJ9_BRANCH
+    } else if (VARIABLES.openj9_branch != null) {
+         OPENJ9_BRANCH = VARIABLES.openj9_branch
+    } else {
+        OPENJ9_BRANCH = ''
+    }
+
+    OPENJ9_SHA = (params.OPENJ9_SHA != null) ? params.OPENJ9_SHA : ''
+
+    if ((params.OMR_REPO != null) && (params.OMR_REPO != '')) {
+         OMR_REPO = params.OMR_REPO
+    } else if (VARIABLES.omr_repo != null) {
+         OMR_REPO = VARIABLES.omr_repo
+    } else {
+        OMR_REPO = ''
+    }
+
+    if ((params.OMR_BRANCH != null) && (params.OMR_BRANCH != '')) {
+        OMR_BRANCH = params.OMR_BRANCH
+    } else if (VARIABLES.omr_branch != null) {
+         OMR_BRANCH = VARIABLES.omr_branch
+    } else {
+        OMR_BRANCH = ''
+    }
+
+    OMR_SHA = (params.OMR_SHA != null) ? params.OMR_SHA : ''
+
+    echo "Using OPENJDK_REPO = ${OPENJDK_REPO} OPENJDK_BRANCH = ${OPENJDK_BRANCH} OPENJDK_SHA = ${OPENJDK_SHA}"
+    echo "Using OPENJ9_REPO = ${OPENJ9_REPO} OPENJ9_BRANCH = ${OPENJ9_BRANCH} OPENJ9_SHA = ${OPENJ9_SHA}"
+    echo "Using OMR_REPO = ${OMR_REPO} OMR_BRANCH = ${OMR_BRANCH} OMR_SHA = ${OMR_SHA}"
+}
+
+/*
+* Returns the value of the element identified by the given key or an empty string
+* if the map contains no mapping for the key.
+*/
+def get_value(MAP, KEY) {
+    for (item in MAP) {
+        if ("${item.key}" == "${KEY}") {
+            return "${item.value}"
+        }
+    }
+
+    return ''
+}
+
+/*
+* Returns Jenkins credentials ID required to connect to GitHub using
+* the ssh protocol.
+* Returns empty string if no values is provided in the variables file (not
+* required for public repositories).
+*/
+def get_git_user_credentials_id () {
+    if (VARIABLES.user != null) {
+        return VARIABLES.user.credentials_id
+    }
+
+    return ''
+}
+
+/*
+* Sets the NODE variable to the labels identifying nodes by platform suitable
+* to run a Jenkins job.
+*/
+def set_node(job_type) {
+    // fetch labels (space separated string) for given platform/spec
+    labels = get_value(VARIABLES."${SPEC}".node_labels, job_type)
+    NODE = labels.replaceAll(" ", "&&")
+}
+
+/*
+* Set the RELEASE variable with the value provided in the variables file.
+*/
+def set_release() {
+    RELEASE = get_value(VARIABLES."${SPEC}".release, SDK_VERSION)
+}
+
+/*
+* Set the JDK_FOLDER variable with the value provided in the variables file.
+*/
+def set_jdk_folder() {
+    JDK_FOLDER = get_value(VARIABLES.jdk_image_dir, SDK_VERSION)
+}
+
+/*
+* Sets variables for a job that builds the OpenJ9 extensions for OpenJDK for a
+* given platform and version.
+*/
+def set_build_variables() {
+    set_repos_variables()
+
+    // fetch values per spec and Java version from the variables file
+    BOOT_JDK = get_value(VARIABLES."${SPEC}".boot_jdk, SDK_VERSION)
+    FREEMARKER = VARIABLES."${SPEC}".freemarker
+    set_release()
+    set_jdk_folder()
+
+    try{
+        SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-${SPEC}-"
+    } catch (e) {
+        SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-${SPEC}-"
+    }
+
+    SDK_SUFFIX = ".tar.gz"
+    TEST_PREFIX = "test-"
+    TEST_SUFFIX = ".tar.gz"
+}
+
+/*
+* Sets variables for a test job on a given platform.
+*/
+def set_test_variables() {
+    set_release()
+    set_jdk_folder()
+    JAVA_VERSION = "SE" + "${SDK_VERSION}" + "0"
+    TEST_DEPENDENCIES_JOB_NAME = VARIABLES.test_dependencies_job_name
+}
+
+/*
+* Initializes all of the required variables for a Jenkins job by given job type.
+*/
+def set_job_variables(job_type) {
+    // initialize VARIABLES
+    parse_variables_file()
+
+    // fetch credentials required to connect to GitHub using ssh protocol
+    USER_CREDENTIALS_ID = get_git_user_credentials_id()
+
+    switch (job_type) {
+        case "build":
+            // set the node the Jenkins build would run on
+            set_node('build')
+            // set variables for a build job
+            set_build_variables()
+            break
+        case "test":
+            // set the node the tests would run on
+            set_node('test')
+            // set variables for a test job
+            set_test_variables()
+            break
+        case "pullRequest":
+            // set the node the pull request job would run on
+            set_node('build')
+            // set variables for a pull request job that builds an SDK
+            set_build_variables()
+            set_test_variables()
+            break
+        case "pipeline":
+            // set variables for a pipeline job
+            set_repos_variables()
+            break
+        default:
+            error("Unknown Jenkins job type!")
+    }
+}
+
+return this

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-linux_390-64_cmprssptrs
@@ -20,21 +20,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('390') {
+SDK_VERSION = '8'
+SPEC = 'linux_390-64_cmprssptrs'
 
-    SDK_VERSION = "8"
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-s390x"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
+
+ node("${NODE}") {
+
+    checkout scm
+    def buildfile = load "buildenv/jenkins/common/build"
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,21 +20,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('ppcle') {
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
 
-    SDK_VERSION = "8"
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-ppc64el"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_390-64_cmprssptrs
@@ -20,21 +20,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('390') {
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
 
-    SDK_VERSION = "9"
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-    BOOT_JDK = "$HOME/openj9/ibm-java-s390x-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,21 +20,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('ppcle') {
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
 
-    SDK_VERSION = "9"
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-    BOOT_JDK = "$HOME/openj9/ibm-java-ppc64le-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64le-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+ node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+def SDK_VERSIONS = ['8', '9']
+def SPECS = ['linux_ppc-64_cmprssptrs_le', 'linux_390-64_cmprssptrs']
+
+def OPENJDK_REPOS = ['8': 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git',
+                     '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git']
+def OPENJDK_BRANCHES = ['8': 'openj9',
+                        '9': 'openj9']
+
+def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
+def OPENJ9_BRANCH = 'master'
+
+def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
+def OMR_BRANCH = 'openj9'
+
+def builds = [:]
+
+node('worker') {
+
+    checkout scm
+    buildFile = load 'buildenv/jenkins/common/pipeline-functions'
+
+    // fetch SHAs
+    OPENJ9_SHA = buildFile.get_sha(OPENJ9_REPO, OPENJ9_BRANCH)
+    OMR_SHA = buildFile.get_sha(OMR_REPO, OMR_BRANCH)
+
+    // update build description
+    currentBuild.description = "OpenJ9: ${OPENJ9_SHA}<br/>OMR: ${OMR_SHA}"
+
+    SDK_VERSIONS.each { SDK_VERSION ->
+        OPENJDK_REPO = OPENJDK_REPOS["${SDK_VERSION}"]
+        OPENJDK_BRANCH = OPENJDK_BRANCHES["${SDK_VERSION}"]
+        OPENJDK_SHA = buildFile.get_sha(OPENJDK_REPO, OPENJDK_BRANCH)
+
+        // append OpenJDK SHA to the build description
+        currentBuild.description += "<br/>OpenJDK${SDK_VERSION}: ${OPENJDK_SHA}"
+
+        echo "Building OpenJ9 extensions for OpenJDK${SDK_VERSION}"
+        echo "OPENJDK_SHA:${OPENJDK_SHA}"
+        echo "OPENJ9_SHA:${OPENJ9_SHA}"
+        echo "OMR_SHA:${OMR_SHA}"
+
+        SPECS.each { SPEC ->
+             builds["build_JDK${SDK_VERSION} ${SPEC}"] = { build(OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, SDK_VERSION, SPEC) }
+         }
+    }
+
+    cleanWs()
+}
+
+parallel builds
+
+/*
+* Returns the Jenkins pipeline job that builds and tests OpenJ9 extensions for
+* OpenJDK for give version and spec.
+*/
+def build(OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, SDK_VERSION, SPEC) {
+    stage ("Build JDK${SDK_VERSION} ${SPEC}") {
+        def JOB_NAME = "Pipeline-Build-Test-JDK${SDK_VERSION}-${SPEC}"
+        JOB = build job: JOB_NAME,
+                parameters: [
+                    string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
+                    string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH),
+                    string(name: 'OPENJDK_SHA', value: OPENJDK_SHA),
+                    string(name: 'OPENJ9_REPO', value: OPENJ9_REPO),
+                    string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH),
+                    string(name: 'OPENJ9_SHA', value: OPENJ9_SHA),
+                    string(name: 'OMR_REPO', value: OMR_REPO),
+                    string(name: 'OMR_BRANCH', value: OMR_BRANCH),
+                    string(name: 'OMR_SHA', value: OMR_SHA)]
+        return JOB
+    }
+}

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs
@@ -20,23 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def OPENJDK_REPO = 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git'
-def OPENJDK_BRANCH = 'openj9'
-def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
-def OPENJ9_BRANCH = 'master'
-def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
-def OMR_BRANCH = 'openj9'
-
 def BUILD_JOB_NAME = 'Build-JDK8-linux_390-64_cmprssptrs'
 def SANITY_JOB_NAME = 'Test-Sanity-JDK8-linux_390-64_cmprssptrs'
 def EXTENDED_JOB_NAME = 'Test-Extended-JDK8-linux_390-64_cmprssptrs'
 
 node('master') {
+    SDK_VERSION = '8'
+    SPEC = 'linux_390-64_cmprssptrs'
+
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/pipeline-functions"
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'])
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
+BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
+SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,23 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def OPENJDK_REPO = 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git'
-def OPENJDK_BRANCH = 'openj9'
-def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
-def OPENJ9_BRANCH = 'master'
-def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
-def OMR_BRANCH = 'openj9'
-
 def BUILD_JOB_NAME = 'Build-JDK8-linux_ppc-64_cmprssptrs_le'
 def SANITY_JOB_NAME = 'Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le'
 def EXTENDED_JOB_NAME = 'Test-Extended-JDK8-linux_ppc-64_cmprssptrs_le'
 
 node('master') {
+    SDK_VERSION = '8'
+    SPEC = 'linux_ppc-64_cmprssptrs_le'
+
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/pipeline-functions"
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'])
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
+BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
+SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_390-64_cmprssptrs
@@ -20,23 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def OPENJDK_REPO = 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git'
-def OPENJDK_BRANCH = 'openj9'
-def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
-def OPENJ9_BRANCH = 'master'
-def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
-def OMR_BRANCH = 'openj9'
-
 def BUILD_JOB_NAME = 'Build-JDK9-linux_390-64_cmprssptrs'
 def SANITY_JOB_NAME = 'Test-Sanity-JDK9-linux_390-64_cmprssptrs'
 def EXTENDED_JOB_NAME = 'Test-Extended-JDK9-linux_390-64_cmprssptrs'
 
 node('master') {
+    SDK_VERSION = '9'
+    SPEC = 'linux_390-64_cmprssptrs'
+
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/pipeline-functions"
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'])
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
+BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
+SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,23 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def OPENJDK_REPO = 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git'
-def OPENJDK_BRANCH = 'openj9'
-def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
-def OPENJ9_BRANCH = 'master'
-def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
-def OMR_BRANCH = 'openj9'
-
 def BUILD_JOB_NAME = 'Build-JDK9-linux_ppc-64_cmprssptrs_le'
 def SANITY_JOB_NAME = 'Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le'
 def EXTENDED_JOB_NAME = 'Test-Extended-JDK9-linux_ppc-64_cmprssptrs_le'
 
 node('master') {
+    SDK_VERSION = '9'
+    SPEC = 'linux_ppc-64_cmprssptrs_le'
+
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/pipeline-functions"
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'])
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber())
+BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
+SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_390-64_cmprssptrs
@@ -20,26 +20,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '8'
+SPEC = 'linux_390-64_cmprssptrs'
 
-    SDK_VERSION = "8"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-s390x"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_pr_compile_only()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,26 +20,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le
 
-    SDK_VERSION = "8"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-ppc64el"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_pr_compile_only()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_390-64_cmprssptrs
@@ -20,26 +20,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
 
-    SDK_VERSION = "9"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "$HOME/openj9/ibm-java-s390x-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_pr_compile_only()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,26 +20,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
 
-    SDK_VERSION = "9"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "$HOME/openj9/ibm-java-ppc64le-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64le-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_pr_compile_only()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_390-64_cmprssptrs
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '8'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_extended'
 
-    SDK_VERSION = "8"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-s390x"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_extended'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_extended'
 
-    SDK_VERSION = "8"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-ppc64el"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_extended'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_390-64_cmprssptrs
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_extended'
 
-    SDK_VERSION = "9"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "$HOME/openj9/ibm-java-s390x-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_extended'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_extended'
 
-    SDK_VERSION = "9"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "$HOME/openj9/ibm-java-ppc64le-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64le-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_extended'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_390-64_cmprssptrs
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '8'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_sanity'
 
-    SDK_VERSION = "8"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-s390x"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_sanity'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_sanity'
 
-    SDK_VERSION = "8"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "/usr/lib/jvm/java-7-openjdk-ppc64el"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64-normal-server-release"
-    JDK_FOLDER = "j2sdk-image"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_sanity'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_390-64_cmprssptrs
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_sanity'
 
-    SDK_VERSION = "9"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "$HOME/openj9/ibm-java-s390x-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_390-64_cmprssptrs-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-s390x-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_sanity'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,36 +20,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_sanity'
 
-    SDK_VERSION = "9"
-
-    // Clone
-    OPENJDK_REPO = "https://github.com/ibmruntimes/openj9-openjdk-jdk${SDK_VERSION}.git"
-    OPENJDK_BRANCH = "openj9"
-
-    // Build
-    BOOT_JDK = "$HOME/openj9/ibm-java-ppc64le-80"
-    FREEMARKER = "$HOME/openj9/freemarker.jar"
-    SDK_PREFIX = "OpenJ9-JDK${SDK_VERSION}-PR${ghprbPullId}-linux_ppc-64_cmprssptrs_le-"
-    SDK_SUFFIX = ".tar.gz"
-    TEST_PREFIX = "test-"
-    TEST_SUFFIX = ".tar.gz"
-    RELEASE = "linux-ppc64le-normal-server-release"
-    JDK_FOLDER = "jdk"
+node('master') {
 
     checkout scm
-    buildfile = load "${WORKSPACE}/buildenv/jenkins/common/build"
-    testfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
 
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
     buildfile.build_pr()
 
     // Test
-    JAVA_BIN = "${WORKSPACE}/build/$RELEASE/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = "SE${SDK_VERSION}0"
-    TEST_TARGET = '_sanity'
-
     archive_test = [:]
     archive_test['Archive'] = { buildfile.archive() }
     archive_test['Test'] = { testfile.test_all() }

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-linux_390-64_cmprssptrs
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('390') {
+SDK_VERSION = '8'
+SPEC = "linux_390-64_cmprssptrs"
+TEST_TARGET = '_extended'
 
-    JDK_FOLDER = "j2sdk-image"
-    RELEASE = "linux-s390x-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = 'SE80'
-    TEST_TARGET = '_extended'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('ppcle') {
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_extended'
 
-    JDK_FOLDER = "j2sdk-image"
-    RELEASE = "linux-ppc64-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = 'SE80'
-    TEST_TARGET = '_extended'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-linux_390-64_cmprssptrs
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('390') {
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_extended'
 
-    JDK_FOLDER = "jdk"
-    RELEASE = "linux-s390x-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = 'SE90'
-    TEST_TARGET = '_extended'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_extended'
 
-    JDK_FOLDER = "jdk"
-    RELEASE = "linux-ppc64le-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = 'SE90'
-    TEST_TARGET = '_extended'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-linux_390-64_cmprssptrs
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '8'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_sanity'
 
-    JDK_FOLDER = "j2sdk-image"
-    RELEASE = "linux-s390x-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = 'SE80'
-    TEST_TARGET = '_sanity'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('ppcle') {
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_sanity'
 
-    JDK_FOLDER = "j2sdk-image"
-    RELEASE = "linux-ppc64-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/jre/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = 'SE80'
-    TEST_TARGET = '_sanity'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-linux_390-64_cmprssptrs
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-node('390') {
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_sanity'
 
-    JDK_FOLDER = "jdk"
-    RELEASE = "linux-s390x-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_390-64_cmprssptrs'
-    JAVA_VERSION = 'SE90'
-    TEST_TARGET = '_sanity'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,16 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- node('ppcle') {
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_sanity'
 
-    JDK_FOLDER = "jdk"
-    RELEASE = "linux-ppc64le-normal-server-release"
-    JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}/bin"
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
-    JAVA_VERSION = 'SE90'
-    TEST_TARGET = '_sanity'
+node('master') {
 
     checkout scm
-    def buildfile = load "${WORKSPACE}/buildenv/jenkins/common/test"
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
     buildfile.test_all_with_fetch()
 }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -1,0 +1,63 @@
+###############################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+#========================================#
+# Git repositories
+#========================================#
+openjdk_repo:
+  8: 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git'
+  9: 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git'
+openjdk_branch: 'openj9'
+#========================================#
+# Miscellaneous settings
+#========================================#
+jdk_image_dir:
+  8: 'j2sdk-image'
+  9: 'jdk'
+test_dependencies_job_name: 'test.getDependency'
+#========================================#
+# Linux PPCLE 64bits Compressed Pointers
+#========================================#
+linux_ppc-64_cmprssptrs_le:
+  boot_jdk:
+    8: '/usr/lib/jvm/java-7-openjdk-ppc64el'
+    9: '${HOME}/openj9/ibm-java-ppc64le-80'
+  release:
+    8: 'linux-ppc64-normal-server-release'
+    9: 'linux-ppc64le-normal-server-release'
+  freemarker: '${HOME}/openj9/freemarker.jar'
+  node_labels:
+    build: 'ppcle'
+    test: 'ppcle'
+#========================================#
+# Linux S390 64bits Compressed Pointers
+#========================================#
+linux_390-64_cmprssptrs:
+  boot_jdk:
+    8: '/usr/lib/jvm/java-7-openjdk-s390x'
+    9: '${HOME}/openj9/ibm-java-s390x-80'
+  release:
+    8: 'linux-s390x-normal-server-release'
+    9: 'linux-s390x-normal-server-release'
+  freemarker: '${HOME}/openj9/freemarker.jar'
+  node_labels:
+    build: '390'
+    test: '390'


### PR DESCRIPTION
Add YAML configuration settings file (default.yml). This provides
support for multiple configuration settings (e.g. production or
development environment, different Jenkins server).
Add groovy script (variables-functions) to parse the YAML file and
initialize the Jenkins jobs parameters.
Remove hard-coded values from the Jenkins files and initialize variables
with values from the configuration file.
Set on-demand nodes for downstream jobs. This allows the jobs to run on
different Jenkins servers. Nodes labels are provided in the
configuration file.
Add top pipeline to build and test OpenJ9 extensions for OpenJDK for all
versions and specs/platforms. This ensures all platforms are testing the
same source level (same OpenJDK, OpenJ9 and OMR SHAs).

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>