### PR TITLE
[Nest mates] Updates java.lang.Class API for new nestmates spec draft

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/Util.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.util;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2010 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -184,5 +184,30 @@ public static String canonicalizePath(String file) {
 		file = file.substring(0, file.lastIndexOf('/', file.length() - 4) + 1);
 	
 	return file;
+}
+
+/**
+ * This class contains a utility method which checks if one class loader is in
+ * the ancestry of another.
+ * 
+ * @param currentLoader classloader whose ancestry is being checked
+ * @param requestedLoader classloader who may be an ancestor of currentLoader
+ * @return true if currentClassLoader is the same or a child of the requestLoader
+ */
+public static boolean doesClassLoaderDescendFrom(ClassLoader currentLoader, ClassLoader requestedLoader) {
+	if (requestedLoader == null) {
+		/* Bootstrap loader is parent of everyone */
+		return true;
+	}
+	if (currentLoader != requestedLoader) {
+		while (currentLoader != null) {
+			if (currentLoader == requestedLoader) {
+				return true;
+			}
+			currentLoader = currentLoader.getParent();
+		}
+		return false;
+	}
+	return true;
 }
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -247,8 +247,8 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	
 /*[IF Valhalla-NestMates]*/
 	/* Store the results of getNestHostImpl() and getNestMembersImpl() respectively */
-	private  Class<?> nestHost;
-	private  Class<?>[] nestMembers;
+	private Class<?> nestHost;
+	private Class<?>[] nestMembers;
 /*[ENDIF] Valhalla-NestMates*/
 	
 /**
@@ -4389,11 +4389,10 @@ private native Class<?>[] getNestMembersImpl();
 /**
  * Answers the host class of the receiver's nest.
  * 
- * @throws 		SecurityException if a returned class is not the current class, a
- * 				security manager, s, is present, the caller's class loader is not
- * 				the same or an ancestor of that returned class, and s.checkPackageAccess()
- * 				denies access
- * @return		the host class of the receiver.
+ * @throws SecurityException if nestHost is not same as the current class, a security manager
+ *	is present, the classloader of the caller is not the same or an ancestor of nestHost
+ * 	class, and checkPackageAccess() denies access
+ * @return the host class of the receiver.
  */
 @CallerSensitive
 public Class<?> getNestHost() throws SecurityException {
@@ -4414,7 +4413,7 @@ public Class<?> getNestHost() throws SecurityException {
 			ClassLoader nestHostClassLoader = nestHost.getClassLoader();			
 			if (!doesClassLoaderDescendFrom(nestHostClassLoader, callerClassLoader)) {
 				String nestHostPackageName = nestHost.getPackageName();
-				if (nestHostPackageName != null) {
+				if ((nestHostPackageName != null) && (nestHostPackageName != "")) {
 					securityManager.checkPackageAccess(nestHostPackageName);
 				}
 			}
@@ -4426,8 +4425,8 @@ public Class<?> getNestHost() throws SecurityException {
 /**
  * Returns true if the class passed has the same nest top as this class.
  * 
- * @param		that		The class to compare
- * @return		true if class is a nestmate of this class; false otherwise.
+ * @param that The class to compare
+ * @return true if class is a nestmate of this class; false otherwise.
  *
  */
 public boolean isNestmateOf(Class<?> that) {
@@ -4445,13 +4444,12 @@ public boolean isNestmateOf(Class<?> that) {
 /**
  * Answers the nest member classes of the receiver's nest host.
  *
- * @throws		SecurityException if a SecurityManager is present and package access is not allowed
- * @throws		LinkageError if there is any problem loading or validating a nest member or the nest host
- * @throws 		SecurityException if a returned class is not the current class, a
- * 				security manager, s, is present, the caller's class loader is not
- * 				the same or an ancestor of that returned class, and s.checkPackageAccess()
- * 				denies access
- * @return		the host class of the receiver.
+ * @throws SecurityException if a SecurityManager is present and package access is not allowed
+ * @throws LinkageError if there is any problem loading or validating a nest member or the nest host
+ * @throws SecurityException if a returned class is not the current class, a security manager is enabled,
+ *	the caller's class loader is not the same or an ancestor of that returned class, and the
+ * 	checkPackageAccess() denies access
+ * @return the host class of the receiver.
  */
 @CallerSensitive
 public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
@@ -4465,7 +4463,7 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 		ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
 		if (!doesClassLoaderDescendFrom(nestMemberClassLoader, callerClassLoader)) {
 			String nestMemberPackageName = this.getPackageName();
-			if (nestMemberPackageName != null) {
+			if ((nestMemberPackageName != null) && (nestMemberPackageName != "")) {
 				securityManager.checkPackageAccess(nestMemberPackageName);
 			}
 		}

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4409,9 +4409,7 @@ public Class<?> getNestHost() throws SecurityException {
 	 */
 	if (nestHost != this) {
 		SecurityManager securityManager = System.getSecurityManager();
-		if (nestHost == null) {
-			nestHost = this;
-		} else if (securityManager != null) {
+		if (securityManager != null) {
 			ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
 			ClassLoader nestHostClassLoader = nestHost.getClassLoader();			
 			if (!doesClassLoaderDescendFrom(nestHostClassLoader, callerClassLoader)) {
@@ -4460,15 +4458,6 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 	if (nestMembers == null) {
 		nestMembers = getNestMembersImpl();
 	}
-	/* The specification requires that if:
-	 *    - a returned class is not the current class
-	 *    - a security manager, s, is present
-	 *    - the caller's class loader is not the same or an ancestor of the returned class
-	 *    - s.checkPackageAccess() disallows access to the package of the returned class
-	 * then throw a SecurityException. Since all classes in the same nest
-	 * must be in the same runtime package and thus the same class loader,
-	 * it is sufficient to check classloader ancestry once.
-	 */
 	SecurityManager securityManager = System.getSecurityManager();
 	if (securityManager != null) {
 		/* All classes in a nest must be in the same runtime package and therefore same classloader */

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -52,9 +52,9 @@ import sun.reflect.generics.scope.ClassScope;
 import sun.reflect.annotation.AnnotationType;
 import java.util.Arrays;
 import com.ibm.oti.vm.VM;
-/*[IF Valhalla-NestMates]*/
+/*[IF Java11]*/
 import static com.ibm.oti.util.Util.doesClassLoaderDescendFrom;
-/*[ENDIF] Valhalla-NestMates*/
+/*[ENDIF] Java11*/
 
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.Unsafe;
@@ -245,11 +245,11 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 		return unsafe;
 	}
 	
-/*[IF Valhalla-NestMates]*/
+/*[IF Java11]*/
 	/* Store the results of getNestHostImpl() and getNestMembersImpl() respectively */
 	private Class<?> nestHost;
 	private Class<?>[] nestMembers;
-/*[ENDIF] Valhalla-NestMates*/
+/*[ENDIF] Java11*/
 	
 /**
  * Prevents this class from being instantiated. Instances

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4410,7 +4410,7 @@ public Class<?> getNestHost() throws SecurityException {
 		SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null) {
 			ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
-			ClassLoader nestHostClassLoader = nestHost.getClassLoader();			
+			ClassLoader nestHostClassLoader = nestHost.internalGetClassLoader();
 			if (!doesClassLoaderDescendFrom(nestHostClassLoader, callerClassLoader)) {
 				String nestHostPackageName = nestHost.getPackageName();
 				if ((nestHostPackageName != null) && (nestHostPackageName != "")) {
@@ -4459,7 +4459,7 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 	SecurityManager securityManager = System.getSecurityManager();
 	if (securityManager != null) {
 		/* All classes in a nest must be in the same runtime package and therefore same classloader */
-		ClassLoader nestMemberClassLoader = this.getClassLoader();
+		ClassLoader nestMemberClassLoader = this.internalGetClassLoader();
 		ClassLoader callerClassLoader = ClassLoader.getCallerClassLoader();
 		if (!doesClassLoaderDescendFrom(nestMemberClassLoader, callerClassLoader)) {
 			String nestMemberPackageName = this.getPackageName();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -46,6 +46,7 @@ import com.ibm.oti.util.Msg;
 import com.ibm.oti.lang.ArgumentHelper;
 import com.ibm.oti.vm.VM;
 import com.ibm.oti.vm.VMLangAccess;
+import static com.ibm.oti.util.Util.doesClassLoaderDescendFrom;
 
 /*[IF Sidecar19-SE]*/
 import java.util.AbstractList;
@@ -1146,27 +1147,6 @@ public class MethodHandles {
 				enclosing = enclosing.getEnclosingClass();
 			}
 			return previous;
-		}
-		
-		/*
-		 * Determine if 'currentClassLoader' is the same or a child of the requestedLoader.  Necessary
-		 * for access checking. 
-		 */
-		private static boolean doesClassLoaderDescendFrom(ClassLoader currentLoader, ClassLoader requestedLoader) {
-			if (requestedLoader == null) {
-				/* Bootstrap loader is parent of everyone */
-				return true;
-			}
-			if (currentLoader != requestedLoader) {
-				while (currentLoader != null) {
-					if (currentLoader == requestedLoader) {
-						return true;
-					}
-					currentLoader = currentLoader.getParent();
-				}
-				return false;
-			}
-			return true;
 		}
 		
 		/**


### PR DESCRIPTION
Earlier spec draft for java.lang.Class nestmates API methods 'getNestHost' and 'getNestMembers' threw no exceptions and LinkageError respectively. A newer spec draft allows both methods to throw a SecurityException. This commit adds the necessary check for this to occur.

Relevant portions of the newer spec draft include:
```
    public Class<?> getNestHost()
    ...
    Throws:
        SecurityException - If the returned class is not the current class, and if a security manager,
 s, is present and the caller's class loader is not the same as or an ancestor of the class loader
for the returned class and invocation of s.checkPackageAccess() denies access to the package of the 
returned class
    ...
    public Class<?>[] getNestMembers()
    ...
    Throws:
    ...
        SecurityException - If any returned class is not the current class, and if a security manager,
s, is present and the caller's class loader is not the same as or an ancestor of the class loader
for that returned class and invocation of s.checkPackageAccess() denies access to the package of that 
returned class
```
(http://cr.openjdk.java.net/%7Edholmes/8010319/specs/java.lang/java/lang/Class.html)

Together with https://github.com/eclipse/openj9/pull/1501, resolves https://github.com/eclipse/openj9/issues/1457. There are no dependencies between the two PRs. 

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>