### PR TITLE
Checkout SCM once for builds

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-aix_ppc-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'aix_ppc-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_390-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_ppc-64_cmprssptrs_le
@@ -24,15 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_x86-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'linux_x86-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-win_x86-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'win_x86-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load "buildenv/jenkins/common/build"
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-aix_ppc-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'aix_ppc-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-linux_390-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load "buildenv/jenkins/common/build"
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-linux_ppc-64_cmprssptrs_le
@@ -24,15 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-linux_x86-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'linux_x86-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-win_x86-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'win_x86-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load "buildenv/jenkins/common/build"
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-aix_ppc-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'aix_ppc-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_390-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_ppc-64_cmprssptrs_le
@@ -24,15 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_x86-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'linux_x86-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-win_x86-64_cmprssptrs
@@ -24,15 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'win_x86-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    def buildfile = load "buildenv/jenkins/common/build"
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-aix_ppc-64_cmprssptrs
@@ -24,16 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'aix_ppc-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_390-64_cmprssptrs
@@ -24,16 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_ppc-64_cmprssptrs_le
@@ -24,16 +24,16 @@ SDK_VERSION = '10'
 SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-aix_ppc-64_cmprssptrs
@@ -24,16 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'aix_ppc-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_390-64_cmprssptrs
@@ -24,16 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_ppc-64_cmprssptrs_le
@@ -24,16 +24,16 @@ SDK_VERSION = '8'
 SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-aix_ppc-64_cmprssptrs
@@ -24,16 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'aix_ppc-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_390-64_cmprssptrs
@@ -24,16 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'linux_390-64_cmprssptrs'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_ppc-64_cmprssptrs_le
@@ -24,16 +24,16 @@ SDK_VERSION = '9'
 SPEC = 'linux_ppc-64_cmprssptrs_le'
 
 node('master') {
-
-    checkout scm
-    variableFile = load 'buildenv/jenkins/common/variables-functions'
-    variableFile.set_job_variables('build')
-    cleanWs()
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
 }
 
 node("${NODE}") {
 
-    checkout scm
-    buildfile = load 'buildenv/jenkins/common/build'
     buildfile.build_all()
 }


### PR DESCRIPTION
- Add timestamps to master block
- Once we checkout scm we can load the common code we need
- No need to re-checkout again on the next node
- Simplifies Build, compile-only PR builds
- Note: We must load for test as JAVA_BIN must be set on the
  testing node.

[ci skip]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>