### PR TITLE
Mark security sensitive Class.forName() as privileged

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Layer;
 /*[ENDIF]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -83,10 +85,17 @@ public final class LoggingMXBeanImpl
 			Module java_logging = ModuleLayer.boot().findModule("java.logging").get(); //$NON-NLS-1$
 /*[ELSE]
 			Module java_logging = Layer.boot().findModule("java.logging").get(); //$NON-NLS-1$
-/*[ENDIF]*/			
-			Class<?> logManagerClass = Class.forName(java_logging, "java.util.logging.LogManager"); //$NON-NLS-1$
-			Class<?> loggerClass = Class.forName(java_logging, "java.util.logging.Logger"); //$NON-NLS-1$
-			Class<?> levelClass = Class.forName(java_logging, "java.util.logging.Level"); //$NON-NLS-1$
+/*[ENDIF]*/
+			Class<?>[] logClasses = AccessController.doPrivileged((PrivilegedAction<Class<?>[]>)
+				() -> new Class[] {
+					Class.forName(java_logging, "java.util.logging.LogManager"), //$NON-NLS-1$
+					Class.forName(java_logging, "java.util.logging.Logger"), //$NON-NLS-1$
+					Class.forName(java_logging, "java.util.logging.Level") //$NON-NLS-1$
+				});
+			Class<?> logManagerClass = logClasses[0];
+			Class<?> loggerClass = logClasses[1];
+			Class<?> levelClass = logClasses[2];
+			
 			logManager_getLogManager = logManagerClass.getMethod("getLogManager"); //$NON-NLS-1$
 			logManager_getLogger = logManagerClass.getMethod("getLogger", String.class); //$NON-NLS-1$
 			logManager_getLoggerNames = logManagerClass.getMethod("getLoggerNames"); //$NON-NLS-1$


### PR DESCRIPTION
Marked following method calls as privileged to avoid throwing `java.security.AccessControlException: Access denied
("java.lang.RuntimePermission" "getClassLoader")`:
```
Class.forName(java_logging, "java.util.logging.LogManager")
Class.forName(java_logging, "java.util.logging.Logger")
Class.forName(java_logging, "java.util.logging.Level")
```

Manually verified that this PR fixed following error:
```
Caused by: java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "getClassLoader")
	at java.security.AccessControlContext.checkPermissionWithCache(java.base@9.0.4-internal/AccessControlContext.java:645)
	at java.security.AccessController.checkPermissionHelper(java.base@9.0.4-internal/AccessController.java:243)
	at java.security.AccessController.checkPermission(java.base@9.0.4-internal/AccessController.java:385)
	at java.lang.SecurityManager.checkPermission(java.base@9.0.4-internal/SecurityManager.java:558)
	at java.lang.Class.forName(java.base@9.0.4-internal/Class.java:427)
	at com.ibm.java.lang.management.internal.LoggingMXBeanImpl.<clinit>(java.management@9.0.4-internal/LoggingMXBeanImpl.java:76)

```

Reviewer @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>