### PR TITLE
Enable Windows stack protection (/GS flag)

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -531,6 +531,14 @@ cnathelp$(UMA_DOT_O):cnathelp.cpp
 	$(CXX) $(CXXFLAGS) -mstackrealign -c $<
 </#if>
 
+# special handling for cnathelp.cpp to disable buffer security check in windows for JIT helpers
+<#if uma.spec.flags.build_newCompiler.enabled && uma.spec.type.windows>	
+cnathelp$(UMA_DOT_O):cnathelp.cpp
+	$(CXX) $(CXXFLAGS) /GS- -c $<
+SharedService$(UMA_DOT_O):SharedService.c
+	$(CC) $(CFLAGS) /GS- -c $<
+</#if>
+
 <#if uma.spec.processor.ppc>
 ifndef USE_PPC_GCC
 # special handling BytecodeInterpreter.cpp and DebugBytecodeInterpreter.cpp

--- a/runtime/makelib/targets.mk.win.inc.ftl
+++ b/runtime/makelib/targets.mk.win.inc.ftl
@@ -1,5 +1,5 @@
 <#-- 
-	Copyright (c) 1998, 2017 IBM Corp. and others
+	Copyright (c) 1998, 2018 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,11 +70,6 @@ endif
 ifndef UMA_DO_NOT_OPTIMIZE_CCODE
 	UMA_OPTIMIZATION_FLAGS=/Ox
 endif
-<#if uma.spec.flags.build_newCompiler.enabled>	
-	#	/GS-: disable buffer security check (on by default)
-	#
-	UMA_OPTIMIZATION_FLAGS+=/GS-
-</#if>
 
 CFLAGS+=$(UMA_OPTIMIZATION_FLAGS)
 CXXFLAGS+=$(UMA_OPTIMIZATION_FLAGS)


### PR DESCRIPTION
Performance summary:
- Throughput: no regression
- Compilation: 2% more CPU spent
- Startup: no regression
- Footprint: no regression

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>