### PR TITLE
Add JIT helper definition to asmprotos.h for consistency

### DIFF
--- a/runtime/codert_vm/asmprotos.h
+++ b/runtime/codert_vm/asmprotos.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -152,6 +152,8 @@ JIT_HELPER(jitReportExceptionCatch);  // asm calling-convention helper
 JIT_HELPER(jitANewArrayNoZeroInit);  // asm calling-convention helper
 JIT_HELPER(jitNewArrayNoZeroInit);  // asm calling-convention helper
 JIT_HELPER(jitNewObjectNoZeroInit);  // asm calling-convention helper
+JIT_HELPER(jitReportFinalFieldModified); // asm calling-convention helper
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
New JIT runtime helper jitReportFinalFieldModified declaration added to
asmprotos.h to keep consistent with other native all platform helpers

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>