### PR TITLE
Update buildenv/docker/jdk9/* Dockerfile(s)

### DIFF
--- a/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
-    openjdk-8-jdk \
     pkg-config \
     qemu \
     realpath \
@@ -67,6 +66,13 @@ RUN cd /root \
   && wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz \
   && tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
   && rm -f freemarker.tgz
+
+# Download and install boot JDK from AdoptOpenJDK
+RUN cd /root \
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary \
+  && tar -xzf bootjdk8.tar.gz \
+  && rm -f bootjdk8.tar.gz \
+  && ls | grep -i jdk | xargs -I % sh -c 'mv % bootjdk8'
 
 # get the toolchain
 RUN cd /root \
@@ -122,11 +128,15 @@ RUN cd /root/debs \
 # Env vars set here will be visibile in the running container, so can be
 # used to convey configuration information to the build scripts.
 
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk8"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
 # Directory containing the cross compilation tool chain
-ENV OPENJ9_CC_DIR /root/gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu
+ENV OPENJ9_CC_DIR="/root/gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu"
 
 # Prefix for the cross compilation tools (without the trailing '-')
-ENV OPENJ9_CC_PREFIX aarch64-linux-gnu
+ENV OPENJ9_CC_PREFIX="aarch64-linux-gnu"
 
 # Add the toolchain bin dir to the PATH for convenience
 ENV PATH="${PATH}:${OPENJ9_CC_DIR}/bin"

--- a/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
+++ b/buildenv/docker/jdk9/aarch64_CC/arm-linux-aarch64/Dockerfile
@@ -83,8 +83,8 @@ RUN cd /root \
 ADD \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2_1.1.3-5_arm64.deb                \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5_arm64.deb            \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8_arm64.deb                  \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8_arm64.deb             \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8%2bdeb9u1_arm64.deb         \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8%2bdeb9u1_arm64.deb    \
     http://ftp.us.debian.org/debian/pool/main/d/dwarfutils/libdwarf-dev_20161124-1+deb9u1_arm64.deb  \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.6.3-3.2_arm64.deb            \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6-dev_2.6.3-3.2_arm64.deb        \

--- a/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
+++ b/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
@@ -83,8 +83,8 @@ RUN cd /root \
 ADD \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2_1.1.3-5_armhf.deb                \
     http://ftp.us.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5_armhf.deb            \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8_armhf.deb                  \
-    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8_armhf.deb             \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcups2-dev_2.2.1-8%2bdeb9u1_armhf.deb         \
+    http://ftp.us.debian.org/debian/pool/main/c/cups/libcupsimage2-dev_2.2.1-8%2bdeb9u1_armhf.deb    \
     http://ftp.us.debian.org/debian/pool/main/d/dwarfutils/libdwarf-dev_20161124-1+deb9u1_armhf.deb  \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.6.3-3.2_armhf.deb            \
     http://ftp.us.debian.org/debian/pool/main/f/freetype/libfreetype6-dev_2.6.3-3.2_armhf.deb        \

--- a/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
+++ b/buildenv/docker/jdk9/armhf_CC/arm-linux-gnueabihf/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
-    openjdk-8-jdk \
     pkg-config \
     qemu \
     realpath \
@@ -67,6 +66,13 @@ RUN cd /root \
   && wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz \
   && tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
   && rm -f freemarker.tgz
+
+# Download and install boot JDK from AdoptOpenJDK
+RUN cd /root \
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary \
+  && tar -xzf bootjdk8.tar.gz \
+  && rm -f bootjdk8.tar.gz \
+  && ls | grep -i jdk | xargs -I % sh -c 'mv % bootjdk8'
 
 # get the toolchain
 RUN cd /root \
@@ -122,11 +128,15 @@ RUN cd /root/debs \
 # Env vars set here will be visibile in the running container, so can be
 # used to convey configuration information to the build scripts.
 
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk8"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
 # Directory containing the cross compilation tool chain
-ENV OPENJ9_CC_DIR /root/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf
+ENV OPENJ9_CC_DIR="/root/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf"
 
 # Prefix for the cross compilation tools (without the trailing '-')
-ENV OPENJ9_CC_PREFIX arm-linux-gnueabihf
+ENV OPENJ9_CC_PREFIX="arm-linux-gnueabihf"
 
 # Add the toolchain bin dir to the PATH for convenience
 ENV PATH="${PATH}:${OPENJ9_CC_DIR}/bin"

--- a/buildenv/docker/jdk9/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/ppc64le/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 #   docker build -t=openj9 .
 #   docker run -it openj9
 
-FROM ppc64le/ibmjava:8-sdk
+FROM ubuntu:16.04
 
 # Install required OS tools
 RUN apt-get update \
@@ -73,5 +73,16 @@ RUN cd /root \
   && wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz \
   && tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
   && rm -f freemarker.tgz
+
+# Download and install boot JDK from AdoptOpenJDK
+RUN cd /root \
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/openjdk8-openj9/releases/ppc64le_linux/latest/binary \
+  && tar -xzf bootjdk8.tar.gz \
+  && rm -f bootjdk8.tar.gz \
+  && ls | grep -i jdk | xargs -I % sh -c 'mv % bootjdk8'
+
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk8"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 WORKDIR /root

--- a/buildenv/docker/jdk9/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/s390x/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 #   docker build -t=openj9 .
 #   docker run -it openj9
 
-FROM s390x/ibmjava:8-sdk
+FROM ubuntu:16.04
 
 # Install required OS tools
 RUN apt-get update \
@@ -72,5 +72,16 @@ RUN cd /root \
   && wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz \
   && tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
   && rm -f freemarker.tgz
+
+# Download and install boot JDK from AdoptOpenJDK
+RUN cd /root \
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/openjdk8-openj9/releases/s390x_linux/latest/binary \
+  && tar -xzf bootjdk8.tar.gz \
+  && rm -f bootjdk8.tar.gz \
+  && ls | grep -i jdk | xargs -I % sh -c 'mv % bootjdk8'
+
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk8"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 WORKDIR /root

--- a/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,6 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
-    openjdk-8-jdk \
     pkg-config \
     realpath \
     ssh \
@@ -74,5 +73,16 @@ RUN cd /root \
   && wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz \
   && tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
   && rm -f freemarker.tgz
+
+# Download and install boot JDK from AdoptOpenJDK
+RUN cd /root \
+  && wget -O bootjdk8.tar.gz https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary \
+  && tar -xzf bootjdk8.tar.gz \
+  && rm -f bootjdk8.tar.gz \
+  && ls | grep -i jdk | xargs -I % sh -c 'mv % bootjdk8'
+
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk8"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 WORKDIR /root


### PR DESCRIPTION
- Use AdoptOpenJDK OpenJ9 build as the boot jdk for JDK9 DockerFile(s).
```
AdoptOpenJDK OpenJ9 build is used as the boot jdk:
1) arm-linux-aarch64 (x64_linux):
https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary
2) arm-linux-gnueabihf (x64_linux):
https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary
3) ppc64le (ppc64le_linux):
https://api.adoptopenjdk.net/openjdk8-openj9/releases/ppc64le_linux/latest/binary
4) s390x (s390x_linux):
https://api.adoptopenjdk.net/openjdk8-openj9/releases/s390x_linux/latest/binary
5) x86_64 (x64_linux):
https://api.adoptopenjdk.net/openjdk8-openj9/releases/x64_linux/latest/binary

For s390x and ppc64le, the base image is changed to "ubuntu:16.04".
```
- Update download links to libcups2-dev and libcupsimage2-dev libraries in JDK9 DockerFile(s).
```
For aarch64_CC and armhf_CC DockerFile(s), download links for the
following libraries were updated: libcups2-dev_2.2.1-8 and
libcupsimage2-dev_2.2.1-8. Old download links don't work anymore.
```

[skip ci]

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>