### PR TITLE
Re-enable AttachAPISanity_SE90

### DIFF
--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -209,8 +209,6 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<!-- failed intermittent on Windows, Openj9 issue #1454 -->
-		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
The failures were caused by machine problems.

Fixes https://github.com/eclipse/openj9/issues/1454

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>