### PR TITLE
Unify JVM_SocketAvailable() return values

### DIFF
--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -57,7 +57,7 @@
 
 /**
  * Masks and constants for describing J2SE shapes.
- *  J2SE_SHAPE_SUN = Sun core libraries (aka IBM 'sidecar', Sun code + IBM kernel)
+ *  J2SE_SHAPE_OPENJDK = OpenJDK core libraries (aka J9 'sidecar', OpenJDK code + J9 kernel)
  *  J2SE_SHAPE_RAW = Pure Oracle code without any IBM modifications
  */
 /*
@@ -66,7 +66,7 @@
  *       nor release file presents.
  */
 #if JAVA_SPEC_VERSION == 8
-	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_SUN
+	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_OPENJDK
 #elif JAVA_SPEC_VERSION == 9
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_B165
 #elif JAVA_SPEC_VERSION == 10
@@ -74,8 +74,7 @@
 #else
 	#define J2SE_SHAPE_LATEST       J2SE_SHAPE_V11
 #endif
-#define J2SE_SHAPE_SUN     		0x10000
-#define J2SE_SHAPE_SUN_OPENJDK	0x20000
+#define J2SE_SHAPE_OPENJDK 		0x10000
 #define J2SE_SHAPE_B136    		0x40000
 #define J2SE_SHAPE_B148    		0x50000
 #define J2SE_SHAPE_B165    		0x60000


### PR DESCRIPTION
Unify `JVM_SocketAvailable()` return values

Remove most of https://github.com/eclipse/openj9/pull/714 such that `JVM_SocketAvailable()` return `0` for failure, and `1` for success consistently;
Keep the code receiving `shape=sun_openjdk` but map it to `J2SE_SHAPE_OPENJDK` instead.

Ported from https://github.com/eclipse/openj9/pull/1296
PR company: https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/55

Reviewer @pshipton
FYI: @danheidinga

Signed-off-by: Jason Feng <fengj@ca.ibm.com>