### PR TITLE
Add missing cmd to cmdLineTester_SCCommandLineOptionTests

### DIFF
--- a/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
+++ b/test/cmdLineTests/shareClassTests/SCCommandLineOptionTests/playlist.xml
@@ -33,6 +33,7 @@
 	$(CD) $(REPORTDIR); \
 	cp $(Q)$(TEST_RESROOT)$(D)SCCommandLineOptionTests.jar$(Q) .; \
 	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf SCCommandLineOptionTests.jar; \
+	$(CONVERT_TO_EBCDIC_CMD) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) -DJDK_HOME=$(Q)$(JDK_HOME)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)CommandLineOptionTests.xml$(Q) \


### PR DESCRIPTION
- Added $(CONVERT_TO_EBCDIC_CMD) for conversion


[ci skip]


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>