### PR TITLE
Fix for incorrect assertion in genZeroInitObject2

### DIFF
--- a/runtime/compiler/trj9/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/x/codegen/J9TreeEvaluator.cpp
@@ -8594,8 +8594,10 @@ static bool genZeroInitObject2(
          case 4:
             generateMemRegInstruction(MOVDMemReg, node, generateX86MemoryReference(targetReg, headerSize + offset, cg), scratchReg, cg);
             break;
+         case 0:
+            break;
          default:
-            TR_ASSERT(false, "residue should only be 4 or 8.");
+            TR_ASSERT(false, "residue size should only be 0, 4 or 8.");
          }
       return false;
       }


### PR DESCRIPTION
An assertion can be incorrectly triggered in
genZeroInitObject2() when the residue size is 0.
Fixing it.

Issue #1597

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>