### PR TITLE
Write CONSTANT_DYNAMIC entry to ROMClass

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -652,7 +652,7 @@ public class J9BCUtil {
 		U32Pointer cpDescription = romClass.cpShapeDescription();
 		long descriptionLong;
 		long i, j, k, numberOfLongs;
-		char symbols[] = new char[] { '.', 'C', 'S', 'I', 'F', 'J', 'D', 'i', 's', 'v', 'x', 'y', 'z', 'T', 'H', 'A', 'x', 'v' };
+		char symbols[] = new char[] { '.', 'C', 'S', 'I', 'F', 'J', 'D', 'i', 's', 'v', 'x', 'y', 'z', 'T', 'H', 'A', '.', 'c', 'x', 'v' };
 		
 		symbols[(int)J9CPTYPE_UNUSED8] = '.';
 

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -32,6 +32,7 @@
 #include "cfr.h"
 #include "cfreader.h"
 #include "ut_j9bcu.h"
+#include "bcnames.h"
 
 #include "BuildResult.hpp"
 
@@ -899,6 +900,7 @@ class NameAndTypeIterator
 	  */
 	bool isConstantLong(U_16 cpIndex) const { return CFR_CONSTANT_Long == _classFile->constantPool[cpIndex].tag; }
 	bool isConstantDouble(U_16 cpIndex) const { return CFR_CONSTANT_Double == _classFile->constantPool[cpIndex].tag; }
+	bool isConstantDynamic(U_16 cpIndex) const { return CFR_CONSTANT_Dynamic == _classFile->constantPool[cpIndex].tag;}
 	bool isConstantInteger0(U_16 cpIndex) const { return (CFR_CONSTANT_Integer == _classFile->constantPool[cpIndex].tag) && (0 == _classFile->constantPool[cpIndex].slot1); }
 	bool isConstantFloat0(U_16 cpIndex) const { return (CFR_CONSTANT_Float == _classFile->constantPool[cpIndex].tag) && (0 == _classFile->constantPool[cpIndex].slot1); }
 	bool isUTF8AtIndexEqualToString(U_16 cpIndex, const char *string, UDATA stringSize) { return (getUTF8Length(cpIndex) == (stringSize - 1)) && (0 == memcmp(getUTF8Data(cpIndex), string, stringSize - 1)); }
@@ -920,6 +922,19 @@ class NameAndTypeIterator
 	bool hasClinit() const { return _hasClinit; }
 	bool annotationRefersDoubleSlotEntry() const { return _annotationRefersDoubleSlotEntry; }
 	bool isInnerClass() const { return _isInnerClass; }
+
+	U_8 constantDynamicType(U_16 cpIndex) const
+	{
+		J9CfrConstantPoolInfo* nas = &_classFile->constantPool[_classFile->constantPool[cpIndex].slot2];
+		J9CfrConstantPoolInfo* signature = &_classFile->constantPool[nas->slot2];
+		if ('D' == signature->bytes[0]) {
+			return JBldc2dw;
+		} else if ('J' == signature->bytes[0]) {
+			return JBldc2lw;
+		} else {
+			Trc_BCU_Assert_ShouldNeverHappen();
+		}
+	}
 
 private:
 	class InterfaceVisitor;
@@ -1040,6 +1055,7 @@ private:
 	VMINLINE void markMethodRefForMHInvocationAsReferenced(U_16 cpIndex);
 
 	VMINLINE void markConstantAsReferenced(U_16 cpIndex);
+	VMINLINE void markConstantDynamicAsReferenced(U_16 cpIndex);
 	VMINLINE void markConstantNameAndTypeAsReferenced(U_16 cpIndex);
 	VMINLINE void markConstantUTF8AsReferenced(U_16 cpIndex);
 

--- a/runtime/bcutil/ConstantPoolMap.hpp
+++ b/runtime/bcutil/ConstantPoolMap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,6 +96,7 @@ public:
 		virtual void visitString(U_16 cfrCPIndex) = 0;
 		virtual void visitMethodType(U_16 cfrCPIndex, U_16 forMethodHandleInvocation) = 0;
 		virtual void visitMethodHandle(U_16 kind, U_16 cfrCPIndex) = 0;
+		virtual void visitConstantDynamic(U_16 bsmIndex, U_16 cfrCPIndex) = 0;
 		virtual void visitSingleSlotConstant(U_32 slot1) = 0;
 		virtual void visitDoubleSlotConstant(U_32 slot1, U_32 slot2) = 0;
 		virtual void visitFieldOrMethod(U_16 classRefCPIndex, U_16 nameAndSignatureCfrCPIndex) = 0;

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -508,6 +508,13 @@ public:
 		_cursor->writeU32((cfrKind << BCT_J9DescriptionCpTypeShift) | BCT_J9DescriptionCpTypeMethodHandle, Cursor::GENERIC);
 	}
 
+	void visitConstantDynamic(U_16 bsmIndex, U_16 cfrCPIndex)
+	{
+		/* assumes format: { SRP to NameAndSignature, (bsmIndex << 4) || cpType } */
+		_cursor->writeSRP(_srpKeyProducer->mapCfrConstantPoolIndexToKey(cfrCPIndex), Cursor::SRP_TO_NAME_AND_SIGNATURE);
+		_cursor->writeU32((bsmIndex << BCT_J9DescriptionCpTypeShift) | BCT_J9DescriptionCpTypeConstantDynamic, Cursor::GENERIC);
+	}
+
 	void visitSingleSlotConstant(U_32 slot1)
 	{
 		_cursor->writeU32(slot1, Cursor::GENERIC);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -241,6 +241,7 @@
 
 /* Constants from J9DescriptionBits */
 #define J9DescriptionCpTypeClass 0x2
+#define J9DescriptionCpTypeConstantDynamic 0x5
 #define J9DescriptionCpTypeMask 0xF
 #define J9DescriptionCpTypeMethodHandle 0x4
 #define J9DescriptionCpTypeMethodType 0x3
@@ -2017,11 +2018,9 @@ typedef struct J9BCTranslationData {
 #define BCT_InitNOP  0
 #define BCT_InitCopyFloatsW  16
 #define BCT_InitStatics  1
-#define BCT_J9DescriptionCpTypeMethodHandle  4
 #define BCT_ErrFlagsInvalid  7
 #define BCT_LittleEndianOutput  0
 #define BCT_PcFlagUnnecessaryGeneric  0x8000000
-#define BCT_J9DescriptionCpTypeClass  2
 #define BCT_ErrNoPathToPC  2
 #define BCT_ErrReservedLiteralsInvalid  8
 #define BCT_ErrLocalAccessOutOfRange  15
@@ -2029,11 +2028,9 @@ typedef struct J9BCTranslationData {
 #define BCT_ObjectSlotAllocated  1
 #define BCT_PcFlagStackMapNeeded  0x100000
 #define BCT_InitCopyFloats  15
-#define BCT_J9DescriptionCpTypeMask  15
 #define BCT_ErrTempsShapeTooSmall  18
 #define BCT_DumpMaps  0x40000000
 #define BCT_ActionTable  5
-#define BCT_J9DescriptionCpTypeObject  1
 #define BCT_ErrPopOnEmptyStack  3
 #define BCT_InitCopyDoublesW  6
 #define BCT_IntermediateDataIsClassfile  0x2000
@@ -2041,6 +2038,14 @@ typedef struct J9BCTranslationData {
 #define BCT_InitInstanceFields  19
 #define BCT_ErrConstantPoolMapTooSmall  14
 #define BCT_InitCopyDoubles  5
+#define BCT_J9DescriptionCpTypeScalar  0
+#define BCT_J9DescriptionCpTypeObject  1
+#define BCT_J9DescriptionCpTypeClass  2
+#define BCT_J9DescriptionCpTypeMethodType  3
+#define BCT_J9DescriptionCpTypeMethodHandle  4
+#define BCT_J9DescriptionCpTypeConstantDynamic 5
+#define BCT_J9DescriptionCpTypeShift  4
+#define BCT_J9DescriptionCpTypeMask  15
 
 /* When adding a new major version update BCT_JavaMaxMajorVersionShifted to
  * the maximum allowed value.
@@ -2055,12 +2060,9 @@ typedef struct J9BCTranslationData {
 #define BCT_ErrFallOffLastInstruction  8
 #define BCT_ActionNone  0
 #define BCT_StripSourceDebugExtension  0x40000
-#define BCT_J9DescriptionCpTypeScalar  0
 #define BCT_ErrTempsShapeInvalid  17
 #define BCT_ErrArgSizeInSlotsInvalid  13
 #define BCT_DoubleSlotAllocated  2
-#define BCT_J9DescriptionCpTypeMethodType  3
-#define BCT_J9DescriptionCpTypeShift  4
 #define BCT_ErrPCMapInvalid  5
 #define BCT_ErrPCMapTooSmall  6
 #define BCT_Java6MajorVersionShifted  0x32000000
@@ -2124,14 +2126,15 @@ typedef struct J9ConstantPool {
 #define J9CPTYPE_METHOD_TYPE  13
 #define J9CPTYPE_METHODHANDLE  14
 #define J9CPTYPE_ANNOTATION_UTF8  15
-
+#define J9CPTYPE_CONSTANT_DYNAMIC 17
 /* 
- * INTERFACE_STATIC and INTERFACE_INSTANT cpType are used to track the classfile tag of a methodref [CFR_CONSTANT_InterfaceMethodref]
+ * INTERFACE_STATIC and INTERFACE_INSTANCE cpType are used to track the classfile tag of a methodref [CFR_CONSTANT_InterfaceMethodref]
  * These types are need to support correct initializer for constantpool due to how cp entries are pre-initialized
  * These will be used to check for cp consistency during resolve time
  */
-#define J9CPTYPE_INTERFACE_STATIC_METHOD 16
-#define J9CPTYPE_INTERFACE_INSTANCE_METHOD 17 
+#define J9CPTYPE_INTERFACE_STATIC_METHOD 18
+#define J9CPTYPE_INTERFACE_INSTANCE_METHOD 19
+
 
 #define J9_CP_BITS_PER_DESCRIPTION  8
 #define J9_CP_DESCRIPTIONS_PER_U32  4
@@ -2164,6 +2167,11 @@ typedef struct J9RAMStringRef {
 	j9object_t stringObject;
 	UDATA unused;
 } J9RAMStringRef;
+
+typedef struct J9RAMConstantDynamicRef {
+	j9object_t value;
+	j9object_t exception;
+} J9RAMConstantDynamicRef;
 
 typedef struct J9RAMFieldRef {
 	UDATA volatile valueOffset;
@@ -2238,6 +2246,11 @@ typedef struct J9ROMStringRef {
 } J9ROMStringRef;
 
 #define J9ROMSTRINGREF_UTF8DATA(base) NNSRP_GET((base)->utf8Data, struct J9UTF8*)
+
+typedef struct J9ROMConstantDynamicRef {
+	J9SRP nameAndSignature;
+	U_32 bsmIndexAndCpType;
+} J9ROMConstantDynamicRef;
 
 typedef struct J9ROMFieldRef {
 	U_32 classRefCPIndex;

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -230,7 +230,7 @@ static I_32 dumpCPShapeDescription( J9PortLibrary *portLib, J9ROMClass *romClass
 	U_32 *cpDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
 	U_32 descriptionLong;
 	U_32 i, j, k, numberOfLongs;
-	char symbols[] = ".CSIFJDi.vxyzTHAxv";
+	char symbols[] = ".CSIFJDi.vxyzTHA.cxv";
 
 	PORT_ACCESS_FROM_PORT( portLib );
 


### PR DESCRIPTION
- mark ConstantDynamic entry in constantpool
- add visit function to ROMClass Writer
- add new CP type for ConstantDynamic
- fixed DDR mapping of new CP type

Close: #1271

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>