### PR TITLE
Invalid reference to cursor->getAssumingPC() in debug mode

### DIFF
--- a/runtime/compiler/trj9/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/trj9/runtime/ClassUnloadAssumption.cpp
@@ -460,9 +460,10 @@ void TR_RuntimeAssumptionTable::markAssumptionsAndDetach(void * md, bool reclaim
             #if defined(PROD_WITH_ASSUMES) || defined(DEBUG)
             TR_RuntimeAssumptionKind kind = cursor->getAssumptionKind();
             TR_ASSERT(kind == RuntimeAssumptionOnClassRedefinitionPIC ||
-               kind == RuntimeAssumptionOnClassRedefinitionUPIC || kind == RuntimeAssumptionOnClassRedefinitionNOP,
-               "non redefinition assumption (RA=%p kind=%d key=%p assumingPC=%p) left after metadata reclamation\n"
-               cursor, kind, cursor->getKey(), cursor->getAssumingPC());
+                      kind == RuntimeAssumptionOnClassRedefinitionUPIC || 
+                      kind == RuntimeAssumptionOnClassRedefinitionNOP,
+               "non redefinition assumption (RA=%p kind=%d key=%p) left after metadata reclamation\n",
+               cursor, kind, cursor->getKey());
             #endif
             cursor->setNextAssumptionForSameJittedBody(notReclaimedList);
             notReclaimedList = cursor;


### PR DESCRIPTION
Code enabled under DEBUG mode refers to runtimeAssumption->getAssumingPC()
which lo longer exists. As such a debug build will fail. Since the bad
code is used in a message for an assert it can be safely removed.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>