### PR TITLE
Bringup Java 11 b04 & raw builds

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -243,6 +243,33 @@
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
 		<parameter name="jxerules:outputdir" value="java/lang"/>
 	</configuration>
+
+	<configuration
+		  label="OPENJ9-RAWBUILD"
+		  outputpath="OPENJ9-RAWBUILD/src"
+		  flags="OpenJ9-RawBuild"
+		  dependencies="JAVA11"
+		  jdkcompliance="1.8">
+		<classpathentry kind="src" path="src/java.base/share/classes"/>
+		<classpathentry kind="src" path="src/java.management/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
+		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
+		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava10.jar"/>
+		<source path="src"/>
+		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
+		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
+		<parameter name="jxerules:outputdir" value="java/lang"/>
+	</configuration>
 	
 	<configuration
 		  label="PANAMA"

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -351,12 +351,27 @@ private static final int PlatformEncoding = 1;
 private static final int FileEncoding = 2;
 private static final int OSEncoding = 3;
 
+/*[IF OpenJ9-RawBuild]*/
+	/* This is a JCL native required only by OpenJ9 raw build.
+	 * OpenJ9 raw build is a combination of OpenJ9 and OpenJDK binaries without JCL patches within extension repo.
+	 * Currently OpenJ9 depends on a JCL patch to initialize platform encoding which is not available to raw build.
+	 * A workaround for raw build is to invoke this JCL native which initializes platform encoding.
+	 * This workaround can be removed if that JCL patch is not required.
+	 */
+private static native Properties initProperties(Properties props);
+/*[ENDIF] OpenJ9-RawBuild */
+
 /**
  * If systemProperties is unset, then create a new one based on the values 
  * provided by the virtual machine.
  */
 @SuppressWarnings("nls")
 private static void ensureProperties() {
+/*[IF OpenJ9-RawBuild]*/
+	// invoke JCL native to initialize platform encoding
+	initProperties(new Properties());
+/*[ENDIF] OpenJ9-RawBuild */
+	
 	systemProperties = new Properties();
 
 	if (osEncoding != null)

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2017 IBM Corp. and others
+ * Copyright (c) 2002, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1525,6 +1525,12 @@ JVM_IHashCode(JNIEnv *env, jobject obj)
 jobject JNICALL
 JVM_InitProperties(JNIEnv* env, jobject properties)
 {
+	/* This JVM method is invoked by JCL native Java_java_lang_System_initProperties
+	 * only for initialization of platform encoding.
+	 * This is only required by Java 11 raw builds.
+	 * This method is not invoked by other Java levels.
+	 */
+#if !defined(J9VM_JCL_SE11)
 	J9JavaVM* vm = ((J9VMThread*)env)->javaVM;
 	jobject syspropsList = (jobject)vm->syspropsListRef;
 	jclass propertiesClass = (*env)->GetObjectClass(env, properties);
@@ -1541,6 +1547,7 @@ JVM_InitProperties(JNIEnv* env, jobject properties)
 		jobject value = (*env)->GetObjectArrayElement(env, syspropsList, index++);
 		(*env)->CallObjectMethod(env, properties, setPropertyMID, key, value);
 	}
+#endif /* J9VM_JCL_SE11 */
 	return properties;
 }
 


### PR DESCRIPTION
Bringup `Java 11 b04` & raw builds

1. Added call to `JCL` native `Java_java_lang_System_initProperties` to ensure `platform encoding` initialized for raw builds `OPENJ9-RAWBUILD`;
2. Modified `JVM_InitProperties` to just return incoming properties for `Java 11` `Java_java_lang_System_initProperties`, otherwise `assert(syspropsList != NULL)` will be triggered whenever `JVM_InitProperties` is called because `syspropsListRef` is defined within `J9JavaVM` but never initialized. I intended to leave the cleanup work to another PR.
3. Added call to `JCL` native `JNU_InitializeEncoding` which is going to exported by a `JCL` patch in `Java 11` extension repo.

Now `Java 11 b04` raw build `-version` output is as following:
```
openjdk version "11-internal" 2018-09-18
OpenJDK Runtime Environment (build 11-internal+0-adhoc.jason.ottj9build)
IBM J9 VM (build 2.9, JRE 11 Linux amd64-64 Compressed References 20180316_381412 (JIT enabled, AOT enabled)
OpenJ9   - 8a5cbe5
OMR      - c96856a
IBM      - 1d267ef)
```
A successful raw build depends on #1460, #1465 and #1466

Reviewer @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>