### PR TITLE
Fix and enable JarFileUpdateTest

### DIFF
--- a/test/VM_Test/j9vm.xml
+++ b/test/VM_Test/j9vm.xml
@@ -87,10 +87,6 @@
 		<reason>Test is run from playlist other than sanity.</reason>
 	</exclude>
 
-	<exclude id="j9vm.test.jarfileupdate.JarFileUpdateTest" platform="all">
-		<reason>134164: shared classes failed to check the time stamp JarFileUpdateTestRunnerResource1 as patch about JVM_ZipHook() is missing in Java9</reason>
-	</exclude>
-
 	<exclude id="j9vm.test.romclasscreation.NewROMCreationAfterModifyingExistingClassTest" platform="all">
 		<reason>134161: Java 9 j9vm test: Error: Agent library jvmtitest could not be opened (libjvmtitest.so: cannot open shared object file: No such file or directory)</reason>
 	</exclude>

--- a/test/VM_Test/src/j9vm/test/jarfileupdate/JarFileUpdateTest.java
+++ b/test/VM_Test/src/j9vm/test/jarfileupdate/JarFileUpdateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,7 +144,6 @@ public class JarFileUpdateTest {
 			factory = Shared.getSharedClassHelperFactory();
 			if (factory != null) {
 				helper = factory.getURLHelper(this);
-				helper.setMinimizeUpdateChecks();
 			} else {
 				System.err.println("Error: Failed to get SharedClassHelperFactory");
 			}


### PR DESCRIPTION
1. Do not call setMinimizeUpdateChecks() so that update of the test
resource jar file is not ignored.
2. Enable JarFileUpdateTest.

Signed-off-by: hangshao <hangshao@ca.ibm.com>