### PR TITLE
Automatically fix interface modifiers for pre-java6 classfiles

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2471,9 +2471,15 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 	classfile->j9Flags = 0;
 
 	if ((classfile->accessFlags & (CFR_ACC_INTERFACE | CFR_ACC_ABSTRACT)) == CFR_ACC_INTERFACE) {
-		errorCode = J9NLS_CFR_ERR_INTERFACE_NOT_ABSTRACT__ID;
-		offset = index - data - 2;
-		goto _errorFound;
+		if ((flags & BCT_MajorClassFileVersionMask) >= BCT_Java6MajorVersionShifted) {
+			/* error out for Java 6 and newer versions */
+			errorCode = J9NLS_CFR_ERR_INTERFACE_NOT_ABSTRACT__ID;
+			offset = index - data - 2;
+			goto _errorFound;
+		} else {
+			/* Just fix old classfiles */
+			classfile->accessFlags |= CFR_ACC_ABSTRACT;
+		}
 	}
 
 	NEXT_U16(classfile->thisClass, index);


### PR DESCRIPTION
Javac used to generate interfaces that didn't have the acc_abstract bit
set.  We used to only do this check under -Xfuture but that led to
behaviour differences.  Now, just fix pre-java6 interfaces and error
on newer classfiles.

Fixes: #1401

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>