### PR TITLE
Relocatable Debug Counters

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -651,6 +651,35 @@ uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          }
          break;
 
+      case TR_DebugCounter:
+         {
+         TR::DebugCounterBase *counter = (TR::DebugCounterBase *) relocation->getTargetAddress();
+         if (!counter || !counter->getReloData() || !counter->getName())
+            comp->failCompilation<TR::CompilationException>("Failed to generate debug counter relo data");
+
+         TR::DebugCounterReloData *counterReloData = counter->getReloData();
+
+         uintptrj_t offset = (uintptrj_t)fej9->sharedCache()->rememberDebugCounterName(counter->getName());
+
+         uint8_t flags = (uint8_t)counterReloData->_seqKind;
+         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
+         *flagsCursor |= (flags & RELOCATION_RELOC_FLAGS_MASK);
+
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_callerIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_bytecodeIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = offset;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_delta;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_fidelity;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_staticDelta;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       }
       return cursor;
    }
@@ -717,6 +746,7 @@ uint32_t J9::ARM::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    0,                                        // TR_NativeMethodAbsolute                = 56,
    0,                                        // TR_NativeMethodRelative                = 57,
    16,                                       // TR_ArbitraryClassAddress               = 58,
+   28                                        // TR_DebugCounter                        = 59
    };
 
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -937,6 +937,41 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   }
                }
             break;
+         case TR_DebugCounter:
+            cursor ++;
+            if (is64BitTarget)
+               {
+               cursor += 4;     // padding
+               ep1 = cursor;    // inlinedSiteIndex
+               ep2 = cursor+8;  // bcIndex
+               ep3 = cursor+16; // offsetOfNameString
+               ep4 = cursor+24; // delta
+               ep5 = cursor+40; // staticDelta
+               cursor += 48;
+               self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+               if (isVerbose)
+                  {
+                  traceMsg(self()->comp(), "\n Debug Counter: Inlined site index = %d, bcIndex = %d, offsetOfNameString = %p, delta = %d, staticDelta = %d",
+                                   *(int64_t *)ep1, *(int32_t *)ep2, *(UDATA *)ep3, *(int32_t *)ep4, *(int32_t *)ep5);
+                  }
+               }
+            else
+               {
+               ep1 = cursor;    // inlinedSiteIndex
+               ep2 = cursor+4;  // bcIndex
+               ep3 = cursor+8;  // offsetOfNameString
+               ep4 = cursor+12; // delta
+               ep5 = cursor+20; // staticDelta
+               cursor += 24;
+               self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+               if (isVerbose)
+                  {
+                  traceMsg(self()->comp(), "\n Debug Counter: Inlined site index = %d, bcIndex = %d, offsetOfNameString = %p, delta = %d, staticDelta = %d",
+                                   *(int32_t *)ep1, *(int32_t *)ep2, *(UDATA *)ep3, *(int32_t *)ep4, *(int32_t *)ep5);
+                  }
+               }
+            break;
+
          default:
             traceMsg(self()->comp(), "Unknown Relocation type = %d\n", kind);
             TR_ASSERT(false, "should be unreachable");

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -526,6 +526,39 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, bool create)
    return chainData;
    }
 
+UDATA
+TR_J9SharedCache::rememberDebugCounterName(const char *name)
+   {
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
+   J9VMThread *vmThread = fej9->getCurrentVMThread();
+
+   J9SharedDataDescriptor dataDescriptor;
+   dataDescriptor.address = (U_8*)name;
+   dataDescriptor.length  = (strlen(name) + 1); // +1 for the \0 terminator
+   dataDescriptor.type    = J9SHR_DATA_TYPE_JITHINT;
+   dataDescriptor.flags   = J9SHRDATA_NOT_INDEXED;
+
+   const U_8 *data = sharedCacheConfig()->storeSharedData(vmThread,
+                                        (const char*)NULL,
+                                        0,
+                                        &dataDescriptor);
+
+   UDATA offset = data ? (UDATA)offsetInSharedCacheFromPointer((void *)data) : (UDATA)-1;
+
+   //printf("\nrememberDebugCounterName: Tried to store %s (%p), data=%p, offset=%p\n", name, name, data, offset);
+
+   return offset;
+   }
+
+const char *
+TR_J9SharedCache::getDebugCounterName(UDATA offset)
+   {
+   const char *name = (offset != (UDATA)-1) ? (const char *)pointerFromOffsetInSharedCache((void *)offset) : NULL;
+
+   //printf("\ngetDebugCounterName: Tried to find %p, name=%s (%p)\n", offset, (name ? name : ""), name);
+
+   return name;
+   }
 
 uint32_t
 TR_J9SharedCache::numInterfacesImplemented(J9Class *clazz)

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -69,6 +69,9 @@ public:
 
    UDATA *rememberClass(J9Class *clazz, bool create=true);
 
+   UDATA rememberDebugCounterName(const char *name);
+   const char *getDebugCounterName(UDATA offset);
+
    bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL);
    bool classMatchesCachedVersion(TR_OpaqueClassBlock *classPtr, UDATA *chainData=NULL)
       {

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -38,6 +38,7 @@
 #include "il/Node_inlines.hpp"
 #include "il/SymbolReference.hpp"
 #include "il/symbol/LabelSymbol.hpp"
+#include "ras/DebugCounter.hpp"
 
 J9::Power::AheadOfTimeCompile::AheadOfTimeCompile(TR::CodeGenerator *cg) :
          J9::AheadOfTimeCompile(_relocationTargetTypeToHeaderSizeMap, cg->comp()),
@@ -801,6 +802,35 @@ uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
          }
          break;
 
+      case TR_DebugCounter:
+         {
+         TR::DebugCounterBase *counter = (TR::DebugCounterBase *) relocation->getTargetAddress();
+         if (!counter || !counter->getReloData() || !counter->getName())
+            comp->failCompilation<TR::CompilationException>("Failed to generate debug counter relo data");
+
+         TR::DebugCounterReloData *counterReloData = counter->getReloData();
+
+         uintptrj_t offset = (uintptrj_t)fej9->sharedCache()->rememberDebugCounterName(counter->getName());
+
+         uint8_t flags = (uint8_t)counterReloData->_seqKind;
+         TR_ASSERT((flags & RELOCATION_CROSS_PLATFORM_FLAGS_MASK) == 0,  "reloFlags bits overlap cross-platform flags bits\n");
+         *flagsCursor |= (flags & RELOCATION_RELOC_FLAGS_MASK);
+
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_callerIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_bytecodeIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = offset;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_delta;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_fidelity;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_staticDelta;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       }
    return cursor;
    }
@@ -867,6 +897,7 @@ uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_
    0,                                        // TR_NativeMethodAbsolute                = 56,
    0,                                        // TR_NativeMethodRelative                = 57,
    32,                                       // TR_ArbitraryClassAddress               = 58,
+   56,                                       // TR_DebugCounter                        = 59
    };
 #else
 uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds] =
@@ -930,6 +961,7 @@ uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_
    0,                                        // TR_NativeMethodAbsolute                = 56,
    0,                                        // TR_NativeMethodRelative                = 57,
    16,                                       // TR_ArbitraryClassAddress               = 58,
+   28                                        // TR_DebugCounter                        = 59
    };
 
 #endif

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -315,6 +315,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_RamMethodSequence:
       case TR_BodyInfoAddressLoad:
       case TR_DataAddress:
+      case TR_DebugCounter:
          return true;
       }
 

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -129,6 +129,16 @@ struct TR_RelocationRecordEmitClassPrivateData
    TR_OpaqueMethodBlock *_method;
    };
 
+struct TR_RelocationRecordDebugCounterPrivateData
+   {
+   int32_t _bcIndex;
+   int32_t _delta;
+   int8_t  _fidelity;
+   int32_t _staticDelta;
+   TR_OpaqueMethodBlock *_method;
+   const char *_name;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -141,6 +151,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordPointerPrivateData pointer;
    TR_RelocationRecordMethodCallPrivateData methodCall;
    TR_RelocationRecordEmitClassPrivateData emitClass;
+   TR_RelocationRecordDebugCounterPrivateData debugCounter;
    };
 
 // TR_RelocationRecord is the base class for all relocation records.  It is used for all queries on relocation
@@ -1072,6 +1083,24 @@ class TR_RelocationRecordEmitClass : public TR_RelocationRecordWithInlinedSiteIn
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
       virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordDebugCounter : public TR_RelocationRecordWithInlinedSiteIndex
+   {
+   public:
+      TR_RelocationRecordDebugCounter() {}
+      TR_RelocationRecordDebugCounter(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordWithInlinedSiteIndex(reloRuntime, record) {}
+      virtual char *name();
+
+      virtual int32_t bytesInHeaderAndPayload();
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+
+   private:
+      TR::DebugCounterBase *findOrCreateCounter(TR_RelocationRuntime *reloRuntime);
    };
 
 #endif   // RELOCATION_RECORD_INCL

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2050,6 +2050,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_RamMethodSequence:
       case TR_BodyInfoAddressLoad:
       case TR_DataAddress:
+      case TR_DebugCounter:
 #endif
          isOrderedPair = true;
          break;

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -676,6 +676,32 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
 #endif
          }
          break;
+
+      case TR_DebugCounter:
+         {
+         TR::DebugCounterBase *counter = (TR::DebugCounterBase *) relocation->getTargetAddress();
+         if (!counter || !counter->getReloData() || !counter->getName())
+            comp()->failCompilation<TR::CompilationException>("Failed to generate debug counter relo data");
+
+         TR::DebugCounterReloData *counterReloData = counter->getReloData();
+
+         uintptrj_t offset = (uintptrj_t)fej9->sharedCache()->rememberDebugCounterName(counter->getName());
+
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_callerIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_bytecodeIndex;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = offset;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_delta;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_fidelity;
+         cursor += SIZEPOINTER;
+         *(uintptrj_t *)cursor = (uintptrj_t)counterReloData->_staticDelta;
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       }
    return cursor;
    }
@@ -986,6 +1012,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    0,                                         // TR_NativeMethodAbsolute                = 56,
    0,                                         // TR_NativeMethodRelative                = 57,
    32,                                        // TR_ArbitraryClassAddress               = 58,
+   56,                                        // TR_DebugCounter                        = 59
    };
 
 #else
@@ -1051,6 +1078,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    0,                                         // TR_NativeMethodAbsolute                = 56,
    0,                                         // TR_NativeMethodRelative                = 57,
    16,                                        // TR_ArbitraryClassAddress               = 58,
+   28                                         // TR_DebugCounter                        = 59
    };
 
 #endif

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 #include "env/jittypes.h"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
+#include "il/symbol/StaticSymbol.hpp"
 #include "z/codegen/S390Instruction.hpp"
 #include "env/VMJ9.h"
 
@@ -123,6 +124,18 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
          cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_BodyInfoAddress, cg),
                            file, line, node);
          }
+      }
+   else if (_reloType==TR_DebugCounter)
+      {
+      TR::DebugCounterBase *counter = cg->comp()->getCounterFromStaticAddress(_symbolReference);
+      if (counter == NULL)
+         {
+         cg->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in TR::S390EncodingRelocation::addRelocation\n");
+         }
+      TR::DebugCounter::generateRelocation(cg->comp(),
+                                           cursor,
+                                           node,
+                                           counter);
       }
    else
       {


### PR DESCRIPTION
Depends on https://github.com/eclipse/omr/pull/2408

I tested this with a simple java program:
```
import java.lang.*;

public class SimpleAddTest {

   private static int iter;
   private static int count;

   public static void addNum(int num) {
         count += num;
   }

   public static void main (String[] args) {

      iter = 100;
      count = 0;
      
      int num = 1;

      int i = 0;
      while (i < iter) {
         addNum(num);
	 i++;
      }

      System.out.println(count);
   }
}
```

This just does an add 100 times and prints out the total (which is 100). I added a dynamic debug counter in simplifier called "CounterTest".

**JIT**
```
$> java '-Xjit:optLevel=cold,count=0,limit={SimpleAddTest.addNum*},debugCounters={CounterTest},verbose={compilePerformance},vlog=vlog' -Xshareclasses:name=debugCounterTest SimpleAddTest
100

== Dynamic debug counters ==
  0: CounterTest |          100 |   __   0 __

 (cold) Compiling SimpleAddTest.addNum(I)V  OrdinaryMethod j9m=0000000002449B58 t=150 compThread=0 memLimit=262144 KB freePhysicalMemory=5228 MB
+ (cold) SimpleAddTest.addNum(I)V @ 00007F0826600034-00007F0826600065 OrdinaryMethod - Q_SZ=0 Q_SZI=0 QW=2 j9m=0000000002449B58 bcsz=9 sync time=695us mem=[region=704 system=16384]KB compThread=0 CpuLoad=73%(18%avg) JvmCpu=0%
```
 
**AOT Compile run**
```
$> java '-Xaot:forceAOT,optLevel=cold,count=0,limit={SimpleAddTest.addNum*},debugCounters={CounterTest},verbose={compilePerformance},vlog=vlog' -Xshareclasses:name=debugCounterTest SimpleAddTest
100

== Dynamic debug counters ==
  0: CounterTest |          100 |   __   0 __

 (AOT cold) Compiling SimpleAddTest.addNum(I)V  OrdinaryMethod j9m=00000000025C4658 t=275 compThread=0 memLimit=262144 KB freePhysicalMemory=5227 MB
+ (AOT cold) SimpleAddTest.addNum(I)V @ 00007F7398A00034-00007F7398A00076 OrdinaryMethod - Q_SZ=0 Q_SZI=0 QW=2 j9m=00000000025C4658 bcsz=9 sync time=791us mem=[region=1408 system=16384]KB compThread=0 CpuLoad=73%(18%avg) JvmCpu=0%
```

**AOT Load run**
```
$> java '-Xaot:forceAOT,optLevel=cold,count=0,limit={SimpleAddTest.addNum*},debugCounters={CounterTest},verbose={compilePerformance},vlog=vlog' -Xshareclasses:name=debugCounterTest SimpleAddTest
100

== Dynamic debug counters ==
  0: CounterTest |          100 |   __   0 __

 (cold) Compiling SimpleAddTest.addNum(I)V  OrdinaryMethod j9m=0000000001D5A658 t=179 compThread=0 memLimit=262144 KB freePhysicalMemory=5227 MB
+ (AOT load) SimpleAddTest.addNum(I)V @ 00007F1D7A400034-00007F1D7A400076 Q_SZ=0 Q_SZI=0 QW=1 j9m=0000000001D5A658 bcsz=9 time=153us compThread=0
```

There's still a bug somewhere though, since if I enable all debug counters, the number printed out by the java code is wrong (though the counters seem ok :P)

**JIT**
```
$> java '-Xjit:optLevel=cold,count=0,limit={SimpleAddTest.addNum*},debugCounters={*},verbose={compilePerformance},vlog=vlog' -Xshareclasses:name=debugCounterTest SimpleAddTest
100

== Dynamic debug counters ==
  0: CounterTest                                                |          100 |   __   0 __
  4: blocks/coldCompiles/warmBlocks/=2                          |          100 |    100.00% |   100.00% |   100.00% |  __   4 __
  5: cg.blocks                                                  |          100 |   __   5 __
  7: cg.epilogues:no-preservedRegStoreBytesSaved                |          100 |    100.00% |  __   7 __
  8: cg.prologues                                               |          100 |   __   8 __
  9: cg.prologues:#frameBytes                                   |          800 |      8.00  |  __   9 __
 10: cg.prologues:#instructionBytes                             |        10800 |    108.00  |  __  10 __
 11: cg.prologues:#peakBytes                                    |          800 |      8.00  |  __  11 __
 12: cg.prologues:inline                                        |          100 |    100.00% |  __  12 __
 13: cg.prologues:no-preservedRegStoreBytesSaved                |          100 |    100.00% |  __  13 __
 21: warmBlocks/byJittedBody/(SimpleAddTest.addNum(I)V)/cold/=2 |          100 |    100.00% |   100.00% |   100.00% |   100.00% |  __  21 __
```

**AOT Compile run**
```
$> java '-Xaot:forceAOT,optLevel=cold,count=0,limit={SimpleAddTest.addNum*},debugCounters={*},verbose={compilePerformance},vlog=vlog' -Xshareclasses:name=debugCounterTest SimpleAddTest
-2030234688

== Dynamic debug counters ==
  0: CounterTest                                                |          100 |   __   0 __
  4: blocks/coldCompiles/warmBlocks/=2                          |          100 |    100.00% |   100.00% |   100.00% |  __   4 __
  5: cg.blocks                                                  |          100 |   __   5 __
  7: cg.epilogues:no-preservedRegStoreBytesSaved                |          100 |    100.00% |  __   7 __
  8: cg.prologues                                               |          100 |   __   8 __
  9: cg.prologues:#frameBytes                                   |          800 |      8.00  |  __   9 __
 10: cg.prologues:#instructionBytes                             |        10400 |    104.00  |  __  10 __
 11: cg.prologues:#peakBytes                                    |          800 |      8.00  |  __  11 __
 12: cg.prologues:inline                                        |          100 |    100.00% |  __  12 __
 13: cg.prologues:no-preservedRegStoreBytesSaved                |          100 |    100.00% |  __  13 __
 21: warmBlocks/byJittedBody/(SimpleAddTest.addNum(I)V)/cold/=2 |          100 |    100.00% |   100.00% |   100.00% |   100.00% |  __  21 __
```

**AOT Load run**
```
$> java '-Xaot:forceAOT,optLevel=cold,count=0,limit={SimpleAddTest.addNum*},debugCounters={*},verbose={compilePerformance},vlog=vlog' -Xshareclasses:name=debugCounterTest SimpleAddTest
1972250816

== Dynamic debug counters ==
  0: CounterTest                                                |          100 |   __   0 __
  4: blocks/coldCompiles/warmBlocks/=2                          |          100 |    100.00% |   100.00% |   100.00% |  __   4 __
  5: cg.blocks                                                  |          100 |   __   5 __
  7: cg.epilogues:no-preservedRegStoreBytesSaved                |          100 |    100.00% |  __   7 __
  8: cg.prologues                                               |          100 |   __   8 __
  9: cg.prologues:#frameBytes                                   |          800 |      8.00  |  __   9 __
 10: cg.prologues:#instructionBytes                             |        10400 |    104.00  |  __  10 __
 11: cg.prologues:#peakBytes                                    |          800 |      8.00  |  __  11 __
 12: cg.prologues:inline                                        |          100 |    100.00% |  __  12 __
 13: cg.prologues:no-preservedRegStoreBytesSaved                |          100 |    100.00% |  __  13 __
 18: warmBlocks/byJittedBody/(SimpleAddTest.addNum(I)V)/cold/=2 |          100 |    100.00% |   100.00% |   100.00% |   100.00% |  __  18 __
```

Credit to @lmaisons for the idea of using the metadata to store the debug counter names.