### PR TITLE
Corrects typo from 'Disallow nestmate changes during class redefinition'

### DIFF
--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3102,7 +3102,7 @@ verifyClassesAreCompatible(J9VMThread * currentThread, jint class_count, J9JVMTI
 			U_16 nestMemberCount = originalROMClass->nestMemberCount;
 
 			/* Nest hosts must both be null or must both contain the same string */
-			if ((NULL != originalNestHostName) || (NULL != replacementNestHostName) {
+			if ((NULL != originalNestHostName) || (NULL != replacementNestHostName)) {
 				if ((NULL == originalNestHostName) || (NULL == replacementNestHostName) {
 					return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;
 				} else if (!J9UTF8_EQUALS(originalNestHostName, replacementNestHostName)) {


### PR DESCRIPTION
An accidental missed bracket from 'Disallow nestmate changes during class redefinition' (PR https://github.com/eclipse/openj9/pull/1412, commit https://github.com/eclipse/openj9/commit/320f56d8a6fa2c22b8db91ef68a12602d300f7bc) during PR review causes compilation failure when J9VM_OPT_VALHALLA_NESTMATES build flag is enabled. This commit adds the missing bracket.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>