### PR TITLE
Exclude tests in memoryCategories on aix_ppc-64_cmprssptrs

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -30,3 +30,4 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generi
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
+j9vm.test.memory.MemoryAllocator																						1355 aix_ppc-64_cmprssptrs

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -36,3 +36,4 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generi
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
+j9vm.test.memory.MemoryAllocator																						1355 aix_ppc-64_cmprssptrs


### PR DESCRIPTION
- temporarily exclude tests in memoryCategories (MemoryAllocator.java)
on aix_ppc-64_cmprssptrs for SE80 and SE90 until the issue is fixed

Issue: #1355

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>