### PR TITLE
Remove unnecessary $(D) in -DRESJAR value for stackSizeInfoTest

### DIFF
--- a/test/cmdLineTests/stackSizeInfoTest/playlist.xml
+++ b/test/cmdLineTests/stackSizeInfoTest/playlist.xml
@@ -30,7 +30,7 @@
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-DRESJAR=$(D)$(CMDLINETESTER_RESJAR)$(D) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stack' \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -verbose:stack' \
 	-Xint -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)StackSizeInfoTest.xml$(Q) \
 	-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError ; \
 	${TEST_STATUS}</command>


### PR DESCRIPTION
Fixes: #831

Signed-off-by: lanxia <lan_xia@ca.ibm.com>