### PR TITLE
Change if condition bug in test archive check

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -166,7 +166,7 @@ def archive() {
             // Do not archive test material in PR jobs, only "Build" jobs
             // https://github.com/eclipse/openj9/issues/1114
             // ghprbPullId is the PullRequest ID which only shows up in Pull Requests
-            if ((params.ghprbPullId == "") || (params.ghprbPullId == "null")) {
+            if (!params.ghprbPullId) {
                 sh "tar -zcvf ${WORKSPACE}/${TEST_PREFIX}`git -C openj9 rev-parse --short HEAD`${TEST_SUFFIX} openj9/test/"
                 archiveArtifacts artifacts: "**/${TEST_PREFIX}*${TEST_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
             }


### PR DESCRIPTION
- should be `== null` not `== "null"`
- We can collapse into `!params.ghprbPullId`

Issue #1320 #1114

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>