### PR TITLE
Add exclude file for SE100

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
@@ -1,0 +1,27 @@
+##############################################################################
+#  Copyright (c) 2016, 2018 IBM Corp. and others
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+##############################################################################
+
+# Exclude tests temporarily
+
+org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
+org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														1582 generic-all
+org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	1583 generic-all


### PR DESCRIPTION
- Added latest_exclude_SE100.txt.
- Exclude failed tests.


[ci skip]


Fixes #1584


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>