### PR TITLE
Fix SCCommandLineOptionTests perl test failures on windows

### DIFF
--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/exclude.xml
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2004, 2017 IBM Corp. and others
+  Copyright (c) 2004, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,22 +28,10 @@
 	<exclude id="nameOption11" platform="all" shouldFix="true">
 			<reason>CMVC 169666 : nameOption11 test fails on zOS systems</reason>
 	</exclude>
-	<exclude id="nameOption14" platform="win_x86-64_cr" shouldFix="true">
-			<reason>Issue 679: cmdLineTester_SCCommandLineOptionTests_win_1 failure</reason>
+	<exclude id="nameOption15" platform="win_x86-64_cr" shouldFix="false">
+			<reason>%g modifier not valid on Windows</reason>
 	</exclude>
-	<exclude id="nameOption15" platform="win_x86-64_cr" shouldFix="true">
-			<reason>Issue 679: cmdLineTester_SCCommandLineOptionTests_win_1 failure</reason>
-	</exclude>
-	<exclude id="nameOption16" platform="win_x86-64_cr" shouldFix="true">
-			<reason>Issue 679: cmdLineTester_SCCommandLineOptionTests_win_1 failure</reason>
-	</exclude>
-	<exclude id="nameOption17" platform="win_x86-64_cr" shouldFix="true">
-				<reason>Issue 679: cmdLineTester_SCCommandLineOptionTests_win_1 failure</reason>
-	</exclude>
-	<exclude id="nameOption18" platform="win_x86-64_cr" shouldFix="true">
-			<reason>Issue 679: cmdLineTester_SCCommandLineOptionTests_win_1 failure</reason>
-	</exclude>
-	<exclude id="nameOption19" platform="win_x86-64_cr" shouldFix="true">
-			<reason>Issue 679: cmdLineTester_SCCommandLineOptionTests_win_1 failure</reason>
+	<exclude id="nameOption19" platform="win_x86-64_cr" shouldFix="false">
+			<reason>%g modifier not valid on Windows</reason>
 	</exclude>
 </suite>

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption14.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption14.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 # @summary and that the destroy command works. The cache name used for
 # @summary testing contains %u
 
+use lib ".";
 require "sharedClassesUtil.pl";
 
 use strict;

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption15.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption15.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 # @summary and that the destroy command works. The cache name used for
 # @summary testing contains %g.
 
+use lib ".";
 require "sharedClassesUtil.pl";
 
 use strict;

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption16.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption16.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,8 @@
 # @author Radhakrishnan Thangamuthu
 # @summary check if a cache can be created with maximum allowed length
 # @summary and that the destroy command works
+
+use lib ".";
 require "sharedClassesUtil.pl";
 
 use strict;

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption17.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption17.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 # rem @summary check if a cache is not created with a length  
 # rem @summary greater than the allowed length
 
+use lib ".";
 require "sharedClassesUtil.pl";
 
 use strict;

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption18.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption18.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 # rem @summary check if a cache is not created with a length  
 # rem @summary greater than the allowed length. The cache name used for testing contains %u
 
+use lib ".";
 require "sharedClassesUtil.pl";
 
 use strict;

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption19.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/nameOption19.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 # rem @summary check if a cache is not created with a length  
 # rem @summary greater than the allowed length. The cache name used for testing contains %u
 
+use lib ".";
 require "sharedClassesUtil.pl";
 
 use strict;

--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/sharedClassesUtil.pl
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2017 IBM Corp. and others
+# Copyright (c) 2009, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,7 +220,7 @@ sub do_create_cache {
 						,$is_output_stream_needed);
 
 	#leaving debug messages commented
-	printf "\n command to execute :$cmd_to_execute: \n" ;
+	print "\n command to execute :$cmd_to_execute: \n" ;
 
 	if( !$is_output_stream_needed && !$is_err_stream_needed ) {
 		`$cmd_to_execute`;
@@ -289,6 +289,7 @@ sub get_path_separator {
 # fails with the error message specified in the argument list
 sub test_unsuccessful_cache_creation {
 	my ($java_bin, $test_name, $cache_name, $error_msg)=@_;
+	$java_bin =~ s/\\/\\\\/g;
 	my $return_status;
 	my $create_status;
 	my $destroy_status;
@@ -301,10 +302,10 @@ sub test_unsuccessful_cache_creation {
 
 	if ($is_create_failed) {
 		$return_status = 1;
-		printf "\n TEST PASSED \n";
+		print "\n TEST PASSED \n";
 	} else 	{
 		$return_status = 0;
-		printf "\n TEST FAILED : missing error message \n";
+		print "\n TEST FAILED : missing error message \n";
 	}
 
 	return $return_status;
@@ -313,6 +314,7 @@ sub test_unsuccessful_cache_creation {
 # Given a cache name it checks for the creation of the cache and declares pass/fail.
 sub test_successful_cache_creation {
 	my ($java_bin, $test_name, $cache_name, $cache_grep_name)=@_;
+	$java_bin =~ s/\\/\\\\/g;
 	my $return_status=0;
 	my $create_status=0;
 	my $destroy_status=0;
@@ -328,10 +330,10 @@ sub test_successful_cache_creation {
 
 	if ($create_status && $destroy_status) {
 		$return_status = 1;
-		printf "\n TEST PASSED \n";
+		print "\n TEST PASSED \n";
 	} else 	{
 		$return_status = 0;
-		printf "\n TEST FAILED : create_status:$create_status destroy_status:$destroy_status \n";
+		print "\n TEST FAILED : create_status:$create_status destroy_status:$destroy_status \n";
 	}
 
 	return $return_status;
@@ -411,7 +413,7 @@ sub cache_name_with_fixed_length_test {
 	# name of the cache that is obtained by expanding %u or %g ( if any ) in the specified_cache_name
 	$expanded_cache_name = $arr[1];
 
-	printf "cache name to create: " . $specified_cache_name . ":to grep: " . "$expanded_cache_name  \n";
+	print "cache name to create: " . $specified_cache_name . ":to grep: " . "$expanded_cache_name  \n";
 	test_successful_cache_creation ($java_bin , $test_name, $specified_cache_name, $expanded_cache_name);
 }
 


### PR DESCRIPTION
Perl 5.26 by default does not include current directory in @INC.
So, add current directory back to @INC for setups without it by default.

Change printf to print in perl scripts since formatting isn't used.

Exclude tests with %g in cache name from Windows since it's not
supported.

Replace backslash with double backslash in perl script due to backslash
being escape character under cygwin shell.
Fixes #679

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Reviewer: @llxia 