### PR TITLE
Refactor MethodHandle source to enable JDK10 compiles

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/CacheKey.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/CacheKey.java
@@ -1,0 +1,43 @@
+/*[INCLUDE-IF Sidecar17]*/
+/*******************************************************************************
+ * Copyright (c) 2010, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package java.lang.invoke;
+
+/**
+ * Base class for CacheKeys used in the HandleCache.  There are two subclasses
+ * FieldCacheKey and MethodCacheKey used by the HandleCache.  
+ */
+abstract class CacheKey {
+	final String name;
+	private final int hashcode;
+	
+	public CacheKey(String name, int hashcode){
+		this.name = name;
+		this.hashcode = hashcode;
+	}
+	
+	@Override
+	public int hashCode() {
+		return hashcode;
+	}
+}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/HandleCache.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/HandleCache.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2010, 2010 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,21 +35,6 @@ final class Cache extends ClassValue<Map<CacheKey, WeakReference<MethodHandle>>>
 	protected Map<CacheKey, WeakReference<MethodHandle>> computeValue(Class<?> arg0) {
 		return Collections.synchronizedMap(new WeakHashMap<CacheKey, WeakReference<MethodHandle>>());
 	}	
-}
-
-abstract class CacheKey {
-	final String name;
-	private final int hashcode;
-	
-	public CacheKey(String name, int hashcode){
-		this.name = name;
-		this.hashcode = hashcode;
-	}
-	
-	@Override
-	public int hashCode() {
-		return hashcode;
-	}
 }
 
 /* Cache key for mapping the methodName and MethodType to the actual MethodHandle */

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -777,10 +777,10 @@ public abstract class MethodHandle {
 	MethodHandle insertArguments(MethodHandle equivalent, MethodHandle unboxingHandle, int location, Object... values) {
 		MethodHandle result = equivalent;
 
-		// Wrap result in an ArgumentMoverHandle
+		// Wrap result in an BruteArgumentMoverHandle
 		int numValues = values.length;
 		MethodType mtype = equivalent.type();
-		int[] permute = ArgumentMoverHandle.insertPermute(ArgumentMoverHandle.identityPermute(mtype), location, numValues, -1);
+		int[] permute = BruteArgumentMoverHandle.insertPermute(BruteArgumentMoverHandle.identityPermute(mtype), location, numValues, -1);
 		if (true) {
 			result = new BruteArgumentMoverHandle(mtype, unboxingHandle, permute, values, result);
 		}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ReceiverBoundHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2009 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,7 @@ final class ReceiverBoundHandle extends DirectHandle {
 	/* We don't want to have the receiver object buried deep in the
 	 * MethodHandle chain, necessitating a long dereference chain to load it.
 	 * Thus, we want permuteArguments and insertArguments to return
-	 * ArgumentMoverHandles that have the receiver in them.
+	 * BruteArgumentMoverHandles that have the receiver in them.
 	 */
 	/*[ENDIF]*/
 	MethodHandle permuteArguments(MethodType permuteType, int... permute) throws NullPointerException, IllegalArgumentException {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInvokeGenericHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInvokeGenericHandle.java
@@ -25,41 +25,50 @@ package java.lang.invoke;
 import java.lang.invoke.VarHandle.AccessMode;
 
 /**
- * Base class for VarHandleInvokers.
- * 
- * Invokers are the MethodHandle-subclasses required to implement
- * the invokeExact and invoke MethodHandle combinators.
+ * Implementation for the invoke varhandle combinator.
  */
-@VMCONSTANTPOOL_CLASS
-abstract class VarHandleInvokeHandle extends PrimitiveHandle {
-	@VMCONSTANTPOOL_FIELD
-	final int operation;
-	@VMCONSTANTPOOL_FIELD
-	final MethodType accessModeType;
-
-	VarHandleInvokeHandle(AccessMode accessMode, MethodType accessModeType, byte kind) {
-		// Prepend a VarHandle receiver argument to match the how this MethodHandle will be invoked
-		super(accessModeType.insertParameterTypes(0, VarHandle.class), null, null, kind, null);
-		this.operation = accessMode.ordinal();
-		// Append a VarHandle argument to match the VarHandle's internal method signature
-		this.accessModeType = accessModeType.appendParameterTypes(VarHandle.class);
+final class VarHandleInvokeGenericHandle extends VarHandleInvokeHandle {
+	VarHandleInvokeGenericHandle(AccessMode accessMode, MethodType accessModeType) {
+		super(accessMode, accessModeType, KIND_VARHANDLEINVOKEGENERIC);
 	}
 
-	VarHandleInvokeHandle(VarHandleInvokeHandle originalHandle, MethodType newType) {
+	VarHandleInvokeGenericHandle(VarHandleInvokeGenericHandle originalHandle, MethodType newType) {
 		super(originalHandle, newType);
-		operation = originalHandle.operation;
-		accessModeType = originalHandle.accessModeType;
 	}
 
-	final void compareWithVarHandleInvoke(VarHandleInvokeHandle left, Comparator c) {
-		c.compareStructuralParameter(left.operation, this.operation);
-		c.compareStructuralParameter(left.accessModeType, this.accessModeType);
+	@Override
+	MethodHandle cloneWithNewType(MethodType newType) {
+		return new VarHandleInvokeGenericHandle(this, newType);
+	}
+
+	@Override
+	final void compareWith(MethodHandle right, Comparator c) {
+		if (right instanceof VarHandleInvokeGenericHandle) {
+			((VarHandleInvokeGenericHandle)right).compareWithVarHandleInvoke(this, c);
+		} else {
+			c.fail();
+		}
 	}
 
 	// {{{ JIT support
+	private static final ThunkTable _thunkTable = new ThunkTable();
+
 	@Override
-	protected final ThunkTuple computeThunks(Object arg) {
-		return thunkTable().get(new ThunkKey(ThunkKey.computeThunkableType(type(), 0, 1)));
+	protected final ThunkTable thunkTable() {
+		return _thunkTable;
+	}
+
+	@FrameIteratorSkip
+	private final int invokeExact_thunkArchetype_X(VarHandle varHandle, int argPlaceholder) {
+		MethodHandle next = varHandle.getFromHandleTable(operation);
+		if (ILGenMacros.isShareableThunk()) {
+			undoCustomizationLogic(next);
+		}
+		if (!ILGenMacros.isCustomThunk()) {
+			doCustomizationLogic();
+		}
+		return ILGenMacros.invokeExact_X(next.asType(accessModeType), ILGenMacros.placeholder(argPlaceholder, varHandle));
 	}
 	// }}} JIT support
 }
+


### PR DESCRIPTION
Address #650 by:
- Making BruteArgumentMoverHandle the class we refer to outside the class instead of ArgumentMoverHandle
- Moving CacheKey to its own file
- Moving the VarHandle `invoke` and `invokeExact` invoker handles to their own files

java -version output:
```
# ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -version
openjdk version "10-internal" 2018-03-20
OpenJDK Runtime Environment (build 10-internal+0-adhoc..build)
Eclipse OpenJ9 VM (build djh/jdk10refactor-4c40cd4, JRE 10 Linux amd64-64 Compressed References 20180312_000000 (JIT enabled, AOT enabled)
OpenJ9   - 4c40cd4
OMR      - 5cbbadf
JCL      - 8fcd4f5 based on jdk-10+43)
```

Many thanks to @andrew-m-leonard for creating #1247 which served as a starting point for this work.