### PR TITLE
Delete unused tenant-related constants

### DIFF
--- a/runtime/jit_vm/ctsupport.c
+++ b/runtime/jit_vm/ctsupport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ jitGetClassOfFieldFromCP(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDA
 	if (J9RAMSTATICFIELDREF_IS_RESOLVED(ramRefWrapper)) {
 		J9Class *classWrapper = J9RAMSTATICFIELDREF_CLASS(ramRefWrapper);
 		UDATA initStatus = classWrapper->initializeStatus;
-		if ((J9ClassInitSucceeded == initStatus)  || (J9ClassInitTenant == initStatus)  || ((UDATA) vmStruct == initStatus)) {
+		if ((J9ClassInitSucceeded == initStatus) || ((UDATA) vmStruct == initStatus)) {
 			result = classWrapper;
 		}
 	}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -165,7 +165,6 @@
 #define J9FieldFlagConstant 0x400000
 #define J9FieldFlagHasFieldAnnotations 0x20000000
 #define J9FieldFlagHasGenericSignature 0x40000000
-#define J9FieldFlagHasTenantAnnotation 0x0
 #define J9FieldFlagHasTypeAnnotations 0x800000
 #define J9FieldFlagIsContended 0x10000000
 #define J9FieldFlagUnused_2000000 0x2000000
@@ -222,13 +221,12 @@
 
 /* @ddr_namespace: map_to_type=J9ClassInitFlags */
 /* Constants from J9ClassInitFlags */
-#define J9ClassInitFailed 0x2
 #define J9ClassInitNotInitialized 0x0
-#define J9ClassInitStatusMask 0xFF
 #define J9ClassInitSucceeded 0x1
-#define J9ClassInitTenant 0x5
-#define J9ClassInitUnprepared 0x4
+#define J9ClassInitFailed 0x2
 #define J9ClassInitUnverified 0x3
+#define J9ClassInitUnprepared 0x4
+#define J9ClassInitStatusMask 0xFF
 
 /* @ddr_namespace: map_to_type=J9DescriptionBits */
 /* Constants from J9DescriptionBits */

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -621,7 +621,7 @@ tryAgain:
 		fieldLookupFlags = 0;
 		if (jitFlags) {
 			UDATA initStatus = resolvedClass->initializeStatus;
-			if ( (J9ClassInitSucceeded != initStatus) && (J9ClassInitTenant != initStatus) ) {
+			if (J9ClassInitSucceeded != initStatus) {
 				goto done;
 			}
 			fieldLookupFlags |= J9_RESOLVE_FLAG_NO_THROW_ON_FAIL;
@@ -715,7 +715,7 @@ illegalAccess:
 			/* If this is a JIT compile-time resolve, do not allow fields declared in uninitialized classes. */
 			if (jitFlags) {
 				UDATA initStatus = localClassAndFlags->initializeStatus;
-				if ( (J9ClassInitSucceeded != initStatus) && (J9ClassInitTenant != initStatus) ) {
+				if (J9ClassInitSucceeded != initStatus) {
 					staticAddress = NULL;
 					goto done;
 				}


### PR DESCRIPTION
Remove constants and all references:
* J9ClassInitTenant
* J9FieldFlagHasTenantAnnotation

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>