### PR TITLE
Remove IBM from copyright check

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheck
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheck
@@ -48,7 +48,7 @@ stage('Copyright Check') {
                 
                 // Set a different Copyright regex depending on the Repo the PR is from
                 if (ghprbGhRepository ==~ "eclipse.*") {
-                    REGEX = "\'Copyright \\(c\\) ([0-9]{4}), ${DATE_YEAR} IBM Corp. and others\'"
+                    REGEX = "\'Copyright \\(c\\) ([0-9]{4}), ${DATE_YEAR}\'"
                 } else if (ghprbGhRepository ==~ "ibmruntimes.*") {
                     REGEX = "\'\\(c\\) Copyright IBM Corp. ([0-9]{4}), ${DATE_YEAR} All Rights Reserved\'"
                 } else {


### PR DESCRIPTION
- Copyrights don't necessarily have to belong to IBM
- Still need to have correct 'current year'

[ci skip]

Issue #1440

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>