### PR TITLE
Remove JVM_InitProperties implementation

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1531,22 +1531,7 @@ JVM_InitProperties(JNIEnv* env, jobject properties)
 	 * This method is not invoked by other Java levels.
 	 */
 #if !defined(J9VM_JCL_SE11)
-	J9JavaVM* vm = ((J9VMThread*)env)->javaVM;
-	jobject syspropsList = (jobject)vm->syspropsListRef;
-	jclass propertiesClass = (*env)->GetObjectClass(env, properties);
-	jmethodID setPropertyMID = (*env)->GetMethodID(env, propertiesClass, "setProperty", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;");
-	jsize pairCount;
-	jsize index;
-
-	assert(syspropsList != NULL);
-	assert(propertiesClass != NULL);
-	assert(setPropertyMID != NULL);
-	pairCount = (*env)->GetArrayLength(env, syspropsList);
-	for (index = 0; index < pairCount; ) {
-		jobject key = (*env)->GetObjectArrayElement(env, syspropsList, index++);
-		jobject value = (*env)->GetObjectArrayElement(env, syspropsList, index++);
-		(*env)->CallObjectMethod(env, properties, setPropertyMID, key, value);
-	}
+	assert(!"JVM_InitProperties should not be called!");
 #endif /* J9VM_JCL_SE11 */
 	return properties;
 }

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5415,7 +5415,6 @@ typedef struct J9JavaVM {
 #endif /* J9VM_PORT_ZOS_CEEHDLRSUPPORT */
 	void* originalSIGPIPESignalAction;
 	void* finalizeSlaveData;
-	j9object_t* syspropsListRef;
 	j9object_t* heapOOMStringRef;
 	UDATA strCompEnabled;
 	struct J9IdentityHashData* identityHashData;


### PR DESCRIPTION
Remove `JVM_InitProperties` implementation

`Java 11` and upward raw builds only need an empty implementation;
Other Java builds don't call this method at all.
Discovered in #1460 

Reviewer @pshipton 
FYI @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>