### PR TITLE
Remove dead code

### DIFF
--- a/buildspecs/aix_ppc-64.spec
+++ b/buildspecs/aix_ppc-64.spec
@@ -161,7 +161,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/aix_ppc-64_cmprssptrs.spec
+++ b/buildspecs/aix_ppc-64_cmprssptrs.spec
@@ -157,7 +157,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/aix_ppc-64_codecov.spec
+++ b/buildspecs/aix_ppc-64_codecov.spec
@@ -147,7 +147,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/aix_ppc.spec
+++ b/buildspecs/aix_ppc.spec
@@ -158,7 +158,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/j9.flags
+++ b/buildspecs/j9.flags
@@ -957,13 +957,6 @@ Currently only available on linux_x86 and win_x96 32 bit builds.</description>
 			<require flag="interp_gpHandler"/>
 		</requires>
 	</flag>
-	<flag id="interp_sigQuitThreadUsesSemaphores">
-		<description>Controls if a SIGQUIT handler thread uses Semaphores or sigwait.</description>
-		<ifRemoved>thread will use sigwait.</ifRemoved>
-		<requires>
-			<require flag="interp_sigQuitThread"/>
-		</requires>
-	</flag>
 	<flag id="interp_smallMonitorSlot">
 		<description>Flag to indicate that on 64-bit platforms, the monitor slot in object headers is a U32 rather than a UDATA.</description>
 		<ifRemoved>The monitor slot is a UDATA.</ifRemoved>

--- a/buildspecs/linux_390-64.spec
+++ b/buildspecs/linux_390-64.spec
@@ -158,7 +158,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_390-64_cmprssptrs.spec
@@ -162,7 +162,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_390-64_cmprssptrs_codecov.spec
+++ b/buildspecs/linux_390-64_cmprssptrs_codecov.spec
@@ -154,7 +154,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_390-64_codecov.spec
+++ b/buildspecs/linux_390-64_codecov.spec
@@ -148,7 +148,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_390.spec
+++ b/buildspecs/linux_390.spec
@@ -159,7 +159,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_arm.spec
+++ b/buildspecs/linux_arm.spec
@@ -167,7 +167,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_arm_linaro.spec
+++ b/buildspecs/linux_arm_linaro.spec
@@ -166,7 +166,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ppc-64.spec
+++ b/buildspecs/linux_ppc-64.spec
@@ -158,7 +158,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs.spec
@@ -156,7 +156,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le.spec
@@ -160,7 +160,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
@@ -160,7 +160,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ppc-64_le.spec
+++ b/buildspecs/linux_ppc-64_le.spec
@@ -160,7 +160,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ppc-64_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_le_gcc.spec
@@ -159,7 +159,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ppc.spec
+++ b/buildspecs/linux_ppc.spec
@@ -157,7 +157,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/linux_x86-64.spec
+++ b/buildspecs/linux_x86-64.spec
@@ -164,7 +164,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -161,7 +161,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs_cs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs_cs.spec
@@ -153,7 +153,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs_panama.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs_panama.spec
@@ -161,7 +161,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_x86-64_codecov.spec
+++ b/buildspecs/linux_x86-64_codecov.spec
@@ -149,7 +149,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_x86.spec
+++ b/buildspecs/linux_x86.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,7 +174,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_x86_codecov.spec
+++ b/buildspecs/linux_x86_codecov.spec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2006, 2017 IBM Corp. and others
+  Copyright (c) 2006, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -148,7 +148,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ztpf_390-64.spec
+++ b/buildspecs/linux_ztpf_390-64.spec
@@ -151,7 +151,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/linux_ztpf_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_ztpf_390-64_cmprssptrs.spec
@@ -149,7 +149,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/osx_x86-64.spec
+++ b/buildspecs/osx_x86-64.spec
@@ -161,7 +161,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/win_x86-64.spec
+++ b/buildspecs/win_x86-64.spec
@@ -170,7 +170,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -167,7 +167,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/win_x86.spec
+++ b/buildspecs/win_x86.spec
@@ -174,7 +174,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>
 		<flag id="ive_jxeNatives" value="true"/>

--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -160,7 +160,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -160,7 +160,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/buildspecs/zos_390.spec
+++ b/buildspecs/zos_390.spec
@@ -157,7 +157,6 @@
 		<flag id="interp_nativeSupport" value="true"/>
 		<flag id="interp_profilingBytecodes" value="true"/>
 		<flag id="interp_sigQuitThread" value="true"/>
-		<flag id="interp_sigQuitThreadUsesSemaphores" value="true"/>
 		<flag id="interp_useUnsafeHelper" value="true"/>
 		<flag id="ive_jxeFileRelocator" value="true"/>
 		<flag id="ive_jxeInPlaceRelocator" value="true"/>

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -903,10 +903,6 @@ typedef struct J9VMDllLoadInfo {
 	void* reserved;
 } J9VMDllLoadInfo;
 
-typedef struct J9VMSemaphore {
-	j9sem_t sem;
-} J9VMSemaphore;
-
 typedef struct J9SigContext {
 	IDATA sigNum;
 	void* sigInfo;
@@ -5028,7 +5024,6 @@ struct J9Pool; /* Forward struct declaration */
 struct J9JXEDescription ; /* Forward struct declaration */
 struct J9SharedClassPreinitConfig; /* Forward struct declaration */
 struct J9ConstantPool ; /* Forward struct declaration */
-struct J9VMSemaphore; /* Forward struct declaration */
 struct J9RASdumpFunctions; /* Forward struct declaration */
 struct J9ROMClass ; /* Forward struct declaration */
 struct J9RAS; /* Forward struct declaration */
@@ -5221,9 +5216,7 @@ typedef struct J9JavaVM {
 	IDATA sigQuitFlags;
 	omrthread_t sigQuitThread;
 	omrthread_monitor_t sigQuitMutex;
-	struct J9VMSemaphore* sigQuitSemaphore;
 	void  ( *J9SigQuitShutdown)(struct J9JavaVM *vm) ;
-	IDATA  ( *j9SemPost)(j9sem_t s) ;
 	U_32 globalEventFlags;
 	void  ( *sidecarInterruptFunction)(struct J9VMThread * vmThread) ;
 	struct J9ReflectFunctionTable reflectFunctions;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5213,9 +5213,6 @@ typedef struct J9JavaVM {
 	UDATA gcPolicy;
 	UDATA gcCycleOn;
 	omrthread_monitor_t gcCycleOnMonitor;
-	IDATA sigQuitFlags;
-	omrthread_t sigQuitThread;
-	omrthread_monitor_t sigQuitMutex;
 	void  ( *J9SigQuitShutdown)(struct J9JavaVM *vm) ;
 	U_32 globalEventFlags;
 	void  ( *sidecarInterruptFunction)(struct J9VMThread * vmThread) ;


### PR DESCRIPTION
1) Removed unused references to j9sem_t.
2) Removed unused fields in struct J9JavaVM: sigQuitFlags, sigQuitThread and sigQuitMutex.
3) Removed obsolete flag from buildspecs: interp_sigQuitThreadUsesSemaphores.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>