### PR TITLE
Export JVM_GetCallerClass according to Java version & API

### DIFF
--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2007, 2017 IBM Corp. and others
+  Copyright (c) 2007, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 <exportlists>
 	<exports group="j9vmnatives">
+		<!-- _JVM_GetCallerClass is exported within module.xml files -->
 		<export name="_JVM_Accept@12" />
 		<export name="_JVM_ActiveProcessorCount@0" />
 		<export name="_JVM_AllocateNewArray@16" />
@@ -58,7 +59,6 @@
 		<export name="_JVM_GC@0" />
 		<export name="_JVM_GCNoCompact@0" />
 		<export name="_JVM_GetAllThreads@8" />
-		<export name="_JVM_GetCallerClass@8" />
 		<export name="_JVM_GetClassAccessFlags@8" />
 		<export name="_JVM_GetClassAnnotations@8" />
 		<export name="_JVM_GetClassConstantPool@8" />

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -29,6 +29,7 @@
 		<export name="JNI_CreateJavaVM" />
 		<export name="JNI_GetCreatedJavaVMs" />
 		<export name="JNI_GetDefaultJavaVMInitArgs" />
+		<export name="_JVM_GetCallerClass@8" />
 	</exports>
 
 	<artifact type="shared" name="jvm" bundle="jvm" loadgroup="" appendrelease="false">

--- a/runtime/j9vm_b150/module.xml
+++ b/runtime/j9vm_b150/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@
 		<export name="JNI_CreateJavaVM"/>
 		<export name="JNI_GetCreatedJavaVMs"/>
 		<export name="JNI_GetDefaultJavaVMInitArgs"/>
+		<export name="_JVM_GetCallerClass@8" />
 	</exports>
 
 	<artifact type="shared" name="jvm" scope="b150" loadgroup="top" buildlocal="true" appendrelease="false">

--- a/runtime/j9vm_b156/module.xml
+++ b/runtime/j9vm_b156/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@
 		<export name="JNI_CreateJavaVM"/>
 		<export name="JNI_GetCreatedJavaVMs"/>
 		<export name="JNI_GetDefaultJavaVMInitArgs"/>
+		<export name="_JVM_GetCallerClass@8" />
 	</exports>
 
 	<artifact type="shared" name="jvm" scope="b156" loadgroup="top" buildlocal="true" appendrelease="false">

--- a/runtime/j9vm_jdk11/module.xml
+++ b/runtime/j9vm_jdk11/module.xml
@@ -29,6 +29,7 @@
 		<export name="JNI_CreateJavaVM"/>
 		<export name="JNI_GetCreatedJavaVMs"/>
 		<export name="JNI_GetDefaultJavaVMInitArgs"/>
+		<export name="_JVM_GetCallerClass@4" />
 	</exports>
 
 	<artifact type="shared" name="jvm" scope="jdk11" loadgroup="top" buildlocal="true" appendrelease="false">

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -23,15 +23,20 @@
 -->
 
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-        
-    <xi:include href="../j9vm/j9vmnatives.xml"><xi:fallback/></xi:include>
-    
+	<xi:include href="../j9vm/j9vmnatives.xml"><xi:fallback/></xi:include>
+	
 	<exports group="all">
 		<export name="JNI_CreateJavaVM" />
 		<export name="JNI_GetCreatedJavaVMs" />
 		<export name="JNI_GetDefaultJavaVMInitArgs" />
 	</exports>
-
+	<exports group="jdk11">
+		<export name="_JVM_GetCallerClass@4" />
+	</exports>
+	<exports group="prejdk11">
+		<export name="_JVM_GetCallerClass@8" />
+	</exports>
+		
 	<artifact type="shared" name="jvm_b150" scope="redirector" loadgroup="top" buildlocal="true" appendrelease="false">
 		<include-if condition="spec.flags.module_j9vm"/>
 		<options>
@@ -40,6 +45,7 @@
 		</options>
 		<phase>core quick j2se</phase>
 		<exports>
+			<group name="prejdk11"/>
 			<group name="all"/>
 			<group name="j9vmnatives"/>
 		</exports>
@@ -89,6 +95,7 @@
 		</options>
 		<phase>core quick j2se</phase>
 		<exports>
+			<group name="prejdk11"/>
 			<group name="all"/>
 			<group name="j9vmnatives"/>
 		</exports>
@@ -138,6 +145,7 @@
 		</options>
 		<phase>core quick j2se</phase>
 		<exports>
+			<group name="jdk11"/>
 			<group name="all"/>
 			<group name="j9vmnatives"/>
 		</exports>
@@ -189,6 +197,7 @@
 		</options>
 		<phase>core quick j2se</phase>		
 		<exports>
+			<group name="prejdk11"/>
 			<group name="all"/>
 			<group name="j9vmnatives"/>
 		</exports>


### PR DESCRIPTION
Export JVM_GetCallerClass according to Java version & API

`JVM_GetCallerClass(env, depth)` matches `JVM_GetCallerClass@8`;
`JVM_GetCallerClass(env)` matches `JVM_GetCallerClass@4`.

Fixes a Windows 32-bit build problem introduced by #1172

Reviewer @pshipton
FYI: @danheidinga

Signed-off-by: Jason Feng <fengj@ca.ibm.com>