### PR TITLE
update TestNG to 6.14.2 version to fix false positive test result

### DIFF
--- a/test/JLM_Tests/playlist.xml
+++ b/test/JLM_Tests/playlist.xml
@@ -34,7 +34,15 @@
 	-XX:SharedCacheHardLimit=16m -Xscmx1m -Xshareclasses:name=testJLM,reset \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-	-testnames JLM_Tests_interface \
+	-testnames TestCompilationMXBean,\
+	TestGarbageCollectorMXBean,\
+	TestMemoryManagerMXBean,\
+	TestMemoryMXBean,\
+	TestOperatingSystemMXBean,\
+	TestRuntimeMXBean,\
+	TestThreadMXBean,\
+	TestClassLoadingMXBean,\
+	TestMemoryPoolMXBean \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS); \
@@ -61,7 +69,15 @@
 	-XX:SharedCacheHardLimit=16m -Xscmx1m -Xshareclasses:name=testJLM,reset \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-	-testnames JLM_Tests_interface \
+	-testnames TestCompilationMXBean,\
+	TestGarbageCollectorMXBean,\
+	TestMemoryManagerMXBean,\
+	TestMemoryMXBean,\
+	TestOperatingSystemMXBean,\
+	TestRuntimeMXBean,\
+	TestThreadMXBean,\
+	TestClassLoadingMXBean,\
+	TestMemoryPoolMXBean \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS); \
@@ -422,6 +438,7 @@
 			<subset>SE80</subset>
 			<subset>SE90</subset>
 		</subsets>
+		<disabled>https://github.com/eclipse/openj9/issues/480</disabled>
 	</test>
 
 	<test>
@@ -452,6 +469,7 @@
 			<subset>SE80</subset>
 			<subset>SE90</subset>
 		</subsets>
+		<disabled>https://github.com/eclipse/openj9/issues/480</disabled>
 	</test>
 
 	<test>
@@ -482,6 +500,7 @@
 			<subset>SE80</subset>
 			<subset>SE90</subset>
 		</subsets>
+		<disabled>https://github.com/eclipse/openj9/issues/480</disabled>
 	</test>
 
 	<test>
@@ -512,6 +531,7 @@
 			<subset>SE80</subset>
 			<subset>SE90</subset>
 		</subsets>
+		<disabled>https://github.com/eclipse/openj9/issues/480</disabled>
 	</test>
 
 	<test>
@@ -545,6 +565,7 @@
 			<subset>SE80</subset>
 			<subset>SE90</subset>
 		</subsets>
+		<disabled>https://github.com/eclipse/openj9/issues/480</disabled>
 	</test>
 
 	<test>

--- a/test/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryPoolMXBean.java
+++ b/test/JLM_Tests/src/org/openj9/test/java/lang/management/TestMemoryPoolMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,7 +116,7 @@ public class TestMemoryPoolMXBean {
 		} catch (Exception me) {
 			Assert.fail("Unexpected exception in setting up MemoryMXBeanImpl test: " + me.getMessage());
 		}
-		logger.info("Starting TestMemoryMXBean tests ..." + "Test MemoryPoolMXBean name = " + testBean.getName());
+		logger.info("Starting TestMemoryPoolMXBean tests ..." + "Test MemoryPoolMXBean name = " + testBean.getName());
 	}
 
 	// IBM extension method

--- a/test/JLM_Tests/testng.xml
+++ b/test/JLM_Tests/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,17 +27,49 @@
 	<listeners>
 		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer" />
 	</listeners>
-	<test name="JLM_Tests_interface">
+	<test name="TestCompilationMXBean">
 		<classes>
 			<class name="org.openj9.test.java.lang.management.TestCompilationMXBean" />
+		</classes>
+	</test>
+	<test name="TestGarbageCollectorMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestGarbageCollectorMXBean" />
+		</classes>
+	</test>
+	<test name="TestMemoryManagerMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestMemoryManagerMXBean" />
+		</classes>
+	</test>
+	<test name="TestMemoryMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestMemoryMXBean" />
-			<class name="org.openj9.test.java.lang.management.TestMemoryPoolMXBean" />
+		</classes>
+	</test>
+	<test name="TestOperatingSystemMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestOperatingSystemMXBean" />
+		</classes>
+	</test>
+	<test name="TestRuntimeMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestRuntimeMXBean" />
+		</classes>
+	</test>
+	<test name="TestThreadMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestThreadMXBean" />
+		</classes>
+	</test>
+	<test name="TestClassLoadingMXBean">
+		<classes>
 			<class name="org.openj9.test.java.lang.management.TestClassLoadingMXBean" />
+		</classes>
+	</test>
+	<test name="TestMemoryPoolMXBean">
+		<classes>
+			<class name="org.openj9.test.java.lang.management.TestMemoryPoolMXBean" />
 		</classes>
 	</test> <!-- JLM_Tests -->
 	<test name="JLM_Tests_class">

--- a/test/Java8andUp/build.xml
+++ b/test/Java8andUp/build.xml
@@ -136,7 +136,6 @@
 					<src path="${transformerListener}" />
 					<exclude name="**/Cmvc194280.java" />
 					<exclude name="**/resources/**"/>
-					<exclude name="**/gpu/**"/>
 					<!-- requires special compilation methods -->
 					<exclude name="**/NoSuchMethod/**" />
 					<classpath>
@@ -162,8 +161,6 @@
 					<!-- PR117298-->
 					<exclude name="**/Cmvc194280.java" />
 					<exclude name="**/resources/**"/>
-					<!-- need to be included when OpenJ9 have them. -->
-					<exclude name="**/gpu/**"/>
 					<!-- requires special compilation methods -->
 					<exclude name="**/NoSuchMethod/**" />
 					<classpath>

--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -209,6 +209,8 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
+		<!-- failed intermittent on Windows, Openj9 issue #1454 -->
+		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -1338,7 +1340,8 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^arch.arm</platformRequirements>
+		<!-- OpenJ9 issue 1421, failed on zos -->
+		<platformRequirements>^arch.arm,^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -1572,6 +1575,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
+	<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/Java8andUp/src/j9vm/test/jni/PthreadTest.java
+++ b/test/Java8andUp/src/j9vm/test/jni/PthreadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,9 +36,10 @@ public class PthreadTest {
 
 	private static boolean worked = false;
 
-
+	@Test
 	public void test_destructor() {
 		worked = attachAndDetach();
+		AssertJUnit.assertTrue("Thread successfully detached", worked);
 	}
 
 	@BeforeMethod
@@ -50,7 +51,6 @@ public class PthreadTest {
 
 	@AfterMethod
 	protected void tearDown() throws Exception {
-		AssertJUnit.assertTrue("Thread successfully detached", worked);
 		logger.debug("---------------------------------------------------------");
 	}
 

--- a/test/Java8andUp/src/org/openj9/test/gpu/SortTest.java
+++ b/test/Java8andUp/src/org/openj9/test/gpu/SortTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corp. and others
+ * Copyright (c) 2013, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -391,12 +391,12 @@ public final class SortTest {
 		}
 	}
 
-	@Test(groups = { "level.sanity" })
+	@Test(groups = { "level.sanity", "level.extended" })
 	public void testBasic() {
 		main(new String[] { "-geometric=10,10000000,31" });
 	}
 
-	@Test(groups = { "level.sanity" })
+	@Test(groups = { "level.sanity", "level.extended" })
 	public void testPowersOf2() {
 		main(new String[] { "-geometric=1,8388608,24" });
 	}

--- a/test/Java8andUp/testacc.policy
+++ b/test/Java8andUp/testacc.policy
@@ -22,5 +22,7 @@ grant {
 	// so we can remove the security manager
 	permission java.lang.RuntimePermission "setSecurityManager";
 	// Allow the test harness to write the log files
-	permission java.io.FilePermission "<<ALL FILES>>", "read,write";
+	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+	permission java.util.PropertyPermission "testng.*", "read";
+	permission java.util.PropertyPermission "fileStringBuffer", "read";
 };

--- a/test/Java8andUp/testng.xml
+++ b/test/Java8andUp/testng.xml
@@ -29,9 +29,7 @@
 	</listeners>
 	<test name="generalTest">
 		<classes>
-			<!-- RTC WI 124170
 			<class name="org.openj9.test.gpu.SortTest" />
-			-->
 		</classes>
 	</test>
 	<test name="regression">

--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -22,8 +22,6 @@
 
 # Exclude tests temporarily
 
-org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										858 generic-all
-org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						858 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -25,8 +25,6 @@
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN												                    AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
 org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														JTC-JAT-133182 generic-all
 org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	BPW-https://github.ibm.com/runtimes/test/issues/109 generic-all
-org.openj9.test.java.security.Test_AccessController:test_doPrivilegedWithCombiner4										124199 generic-all
-org.openj9.test.java.security.Test_AccessController:test_doPrivileged_createAccessControlContext						124199 generic-all
 org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all

--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -82,9 +82,9 @@ my %junit4 = (
 	sha1 => 'e4f1766ce7404a08f45d859fb9c226fc9e41a861'
 );
 my %testng = (
-	url => 'http://central.maven.org/maven2/org/testng/testng/6.10/testng-6.10.jar',
+	url => 'http://central.maven.org/maven2/org/testng/testng/6.14.2/testng-6.14.2.jar',
 	fname => 'testng.jar',
-	sha1 => '368d38d0f6906934b572e1a26441b6f47c58b134'
+	sha1 => '10c93c2c0d165e895a7582dfd8b165f108658db5'
 );
 my %jcommander = (
 	url => 'http://central.maven.org/maven2/com/beust/jcommander/1.48/jcommander-1.48.jar',

--- a/test/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/cmdLineTests/classesdbgddrext/playlist.xml
@@ -73,7 +73,7 @@
 	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>^os.zos,^os.zos</platformRequirements>
+		<platformRequirements>^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/docs/DependentLibs.md
+++ b/test/docs/DependentLibs.md
@@ -29,7 +29,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
   * javassist-3.20.0-GA.jar
   * jcommander-1.48.jar
   * junit-4.10.jar
-  * testng-6.10.jar
+  * testng-6.14.2.jar
 
 These libs will be downloaded automatically as part of `make compile` 
 process.


### PR DESCRIPTION
* TestNG before 6.14 treats configuration failure as pass
* this has been fixed since TestNG 6.14
* update TestNG version to 6.14.2 to fix this bug in product build
* separate JLM test targets to avoid OOM failure
* re-enable tests which are fixed and passing
* update exlucde file which failed on TestNG 6.14.2
* exclude reattachAfterExit from win since it is not supported on win

fixed:#1367
fixed:#1112
Issue:#1454

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>