### PR TITLE
Remove extra directories from SDK tarballs

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -170,7 +170,7 @@ def archive() {
                 sh "tar -zcvf ${TEST_PREFIX}`git -C openj9 rev-parse --short HEAD`${TEST_SUFFIX} openj9/test/"
                 archiveArtifacts artifacts: "**/${TEST_PREFIX}*${TEST_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
             }
-            sh "tar -zcvf ${SDK_PREFIX}`date +%Y%d%m%H%M`${SDK_SUFFIX} build/$RELEASE/images/${JDK_FOLDER}"
+            sh "tar -C build/$RELEASE/images/ -zcvf ${SDK_PREFIX}`date +%Y%d%m%H%M`${SDK_SUFFIX} ${JDK_FOLDER}"
             archiveArtifacts artifacts: "**/${SDK_PREFIX}*${SDK_SUFFIX}", fingerprint: true, onlyIfSuccessful: true
         }
     }

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -26,7 +26,12 @@
 // set_job_variables() is usually called on the master not on the node (where
 // the tests run) and the master's WORKSPACE is different than the node's WORKSPACE
 JRE_FOLDER = (SDK_VERSION == '8') ? '/jre' : ''
-JAVA_BIN = "${WORKSPACE}/build/${RELEASE}/images/${JDK_FOLDER}${JRE_FOLDER}/bin"
+
+BUILD_RELEASE_IMAGES = ''
+if (params.ghprbPullId) {
+    BUILD_RELEASE_IMAGES = "build/${RELEASE}/images/"
+}
+JAVA_BIN = "${WORKSPACE}/${BUILD_RELEASE_IMAGES}${JDK_FOLDER}${JRE_FOLDER}/bin"
 
 def fetch_artifacts(){
     stage('Fetch Artifacts') {


### PR DESCRIPTION
- Remove build/RELEASE/images
- Set JAVA_BIN differently in PR builds

[ci skip]

Fixes #1451

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>