### PR TITLE
Add new CP types to DDR

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -652,7 +652,7 @@ public class J9BCUtil {
 		U32Pointer cpDescription = romClass.cpShapeDescription();
 		long descriptionLong;
 		long i, j, k, numberOfLongs;
-		char symbols[] = new char[] { '.', 'C', 'S', 'I', 'F', 'J', 'D', 'i', 's', 'v', 'x', 'y', 'z', 'T', 'H', 'A' };
+		char symbols[] = new char[] { '.', 'C', 'S', 'I', 'F', 'J', 'D', 'i', 's', 'v', 'x', 'y', 'z', 'T', 'H', 'A', 'x', 'v' };
 		
 		symbols[(int)J9CPTYPE_UNUSED8] = '.';
 

--- a/runtime/util/rcdump.c
+++ b/runtime/util/rcdump.c
@@ -230,7 +230,7 @@ static I_32 dumpCPShapeDescription( J9PortLibrary *portLib, J9ROMClass *romClass
 	U_32 *cpDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
 	U_32 descriptionLong;
 	U_32 i, j, k, numberOfLongs;
-	char symbols[] = ".CSIFJDi.vxyzTHA";
+	char symbols[] = ".CSIFJDi.vxyzTHAxv";
 
 	PORT_ACCESS_FROM_PORT( portLib );
 


### PR DESCRIPTION
- add J9CPTYPE_INTERFACE_STATIC_Method, J9CPTYPE_INTERFACE_INSTANCE_METHOD
  to DDR cpShapeDescription mapping

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>