### PR TITLE
Fix -DREPORTDIR path for cmdLineTester_verbostest

### DIFF
--- a/test/cmdLineTests/verbosetest/playlist.xml
+++ b/test/cmdLineTests/verbosetest/playlist.xml
@@ -34,7 +34,7 @@
 			<variation>Mode351</variation>
 			<variation>Mode551</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DTESTNG=$(Q)$(TESTNG)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) -DJAVA_VERSION=$(Q)$(JAVA_VERSION)$(Q) -DREPORTDIR=$(Q)$(REPORTDIR)$(Q) -DTEST_GROUP=$(Q)$(TEST_GROUP)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)verbosetests.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DTESTNG=$(Q)$(TESTNG)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) -DJAVA_VERSION=$(Q)$(JAVA_VERSION)$(Q) -DREPORTDIR=$(REPORTDIR) -DTEST_GROUP=$(Q)$(TEST_GROUP)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)verbosetests.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>

--- a/test/cmdLineTests/verbosetest/verbosetests.xml
+++ b/test/cmdLineTests/verbosetest/verbosetests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2010, 2017 IBM Corp. and others
+  Copyright (c) 2010, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="Test -verbose parsing" timeout="900">
-	<variable name="PROGRAM" value="-cp $Q$$RESOURCES_DIR$$CPDL$$TESTNG$$CPDL$$JVM_TEST_ROOT$/JIT_Test/jitt.jar$Q$ org.testng.TestNG -d $REPORTDIR$ $Q$$JVM_TEST_ROOT$/JIT_Test/testng.xml$Q$ -testnames AllocationTest -groups $TEST_GROUP$" />
+	<variable name="PROGRAM" value="-cp $Q$$RESOURCES_DIR$$CPDL$$TESTNG$$CPDL$$JVM_TEST_ROOT$/JIT_Test/jitt.jar$Q$ org.testng.TestNG -d $Q$$REPORTDIR$$Q$ $Q$$JVM_TEST_ROOT$/JIT_Test/testng.xml$Q$ -testnames AllocationTest -groups $TEST_GROUP$" />
 	<variable name="VGC" value="<verbosegc" />
 	<variable name="VCLASS" value="class load: java/lang/Object" />
 	<variable name="VJNI" value="<JNI FindClass: java/lang/Class>" />


### PR DESCRIPTION
- Remove the duplicate double quotes.
- Add double quotes in verbosetests.xml.

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>