### PR TITLE
Update the Javadoc for com.ibm.oti.shared

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedAbstractHelperFactory.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedAbstractHelperFactory.java
@@ -4,7 +4,7 @@ package com.ibm.oti.shared;
 import java.security.AccessControlException;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,10 @@ import java.security.AccessControlException;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+/**
+ * SharedAbstractHelperFactory is an abstract superclass for helper factory subclasses.
+ * <p>
+ */
 public abstract class SharedAbstractHelperFactory {
 
 	private static int idCount;		/* Single id count shared by all factories */

--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassCacheInfo.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassCacheInfo.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.shared;
 
 /*******************************************************************************
- * Copyright (c) 2010, 2016 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,11 +46,12 @@ public class SharedClassCacheInfo {
 	 * Specifies a Java 8 cache. 
 	 */
 	static final public int JVMLEVEL_JAVA8 = 4;
+	/*[IF Sidecar19-SE]*/
 	/**
-	 * Specifies a Java 9 cache. 
+	 * Specifies a Java 9 cache.
 	 */
 	static final public int JVMLEVEL_JAVA9 = 5;
-
+	/*[ENDIF] Sidecar19-SE */
 	/**
 	 * Specifies a 32-bit cache.
 	 */


### PR DESCRIPTION
1. Add description for SharedAbstractHelperFactory
2. Constant JVMLEVEL_JAVA9 should only be defined in Java 9

Signed-off-by: hangshao <hangshao@ca.ibm.com>