### PR TITLE
Refactor check visiblity code

### DIFF
--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1259,6 +1259,7 @@ extern J9_CFUNC void  dbgDumpStack (J9VMThread *vmThread, IDATA delta);
 #ifndef _J9VMVISIBILITY_
 #define _J9VMVISIBILITY_
 extern J9_CFUNC IDATA  checkVisibility (J9VMThread* currentThread, J9Class* sourceClass, J9Class* destClass, UDATA modifiers, UDATA lookupOptions);
+extern J9_CFUNC IDATA  checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions);
 #endif /* _J9VMVISIBILITY_ */
 
 /* J9VMVolatileLongFunctions*/

--- a/runtime/util/module.tdf
+++ b/runtime/util/module.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2017 IBM Corp. and others
+// Copyright (c) 2017, 2018 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,3 +41,4 @@ TraceEvent=Trc_MODULE_add_module_package Overhead=1 Level=5 Test Template="JVM_A
 TraceEvent=Trc_MODULE_setting_package Overhead=1 Level=5 Test Template="internally set package/class: %.*s, loader: %s, module: %s"
 
 TraceException=Trc_VM_checkVisibility_failed_with_errortype Overhead=1 Level=1 Template="checkVisibility from %p (%.*s) to %p (%.*s) failed, error type: %s"
+TraceException=Trc_VM_checkVisibility_failed_with_errortype_romclass Overhead=1 Level=1 Template="checkVisibility from romClass=%p (%.*s) j9mod=%p to romClass=%p (%.*s) j9mod=%p failed, packagedef'n errcode=%zu, error type: %s"


### PR DESCRIPTION
Refactor check visiblity code

Split out the modularity access checks from the check visibility code so it can be called separately. Modify the tracepoints to output romClasses and J9Module info. J9Module also knows about the classLoader so we can determine runtime types from trace output. 


Signed-off-by: tajila <atobia@ca.ibm.com>