### PR TITLE
Adjust DDR in preparation for use of OMR's ddrgen

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureTypeManager.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureTypeManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,8 +149,6 @@ public class StructureTypeManager
 	
 	public int getType(String type)
 	{
-		CTypeParser parser = new CTypeParser(type);
-		
 		// trim off the const modifier, if present
 		if(type.startsWith("const ")) {
 			return getType(type.substring("const ".length()).trim());
@@ -196,7 +194,9 @@ public class StructureTypeManager
 		if (type.equals("iconv_t")) {
 			return TYPE_IDATA;
 		}	
-		
+
+		CTypeParser parser = new CTypeParser(type);
+
 		// array?
 		if(parser.getSuffix().endsWith("]")) {
 			return TYPE_ARRAY;
@@ -241,13 +241,17 @@ public class StructureTypeManager
 			}
 		}
 		
-		// SRP?
-		if(type.startsWith("J9SRP")) {
+		/* SRP?
+		 * Match types like J9SRP or J9SRP(UDATA) but not J9SRP* or J9SRPHashTable.
+		 */
+		if (type.equals("J9SRP") || type.startsWith("J9SRP(")) {
 			return TYPE_J9SRP;
 		}
-		
-		// WSRP?
-		if(type.startsWith("J9WSRP")) {
+
+		/* WSRP?
+		 * Match types like J9WSRP or J9WSRP(UDATA) but not J9WSRP*.
+		 */
+		if (type.equals("J9WSRP") || type.startsWith("J9WSRP(")) {
 			return TYPE_J9WSRP;
 		}
 		

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/AlgorithmPicker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/AlgorithmPicker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,12 @@
 package com.ibm.j9ddr.vm29.j9;
 
 /**
- * Class containing the boilerplate code for picking an appropriate algorithm
- * @author andhall
+ * Class containing the boilerplate code for picking an appropriate algorithm.
  *
+ * @author andhall
  */
-public abstract class AlgorithmPicker<T extends IAlgorithm>
+/* In Java 8 builds, the (interim) compiler gets confused if IAlgorithm is not fully qualified. */
+public abstract class AlgorithmPicker<T extends com.ibm.j9ddr.vm29.j9.IAlgorithm>
 {
 	private final String algorithmId;
 	

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -82,6 +82,7 @@ import static com.ibm.j9ddr.vm29.structure.J9Consts.*;
 import static com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags.*;
 import static com.ibm.j9ddr.vm29.structure.J9StackWalkConstants.*;
 import static com.ibm.j9ddr.vm29.structure.J9StackWalkState.*;
+import static com.ibm.j9ddr.vm29.structure.MethodMetaDataConstants.INTERNAL_PTR_REG_MASK;
 
 /**
  * Stack walker for processing JIT frames. Don't call directly - go through

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@ import static com.ibm.j9ddr.vm29.j9.stackwalker.StackWalkerUtils.*;
 import static com.ibm.j9ddr.vm29.pointer.generated.J9StackWalkFlags.J9SW_REGISTER_MAP_WALK_REGISTERS_LOW_TO_HIGH;
 import static com.ibm.j9ddr.vm29.structure.J9StackWalkConstants.J9SW_POTENTIAL_SAVED_REGISTERS;
 import static com.ibm.j9ddr.vm29.structure.J9StackWalkConstants.J9SW_REGISTER_MAP_MASK;
+import static com.ibm.j9ddr.vm29.structure.MethodMetaDataConstants.INTERNAL_PTR_REG_MASK;
 import static com.ibm.j9ddr.vm29.structure.MethodMetaDataConstants.J9TR_SHRINK_WRAP;
 import static com.ibm.j9ddr.vm29.structure.J9JITExceptionTable.*;
 
@@ -35,8 +36,6 @@ import java.util.List;
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.j9.AlgorithmPicker;
 import com.ibm.j9ddr.vm29.j9.AlgorithmVersion;
-import com.ibm.j9ddr.vm29.j9.BaseAlgorithm;
-import com.ibm.j9ddr.vm29.j9.IAlgorithm;
 import com.ibm.j9ddr.vm29.pointer.PointerPointer;
 import com.ibm.j9ddr.vm29.pointer.U16Pointer;
 import com.ibm.j9ddr.vm29.pointer.U32Pointer;
@@ -82,8 +81,6 @@ public class MethodMetaData
 	public static final long REGISTER_MAP_VALUE_FOR_GAP = 0xFADECAFE;
 	
 	public static final long BYTE_CODE_INFO_VALUE_FOR_GAP = 0x0;
-	
-	public static final long INTERNAL_PTR_REG_MASK = TRBuildFlags.host_POWER ? 0x00040000 : 0x80000000;
 	
 	public static I16 getJitTotalFrameSize(J9JITExceptionTablePointer md) throws CorruptDataException
 	{
@@ -279,7 +276,8 @@ public class MethodMetaData
 		return impl;
 	}
 	
-	private static interface MethodMetaDataImpl extends IAlgorithm
+	/* In Java 8 builds, the (interim) compiler gets confused if IAlgorithm is not fully qualified. */
+	private static interface MethodMetaDataImpl extends com.ibm.j9ddr.vm29.j9.IAlgorithm
 	{
 		public UDATAPointer getObjectTempScanCursor(WalkState walkState) throws CorruptDataException;
 		
@@ -355,8 +353,8 @@ public class MethodMetaData
 		public void markClassesInInlineRanges(J9JITExceptionTablePointer metaData, WalkState walkState) throws CorruptDataException;
 	}
 
-
-	private static class MethodMetaData_29_V0 extends BaseAlgorithm implements MethodMetaDataImpl
+	/* In Java 8 builds, the (interim) compiler gets confused if BaseAlgorithm is not fully qualified. */
+	private static class MethodMetaData_29_V0 extends com.ibm.j9ddr.vm29.j9.BaseAlgorithm implements MethodMetaDataImpl
 	{
 
 		private static boolean alignStackMaps = TRBuildFlags.host_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;


### PR DESCRIPTION
Issue: #378
* remove duplicate definition of INTERNAL_PTR_REG_MASK
* recognize types whose names start with "J9SRP(" or "J9WSRP("
* use reflection to find TDumpReader (only available on z/OS)
* workaround java compile problems for openjdk8