### PR TITLE
Fix potential memory leak issue with mapTable

### DIFF
--- a/runtime/compiler/trj9/runtime/HookHelpers.cpp
+++ b/runtime/compiler/trj9/runtime/HookHelpers.cpp
@@ -124,20 +124,6 @@ namespace  {
       // expunge any runtime assumptions in the RAT that have previously been marked
       pointer_cast<TR_PersistentMemory *>( jitConfig->scratchSegment )->getPersistentInfo()->getRuntimeAssumptionTable()->reclaimMarkedAssumptionsFromRAT();
       }
-
-   inline void freeFastWalkCache(J9VMThread *vmThread, J9JITExceptionTable *metaData)
-      {
-      if (metaData->bodyInfo)
-         {
-         void * mapTable = ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->getMapTable();
-         if (mapTable && mapTable != (void *)-1)
-            {
-            PORT_ACCESS_FROM_VMC(vmThread);
-            j9mem_free_memory(mapTable);
-            }
-         ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->setMapTable(NULL);
-         }
-      }
    
    // We need to update the nextMethod and prevMethod pointers of the J9JITExceptionTable that
    // point to the old J9JITExceptionTable to now point to the new (stub) J9JITExceptionTable.
@@ -394,6 +380,20 @@ void jitReclaimMarkedAssumptions()
       reclaimMarkedAssumptionsFromRAT();
       }
    }
+
+void freeFastWalkCache(J9VMThread *vmThread, J9JITExceptionTable *metaData)
+      {
+      if (metaData->bodyInfo)
+         {
+         void * mapTable = ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->getMapTable();
+         if (mapTable && mapTable != (void *)-1)
+            {
+            PORT_ACCESS_FROM_VMC(vmThread);
+            j9mem_free_memory(mapTable);
+            }
+         ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->setMapTable(NULL);
+         }
+      }
 
 void vlogReclamation(const char * prefix, J9JITExceptionTable *metaData, size_t bytesToSaveAtStart)
    {

--- a/runtime/compiler/trj9/runtime/HookHelpers.hpp
+++ b/runtime/compiler/trj9/runtime/HookHelpers.hpp
@@ -37,6 +37,7 @@ void jitReleaseCodeCollectMetaData(J9JITConfig *jitConfig, J9VMThread *vmThread,
 void jitRemoveAllMetaDataForClassLoader(J9VMThread * vmThread, J9ClassLoader * classLoader);
 void jitReclaimMarkedAssumptions();
 void vlogReclamation(const char *prefix, J9JITExceptionTable *metaData, size_t bytesToSaveAtStart);
+void freeFastWalkCache(J9VMThread *vmThread, J9JITExceptionTable *metaData);
 
 // Defined in Runtime.cpp
 OMR::CodeCacheMethodHeader *getCodeCacheMethodHeader(char *p, int searchLimit, J9JITExceptionTable* metaData = NULL);

--- a/runtime/compiler/trj9/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/trj9/runtime/J9CodeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,7 @@
 #include "env/VMJ9.h"
 #include "runtime/ArtifactManager.hpp"
 #include "env/IO.hpp"
+#include "runtime/HookHelpers.hpp"
 
 
 /*
@@ -427,6 +428,9 @@ J9::CodeCache::addFreeBlock(void  *voidMetaData)
             if (!pmi || !pmi->isInDataCache())
                {
                TR_Memory::jitPersistentFree(bi);
+               // If we free bodyInfo, we need to also free metaData->bodyInfo->mapTable by calling freeFastWalkCache()
+               J9VMThread *currentVMThread = _manager->javaVM()->internalVMFunctions->currentVMThread(_manager->javaVM());
+               freeFastWalkCache(currentVMThread, metaData);
                metaData->bodyInfo = NULL;
                }
 


### PR DESCRIPTION
- the jittedBodyInfo contains a pointer to mapTable(mapTable is a cache used for speeding up stack walking)
- when bodyInfo was freed in J9::CodeCache::addFreeBlock() during class unloading  we should also free mapTable but we did not
- used freeFastWalkCache() to free its mapTable

Issue: #1552
Signed-off-by: Harry Yu <harryyu1994@gmail.com>