### PR TITLE
Add shared class CML test cases

### DIFF
--- a/test/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -24,7 +24,7 @@
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<!-- Test 1 to Test 52: 68 tests -->
+<!-- Test 1 to Test 54: 70 tests -->
 
 <suite id="Shared Classes CommandLineOptionTests Suite ">
 
@@ -942,6 +942,30 @@
 		
 		<output type="failure" caseSensitive="yes" regex="no">com.ibm.oti.shared.enabled = true</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 53: Make sure classes are being stored to the shared cache " timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,verboseIO $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Stored class java/.* in shared cache for class-loader id 0 with URL .* \(index</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Stored class org/openj9/test/ivj/.* in shared cache for class-loader id [2-9].*[\\/]utils.jar \(index 0\)</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 54: Make sure classes are being found in the shared cache " timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,verboseIO $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Found class java/.* in shared cache for class-loader id 0</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Found class org/openj9/test/ivj/.* in shared cache for class-loader id [2-9]</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/SharedClassesModularityTests.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/SharedClassesModularityTests.xml
@@ -161,6 +161,18 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
+	
+	<test id="Test 4: Test classes are being found in the shared cache when running an application module" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,verboseIO --module-path $UTILSJAR$ -m utils/$PROGRAM_HANOI$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Found class java/.* in shared cache for class-loader id 0</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Found class org/openj9/test/ivj/.* in shared cache for class-loader id [2-9] with URL .*[\\/]utils.jar</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
 
 	<test id="At end destroy cache for cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,destroy</command>


### PR DESCRIPTION
1. Add a CML test case that classes are being stored/found in shared
cache when using class path. 
2. Add a CML test case classes are being stored/found in shared cache
when using module path. 

Signed-off-by: hangshao <hangshao@ca.ibm.com>