### PR TITLE
Update release process to remove `releasenote` tag after the release

### DIFF
--- a/doc/processes/release_process.md
+++ b/doc/processes/release_process.md
@@ -123,6 +123,8 @@ corresponding to the tagged level.  The release should link to the Eclipse Relea
 document, the release issue, and the AdoptOpenJDK download links.
 1. Open an Eclipse Bugzilla requesting the branch be marked `protected` to prevent 
 commits after the release is complete.
+1. Remove the `doc:releasenote` tag from items that were included in the release 
+notes.
 
 For a milestone release, the tag will be of the form: `openj9-0.8.0-m1`.
 


### PR DESCRIPTION
Once a release is complete, the `doc:releasenote` tag should be removed
from any tagged items that are included in the release note.

New items will be (re)tagged as needed throughout the next release.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>