### PR TITLE
Fix use of obsolete preprocessor config by Unsafe

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar19-SE-B174]*/
+/*[INCLUDE-IF Sidecar19-SE-OpenJ9]*/
 /*******************************************************************************
  * Copyright (c) 2017, 2018 IBM Corp. and others
  *


### PR DESCRIPTION
#1178 obsoleted some preprocessor configurations. A change to
jdk.internal.misc.Unsafe was delivered after #1178 was created, but
before it was merged, using one of the obsolete configs.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>