### PR TITLE
Change fastIdentityHashCode() to use unsigned int to long conversion

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -30,7 +30,7 @@ import com.ibm.oti.util.Msg;
 
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -439,7 +439,7 @@ final class J9VMInternals {
 				}
 			}
 		} else {
-			long ptr = (com.ibm.oti.vm.VM.FJ9OBJECT_SIZE == 4) ?  h.getIntFromObject(anObject, 0L) : h.getLongFromObject(anObject, 0L);
+			long ptr = (com.ibm.oti.vm.VM.FJ9OBJECT_SIZE == 4) ? Integer.toUnsignedLong(h.getIntFromObject(anObject, 0L)) : h.getLongFromObject(anObject, 0L);
 			if ((ptr & com.ibm.oti.vm.VM.OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS) != 0) {
 				if (!h.isArray(anObject)) {
 					long j9class = ptr & com.ibm.oti.vm.VM.J9_JAVA_CLASS_MASK;

--- a/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/trj9/codegen/J9RecognizedMethodsEnum.hpp
@@ -427,6 +427,7 @@
    java_lang_Integer_rotateLeft,
    java_lang_Integer_rotateRight,
    java_lang_Integer_valueOf,
+   java_lang_Integer_toUnsignedLong,
    java_lang_Long_bitCount,
    java_lang_Long_lowestOneBit,
    java_lang_Long_highestOneBit,

--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -3359,6 +3359,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {x(TR::java_lang_Integer_rotateRight,             "rotateRight",           "(II)I")},
       {x(TR::java_lang_Integer_valueOf,                 "valueOf",               "(I)Ljava/lang/Integer;")},
       {  TR::java_lang_Integer_init,              6,    "<init>", (int16_t)-1,    "*"},
+      {x(TR::java_lang_Integer_toUnsignedLong,          "toUnsignedLong",         "(I)J")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -405,6 +405,7 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_util_HashMap_getNode:
       case TR::java_lang_String_getChars_charArray:
       case TR::java_lang_String_getChars_byteArray:
+      case TR::java_lang_Integer_toUnsignedLong:
          return true;
          
       // In Java9 the following enum values match both sun.misc.Unsafe and


### PR DESCRIPTION
J9VMInternals.fastIdentityHashCode(Object) incorrectly sign-extended the
32bit J9Class pointer when reading it from an object header in a
compressedrefs VM.

This can can cause crashes with i.e. InaccessibleReadAddress=FFFFFFFF999609D8
in Java_com_ibm_jit_JITHelpers_getBackfillOffsetFromJ9Class64.

The int value needs to be assigned to the long without sign-extension.
Code now uses Integer.toUnsignedLong(int) to work around the issue.

JShell example showing this is valid:
```
jshell> int ptr = 0x99960900
ptr ==> -1718220544

jshell> long lptr = Integer.toUnsignedLong(ptr)
lptr ==> 2576746752

jshell> Long.toHexString(lptr)
$3 ==> "99960900"

jshell> long castptr = ptr
castptr ==> -1718220544

jshell> Long.toHexString(castptr)
$5 ==> "ffffffff99960900"
```

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>