### PR TITLE
Check JAVA_IMPL to optionally include openj9 extra settings

### DIFF
--- a/test/TestConfig/openj9Settings.mk
+++ b/test/TestConfig/openj9Settings.mk
@@ -21,7 +21,7 @@
 ##############################################################################
 
 #
-# This makefile contains J9 specific settings
+# This makefile contains openJ9 specific settings
 #
 
 #######################################

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -200,9 +200,11 @@ else
 endif
 
 #######################################
-# include sub makefile
+# include openj9 specific settings
 #######################################
--include $(JVM_TEST_ROOT)$(D)TestConfig$(D)extraSettings.mk
+ifeq ($(JAVA_IMPL), openj9)
+	include $(TEST_ROOT)$(D)TestConfig$(D)openj9Settings.mk
+endif
 
 #######################################
 # generic target


### PR DESCRIPTION
- Rename extraSettings.mk to openj9Settings.mk.
- Include openj9Settings.mk when JAVA_IMPL is openj9.

Fixes: #1314


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>