### PR TITLE
Corrects compilation failure in visible.c

### DIFF
--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -60,7 +60,7 @@
  * 			J9_VISIBILITY_MODULE_READ_ACCESS_ERROR if module read access error occurred,
  * 			J9_VISIBILITY_MODULE_PACKAGE_EXPORT_ERROR if module package access error
  */
-VMINLINE IDATA
+IDATA
 checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions)
 {
 	UDATA result = J9_VISIBILITY_ALLOWED;


### PR DESCRIPTION
A compilation failure caused by inlining function `checkModuleAccess` in vm.visible.c from a02ca22db89b5ef19320a730042c4d96b6cd3d5e. This commit removes the vminline tag so that `checkModuleAccess` is visible outside its source file.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>