### PR TITLE
Fix failed target

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -114,16 +114,6 @@ make test
 
 4. Run tests:
 
-  * all tests
-    - compile & run tests
-        ```
-        make test
-        ```
-    - run all tests without recompiling them
-        ```
-        make runtest
-        ```
-
   * group of tests <br />
     make _group <br />
     e.g., 
@@ -161,6 +151,16 @@ make test
     make -f autoGen.mk _sanity
     ```
 
+  * all tests
+    - compile & run tests
+        ```
+        make test
+        ```
+    - run all tests without recompiling them
+        ```
+        make runtest
+        ```
+
   * against specific (e.g., hotspot SE80) SDK
 
     impl and subset are used to annotate tests in playlist.xml, 
@@ -169,7 +169,7 @@ make test
 
   * rerun the failed tests from the last run
     ```
-    make failed
+    make _failed
     ```
 
   * with a different set of JVM options

--- a/test/TestConfig/makefile
+++ b/test/TestConfig/makefile
@@ -51,11 +51,19 @@ test: compile runtest
 
 .NOTPARALLEL: test
 
+failed:
+	@$(MAKE) -f failedtargets.mk failed
+
+.PHONY: failed
+
+.NOTPARALLEL: failed
+
 cleanBuild:
 	$(RM) -r $(BUILD_ROOT)
 
 clean: cleanBuild
 	$(RM) -r $(TEST_ROOT)$(D)TestConfig$(D)test_output_*
+	$(RM) $(FAILEDTARGETS)
 
 .PHONY: cleanBuild clean
 

--- a/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
+++ b/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
@@ -174,12 +174,17 @@ sub failureMkGen {
 		. "########################################################\n"
 		. "\n";
 		print $fhOut $headerComments;
-		print $fhOut "failed:";
-		print $fhOut " \\\nrmResultFile";
+		print $fhOut ".DEFAULT_GOAL := failed\n\n"
+					. "D = /\n\n"
+					. "ifndef TEST_ROOT\n"
+					. "\tTEST_ROOT := \$(shell pwd)\$(D)..\n"
+					. "endif\n\n"
+					. "failed:\n";
 		foreach my $target (@$failureTargets) {
-			print $fhOut " \\\n" . $target;
+			print $fhOut '	@$(MAKE) -C $(TEST_ROOT) -f autoGen.mk ' . $target . "\n";
 		}
-		print $fhOut " \\\nresultsSummary";
+		print $fhOut "\n.PHONY: failed\n"
+					. ".NOTPARALLEL: failed";
 		close $fhOut;
 	}
 }

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -255,9 +255,7 @@ endif
 #######################################
 # failed target
 #######################################
-FAILEDTARGETS = $(TESTOUTPUT)$(D)failedtargets.mk
-#TODO: disable failed target until fix
-#-include $(FAILEDTARGETS)
+FAILEDTARGETS = $(TEST_ROOT)$(D)TestConfig$(D)failedtargets.mk
 
 #######################################
 # result Summary


### PR DESCRIPTION
- Failed target is used to rerun failed targets in last run.
- The mechanism was broken due to the latest testKitGen update. 
- This PR provides fix the mechanism.
- Update test README.md

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>