### PR TITLE
Fix assertion failure at cphelp.c:96

### DIFF
--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2017 IBM Corp. and others
+// Copyright (c) 2006, 2018 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2905,3 +2905,4 @@ TraceEntry=Trc_SHR_API_j9shr_createSharedClass_Entry3 Overhead=1 Level=2 Templat
 TraceExit=Trc_SHR_CM_allocateROMClass_Exit3 Overhead=1 Level=3 Template="CM allocateROMClass : exit retval=%d (Class=%.*s  romClass=%p lineNumberTable=%p localVariableTable=%p flags=0x%x)"
 
 TraceEvent=Trc_SHR_INIT_isClassFromPatchedModule_ClassFromPatchedModule_Event Test Overhead=1 Level=3 Template="INIT isClassFromPatchedModule: Class (classname=%.*s) is from a patched module (URL=%.*s)."
+TraceEvent=Trc_SHR_INIT_hookFindSharedClass_classFromUnresolvedModule Overhead=1 Level=3 Template="INIT hookFindSharedClass: Class (classname=%.*s) is from an unresolved module. Returning NULL."

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/SharedClassesModularityTests.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/SharedClassesModularityTests.xml
@@ -124,6 +124,43 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
+	
+	<test id="Test 3 cleanup" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="yes" regex="no">JVM requested Java dump</output>
+		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
+	</test>
+
+	<test id="Test 4 set-up: create a shared cache" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ -version</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test 4: Class from unresolved module should not be found" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ -Xtrace:print={j9shr.2262} -verbose --module-path $UTILSJAR$ -m utils/$PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">INIT hookFindSharedClass: Class .* is from an unresolved module. Returning NULL.</output>
+
+		<!-- OpenJ9 issue 1081: assertion failure at j9vmutil(j9vrb).15 if class from unresolved module is found -->
+		<output type="failure" caseSensitive="no" regex="no">ASSERTION FAILED</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
 
 	<test id="At end destroy cache for cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,destroy</command>


### PR DESCRIPTION
1. Do not return class in unresolved modules from the shared cache for
Bootstrap class loader.
2. Add a CML test case.

Fixes #1081

Signed-off-by: hangshao <hangshao@ca.ibm.com>