### PR TITLE
enable classesdbgddrext since ddr.jar is in OpenJ9

### DIFF
--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -112,7 +112,7 @@ sub generateOnDir {
 				$JCL_VERSION = "latest";
 			}
 			# temporarily exclude projects for CCM build (i.e., when JCL_VERSION is latest)
-			my $latestDisabledDir = "jvmtitests proxyFieldAccess classesdbgddrext dumpromtests jep178staticLinkingTest pltest Panama NativeTest SharedCPEntryInvokerTests gcCheck classvertest";
+			my $latestDisabledDir = "jvmtitests proxyFieldAccess dumpromtests jep178staticLinkingTest pltest Panama NativeTest SharedCPEntryInvokerTests classvertest";
 			# Temporarily exclude SVT_Modularity tests from integration build where we are still using b148 JCL level
 			my $currentDisableDir= "SVT_Modularity OpenJ9_Jsr_292_API";
 			$tempExclude = (($JCL_VERSION eq "latest") and ($latestDisabledDir =~ /\Q$entry\E/ )) or (($JCL_VERSION eq "current") and ($currentDisableDir =~ /\Q$entry\E/ ));

--- a/test/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/cmdLineTests/classesdbgddrext/playlist.xml
@@ -34,7 +34,7 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
-	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
@@ -68,14 +68,15 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
-	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
 	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>^os.zos</platformRequirements>
+		<!-- j9ddr.jar is not supported in Windows OpenJ9 JDKs, OpenJ9 issue 1511-->
+		<platformRequirements>^os.zos,^os.win,^os.aix</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -101,7 +102,7 @@
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
-	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
@@ -121,7 +122,6 @@
 			<subset>SE100</subset>
 			<subset>SE110</subset>
 		</subsets>
+		<disabled>github.com/eclipse/openj9/issues/1511</disabled>
 	</test>
-
-
 </playlist>

--- a/test/cmdLineTests/dumpromtests/playlist.xml
+++ b/test/cmdLineTests/dumpromtests/playlist.xml
@@ -32,7 +32,7 @@
 	-DJVM_TEST_ROOT="$(JVM_TEST_ROOT)" \
 	-DEXE=$(JAVA_COMMAND) \
 	-DGENERAL_TEST_DIR=$(Q)$(JVM_TEST_ROOT)$(D)Java8andUp$(D)SE80$(Q) \
-	-DJDMPVIEW_EXE="$(JAVA_BIN)$(D)jdmpview" \
+	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)dumpromclasstests.xml$(Q) -explainExcludes \


### PR DESCRIPTION
* enable classesdbgddrext since ddr.jar is available in OpenJ9
* enable on x,p,z linux and exclude from aix and win

Issue:#362
Issue:#1511

[ci skip]

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>