### PR TITLE
Bringup Java 11 b04 - implement j.l.String.valueOfCodePoint()

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1276,3 +1276,6 @@ K0700="Update spans the word, not supported"
 K0701="Component type is null"
 K0702="Component type is not primitive"
 K0703="Negative length"
+
+#java.lang.String
+K0800="Invalid Unicode code point - {0}"

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -5354,4 +5354,41 @@ written authorization of the copyright holder.
 		return value;
 	}
 /*[ENDIF] Java10 */	
+
+/*[IF Java11]*/
+	/**
+	 * Returns a string object containing the character (Unicode code point)
+	 * specified.
+	 * 
+	 * @param codePoint
+	 *            a Unicode code point.
+	 * @return a string containing the character (Unicode code point) supplied.
+	 * @throws IllegalArgumentException
+	 *             if the codePoint is not a valid Unicode code point.
+	 * @since 11
+	 */
+	static String valueOfCodePoint(int codePoint) {
+		String string;
+		if ((codePoint < Character.MIN_CODE_POINT) || (codePoint > Character.MAX_CODE_POINT)) {
+			/*[MSG "K0800", "Invalid Unicode code point - {0}"]*/
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0800", Integer.toString(codePoint)));	//$NON-NLS-1$
+		} else if (codePoint <= 255) {
+			if (enableCompression) {
+				string = new String(compressedAsciiTable[codePoint], LATIN1);
+			} else {
+				string = new String(decompressedAsciiTable[codePoint], UTF16);
+			}
+		} else if (codePoint < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
+			byte[] buffer = new byte[2];
+			helpers.putCharInArrayByIndex(buffer, 0, (char) codePoint);
+			string = new String(buffer, UTF16);
+		} else {
+			byte[] buffer = new byte[4];
+			helpers.putCharInArrayByIndex(buffer, 0, Character.highSurrogate(codePoint));
+			helpers.putCharInArrayByIndex(buffer, 1, Character.lowSurrogate(codePoint));
+			string = new String(buffer, UTF16);
+		}
+		return string;
+	}
+/*[ENDIF] Java11 */
 }

--- a/test/Java11andUp/.classpath
+++ b/test/Java11andUp/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/test/Java11andUp/.project
+++ b/test/Java11andUp/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Java11andUp</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/test/Java11andUp/.settings/org.eclipse.jdt.core.prefs
+++ b/test/Java11andUp/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/test/Java11andUp/build.xml
+++ b/test/Java11andUp/build.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="Java11AndUp" default="build" basedir=".">
+	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+	<description>
+		Tests for Java 11 and up
+	</description>
+	
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/Java11andUp" />
+	<property name="BUILDINFO_FSROOT" value="${BUILD_ROOT}" />
+		
+	<!--Properties for this particular build-->
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+	<property name="transformerListener" location="../Utils/src"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}"/>
+	</target>
+	
+	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source " >
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:		${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:			${DEST}</echo>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}"/>
+			<src path="${transformerListener}" />
+			<compilerarg line="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED" />
+			<classpath>
+				<pathelement location="../TestConfig/lib/testng.jar"/>
+				<pathelement location="../TestConfig/lib/jcommander.jar"/>
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution" >
+		<mkdir dir="${DEST}"/>
+		<jar jarfile="${DEST}/GeneralTest.jar" filesonly="true">
+			<fileset dir="${build}"/>
+			<fileset dir="${src}/../" includes="*.properties,*.xml"/>
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.mk" />
+		</copy>
+	</target>
+	
+	<target name="build" >
+		<if>
+			<not>
+				<matches string="${JAVA_VERSION}" pattern="^SE(8|9|10)0$$" />
+			</not>
+			<then>
+				<antcall target="clean" inheritall="true" />
+			</then>
+		</if>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up" >
+		<delete dir="${build}"/>
+	</target>
+</project>

--- a/test/Java11andUp/playlist.xml
+++ b/test/Java11andUp/playlist.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>StringvalueOfCodePoint_JDK11_CompactStrings_Enabled</testCaseName>
+		<variations>
+			<variation>-XX:+CompactStrings</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Test_String \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>StringvalueOfCodePoint_JDK11_CompactStrings_Disabled</testCaseName>
+		<variations>
+			<variation>-XX:-CompactStrings</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Test_String \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/test/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -51,12 +51,14 @@ public class Test_String {
 		// Verify that IllegalArgumentException is thrown for Character.MIN_CODE_POINT - 1.
 		try {
 			method.invoke(null, Character.MIN_CODE_POINT - 1);
+			Assert.fail("Failed to detect invalid Unicode point - Character.MIN_CODE_POINT - 1");
 		} catch (IllegalArgumentException | InvocationTargetException e) {
 			// Expected exception
 		}
 		// Verify that IllegalArgumentException is thrown for Character.MAX_CODE_POINT + 1.
 		try {
 			method.invoke(null, Character.MAX_CODE_POINT + 1);
+			Assert.fail("Failed to detect invalid Unicode point - Character.MAX_CODE_POINT + 1");
 		} catch (IllegalArgumentException | InvocationTargetException e) {
 			// Expected exception
 		}

--- a/test/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/**
+ * This test Java.lang.String API added in Java 11 and later version.
+ *
+ */
+public class Test_String {
+	public static Logger logger = Logger.getLogger(Test_String.class);
+
+	/*
+	 * Test Java 11 API String.valueOfCodePoint(codePoint)
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testValueOfCodePoint() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+		Method method = String.class.getDeclaredMethod("valueOfCodePoint", int.class);
+		method.setAccessible(true);
+		// Verify that for each valid Unicode code point i,
+		// i equals to String.valueOfCodePoint(i).codePointAt(0).
+		for (int i = Character.MIN_CODE_POINT; i <= Character.MAX_CODE_POINT; i++) {
+			String str = (String) method.invoke(null, i);
+			Assert.assertEquals(i, str.codePointAt(0), "Unicode code point mismatch at " + i);
+		}
+		// Verify that IllegalArgumentException is thrown for Character.MIN_CODE_POINT - 1.
+		try {
+			method.invoke(null, Character.MIN_CODE_POINT - 1);
+		} catch (IllegalArgumentException | InvocationTargetException e) {
+			// Expected exception
+		}
+		// Verify that IllegalArgumentException is thrown for Character.MAX_CODE_POINT + 1.
+		try {
+			method.invoke(null, Character.MAX_CODE_POINT + 1);
+		} catch (IllegalArgumentException | InvocationTargetException e) {
+			// Expected exception
+		}
+	}
+}

--- a/test/Java11andUp/testng.xml
+++ b/test/Java11andUp/testng.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Java11andUp suite" parallel="none" verbose="2">
+	<listeners>
+		<listener class-name="org.openj9.test.util.IncludeExcludeTestAnnotationTransformer"/>
+	</listeners>
+	<test name="Test_String">
+		<classes>
+			<class name="org.openj9.test.java_lang.Test_String" />
+		</classes>
+	</test>
+</suite>


### PR DESCRIPTION
Bringup `Java 11 b04` - implement `j.l.String.valueOfCodePoint()`

Implemented `j.l.String.valueOfCodePoint()`, manually verified that the output of `String.valueOfCodePoint(codePoint).codePointAt(0)` equals `codePoint` for all Unicode code point.

closes: #1439

Reviewer @DanHeidinga @fjeremic 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>