### PR TITLE
Fix potential null element in AccessControlContext.context

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -333,7 +333,9 @@ final class J9VMInternals {
 	private static void checkPackageAccess(final Class clazz, ProtectionDomain pd) {
 		final SecurityManager sm = System.getSecurityManager();
 		if (sm != null) {
-			AccessController.doPrivileged(new PrivilegedAction() {
+			ProtectionDomain[] pdArray = (pd == null) ? new ProtectionDomain[]{} : new ProtectionDomain[]{pd};
+			AccessController.doPrivileged(new PrivilegedAction<Object>() {
+				@Override
 				public Object run() {
 					String packageName = clazz.getPackageName();
 					if (packageName != null) {
@@ -346,7 +348,7 @@ final class J9VMInternals {
 					}					
 					return null;
 				}
-			}, new AccessControlContext(new ProtectionDomain[]{pd}));
+			}, new AccessControlContext(pdArray));
 		}
 	}
 

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -882,7 +882,8 @@ public static <T> T doPrivilegedWithCombiner(PrivilegedAction<T> action,
 {
 	checkPermsNPE(perms);
 	ProtectionDomain domain = getCallerPD(1);
-	return doPrivileged(action, new AccessControlContext(context, new ProtectionDomain[] { domain }, getNewAuthorizedState(context, domain)), perms);
+	ProtectionDomain[] pdArray = (domain == null) ? null : new ProtectionDomain[] { domain };
+	return doPrivileged(action, new AccessControlContext(context, pdArray, getNewAuthorizedState(context, domain)), perms);
 }
 
 /**
@@ -958,7 +959,8 @@ public static <T> T doPrivilegedWithCombiner(PrivilegedExceptionAction<T> action
 {
 	checkPermsNPE(perms);
 	ProtectionDomain domain = getCallerPD(1);
-	return doPrivileged(action, new AccessControlContext(context, new ProtectionDomain[] {domain}, getNewAuthorizedState(context, domain)), perms);
+	ProtectionDomain[] pdArray = (domain == null) ? null : new ProtectionDomain[] { domain };
+	return doPrivileged(action, new AccessControlContext(context, pdArray, getNewAuthorizedState(context, domain)), perms);
 }
 
 }


### PR DESCRIPTION
Fix potential `null` element in `AccessControlContext.context`

Added `null` check for the `ProtectionDomain` object before adding it into an array and pass to an `AccessControlContext` constructor.

Reviewer @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>