### PR TITLE
fix option permit-illegal-access issue

### DIFF
--- a/test/JLM_Tests/playlist.xml
+++ b/test/JLM_Tests/playlist.xml
@@ -968,7 +968,7 @@
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-DRUNLOCAL=true --permit-illegal-access \
+	-DRUNLOCAL=true --illegal-access=permit \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames testJCMMXBean \
@@ -1021,7 +1021,7 @@
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-DRUNLOCAL=false --permit-illegal-access \
+	-DRUNLOCAL=false --illegal-access=permit \
 	-Dremote.server.option=$(Q)$(JVM_OPTIONS) -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \


### PR DESCRIPTION
* permit-illegal-access has been changed to illegal-access
* illegal-access=permit is default
* change options to illegal-access=permit

[ci skip]

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>