### PR TITLE
Enable System.startSNMPAgent in OpenJ9 Java 8

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -184,8 +184,10 @@ void completeInitialization() {
 	contextClassLoader = ClassLoader.getSystemClassLoader();
 	/*[IF Sidecar19-SE]*/
 	jdk.internal.misc.VM.initLevel(4);
+	/*[ENDIF]*/ // Sidecar19-SE
+	/*[IF Sidecar19-SE|Sidecar18-SE-OpenJ9]*/
 	System.startSNMPAgent();
-	/*[ENDIF]*/
+	/*[ENDIF]*/ // Sidecar19-SE|Sidecar18-SE-OpenJ9
 }
 
 /**

--- a/runtime/jcl/uma/se8_exports.xml
+++ b/runtime/jcl/uma/se8_exports.xml
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2014, 2017 IBM Corp. and others
+	Copyright (c) 2014, 2018 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,4 +28,5 @@
 	<export name="Java_java_util_stream_IntPipeline_promoteGPUCompile" />
 	<export name="Java_com_ibm_lang_management_internal_UnixExtendedOperatingSystem_getMaxFileDescriptorCountImpl" />
 	<export name="Java_com_ibm_lang_management_internal_UnixExtendedOperatingSystem_getOpenFileDescriptorCountImpl" />
+	<export name="Java_java_lang_System_startSNMPAgent" />
 </exports>

--- a/runtime/jcl/uma/se9_exports.xml
+++ b/runtime/jcl/uma/se9_exports.xml
@@ -50,7 +50,6 @@
 	<export name="Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefIndexAt0" />
 	<export name="Java_jdk_internal_reflect_ConstantPool_getNameAndTypeRefInfoAt0" />
 	<export name="Java_jdk_internal_reflect_ConstantPool_getTagAt0" />
-	<export name="Java_java_lang_System_startSNMPAgent" />
 	<export name="Java_java_lang_StackWalker_walkWrapperImpl" />
 	<export name="Java_java_lang_StackWalker_getImpl" />
 	<export name="Java_java_lang_invoke_MethodHandles_findNativeAddress">


### PR DESCRIPTION
Enable the same code as Java 9 for launching mbean server.

Fixes #1196 

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>