### PR TITLE
Add Jenkins files for Windows x86 build and test pipelines

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -149,13 +149,13 @@ def checkout_pullrequest() {
 def build() {
     stage('Compile') {
         timestamps {
-            sh "bash ./configure --with-freemarker-jar=$FREEMARKER --with-boot-jdk=$BOOT_JDK $EXTRA_CONFIGURE_OPTIONS"
+            sh "bash ./configure --with-freemarker-jar='$FREEMARKER' --with-boot-jdk='$BOOT_JDK' $EXTRA_CONFIGURE_OPTIONS"
             sh "make all"
         }
     }
     stage('Java Version') {
         timestamps {
-            sh "build/$RELEASE/images/${(SDK_VERSION == '8') ? 'j2sdk-image' : 'jdk'}/bin/java -version"
+            sh "build/$RELEASE/images/$JDK_FOLDER/bin/java -version"
         }
     }
 }
@@ -167,10 +167,10 @@ def archive() {
             // https://github.com/eclipse/openj9/issues/1114
             // ghprbPullId is the PullRequest ID which only shows up in Pull Requests
             if (!params.ghprbPullId) {
-                sh "tar -zcvf ${WORKSPACE}/${TEST_PREFIX}`git -C openj9 rev-parse --short HEAD`${TEST_SUFFIX} openj9/test/"
+                sh "tar -zcvf ${TEST_PREFIX}`git -C openj9 rev-parse --short HEAD`${TEST_SUFFIX} openj9/test/"
                 archiveArtifacts artifacts: "**/${TEST_PREFIX}*${TEST_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
             }
-            sh "tar -zcvf ${WORKSPACE}/${SDK_PREFIX}`date +%Y%d%m%H%M`${SDK_SUFFIX} build/$RELEASE/images/${JDK_FOLDER}"
+            sh "tar -zcvf ${SDK_PREFIX}`date +%Y%d%m%H%M`${SDK_SUFFIX} build/$RELEASE/images/${JDK_FOLDER}"
             archiveArtifacts artifacts: "**/${SDK_PREFIX}*${SDK_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
         }
     }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-win_x86-64_cmprssptrs
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'win_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load "buildenv/jenkins/common/build"
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-win_x86-64_cmprssptrs
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'win_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('build')
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load "buildenv/jenkins/common/build"
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-win_x86-64_cmprssptrs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'win_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-win_x86-64_cmprssptrs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'win_x86-64_cmprssptrs'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow()

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-win_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'win_x86-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-win_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'win_x86-64_cmprssptrs'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-win_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'win_x86-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-win_x86-64_cmprssptrs
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'win_x86-64_cmprssptrs'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}


### PR DESCRIPTION
Add build and tests pipelines for JDK 8 and 9.
[ci skip]

By default the stage runs in the build workspace. Is not necessary to specify it.
On Windows, tar fails due to the fact that `WORKSPACE` is not converted to cygpath (it's a windows path C:\Users\...).

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>