### PR TITLE
Use native cast for int to float on ARM

### DIFF
--- a/runtime/util/fltconv.c
+++ b/runtime/util/fltconv.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -277,8 +277,11 @@ jfloat
 helperCConvertIntegerToFloat(I_32 src)
 {
 	jfloat tmpDst;
-	
-#if defined USE_NATIVE_CAST
+
+#if defined(USE_NATIVE_CAST) || defined(ARM)
+	/* Enabling native cast for ARM avoids a compiler bug in
+	 * gcc-linaro-4.9.4-2017.01
+	 */
 	tmpDst = (jfloat)src;
 #else
 	{
@@ -424,6 +427,11 @@ fltconv_indexLeadingOne32(U_32 u32val)
 		leading = 7;
 		mask = 0x00000080;
 	}
+	/* WARNING This loop will busy hang when compiled with
+	 * gcc-linaro-4.9.4-2017.01 for armhf if the match should happen on
+	 * the first iteration. The loop exit condition is moved to the end of
+	 * the loop and doesn't execute before the first shift of mask.
+	 */
 	while((mask & u32val) == 0) {
 		mask >>= 1;
 		leading--;
@@ -433,5 +441,3 @@ fltconv_indexLeadingOne32(U_32 u32val)
 
 
 #endif /* J9VM_INTERP_FLOAT_SUPPORT */ /* End File Level Build Flags */
-
-


### PR DESCRIPTION
Some int to float conversions hang when running on armhf. The problem appears
to be with gcc-linaro-4.9.4-2017.01 which generates incorrect code for the
while loop in fltconv_indexLeadingOne32. Then entire code path can be avoided
by enabling native cast in helperCConvertIntegerToFloat, which should also
improve performance.

Fixes: #1207 

Signed-off-by: James Kingdon <jkingdon@ca.ibm.com>