### PR TITLE
Merge two cmdLineTester_SCCommandLineOptionTests

### DIFF
--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
@@ -24,7 +24,7 @@
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>cmdLineTester_SCCommandLineOptionTests_win</testCaseName>
+		<testCaseName>cmdLineTester_SCCommandLineOptionTests</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -32,45 +32,14 @@
 		<command>$(MKTREE) $(REPORTDIR); \
 	$(CD) $(REPORTDIR); \
 	cp $(Q)$(TEST_RESROOT)$(D)SCCommandLineOptionTests.jar$(Q) .; \
-	$(Q)$(JDK_HOME)$(D)bin$(D)jar.exe$(Q) xf SCCommandLineOptionTests.jar; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(Q)cmd /c$(Q) -DSCRIPT_SUFFIX=.bat -DEXECUTABLE_SUFFIX=.exe -DJDK_HOME=$(Q)$(JDK_HOME)$(Q) \
+	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf SCCommandLineOptionTests.jar; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) -DJDK_HOME=$(Q)$(JDK_HOME)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)CommandLineOptionTests.xml$(Q) \
 	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.win</platformRequirements>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-		</subsets>
-	</test>
-	<test>
-		<testCaseName>cmdLineTester_SCCommandLineOptionTests_unix</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>	
-		</variations>
-		<command>$(MKTREE) $(REPORTDIR); \
-	$(CD) $(REPORTDIR); \
-	cp $(Q)$(TEST_RESROOT)$(D)SCCommandLineOptionTests.jar$(Q) .; \
-	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(Q) xf SCCommandLineOptionTests.jar; \
-	$(CONVERT_TO_EBCDIC_CMD) \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(Q)sh$(Q) -DSCRIPT_SUFFIX=.sh -DEXECUTABLE_SUFFIX= -DJDK_HOME=$(Q)$(JDK_HOME)$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)CommandLineOptionTests.xml$(Q) \
-	-xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
-	-nonZeroExitWhenError \
-	-outputLimit 300; \
-	$(TEST_STATUS)</command>
-		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Merge two playlist entries into one by using variable.


[ci skip]


Fixes #1318


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>