### PR TITLE
Print test name before time stamp

### DIFF
--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -407,7 +407,7 @@ sub writeTargets {
 			print $fhOut "$indent\@echo \"===============================================\" | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
 			print $fhOut "$indent\@echo \"Running test \$\@ ...\" | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
 			print $fhOut "$indent\@echo \"===============================================\" | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
-			print $fhOut "$indent\@perl \'-MTime::HiRes=gettimeofday\' -e \'print \"Start Time: \" . localtime() . \" Epoch Time (ms): \" . int (gettimeofday * 1000) . \"\\n\"\' | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
+			print $fhOut "$indent\@perl \'-MTime::HiRes=gettimeofday\' -e \'print \"$name start Time: \" . localtime() . \" Epoch Time (ms): \" . int (gettimeofday * 1000) . \"\\n\"\' | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
 			if ($condition_platform) {
 				print $fhOut "ifeq (\$($condition_platform),)\n";
 			}
@@ -445,7 +445,7 @@ sub writeTargets {
 				}
 				print $fhOut "endif\n";
 			}
-			print $fhOut "$indent\@perl \'-MTime::HiRes=gettimeofday\' -e \'print \"Finish Time: \" . localtime() . \" Epoch Time (ms): \" . int (gettimeofday * 1000) . \"\\n\"\' | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q)\n";
+			print $fhOut "$indent\@perl \'-MTime::HiRes=gettimeofday\' -e \'print \"$name finish Time: \" . localtime() . \" Epoch Time (ms): \" . int (gettimeofday * 1000) . \"\\n\"\' | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q)\n";
 
 			print $fhOut "\n.PHONY: $name\n\n"; 
 

--- a/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
+++ b/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
@@ -75,9 +75,9 @@ sub resultReporter {
 					$output .= '        ' . $result;
 					if ($result =~ /Running test (.*) \.\.\.\n/) {
 						$testName = $1;
-					} elsif ($result =~ /Start Time: .* Epoch Time \(ms\): (.*)\n/) {
+					} elsif ($result =~ /^\Q$testName\E start Time: .* Epoch Time \(ms\): (.*)\n/) {
 						$startTime = $1;
-					} elsif ($result =~ /Finish Time: .* Epoch Time \(ms\): (.*)\n/) {
+					} elsif ($result =~ /^\Q$testName\E finish Time: .* Epoch Time \(ms\): (.*)\n/) {
 						$endTime = $1;
 						$tapString .= "    duration_ms: " . ($endTime - $startTime) . "\n  ...\n";
 						last;


### PR DESCRIPTION
- Print test name to make the time stamp deterministic for parser.

[ci skip]


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>