### PR TITLE
Initial commit for JDK10 Jenkins files

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -264,6 +264,15 @@ def set_slack_channel() {
 }
 
 /*
+* Sets the names of the downstream build & test jobs
+*/
+def set_job_names() {
+    BUILD_JOB_NAME = VARIABLES.build_job_prefix + "${SDK_VERSION}-${SPEC}"
+    SANITY_JOB_NAME = VARIABLES.sanity_job_prefix + "${SDK_VERSION}-${SPEC}"
+    EXTENDED_JOB_NAME = VARIABLES.extended_job_prefix + "${SDK_VERSION}-${SPEC}"
+}
+
+/*
 * Initializes all of the required variables for a Jenkins job by given job type.
 */
 def set_job_variables(job_type) {
@@ -298,6 +307,7 @@ def set_job_variables(job_type) {
             set_repos_variables()
             set_test_targets()
             set_slack_channel()
+            set_job_names()
             break
         default:
             error("Unknown Jenkins job type!")

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+ node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_x86-64_cmprssptrs
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-win_x86-64_cmprssptrs
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'win_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load "buildenv/jenkins/common/build"
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_x86-64_cmprssptrs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-win_x86-64_cmprssptrs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'win_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+
+    parallel archive_test
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+
+    parallel archive_test
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+
+    parallel archive_test
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+
+    parallel archive_test
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+
+    parallel archive_test
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+
+    parallel archive_test
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-win_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'win_x86-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-aix_ppc-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'aix_ppc-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_390-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_390-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-win_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'win_x86-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -25,6 +25,7 @@
 openjdk_repo:
   8: 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git'
   9: 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git'
+  10: 'https://github.com/ibmruntimes/openj9-openjdk-jdk10.git'
 openjdk_branch: 'openj9'
 #========================================#
 # Miscellaneous settings
@@ -32,8 +33,12 @@ openjdk_branch: 'openj9'
 jdk_image_dir:
   8: 'j2sdk-image'
   9: 'jdk'
+  10: 'jdk'
 test_dependencies_job_name: 'test.getDependency'
 slack_channel: '#jenkins'
+build_job_prefix: 'Build-JDK-'
+sanity_job_prefix: 'Sanity-JDK-'
+extended_job_prefix: 'Extended-JDK-'
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#
@@ -41,9 +46,11 @@ linux_ppc-64_cmprssptrs_le:
   boot_jdk:
     8: '/usr/lib/jvm/java-7-openjdk-ppc64el'
     9: '/usr/lib/jvm/adoptojdk-java-ppc64le-80'
+    10: '/usr/lib/jvm/adoptojdk-java-ppc64le-90'
   release:
     8: 'linux-ppc64-normal-server-release'
     9: 'linux-ppc64le-normal-server-release'
+    10: 'linux-ppc64le-normal-server-release'
   freemarker: '/home/jenkins/freemarker.jar'
   node_labels:
     build: 'ppcle'
@@ -57,9 +64,11 @@ linux_390-64_cmprssptrs:
   boot_jdk:
     8: '/usr/lib/jvm/adoptojdk-java-s390x-80'
     9: '/usr/lib/jvm/adoptojdk-java-s390x-80'
+    10: '/usr/lib/jvm/adoptojdk-java-s390x-90'
   release:
     8: 'linux-s390x-normal-server-release'
     9: 'linux-s390x-normal-server-release'
+    10: 'linux-s390x-normal-server-release'
   freemarker: '/home/jenkins/freemarker.jar'
   node_labels:
     build: '390'
@@ -71,9 +80,11 @@ aix_ppc-64_cmprssptrs:
   boot_jdk:
     8: '/usr/java7'
     9: '/usr/java8_64'
+    10: '/usr/java9_64'
   release:
     8: 'aix-ppc64-normal-server-release'
     9: 'aix-ppc64-normal-server-release'
+    10: 'aix-ppc64-normal-server-release'
   freemarker: '/home/jenkins/freemarker.jar'
   node_labels:
     build: 'aix'
@@ -81,3 +92,4 @@ aix_ppc-64_cmprssptrs:
   extra_configure_options:
     8: '--with-cups-include=/opt/freeware/include --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread DF=/usr/sysv/bin/df --disable-ccache --with-jobs=8'
     9: '--with-cups-include=/opt/freeware/include --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread DF=/usr/sysv/bin/df --disable-warnings-as-errors --with-jobs=8'
+    10: '--with-cups-include=/opt/freeware/include --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread DF=/usr/sysv/bin/df --disable-warnings-as-errors --with-jobs=8'


### PR DESCRIPTION
- Add JDK10 Jenkins files for
  - Build
  - Test-Sanity
  - Test-Extended
  - PullRequest-Compile
  - PullRequest-Extended
  - PullRequest-Sanity
  - Pipeline-Build-Test
- Update defauts variable file with JDK10 values
- Move Job Name prefixes to variable file
- Add function to set job names in pipeline builds

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>