### PR TITLE
add $(ADD_JVM_LIB_DIR_TO_LIBPATH) in memoryCategories

### DIFF
--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -1186,6 +1186,7 @@
 		<testCaseName>memoryCategories</testCaseName>
 		<command>$(MKDIR) -p $(REPORTDIR); \
 		cd $(REPORTDIR); \
+		$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 		$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \

--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -30,4 +30,3 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generi
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
-j9vm.test.memory.MemoryAllocator																						1355 aix_ppc-64_cmprssptrs

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -35,4 +35,3 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generi
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
-j9vm.test.memory.MemoryAllocator																						1355 aix_ppc-64_cmprssptrs


### PR DESCRIPTION
In AIX, we need to export LIBPATH with lib dir, so the memoryCategories test can find libj9ben.so

[ci skip]

Fixes: #1355

Signed-off-by: lanxia <lan_xia@ca.ibm.com>