### PR TITLE
[Nest mates] Adds JVMTI nestmates tests for class redefinition

### DIFF
--- a/test/cmdLineTests/jvmtitests/agent/tests.c
+++ b/test/cmdLineTests/jvmtitests/agent/tests.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,6 +121,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "aln001",    aln001,    "com.ibm.jvmti.tests.agentLibraryNatives.aln001",               "Test natives in agent libraries" },
 	{ "rbc001",   rbc001,   "com.ibm.jvmti.tests.redefineBreakpointCombo.rbc001", "Test Redefine-breakpoint combination"},
 	{ "mt001",   mt001,   "com.ibm.jvmti.tests.modularityTests.mt001", "Test Modularity functions"},
+	{ "nmr001",     nmr001,    "com.ibm.jvmti.tests.nestMatesRedefinition.nmr001", "Test nestmates redefinition"},
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/test/cmdLineTests/jvmtitests/include/jvmti_test.h
+++ b/test/cmdLineTests/jvmtitests/include/jvmti_test.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -236,5 +236,6 @@ jint JNICALL ria001(agentEnv * agent_env, char * args);
 jint JNICALL rnwr001(agentEnv * agent_env, char * args);
 jint JNICALL aln001(agentEnv * agent_env, char * args);
 jint JNICALL mt001(agentEnv * agent_env, char * args);
+jint JNICALL nmr001(agentEnv * agent_env, char * args);
 
 #endif /*JVMTI_TEST_H_*/

--- a/test/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -331,6 +331,11 @@
 
 	<test id="rbc001">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:rbc001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+	
+	<test id="nmr001">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:nmr001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 

--- a/test/cmdLineTests/jvmtitests/jvmtitests_excludesSE10.xml
+++ b/test/cmdLineTests/jvmtitests/jvmtitests_excludesSE10.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+
+<suite id="jvmtitest">
+
+	<!-- Define exclude configs here (all & platform names are parsed for free by harness) -->
+	<platform id="all"/>
+	<platform id="aix_ppc-64"/>
+	<platform id="win_x86_newrom"/>
+
+	<!-- AIX64 - The test creates thousands of threads without exhausting its available heap. Probably due to some sort of lazy stack mapping on the OS side -->
+	<exclude id="re002" platform="all" shouldFix="true">
+		<reason>No reliable cross-platform way of simulating this condition</reason>
+	</exclude>
+
+	<exclude id="gts001" platform="all" shouldFix="true">
+		<reason>Test is not very robust at the moment. Time dependency might cause it to fail</reason>
+	</exclude>
+
+	<exclude id="fer001" platform="all" shouldFix="true">
+		<reason>Testcase deadlocks due to bogus locking, replaced by fer003. keep fer001 for component debugging</reason>
+	</exclude>
+
+	<!-- Windows IA32 New ROMClass Builder - the test requires retransform support, which will be implemented under JAZZ 19331 -->
+	<exclude id="gpc002" platform="win_x86_newrom" shouldFix="true" expiry="Oct 8 2009">
+		<reason>Testcase requires retransform support, which will be implemented under JAZZ 19331</reason>
+	</exclude>
+
+	<exclude id="nmr001" platform="all">
+		<reason>Nestmates are not enabled on java10</reason>
+	</exclude>
+	
+</suite>

--- a/test/cmdLineTests/jvmtitests/jvmtitests_excludesSE80.xml
+++ b/test/cmdLineTests/jvmtitests/jvmtitests_excludesSE80.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,10 @@
 	<!-- Windows IA32 New ROMClass Builder - the test requires retransform support, which will be implemented under JAZZ 19331 -->
 	<exclude id="gpc002" platform="win_x86_newrom" shouldFix="true" expiry="Oct 8 2009">
 		<reason>Testcase requires retransform support, which will be implemented under JAZZ 19331</reason>
+	</exclude>
+	
+	<exclude id="nmr001" platform="all">
+		<reason>Nestmates are not enabled on java8</reason>
 	</exclude>
 
 </suite>

--- a/test/cmdLineTests/jvmtitests/jvmtitests_excludesSE90.xml
+++ b/test/cmdLineTests/jvmtitests/jvmtitests_excludesSE90.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,4 +50,8 @@
 		<reason>Testcase requires retransform support, which will be implemented under JAZZ 19331</reason>
 	</exclude>
 
+	<exclude id="nmr001" platform="all">
+		<reason>Nestmates are not enabled on java9</reason>
+	</exclude>
+	
 </suite>

--- a/test/cmdLineTests/jvmtitests/module.xml
+++ b/test/cmdLineTests/jvmtitests/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2017 IBM Corp. and others
+  Copyright (c) 2001, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -194,6 +194,7 @@
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleUses" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleOpens" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleProvides" />
+		<export name="Java_com_ibm_jvmti_tests_nestMatesRedefinition_nmr001_redefineClass" />
 	</exports>
 
 	<artifact type="shared" name="jvmtitest" bundle="jvmti_test" appendrelease="false" all="false">

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/ClassGenerator.java
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/ClassGenerator.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.jvmti.tests.nestMatesRedefinition;
+
+import org.objectweb.asm.*;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ClassGenerator implements Opcodes {
+	
+	public static byte[] generateClass(String name, RedefinitionPhase phase, Attribute[] attributes) {
+		ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+		classWriter.visit(V1_8, ACC_PUBLIC | ACC_SUPER, name, null, "java/lang/Object", null);
+		
+		switch(phase) {
+		case ORIGINAL:
+			/* Original has the source attribute */
+			classWriter.visitSource(name + ".java", null);	
+			break;
+		case REDEFINE:
+			/* REDEFINE has no source attribute to ensure the VM can't skip the redefine */
+			break;
+		default:
+			throw new IllegalArgumentException("Phase must be set correctly");
+		}
+		
+		/* Generate base constructor which just calls super.<init>() */
+		MethodVisitor methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+		methodVisitor.visitCode();
+		methodVisitor.visitVarInsn(ALOAD, 0);
+		methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+		methodVisitor.visitInsn(RETURN);
+		methodVisitor.visitMaxs(1, 1);
+		methodVisitor.visitEnd();
+
+		/* Generate passed in attributes if there are any */
+		if (null != attributes) {
+			for (Attribute attr : attributes) {
+				classWriter.visitAttribute(attr);
+			}
+		}
+
+		classWriter.visitEnd();
+		return classWriter.toByteArray();
+	}
+
+	static byte[] testClassNoAttribute () throws Exception {
+		return generateClass("TestClass", RedefinitionPhase.ORIGINAL, null);
+	}
+	
+	static byte[] testClassNoAttributeForceRedefinition () throws Exception {
+		return generateClass("TestClass", RedefinitionPhase.REDEFINE, null);
+	}
+
+	static byte[] testClassWithNestMembersAttribute () throws Exception {
+		String[] nestMembers = {"A", "B", "C"};
+		NestMembersAttribute attr = new NestMembersAttribute(nestMembers);
+		return generateClass("TestClass", RedefinitionPhase.ORIGINAL, new Attribute[]{ attr });
+	}
+	
+	static byte[] testClassWithNestMembersAttributeForceRedefinition () throws Exception {
+		String[] nestMembers = {"A", "B", "C"};
+		NestMembersAttribute attr = new NestMembersAttribute(nestMembers);
+		return generateClass("TestClass", RedefinitionPhase.REDEFINE, new Attribute[]{ attr });
+	}
+
+	static byte[] nestMemberNoAttributeForceRedefinition () throws Exception {
+		return generateClass("TestClass", RedefinitionPhase.REDEFINE, null);
+	}
+
+	static byte[] testClassWithNestHostAttribute () throws Exception {
+		NestHostAttribute attr = new NestHostAttribute("host");
+		return generateClass("TestClass", RedefinitionPhase.ORIGINAL, new Attribute[]{ attr });
+	}
+	
+	static byte[] testClassWithNestHostAttributeForceRedefinition () throws Exception {
+		NestHostAttribute attr = new NestHostAttribute("host");
+		return generateClass("TestClass", RedefinitionPhase.REDEFINE, new Attribute[]{ attr });
+	}
+
+	static byte[] testClassWithAlteredNestMembersAttributeData () throws Exception {
+		String[] nestMembers = {"D", "E", "F"};
+		NestMembersAttribute attr = new NestMembersAttribute(nestMembers);
+		return generateClass("TestClass", RedefinitionPhase.ORIGINAL, new Attribute[]{ attr });
+	}
+
+	static byte[] testClassWithAlteredNestMembersAttributeLength () throws Exception {
+		String[] nestMembers = {"A", "B"};
+		NestMembersAttribute attr = new NestMembersAttribute(nestMembers);
+		return generateClass("TestClass", RedefinitionPhase.ORIGINAL, new Attribute[]{ attr });
+	}
+
+	static byte[] testClassWithAlteredNestHostAttribute () throws Exception {
+		NestHostAttribute attr = new NestHostAttribute("AlteredHostName");
+		return generateClass("TestClass", RedefinitionPhase.ORIGINAL, new Attribute[]{ attr });
+	}
+}

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/CustomClassLoader.java
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/CustomClassLoader.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.jvmti.tests.nestMatesRedefinition;
+
+class CustomClassLoader extends ClassLoader {
+	public Class<?> getClass(String name, byte[] bytes){
+		return defineClass(name, bytes, 0, bytes.length);
+	}
+}

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/NestHostAttribute.java
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/NestHostAttribute.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.jvmti.tests.nestMatesRedefinition;
+
+import org.objectweb.asm.Attribute;
+import org.objectweb.asm.ByteVector;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+
+/*
+ * Nestmates attributes are a future java feature and, as such, the ASM6 API
+ * does not provide built-in methods for them. However, ASM6 allows the
+ * subclassing and use of its Attribute class. This can be leveraged to create
+ * a NestHostAttribute in order to write nest host attribute data.
+ * 
+ * Documentation on the ASM6 attribute class can be found here:
+ * http://asm.ow2.org/asm60/javadoc/user/org/objectweb/asm/Attribute.html
+ * Nestmates utilities are expected to be available in ASM7.
+ * 
+ * Nest hosts attributes have the format:
+ *		NestHost_attribute { 
+ *			u2 attribute_name_index; 
+ *			u4 attribute_length;
+ *			u2 host_class_index;
+ *		}
+ *
+ * Note that the spec explicitly disallows having more than one nestmates
+ * attribute (nest host attribute or nest members attribute) but that use
+ * of this workaround permits defining multiple nest attributes for a
+ * class.
+ */
+final class NestHostAttribute extends Attribute {
+	private String nestHost;
+
+	public Label[] getLabels(){
+		return null;
+	}
+	
+	public NestHostAttribute(String nestTop){
+		super("NestHost");
+		this.nestHost = nestTop;
+	}
+	
+	public boolean isCodeAttribute(){
+		return false;
+	}
+
+	public boolean isUnknown(){
+		return true;
+	}
+	
+	public ByteVector write(ClassWriter cw, byte[] code, int len, int maxStack, int maxLocals){
+		int topclass_index = cw.newClass(nestHost);		
+		ByteVector b = new ByteVector();
+		b.putShort(topclass_index);
+		return b;
+	}
+}

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/NestMembersAttribute.java
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/NestMembersAttribute.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.jvmti.tests.nestMatesRedefinition;
+
+import org.objectweb.asm.Attribute;
+import org.objectweb.asm.ByteVector;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+
+/*
+ * Nestmates attributes are a future java feature and, as such, the ASM6 API
+ * does not provide built-in methods for them. However, ASM6 allows the
+ * subclassing and use of its Attribute class. This can be leveraged to create
+ * a NestMembersAttribute in order to write nest members attribute data.
+ * 
+ * Documentation on the ASM6 attribute class can be found here:
+ * http://asm.ow2.org/asm60/javadoc/user/org/objectweb/asm/Attribute.html
+ * Nestmates utilities are expected to be available in ASM7.
+ * 
+ * Nest members attributes have the format:
+ *		NestMembers_attribute {
+ *			u2 attribute_name_index; 
+ *			u4 attribute_length;
+ *			u2 number_of_classes;
+ *			u2 classes[number_of_classes];
+ *		}
+ *		
+ * Note that the spec explicitly disallows having more than one nestmates
+ * attribute (nest host attribute or nest members attribute) but that use
+ * of this workaround permits defining multiple nest attributes for a
+ * class.
+ */
+
+final class NestMembersAttribute extends Attribute{
+	private String[] nestMembers;
+
+	public Label[] getLabels(){
+		return null;
+	}
+
+	public NestMembersAttribute(String[] nestMembers){
+		super("NestMembers");
+		this.nestMembers = nestMembers;
+	}
+
+	public boolean isCodeAttribute(){
+		return false;
+	}
+
+	public boolean isUnknown(){
+		return true;
+	}
+
+	public ByteVector write(ClassWriter cw, byte[] code, int len, int maxStack, int maxLocals){
+		ByteVector b = new ByteVector();
+		b.putShort(nestMembers.length);
+		
+		for(int i = 0; i < nestMembers.length; i++){
+			int nestMemberIndex = cw.newClass(nestMembers[i]);
+			b.putShort(nestMemberIndex);
+		}
+		
+		return b;
+	}
+}

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/RedefinitionPhase.java
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/RedefinitionPhase.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.jvmti.tests.nestMatesRedefinition;
+
+public enum RedefinitionPhase { ORIGINAL, REDEFINE };

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/nmr001.c
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/nmr001.c
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <string.h>
+
+#include "jvmti_test.h"
+
+static agentEnv *env;
+
+
+jint JNICALL
+nmr001(agentEnv *agent_env, char *args)
+{
+	jvmtiError err = JVMTI_ERROR_NONE;
+	jvmtiCapabilities capabilities = {0};
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+
+	env = agent_env; 
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_redefine_classes = 1;
+	/* Following capability is required to enable FSD */
+	capabilities.can_generate_breakpoint_events = 1;
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to AddCapabilities");
+		return JNI_ERR;
+	}						
+
+	return JNI_OK;
+}
+
+jint JNICALL
+Java_com_ibm_jvmti_tests_nestMatesRedefinition_nmr001_redefineClass(JNIEnv *jni_env, jclass klass, jclass originalClass, jint classBytesSize, jbyteArray redefinedClassByteData)
+{
+	JVMTI_ACCESS_FROM_AGENT(env);
+	jbyte *classByteDataRegion = NULL;
+	char *classFileName = env->testArgs;
+	jvmtiClassDefinition classdef = {0};
+	jvmtiError err = JVMTI_ERROR_NONE;
+
+	err = (*jvmti_env)->Allocate(jvmti_env, classBytesSize, (unsigned char **) &classByteDataRegion);
+	if (err != JVMTI_ERROR_NONE) {
+		goto done;
+	}
+
+	(*jni_env)->GetByteArrayRegion(jni_env, redefinedClassByteData, 0, classBytesSize, classByteDataRegion);
+	if ((*jni_env)->ExceptionCheck(jni_env)) {
+		err = JVMTI_ERROR_INTERNAL;
+		goto freeMem;
+	}
+
+	classdef.class_bytes = (unsigned char *) classByteDataRegion;
+	classdef.class_byte_count = classBytesSize;
+	classdef.klass = originalClass;
+
+	err = (*jvmti_env)->RedefineClasses(jvmti_env, 1, &classdef);
+
+freeMem:
+	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *) classByteDataRegion);
+done:
+	return (jint) err;
+}

--- a/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/nmr001.java
+++ b/test/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/nestMatesRedefinition/nmr001.java
@@ -1,0 +1,239 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package com.ibm.jvmti.tests.nestMatesRedefinition;
+
+public class nmr001 {
+	/*
+	 * Redefines a class with given class bytes
+	 * 
+	 * @param name class being redefined
+	 * @param classBytesSize size of the new class bytes
+	 * @param classBytes new class bytes
+	 * 
+	 * @return	jvmti error code
+	 */
+	public static native int redefineClass(Class name, int classBytesSize, byte[] classBytes);
+
+	/*
+	 * Every JVMTI function returns a jvmtiError code with values as defined
+	 * by the specification.
+	 */
+	static final int JVMTI_ERROR_NONE = 0;
+	static final int JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED = 72;
+	
+	static boolean runRedefinitionTest(int expectedErrorCode, String className, byte[] originalDefinition, byte[] newDefinition) {
+		int redefinitionErrorCode = 0;
+		try {
+			CustomClassLoader classloader = new CustomClassLoader();
+			Class<?> clazz = classloader.getClass(className, originalDefinition);
+			Object instance = clazz.getDeclaredConstructor().newInstance();
+			redefinitionErrorCode = redefineClass(clazz, newDefinition.length, newDefinition);
+		} catch (Exception e) {
+			return false;
+		}
+		return expectedErrorCode == redefinitionErrorCode;
+	}
+	
+	/* 
+	 * Valid class definitions have the same nestmates attributes as the original
+	 * definition - either no nestmates attribute, a nest host attribute with the 
+	 * same nest host, or a nest members attribute with the same nest members in 
+	 * the same order.
+	 */
+
+	/*
+	 * Tests valid nest redefinition with a nest host attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionWithNestHostAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestMembersAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithNestMembersAttributeForceRedefinition();
+			return runRedefinitionTest(JVMTI_ERROR_NONE, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+	
+	/*
+	 * Tests valid nest redefinition with a nest members attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionWithNestMembersAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestHostAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithNestHostAttributeForceRedefinition();
+			return runRedefinitionTest(JVMTI_ERROR_NONE, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/* 
+	 * It is disallowed to add or to remove a nest host or nest members attribute
+	 * when redefining a class.
+	 */
+	
+	/*
+	 * Tests invalid nest redefinition by adding a nest host attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionAddingNestHostAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassNoAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithNestHostAttribute();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+	
+	/*
+	 * Tests invalid nest redefinition by adding a nest members attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionAddingNestMembersAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassNoAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithNestMembersAttribute();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+	
+	/*
+	 * Tests invalid nest redefinition by removing a nest host attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionRemovingNestHostAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestHostAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassNoAttribute();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+	
+	/*
+	 * Tests invalid nest redefinition by removing a nest members attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionRemovingNestMembersAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestMembersAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassNoAttribute();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/*
+	 * It is disallowed to alter the contents of a nest host or a nest members
+	 * attribute.
+	 */
+
+	/*
+	 * Tests invalid nest redefinition by altering a nest host attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionAlteringNestHostAttribute() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestHostAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithAlteredNestHostAttribute();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+	
+	/*
+	 * Tests invalid nest redefinition by altering a nest members attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionAlteringNestMembersLength() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestMembersAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithAlteredNestMembersAttributeLength();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+	
+	/*
+	 * Tests invalid nest redefinition by altering a nest members attribute
+	 * 
+	 * @return boolean true if test passes; false otherwise
+	 */
+	static public boolean testRedefinitionAlteringNestMembersContent() {
+		try {
+			byte[] originalBytes = ClassGenerator.testClassWithNestMembersAttribute();
+			byte[] redefinedBytes = ClassGenerator.testClassWithAlteredNestMembersAttributeData();
+			return runRedefinitionTest(JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED, "TestClass", originalBytes, redefinedBytes);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public String helpRedefinitionNoNestAttributes() {
+		return "testRedefinitionNoNestAttributes tests valid redefinition with no nest attributes.";
+	}
+	public String helpRedefinitionWithNestHostAttribute() {
+		return "testRedefinitionWithNestHostAttribute tests valid redefinition with a nest host attribute.";
+	}
+	public String helpRedefinitionWithNestMembersAttribute() {
+		return "testRedefinitionWithNestMembersAttribute tests valid redefinition with a nest members attribute.";
+	}
+	public String helpRedefinitionAddingNestHostAttribute() {
+		return "testRedefinitionAddingNestHostAttribute tests invalid redefinition by adding a nest host attribute.";
+	}
+	public String helpRedefinitionAddingNestMembersAttribute() {
+		return "testRedefinitionAddingNestMembersAttribute tests invalid redefinition by adding a nest members attribute.";
+	}
+	public String helpRedefinitionRemovingNestHostAttribute() {
+		return "testRedefinitionRemovingNestHostAttribute tests invalid redefinition by removing a nest host attribute.";
+	}
+	public String helpRedefinitionRemovingNestMembersAttribute() {
+		return "testRedefinitionRemovingNestHostAttribute tests invalid redefinition by removing a nest members attribute.";
+	}
+	public String helpRedefinitionAlteringNestHostAttribute() {
+		return "testRedefinitionAlteringNestHostAttribute tests invalid redefinition by altering a nest host attribute.";
+	}
+	public String helpRedefinitionAlteringNestMembersLength() {
+		return "testRedefinitionAlteringNestMembersLength tests invalid redefinition by altering nest members attribute length (# of members)";
+	}
+	public String helpRedefinitionAlteringNestMembersContent() {
+		return "testRedefinitionAlteringNestMembersContent tests invalid redefinition by altering the contents of the nest members attribute.";
+	}
+}


### PR DESCRIPTION
Nestmates spec disallows for changes in nest mates
attributes during class redefinition.

See: https://github.com/eclipse/openj9/issues/1165

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>