### PR TITLE
Read Barrier on collected reference dereference

### DIFF
--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -504,12 +504,13 @@ public:
 
    uint32_t                   getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock * clazz);
 
-   virtual TR_OpaqueClassBlock *getObjectClass(uintptrj_t objectPointer);
-   virtual uintptrj_t           getReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
-   virtual uintptrj_t           getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
-   virtual uintptrj_t           getReferenceFieldAtAddress(uintptrj_t fieldAddress);
-   virtual uintptrj_t           getReferenceFieldAtAddress(void *fieldAddress){ return getReferenceFieldAtAddress((uintptrj_t)fieldAddress); }
-   int32_t                      getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset);
+   TR_OpaqueClassBlock *getObjectClass(uintptrj_t objectPointer);
+   uintptrj_t           getReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
+   uintptrj_t           getVolatileReferenceFieldAt(uintptrj_t objectPointer, uintptrj_t offsetFromHeader);
+   uintptrj_t           getReferenceFieldAtAddress(uintptrj_t fieldAddress);
+   uintptrj_t           getReferenceFieldAtAddress(void *fieldAddress){ return getReferenceFieldAtAddress((uintptrj_t)fieldAddress); }
+   uintptrj_t           getStaticReferenceFieldAtAddress(uintptrj_t fieldAddress);
+   int32_t              getInt32FieldAt(uintptrj_t objectPointer, uintptrj_t fieldOffset);
 
    int32_t getInt32Field(uintptrj_t objectPointer, char *fieldName)
       {
@@ -977,8 +978,6 @@ public:
 
    virtual bool acquireClassTableMutex();
    virtual void releaseClassTableMutex(bool);
-
-   virtual TR_OpaqueClassBlock *getClassFromStatic(void *p);
 
    // --------------------------------------------------------------------------
    // Object model

--- a/runtime/compiler/trj9/ilgen/Walker.cpp
+++ b/runtime/compiler/trj9/ilgen/Walker.cpp
@@ -2799,7 +2799,7 @@ TR_J9ByteCodeIlGenerator::loadConstantValueIfPossible(TR::Node *topNode, uintptr
 
          if (loadConstantValueCriticalSection.hasVMAccess())
             {
-            uintptrj_t objectPointer = *(uintptrj_t*)symbol->getStaticAddress();
+            uintptrj_t objectPointer = comp()->fej9()->getStaticReferenceFieldAtAddress((uintptrj_t)symbol->getStaticAddress());
             if (objectPointer)
                {
                switch (symbol->getDataType())
@@ -6358,7 +6358,7 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
       switch (type)
          {
          case TR::Address:
-            if (*(void **)p == 0)
+            if ((void *)comp()->fej9()->getStaticReferenceFieldAtAddress((uintptrj_t)p) == 0)
                {
                loadConstant(TR::aconst, 0);
                break;

--- a/runtime/compiler/trj9/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/trj9/optimizer/J9Inliner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -665,10 +665,11 @@ bool TR_J9MutableCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_Inlin
          {
          TR::VMAccessCriticalSection mutableCallSiteEpoch(comp()->fej9());
          vgs->_mutableCallSiteEpoch = TR::KnownObjectTable::UNKNOWN;
-         if (*mcsReferenceLocation)
+         uintptrj_t mcsObject = comp()->fej9()->getStaticReferenceFieldAtAddress((uintptrj_t)mcsReferenceLocation);
+         if (mcsObject)
             {
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fej9());
-            uintptrj_t currentEpoch = fej9->getVolatileReferenceField(*mcsReferenceLocation, "epoch", "Ljava/lang/invoke/MethodHandle;");
+            uintptrj_t currentEpoch = fej9->getVolatileReferenceField(mcsObject, "epoch", "Ljava/lang/invoke/MethodHandle;");
             if (currentEpoch)
                vgs->_mutableCallSiteEpoch = knot->getIndex(currentEpoch);
             }

--- a/runtime/compiler/trj9/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/trj9/optimizer/J9ValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -406,7 +406,8 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                                                         TR::VMAccessCriticalSection::tryToAcquireVMAccess);
             if (!getStringlength.hasVMAccess())
                break;
-            len = comp()->fej9()->getStringLength(*stringLocation);
+            uintptrj_t stringObject = comp()->fej9()->getStaticReferenceFieldAtAddress((uintptrj_t)stringLocation);
+            len = comp()->fej9()->getStringLength(stringObject);
             }
             // java/lang/String.lengthInternal is used internally and HCR guards can be skipped for calls to it.
             transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, len, receiverChildGlobal, transformNonnativeMethodInPlace || rm == TR::java_lang_String_lengthInternal);

--- a/runtime/compiler/trj9/optimizer/StringBuilderTransformer.cpp
+++ b/runtime/compiler/trj9/optimizer/StringBuilderTransformer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -616,7 +616,9 @@ int32_t TR_StringBuilderTransformer::computeHeuristicStringBuilderInitCapacity(L
 
                      if (stringBuildAppendStringCriticalSection.hasVMAccess())
                         {
-                        capacity += comp()->fe()->getStringUTF8Length(*static_cast<uintptrj_t*>(symbol->castToStaticSymbol()->getStaticAddress()));
+                        uintptrj_t stringObjectLocation = (uintptrj_t)symbol->castToStaticSymbol()->getStaticAddress();
+                        uintptrj_t stringObject = comp()->fej9()->getStaticReferenceFieldAtAddress(stringObjectLocation);
+                        capacity += comp()->fe()->getStringUTF8Length(stringObject);
 
                         break;
                         }


### PR DESCRIPTION
The compiler must use read barriers when dereferencing collected references.

Depends on https://github.com/eclipse/omr/pull/2344