### PR TITLE
Update the count mechanism for testKitGen

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -28,6 +28,7 @@ test_output_*
 # misc auto generated files
 autoGen.mk
 TestConfig/utils.mk
+TestConfig/count.mk
 TestConfig/specToPlat.mk
 TestConfig/*.log
 TestConfig/*.tap

--- a/test/TestConfig/makefile
+++ b/test/TestConfig/makefile
@@ -36,6 +36,8 @@ endif
 
 include settings.mk
 
+include count.mk
+
 #######################################
 # run all tests under $(TEST_ROOT)
 #######################################

--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -35,6 +35,7 @@ my $headerComments =
 
 my $mkName = "autoGen.mk";
 my $utilsmk = "utils.mk";
+my $countmk = "count.mk";
 my $settings = "settings.mk";
 my $projectRootDir = '';
 my $testRoot = '';
@@ -77,6 +78,7 @@ sub runmkgen {
 		$sp_hs = $data->{'specPlatMapping'};
 	}
 
+	$targetGroup{"all"} = 0;
 	foreach my $eachLevel (sort @{$allLevels}) {
 		foreach my $eachGroup (sort @{$allGroups}) {
 			my $groupTargetKey = $eachLevel . '.' . $eachGroup;
@@ -86,6 +88,7 @@ sub runmkgen {
 
 	generateOnDir();
 	utilsGen();
+	countGen();
 }
 
 sub generateOnDir {
@@ -183,7 +186,6 @@ sub writeVars {
 	}
 	
 	print $fhOut $headerComments ."\n";
-	print $fhOut ".DEFAULT_GOAL := all\n\n";
 	print $fhOut "D=/\n\n";
 	print $fhOut "ifndef TEST_ROOT\n";
 	print $fhOut "\tTEST_ROOT := $testRoot\n";
@@ -583,15 +585,23 @@ sub utilsGen {
 		}
 	}
 	print $fhOut $spec2platform;
-	
+	close $fhOut;
+	print "\nGenerated $utilsmk\n";
+}
+
+sub countGen {
+	my $countmkpath = $testRoot . "/TestConfig/" . $countmk;
+	open( my $fhOut, '>', $countmkpath ) or die "Cannot create file $countmkpath";
+
 	foreach my $eachLevel (sort @{$allLevels}) {
 		$targetGroup{$eachLevel} = 0;
 		foreach my $eachGroup (sort @{$allGroups}) {
 			my $groupTargetKey = $eachLevel . '.' . $eachGroup;
 			$targetGroup{$eachLevel} += $targetGroup{$groupTargetKey};
 		}
+		$targetGroup{"all"} += $targetGroup{$eachLevel};
 	}
-	
+
 	foreach my $eachGroup (sort @{$allGroups}) {
 		$targetGroup{$eachGroup} = 0;
 		foreach my $eachLevel (sort @{$allLevels}) {
@@ -602,7 +612,6 @@ sub utilsGen {
 
 	print $fhOut "_GROUPTARGET = \$(firstword \$(MAKECMDGOALS))\n\n";
 	print $fhOut "GROUPTARGET = \$(patsubst _%,%,\$(_GROUPTARGET))\n\n";
-	print $fhOut "TOTALCOUNT := 0\n\n";
 	foreach my $targetGroupKey (keys %targetGroup) {
 		print $fhOut "ifeq (\$(GROUPTARGET),$targetGroupKey)\n";
 		print $fhOut "\tTOTALCOUNT := $targetGroup{$targetGroupKey}\n";
@@ -610,7 +619,7 @@ sub utilsGen {
 	}
 
 	close $fhOut;
-	print "\nGenerated $utilsmk\n";
+	print "\nGenerated $countmk\n";
 }
 
 1;

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -182,7 +182,7 @@ REPORTDIR = $(Q)$(TESTOUTPUT)$(D)$@$(Q)
 #######################################
 # TEST_STATUS
 #######################################
-TEST_STATUS=if [ $$? -eq 0 ] ; then $(ECHO) $(Q)$@$(Q)$(Q)_PASSED$(Q); else $(ECHO) $(Q)$@$(Q)$(Q)_FAILED$(Q); fi
+TEST_STATUS=if [ $$? -eq 0 ] ; then $(ECHO) $(Q)$@$(Q)$(Q)_PASSED$(Q); else $(ECHO) -e $(Q)\n$@$(Q)$(Q)_FAILED\n$(Q); fi
 ifneq ($(DEBUG),)
 $(info TEST_STATUS is $(TEST_STATUS))
 endif
@@ -223,6 +223,8 @@ _$(TESTTARGET): setup_$(TESTTARGET) rmResultFile $(TESTTARGET) resultsSummary
 .PHONY: _$(TESTTARGET) $(TESTTARGET) $(SUBDIRS) $(SUBDIRS_TESTTARGET)
 
 .NOTPARALLEL: _$(TESTTARGET) $(TESTTARGET) $(SUBDIRS) $(SUBDIRS_TESTTARGET)
+
+TOTALCOUNT := 0
 
 setup_%:
 	@$(ECHO)


### PR DESCRIPTION
- Keep count information in a separate make file.
- The count will only be printed out when testing under TestConfig.
- Add count for target all.

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>