### PR TITLE
Allow tests targets selection

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -89,4 +89,33 @@ def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, VA
         return JOB
     }
 }
+
+def workflow() {
+    def jobs = [:]
+
+    // compile the source and build the SDK
+    BUILD_JOB_NAME = "Build-JDK${SDK_VERSION}-${SPEC}"
+    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
+
+    levels = TESTS_TARGETS.split(",")
+    levels.each { level ->
+        switch (level.trim().toLowerCase()) {
+            case "_sanity":
+                TEST_JOB_NAME = "Test-Sanity-JDK${SDK_VERSION}-${SPEC}"
+                break
+            case "_extended":
+                TEST_JOB_NAME = "Test-Extended-JDK${SDK_VERSION}-${SPEC}"
+                break
+            default:
+                echo "error: Unknown test target: ${level}"
+                error()
+        }
+
+        // run tests against the SDK build in the upstream job: Build-JDK${SDK_VERSION}-${SPEC}
+        jobs["${level}"] = build_with_one_upstream(TEST_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+    }
+
+    // return jobs for further reference
+    return jobs
+}
 return this

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -126,9 +126,11 @@ def set_repos_variables() {
 * if the map contains no mapping for the key.
 */
 def get_value(MAP, KEY) {
-    for (item in MAP) {
-        if ("${item.key}" == "${KEY}") {
-            return "${item.value}"
+    if (MAP != null) {
+        for (item in MAP) {
+            if ("${item.key}" == "${KEY}") {
+                return "${item.value}"
+            }
         }
     }
 
@@ -141,9 +143,16 @@ def get_value(MAP, KEY) {
 * Returns empty string if no values is provided in the variables file (not
 * required for public repositories).
 */
-def get_git_user_credentials_id () {
-    if (VARIABLES.user != null) {
-        return VARIABLES.user.credentials_id
+def get_git_user_credentials_id() {
+    return get_user_credentials_id("git")
+}
+
+/*
+* Returns Jenkins credentials ID from the variable file for given key.
+*/
+def get_user_credentials_id(KEY) {
+    if ((VARIABLES.credentials != null) && (VARIABLES.credentials."${KEY}" != null)) {
+        return VARIABLES.credentials."${KEY}"
     }
 
     return ''
@@ -208,6 +217,17 @@ def set_test_variables() {
 }
 
 /*
+* Set TESTS_TARGETS, indicating the level of testing. 
+*/
+def set_test_targets() {
+    TESTS_TARGETS = params.TESTS_TARGETS
+    if (!TESTS_TARGETS) {
+        // set default TESTS_TARGETS for pipeline job (run all tests)
+        TESTS_TARGETS = "_sanity,_extended"
+    }
+}
+
+/*
 * Initializes all of the required variables for a Jenkins job by given job type.
 */
 def set_job_variables(job_type) {
@@ -240,6 +260,7 @@ def set_job_variables(job_type) {
         case "pipeline":
             // set variables for a pipeline job
             set_repos_variables()
+            set_test_targets()
             break
         default:
             error("Unknown Jenkins job type!")

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs
@@ -20,13 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def BUILD_JOB_NAME = 'Build-JDK8-linux_390-64_cmprssptrs'
-def SANITY_JOB_NAME = 'Test-Sanity-JDK8-linux_390-64_cmprssptrs'
-def EXTENDED_JOB_NAME = 'Test-Extended-JDK8-linux_390-64_cmprssptrs'
+SDK_VERSION = '8'
+SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-    SDK_VERSION = '8'
-    SPEC = 'linux_390-64_cmprssptrs'
 
     checkout scm
     def commonFile = load 'buildenv/jenkins/common/variables-functions'
@@ -36,6 +33,4 @@ node('master') {
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le
@@ -20,13 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def BUILD_JOB_NAME = 'Build-JDK8-linux_ppc-64_cmprssptrs_le'
-def SANITY_JOB_NAME = 'Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le'
-def EXTENDED_JOB_NAME = 'Test-Extended-JDK8-linux_ppc-64_cmprssptrs_le'
+SDK_VERSION = '8'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-    SDK_VERSION = '8'
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
 
     checkout scm
     def commonFile = load 'buildenv/jenkins/common/variables-functions'
@@ -36,6 +33,4 @@ node('master') {
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_390-64_cmprssptrs
@@ -20,13 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def BUILD_JOB_NAME = 'Build-JDK9-linux_390-64_cmprssptrs'
-def SANITY_JOB_NAME = 'Test-Sanity-JDK9-linux_390-64_cmprssptrs'
-def EXTENDED_JOB_NAME = 'Test-Extended-JDK9-linux_390-64_cmprssptrs'
+SDK_VERSION = '9'
+SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-    SDK_VERSION = '9'
-    SPEC = 'linux_390-64_cmprssptrs'
 
     checkout scm
     def commonFile = load 'buildenv/jenkins/common/variables-functions'
@@ -36,6 +33,4 @@ node('master') {
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_ppc-64_cmprssptrs_le
@@ -20,13 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def BUILD_JOB_NAME = 'Build-JDK9-linux_ppc-64_cmprssptrs_le'
-def SANITY_JOB_NAME = 'Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le'
-def EXTENDED_JOB_NAME = 'Test-Extended-JDK9-linux_ppc-64_cmprssptrs_le'
+SDK_VERSION = '9'
+SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-    SDK_VERSION = '9'
-    SPEC = 'linux_ppc-64_cmprssptrs_le'
 
     checkout scm
     def commonFile = load 'buildenv/jenkins/common/variables-functions'
@@ -36,6 +33,4 @@ node('master') {
     SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 }
 
-BUILD_JOB = buildfile.build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE)
-SANITY_JOB = buildfile.build_with_one_upstream(SANITY_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
-EXTENDED_JOB = buildfile.build_with_one_upstream(EXTENDED_JOB_NAME, BUILD_JOB_NAME, BUILD_JOB.getNumber(), params.VARIABLE_FILE)
+jobs = buildfile.workflow()


### PR DESCRIPTION
Allow users to choose what tests to run.
Reformat Jenkins files to check for test targets build parameter.
By default it runs sanity and extended tests.
Remove hard-coded values for the downstream jobs name.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>