### PR TITLE
Update nestmates fields during class redefinition

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1102,6 +1102,11 @@ redefineClassesCommon(jvmtiEnv* env,
 
 				/* Indicate that a redefine has occurred */
 				vm->hotSwapCount += 1;
+
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+				/* Update nests with redefined nest tops */
+				fixNestMembers(currentThread, classPairs);
+#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 				/* Notify the JIT about redefined classes */

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2126,6 +2126,11 @@ jitClassRedefineEvent(J9VMThread * currentThread, J9JVMTIHCRJitEventData * jitEv
 void
 notifyGCOfClassReplacement(J9VMThread * currentThread, J9HashTable * classPairs, UDATA isFastHCR);
 
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+void
+fixNestMembers(J9VMThread * currentThread, J9HashTable * classPairs);
+#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+
 #endif /* J9VM_INTERP_HOT_CODE_REPLACEMENT */
 
 /* ---------------- filecache.c ---------------- */

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2149,6 +2149,54 @@ flushClassLoaderReflectCache(J9VMThread * currentThread, J9HashTable * classPair
 }
 
 
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+/**
+ * \brief  Fix any resolved nest members
+ * \ingroup
+ *
+ * @param[in] currentThread
+ * @param[in] classPairs
+ * @return
+ *
+ *	Within Project Valhalla nestmates, a nest member class will resolve a link
+ *	to its nest host class when necessary to verify private access to another
+ *	class within its next class. In order for these access checks to be accurate
+ *	post nest host resolution, any classes that point to the original class def
+ *	as their nest host must be updated to point do the replaced class def instead.
+ *
+ */
+void
+fixNestMembers(J9VMThread * currentThread, J9HashTable * classPairs)
+{
+	J9HashTableState hashTableState = {0};
+	J9JVMTIClassPair *classPair = hashTableStartDo(classPairs, &hashTableState);
+	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+
+	while (NULL != classPair) {
+		J9Class *originalRAMClass = classPair->originalRAMClass;
+		J9Class *replacementRAMClass = classPair->replacementClass.ramClass;
+
+		if ((NULL != originalRAMClass) && (NULL != replacementRAMClass)) {
+			J9ClassLoader *classLoader = originalRAMClass->classLoader;
+			J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(originalRAMClass->romClass);
+			U_16 nestMemberCount = originalRAMClass->romClass->nestMemberCount;
+			U_16 i = 0;
+
+			for (i = 0; i < nestMemberCount; i++) {
+				J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
+				J9Class *nestMember = vmFuncs->hashClassTableAt(classLoader, J9UTF8_DATA(nestMemberName), J9UTF8_LENGTH(nestMemberName));
+				if (NULL != nestMember) {
+					if (nestMember->nestHost == originalRAMClass) {
+						nestMember->nestHost = replacementRAMClass;
+					}
+				}
+			}
+		}
+		classPair = hashTableNextDo(&hashTableState);
+	}
+}
+#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+
 static void
 swapClassesForFastHCR(J9Class *originalClass, J9Class *obsoleteClass)
 {


### PR DESCRIPTION
With the introduction of JEP 181, classes belong to a 'nest' - a group of classes that share access between private fields. In order to define a class's nest, class files gain two nestmates attributes: 'NestHost' and 'NestMembers'. A class determines its nest by providing the name of its 'NestHost'. In return, the 'NestHost' confirms a list of 'NestMembers'. During access checking, the NestHost field of two classes is compared in order to determine whether they have the same nest host, and thus the same nest.

During class redefinition, the nest host must find any nest members that have already claimed it and update them. Any nest member class which points to a nest host will leave its NestHost field blank during class loading and set it if/when necessary in a visibility check - these classes therefore do not need to update themselves during redefinition.

Related issue here: https://github.com/eclipse/openj9/issues/1165

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>