### PR TITLE
Enable support for cgroups in VM

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -418,6 +418,9 @@ enum INIT_STAGE {
 #define VMOPT_XXENABLEHCR "-XX:+EnableHCR"
 #define VMOPT_XXNOENABLEHCR "-XX:-EnableHCR"
 
+#define VMOPT_XXUSECONTAINERSUPPORT "-XX:+UseContainerSupport"
+#define VMOPT_XXNOUSECONTAINERSUPPORT "-XX:-UseContainerSupport"
+
 #define MAPOPT_AGENTLIB_JDWP_EQUALS "-agentlib:jdwp="
 
 #define MAPOPT_XCOMP "-Xcomp"

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -763,3 +763,5 @@ TraceException=Trc_VM_CreateRAMClassFromROMClass_nestHostNotVerified Overhead=1 
 TraceEntry=Trc_VM_sendResolveMethodTypeRefInto_Entry Overhead=1 Level=5 Template="sendResolveMethodTypeRefInto ramCP=%p cpIndex=%zu resolveFlags=%zu"
 TraceException=Trc_VM_sendResolveMethodTypeRefInto_Exception Overhead=1 Level=1 Template="Sender class=%p cannot access receiver class=%p, errorCode=%zi."
 TraceExit=Trc_VM_sendResolveMethodTypeRefInto_Exit Overhead=1 Level=5 Template="sendResolveMethodTypeRefInto methodType=%p."
+
+TraceException=Trc_VM_CgroupSubsystemsNotEnabled Overhead=1 Level=1 Template="Cgroup subsystems available: 0x%llx, enabled: 0x%llx"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1899,6 +1899,19 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 			vm->vmRuntimeStateListener.runtimeStateListenerState = J9VM_RUNTIME_STATE_LISTENER_UNINITIALIZED;
 			vm->vmRuntimeStateListener.vmRuntimeState = J9VM_RUNTIME_STATE_ACTIVE;
 
+			argIndex = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXUSECONTAINERSUPPORT, NULL);
+			argIndex2 = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXNOUSECONTAINERSUPPORT, NULL);
+
+			if (argIndex > argIndex2) {
+				OMRPORT_ACCESS_FROM_J9PORT(vm->portLibrary);
+				uint64_t subsystemsEnabled = omrsysinfo_cgroup_enable_subsystems(OMR_CGROUP_SUBSYSTEM_ALL);
+
+				if (OMR_CGROUP_SUBSYSTEM_ALL != subsystemsEnabled) {
+					uint64_t subsystemsAvailable = omrsysinfo_cgroup_get_available_subsystems();
+					Trc_VM_CgroupSubsystemsNotEnabled(vm->mainThread, subsystemsAvailable, subsystemsEnabled);
+				}
+			} 
+
 			break;
 
 		case ALL_DEFAULT_LIBRARIES_LOADED :


### PR DESCRIPTION
- Added a new options -XX:[+-]UseContainerSupport to enable
support for cgroup
- By default cgroup support is disabled

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>