### PR TITLE
Split zOS system linkage call dependencies

### DIFF
--- a/runtime/compiler/trj9/z/codegen/J9S390SystemLinkage.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9S390SystemLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,8 +98,7 @@ public:
    virtual int32_t storeExtraEnvRegForBuildArgs(TR::Node * callNode, TR::Linkage* linkage, TR::RegisterDependencyConditions * dependencies,
          bool isFastJNI, int32_t stackOffset, int8_t gprSize, uint32_t &numIntegerArgs);
 
-   virtual TR::Instruction * genCallNOPAndDescriptor(TR::Instruction * cursor, TR::Node *node, TR::Node *callNode, TR_XPLinkCallTypes callType);
-   virtual TR::S390ConstantDataSnippet *createCallDescriptor(TR::Node *node, uint64_t initialValue);
+   TR::Instruction * genCallNOPAndDescriptor(TR::Instruction * cursor, TR::Node *node, TR::Node *callNode, TR_XPLinkCallTypes callType);
    };
 
 }


### PR DESCRIPTION
Split the zOS system linkage call dependencies by attaching the
pre-dependencies to the BASR call instruction, and attaching the
post-dependencies to the function call descriptor instruction.

The C XPLINK return will need a NOP after the BASR for entry to valid
instructions. If they are separated by spills, returning from C code can
cause exceptions. Having a post-dependency group after the NOP ensures
that no such spill can happen.

This pull request also contains  miscellaneous zOS system linkage code simplifications

    1. Simplify NOP and call descriptor generation for zOS system linkage.

    2. Use the insetPad() API to insert NOP after the BASR call in system
    linkage.

    3. Remove the oneliner createCallDescriptor() function.  Do the same thing inline.

    4. genCallNOPAndDescriptor() does not have to be virtual. Remove the virtual
    keyword.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>