### PR TITLE
Add CONSTANT_Dynamic to classfile parsing

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1130,7 +1130,7 @@ readPool(J9CfrClassFile* classfile, U_8* data, U_8* dataEnd, U_8* segment, U_8* 
 
 		case CFR_CONSTANT_Dynamic:
 			if (classfile->majorVersion < 55) {
-				errorCode = J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V51__ID;
+				errorCode = J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V55__ID;
 				offset = (U_32) (index - data - 1);
 				goto _errorFound;
 			}

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1128,12 +1128,20 @@ readPool(J9CfrClassFile* classfile, U_8* data, U_8* dataEnd, U_8* segment, U_8* 
 			i++;
 			break;
 
+		case CFR_CONSTANT_Dynamic:
+			if (classfile->majorVersion < 55) {
+				errorCode = J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V51__ID;
+				offset = (U_32) (index - data - 1);
+				goto _errorFound;
+			}
+			/* fall through */
 		case CFR_CONSTANT_InvokeDynamic:
 			if (classfile->majorVersion < 51) {
 				errorCode = J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V51__ID;
 				offset = (U_32) (index - data - 1);
 				goto _errorFound;
 			}
+			/* fall through */
 		case CFR_CONSTANT_Fieldref:
 		case CFR_CONSTANT_Methodref:
 		case CFR_CONSTANT_InterfaceMethodref:
@@ -1384,6 +1392,7 @@ checkPool(J9CfrClassFile* classfile, U_8* segment, U_8* poolStart, I_32 *maxBoot
 			index += 4;
 			break;
 
+		case CFR_CONSTANT_Dynamic: /* fall through */
 		case CFR_CONSTANT_InvokeDynamic:
 			/* Slot1 is an index into the BootstrapMethods_attribute - can't be validated yet */
 			if (((I_32) info->slot1) > *maxBootstrapMethodIndex) {

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1356,3 +1356,8 @@ J9NLS_CFR_ERR_MODULE_IS_INVALID_CLASS.user_response=Contact the provider of the 
 
 # END NON-TRANSLATABLE
 
+J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V55=Constant pool entry not valid in class files with versions < 55.0
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V55.explanation=Please consult the Java Virtual Machine Specification for a detailed explaination.
+J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V55.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_CP_ENTRY_INVALID_BEFORE_V55.user_response=Contact the provider of the classfile for a corrected version.

--- a/runtime/oti/cfr.h
+++ b/runtime/oti/cfr.h
@@ -531,6 +531,7 @@ typedef struct J9CfrConstantPoolInfo {
 #define CFR_CONSTANT_NameAndType  12
 #define CFR_CONSTANT_MethodHandle  15
 #define CFR_CONSTANT_MethodType  16
+#define CFR_CONSTANT_Dynamic  17
 #define CFR_CONSTANT_InvokeDynamic  18
 #define CFR_CONSTANT_Module 19
 #define CFR_CONSTANT_Package 20


### PR DESCRIPTION
Adds parsing for Constant Pool type CFR_CONSTANT_Dynamic for
classfile version 55 or higher

Close: #1270

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>