### PR TITLE
Bringup Java 11 b04 - adding JVM_BeforeHalt()

### DIFF
--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -1777,3 +1777,11 @@ JVM_GetNanoTimeAdjustment(JNIEnv *env, jclass clazz, jlong offsetSeconds)
 	
 	return result;
 }
+
+#if J9VM_JCL_SE11
+void JNICALL
+JVM_BeforeHalt()
+{
+	/* To be implemented via https://github.com/eclipse/openj9/issues/1459 */
+}
+#endif /* J9VM_JCL_SE11 */

--- a/runtime/j9vm_jdk11/module.xml
+++ b/runtime/j9vm_jdk11/module.xml
@@ -30,6 +30,7 @@
 		<export name="JNI_GetCreatedJavaVMs"/>
 		<export name="JNI_GetDefaultJavaVMInitArgs"/>
 		<export name="_JVM_GetCallerClass@4" />
+		<export name="JVM_BeforeHalt" />
 	</exports>
 
 	<artifact type="shared" name="jvm" scope="jdk11" loadgroup="top" buildlocal="true" appendrelease="false">

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -311,3 +311,5 @@ _X(JVM_GetAndClearReferencePendingList,JNICALL,false,jobject ,JNIEnv *env)
 _X(JVM_HasReferencePendingList,JNICALL,false,jboolean ,JNIEnv *env)
 _X(JVM_WaitForReferencePendingList,JNICALL,false,void ,JNIEnv *env)
 _X(JVM_GetNanoTimeAdjustment,JNICALL,true,jlong ,JNIEnv *env, jclass clazz, jlong offsetSeconds)
+_IF([defined(J9VM_JCL_SE11)],
+	[_X(JVM_BeforeHalt,JNICALL,false,void,void)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -32,6 +32,7 @@
 	</exports>
 	<exports group="jdk11">
 		<export name="_JVM_GetCallerClass@4" />
+		<export name="JVM_BeforeHalt" />
 	</exports>
 	<exports group="prejdk11">
 		<export name="_JVM_GetCallerClass@8" />


### PR DESCRIPTION
Bringup `Java 11 b04` - adding `JVM_BeforeHalt()`

Added an empty `JVM_BeforeHalt()`, created issue #1459 for actual implementation later;
`JVM_BeforeHalt()` is called, hence no `assert` added within the method body.
Exported JVM_BeforeHalt() for Java 11 only.

Reviewer @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>