### PR TITLE
Linux s390 must use an Adopt JDK8 as the boot jdk

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -50,10 +50,12 @@ linux_ppc-64_cmprssptrs_le:
     test: 'ppcle'
 #========================================#
 # Linux S390 64bits Compressed Pointers
+# Note: boot_jdk 8 must use an Adopt JDK8 build rather than an 
+# IBM 7 for the bootJDK or compiling corba will fail to find Object.
 #========================================#
 linux_390-64_cmprssptrs:
   boot_jdk:
-    8: '/usr/lib/jvm/ibm-java-s390x-70'
+    8: '/usr/lib/jvm/adoptojdk-java-s390x-80'
     9: '/usr/lib/jvm/adoptojdk-java-s390x-80'
   release:
     8: 'linux-s390x-normal-server-release'


### PR DESCRIPTION
Using an IBM JDK 7 (the previous release), will lead to failures
compiling corba.

```
00:21:09 ## Starting corba
00:21:09 Compiling 6 files for BUILD_LOGUTIL
00:21:10 /home/jenkins/jenkins-agent/workspace/Build-JDK8-linux_390
-64_cmprssptrs/corba/src/share/classes/com/sun/tools/corba/se/
logutil/IndentingPrintWriter.java:35: error: cannot access Object
00:21:10 public class IndentingPrintWriter extends PrintWriter {
00:21:10        ^
00:21:10   class file for java.lang.Object not found
```

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>