### PR TITLE
Fix a crash in findClassInfo on PPC

### DIFF
--- a/runtime/compiler/trj9/env/PersistentCHTable.cpp
+++ b/runtime/compiler/trj9/env/PersistentCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,7 +290,10 @@ TR_PersistentCHTable::findSingleJittedImplementer(
    return resolvedMethod;
    }
 
-
+/**
+ * Find persistent JIT class information for a given class.
+ * The caller must insure that class table lock is obtained
+ */
 TR_PersistentClassInfo *
 TR_PersistentCHTable::findClassInfo(TR_OpaqueClassBlock * classId)
    {
@@ -301,7 +304,10 @@ TR_PersistentCHTable::findClassInfo(TR_OpaqueClassBlock * classId)
    return cl;
    }
 
-
+/**
+ * Find persistent JIT class information for a given class.
+ * The class table lock is used to synchronize use of this method
+ */
 TR_PersistentClassInfo *
 TR_PersistentCHTable::findClassInfoAfterLocking(
       TR_OpaqueClassBlock *classId,
@@ -313,17 +319,22 @@ TR_PersistentCHTable::findClassInfoAfterLocking(
 
    if (comp->getOption(TR_DisableCHOpts))
       return NULL;
-
-   TR_PersistentClassInfo * cl = NULL;
-
-      {
-      TR::ClassTableCriticalSection findClassInfoAfterLocking(comp->fe());
-      cl = findClassInfo(classId);
-      }
-
-   return cl;
+   return findClassInfoAfterLocking(classId, comp->fe(), returnClassInfoForAOT);
    }
 
+/**
+ * Find persistent JIT class information for a given class.
+ * The class table lock is used to synchronize use of this method
+ */
+TR_PersistentClassInfo *
+TR_PersistentCHTable::findClassInfoAfterLocking(
+      TR_OpaqueClassBlock *classId,
+      TR_FrontEnd *fe,
+      bool returnClassInfoForAOT)
+   {
+   TR::ClassTableCriticalSection findClassInfoAfterLocking(fe);
+   return findClassInfo(classId);
+   }
 
 bool
 TR_PersistentCHTable::isOverriddenInThisHierarchy(

--- a/runtime/compiler/trj9/env/PersistentCHTable.hpp
+++ b/runtime/compiler/trj9/env/PersistentCHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,7 @@ class TR_PersistentCHTable
    TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId);
 
    TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false);
+   TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR_FrontEnd *, bool returnClassInfoForAOT = false);
 
    void dumpMethodCounts(TR_FrontEnd *fe, TR_Memory &trMemory);         // A routine to dump initial method compilation counts
 

--- a/runtime/compiler/trj9/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/trj9/env/annotations/AnnotationBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,7 +120,7 @@ bool TR_AnnotationBase::scanForKnownAnnotationsAndRecord(TR::CompilationInfo *co
       {
       TR_OpaqueClassBlock *cl=J9JitMemory::convertClassPtrToClassOffset(clazz);
 
-      classInfo = compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfo(cl);
+      classInfo = compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(cl, fe);
 
       if(classInfo)
          {

--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -2009,8 +2009,8 @@ static bool doResolveAtRuntime(J9Method *method, I_32 cpIndex, TR::Compilation *
       return false;
    else if (fej9->getJ9JITConfig()->runtimeFlags & J9JIT_RUNTIME_RESOLVE)
       return performTransformation(comp, "Setting as unresolved static call cpIndex=%d\n", cpIndex);
-   else
-      return false;
+
+   return false;
    }
 
 
@@ -4605,7 +4605,11 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
       TR_OpaqueClassBlock *clazz = fej9()->getClassOfMethod(getPersistentIdentifier());
       J9JITConfig * jitConfig = fej9()->getJ9JITConfig();
       TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
-      TR_PersistentClassInfo *clazzInfo = compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfo(clazz);
+      TR_PersistentClassInfo *clazzInfo = NULL;
+      if (compInfo->getPersistentInfo()->getPersistentCHTable())
+         {
+         clazzInfo = compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, fej9());
+         }
 
       if (!clazzInfo)
          {

--- a/runtime/compiler/trj9/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/trj9/optimizer/StringPeepholes.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2147,7 +2147,7 @@ bool TR_StringPeepholes::classRedefined(TR_OpaqueClassBlock *clazz)
    {
    if (!clazz)
       return true;
-   TR_PersistentClassInfo *clazzInfo = comp()->getPersistentInfo()->getPersistentCHTable()->findClassInfo(clazz);
+   TR_PersistentClassInfo *clazzInfo = comp()->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, fe());
    return !clazzInfo || clazzInfo->classHasBeenRedefined();
    }
 

--- a/runtime/compiler/trj9/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/trj9/runtime/ClassUnloadAssumption.cpp
@@ -1209,7 +1209,7 @@ J9::PersistentInfo::isObsoleteClass(void *v, TR_FrontEnd *fe)
       return true;
    else if (!getPersistentCHTable())
       return false; // HCR TODO: Support fixed opt levels
-   else if (!getPersistentCHTable()->findClassInfo((TR_OpaqueClassBlock*)v))
+   else if (!getPersistentCHTable()->findClassInfoAfterLocking((TR_OpaqueClassBlock*)v, fe))
       return false; // It's not a class, so it can't be a replaced class
    else
       return fe->classHasBeenReplaced((TR_OpaqueClassBlock*)v);


### PR DESCRIPTION
Due to PPCs weak memory coherency it's possible for a crash
to occur in findClassInfo() if the caller has not obtained
the class table lock. This fix changes call to findClassInfo
into calls to findClassInfoAfterLocking in places where
the class table lock is not held.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>