### PR TITLE
Add new ThreadMXBean APIs

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1158,6 +1158,7 @@ K05FE="Collection usage threshold cannot be negative."
 K05FF="Collection usage threshold cannot exceed maximum amount of memory for pool."
 K0660="Internal error while obtaining private constructor."
 K0661="Internal error while obtaining GcInfo instance."
+K0662="maxDepth must not be negative."
 
 #java.lang.management
 K0600="className cannot be null"

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2016 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -281,6 +281,23 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	@Override
 	public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors,
 			boolean lockedSynchronizers) {
+		return getThreadInfoCommon(ids, lockedMonitors, lockedSynchronizers, Integer.MAX_VALUE);
+	}
+
+	/*[IF Java10]*/
+	@Override
+	public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors,
+			boolean lockedSynchronizers, int maxDepth) {
+		/*[MSG "K0662", "maxDepth must not be negative."]*/
+		if (maxDepth < 0) {
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0662")); //$NON-NLS-1$
+		}
+		return getThreadInfoCommon(ids, lockedMonitors, lockedSynchronizers, maxDepth);
+	}
+	/*[ENDIF]*/ // Java10
+
+	private ThreadInfo[] getThreadInfoCommon(long[] ids, boolean lockedMonitors,
+			boolean lockedSynchronizers, int maxDepth) {
 		// Verify inputs
 		if (lockedMonitors && !isObjectMonitorUsageSupported()) {
 			/*[MSG "K05FC", "Monitoring of object monitors is not supported on this virtual machine"]*/
@@ -305,7 +322,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		}
 
 		// Create an array and populate with individual ThreadInfos
-		return this.getMultiThreadInfoImpl(ids, Integer.MAX_VALUE,
+		return this.getMultiThreadInfoImpl(ids, maxDepth,
 				lockedMonitors, lockedSynchronizers);
 	}
 
@@ -619,6 +636,11 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 */
 	@Override
 	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors, boolean lockedSynchronizers) {
+		return dumpAllThreadsCommon(lockedMonitors, lockedSynchronizers, Integer.MAX_VALUE);
+	}
+
+	private ThreadInfo[] dumpAllThreadsCommon(boolean lockedMonitors,
+			boolean lockedSynchronizers, int maxDepth) {
 		if (lockedMonitors && !isObjectMonitorUsageSupported()) {
 			/*[MSG "K05FC", "Monitoring of object monitors is not supported on this virtual machine"]*/
 			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K05FC")); //$NON-NLS-1$
@@ -631,9 +653,24 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 		if (security != null) {
 			security.checkPermission(ManagementPermissionHelper.MPMONITOR);
 		}
-		return dumpAllThreadsImpl(lockedMonitors, lockedSynchronizers);
+		return dumpAllThreadsImpl(lockedMonitors, lockedSynchronizers, maxDepth);
 	}
 
+	/*[IF Java10]*/
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
+			boolean lockedSynchronizers, int maxDepth) {
+		/*[MSG "K0662", maxDepth must not be negative.]*/
+		if (maxDepth < 0) {
+			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0662")); //$NON-NLS-1$
+		}
+		return dumpAllThreadsCommon(lockedMonitors, lockedSynchronizers, maxDepth);
+	}
+	/*[ENDIF]*/ // Java10
+	
 	/**
 	 * @param lockedMonitors
 	 *            if <code>true</code> then include details of locked object
@@ -641,11 +678,14 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	 * @param lockedSynchronizers
 	 *            if <code>true</code> then include details of locked ownable
 	 *            synchronizers in returned array
+	 * @param maxDepth
+	 *            Limit the number of frames returned.  Negative values indicate no limit.
 	 * @return an array of <code>ThreadInfo</code> objects&nbsp;-&nbsp;one for
 	 *         each thread running in the virtual machine
+	 * @since 10
 	 */
 	private native ThreadInfo[] dumpAllThreadsImpl(boolean lockedMonitors,
-			boolean lockedSynchronizers);
+			boolean lockedSynchronizers, int maxDepth);
 
 	/**
 	 * Answers an array of instances of the ThreadInfo class according to ids

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -633,5 +633,105 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 */
 	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
 			boolean lockedSynchronizers);
+	/*[IF Java10]*/
 
+	/**
+	 * Returns an array of {@link ThreadInfo} objects holding information on all
+	 * threads that were alive when the call was invoked.
+	 * 
+	 * @param lockedMonitors
+	 *            boolean indication of whether or not information on all
+	 *            currently locked object monitors is to be included in the
+	 *            returned array
+	 * @param lockedSynchronizers
+	 *            boolean indication of whether or not information on all
+	 *            currently locked ownable synchronizers is to be included in
+	 *            the returned array
+	 * @param maxDepth limits the number of stack frames returned
+	 * @return an array of <code>ThreadInfo</code> objects
+	 * @throws SecurityException
+	 *             if there is a security manager in effect and the caller does
+	 *             not have {@link ManagementPermission} of &quot;monitor&quot;.
+	 * @throws UnsupportedOperationException
+	 * 	if either of the following conditions apply:
+	 *  	<ul>
+	 *			<li><code>lockedMonitors</code> is <code>true</code> but
+	 *			a call to {@link #isObjectMonitorUsageSupported()} would
+	 *			result in a <code>false</code> value</li>
+	 *			<li><code>lockedSynchronizers</code> is <code>true</code>
+	 *			but a call to {@link #isSynchronizerUsageSupported()} would
+	 *			result in a <code>false</code> value</li>
+	 *	</ul>
+	 * @since 10
+	 */
+
+	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
+            boolean lockedSynchronizers,
+            int maxDepth);
+
+
+	/**
+	 * Returns an array of {@link ThreadInfo} objects; one for each of the
+	 * threads specified in the <code>ids</code> argument. Each
+	 * <code>ThreadInfo</code> will hold details of all of the stack trace
+	 * information for each specified thread. The returned
+	 * <code>ThreadInfo</code> objects will optionally contain details of all
+	 * monitor objects and synchronizers locked by the corresponding thread. In
+	 * order to retrieve locked monitor information the
+	 * <code>lockedMonitors</code> argument should be set to <code>true</code>;
+	 * in order to retrieve locked synchronizers information
+	 * <code>lockedSynchronizers</code> should be set to <code>true</code>.
+	 * For a given <code>ThreadInfo</code> element of the return array the
+	 * optional information may be inspected by calling
+	 * {@link ThreadInfo#getLockedMonitors()} and
+	 * {@link ThreadInfo#getLockedSynchronizers()} respectively.
+	 * <p>
+	 * Both <code>lockedMonitors</code> and <code>lockedSynchronizers</code>
+	 * arguments should only be set to <code>true</code> if the virtual
+	 * machine supports the requested monitoring.
+	 * </p>
+	 * 
+	 * @param ids
+	 *            an array of thread identifiers. Each one must be a positive
+	 *            number greater than zero.
+	 * @param lockedMonitors
+	 *            boolean indication of whether or not each returned
+	 *            <code>ThreadInfo</code> should hold information on locked
+	 *            object monitors
+	 * @param lockedSynchronizers
+	 *            boolean indication of whether or not each returned
+	 *            <code>ThreadInfo</code> should hold information on locked
+	 *            synchronizers
+	 * @param maxDepth limits the number of stack frames returned
+	 * @return an array of {@link ThreadInfo} objects with each entry
+	 *         corresponding to one of the threads specified in the input array
+	 *         of identifiers. The return array will therefore have an identical
+	 *         number of elements to the input <code>ids</code> array. If an
+	 *         entry in the <code>ids</code> array is invalid (there is no
+	 *         living thread with the supplied identifier in the virtual
+	 *         machine) then the corresponding entry in the return array will be
+	 *         a <code>null</code>.
+	 * @throws IllegalArgumentException
+	 *             if any of the entries in the <code>ids</code> array is
+	 *             &lt;=0.
+	 * @throws SecurityException
+	 *             if there is a security manager in effect and the caller does
+	 *             not have {@link ManagementPermission} of &quot;monitor&quot;.
+	 * @throws UnsupportedOperationException
+	 * if either of the following conditions apply:
+	 *  <ul>
+	 *  	<li><code>lockedMonitors</code> is <code>true</code> but
+	 *			a call to {@link #isObjectMonitorUsageSupported()} would
+	 * 			result in a <code>false</code> value</li>
+	 *      <li><code>lockedSynchronizers</code> is <code>true</code>
+	 *          but a call to {@link #isSynchronizerUsageSupported()} would
+	 *          result in a <code>false</code> value</li>
+	 *  </ul>
+	 * @since 10
+	 */
+	public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors,
+			boolean lockedSynchronizers, int maxDepth);
+
+
+	/*[ENDIF]*/ // Java 10
 }

--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -657,7 +657,7 @@ Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_getMultiThreadInfoIm
 
 jobjectArray JNICALL
 Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_dumpAllThreadsImpl(JNIEnv *env, jobject beanInstance,
-	jboolean getLockedMonitors, jboolean getLockedSynchronizers)
+	jboolean getLockedMonitors, jboolean getLockedSynchronizers, jint maxDepth)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	PORT_ACCESS_FROM_VMC(currentThread);
@@ -705,7 +705,7 @@ Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_dumpAllThreadsImpl(J
 				{
 					++numThreads;
 					exc = getThreadInfo(currentThread, vmThread, info,
-							J9_THREADINFO_MAX_STACK_DEPTH, getLockedMonitors);
+							maxDepth, getLockedMonitors);
 					if (exc > 0) {
 						freeThreadInfos(currentThread, allinfo, numThreads);
 						goto dumpAll_failWithExclusive;

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -281,7 +281,7 @@ Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_getMultiThreadInfoIm
 	jlongArray ids, jint maxStackDepth, jboolean lockedMonitors, jboolean lockedSynchronizers);
 extern J9_CFUNC jobjectArray JNICALL
 Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_dumpAllThreadsImpl(JNIEnv *env, jobject beanInstance,
-	jboolean lockedMonitors, jboolean lockedSynchronizers);
+	jboolean lockedMonitors, jboolean lockedSynchronizers, jint maxDepth);
 
 /* J9SourceJclReflect*/
 extern J9_CFUNC UDATA

--- a/test/Java10andUp/playlist.xml
+++ b/test/Java10andUp/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,27 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE100</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>threadMXBeanTestSuiteJava10</testCaseName>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS)\
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames \
+	threadMXBeanTestSuiteJava10 \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/APITestJava10.java
+++ b/test/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/APITestJava10.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java.lang.management.ThreadMXBean;
+
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+import static org.testng.Assert.fail;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * Verify Java 10 additions, specfifically depth-limited stack traces.
+ */
+public class APITestJava10 extends ThreadMXBeanTestCase {
+	private static final int MAXDEPTH = 10;
+	public Object waitObject = new Object();
+	ThreadMXBean myBean;
+
+	public APITestJava10() {
+		myBean = ManagementFactory.getThreadMXBean();
+	}
+
+	class TestThread extends Thread{
+		int stackDepth;
+		public TestThread(int depth) {
+			stackDepth = depth;
+			this.setDaemon(true); // Prevent this from blocking test exit.
+		}
+
+		public void run() {
+			logger.debug("start TestThread #"+Thread.currentThread().getId());
+			if (stackDepth > 0) {
+				myMethod(stackDepth - 1);
+			} else { // Create the shortest stack possible.
+				synchronized (waitObject) {
+					try {
+						waitObject.wait();
+					} catch (InterruptedException e) {
+						// ignore
+					}
+				}
+			}
+			logger.debug("end TestThread #"+Thread.currentThread().getId());
+		}
+
+		/*
+		 * Build up a stack of specified depth.
+		 */
+		public Integer myMethod(Integer depth) {
+			if (depth > 0) {
+				myMethod(depth - 1);
+			} else {
+				synchronized (waitObject) {
+					try {
+						waitObject.wait();
+					} catch (InterruptedException e) {
+						// ignore
+					}
+				}
+			}
+			return Integer.valueOf(0);
+		}
+	}
+
+	class MethodHandleTestThread extends TestThread {
+		public MethodHandleTestThread(int depth) {
+			super(depth);
+		}
+
+		@Override
+		public void run() {
+			try {
+				Method m = TestThread.class.getMethod("myMethod", Integer.class);
+				m.invoke(this, Integer.valueOf(stackDepth));
+			} catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				fail("Unexpected exception", e);
+			}
+		}
+	}
+
+	class LambdaTestThread extends TestThread {
+		public LambdaTestThread(int depth) {
+			super(depth);
+		}
+
+		@Override
+		public void run() {
+			try {
+				UnaryOperator<Integer> myLambda = s -> myMethod(s);
+				myLambda.apply(Integer.valueOf(stackDepth));
+			} catch (IllegalArgumentException e) {
+				fail("Unexpected exception", e);
+			}
+		}
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testDumpLimits() throws InterruptedException {
+		logger.debug("testDumpLimits");
+		ArrayList<Thread> myThreads = new ArrayList<>();
+		Thread currentThread = Thread.currentThread();
+		long myId = currentThread.getId();
+		long ids[] = new long[MAXDEPTH];
+		HashMap<Long, Integer> expectedDepths = new HashMap<>();
+		for (int requestedDepth = 0; requestedDepth < MAXDEPTH; requestedDepth++) {
+			Thread t = new TestThread(requestedDepth);
+			myThreads.add(t);
+			long id = t.getId();
+			logger.debug("start "+id);
+			t.start();
+			while (t.getState() != Thread.State.WAITING) {
+				try {
+					Thread.sleep(1);
+				} catch (InterruptedException e) {
+					// ignore
+				}
+			}
+			ids[requestedDepth] = id;
+			/*
+			 * every thread will have one stack frame for the run() method,
+			 * plus the specified number of extra frames.
+			 */
+			expectedDepths.put(id, requestedDepth + 1);
+		}
+
+		for (int maxDepth = 0; maxDepth < MAXDEPTH; maxDepth++) {
+			logger.debug("maxDepth = "+maxDepth);
+			for (ThreadInfo ti: myBean.dumpAllThreads(false, false, maxDepth)) {
+				StackTraceElement[] trace = ti.getStackTrace();
+				Assert.assertTrue(trace.length <= maxDepth, "dumpAllThreads: Wrong stack size when maxDepth = "+maxDepth);
+				long id = ti.getThreadId();
+				Integer requestedDepthTemp = expectedDepths.get(id);
+				if (Objects.isNull(requestedDepthTemp)) {
+					/* non-test thread */
+					continue;
+				}
+				int requestedDepth = requestedDepthTemp.intValue();
+				checkDepth(requestedDepth, maxDepth, trace, "dumpAllThreads");
+			}
+			for (ThreadInfo ti: myBean.getThreadInfo(ids, maxDepth)) {
+				StackTraceElement[] trace = ti.getStackTrace();
+				Assert.assertTrue(trace.length <= maxDepth, "getThreadInfo: Wrong stack size when maxDepth = "+maxDepth);
+				long id = ti.getThreadId();
+				Integer requestedDepthTemp = expectedDepths.get(id);
+				if (null == requestedDepthTemp) {
+					/* non-test thread */
+					continue;
+				}
+				int requestedDepth = requestedDepthTemp;
+				checkDepth(requestedDepth, maxDepth, trace, "getThreadInfo");
+			}
+		}
+		synchronized (waitObject) {
+			waitObject.notifyAll();
+		}
+		for (Thread t: myThreads) {
+			logger.debug("wait for "+t.getId());
+			t.join(10000);
+		}
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testDumpLimitsWithMethodHandles() {
+		final int REQUESTED_DEPTH = 5;
+		Thread t = new MethodHandleTestThread(REQUESTED_DEPTH - 1); // Subtract 1 for the run() method.
+		checkThreadInfo(REQUESTED_DEPTH, t);
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testDumpLimitsWithLambdas() {
+		final int REQUESTED_DEPTH = 5;
+		Thread t = new LambdaTestThread(REQUESTED_DEPTH - 2); // Subtract 1 for the run() method and 1 for the lambda.
+		checkThreadInfo(REQUESTED_DEPTH, t);
+	}
+
+	private void checkThreadInfo(int requestedDepth, Thread t) {
+		t.start();
+		final long ids[] = {t.getId()};
+		while (t.getState() != Thread.State.WAITING) {
+			try {
+				Thread.sleep(1);
+			} catch (InterruptedException e) {
+				// ignore
+			}
+		}
+
+		for (int maxDepth = 0; maxDepth <= requestedDepth + 1; ++maxDepth) {
+
+			for (ThreadInfo ti: myBean.dumpAllThreads(false, false, maxDepth)) {
+				StackTraceElement[] trace = ti.getStackTrace();
+				long id = ti.getThreadId();
+				if (id != ids[0]) {
+					continue;
+				} else {
+					checkDepth(requestedDepth, maxDepth, trace, "dumpAllThreads");
+				}
+			}
+			ThreadInfo ti = (myBean.getThreadInfo(ids, maxDepth))[0];
+			StackTraceElement[] trace = ti.getStackTrace();
+			checkDepth(requestedDepth, maxDepth, trace, "getThreadInfo");
+		}
+	}
+
+	private void checkDepth(int requestedDepth, int maxDepth, StackTraceElement[] trace, String msg) {
+		/* the actual depth may be greater than the requested depth due to calls inside wait() */
+		if (requestedDepth >= maxDepth) {
+			Assert.assertEquals(trace.length, maxDepth, msg+": Wrong stack size when requested depth > maxDepth = "+maxDepth);
+		} else {
+			Assert.assertTrue(trace.length >= maxDepth, msg+": Stack exceeds maxDepth = "+maxDepth);
+			Assert.assertTrue(trace.length <= requestedDepth, msg+": Stack less than minimum expected");
+		}
+	}
+}

--- a/test/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/ThreadMXBeanTestCase.java
+++ b/test/Java10andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/ThreadMXBeanTestCase.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java.lang.management.ThreadMXBean;
+
+import java.lang.management.ThreadInfo;
+
+public abstract class ThreadMXBeanTestCase extends ThreadMXBeanTestCaseCommon {
+
+	@Override
+	void printExtraAttributes(ThreadInfo ti) {
+		logger.debug("\tis daemon        " + ti.isDaemon()); //$NON-NLS-1$
+		logger.debug("\tthread priority  " + ti.getPriority()); //$NON-NLS-1$
+	}
+
+}

--- a/test/Java10andUp/testng.xml
+++ b/test/Java10andUp/testng.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2017, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,11 @@
 	<test name="StackWalkerTestJava10">
 		<classes>
 			<class name="org.openj9.test.stackWalker.StackWalkerTestJava10" />
+		</classes>
+	</test>
+	<test name="threadMXBeanTestSuiteJava10">
+		<classes>
+			<class name="org.openj9.test.java.lang.management.ThreadMXBean.APITestJava10" />
 		</classes>
 	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
Add Add ThreadMXBean.dumpAllThreads(..., int maxDepth) and getThreadInfo(..., int maxDepth) APIs
for Java 10.

Add tests for the new APIs, including stack frames with method handles and lambdas.

Fix incorrect copyright.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>