### PR TITLE
Fix Clang error

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -4542,8 +4542,11 @@ JVM_RegisterSignal(jint sigNum, void* handler)
 	void *oldHandler = (void *)J9_SIG_ERR;
 
 #if !defined(WIN32)
-	struct sigaction newSignalAction = {{0}};
-	struct sigaction oldSignalAction = {{0}};
+	struct sigaction newSignalAction;
+	struct sigaction oldSignalAction;
+
+	memset(&newSignalAction, 0, sizeof(struct sigaction));
+	memset(&oldSignalAction, 0, sizeof(struct sigaction));
 #endif /* !defined(WIN32) */
 
 	Trc_SC_RegisterSignal();


### PR DESCRIPTION
Clang compilation issues an error when we initialize `sigaction` variables
using `{{0}}`. `sigaction` variables need to be initialized using `memset`
in order to fix the Clang compilation error.

`error : braces around scalar initializer [-Werror,-Wbraced-scalar-init]`

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>