### PR TITLE
Fix JPP format error

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ThreadMXBeanImpl.java
@@ -663,7 +663,7 @@ public class ThreadMXBeanImpl implements ThreadMXBean {
 	@Override
 	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
 			boolean lockedSynchronizers, int maxDepth) {
-		/*[MSG "K0662", maxDepth must not be negative.]*/
+		/*[MSG "K0662", "maxDepth must not be negative."]*/
 		if (maxDepth < 0) {
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0662")); //$NON-NLS-1$
 		}


### PR DESCRIPTION
Fix `JPP` format error

This causes `JPP` failure due to `ERROR [preprocessor] MSG command syntax error, command ignored: MSG "K0662", maxDepth must not be negative.`
Manually verified this PR fixed the error in a raw build.

closes: #1509 

Reviewer @pshipton 
FYI @DanHeidinga @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>