### PR TITLE
Add JDK10 to nightly builds

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -38,7 +38,7 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - Build Types: compile,test
     - Levels: sanity,extended (only if Build Type is test)
     - Platforms: zlinux,plinux,aix
-    - Java Versions: jdk8,jdk9
+    - Java Versions: jdk8,jdk9,jdk10
 - Note: You can use keyword `all` for level, platform or version
 
 ###### Examples
@@ -106,6 +106,14 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - This job is used in other pipelines but can be launched manually
 
+- Build-JDK10-aix_ppc-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Build-JDK10-aix_ppc-64_cmprssptrs)
+    - Description:
+        - Compiles java10 on aix_ppc-64_cmprssptrs
+        - Archives the SDK and test material for use in downstream jobs
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
 - Build-JDK8-linux_390-64_cmprssptrs
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK8-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Build-JDK8-linux_390-64_cmprssptrs)
     - Description:
@@ -122,6 +130,14 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - This job is used in other pipelines but can be launched manually
 
+- Build-JDK10-linux_390-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Build-JDK10-linux_390-64_cmprssptrs)
+    - Description:
+        - Compiles java10 on linux_390-64_cmprssptrs
+        - Archives the SDK and test material for use in downstream jobs
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
 - Build-JDK8-linux_ppc-64_cmprssptrs_le
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK8-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Build-JDK8-linux_ppc-64_cmprssptrs_le)
     - Description
@@ -134,6 +150,14 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK9-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Build-JDK9-linux_ppc-64_cmprssptrs_le)
     - Description
         - Compiles java9 on linux_ppc-64_cmprssptrs_le
+        - Archives the SDK and test material for use in downstream jobs
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
+- Build-JDK10-linux_ppc-64_cmprssptrs_le
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Build-JDK10-linux_ppc-64_cmprssptrs_le)
+    - Description
+        - Compiles java10 on linux_ppc-64_cmprssptrs_le
         - Archives the SDK and test material for use in downstream jobs
     - Trigger:
         - This job is used in other pipelines but can be launched manually
@@ -189,6 +213,18 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - build periodically, @midnight
 
+- Pipeline-Build-Test-JDK10-aix_ppc-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Pipeline-Build-Test-JDK10-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Pipeline-Build-Test-JDK10-aix_ppc-64_cmprssptrs)
+    - Description:
+        - Compile and Test java10 Sanity & Extended
+        - Triggers
+            - `Build-JDK10-aix_ppc-64_cmprssptrs`
+            - `Test-Sanity-JDK10-aix_ppc-64_cmprssptrs`
+            - `Test-Extended-JDK10-aix_ppc-64_cmprssptrs`
+
+    - Trigger:
+        - build periodically, @midnight
+
 - Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs)
     - Description:
@@ -213,6 +249,18 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - build periodically, @midnight
 
+- Pipeline-Build-Test-JDK10-linux_390-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Pipeline-Build-Test-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Pipeline-Build-Test-JDK10-linux_390-64_cmprssptrs)
+    - Description:
+        - Compile and Test java10 Sanity & Extended
+        - Triggers
+            - `Build-JDK10-linux_390-64_cmprssptrs`
+            - `Test-Sanity-JDK10-linux_390-64_cmprssptrs`
+            - `Test-Extended-JDK10-linux_390-64_cmprssptrs`
+
+    - Trigger:
+        - build periodically, @midnight
+
 - Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Pipeline-Build-Test-JDK8-linux_ppc-64_cmprssptrs_le)
     - Description:
@@ -232,6 +280,17 @@ You can also request a Pull Request build from the extensions repos or openj9-om
             - `Build-JDK9-linux_ppc-64_cmprssptrs_le`
             - `Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le`
             - `Test-Extended-JDK9-linux_ppc-64_cmprssptrs_le`
+    - Trigger:
+        - build periodically, @midnight
+
+- Pipeline-Build-Test-JDK10-linux_ppc-64_cmprssptrs_le
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Pipeline-Build-Test-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Pipeline-Build-Test-JDK10-linux_ppc-64_cmprssptrs_le)
+    - Description:
+        - Compile and Test java10 Sanity & Extended
+        - Triggers
+            - `Build-JDK10-linux_ppc-64_cmprssptrs_le`
+            - `Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le`
+            - `Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le`
     - Trigger:
         - build periodically, @midnight
 
@@ -300,6 +359,13 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - This job is used in other pipelines but can be launched manually
 
+- Test-Extended-JDK10-aix_ppc-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK10-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-aix_ppc-64_cmprssptrs)
+    - Description:
+        - Runs extended test suite against the SDK and test material that is passed as parameters
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
 - Test-Extended-JDK8-linux_390-64_cmprssptrs
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK8-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK8-linux_390-64_cmprssptrs)
     - Description:
@@ -309,6 +375,13 @@ You can also request a Pull Request build from the extensions repos or openj9-om
 
 - Test-Extended-JDK9-linux_390-64_cmprssptrs
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK9-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK9-linux_390-64_cmprssptrs)
+    - Description:
+        - Runs extended test suite against the SDK and test material that is passed as parameters
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
+- Test-Extended-JDK10-linux_390-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-linux_390-64_cmprssptrs)
     - Description:
         - Runs extended test suite against the SDK and test material that is passed as parameters
     - Trigger:
@@ -328,6 +401,13 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - This job is used in other pipelines but can be launched manually
 
+- Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le)
+    - Description:
+        - Runs extended test suite against the SDK and test material that is passed as parameters
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
 - Test-Sanity-JDK8-aix_ppc-64_cmprssptrs
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK8-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK8-aix_ppc-64_cmprssptrs)
     - Description:
@@ -337,6 +417,13 @@ You can also request a Pull Request build from the extensions repos or openj9-om
 
 - Test-Sanity-JDK9-aix_ppc-64_cmprssptrs
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK9-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK9-aix_ppc-64_cmprssptrs)
+    - Description:
+        - Runs sanity test suite against the SDK and test material that is passed as parameters
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
+- Test-Sanity-JDK10-aix_ppc-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK10-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-aix_ppc-64_cmprssptrs)
     - Description:
         - Runs sanity test suite against the SDK and test material that is passed as parameters
     - Trigger:
@@ -356,6 +443,13 @@ You can also request a Pull Request build from the extensions repos or openj9-om
     - Trigger:
         - This job is used in other pipelines but can be launched manually
 
+- Test-Sanity-JDK10-linux_390-64_cmprssptrs
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-linux_390-64_cmprssptrs)
+    - Description:
+        - Runs sanity test suite against the SDK and test material that is passed as parameters
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
 - Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK8-linux_ppc-64_cmprssptrs_le)
     - Description:
@@ -365,6 +459,13 @@ You can also request a Pull Request build from the extensions repos or openj9-om
 
 - Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
     - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK9-linux_ppc-64_cmprssptrs_le)
+    - Description:
+        - Runs sanity test suite against the SDK and test material that is passed as parameters
+    - Trigger:
+        - This job is used in other pipelines but can be launched manually
+
+- Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
+    - [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le)
     - Description:
         - Runs sanity test suite against the SDK and test material that is passed as parameters
     - Trigger:

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -20,13 +20,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def SDK_VERSIONS = ['8', '9']
+def SDK_VERSIONS = ['8', '9', '10']
 def SPECS = ['linux_ppc-64_cmprssptrs_le', 'linux_390-64_cmprssptrs', 'aix_ppc-64_cmprssptrs']
 
 def OPENJDK_REPOS = ['8': 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git',
-                     '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git']
+                     '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git',
+                     '10': 'https://github.com/ibmruntimes/openj9-openjdk-jdk10.git']
 def OPENJDK_BRANCHES = ['8': 'openj9',
-                        '9': 'openj9']
+                        '9': 'openj9',
+                        '10': 'openj9']
 
 def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
 def OPENJ9_BRANCH = 'master'


### PR DESCRIPTION
~Depends #1285~ merged

#### Build
- AIX [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK10-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Build-JDK10-aix_ppc-64_cmprssptrs)
- zLinux [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Build-JDK10-linux_390-64_cmprssptrs)
- pLinux [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Build-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Build-JDK10-linux_ppc-64_cmprssptrs_le)

#### Sanity
- AIX [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK10-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-aix_ppc-64_cmprssptrs)
- zLinux [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-linux_390-64_cmprssptrs)
- pLinux [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-linux_ppc-64_cmprssptrs_le)

#### Extended
- AIX [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK10-aix_ppc-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-aix_ppc-64_cmprssptrs)
- zLinux [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK10-linux_390-64_cmprssptrs)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-linux_390-64_cmprssptrs)
- pLinux [![Build Status](https://ci.eclipse.org/openj9/buildStatus/icon?job=Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-linux_ppc-64_cmprssptrs_le)