### PR TITLE
Add shared classes support for nested jar

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassAbstractHelper.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassAbstractHelper.java
@@ -12,7 +12,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,16 +94,42 @@ public abstract class SharedClassAbstractHelper extends SharedAbstractHelper imp
 		if (jarName==null)
 			return null;
 
-		int lastIndexBang = jarName.lastIndexOf("!/"); //$NON-NLS-1$
 		boolean startsWithJar = jarName.startsWith("jar:"); //$NON-NLS-1$
+		boolean endsWithBang = jarName.endsWith("!/");//$NON-NLS-1$
 		int subStringStart = startsWithJar ? 4 : 0;
-		int subStringEnd = lastIndexBang>=0 ? lastIndexBang : jarName.length();
+		int len = jarName.length();
+		/*
+		 * The possible separator "!/" at the end of the URL path is useless for us. Throw it away. 
+		 * We only care about the actual path string before "!/" .
+		 * 
+		 * We do not trim "!/" in the middle of the URL path. We need the string after "!/" to distinguish 
+		 * between different entries from the same nested jar.
+		 * e.g. /path/A.jar!/lib/B.jar, /path/A.jar!/lib/C.jar, /path/A.jar are treated as different paths even though they are from the same jar.
+		 */
+		int subStringEnd = endsWithBang ? len -2 : len;
 
-		if (!startsWithJar && lastIndexBang==-1) {
+		if (!startsWithJar && !endsWithBang) {
 			return jarName;
 		} else {
 			return recursiveJarTrim(jarName.substring(subStringStart, subStringEnd));
 		}
+	}
+	
+	private static URL getURLToCheck(URL url) {
+		String pathString = url.toString();
+		int indexBang = pathString.indexOf("!/"); //$NON-NLS-1$
+		if (-1 != indexBang) {
+			/* For a nested jar (e.g. /path/A.jar!/lib/B.jar), validate the external jar file only (/path/A.jar), 
+			 * so trim the entry within the jar after "!/" 
+			 */
+			pathString = pathString.substring(0, indexBang);
+			try {
+				return new URL(pathString);
+			} catch (MalformedURLException e) {
+				return url;
+			}
+		}
+		return url;
 	}
 
 	boolean validateClassLoader(ClassLoader loader, Class<?> clazz) {
@@ -131,7 +157,7 @@ public abstract class SharedClassAbstractHelper extends SharedAbstractHelper imp
 			return false;
 		}
 		if (checkExists) {
-			final URL urlToCheck = url;
+			final URL urlToCheck = getURLToCheck(url);
 			Integer fExists = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
 				@Override
 				public Integer run() {

--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -561,7 +561,7 @@ getCpeTypeForProtocol(char* protocol, jsize protocolLen, const char* pathChars, 
 	}
 	if (strncmp(protocol, "file", 5)==0) {
 		char* endsWith = (char*)(pathChars + (pathLen-4));
-		if ((strncmp(endsWith, ".jar", 4)==0) || (strncmp(endsWith, ".zip", 4)==0)) {
+		if ((strncmp(endsWith, ".jar", 4)==0) || (strncmp(endsWith, ".zip", 4)==0) || strstr(pathChars,"!/")) {
 			Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJAR();
 			return CPE_TYPE_JAR;
 		} else {

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4175,7 +4175,7 @@ SH_CacheMap::markStale(J9VMThread* currentThread, ClasspathEntryItem* cpei, bool
 	ShcItem* it = NULL;
 	IDATA retryCount = 0;
 	U_16 cpeiPathLen = 0;
-	const char* cpeiPath = cpei->getPath(&cpeiPathLen);
+	const char* cpeiPath = cpei->getLocation(&cpeiPathLen);
 	UDATA oldState = currentThread->omrVMThread->vmState;
 	IDATA returnVal = 0;
 	const char* fnName = "markStale";
@@ -5034,7 +5034,7 @@ SH_CacheMap::createPathString(J9VMThread* currentThread, J9SharedClassConfig* co
 {
 	char* fullPath = *pathBuf;
 	U_16 cpeiPathLen = 0;
-	const char* cpeiPath = cpei->getPath(&cpeiPathLen);
+	const char* cpeiPath = cpei->getLocation(&cpeiPathLen);
 	char* classNamePos = (char*)className;
 	UDATA cNameLen = classNameLen;
 	char* lastSlashPos = NULL;

--- a/runtime/shared_common/ClasspathItem.cpp
+++ b/runtime/shared_common/ClasspathItem.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,6 +56,15 @@ ClasspathEntryItem::initialize(const char* path_, U_16 pathLen_, UDATA protocol_
 
 	path = (char*)path_;
 	pathLen = pathLen_;
+	locationPathLen = pathLen_;
+	if (protocol == PROTO_JAR) {
+		if (NULL != path) {
+			char* jarPath = strstr(path,"!/");
+			if (NULL != jarPath) {
+				locationPathLen = jarPath - path;
+			}
+		}
+	}
 
 	return 0;
 }
@@ -105,6 +114,19 @@ ClasspathEntryItem::hash(J9InternalVMFunctions* functionTable)
 		return (hashValue = (functionTable->computeHashForUTF8((U_8*)path, pathLen) + protocol));
 	}
 	return hashValue;
+}
+
+const char*
+ClasspathEntryItem::getLocation(U_16* locationPathLen_) const
+{
+	if (locationPathLen_) {
+		*locationPathLen_ = (U_16)locationPathLen;
+	}
+	if ((flags & IS_IN_CACHE_FLAG)==0) {
+		return path;
+	} else {
+		return (((BlockPtr)this) + sizeof(ClasspathEntryItem));
+	}
 }
 
 void

--- a/runtime/shared_common/ClasspathItem.hpp
+++ b/runtime/shared_common/ClasspathItem.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,7 @@ public:
 	I_64 timestamp;
 	UDATA flags;
 	UDATA pathLen;
+	UDATA locationPathLen;
 
 	/* 
 	 * Construct new ClasspathEntryItem
@@ -81,6 +82,20 @@ public:
 	 *   pathLen			Path length of the path returned
 	 */
 	const char* getPath(U_16* pathLen) const;
+	
+	/*
+	 * Returns the same string path as getPath() except for a nested jar.
+	 * If the ClasspathEntryItem is a nested jar, getPath() returns a path string including the entry inside the external jar,
+	 * while getLocation() returns a path string including the external jar only.
+	 * e.g. For /path/A.jar!/lib/B.jar, getPath() returns "/path/A.jar!/lib/B.jar", getLocation() returns "/path/A.jar"
+	 *
+	 * If object in memory, returns private path field.
+	 * If object in cache, returns path in cache.
+	 *
+	 * Parameters:
+	 *   locationPathLen	Path length of the path returned
+	 */
+	const char* getLocation(U_16* locationPathLen) const;
 
 	/*
 	 * Get a hashcode for this cpei.

--- a/runtime/shared_common/ClasspathManagerImpl2.cpp
+++ b/runtime/shared_common/ClasspathManagerImpl2.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2016 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -390,7 +390,7 @@ SH_ClasspathManagerImpl2::hasTimestampChanged(J9VMThread* currentThread, Classpa
 		if (knownLLH) {
 			header = knownLLH;		/* Optimization: Don't need to get mutex and do lookup if header is provided */
 		} else {
-			itemPath = itemToCheck->getPath(&pathLen);
+			itemPath = itemToCheck->getLocation(&pathLen);
 			header = cpeTableLookup(currentThread, itemPath, pathLen, 0);			/* 0 = isToken. Certainly won't be a token. */
 			if (header == NULL) {
 				/* CMVC 131285: This is not expected to happen, but has been seen with concurrent writing 
@@ -743,7 +743,7 @@ SH_ClasspathManagerImpl2::localUpdate_CheckManually(J9VMThread* currentThread, C
 
 	Trc_SHR_CMI_localUpdate_CheckManually_Entry(currentThread, cp);
 
-	path = cp->itemAt(0)->getPath(&pathLen);
+	path = cp->itemAt(0)->getLocation(&pathLen);
 	known = cpeTableLookup(currentThread, path, pathLen, (cp->getType()==CP_TYPE_TOKEN));
 	if (known && known->_list) {
 		CpLinkedListImpl* cpInCache = NULL;
@@ -1229,7 +1229,7 @@ SH_ClasspathManagerImpl2::storeNew(J9VMThread* currentThread, const ShcItem* ite
 	for (I_16 i=0; i<cpi->getItemsAdded(); i++) {
 		bool isLastItem = (i==(cpi->getItemsAdded()-1));
 		U_16 pathLen = 0;
-		const char* path = cpi->itemAt(i)->getPath(&pathLen);
+		const char* path = cpi->itemAt(i)->getLocation(&pathLen);
 		U_8 isToken = (cpi->getType()==CP_TYPE_TOKEN);
 
 		if (!cpeTableUpdate(currentThread, path, pathLen, i, itemInCache, isToken, isLastItem, cachelet)) {
@@ -1272,7 +1272,7 @@ SH_ClasspathManagerImpl2::markClasspathsStale(J9VMThread* currentThread, Classpa
 	const char* path = NULL;
 	CpLinkedListHdr* header = NULL;
 
-	path = cpei->getPath(&pathLen);
+	path = cpei->getLocation(&pathLen);
 	Trc_SHR_CMI_markClasspathsStale_Entry(currentThread, pathLen, path);
 
 	header = cpeTableLookup(currentThread, path, pathLen, 0);		/* 0 == isToken. We will never mark token cpei stale */
@@ -1282,7 +1282,7 @@ SH_ClasspathManagerImpl2::markClasspathsStale(J9VMThread* currentThread, Classpa
 		Trc_SHR_Assert_ShouldNeverHappen();
 		return;
 	}
-	
+
 	if (cpToMark) {
 		walk = cpToMark;
 		do {


### PR DESCRIPTION
1. When constructing URL using recursiveJarTrim() for a nested jar, do
not trim the entry within the external jar so that it is kept in the
URL. For example, /path/A.jar!/lib/B.jar won't be trimmed to /path/A.jar
anymore.
2. Add a new API ClasspathEntryItem::getLocation() to return the path
for the external jar file. For example, in the case of
/path/A.jar!/lib/B.jar, getLocation() returns /path/A.jar, which will be
used in time stamping and stale marking operations. The full path
/path/A.jar!/lib/B.jar, returned by ClasspathEntryItem::getPath() will
be used in ClasspathEntryItem comparison, and trace/verbose/statistic
messages.

Fixes #1244 

Signed-off-by: hangshao <hangshao@ca.ibm.com>