### PR TITLE
Fix cmdLineTester_test_0 test 12 error on windows

### DIFF
--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -35,6 +35,7 @@ MKTREE    = mkdir -p
 PWD       = pwd
 EXECUTABLE_SUFFIX =
 RUN_SCRIPT = sh
+RUN_SCRIPT_STRING = "sh -c"
 SCRIPT_SUFFIX=.sh
 Q="
 P=:
@@ -93,6 +94,7 @@ P=;
 D=\\
 EXECUTABLE_SUFFIX=.exe
 RUN_SCRIPT="cmd /c" 
+RUN_SCRIPT_STRING=$(RUN_SCRIPT)
 SCRIPT_SUFFIX=.bat
 PROPS_DIR=props_win
 endif

--- a/test/cmdLineTests/cmdlinetestertests/cmdlinetests.xml
+++ b/test/cmdLineTests/cmdlinetestertests/cmdlinetests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2009, 2017 IBM Corp. and others
+  Copyright (c) 2009, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@
 
 <suite id="CmdLineTester Tests" timeout="600">
 
- <variable name="J9CMDLINE" value="$EXE$ -DRESJAR=$Q$$RESJAR$$Q$ -DTESTDIR=$Q$$TESTDIR$$Q$ -DCMDLINETESTERJAR=$Q$$CMDLINETESTERJAR$$Q$ -Dcmdlinetester.test=testval -Xint -jar $Q$$CMDLINETESTERJAR$$Q$ -explainExcludes -config $Q$$TESTDIR$$file.separator$" />
+ <variable name="J9CMDLINE" value="$EXE$ -DRESJAR=$Q$$RESJAR$$Q$ -DTESTDIR=$Q$$TESTDIR$$Q$ -DCMDLINETESTERJAR=$Q$$CMDLINETESTERJAR$$Q$ -DRUN_SCRIPT_STRING=$Q$$RUN_SCRIPT_STRING$$Q$ -Dcmdlinetester.test=testval -Xint -jar $Q$$CMDLINETESTERJAR$$Q$ -explainExcludes -config $Q$$TESTDIR$$file.separator$" />
 
  <test id="Test 1 (correct number of passes/fails reported)">
   <command>$J9CMDLINE$test1.xml$Q$</command>

--- a/test/cmdLineTests/cmdlinetestertests/exclude.xml
+++ b/test/cmdLineTests/cmdlinetestertests/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,4 @@
 <!DOCTYPE suite SYSTEM "excludes.dtd">
 <?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
 <suite id="CmdLineTester Tests">
-	<exclude id="Test 12 (curlies outside of dollar signs)" platform="win_x86-64_cr" shouldFix="true">
-		<reason>Issue 691: cmdLineTester_test_0: Test 12 (curlies outside of dollar signs) failure on windows platform</reason>
-	</exclude>
 </suite>

--- a/test/cmdLineTests/cmdlinetestertests/playlist.xml
+++ b/test/cmdLineTests/cmdlinetestertests/playlist.xml
@@ -27,7 +27,8 @@
 		<testCaseName>cmdLineTester_test</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DCMDLINETESTERJAR=$(CMDLINETESTER_JAR) \
-	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)cmdlinetests.xml$(Q) \
+	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -DRUN_SCRIPT_STRING=$(RUN_SCRIPT_STRING) \
+	-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)cmdlinetests.xml$(Q) \
 	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>

--- a/test/cmdLineTests/cmdlinetestertests/test12.xml
+++ b/test/cmdLineTests/cmdlinetestertests/test12.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2009, 2017 IBM Corp. and others
+  Copyright (c) 2009, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
  <variable name="TEMP1" value="error}{" />
 
  <test id="curlies outside of dollar signs">
-  <command>echo $TEMP0$</command>
+  <command>$RUN_SCRIPT_STRING$ "echo $TEMP0$"</command>
   <output regex="no" type="success">no{error}{}here</output>
  </test>
 


### PR DESCRIPTION
Invoke native shell to do echo command instead of trying to find an echo
executable.
Add the RUN_SCRIPT_STRING variable to testkitgen to be able to invoke
shell with string arguments instead of just file arguments.

Fixes #691 

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Reviewer: @llxia 