### PR TITLE
Don't report final field modification at jit compile time

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -687,6 +687,13 @@ illegalAccess:
 					staticAddress = NULL;
 					goto done;
 				} else { /* finalFieldSetAllowed */
+					if (0 != jitFlags) {
+						/* Don't report the final field modification for JIT compile-time resolves.
+					 	 * Reporting may deadlock due to interaction between safepoint and ClassUnloadMutex.
+					 	 */
+						staticAddress = NULL;
+						goto done;
+					}
 					VM_VMHelpers::reportFinalFieldModified(vmStruct, definingClass);
 				}
 			}


### PR DESCRIPTION
JIT compile time resolves shouldn't report the final field modifications.
Reporting can cause deadlocks between the safepoint exclusive and
ClassUnloadMutex.

Better to fail the compile resolve and act as though unresolved.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>