### PR TITLE
Automate build instructions using Ansible

### DIFF
--- a/buildenv/ansible/inventories/local/hosts
+++ b/buildenv/ansible/inventories/local/hosts
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+all:
+  vars:
+    os: linux                       # linux, aix
+    version: jdk8                   # jdk8 or jdk9
+    platform: x86_64                # ppc64le, s390x, x86_64
+    target:
+      namespace: eclipse            
+      javahome: /opt/openj9
+      user: openj9
+      userid: 777
+      group: openj9
+      groupid: 777
+      push: no                      # do you wish to publish the image
+    build:
+      cleanup: yes                  # delete the build environment after a build
+  hosts:
+    localhost:                      # environment-related variables
+      ansible_connection: local
+      build_dir: /tmp/openj9-build
+      host_dir: /tmp/openj9-build/image
+  children:
+    buildserver:
+      hosts:
+        localhost

--- a/buildenv/ansible/openj9-docker-image.yml
+++ b/buildenv/ansible/openj9-docker-image.yml
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+---
+# This playbook builds the OpenJ9 JVM and publishes it as a Docker image
+
+- hosts: buildserver
+  force_handlers: no
+  remote_user: ansible
+
+  roles:
+    - openj9-build-environment
+    - openj9-from-sources
+    - openj9-image
+    - openj9-cleanup-build-environment
+

--- a/buildenv/ansible/roles/openj9-build-environment/tasks/main.yml
+++ b/buildenv/ansible/roles/openj9-build-environment/tasks/main.yml
@@ -1,0 +1,134 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+---
+- name: Create a build folder
+  file:
+    dest: "{{ build_dir }}" 
+    mode: 0755 
+    state: directory
+  tags:
+    - buildenv
+- name: Get Dockerfile for the building environment
+  get_url:
+    dest: "{{ build_dir }}/Dockerfile-base"
+    url: "https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/{{ version }}/{{ platform }}/ubuntu16/Dockerfile"
+    mode: 0644
+    validate_certs: no
+  tags:
+    - buildenv
+- name: Build the docker image for the building environment
+  docker_image:
+    path: "{{ build_dir }}"
+    dockerfile: Dockerfile-base
+    name: "openj9-{{ version }}-build"
+    tag: "latest"
+    rm: yes
+    push: no
+  tags:
+    - buildenv
+- name: Create a build result folder
+  file:
+    dest: "{{ host_dir }}" 
+    mode: 0755 
+    state: directory
+  tags:
+    - buildenv
+- name: Start the building environment as a docker container 
+  docker_container:
+    name: "openj9-{{ version }}-build"
+    image: "openj9-{{ version }}-build:latest"
+    state: started
+    restart: yes # without restart, the container wouldn't be able to touch any file in the host_dir folder
+    interactive: yes # without interactive, the container would be stopped just after it has been started
+    volumes: "{{ host_dir }}:/root/hostdir"
+  tags:
+    - buildenv
+- name: Get the ansible user
+  command: whoami
+  register: ansible_user
+  tags:
+    - buildenv
+    - build
+- name: Get the ansible uid
+  shell: "id {{ ansible_user.stdout }} | awk -F'uid=' '{printf \"%d\", $2}'"
+  register: ansible_uid
+  tags:
+    - buildenv
+- name: Get the ansible group
+  shell: "groups {{ ansible_user.stdout }} | awk -F' ' '{printf \"%s\", $3}'"
+  register: ansible_group
+  tags:
+    - buildenv
+    - build
+- name: Get the ansible gid
+  shell: "id {{ ansible_user.stdout }} | awk -F'gid=' '{printf \"%d\", $2}'"
+  register: ansible_gid
+  tags:
+    - buildenv
+- name: Add the container to inventory
+  add_host:      
+    name: "openj9-{{ version }}-build"
+    ansible_connection: docker
+    ansible_user: root
+  changed_when: false
+  tags:
+    - buildenv
+    - build
+- name: Install python to the container if there is no one
+  raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - buildenv
+- name: Add group "{{ target.group }}"
+  group: 
+    name: "{{ target.group }}"
+    gid:  "{{ target.groupid }}"
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - buildenv
+- name: Add user "{{ target.user }}"
+  user: 
+    name: "{{ target.user }}"
+    uid:  "{{ target.userid }}"
+    group: "{{ target.group }}" 
+    createhome: no
+    shell: /sbin/nologin
+  delegate_to: "openj9-{{ version }}-build"
+  tags: 
+    - buildenv
+- name: Add group "{{ ansible_group.stdout }}"
+  group: 
+    name: "{{ ansible_group.stdout }}"
+    gid:  "{{ ansible_gid.stdout }}"
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - buildenv
+- name: Add user "{{ ansible_user.stdout }}"
+  user: 
+    name: "{{ ansible_user.stdout }}"
+    uid:  "{{ ansible_uid.stdout }}"
+    group: "{{ ansible_group.stdout }}" 
+    createhome: no
+    shell: /sbin/nologin
+  delegate_to: "openj9-{{ version }}-build"
+  tags: 
+    - buildenv

--- a/buildenv/ansible/roles/openj9-cleanup-build-environment/tasks/main.yml
+++ b/buildenv/ansible/roles/openj9-cleanup-build-environment/tasks/main.yml
@@ -1,0 +1,51 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+---
+- name: Remove the building environment
+  docker_container:
+    name: "openj9-{{ version }}-build"
+    state: absent
+  when: build.cleanup
+  tags:
+    - cleanup
+- name: Remove the docker image for the building environment
+  docker_image:
+    name: "openj9-{{ version }}-build"    
+    tag: latest
+    state: absent
+  when: build.cleanup
+  tags:
+    - cleanup
+- name: Drop the build result folder
+  file:
+    dest: "{{ host_dir }}" 
+    state: absent
+  when: build.cleanup
+  tags:
+    - cleanup
+- name: Drop the build folder
+  file:
+    dest: "{{ build_dir }}" 
+    state: absent
+  when: build.cleanup
+  tags:
+    - cleanup

--- a/buildenv/ansible/roles/openj9-from-sources/tasks/main.yml
+++ b/buildenv/ansible/roles/openj9-from-sources/tasks/main.yml
@@ -1,0 +1,121 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+---
+- name: Checkout ibmruntimes
+  delegate_to: "openj9-{{ version }}-build"
+  git:
+    repo: "https://github.com/ibmruntimes/openj9-openjdk-{{ version }}"
+    dest: "/root/openj9-openjdk-{{ version }}"
+    version: openj9
+    update: yes
+    force: yes
+    accept_hostkey: yes
+  tags:
+    - build
+- name: Set get_source.sh as executable
+  delegate_to: "openj9-{{ version }}-build"
+  file:
+    path: "/root/openj9-openjdk-{{ version }}/get_source.sh"
+    mode: 0755
+  tags:
+    - build
+- name: Get the sources
+  delegate_to: "openj9-{{ version }}-build"
+  shell: "/root/openj9-openjdk-{{ version }}/get_source.sh"
+  args:
+    chdir: "/root/openj9-openjdk-{{ version }}"
+  tags:
+    - build
+- name: Set configure as executable
+  delegate_to: "openj9-{{ version }}-build"
+  file:
+    path: "/root/openj9-openjdk-{{ version }}/configure"
+    mode: 0755
+  tags:
+    - build
+- name: Configure
+  delegate_to: "openj9-{{ version }}-build"
+  shell: "/root/openj9-openjdk-{{ version }}/configure --with-freemarker-jar=/root/freemarker.jar"
+  args:
+    chdir: "/root/openj9-openjdk-{{ version }}"
+  tags:
+    - build
+    - compile
+- name: Make clean
+  delegate_to: "openj9-{{ version }}-build"
+  shell: "make clean"
+  args:
+    chdir: "/root/openj9-openjdk-{{ version }}"
+  when: not build.cleanup
+  tags:
+    - build
+    - compile
+- name: Make all
+  delegate_to: "openj9-{{ version }}-build"
+  shell: "make all"
+  args:
+    chdir: "/root/openj9-openjdk-{{ version }}"
+  tags:
+    - build
+    - compile
+- name: Check if j2sdk-image exists
+  stat:
+    path: "/root/openj9-openjdk-{{ version }}/build/{{ os }}-{{ platform }}-normal-server-release/images/j2sdk-image"
+  register: j2sdk
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - build
+- name: Create symlink j2sdk to jdk
+  file:
+    src: "/root/openj9-openjdk-{{ version }}/build/{{ os }}-{{ platform }}-normal-server-release/images/jdk"
+    dest: "/root/openj9-openjdk-{{ version }}/build/{{ os }}-{{ platform }}-normal-server-release/images/j2sdk-image"
+    state: link
+  when: not j2sdk.stat.exists
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - build
+- name: Change the owner of the built JDK
+  file:
+    path: "/root/openj9-openjdk-{{ version }}/build/{{ os }}-{{ platform }}-normal-server-release/images/j2sdk-image/"
+    recurse: yes
+    owner: "{{ target.user }}"
+    group: "{{ target.group }}"
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - build
+- name: Remove the previous version of the JDK archive
+  file:
+    path: "/root/hostdir/openj9-{{ version }}-{{ os }}-{{ platform }}.tar.gz"
+    state: absent
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - build
+- name: Archive the JDK
+  archive:
+    path: "/root/openj9-openjdk-{{ version }}/build/{{ os }}-{{ platform }}-normal-server-release/images/j2sdk-image/*"
+    dest: "/root/hostdir/openj9-{{ version }}-{{ os }}-{{ platform }}.tar.gz"
+    mode: 0644
+    owner: "{{ ansible_user.stdout }}"
+    group: "{{ ansible_group.stdout }}"
+  delegate_to: "openj9-{{ version }}-build"
+  tags:
+    - build

--- a/buildenv/ansible/roles/openj9-image/files/Dockerfile-ubuntu
+++ b/buildenv/ansible/roles/openj9-image/files/Dockerfile-ubuntu
@@ -1,0 +1,86 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+FROM ubuntu:16.04
+
+MAINTAINER Pavel Samolysov <samolisov@gmail.com> (@samolisov)
+
+# This section:
+# - Gets the prerequisites for the add-apt-repository
+# - Installs the required OS tools.
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+  && apt-get update
+
+# Set the java home directory
+ARG JAVA_HOME=/opt/openj9
+
+# Set group and group id
+ARG GROUP=openj9
+ARG GROUPID=999
+
+# Set user and user id
+ARG USER=openj9
+ARG USERID=999
+
+# Set the version, operating system and platform
+ARG VERSION=jdk8
+ARG OS=linux
+ARG PLATFORM=x86_64
+
+# Explicitly set user/group IDs
+RUN groupadd -r $GROUP --gid=$GROUPID && useradd -r -g $GROUP --uid=$USERID $USER
+
+# Create the java home directory
+RUN  mkdir -p $JAVA_HOME \
+  && chown -R $USER:$GROUP $JAVA_HOME
+
+# Copy in the JDK archive
+ADD openj9-$VERSION-$OS-$PLATFORM.tar.gz $JAVA_HOME
+
+# I have no idea why docker sets the owner of these folders
+# to root:root, chown returns the correct owner and doesn't 
+# increase the size of the image.
+RUN chown -f $USER:$GROUP $JAVA_HOME/bin || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/conf || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/demo || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/include || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/jmods || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/jre || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/legal || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/lib || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/man || : \
+  && chown -f $USER:$GROUP $JAVA_HOME/sample || :
+  # small hach to ensure chown for a non-exist directory won't interrupt the build process.
+
+# Change to the OpenJ9 user.
+USER $USER
+
+# Set the PATH environment variable
+ENV PATH $PATH:$JAVA_HOME/bin
+
+# Set the JAVA_HOME environment variable
+ENV JAVA_HOME $JAVA_HOME
+
+# Change the entry dir
+WORKDIR $JAVA_HOME

--- a/buildenv/ansible/roles/openj9-image/tasks/main.yml
+++ b/buildenv/ansible/roles/openj9-image/tasks/main.yml
@@ -1,0 +1,59 @@
+###############################################################################
+# Copyright (c) 2018, 2018 Pavel Samolysov
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+---
+- set_fact:
+    timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
+  tags:
+    - image
+- name: Create a target image build folder
+  file:
+    dest: "{{ host_dir }}" 
+    mode: 0755 
+    state: directory
+  tags:
+    - image
+- name: Get Dockerfile for the target image
+  copy:
+    src: Dockerfile-ubuntu
+    dest: "{{ host_dir }}/Dockerfile"
+    mode: 0644
+  tags:
+    - image
+- name: Build the target docker image
+  docker_image:
+    path: "{{ build_dir }}/image"
+    dockerfile: Dockerfile
+    name: "{{ target.namespace }}/openj9-{{ version }}"
+    tag: "{{ os }}-{{ platform }}-{{ timestamp }}"
+    rm: yes
+    push: "{{ target.push }}"
+    buildargs:
+      JAVA_HOME: "{{ target.javahome }}"
+      GROUP: "{{ target.group }}"
+      GROUPID: "{{ target.groupid }}"
+      USER: "{{ target.user }}"
+      USERID: "{{ target.userid }}"
+      OS: "{{ os }}"
+      VERSION: "{{ version }}"
+      PLATFORM: "{{ platform }}"
+  tags:
+    - image


### PR DESCRIPTION
Ansible is the most popular open source automation tool on GitHub today
with more than a quarter million downloads per month.

The ansible playbook produces a docker image based on Ubuntu 16.4. The docker
image contains the Eclipse OpenJ9 virtual machine. The owner of the virtual
machine is the `openj9` user (configurable) who is a member of the `openj9` group
(configurable). A container created over the image runs as the `openj9`
non-privileged user.

The build process is broken down into the following phases:
 - create a docker container with the build environment
 - checkout the sources of ibmruntimes, omr and openj9
 - build openj9 from sources
 - archive the jdk
 - create a docker image and put the jdk inside
 - clean-up the build-environment

How to run the build:
```bash
$  ansible-playbook -i inventories/local/hosts openj9-docker-image.yml
```
**Note:** Ansible 2.4+ is required.
