### PR TITLE
Relax AOT processor feature compatibility check

### DIFF
--- a/runtime/compiler/trj9/control/rossa.cpp
+++ b/runtime/compiler/trj9/control/rossa.cpp
@@ -1082,7 +1082,7 @@ onLoadInternal(
       return -1;
 
 #if defined(TR_TARGET_X86)
-   TR_J9VM::initializeX86ProcessorVendorId(jitConfig);
+   TR_J9VM::initializeX86ProcessorInfo(jitConfig);
 #endif
 
    if (!TR_J9VMBase::createGlobalFrontEnd(jitConfig, TR::CompilationInfo::get()))

--- a/runtime/compiler/trj9/env/J9CPU.cpp
+++ b/runtime/compiler/trj9/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,69 +49,3 @@ J9::CPU::TO_PORTLIB_getJ9ProcessorDesc()
    return &processorDesc;
    }
 
-
-bool
-J9::CPU::getPPCSupportsVMX()
-   {
-#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
-   return FALSE;
-#else
-   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
-   BOOLEAN feature = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_ALTIVEC);
-   return (TRUE == feature);
-#endif
-   }
-
-bool
-J9::CPU::getPPCSupportsVSX()
-   {
-#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
-   return FALSE;
-#else
-   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
-   BOOLEAN feature = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_VSX);
-   return (TRUE == feature);
-#endif
-   }
-
-bool
-J9::CPU::getPPCSupportsAES()
-   {
-#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
-   return FALSE;
-#else
-   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
-   BOOLEAN hasVMX  = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_ALTIVEC);
-   BOOLEAN hasVSX  = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_VSX);
-   BOOLEAN isP8    = (processorDesc->processor >= PROCESSOR_PPC_P8);
-   return (isP8 && hasVMX && hasVSX);
-#endif
-   }
-
-bool
-J9::CPU::getPPCSupportsTM()
-   {
-#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
-   return FALSE;
-#else
-   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
-   BOOLEAN feature = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HTM);
-   return (TRUE == feature);
-#endif
-   }
-   
-bool
-J9::CPU::getPPCSupportsLM()
-  {
-#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
-  return FALSE;
-#else
-  J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
-  BOOLEAN isP9    = (processorDesc->processor >= PROCESSOR_PPC_P9);
-  return FALSE;
-#endif
-   }

--- a/runtime/compiler/trj9/env/J9CPU.hpp
+++ b/runtime/compiler/trj9/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,6 @@ namespace J9 { typedef CPU CPUConnector; }
 #include "env/OMRCPU.hpp"
 #include "j9port.h"
 
-
 namespace J9
 {
 class CPU : public OMR::CPUConnector
@@ -44,11 +43,7 @@ protected:
    CPU() : OMR::CPUConnector() {}
 
 public:
-   bool getPPCSupportsVMX();
-   bool getPPCSupportsVSX();
-   bool getPPCSupportsAES();
-   bool getPPCSupportsTM();
-   bool getPPCSupportsLM();
+
    J9ProcessorDesc *TO_PORTLIB_getJ9ProcessorDesc();
    };
 }

--- a/runtime/compiler/trj9/env/ProcessorDetection.cpp
+++ b/runtime/compiler/trj9/env/ProcessorDetection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -570,7 +570,7 @@ char TR_J9VMBase::x86VendorID[] = {'U','n','k','n','o','w','n','B','r','a','n','
 bool TR_J9VMBase::x86VendorIDInitialized = false;
 
 void
-TR_J9VMBase::initializeX86ProcessorVendorId(J9JITConfig *jitConfig)
+TR_J9VMBase::initializeX86ProcessorInfo(J9JITConfig *jitConfig)
    {
    TR_ASSERT(jitConfig, "jitConfig is not defined!");
    TR_ASSERT(jitConfig->javaVM, "jitConfig->javaVM is not defined!");
@@ -579,9 +579,17 @@ TR_J9VMBase::initializeX86ProcessorVendorId(J9JITConfig *jitConfig)
    //
    strncpy(x86VendorID, queryX86TargetCPUID(jitConfig->javaVM)->_vendorId, 12);
    x86VendorID[12] = '\0';
-
    x86VendorIDInitialized = true;
+
+   // Initialize processorFeatureFlags
+   //
+#if defined(TR_TARGET_X86)
+   TR::Compiler->target.cpu.setX86ProcessorFeatureFlags(queryX86TargetCPUID(jitConfig->javaVM)->_featureFlags);
+   TR::Compiler->target.cpu.setX86ProcessorFeatureFlags2(queryX86TargetCPUID(jitConfig->javaVM)->_featureFlags2);
+   TR::Compiler->target.cpu.setX86ProcessorFeatureFlags8(queryX86TargetCPUID(jitConfig->javaVM)->_featureFlags8);
+#endif // TR_TARGET_X86
    }
+
 
 const char *
 TR_J9VMBase::getX86ProcessorVendorId()
@@ -654,6 +662,7 @@ TR_J9VMBase::getX86SupportsPOPCNT()
       return true;
    else return false;
    }
+
 
 // -----------------------------------------------------------------------------
 

--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -273,7 +273,7 @@ public:
    static TR_J9VMBase * get(J9JITConfig *, J9VMThread *, VM_TYPE vmType=DEFAULT_VM);
    static char *getJ9FormattedName(J9JITConfig *, J9PortLibrary *, char *, int32_t, char *, char *, bool suffix=false);
    static TR_Processor getPPCProcessorType();
-   static void initializeX86ProcessorVendorId(J9JITConfig *);
+   static void initializeX86ProcessorInfo(J9JITConfig *);
 
    static bool isBigDecimalClass(J9UTF8 * className);
    bool isCachedBigDecimalClassFieldAddr(){ return cachedStaticDFPAvailField; }

--- a/runtime/compiler/trj9/p/env/J9CPU.cpp
+++ b/runtime/compiler/trj9/p/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,9 +31,76 @@ namespace J9
 namespace Power
 {
 
+bool
+CPU::getPPCSupportsVMX()
+   {
+#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
+   return FALSE;
+#else
+   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
+   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
+   BOOLEAN feature = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_ALTIVEC);
+   return (TRUE == feature);
+#endif
+   }
+
+bool
+CPU::getPPCSupportsVSX()
+   {
+#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
+   return FALSE;
+#else
+   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
+   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
+   BOOLEAN feature = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_VSX);
+   return (TRUE == feature);
+#endif
+   }
+
+bool
+CPU::getPPCSupportsAES()
+   {
+#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
+   return FALSE;
+#else
+   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
+   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
+   BOOLEAN hasVMX  = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_ALTIVEC);
+   BOOLEAN hasVSX  = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HAS_VSX);
+   BOOLEAN isP8    = (processorDesc->processor >= PROCESSOR_PPC_P8);
+   return (isP8 && hasVMX && hasVSX);
+#endif
+   }
+
+bool
+CPU::getPPCSupportsTM()
+   {
+#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
+   return FALSE;
+#else
+   J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
+   J9PortLibrary     *privatePortLibrary  = TR::Compiler->portLib;
+   BOOLEAN feature = j9sysinfo_processor_has_feature(processorDesc, J9PORT_PPC_FEATURE_HTM);
+   return (TRUE == feature);
+#endif
+   }
+   
+bool
+CPU::getPPCSupportsLM()
+  {
+#if defined(J9OS_I5) && defined(J9OS_I5_V5R4)
+  return FALSE;
+#else
+  J9ProcessorDesc   *processorDesc       = TR::Compiler->target.cpu.TO_PORTLIB_getJ9ProcessorDesc();
+  BOOLEAN isP9    = (processorDesc->processor >= PROCESSOR_PPC_P9);
+  return FALSE;
+#endif
+   }
+
 // Double check with os400 team to see if we can enable popcnt on I
 //
-bool CPU::hasPopulationCountInstruction()
+bool 
+CPU::hasPopulationCountInstruction()
    {
 #if defined(J9OS_I5)
    return false;
@@ -43,7 +110,8 @@ bool CPU::hasPopulationCountInstruction()
    }
 
 
-bool CPU::supportsDecimalFloatingPoint()
+bool
+CPU::supportsDecimalFloatingPoint()
    {
 #if !defined(TR_HOST_POWER) || (defined(J9OS_I5) && defined(J9OS_I5_V5R4))
    return FALSE;
@@ -55,7 +123,33 @@ bool CPU::supportsDecimalFloatingPoint()
 #endif
    }
 
+TR_ProcessorFeatureFlags
+CPU::getProcessorFeatureFlags()
+   {
+   TR_ProcessorFeatureFlags processorFeatureFlags = { {0} };
+   return processorFeatureFlags;
+   }
 
+bool
+CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+   {
+   TR_Processor targetProcessor = self()->id();
+   // Backwards compatibility only applies to p4,p5,p6,p7 and onwards
+   // Looks for equality otherwise
+   if ((processorSignature == TR_PPCgp 
+       || processorSignature == TR_PPCgr 
+       || processorSignature == TR_PPCp6 
+       || (processorSignature >= TR_PPCp7 && processorSignature <= TR_LastPPCProcessor))
+       && (targetProcessor == TR_PPCgp 
+        || targetProcessor == TR_PPCgr 
+        || targetProcessor == TR_PPCp6 
+        || targetProcessor >= TR_PPCp7 && targetProcessor <= TR_LastPPCProcessor))
+      {
+      return self()->isAtLeast(processorSignature);
+      }
+   return self()->is(processorSignature);
+   }
+   
 }
 
 }

--- a/runtime/compiler/trj9/p/env/J9CPU.hpp
+++ b/runtime/compiler/trj9/p/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,19 @@ namespace J9 { typedef J9::Power::CPU CPUConnector; }
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PROCESSOR_FEATURES_SIZE 1
+typedef struct TR_ProcessorFeatureFlags {
+  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
+} TR_ProcessorFeatureFlags;
+
+#ifdef __cplusplus
+}
+#endif
+
 namespace J9
 {
 
@@ -54,9 +67,17 @@ protected:
       {}
 
 public:
+   bool getPPCSupportsVMX();
+   bool getPPCSupportsVSX();
+   bool getPPCSupportsAES();
+   bool getPPCSupportsTM();
+   bool getPPCSupportsLM();
 
    bool hasPopulationCountInstruction();
    bool supportsDecimalFloatingPoint();
+
+   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
+   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
 
    };
 

--- a/runtime/compiler/trj9/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/trj9/runtime/RelocationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
 #include "trj9/env/j9method.h"
 #include "trj9/runtime/HWProfiler.hpp"
 #include "env/VMJ9.h"
+#include "env/J9CPU.hpp" // for TR_ProcessorFeatureFlags
 
 namespace TR { class CompilationInfo; }
 class TR_RelocationRecord;
@@ -60,7 +61,7 @@ extern "C" {
  */
 
 #define TR_AOTHeaderMajorVersion 5
-#define TR_AOTHeaderMinorVersion 0
+#define TR_AOTHeaderMinorVersion 1
 #define TR_AOTHeaderEyeCatcher   0xA0757A27
 
 /* AOT Header Flags */
@@ -103,11 +104,7 @@ typedef struct TR_AOTHeader {
     uintptr_t compressedPointerShift;
     uint32_t lockwordOptionHashValue;
     int32_t   arrayLetLeafSize;
-#if defined(TR_TARGET_X86)
-    uint32_t x86FeatureFlags;
-    uint32_t x86FeatureFlags2;
-    uint32_t x86FeatureFlags8;
-#endif
+    TR_ProcessorFeatureFlags processorFeatureFlags;
 } TR_AOTHeader;
 
 typedef struct TR_AOTRuntimeInfo {

--- a/runtime/compiler/trj9/x/env/J9CPU.cpp
+++ b/runtime/compiler/trj9/x/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,43 @@ bool
 CPU::testOSForSSESupport(TR::Compilation *comp)
    {
    return comp->fej9()->testOSForSSESupport();
+   }
+
+void
+CPU::setX86ProcessorFeatureFlags(uint32_t flags)
+   {
+   _featureFlags = flags;
+   }
+
+void
+CPU::setX86ProcessorFeatureFlags2(uint32_t flags2)
+   {
+   _featureFlags2 = flags2;
+   }
+
+void
+CPU::setX86ProcessorFeatureFlags8(uint32_t flags8)
+   {
+   _featureFlags8 = flags8;
+   }
+
+TR_ProcessorFeatureFlags
+CPU::getProcessorFeatureFlags()
+   {
+   TR_ProcessorFeatureFlags processorFeatureFlags = { {_featureFlags, _featureFlags2, _featureFlags} };
+   return processorFeatureFlags;
+   }
+
+bool
+CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+   {
+   for (int i = 0; i < PROCESSOR_FEATURES_SIZE; i++)
+      {
+      // Check to see if the current processor contains all the features that code cache's processor has
+      if ((processorFeatureFlags.featureFlags[i] & self()->getProcessorFeatureFlags().featureFlags[i]) != processorFeatureFlags.featureFlags[i])
+         return false;
+      }
+   return true;
    }
 
 }

--- a/runtime/compiler/trj9/x/env/J9CPU.hpp
+++ b/runtime/compiler/trj9/x/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,18 @@ namespace J9 { typedef J9::X86::CPU CPUConnector; }
 
 namespace TR { class Compilation; }
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PROCESSOR_FEATURES_SIZE 3
+typedef struct TR_ProcessorFeatureFlags {
+  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
+} TR_ProcessorFeatureFlags;
+
+#ifdef __cplusplus
+}
+#endif
 
 namespace J9
 {
@@ -50,7 +62,10 @@ class CPU : public J9::CPU
 protected:
 
    CPU() :
-         J9::CPU()
+         J9::CPU(),
+         _featureFlags(0),
+         _featureFlags2(0),
+         _featureFlags8(0)
       {}
 
 public:
@@ -61,7 +76,20 @@ public:
    uint32_t getX86ProcessorFeatureFlags2(TR::Compilation *comp);
    uint32_t getX86ProcessorFeatureFlags8(TR::Compilation *comp);
 
+   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
+   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
+
    bool testOSForSSESupport(TR::Compilation *comp);
+
+   void setX86ProcessorFeatureFlags(uint32_t flags);
+   void setX86ProcessorFeatureFlags2(uint32_t flags2);
+   void setX86ProcessorFeatureFlags8(uint32_t flags8);
+
+private:
+   uint32_t _featureFlags;
+   uint32_t _featureFlags2;
+   uint32_t _featureFlags8;
+
    };
 
 }

--- a/runtime/compiler/trj9/z/env/J9CPU.cpp
+++ b/runtime/compiler/trj9/z/env/J9CPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -772,6 +772,28 @@ CPU::initializeS390zOSProcessorFeatures()
       }
    }
 
+TR_ProcessorFeatureFlags
+CPU::getProcessorFeatureFlags()
+   {
+   TR_ProcessorFeatureFlags processorFeatureFlags = { {_flags.getValue()} };
+   return processorFeatureFlags;
+   }
+
+bool
+CPU::isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags)
+   {
+   if (!self()->isAtLeast(processorSignature))
+      {
+      return false;
+      }
+   for (int i = 0; i < PROCESSOR_FEATURES_SIZE; i++)
+      {
+      // Check to see if the current processor contains all the features that code cache's processor has
+      if ((processorFeatureFlags.featureFlags[i] & self()->getProcessorFeatureFlags().featureFlags[i]) != processorFeatureFlags.featureFlags[i])
+         return false;
+      }
+   return true;
+   }
 
 }
 

--- a/runtime/compiler/trj9/z/env/J9CPU.hpp
+++ b/runtime/compiler/trj9/z/env/J9CPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,19 @@ namespace J9 { typedef J9::Z::CPU CPUConnector; }
 #include "env/ProcessorInfo.hpp"
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PROCESSOR_FEATURES_SIZE 1
+typedef struct TR_ProcessorFeatureFlags {
+  uint32_t featureFlags[PROCESSOR_FEATURES_SIZE];
+} TR_ProcessorFeatureFlags;
+
+#ifdef __cplusplus
+}
+#endif
 
 namespace J9
 {
@@ -186,6 +199,9 @@ public:
 
    void initializeS390zLinuxProcessorFeatures();
    void initializeS390zOSProcessorFeatures();
+
+   TR_ProcessorFeatureFlags getProcessorFeatureFlags();
+   bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
 
 private:
 


### PR DESCRIPTION
- Currently AOT compatibility check looks for a perfect match in terms of processor models and processor features
- This fix will allow AOT loads to be permitted when the features of the processor are the same or a super set and when the processor models are compatible

Issue: #1105
Signed-off-by: Harry Yu <harryyu1994@gmail.com>