### PR TITLE
Add libdwarf-dev to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,7 @@ addons:
       - git-core
       - libasound2-dev
       - libcups2-dev
+      - libdwarf-dev
       - libelf-dev
       - libfreetype6-dev
       - libnuma-dev


### PR DESCRIPTION
- Required for ddrgen

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>