### PR TITLE
Do not archive test material in pr builds

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -163,9 +163,15 @@ def build() {
 def archive() {
     stage('Archive') {
         timestamps {
+            // Do not archive test material in PR jobs, only "Build" jobs
+            // https://github.com/eclipse/openj9/issues/1114
+            // ghprbPullId is the PullRequest ID which only shows up in Pull Requests
+            if ((params.ghprbPullId == "") || (params.ghprbPullId == "null")) {
+                sh "tar -zcvf ${WORKSPACE}/${TEST_PREFIX}`git -C openj9 rev-parse --short HEAD`${TEST_SUFFIX} openj9/test/"
+                archiveArtifacts artifacts: "**/${TEST_PREFIX}*${TEST_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
+            }
             sh "tar -zcvf ${WORKSPACE}/${SDK_PREFIX}`date +%Y%d%m%H%M`${SDK_SUFFIX} build/$RELEASE/images/${JDK_FOLDER}"
-            sh "tar -zcvf ${WORKSPACE}/${TEST_PREFIX}`git -C openj9 rev-parse --short HEAD`${TEST_SUFFIX} openj9/test/"
-            archiveArtifacts artifacts: "**/${SDK_PREFIX}*${SDK_SUFFIX}, **/${TEST_PREFIX}*${TEST_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
+            archiveArtifacts artifacts: "**/${SDK_PREFIX}*${SDK_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
         }
     }
 }


### PR DESCRIPTION
Because we were archiving in parallel to testing,
archiving the test material would often fail in PR
builds becasue we are trying to write to the test
folder at the same time we are trying to tar it.
This PR will change the behaviour so we do not
bother archiving the test material in PR builds. Since we
compile & test on the same machine in PRs. In non-pr
builds we do compile on one machine and then test on
another.

Fixes #1114

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>