### PR TITLE
Enable peeking for Inliner under HCR

### DIFF
--- a/runtime/compiler/trj9/env/j9method.cpp
+++ b/runtime/compiler/trj9/env/j9method.cpp
@@ -1292,9 +1292,6 @@ TR_ResolvedJ9MethodBase::isCold(TR::Compilation * comp, bool isIndirectCall, TR:
 TR::SymbolReferenceTable *
 TR_ResolvedJ9MethodBase::_genMethodILForPeeking(TR::ResolvedMethodSymbol *methodSymbol, TR::Compilation *c, bool resetVisitCount,  TR_PrexArgInfo* argInfo)
    {
-   if (c->getOption(TR_EnableHCR))
-      return 0; // Methods can change after peeking them, so peeking is not safe
-
    // Check if the size of method being peeked exceeds the limit
    TR_ResolvedJ9Method * j9method = static_cast<TR_ResolvedJ9Method *>(methodSymbol->getResolvedMethod());
    if (_fe->_jitConfig->bcSizeLimit && (j9method->maxBytecodeIndex() > _fe->_jitConfig->bcSizeLimit))

--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -2906,7 +2906,7 @@ TR_MultipleCallTargetInliner::walkCallSite(
       dumpOptDetails(comp(), "O^O INLINER: Peeking into the IL from walkCallSites as part of the inlining heuristic for [%p]\n", calleeSymbol);
 
       //comp()->setVisitCount(1);
-      genILSucceeded = (NULL != calleeSymbol->getResolvedMethod()->genMethodILForPeeking(calleeSymbol, comp()));
+      genILSucceeded = (NULL != calleeSymbol->getResolvedMethod()->genMethodILForPeekingEvenUnderMethodRedefinition(calleeSymbol, comp()));
       //comp()->setVisitCount(visitCount);
       }
 

--- a/runtime/compiler/trj9/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/trj9/optimizer/J9EstimateCodeSize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1061,7 +1061,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       _recursionDepth, calltarget);
 
       methodSymbol = TR::ResolvedMethodSymbol::create(comp()->trHeapMemory(),calltarget->_calleeMethod,comp());
-      bool ilgenSuccess = (NULL != methodSymbol->getResolvedMethod()->genMethodILForPeeking(methodSymbol, comp(), false, NULL));
+      bool ilgenSuccess = (NULL != methodSymbol->getResolvedMethod()->genMethodILForPeekingEvenUnderMethodRedefinition(methodSymbol, comp(), false, NULL));
       if (ilgenSuccess)
          {
          heuristicTrace(tracer(), "*** Depth %d: ECS CSI -- peeking was successfull for calltarget %p", _recursionDepth, calltarget);


### PR DESCRIPTION
genMethodILForPeeking in OMR has already disabled peeking under HCR.
Remove the same logic in _genMethodILForPeeking and call
genMethodILForPeekingEvenUnderMethodRedefinition to enable peeking in
inliner.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>