### PR TITLE
Reduce use of j9vm/jvm.h

### DIFF
--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -34,9 +34,6 @@
 #include "jni.h"
 #include "j9protos.h"
 #include "jvminit.h"
-/* Avoid renaming malloc/free */
-#define LAUNCHERS
-#include "../../j9vm/jvm.h"
 #include "jclprots.h"
 #include "omrlinkedlist.h"
 #include "ut_j9jcl.h"

--- a/runtime/tests/j9vm/module.xml
+++ b/runtime/tests/j9vm/module.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2009, 2017 IBM Corp. and others
+   Copyright (c) 2009, 2018 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,9 +20,7 @@
 
    SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
-<module
-        >
+<module>
         
 	<exports group="all">
 		<export name="Java_com_ibm_oti_jvmtests_SupportJVM_GetSystemPackage"/>
@@ -63,6 +60,9 @@
 			<option name="prototypeHeaderFileNames" data="j9protos.h"/>
 		</options>
 		<phase>util</phase>
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
 		<exports>
 			<group name="all"/>
 		</exports>

--- a/runtime/tests/jni/jnitest.c
+++ b/runtime/tests/jni/jnitest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include "j9port.h"
 #include "j9.h"
 #include "vmi.h"
-#include "../j9vm/jvm.h"
 #ifndef WIN32
 #include <pthread.h>
 #include <stdlib.h>

--- a/runtime/tests/jni/jnitest.c
+++ b/runtime/tests/jni/jnitest.c
@@ -24,7 +24,10 @@
 #include "j9port.h"
 #include "j9.h"
 #include "vmi.h"
-#ifndef WIN32
+#ifdef WIN32
+#include <stdlib.h>
+#include <malloc.h>
+#else
 #include <pthread.h>
 #include <stdlib.h>
 #endif


### PR DESCRIPTION
* don't include jvm.h where it's not needed
* add module dependency where it is needed
Supersedes #1326.