### PR TITLE
Set InterfaceHandle correctly for methods inherited from Object

### DIFF
--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1888,6 +1888,8 @@ getITableIndexForMethod(J9Method * method, J9Class *targetInterface);
  * Returns the first ROM method following the argument.
  * If this is called on the last ROM method in a ROM class
  * it will return an undefined value.
+ * The defining class of method must be an interface; do not use this
+ * for methods inherited from java.lang.Object.
  *
  * @param[in] romMethod - the current ROM method
  * @return - the ROM method following the current one


### PR DESCRIPTION
When calling lookup().getVirtual() on an interface for a method in
java.lang.Object, don't check the itables for the method.  Instead, set the
methodIndex to -1 and return the concrete method.

Fixes https://github.com/eclipse/openj9/issues/1524

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>