### PR TITLE
Remove vendor_version.h from j9cfg.h

### DIFF
--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -36,6 +36,7 @@
 #include "j9cp.h"
 #include "bcutil_api.h"
 #include "cfdumper_internal.h"
+#include "vendor_version.h"
 
 #if defined(J9ZOS390)
 #include "atoe.h"

--- a/runtime/gc_check/CheckCycle.cpp
+++ b/runtime/gc_check/CheckCycle.cpp
@@ -23,6 +23,7 @@
 
 #include <string.h>
 
+#include "vendor_version.h"
 #include "CheckCycle.hpp"
 #include "CheckClassHeap.hpp"
 #include "CheckClassLoaders.hpp"

--- a/runtime/include/j9cfg.h.ftl
+++ b/runtime/include/j9cfg.h.ftl
@@ -33,7 +33,6 @@ extern "C" {
 #endif
 
 #include "omrcfg.h"
-#include "vendor_version.h"
 
 #define J9_COPYRIGHT_STRING "(c) Copyright 1991, ${uma.year} IBM Corp. and others."
 

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -42,6 +42,7 @@
 #include "jnicheck.h"
 #include "jnichk_internal.h"
 #include "ut_j9jni.h"
+#include "vendor_version.h"
 
 static void jniCallIn (J9VMThread * vmThread);
 static void methodExitHook (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);

--- a/runtime/vmchk/vmcheck.c
+++ b/runtime/vmchk/vmcheck.c
@@ -32,6 +32,7 @@
 #include "mmomrhook.h"
 #include "vmcheck.h"
 #include "ut_j9vmchk.h"
+#include "vendor_version.h"
 
 #include <stdarg.h>
 


### PR DESCRIPTION
#1095 added vendor_verison.h in j9cfg.h, which at the time seemed
necessary, but subsequent design decisions make it unnecessary. Remove
it so that changing the version information such as the OPENJDK_SHA
doesn't cause recompilation of everything when doing an incremental
build.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>