### PR TITLE
Add null check for j.l.security.AccessControlContext.context

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -838,16 +838,10 @@ public boolean equals(Object o) {
 public int hashCode() {
 	int result = 0;
 	int i = context == null ? 0 : context.length;
-	while (--i >= 0)
+	while ((--i >= 0) && (context[i] != null)) {
 		result ^= context[i].hashCode();
-/*
-	// JCK test doesn't include following two fields during hashcode calculation
-	if (null != this.domainCombiner) {
-		result ^= this.domainCombiner.hashCode();
 	}
 
-	result = result + (this.isAuthorized ? 1231 : 1237);
-*/
 	// RI equals not impacted by limited context,
 	// JCK still passes with following cause the AccessControlContext in question doesn't have limited context
 	// J9 might fail JCK test if JCK hashcode test changes

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -240,10 +240,12 @@ private static boolean checkPermissionHelper(Permission perm, AccessControlConte
 			checked = new AccessCache(); /* checked was null initially when Pre-JEP140 format */
 			return AccessControlContext.checkPermissionWithCache(perm, pDomains, debug, acc, false, null, null, checked);
 		} else {
-			for (int i = 0; i < length ; ++i) {
-				// invoke PD within acc.context first
-				if (null != pDomains && !pDomains[length - i - 1].implies(perm)) {
-					throwACE((debug & AccessControlContext.DEBUG_ACCESS_DENIED) != 0, perm, pDomains[length - i - 1], false);
+			if (pDomains != null) {
+				for (int i = 0; i < length ; ++i) {
+					// invoke PD within acc.context first
+					if ((pDomains[length - i - 1] != null) && !pDomains[length - i - 1].implies(perm)) {
+						throwACE((debug & AccessControlContext.DEBUG_ACCESS_DENIED) != 0, perm, pDomains[length - i - 1], false);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Add `null` check for `j.l.security.AccessControlContext.context`

This is to guard potential `null` elements returned from `j.l.security.DomainCombiner.combine()`.

Reviewer @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>