### PR TITLE
OpenJ9 Java 10 set java.vendor.version

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -772,6 +772,13 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
+	if (J2SE_V10 <= j2seVersion) {
+		rc = addSystemProperty(vm, "java.vendor.version", "", 0);
+		if (J9SYSPROP_ERROR_NONE != rc) {
+			goto fail;
+		}
+	}
+
 #if defined(J9JDK_EXT_NAME)
 	rc = addSystemProperty(vm, "jdk.extensions.name", J9JDK_EXT_NAME, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {


### PR DESCRIPTION
`OpenJ9 Java 10` set `java.vendor.version`

This new system property for `Java 10` and onward is set to an empty string for now.

Did a `Java 10` build, and got following system property output:
```
java.vendor.version =
```

closes #842 

Reviewer @pshipton 
FYI @DanHeidinga  

Signed-off-by: Jason Feng <fengj@ca.ibm.com>