### PR TITLE
Disallow nestmate changes during class redefinition

### DIFF
--- a/runtime/include/jvmti.h
+++ b/runtime/include/jvmti.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -340,6 +340,9 @@ typedef enum jvmtiError {
 	JVMTI_ERROR_NAMES_DONT_MATCH = 69,
 	JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_MODIFIERS_CHANGED = 70,
 	JVMTI_ERROR_UNSUPPORTED_REDEFINITION_METHOD_MODIFIERS_CHANGED = 71,
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+	JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED = 72,
+#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 	JVMTI_ERROR_UNMODIFIABLE_CLASS = 79,
 	JVMTI_ERROR_UNMODIFIABLE_MODULE = 80,
 	JVMTI_ERROR_NOT_AVAILABLE = 98,

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,9 @@ static const J9JvmtiErrorMapping errorMap[] = {
 	{ "JVMTI_ERROR_NAMES_DONT_MATCH" , 69 },
 	{ "JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_MODIFIERS_CHANGED" , 70 },
 	{ "JVMTI_ERROR_UNSUPPORTED_REDEFINITION_METHOD_MODIFIERS_CHANGED" , 71 },
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+	{ "JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED" , 72 },
+#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 	{ "JVMTI_ERROR_UNMODIFIABLE_CLASS" , 79 },
 	{ "JVMTI_ERROR_UNMODIFIABLE_MODULE" , 80 },
 	{ "JVMTI_ERROR_NOT_AVAILABLE" , 98 },

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3046,6 +3046,40 @@ verifyClassesAreCompatible(J9VMThread * currentThread, jint class_count, J9JVMTI
 			return rc;
 		}
 
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+		/* Verify that the nestmates attributes - nest host & nest members - are the same */
+		{
+			J9UTF8 *originalNestHostName = J9ROMCLASS_NESTHOSTNAME(originalROMClass);
+			J9UTF8 *replacementNestHostName = J9ROMCLASS_NESTHOSTNAME(replacementROMClass);
+			U_16 nestMemberCount = originalROMClass->nestMemberCount;
+
+			/* Nest hosts must both be null or must both contain the same string */
+			if ((NULL != originalNestHostName) || (NULL != replacementNestHostName) {
+				if ((NULL == originalNestHostName) || (NULL == replacementNestHostName) {
+					return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;
+				} else if (!J9UTF8_EQUALS(originalNestHostName, replacementNestHostName)) {
+					return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;
+				}
+			}
+
+			if (nestMemberCount != replacementROMClass->nestMemberCount) {
+				return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;
+			} else if (0 != nestMemberCount) {
+				J9SRP *originalNestMembers = J9ROMCLASS_NESTMEMBERS(originalROMClass);
+				J9SRP *replacementNestMembers = J9ROMCLASS_NESTMEMBERS(replacementROMClass);
+				U_16 i = 0;
+
+				for (i = 0; i < nestMemberCount; i++) {
+					J9UTF8 *originalNestMemberName = NNSRP_GET(originalNestMembers[i], J9UTF8*);
+					J9UTF8 *replacementNestMemberName = NNSRP_GET(replacementNestMembers[i], J9UTF8*);
+					if (!J9UTF8_EQUALS(originalNestMemberName, replacementNestMemberName)) {
+						return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;
+					}
+				}
+			}
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+
 		if (0 != classUsesExtensions) {
 			classPairs[i].flags |= J9JVMTI_CLASS_PAIR_FLAG_USES_EXTENSIONS;
 			*extensionsUsed = 1;


### PR DESCRIPTION
With the introduction of JEP 181, classes belong to a 'nest' - a group of classes that share access between private fields. In order to define a class's nest, class files gain two nestmates attributes: 'NestHost' and 'NestMembers'. When redefining a class, there are restrictions on the type of redefinition allowed. In particular, classes can not change their nestmates attributes. This commit adds verification to prevent these nestmate attribute changes from occuring.

Related issue here: https://github.com/eclipse/openj9/issues/1165

It corresponds to jvmti tests here: https://github.com/eclipse/openj9/pull/1262

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>