### PR TITLE
Fix the JAVA_VERSION conditional logic in build.xml

### DIFF
--- a/test/JLM_Tests/build.xml
+++ b/test/JLM_Tests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,8 +53,20 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${build}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${src_80}" />
+					<src path="${transformerListener}" />
+					<classpath>
+						<pathelement location="../TestConfig/lib/testng.jar" />
+						<pathelement location="../TestConfig/lib/jcommander.jar" />
+						<pathelement location="../TestConfig/lib/commons-exec.jar" />
+					</classpath>
+				</javac>
+			</then>
+			<else>
 				<if>
 					<equals arg1="${JCL_VERSION}" arg2="latest"/>
 					<then>
@@ -69,18 +81,6 @@
 					<src path="${src_90}" />
 					<src path="${transformerListener}" />
 					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="../TestConfig/lib/testng.jar" />
-						<pathelement location="../TestConfig/lib/jcommander.jar" />
-						<pathelement location="../TestConfig/lib/commons-exec.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_80}" />
-					<src path="${transformerListener}" />
 					<classpath>
 						<pathelement location="../TestConfig/lib/testng.jar" />
 						<pathelement location="../TestConfig/lib/jcommander.jar" />

--- a/test/Java10andUp/build.xml
+++ b/test/Java10andUp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,9 @@
 	
 	<target name="build" >
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE100"/>
+			<not>
+				<matches string="${JAVA_VERSION}" pattern="^SE(8|9)0$$" />
+			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/Java9andUp/build.xml
+++ b/test/Java9andUp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,7 +103,9 @@
 	
 	<target name="build" >
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<not>
+				<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/Jsr292/build.xml
+++ b/test/Jsr292/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,8 +110,14 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${bootstrapSrc}"/>
+					<src path="${bootstrapSrc_80}"/>
+				</javac>
+			</then>
+			<else>
 				<if>
 					<equals arg1="${JCL_VERSION}" arg2="latest"/>
 					<then>
@@ -125,12 +131,6 @@
 					<src path="${bootstrapSrc}"/>
 					<src path="${bootstrapSrc_90}"/>
 					<compilerarg line='${addExports}' />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${bootstrapSrc}"/>
-					<src path="${bootstrapSrc_80}"/>
 				</javac>
 			</else>
 		</if>

--- a/test/OpenJ9_Jsr_292_API/build.xml
+++ b/test/OpenJ9_Jsr_292_API/build.xml
@@ -67,7 +67,9 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<not>
+				<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+			</not>
 			<then>
 				<property name="modulec_path" value="--module-path ${mods_dir} -d ${modulec_bin}" />
 				<javac srcdir="${modulec_src}" destdir="${modulec_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
@@ -88,7 +90,9 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<not>
+				<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+			</not>
 			<then>
 				<property name="moduleb_path" value="--module-path ${mods_dir} -d ${moduleb_bin}" />
 				<javac srcdir="${moduleb_src}" destdir="${moduleb_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
@@ -109,7 +113,9 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<not>
+				<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+			</not>
 			<then>
 				<property name="modulea_path" value="--module-path ${mods_dir} -d ${modulea_bin}" />
 				<javac srcdir="${modulea_src}" destdir="${modulea_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
@@ -129,7 +135,9 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<not>
+				<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+			</not>
 			<then>
 				<property name="addModules" value="--add-modules ${modulea_name},${moduleb_name},${modulec_name}  --module-path ${mods_dir}" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
@@ -167,7 +175,7 @@
 		<if>
 			<not>
 				<and>
-					<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+					<matches string="${JAVA_VERSION}" pattern="^SE(9|10)0$$" />
 					<equals arg1="${JCL_VERSION}" arg2="current"/>
 				</and>
 			</not>

--- a/test/SharedCPEntryInvokerTests/build.xml
+++ b/test/SharedCPEntryInvokerTests/build.xml
@@ -84,7 +84,7 @@
 		<if>
 			<not>
 				<and>
-					<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+					<matches string="${JAVA_VERSION}" pattern="^SE(9|10)0$$" />
 					<equals arg1="${JCL_VERSION}" arg2="latest"/>
 				</and>
 			</not>

--- a/test/UnsafeTest/build.xml
+++ b/test/UnsafeTest/build.xml
@@ -51,22 +51,22 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
-				<property name="addModules" value="--add-modules java.se.ee" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_90}" />
+					<src path="${src_80}" />
 					<src path="${transformerListener}" />
-					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
 					<classpath>
 						<pathelement location="../TestConfig/lib/testng.jar" />
 					</classpath>
 				</javac>
 			</then>
 			<else>
+				<property name="addModules" value="--add-modules java.se.ee" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_80}" />
+					<src path="${src_90}" />
 					<src path="${transformerListener}" />
+					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
 					<classpath>
 						<pathelement location="../TestConfig/lib/testng.jar" />
 					</classpath>

--- a/test/VM_Test/build.xml
+++ b/test/VM_Test/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,8 +76,13 @@
 		</javac>
 
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
+					<src path="${excludeFiles}"/>
+				</javac>
+			</then>
+			<else>
 				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports=java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports=jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
 					<src path="${excludeFiles}"/>
@@ -85,11 +90,6 @@
 					<exclude name="**/ClassPathSettingClassLoader.java" />
 					<exclude name="**/ClassPathSettingClassLoaderTest.java" />
 					<compilerarg line='${addExports}' />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-					<src path="${excludeFiles}"/>
 				</javac>
 			</else>
 		</if>

--- a/test/cmdLineTests/jvmtitests/build.xml
+++ b/test/cmdLineTests/jvmtitests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,8 +48,18 @@
 		<echo>===destdir:                      ${build}</echo>
 
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<exclude name="**/modularityTests/**"/>
+					<classpath>
+						<pathelement location="${asm.jar}" />
+						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
+					</classpath>
+				</javac>
+			</then>
+			<else>
 				<if>
 					<equals arg1="${JCL_VERSION}" arg2="latest"/>
 					<then>
@@ -64,16 +74,6 @@
 					<compilerarg line='${addExports}' />
 					<classpath>
 						<pathelement location="${asm.jar}" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<exclude name="**/modularityTests/**"/>
-					<classpath>
-						<pathelement location="${asm.jar}" />
-						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
 					</classpath>
 				</javac>
 			</else>

--- a/test/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/cmdLineTests/lockWordAlignment/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,8 +47,16 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:				${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<classpath>
+						<pathelement location="../../TestConfig/lib/asm-all.jar" />
+					</classpath>
+				</javac>
+			</then>
+			<else>
 				<if>
 					<equals arg1="${JCL_VERSION}" arg2="latest"/>
 					<then>
@@ -62,14 +70,6 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="../../TestConfig/lib/asm-all.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
 					<classpath>
 						<pathelement location="../../TestConfig/lib/asm-all.jar" />
 					</classpath>

--- a/test/cmdLineTests/proxyFieldAccess/build.xml
+++ b/test/cmdLineTests/proxyFieldAccess/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,8 +41,13 @@
 		<echo>===debug:				on</echo>
 		<echo>===destdir:			${DEST}</echo>
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src.dir}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${src.dir}" />
+				</javac>
+			</then>
+			<else>
 				<property name="CompileArgs1" value='-Xmodule:java.base --add-modules jdk.unsupported --add-reads java.base=jdk.unsupported' />
 				<property name="CompileArgs2" value='--patch-module java.base=${src.dir} --add-reads java.base=jdk.unsupported' />
 				<javac srcdir="${src.dir}/java" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
@@ -52,11 +57,6 @@
 				<javac srcdir="${src.dir}/defect" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src.dir}/defect" />
 					<compilerarg line='${CompileArgs2}' />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src.dir}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${src.dir}" />
 				</javac>
 			</else>
 		</if>

--- a/test/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/cmdLineTests/runtimemxbeanTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2017, 2017 IBM Corp. and others
+  Copyright (c) 2017, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,9 @@
 
 	<target name="build">
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE100"/>
+			<not>
+				<matches string="${JAVA_VERSION}" pattern="^SE(8|9)0$$" />
+			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/cmdLineTests/shareClassTests/DataHelperTests/build.xml
+++ b/test/cmdLineTests/shareClassTests/DataHelperTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,17 +94,17 @@
 		</copy>		
 		
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
+					<src path="${src}" />
+				</javac>
+			</then>
+			<else>
 				<property name="addExports" value="--add-modules openj9.sharedclasses" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
 					<src path="${src}" />
 					<compilerarg line='${addExports}' />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
-					<src path="${src}" />
 				</javac>
 			</else>
 		</if>

--- a/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/build.xml
+++ b/test/cmdLineTests/shareClassTests/SCHelperCompatabilityTests/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,8 +63,31 @@
 		</copy>
 	
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				<javac srcdir="${build}" includes="PartitioningURLHelperURLClassPathHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				<javac srcdir="${build}" includes="TokenIncompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+			</then>
+			<else>
 				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
 				<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
 					<src path="${SharedClassUtils_srddir}"/>
@@ -93,29 +116,6 @@
 				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
 					<src path="${SharedClassUtils_srddir}"/>
 					<compilerarg line='${addExports}' />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="PartitioningURLHelperURLClassPathHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="TokenIncompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatabilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
 				</javac>
 			</else>
 		</if>

--- a/test/cmdLineTests/shareClassTests/testClasses/build.xml
+++ b/test/cmdLineTests/shareClassTests/testClasses/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,10 +114,87 @@
 			<fileset dir="${sharedClassTestClasses_srddir}/Vowels"/>
 		</copy>			
 
+		<!-- compile sources -->
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
-				<!-- compile sources -->
+				<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AlphabetJar" classpath="${build}" destdir="${build}/AlphabetJar" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<jar destfile="${build}/AlphabetJar/Alphabet.jar" basedir="${build}/AlphabetJar/" includes="*.class" duplicate="fail"/>
+				<delete dir="${build}/AlphabetJar/" excludes="*.jar,*.java" />
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Animals" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Animals" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AnimalsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/AnimalsJar" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<jar destfile="${build}/AnimalsJar/Animals.jar" basedir="${build}/AnimalsJar/" includes="*.class" duplicate="fail"/>
+				<delete dir="${build}/AnimalsJar/" excludes="*.jar,*.java" />
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}BallSports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/BallSports" debug="on">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}DuplicateOrphansTest" excludes="temp/DuplicateOrphan.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/DuplicateOrphansTest" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Food" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Food" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}FoodJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/FoodJar" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<jar destfile="${build}/FoodJar/Food.jar" basedir="${build}/FoodJar/" includes="*.class" duplicate="fail"/>
+				<delete dir="${build}/FoodJar/" excludes="*.jar,*.java" />
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pets" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pets" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pudding" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pudding" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Sports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Sports" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}SportsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/SportsJar" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+				
+				<jar destfile="${build}/SportsJar/Sports.jar" basedir="${build}/SportsJar/" includes="*.class" duplicate="fail"/>
+				<delete dir="${build}/SportsJar/" excludes="*.jar,*.java" />
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest/temp" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest/temp" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest1" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest1" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+
+				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source">
+					<src path="${SharedClassUtils_srddir}"/>
+				</javac>
+			</then>
+			<else>
 				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
 
 				<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
@@ -210,84 +287,6 @@
 				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source">
 					<src path="${SharedClassUtils_srddir}"/>
 					<compilerarg line='${addExports}' />
-				</javac>
-			</then>
-			<else>
-				<!-- compile sources -->
-				<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AlphabetJar" classpath="${build}" destdir="${build}/AlphabetJar" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<jar destfile="${build}/AlphabetJar/Alphabet.jar" basedir="${build}/AlphabetJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/AlphabetJar/" excludes="*.jar,*.java" />
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Animals" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Animals" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AnimalsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/AnimalsJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<jar destfile="${build}/AnimalsJar/Animals.jar" basedir="${build}/AnimalsJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/AnimalsJar/" excludes="*.jar,*.java" />
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}BallSports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/BallSports" debug="on">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}DuplicateOrphansTest" excludes="temp/DuplicateOrphan.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/DuplicateOrphansTest" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Food" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Food" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}FoodJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/FoodJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<jar destfile="${build}/FoodJar/Food.jar" basedir="${build}/FoodJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/FoodJar/" excludes="*.jar,*.java" />
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pets" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pets" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pudding" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pudding" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Sports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Sports" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}SportsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/SportsJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				
-				<jar destfile="${build}/SportsJar/Sports.jar" basedir="${build}/SportsJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/SportsJar/" excludes="*.jar,*.java" />
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest/temp" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest/temp" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest1" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest1" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
 				</javac>
 			</else>
 		</if>

--- a/test/cmdline_options_testresources/build.xml
+++ b/test/cmdline_options_testresources/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,8 +52,14 @@
 
 
 		<if>
-			<equals arg1="${JAVA_VERSION}" arg2="SE90"/>
+			<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
 			<then>
+				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+					<src path="${src}" />
+					<src path="${src_80}" />
+				</javac>
+			</then>
+			<else>
 				<if>
 					<equals arg1="${JCL_VERSION}" arg2="latest"/>
 					<then>
@@ -67,12 +73,6 @@
 					<src path="${src}" />
 					<src path="${src_90}" />
 					<compilerarg line='${addExports}' />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_80}" />
 				</javac>
 			</else>
 		</if>


### PR DESCRIPTION
- The current logic doesn't support JAVA_VERSION higher than SE90.
- Replace logic from JAVA_VERSION==SE90 to JAVA_VERSION!=SE80.


Fixes #1543


[ci skip]


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>