### PR TITLE
Fix the java doc contents in openJ9 class files to work with JDK file make/CompileJavaModules.gmk

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -1300,7 +1300,7 @@ private native Field[] getFieldsImpl();
  * specified in the receiver classes <code>implements</code>
  * declaration
  *
- * @return		Class<?>[]
+ * @return		{@code Class<?>[]}
  *					the interfaces the receiver claims to implement.
  */
 public Class<?>[] getInterfaces()
@@ -1314,7 +1314,7 @@ public Class<?>[] getInterfaces()
  *
  * @param		name String
  *					the name of the method
- * @param		parameterTypes Class<?>[]
+ * @param		parameterTypes {@code Class<?>[]}
  *					the types of the arguments.
  * @return		Method
  *					the method described by the arguments.
@@ -2820,8 +2820,7 @@ public boolean isAnnotationPresent(Class<? extends Annotation> annotation) {
 
 /**
  * Cast this Class to a subclass of the specified Class. 
- * 
- * @param cls the Class to cast to
+ * @param <U> cls the Class to cast to
  * @return this Class, cast to a subclass of the specified Class
  * 
  * @throws ClassCastException if this Class is not the same or a subclass

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -138,7 +138,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		 *			  an Object to compare
 		 * @param o2
 		 *			  an Object to compare
-		 * @return an int < 0 if object1 is less than object2, 0 if they are equal, and > 0 if object1 is greater
+		 * @return an {@code int < 0} if object1 is less than object2, 0 if they are equal, and {@code > 0} if object1 is greater
 		 *
 		 * @exception ClassCastException
 		 *					when objects are not the correct type
@@ -505,7 +505,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *			  the number of bytes to convert
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				when {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws NullPointerException
 	 *				when data is null
 	 *
@@ -585,7 +585,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *			  the number of bytes to convert
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				when {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws NullPointerException
 	 *				when data is null
 	 *
@@ -670,7 +670,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *			  the encoding
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				when {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws UnsupportedEncodingException
 	 *				when encoding is not supported
 	 * @throws NullPointerException
@@ -912,7 +912,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *			  the number of characters to use
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				when {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws NullPointerException
 	 *				when data is null
 	 */
@@ -1927,7 +1927,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @return the character at the index
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>index < 0</code> or <code>index >= length()</code>
+	 *				when {@code index < 0} or {@code index >= length()}
 	 */
 	/*[IF]*/
 	// TODO : Is it better to throw the AIOOB here implicitly and catch and rethrow?
@@ -2071,7 +2071,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *
 	 * @param string
 	 *			  a String
-	 * @return an int < 0 if this String is less than the specified String, 0 if they are equal, and > 0 if this String is greater
+	 * @return an {@code int < 0} if this String is less than the specified String, 0 if they are equal, and {@code > 0} if this String is greater
 	 */
 	public int compareToIgnoreCase(String string) {
 		String s1 = this;
@@ -2225,7 +2225,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @return the new String
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				if <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				if {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws NullPointerException
 	 *				if data is null
 	 */
@@ -2505,7 +2505,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @throws NullPointerException
 	 *				when data is null
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>start < 0, end > length(), index < 0, end - start > data.length - index</code>
+	 *				when {@code start < 0, end > length(), index < 0, end - start > data.length - index}
 	 *
 	 * @deprecated Use getBytes() or getBytes(String)
 	 */
@@ -2607,8 +2607,8 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *			  the starting offset in the character array
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>start < 0, end > length(),
-	 * 				start > end, index < 0, end - start > buffer.length - index</code>
+	 *				when {@code start < 0, end > length(),
+	 * 				start > end, index < 0, end - start > buffer.length - index}
 	 * @throws NullPointerException
 	 *				when buffer is null
 	 */
@@ -3449,7 +3449,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @return a new String containing the characters from start to the end of the string
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>start < 0</code> or <code>start > length()</code>
+	 *				when {@code start < 0} or {@code start > length()}
 	 */
 	public String substring(int start) {
 		if (start == 0) {
@@ -3480,7 +3480,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @return a String containing the characters from start to end - 1
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>start < 0, start > end</code> or <code>end > length()</code>
+	 *				when {@code start < 0, start > end} or {@code end > length()}
 	 */
 	public String substring(int start, int end) {
 		int len = lengthInternal();
@@ -4084,7 +4084,7 @@ written authorization of the copyright holder.
 	/**
 	 * Removes white space characters from the beginning and end of the string.
 	 *
-	 * @return a String with characters <code><= \\u0020</code> removed from the beginning and the end
+	 * @return a String with characters {@code <= \\u0020} removed from the beginning and the end
 	 */
 	public String trim() {
 		int start = 0;
@@ -4153,7 +4153,7 @@ written authorization of the copyright holder.
 	 * @return the String
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				when {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws NullPointerException
 	 *				when data is null
 	 */
@@ -5129,7 +5129,7 @@ written authorization of the copyright holder.
 	 *			  the Charset to use
 	 *
 	 * @throws IndexOutOfBoundsException
-	 *				when <code>length < 0, start < 0</code> or <code>start + length > data.length</code>
+	 *				when {@code length < 0, start < 0} or {@code start + length > data.length}
 	 * @throws NullPointerException
 	 *				when data is null
 	 *

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -316,8 +316,8 @@ public synchronized StringBuffer append (char[] chars) {
  * @param		length	the number of characters
  * @return		this StringBuffer
  *
- * @exception	IndexOutOfBoundsException when <code>length < 0, start < 0</code> or
- *				<code>start + length > chars.length</code>
+ * @exception	IndexOutOfBoundsException when {@code length < 0, start < 0} or
+ *				{@code start + length > chars.length}
  * @exception	NullPointerException when chars is null
  */
 public synchronized StringBuffer append (char chars[], int start, int length) {
@@ -774,8 +774,8 @@ int capacityInternal() {
  * @param 		index	the zero-based index in this StringBuffer
  * @return		the character at the index
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index >= length()</code>
+ * @exception	IndexOutOfBoundsException
+ *              If {@code index < 0} or {@code index >= length()}
  */
 public synchronized char charAt(int index) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -803,8 +803,8 @@ public synchronized char charAt(int index) {
  * @param		end	the offset one past the last character
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public synchronized StringBuffer delete(int start, int end) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -901,8 +901,8 @@ public synchronized StringBuffer delete(int start, int end) {
  * @param		location	the offset of the character to delete
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>location < 0</code> or
- *				<code>location >= length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code location < 0} or
+ *				{@code location >= length()}
  */
 public synchronized StringBuffer deleteCharAt(int location) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -974,8 +974,8 @@ private void ensureCapacityImpl(int min) {
  * @param		buffer	the destination character array
  * @param		index	the starting offset in the character array
  *
- * @exception	IndexOutOfBoundsException when <code>start < 0, end > length(),
- *				start > end, index < 0, end - start > buffer.length - index</code>
+ * @exception	IndexOutOfBoundsException when {@code start < 0, end > length(),
+ *				start > end, index < 0, end - start > buffer.length - index}
  * @exception	NullPointerException when buffer is null
  */
 public synchronized void getChars(int start, int end, char[] buffer, int index) {
@@ -1019,8 +1019,8 @@ public synchronized void getChars(int start, int end, char[] buffer, int index) 
  * @param		chars	the character array to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  * @exception	NullPointerException when chars is null
  */
 public synchronized StringBuffer insert(int index, char[] chars) {
@@ -1074,9 +1074,9 @@ public synchronized StringBuffer insert(int index, char[] chars) {
  * @param		length	the number of characters
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>length < 0, start < 0,</code>
- *				<code>start + length > chars.length, index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code length < 0, start < 0,
+ *				start + length > chars.length, index < 0} or
+ *				{@code index > length()}
  * @exception	NullPointerException when chars is null
  */
 public synchronized StringBuffer insert(int index, char[] chars, int start, int length) {
@@ -1170,8 +1170,8 @@ synchronized StringBuffer insert(int index, char[] chars, int start, int length,
  * @param		ch	the character to insert
  * @return		this StringBuffer
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public synchronized StringBuffer insert(int index, char ch) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -1229,8 +1229,8 @@ public synchronized StringBuffer insert(int index, char ch) {
  * @param		value	the double to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuffer insert(int index, double value) {
 	return insert(index, String.valueOf(value));
@@ -1244,8 +1244,8 @@ public StringBuffer insert(int index, double value) {
  * @param		value	the float to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuffer insert(int index, float value) {
 	return insert(index, String.valueOf(value));
@@ -1259,8 +1259,8 @@ public StringBuffer insert(int index, float value) {
  * @param		value	the integer to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuffer insert(int index, int value) {
 	return insert(index, Integer.toString(value));
@@ -1274,8 +1274,8 @@ public StringBuffer insert(int index, int value) {
  * @param		value	the long to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuffer insert(int index, long value) {
 	return insert(index, Long.toString(value));
@@ -1289,8 +1289,8 @@ public StringBuffer insert(int index, long value) {
  * @param		value	the object to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuffer insert(int index, Object value) {
 	return insert(index, String.valueOf(value));
@@ -1303,8 +1303,8 @@ public StringBuffer insert(int index, Object value) {
  * @param		string	the string to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public synchronized StringBuffer insert(int index, String string) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -1360,8 +1360,8 @@ public synchronized StringBuffer insert(int index, String string) {
  * @param		value	the boolean to insert
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuffer insert(int index, boolean value) {
 	return insert(index, String.valueOf(value));
@@ -1484,8 +1484,8 @@ private void move(int size, int index) {
  * @param		string	a String
  * @return		this StringBuffer
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0</code> or
- *				<code>start > end</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0} or
+ *				{@code start > end}
  */
 public synchronized StringBuffer replace(int start, int end, String string) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -1910,8 +1910,8 @@ public synchronized StringBuffer reverse() {
  * @param 		index	the zero-based index in this StringBuffer
  * @param		ch	the character
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index >= length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index >= length()}
  */
 public synchronized void setCharAt(int index, char ch) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -1995,7 +1995,7 @@ public synchronized void setCharAt(int index, char ch) {
  *
  * @param		length	the new length of this StringBuffer
  *
- * @exception	IndexOutOfBoundsException when <code>length < 0</code>
+ * @exception	IndexOutOfBoundsException when {@code length < 0}
  *
  * @see			#length
  */
@@ -2099,8 +2099,8 @@ public synchronized void setLength(int length) {
  * @return		a new String containing the characters from start to the end
  *				of the string
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0</code> or
- *				<code>start > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0} or
+ *				{@code start > length()}
  */
 public synchronized String substring(int start) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -2128,8 +2128,8 @@ public synchronized String substring(int start) {
  * @param		end	the offset one past the last character
  * @return		a new String containing the characters from start to end - 1
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public synchronized String substring(int start, int end) {
 	int currentLength = lengthInternalUnsynchronized();
@@ -2347,8 +2347,8 @@ public synchronized StringBuffer append(StringBuffer buffer) {
  * @param		end	the offset one past the last character
  * @return		a new String containing the characters from start to end - 1
  *
- * @exception	IndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  * 
  * @since 1.4
  */
@@ -2814,8 +2814,8 @@ public synchronized StringBuffer append(CharSequence sequence) {
  * @param		end	the offset one past the last character
  * @return		this StringBuffer
  * 
- * @exception	IndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  * 
  * @since 1.5
  */
@@ -2926,8 +2926,8 @@ public synchronized StringBuffer append(CharSequence sequence, int start, int en
  * @param		sequence	the CharSequence to insert
  * @return		this StringBuffer
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  * 
  * @since 1.5
  */
@@ -3038,9 +3038,9 @@ public synchronized StringBuffer insert(int index, CharSequence sequence) {
  * @param		end	the offset one past the last character
  * @return		this StringBuffer
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>, or when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}, or when {@code start < 0, start > end} or
+ *				{@code end > length()}
  * 
  * @since 1.5
  */

--- a/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -306,8 +306,8 @@ public StringBuilder append (char[] chars) {
  * @param		length	the number of characters
  * @return		this StringBuilder
  *
- * @exception	IndexOutOfBoundsException when <code>length < 0, start < 0</code> or
- *				<code>start + length > chars.length</code>
+ * @exception	IndexOutOfBoundsException when {@code length < 0, start < 0} or
+ *				{@code start + length > chars.length}
  * @exception	NullPointerException when chars is null
  */
 public StringBuilder append (char chars[], int start, int length) {
@@ -766,8 +766,8 @@ int capacityInternal() {
  * @param 		index	the zero-based index in this StringBuilder
  * @return		the character at the index
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index >= length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index >= length()}
  */
 public char charAt(int index) {
 	int currentLength = lengthInternal();
@@ -795,8 +795,8 @@ public char charAt(int index) {
  * @param		end	the offset one past the last character
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public StringBuilder delete(int start, int end) {
 	int currentLength = lengthInternal();
@@ -893,8 +893,8 @@ public StringBuilder delete(int start, int end) {
  * @param		location	the offset of the character to delete
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>location < 0</code> or
- *				<code>location >= length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code location < 0} or
+ *				{@code location >= length()}
  */
 public StringBuilder deleteCharAt(int location) {
 	int currentLength = lengthInternal();
@@ -966,8 +966,8 @@ private void ensureCapacityImpl(int min) {
  * @param		buffer	the destination character array
  * @param		index	the starting offset in the character array
  *
- * @exception	IndexOutOfBoundsException when <code>start < 0, end > length(),
- *				start > end, index < 0, end - start > buffer.length - index</code>
+ * @exception	IndexOutOfBoundsException when {@code start < 0, end > length(),
+ *				start > end, index < 0, end - start > buffer.length - index}
  * @exception	NullPointerException when buffer is null
  */
 public void getChars(int start, int end, char[] buffer, int index) {
@@ -1011,8 +1011,8 @@ public void getChars(int start, int end, char[] buffer, int index) {
  * @param		chars	the character array to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  * @exception	NullPointerException when chars is null
  */
 public StringBuilder insert(int index, char[] chars) {
@@ -1067,9 +1067,9 @@ public StringBuilder insert(int index, char[] chars) {
  * @param		length	the number of characters
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>length < 0, start < 0,</code>
- *				<code>start + length > chars.length, index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code length < 0, start < 0, 
+ *              start + length > chars.length, index < 0} or
+ *				{@code index > length()}
  * @exception	NullPointerException when chars is null
  */
 public StringBuilder insert(int index, char[] chars, int start, int length) {
@@ -1163,8 +1163,8 @@ StringBuilder insert(int index, char[] chars, int start, int length, boolean com
  * @param		ch	the character to insert
  * @return		this StringBuilder
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, char ch) {
 	int currentLength = lengthInternal();
@@ -1222,8 +1222,8 @@ public StringBuilder insert(int index, char ch) {
  * @param		value	the double to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, double value) {
 	return insert(index, String.valueOf(value));
@@ -1237,8 +1237,8 @@ public StringBuilder insert(int index, double value) {
  * @param		value	the float to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, float value) {
 	return insert(index, String.valueOf(value));
@@ -1252,8 +1252,8 @@ public StringBuilder insert(int index, float value) {
  * @param		value	the integer to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, int value) {
 	return insert(index, Integer.toString(value));
@@ -1267,8 +1267,8 @@ public StringBuilder insert(int index, int value) {
  * @param		value	the long to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, long value) {
 	return insert(index, Long.toString(value));
@@ -1282,8 +1282,8 @@ public StringBuilder insert(int index, long value) {
  * @param		value	the object to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, Object value) {
 	return insert(index, String.valueOf(value));
@@ -1296,8 +1296,8 @@ public StringBuilder insert(int index, Object value) {
  * @param		string	the string to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, String string) {
 	int currentLength = lengthInternal();
@@ -1353,8 +1353,8 @@ public StringBuilder insert(int index, String string) {
  * @param		value	the boolean to insert
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, boolean value) {
 	return insert(index, String.valueOf(value));
@@ -1474,8 +1474,8 @@ private void move(int size, int index) {
  * @param		string	a String
  * @return		this StringBuilder
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0</code> or
- *				<code>start > end</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0} or
+ *				{@code start > end}
  */
 public StringBuilder replace(int start, int end, String string) {
 	int currentLength = lengthInternal();
@@ -1901,8 +1901,8 @@ public StringBuilder reverse() {
  * @param 		index	the zero-based index in this StringBuilder
  * @param		ch	the character
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index >= length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index >= length()}
  */
 public void setCharAt(int index, char ch) {
 	int currentLength = lengthInternal();
@@ -1986,7 +1986,7 @@ public void setCharAt(int index, char ch) {
  *
  * @param		length	the new length of this StringBuilder
  *
- * @exception	IndexOutOfBoundsException when <code>length < 0</code>
+ * @exception	IndexOutOfBoundsException when {@code length < 0}
  *
  * @see			#length
  */
@@ -2090,8 +2090,8 @@ public void setLength(int length) {
  * @return		a new String containing the characters from start to the end
  *				of the string
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0</code> or
- *				<code>start > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0} or
+ *				{@code start > length()}
  */
 public String substring(int start) {
 	int currentLength = lengthInternal();
@@ -2119,8 +2119,8 @@ public String substring(int start) {
  * @param		end	the offset one past the last character
  * @return		a new String containing the characters from start to end - 1
  *
- * @exception	StringIndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	StringIndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public String substring(int start, int end) {
 	int currentLength = lengthInternal();
@@ -2331,8 +2331,8 @@ public StringBuilder append(StringBuffer buffer) {
  * @param		end	the offset one past the last character
  * @return		a new String containing the characters from start to end - 1
  *
- * @exception	IndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public CharSequence subSequence(int start, int end) {
 	return substring(start, end);
@@ -2793,8 +2793,8 @@ public StringBuilder append(CharSequence sequence) {
  * @param		end	the offset one past the last character
  * @return		this StringBuilder
  * 
- * @exception	IndexOutOfBoundsException when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public StringBuilder append(CharSequence sequence, int start, int end) {
 	if (sequence == null) {
@@ -2903,8 +2903,8 @@ public StringBuilder append(CharSequence sequence, int start, int end) {
  * @param		sequence	the CharSequence to insert
  * @return		this StringBuilder
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}
  */
 public StringBuilder insert(int index, CharSequence sequence) {
 	int currentLength = lengthInternal();
@@ -3013,9 +3013,9 @@ public StringBuilder insert(int index, CharSequence sequence) {
  * @param		end	the offset one past the last character
  * @return		this StringBuilder
  *
- * @exception	IndexOutOfBoundsException when <code>index < 0</code> or
- *				<code>index > length()</code>, or when <code>start < 0, start > end</code> or
- *				<code>end > length()</code>
+ * @exception	IndexOutOfBoundsException when {@code index < 0} or
+ *				{@code index > length()}, or when {@code start < 0, start > end} or
+ *				{@code end > length()}
  */
 public StringBuilder insert(int index, CharSequence sequence, int start, int end) {
 	int currentLength = lengthInternal();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/ConstantCallSite.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ConstantCallSite.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2011 IBM Corp. and others
+ * Copyright (c) 2011, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,7 @@ public class ConstantCallSite extends CallSite {
 	
 	/**
 	 * Create a ConstantCallSite and assign the hook MethodHandle's result to its permanent target.
-	 * The hook MethodHandle is invoked as though by {@link MethodHandle#invoke(this)} and must return a MethodHandle that will be installed 
+	 * The hook MethodHandle is invoked as though by (@link MethodHandle#invoke(this)) and must return a MethodHandle that will be installed 
 	 * as the ConstantCallSite's target.
 	 * <p>
 	 * The hook MethodHandle is required if the ConstantCallSite's target needs to have access to the ConstantCallSite instance.  This is an

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3705,7 +3705,7 @@ public class MethodHandles {
 	}
 	
 	/**
-	 * Produce a loop handle that iterates over a range of values produced by an Iterator<T>
+	 * Produce a loop handle that iterates over a range of values produced by an {@code Iterator<T>}
 	 * Loop variables are updated by the return values of the corresponding step handles 
 	 * (including the loop body) in each iteration.
 	 * 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -318,7 +318,7 @@ public final class MethodType implements Serializable {
 	 * <li>(II)V - method taking two ints and return void</li>
 	 * <li>(I)Ljava/lang/Integer; - method taking an int and returning an Integer</li>
 	 * <li>([I)I - method taking an array of ints and returning an int</li>
-	 * <ul>
+	 * </ul>
 	 * 
 	 * @param methodDescriptor - the method descriptor string 
 	 * @param loader - the ClassLoader to be used or null for System ClassLoader 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MutableCallSite.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MutableCallSite.java
@@ -71,7 +71,7 @@ public class MutableCallSite extends CallSite {
 	
 	/**
 	 * Create a MutableCallSite permanently set to the same type as the <i>mutableTarget</i> and using
-	 * the mutableTarget</i> as the initial target value.
+	 * the <i>mutableTarget</i> as the initial target value.
 	 * 
 	 * @param mutableTarget - the initial target of the CallSite
 	 * @throws NullPointerException - if the <i>mutableTarget</i> is null.

--- a/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,18 +30,17 @@ package java.lang.management;
  * available to management clients.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
- * <li>Invoking the static ManagementFactory.getClassLoadingMXBean() method.
- * </li>
+ * <li>Invoking the static ManagementFactory.getClassLoadingMXBean() method.</li>
  * <li>Using a javax.management.MBeanServerConnection.</li>
  * <li>Obtaining a proxy MXBean from the static
- * ManagementFactory.newPlatformMXBeanProxy(MBeanServerConnection connection,
- * String mxbeanName, Class <T>mxbeanInterface) method, passing in
+ * {@code ManagementFactory.newPlatformMXBeanProxy(MBeanServerConnection connection,
+ * String mxbeanName, Class<T> mxbeanInterface())} method, passing in
  * &quot;java.lang:type=ClassLoading&quot; for the value of the mxbeanName
  * parameter.</li>
  * </ol>
- * </p>
+ * 
  */
 public interface ClassLoadingMXBean extends PlatformManagedObject {
 

--- a/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ package java.lang.management;
  * Otherwise, there will be no instances of this <code>MXBean</code> available.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
  * <li>Invoking the static ManagementFactory.getCompilationMXBean() method.
  * </li>
@@ -42,8 +42,6 @@ package java.lang.management;
  * the value of the second parameter.
  * </li>
  * </ol>
- * </p>
- *
  */
 public interface CompilationMXBean extends PlatformManagedObject {
 

--- a/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ package java.lang.management;
  * </p>
  * <p>
  * Accessing this kind of <code>MXBean</code> can be done in one of three
- * ways. <br/>
+ * ways.
  * <ol>
  * <li>Invoking the static
  * {@link ManagementFactory#getGarbageCollectorMXBeans()} method which returns a
@@ -43,8 +43,7 @@ package java.lang.management;
  * string &quot;java.lang:type=GarbageCollector,name= <i>unique collector's name
  * </i>&quot; for the value of the second parameter.</li>
  * </ol>
- * </p>
- * 
+ *  
  * @since 1.5
  */
 public interface GarbageCollectorMXBean extends MemoryManagerMXBean {

--- a/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/LockInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,18 +91,19 @@ public class LockInfo {
 	 * Returns a {@code LockInfo} object represented by the given
 	 * {@code CompositeData}. The given {@code CompositeData} must contain the
 	 * following attributes: <blockquote>
-	 * <table border summary="The attributes and the types the given CompositeData contains">
+	 * <table>
+	 * <caption>The attributes and the types the given CompositeData contains</caption>
 	 * <tr>
-	 * <th align=left>Attribute Name</th>
-	 * <th align=left>Type</th>
+	 * <th style="float:left">Attribute Name</th>
+	 * <th style="float:left">Type</th>
 	 * </tr>
 	 * <tr>
 	 * <td>className</td>
-	 * <td><tt>java.lang.String</tt></td>
+	 * <td><code>java.lang.String</code></td>
 	 * </tr>
 	 * <tr>
 	 * <td>identityHashCode</td>
-	 * <td><tt>java.lang.Integer</tt></td>
+	 * <td><code>java.lang.Integer</code></td>
 	 * </tr>
 	 * </table>
 	 * </blockquote>
@@ -145,7 +146,7 @@ public class LockInfo {
 	 * The string will hold both the name of the lock object's class and it's
 	 * identity hash code expressed as an unsigned hexadecimal. i.e.<br>
 	 * <p>
-	 * {@link #getClassName()}&nbsp;+&nbsp;&commat;&nbsp;+&nbsp;Integer.toHexString({@link #getIdentityHashCode()})
+	 * {@link #getClassName()} &nbsp;+&nbsp;&#64;&nbsp;+&nbsp;Integer.toHexString({@link #getIdentityHashCode()})
 	 * </p>
 	 *
 	 * @return a string containing the key details of the lock

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@ package java.lang.management;
  * clients.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
  * <li>Invoking the static {@link ManagementFactory#getMemoryMXBean} method.
  * </li>
@@ -40,7 +40,7 @@ package java.lang.management;
  * string &quot;java.lang:type=ClassLoading&quot; for the value of the second
  * parameter.</li>
  * </ol>
- * </p>
+ * 
  */
 public interface MemoryMXBean extends PlatformManagedObject {
 

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ package java.lang.management;
  * </p>
  * <p>
  * Accessing this kind of <code>MXBean</code> can be done in one of three
- * ways. <br/>
+ * ways.
  * <ol>
  * <li>Invoking the static {@link ManagementFactory#getMemoryManagerMXBeans()}
  * method which returns a {@link java.util.List} of all currently instantiated
@@ -43,7 +43,7 @@ package java.lang.management;
  * string &quot;java.lang:type=MemoryManager,name= <i>unique manager's name
  * </i>&quot; for the value of the second parameter.</li>
  * </ol>
- * </p>
+ * 
  */
 public interface MemoryManagerMXBean extends PlatformManagedObject {
 

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ package java.lang.management;
  * </P>
  * <p>
  * Accessing this kind of <code>MXBean</code> can be done in one of three
- * ways. <br/>
+ * ways.
  * <ol>
  * <li>Invoking the static {@link ManagementFactory#getMemoryPoolMXBeans()}
  * method which returns a {@link java.util.List} of all currently instantiated
@@ -44,8 +44,7 @@ package java.lang.management;
  * string &quot;java.lang:type=MemoryPool,name= <i>unique memory pool name
  * </i>&quot; for the value of the second parameter.</li>
  * </ol>
- * </p>
- * 
+ *  
  * @since 1.5
  */
 public interface MemoryPoolMXBean extends PlatformManagedObject {

--- a/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@ package java.lang.management;
  * clients.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
  * <li>Invoking the static ManagementFactory.getOperatingSystemMXBean() method.
  * </li>
@@ -40,8 +40,7 @@ package java.lang.management;
  * &quot;java.lang:type=OperatingSystem&quot; for the value of the second
  * parameter.</li>
  * </ol>
- * </p>
- * 
+ *  
  * @since 1.5
  */
 public interface OperatingSystemMXBean extends PlatformManagedObject {

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ import java.util.List;
  * clients.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
  * <li>Invoking the static {@link ManagementFactory#getPlatformMXBean()} method.
  * </li>
@@ -41,8 +41,7 @@ import java.util.List;
  * &quot;java.util.logging:type=Logging&quot; for the value of the second parameter.
  * </li>
  * </ol>
- * </p>
- *
+ * 
  * @since 1.5
  */
 public interface PlatformLoggingMXBean extends PlatformManagedObject{

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ import java.util.Map;
  * clients.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
  * <li>Invoking the static ManagementFactory.getRuntimeMXBean() method.</li>
  * <li>Using a javax.management.MBeanServerConnection.</li>
@@ -44,8 +44,7 @@ import java.util.Map;
  * &quot;java.lang:type=Runtime&quot; for the value of the second parameter.
  * </li>
  * </ol>
- * </p>
- * 
+ *  
  * @since 1.5
  */
 public interface RuntimeMXBean extends PlatformManagedObject {

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -278,7 +278,6 @@ public class ThreadInfo {
 	 * <li><code>@</code>
 	 * <li><code>Integer.toHexString(System.identityHashCode(monitor))</code>
 	 * </ul>
-	 * </p>
 	 * @return if blocked or waiting on a monitor, a string representation of
 	 *         the monitor object. Otherwise, <code>null</code>.
 	 * @see Integer#toHexString(int)
@@ -345,7 +344,7 @@ public class ThreadInfo {
 	/**
 	 * If available, returns the stack trace for the thread represented by this
 	 * <code>ThreadInfo</code> instance. The stack trace is returned in an
-	 * array of {@link StackTraceElement} objects with the &quot;top&quot of the
+	 * array of {@link StackTraceElement} objects with the &quot;top&quot; of the
 	 * stack encapsulated in the first array element and the &quot;bottom&quot;
 	 * of the stack in the last array element.
 	 * <p>
@@ -511,7 +510,7 @@ public class ThreadInfo {
 	 *             <code>java.lang.Long</code>)
 	 *             <li><code>blockedTime</code>(<code>java.lang.Long</code>)
 	 *             <li><code>waitedCount</code>(<code>java.lang.Long</code>)
-	 *             <li><code>waitedTime<code> (<code>java.lang.Long</code>)
+	 *             <li><code>waitedTime</code> (<code>java.lang.Long</code>)
 /*[IF Sidecar19-SE]
 	 *             <li><code>daemon</code> (<code>java.lang.Boolean</code>)
 	 *             <li><code>priority</code> (<code>java.lang.Integer</code>)

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -30,7 +30,7 @@ package java.lang.management;
  * clients.
  * </p>
  * <p>
- * Accessing this <code>MXBean</code> can be done in one of three ways. <br/>
+ * Accessing this <code>MXBean</code> can be done in one of three ways.
  * <ol>
  * <li>Invoking the static {@link ManagementFactory#getThreadMXBean} method.
  * </li>
@@ -40,8 +40,7 @@ package java.lang.management;
  * &quot;java.lang:type=Threading&quot; for the value of the second parameter.
  * </li>
  * </ol>
- * </p>
- * 
+ *  
  * @since 1.5
  */
 public interface ThreadMXBean extends PlatformManagedObject {


### PR DESCRIPTION
Fix the java doc contents in openJ9 class files to work with JDK file make/CompileJavaModules.gmk without making any patch changes.

Fixes : https://github.com/eclipse/openj9/issues/1569

Explanation:
Build has been failing with these 20 files.
**Basically these errors are related to 2 issues and the fixes is required to work is detailed here**

- code text in the generated HTML
Text within {@code ...} will be automatically HTML-escaped however <code> is not which is why above most of the files failed during compile.
{@code ...} is more concise: easier to read (and type).

The {@code} is equivalent to <code> except that it uses allows you to use angle brackets < and > instead of HTML-entities &lt; and &gt.
For example, {@code List<String>} is equivalent to  <code>List&lt;String&gt;</code>.

See also the documentation for {@code}.
https://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/javadoc.html#%7B@code%7D

also

https://blogs.oracle.com/darcy/javadoc-tip:-code-and-literal

- Invalid syntax which has not been supported by HTML5
example : align or summary in is not supported in HTML5, 
another example.
also there were few error such as take not closed or parameter was not given.

These 20 files I have fixed and I have created a pull request.
After these fixes, My personal local build is successfully passed. 


Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>