### PR TITLE
Re-include jvm.h in jnitest.c

### DIFF
--- a/runtime/tests/jni/jnitest.c
+++ b/runtime/tests/jni/jnitest.c
@@ -24,6 +24,11 @@
 #include "j9port.h"
 #include "j9.h"
 #include "vmi.h"
+/*
+ * jvm.h is required by MemoryAllocator_allocateMemory:
+ * https://github.com/eclipse/openj9/issues/1377
+ */
+#include "../j9vm/jvm.h"
 #ifdef WIN32
 #include <stdlib.h>
 #include <malloc.h>

--- a/runtime/tests/jni/module.xml
+++ b/runtime/tests/jni/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-   Copyright (c) 2006, 2017 IBM Corp. and others
+   Copyright (c) 2006, 2018 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -367,6 +367,9 @@
 			<option name="prototypeHeaderFileNames" data="j9protos.h jnitest_internal.h"/>
 		</options>
 		<phase>core j2se</phase>
+		<dependencies>
+			<dependency name="generate_j9vm"/>
+		</dependencies>
 		<exports>
 			<group name="all"/>
 		</exports>


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/1377

This reverts part of https://github.com/eclipse/openj9/pull/1335.
The memory allocation test relies on jvm.h to override malloc().

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>