### PR TITLE
Add required dependencies on generate_j9vm

### DIFF
--- a/runtime/jcl/cl_se10/module.xml
+++ b/runtime/jcl/cl_se10/module.xml
@@ -20,7 +20,6 @@
 
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
 	<xi:include href="../uma/sun_misc_Unsafe_exports.xml"></xi:include>
@@ -68,7 +67,10 @@
 			<option name="dllDescription" data="Java SE 10"/>
 		</options>
 		<phase>core j2se</phase>
-		
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
+
 		<exports>
 			<group name="se6_vm-side_lifecycle"/>
 			<group name="se6_vm-side_natives"/>

--- a/runtime/jcl/cl_se11/module.xml
+++ b/runtime/jcl/cl_se11/module.xml
@@ -20,7 +20,6 @@
 
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
 	<xi:include href="../uma/sun_misc_Unsafe_exports.xml"></xi:include>
@@ -68,7 +67,10 @@
 			<option name="dllDescription" data="Java SE 11"/>
 		</options>
 		<phase>core j2se</phase>
-		
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
+
 		<exports>
 			<group name="se6_vm-side_lifecycle"/>
 			<group name="se6_vm-side_natives"/>

--- a/runtime/jcl/cl_se7_basic/module.xml
+++ b/runtime/jcl/cl_se7_basic/module.xml
@@ -20,7 +20,6 @@
 
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
 	<xi:include href="../uma/sun_misc_Unsafe_exports.xml"></xi:include>
@@ -68,7 +67,10 @@
 			<option name="dllDescription" data="Java SE 7 Basic"/>
 		</options>
 		<phase>core j2se</phase>
-		
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
+
 		<exports>
 			<group name="se6_vm-side_lifecycle"/>
 			<group name="se6_vm-side_natives"/>

--- a/runtime/jcl/cl_se9/module.xml
+++ b/runtime/jcl/cl_se9/module.xml
@@ -20,7 +20,6 @@
 
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
 	<xi:include href="../uma/sun_misc_Unsafe_exports.xml"></xi:include>
@@ -68,7 +67,10 @@
 			<option name="dllDescription" data="Java SE 9"/>
 		</options>
 		<phase>core j2se</phase>
-		
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
+
 		<exports>
 			<group name="se6_vm-side_lifecycle"/>
 			<group name="se6_vm-side_natives"/>

--- a/runtime/jcl/cl_se9_before_b165/module.xml
+++ b/runtime/jcl/cl_se9_before_b165/module.xml
@@ -20,7 +20,6 @@
 
 	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
 	<xi:include href="../uma/sun_misc_Unsafe_exports.xml"></xi:include>
@@ -68,6 +67,9 @@
 			<option name="dllDescription" data="Java SE 9"/>
 		</options>
 		<phase>core j2se</phase>
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
 		
 		<exports>
 			<group name="se6_vm-side_lifecycle"/>

--- a/runtime/jcl/cl_se9_before_b165/module.xml
+++ b/runtime/jcl/cl_se9_before_b165/module.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-	Copyright (c) 2017, 2018 IBM Corp. and others
-	
-	This program and the accompanying materials are made available under
-	the terms of the Eclipse Public License 2.0 which accompanies this
-	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-	or the Apache License, Version 2.0 which accompanies this distribution and
-	is available at https://www.apache.org/licenses/LICENSE-2.0.
-	
-	This Source Code may also be made available under the following
-	Secondary Licenses when the conditions for such availability set
-	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-	General Public License, version 2 with the GNU Classpath
-	Exception [1] and GNU General Public License, version 2 with the
-	OpenJDK Assembly Exception [2].
-	
-	[1] https://www.gnu.org/software/classpath/license.html
-	[2] http://openjdk.java.net/legal/assembly-exception.html
+<!--
+Copyright (c) 2017, 2018 IBM Corp. and others
 
-	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -38,7 +38,7 @@
 		<xi:fallback/>
 	</xi:include>
 
-	<xi:include href="../uma/sun_misc_Unsafe_objects.xml"></xi:include>	
+	<xi:include href="../uma/sun_misc_Unsafe_objects.xml"></xi:include>
 	<xi:include href="../uma/se6_vm-side_natives_objects.xml"></xi:include>
 	<xi:include href="../uma/se6_vm-side_lifecycle_objects.xml"></xi:include>
 	<xi:include href="../uma/attach_objects.xml"></xi:include>
@@ -70,7 +70,7 @@
 		<dependencies>
 			<dependency name="generate_j9vm"/>
 		</dependencies>
-		
+
 		<exports>
 			<group name="se6_vm-side_lifecycle"/>
 			<group name="se6_vm-side_natives"/>
@@ -86,13 +86,13 @@
 			<group name="se829"/>
 			<group name="se9" />
 		</exports>
-		
+
 		<flags>
-			<!-- add a -D to access the Hursley build ID from java code - $MY_LEVEL will be set by the build environment -->	
+			<!-- add a -D to access the Hursley build ID from java code - $MY_LEVEL will be set by the build environment -->
 			<flag name='J9_BUILD_LEVEL' value='&apos;"$(MY_LEVEL)"&apos;' asmflag='false'/>
 			<flag name="J9VM_JCL_SE9"/>
 		</flags>
-		
+
 		<includes>
 			<include path="j9include"/>
 			<include path="j9oti"/>
@@ -124,7 +124,7 @@
 			<vpath pattern="%" path="../inl" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="%" path="../." augmentIncludes="true" type="relativepath"/>
 		</vpaths>
-		
+
 		<objects>
 			<group name="se6_vm-side_lifecycle"/>
 			<group name="se6_vm-side_natives"/>
@@ -138,9 +138,9 @@
 
 			<group name="se8"/>
 			<group name="se9"/>
-			
+
 			<group name="vendor_jcl"/>
-			
+
 			<!-- Groups must be before Objects -->
 			<object name="j9vmconstantpool_se9_before_b165" />
 		</objects>
@@ -163,7 +163,7 @@
 			<library name="j9util"/>
 			<library name="j9utilcore"/>
 			<library name="j9avl" type="external"/>
-			<library name="j9hashtable" type="external"/>						
+			<library name="j9hashtable" type="external"/>
 			<library name="j9pool" type="external"/>
 			<library name="j9thr"/>
 			<library name="j9vmi"/>

--- a/runtime/tests/j9vm/module.xml
+++ b/runtime/tests/j9vm/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2009, 2017 IBM Corp. and others
+   Copyright (c) 2009, 2018 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,9 +20,7 @@
 
    SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
-<module
-        >
+<module>
         
 	<exports group="all">
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetSystemPackage"/>
@@ -63,6 +60,9 @@
 			<option name="prototypeHeaderFileNames" data="j9protos.h"/>
 		</options>
 		<phase>util</phase>
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
 		<exports>
 			<group name="all"/>
 		</exports>

--- a/runtime/tests/jni/module.xml
+++ b/runtime/tests/jni/module.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2018 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <module>
-        
+
 <exports group="all">
 	<export name="JNI_OnLoad"/>
 	<export name="JNI_OnUnload"/>
@@ -189,7 +189,7 @@
 	<export name="Java_j9vm_test_jnichk_ReturnInvalidReference_validGlobalRef"/>
 	<export name="Java_j9vm_test_jnichk_ReturnInvalidReference_validLocalRef"/>
 	<export name="Java_j9vm_test_jnichk_CriticalAlwaysCopy_testArray"/>
-	<export name="Java_j9vm_test_jnichk_CriticalAlwaysCopy_testString"/>	
+	<export name="Java_j9vm_test_jnichk_CriticalAlwaysCopy_testString"/>
 	<export name="Java_j9vm_test_monitor_Helpers_getLastReturnCode"/>
 	<export name="Java_j9vm_test_monitor_Helpers_monitorEnter"/>
 	<export name="Java_j9vm_test_monitor_Helpers_monitorExit"/>

--- a/runtime/tests/jni/module.xml
+++ b/runtime/tests/jni/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2006, 2017 IBM Corp. and others
+   Copyright (c) 2006, 2018 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +20,6 @@
 
    SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module>
         
 <exports group="all">
@@ -367,6 +365,9 @@
 			<option name="prototypeHeaderFileNames" data="j9protos.h jnitest_internal.h"/>
 		</options>
 		<phase>core j2se</phase>
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
 		<exports>
 			<group name="all"/>
 		</exports>


### PR DESCRIPTION
If make attempts to build some modules (e.g.  `jclse9_`) before `generate_j9vm` compiles will fail due to a missing `generated.h`. Adding these dependencies prevents those problems.