### PR TITLE
Remove #if defined in j9nonbuilder.h to fix DDR compile error

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -139,9 +139,7 @@
 #define J9AccSynchronized 0x20
 #define J9AccSynthetic 0x1000
 #define J9AccTransient 0x80
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 #define J9AccValueType 0x100
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #define J9AccVarArgs 0x80
 #define J9AccVolatile 0x40
 #define J9StaticFieldRefBaseType 0x1


### PR DESCRIPTION
Resolves DDR compile error introduced in:
9a88388c32389458b98adb3bfa26ab882f59cf53

Signed-off-by: Eric Zhang <eric99.zhang@gmail.com>