### PR TITLE
WIP: Add jProfilingRecompilation test in loop

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -219,7 +219,7 @@ def build() {
     stage('Compile') {
         timestamps {
             sh "bash ./configure --with-freemarker-jar='$FREEMARKER' --with-boot-jdk='$BOOT_JDK' $EXTRA_CONFIGURE_OPTIONS"
-            sh "make all"
+            sh "make $EXTRA_MAKE_OPTIONS all"
         }
     }
     stage('Java Version') {

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -230,6 +230,7 @@ def set_build_variables() {
     BOOT_JDK = get_value(VARIABLES."${SPEC}".boot_jdk, SDK_VERSION)
     FREEMARKER = VARIABLES."${SPEC}".freemarker
     EXTRA_CONFIGURE_OPTIONS = get_value(VARIABLES."${SPEC}".extra_configure_options, SDK_VERSION)
+    EXTRA_MAKE_OPTIONS = get_value(VARIABLES."${SPEC}".extra_make_options, SDK_VERSION)
     OPENJDK_REFERENCE_REPO = VARIABLES."${SPEC}".openjdk_reference_repo
     set_release()
     set_jdk_folder()

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_x86-64_cmprssptrs_cmake
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_x86-64_cmprssptrs_cmake
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64_cmprssptrs_cmake'
+
+node('master') {
+    timestamps {
+        retry(5) {
+            checkout scm
+        }
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('build')
+        buildfile = load 'buildenv/jenkins/common/build'
+        cleanWs()
+    }
+}
+
+node("${NODE}") {
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
@@ -80,6 +80,16 @@ timeout(time: 8, unit: 'HOURS') {
                  }
             }
 
+            // Note: we are doing this as a special case rather than include it in SPECS,
+            // because at the moment cmake builds are only supported on java 9.
+            // Also we dont want to bother running tests at the moment.
+            def CMAKE_SDK_VERSION = '9'
+            def SHAS = [:]
+            SHAS['OPENJ9'] = ALL_SHAS['OPENJ9']
+            SHAS['OMR'] = ALL_SHAS['OMR']
+            SHAS['OPENJDK'] = buildFile.get_sha(OPENJDK_REPOS[CMAKE_SDK_VERSION].repo, OPENJDK_REPOS[CMAKE_SDK_VERSION].branch)
+            JOBS["Build-TestJDK${CMAKE_SDK_VERSION}-linux_x86-64_cmprssptrs_cmake"] = { buildFile.workflow(CMAKE_SDK_VERSION as int, linux_x86-64_cmprssptrs_cmake, SHAS, OPENJDK_REPOS[CMAKE_SDK_VERSION].repo, OPENJDK_REPOS[CMAKE_SDK_VERSION].branch, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, 'none') }
+
             cleanWs()
         }
     }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
@@ -88,7 +88,7 @@ timeout(time: 8, unit: 'HOURS') {
             SHAS['OPENJ9'] = ALL_SHAS['OPENJ9']
             SHAS['OMR'] = ALL_SHAS['OMR']
             SHAS['OPENJDK'] = buildFile.get_sha(OPENJDK_REPOS[CMAKE_SDK_VERSION].repo, OPENJDK_REPOS[CMAKE_SDK_VERSION].branch)
-            JOBS["Build-TestJDK${CMAKE_SDK_VERSION}-linux_x86-64_cmprssptrs_cmake"] = { buildFile.workflow(CMAKE_SDK_VERSION as int, linux_x86-64_cmprssptrs_cmake, SHAS, OPENJDK_REPOS[CMAKE_SDK_VERSION].repo, OPENJDK_REPOS[CMAKE_SDK_VERSION].branch, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, 'none') }
+            JOBS["Build-TestJDK${CMAKE_SDK_VERSION}-linux_x86-64_cmprssptrs_cmake"] = { buildFile.workflow(CMAKE_SDK_VERSION as int, 'linux_x86-64_cmprssptrs_cmake', SHAS, OPENJDK_REPOS[CMAKE_SDK_VERSION].repo, OPENJDK_REPOS[CMAKE_SDK_VERSION].branch, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, 'none') }
 
             cleanWs()
         }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -158,6 +158,37 @@ linux_x86-64_cmprssptrs:
       9: 'hw.arch.x86 && sw.os.ubuntu.16'
       10: 'hw.arch.x86 && sw.os.ubuntu.16'
 #========================================#
+# Linux x86 64bits Compressed Pointers /w CMake
+#========================================#
+linux_x86-64_cmprssptrs_cmake:
+  boot_jdk:
+    8: '/usr/lib/jvm/java-7-openjdk-amd64'
+    9: '/usr/lib/jvm/adoptojdk-java-80'
+    10: '/usr/lib/jvm/adoptojdk-java-90'
+  release:
+    8: 'linux-x86_64-normal-server-release'
+    9: 'linux-x86_64-normal-server-release'
+    10: 'linux-x86_64-normal-server-release'
+  freemarker: '/home/jenkins/freemarker.jar'
+  openjdk_reference_repo: '/home/jenkins/openjdk_cache'
+  node_labels:
+    build:
+      8: 'hw.arch.x86 && sw.os.ubuntu.16'
+      9: 'hw.arch.x86 && sw.os.ubuntu.16'
+      10: 'hw.arch.x86 && sw.os.ubuntu.16'
+    test:
+      8: 'hw.arch.x86 && sw.os.ubuntu.16'
+      9: 'hw.arch.x86 && sw.os.ubuntu.16'
+      10: 'hw.arch.x86 && sw.os.ubuntu.16'
+  extra_configure_options:
+    8: '--with-cmake --disable-ddr'
+    9: '--with-cmake --disable-ddr'
+    10: '--with-cmake --disable-ddr'
+  extra_make_options:
+    8: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
+    9: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
+    10: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
+#========================================#
 # Linux x86 64bits Large Heap
 #========================================#
 linux_x86-64:

--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -43,6 +43,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     compiler/optimizer/JitProfiler.cpp \
     compiler/optimizer/JProfilingBlock.cpp \
     compiler/optimizer/JProfilingValue.cpp \
+    compiler/optimizer/JProfilingRecompLoopTest.cpp \
     compiler/optimizer/LiveVariablesForGC.cpp \
     compiler/optimizer/LoopAliasRefiner.cpp \
     compiler/optimizer/MonitorElimination.cpp \

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -207,7 +207,8 @@ J9::Recompilation::beforeOptimization()
    //
    if (self()->isProfilingCompilation()) // this asks the bodyInfo
       {
-      _useSampling = _compilation->getProfilingMode() != JitProfiling;
+      //_useSampling = _compilation->getProfilingMode() != JitProfiling;
+      _useSampling = false;
       self()->findOrCreateProfileInfo()->setProfilingCount     (DEFAULT_PROFILING_COUNT);
       self()->findOrCreateProfileInfo()->setProfilingFrequency (DEFAULT_PROFILING_FREQUENCY);
       }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -292,6 +292,11 @@ j9jit_testarossa_err(
             if (fe->isAsyncCompilation())
                return 0; // early return because the method is queued for compilation
             }
+         // If PersistentJittedBody contains the profile Info and has BlockFrequencyInfo, it will set the 
+         // isQueuedForRecompilation field which can be used by the jitted code at runtime to skip the profiling
+         // code if it has made request to recompile this method. 
+         if (jbi->getProfileInfo() != NULL && jbi->getProfileInfo()->getBlockFrequencyInfo() != NULL)
+            jbi->getProfileInfo()->getBlockFrequencyInfo()->setIsQueuedForRecompilation();
          event._eventType = TR_MethodEvent::OtherRecompilationTrigger;
          }
       }

--- a/runtime/compiler/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,6 +117,9 @@ J9::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFacto
          break;
       case OMR::jProfilingBlock:
          _flags.set(doesNotRequireAliasSets);
+         break;
+      case OMR::jProfilingRecompLoopTest:
+         _flags.set(requiresStructure);
          break;
       default:
          // do nothing

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -72,6 +72,7 @@
 #include "optimizer/OSRGuardRemoval.hpp"
 #include "optimizer/JProfilingBlock.hpp"
 #include "optimizer/JProfilingValue.hpp"
+#include "optimizer/JProfilingRecompLoopTest.hpp"
 #include "runtime/J9Profiler.hpp"
 #include "optimizer/UnsafeFastPath.hpp"
 #include "optimizer/VarHandleTransformer.hpp"
@@ -279,6 +280,7 @@ static const OptimizationStrategy coldStrategyOpts[] =
    { OMR::rematerialization                                                     },
    { OMR::compactNullChecks,                         OMR::IfEnabled                  },
    { OMR::signExtendLoadsGroup,                      OMR::IfEnabled                  },
+   { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
    { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::trivialDeadTreeRemoval,                                               },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfAOTAndEnabled            },
@@ -364,6 +366,7 @@ static const OptimizationStrategy warmStrategyOpts[] =
    { OMR::globalDeadStoreElimination,                OMR::IfVoluntaryOSR            },
    { OMR::arraysetStoreElimination                                              },
    { OMR::checkcastAndProfiledGuardCoalescer                                    },
+   { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
    { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                  },
    { OMR::globalDeadStoreGroup,                                                 },
@@ -398,6 +401,7 @@ static const OptimizationStrategy reducedWarmStrategyOpts[] =
    { OMR::localCSE                                                              },
    { OMR::treeSimplification,                        OMR::MarkLastRun                 },
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // cleanup at the end
+   { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
    { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                  },
    { OMR::endOpts                                                               }
@@ -459,6 +463,7 @@ const OptimizationStrategy hotStrategyOpts[] =
    { OMR::localValuePropagation,                 OMR::MarkLastRun              },
    { OMR::arraycopyTransformation      },
    { OMR::checkcastAndProfiledGuardCoalescer                              },
+   { OMR::jProfilingRecompLoopTest,              OMR::IfLoops                  },
    { OMR::jProfilingValue,                           OMR::MustBeDone           },
    { OMR::tacticalGlobalRegisterAllocatorGroup,  OMR::IfEnabled                },
    { OMR::globalDeadStoreElimination,            OMR::IfMoreThanOneBlock       }, // global dead store removal
@@ -708,6 +713,7 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // cleanup at the end
    { OMR::treeSimplification,                        OMR::IfEnabledMarkLastRun       }, // Simplify non-normalized address computations introduced by prefetch insertion
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                  }, // final cleanup before opcode expansion
+   { OMR::jProfilingRecompLoopTest,                  OMR::IfLoops                    },
    { OMR::jProfilingValue,                           OMR::MustBeDone                 },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup, OMR::IfEnabled                  },
    { OMR::globalDeadStoreGroup,                                                 },
@@ -811,6 +817,8 @@ J9::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *method
       new (comp->allocator()) TR::OptimizationManager(self(), TR_OSRGuardRemoval::create, OMR::osrGuardRemoval);
    _opts[OMR::jProfilingBlock] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_JProfilingBlock::create, OMR::jProfilingBlock);
+   _opts[OMR::jProfilingRecompLoopTest] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR_JProfilingRecompLoopTest::create, OMR::jProfilingRecompLoopTest);
    _opts[OMR::jProfilingValue] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_JProfilingValue::create, OMR::jProfilingValue);
    // NOTE: Please add new J9 optimizations here!

--- a/runtime/compiler/optimizer/JProfilingBlock.cpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.cpp
@@ -903,16 +903,6 @@ TR_JProfilingBlock::generateBlockRawCountCalculationNode(TR::Compilation *comp, 
  */   
 void TR_JProfilingBlock::addRecompilationTests(TR_BlockFrequencyInfo *blockFrequencyInfo, TR_BitVector **componentCounters)
    {
-   // add invocation check to the top of the method
-   int32_t *thresholdLocation = NULL;
-   if (comp()->getMethodSymbol()->mayHaveNestedLoops())
-      thresholdLocation = &nestedLoopRecompileThreshold;
-   else if (comp()->getMethodSymbol()->mayHaveLoops())
-      thresholdLocation = &loopRecompileThreshold;
-   else
-      thresholdLocation = &recompileThreshold;
-
-
    int32_t startBlockNumber = comp()->getStartBlock()->getNumber();
    blockFrequencyInfo->setEntryBlockNumber(startBlockNumber);
 
@@ -931,11 +921,11 @@ void TR_JProfilingBlock::addRecompilationTests(TR_BlockFrequencyInfo *blockFrequ
          guardBlock1->append(enableTree);
          }
 
-      int32_t profilingCompileThreshold2 = comp()->getOptions()->getJProfilingMethodRecompThreshold();
+      static int32_t profilingCompileThreshold = comp()->getOptions()->getJProfilingMethodRecompThreshold();
 
-      traceMsg(comp(),"Profiling Compile Threshold for method = %d\n", profilingCompileThreshold2);
+      traceMsg(comp(),"Profiling Compile Threshold for method = %d\n", profilingCompileThreshold);
       TR::Block *guardBlock2 = TR::Block::createEmptyBlock(node, comp(), originalFirstBlock->getFrequency());
-      TR::Node *recompThreshold = TR::Node::iconst(node, profilingCompileThreshold2);
+      TR::Node *recompThreshold = TR::Node::iconst(node, profilingCompileThreshold);
       TR::Node *cmpFlagNode = TR::Node::createif(TR::ificmplt, root, recompThreshold, originalFirstBlock->getEntry());
       TR::TreeTop *cmpFlag = TR::TreeTop::create(comp(), cmpFlagNode);
       cmpFlagNode->setIsProfilingCode();

--- a/runtime/compiler/optimizer/JProfilingBlock.cpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.cpp
@@ -924,7 +924,6 @@ void TR_JProfilingBlock::addRecompilationTests(TR_BlockFrequencyInfo *blockFrequ
 
       TR::Block *guardBlock1 = TR::Block::createEmptyBlock(node, comp(), originalFirstBlock->getFrequency());
          {
-         //TR::SymbolReference *symRef = comp()->getSymRefTab()->createKnownStaticDataSymbolRef(blockFrequencyInfo->getEnableJProfilingRecompilation(), TR::Int32);
          TR::Node *enableLoad = TR::Node::createWithSymRef(node, TR::iload, 0, blockFrequencyInfo->getOrCreateSymRefForIsQueuedForRecompilation(comp()));
          TR::Node *enableTest = TR::Node::createif(TR::ificmpeq, enableLoad, TR::Node::iconst(node, -1), originalFirstBlock->getEntry());
          TR::TreeTop *enableTree = TR::TreeTop::create(comp(), enableTest);

--- a/runtime/compiler/optimizer/JProfilingBlock.hpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.hpp
@@ -46,7 +46,6 @@ class TR_JProfilingBlock : public TR::Optimization
    static int32_t nestedLoopRecompileThreshold;
    static int32_t loopRecompileThreshold;
    static int32_t recompileThreshold;
-   static int32_t profilingCompileThreshold;
    TR_JProfilingBlock(TR::OptimizationManager *manager)
       : TR::Optimization(manager)
       {}

--- a/runtime/compiler/optimizer/JProfilingBlock.hpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,7 +57,7 @@ class TR_JProfilingBlock : public TR::Optimization
 
    virtual int32_t perform();
    virtual const char * optDetailString() const throw();
-
+   static TR::Node *generateBlockRawCountCalculationNode(TR::Compilation *comp, int32_t blockNumber, TR::Node *node, TR_BlockFrequencyInfo *bfi, TR_BitVector **componentCounters = NULL);
    protected:
    void computeMinimumSpanningTree(BlockParents &parents, BlockPriorityQueue &Q, TR::StackMemoryRegion &stackMemoryRegion);
    int32_t processCFGForCounting(BlockParents &parent, TR::BlockChecklist &countedBlocks, TR::CFGEdge &loopBack);

--- a/runtime/compiler/optimizer/JProfilingRecompLoopTest.cpp
+++ b/runtime/compiler/optimizer/JProfilingRecompLoopTest.cpp
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include "JProfilingRecompLoopTest.hpp"
+#include "il/Block.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/Checklist.hpp"
+#include "infra/ILWalk.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "il/Node_inlines.hpp"
+#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "ras/DebugCounter.hpp"
+#include "control/Recompilation.hpp"              // for TR_Recompilation, etc
+#include "control/RecompilationInfo.hpp"              // for TR_Recompilation, etc
+#include "codegen/CodeGenerator.hpp"
+#include "optimizer/TransformUtil.hpp"            // for TransformUtil
+#include "optimizer/JProfilingBlock.hpp"
+
+
+/**
+ * Walks the TR_RegionStructure counting loops to get the nesting depth of the block
+ */ 
+int32_t TR_JProfilingRecompLoopTest::getLoopNestingDepth(TR::Compilation *comp, TR::Block *block)
+   {
+   TR_RegionStructure *region = block->getParentStructureIfExists(comp->getFlowGraph());
+   int32_t nestingDepth = 0;
+   while (region && !region->isAcyclic())
+      {
+      nestingDepth++;
+      region = region->getParent();
+      }
+   return nestingDepth;
+   }
+
+/**
+ * A utility function that iterates through the TR::list of byte code info and checks if passed bytecode info exists in list
+ * by checking bytecode index and caller index of the bytecode info
+ */ 
+bool
+TR_JProfilingRecompLoopTest::isByteCodeInfoInCurrentTestLocationList(TR_ByteCodeInfo &bci, TR::list<TR_ByteCodeInfo, TR::Region&> &addedLocationBCIList)
+   {
+   for (auto iter = addedLocationBCIList.begin(), listEnd = addedLocationBCIList.end(); iter != listEnd; ++iter)
+      {
+      TR_ByteCodeInfo iterBCI = *iter;
+      if (iterBCI.getByteCodeIndex() == bci.getByteCodeIndex() && iterBCI.getCallerIndex() == bci.getCallerIndex())
+         return true;   
+      }
+   return false;
+   }
+
+int32_t
+TR_JProfilingRecompLoopTest::perform()
+   {
+   if (comp()->getOption(TR_EnableJProfiling))
+      {
+      if (trace())
+         traceMsg(comp(), "JProfiling has been enabled, run JProfiling\n");
+      }
+   else if (comp()->getProfilingMode() == JProfiling)
+      {
+      if (trace())
+         traceMsg(comp(), "JProfiling has been enabled for profiling compilations, run JProfilingRecompLoopTest\n");
+      }
+   else
+      {
+      if (trace())
+         traceMsg(comp(), "JProfiling has not been enabled, skip JProfilingRecompLoopTest\n");
+      return 0;
+      }
+   RecompilationTestLocations testLocations(RecompilationTestLocationAllocator(comp()->trMemory()->currentStackRegion()));
+   TR::TreeTop *cursor = comp()->getStartTree();
+   TR::CFG *cfg = comp()->getFlowGraph();
+   TR::Block *currentBlock = NULL;
+   TR::list<TR_ByteCodeInfo, TR::Region&> addedLocationBCIList(comp()->trMemory()->currentStackRegion());
+   while (cursor)
+      {
+      if (cursor->getNode()->getOpCodeValue() == TR::BBStart)
+         {
+         currentBlock = cursor->getNode()->getBlock();
+         /**
+           * As we are already walking down the tree tops, we can get the enclosing block by tracking TR::BBStart nodes and currentBlock contains
+           * this information. 
+           * We also keep local list of ByteCodeInfo for each test locations (asyncchecknode) in the extended basic blocks.
+           * This can avoid adding multiple tests for multiple locations with same byte code info in extended basic block.
+           * As soon as we encounter a block which is not extenstion of previous block, we clear the list of byte code info.
+           */    
+         if (!currentBlock->isExtensionOfPreviousBlock() && !addedLocationBCIList.empty())
+            addedLocationBCIList.clear();
+         }
+      else if (cursor->getNode()->getOpCodeValue() == TR::asynccheck)
+         {
+         TR_ASSERT_FATAL(currentBlock != NULL,"We should have encountered BBStart before and should have the enclosing block");
+         if (currentBlock->getStructureOf()->getContainingLoop() != NULL)
+            {
+            TR_ByteCodeInfo bci = cursor->getNode()->getByteCodeInfo();
+            // If the list of TR_ByteCodeInfo used to track the tree tops in extended basic blocks is empty or the bytecode info
+            // of current asynccheck node does not match with any tracked bytecode info, we will add the test otherwise skip it.   
+            if (addedLocationBCIList.empty() || !isByteCodeInfoInCurrentTestLocationList(bci, addedLocationBCIList))
+               {
+               addedLocationBCIList.push_back(bci);
+               int32_t loopDepth = getLoopNestingDepth(comp(), currentBlock);
+               testLocations.push_back(std::make_pair(std::make_pair(cursor, currentBlock),loopDepth));
+               }
+            }
+         }
+      cursor = cursor->getNextTreeTop(); 
+      }
+   if (!testLocations.empty())
+      addRecompilationTests(comp(), testLocations);
+   return 1;
+   }
+
+/**   \brief   Adds trees and control flow to check the loop raw frequency and trip recompilation of the method
+ *             if it has spent enough time in the loop. 
+ *    \details Iterates a list of recompilation test locations passed by callee and adds the following trees and blocks.
+ *             -----------------
+ *             |...            |    <-- originalBlock
+ *             |testLocationTT |
+ *             |...            |
+ *             -----------------
+ *             Test location block shown above becomes,
+ *             ----------------------------------------------
+ *             |...                                         |  <--- originalBlock
+ *             |testLocationTT                              |
+ *             |ifcmple goto remainingCodeBlock             |---------------------------------------
+ *             |  rawFrequencyOfLoopContainingTestLocation  |                                      |
+ *             |  recompilationThreshold                    |                                      |
+ *             ----------------------------------------------                                      |
+ *                                  |                                                              |
+ *                                  |                                                              |
+ *                                  V                                                              |
+ *             -----------------------------------------------                                     |
+ *             |call TR_jitRetranslateCallerWithPrep         | <--- callRecompilation block        |
+ *             |       loadaddr startPC                      |                                     |
+ *             |       loadaddr                              |                                     |
+ *             -----------------------------------------------                                     |
+ *                                  |                                                              |
+ *                                  |                                                              |
+ *                                  V                                                              |
+ *                   --------------------------------                                              |
+ *                   |treeTops after insertion Point|  <--- remainingCodeBlock                     |
+ *                   |from original block           |                                              |
+ *                   |...                           |<----------------------------------------------   
+ *                   --------------------------------
+ *    \param comp Current compilation object
+ *    \param testLocations RecompilationTestLocation list containing TreeTops after which test are required to be added
+ *                         And corresponding to that location, a loop nesting depth 
+ */
+
+void 
+TR_JProfilingRecompLoopTest::addRecompilationTests(TR::Compilation *comp, RecompilationTestLocations &testLocations)
+   {
+   TR_PersistentProfileInfo *profileInfo = comp->getRecompilationInfo()->findOrCreateProfileInfo();
+   TR_BlockFrequencyInfo *bfi = TR_BlockFrequencyInfo::get(profileInfo);
+   TR::CFG *cfg = comp->getFlowGraph();
+   cfg->setStructure(NULL);
+
+   // Following environment sets up the base recompilation threshold for the loop.
+   // This base recompile threshold in conjunction with the depth in loop is compared with the raw count of the
+   // loop to decide if we have run this loop enough time to trip method recompilation. 
+   // TODO: Currently set base recompilation threshold needs some tuning. 
+   static char *p = feGetEnv("TR_LoopRecompilationThresholdBase");
+   static int32_t recompileThreshold = p ? atoi(p) : 4096;
+   // Iterating backwards to avoid losing original block associated with the test location tree tops in case we have found multiple
+   // recompilation test location in same block.
+   for (auto testLocationIter = testLocations.rbegin(), testLocationEnd = testLocations.rend(); testLocationIter != testLocationEnd; ++testLocationIter)
+      {
+      TR::TreeTop *asyncCheckTreeTop = testLocationIter->first.first;
+      TR::Block *originalBlock = testLocationIter->first.second;
+      TR::Node *node = asyncCheckTreeTop->getNode();
+      int32_t depth = testLocationIter->second;
+      if (trace())
+         traceMsg(comp, "block_%d, n%dn, depth = %d\n",originalBlock->getNumber(), asyncCheckTreeTop->getNode()->getGlobalIndex(), depth);
+      TR_ByteCodeInfo bci = asyncCheckTreeTop->getNode()->getByteCodeInfo();
+      
+      TR::Node *root = TR_JProfilingBlock::generateBlockRawCountCalculationNode(comp, bfi->getOriginalBlockNumberToGetRawCount(bci,comp), node, bfi);
+      
+      // If we got a bad counters/ bad block frequency info, above API would return NULL, if that is the case we can not generate a recompilation test for that location.
+      if (!root)
+         {
+         TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp, "jprofiling.instrument/badcounters/(%s)", comp->signature()));
+         continue;
+         }
+      dumpOptDetails(comp, "%s Add recompilation test after asyncCheck node n%dn\n", optDetailString(), node->getGlobalIndex());
+
+      //Splitting the original block from AsyncCheckTT
+      TR::Block *remainingCodeBlock = originalBlock->split(asyncCheckTreeTop->getNextTreeTop(), cfg, true, true);
+      TR::Block *callRecompileBlock = TR::Block::createEmptyBlock(node, comp, UNKNOWN_COLD_BLOCK_COUNT);
+      callRecompileBlock->setIsCold(true);
+      
+      TR::Node *callNode = TR::Node::createWithSymRef(node, TR::icall, 2, comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_jitRetranslateCallerWithPrep, false, false, true));
+      callNode->setAndIncChild(0, TR::Node::createWithSymRef(node, TR::loadaddr, 0, comp->getSymRefTab()->findOrCreateStartPCSymbolRef()));
+      callNode->setAndIncChild(1, TR::Node::createWithSymRef(node, TR::loadaddr, 0, comp->getSymRefTab()->findOrCreateCompiledMethodSymbolRef()));
+      TR::TreeTop *callTree = TR::TreeTop::create(comp, TR::Node::create(node, TR::treetop, 1, callNode));
+      callTree->getNode()->setIsProfilingCode();
+      callRecompileBlock->append(callTree);
+      cfg->addNode(callRecompileBlock);
+      
+      TR::Node *loadBaseThreshold = TR::Node::createWithSymRef(node, TR::iload, 0, comp->getSymRefTab()->createKnownStaticDataSymbolRef(&recompileThreshold, TR::Int32));
+      //TR::Node *adjustThreshold = TR::Node::create(node, TR::ishl, 2, loadBaseThreshold, TR::Node::iconst(node, (depth-1)*3));
+      // threshold for this particular test location is calculated from the base recompile threshold and the nesting depth of the loop
+      // If threshold becomes larger than the maximum signed 32-Bit int then it will use the max value allowed as threshold.
+      int32_t threshold = recompileThreshold << ((depth-1)*1);  
+      TR::Node *cmpNode = TR::Node::createif(TR::ificmple, root, TR::Node::iconst(node, threshold > 0 ? threshold : TR::getMaxSigned<TR::Int32>()-1), remainingCodeBlock->getEntry());
+      
+      TR::TreeTop *cmpFlag = TR::TreeTop::create(comp, asyncCheckTreeTop, cmpNode);
+      remainingCodeBlock->getEntry()->insertTreeTopsBeforeMe(callRecompileBlock->getEntry(), callRecompileBlock->getExit());
+      cfg->addEdge(TR::CFGEdge::createEdge(callRecompileBlock, remainingCodeBlock, comp->trMemory()));
+      cfg->addEdge(TR::CFGEdge::createEdge(originalBlock, callRecompileBlock, comp->trMemory()));
+      if (trace())
+         traceMsg(comp,"\t\t Newly created recompilation Test : n%dn in block_%d\n\t\tRecompilation Call in block_%d\n",
+            callNode->getGlobalIndex(), originalBlock->getNumber(), callRecompileBlock->getNumber());
+      }
+   }
+
+const char *
+TR_JProfilingRecompLoopTest::optDetailString() const throw()
+   {
+   return "O^O JPROFILER RECOMP TEST: ";
+   }

--- a/runtime/compiler/optimizer/JProfilingRecompLoopTest.hpp
+++ b/runtime/compiler/optimizer/JProfilingRecompLoopTest.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <stdint.h>                           // for int32_t
+#include "optimizer/Optimization.hpp"         // for Optimization
+#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "infra/Checklist.hpp"                // fir NodeChecklist
+#include "runtime/J9Profiler.hpp"
+#include "optimizer/Structure.hpp"
+/**
+ * Class TR_JProfilingRecompLoopTest
+ * ===================================
+ *
+ * When jProfiling in compilations are enabled, we have only one recompilation
+ * test that counts the method invocation to trip up recompilation. For work loads
+ * where we are spending a lot of time in loops, we are hitting a risk where we
+ * are running into compiled method body with profiling trees if we just rely on
+ * method invocations. This optimization scans the method body and puts 
+ * recompilation test after asynccheck node to consider number of times a loop
+ * is running.
+ */
+class TR_JProfilingRecompLoopTest : public TR::Optimization
+   {
+   public:
+   typedef TR::typed_allocator<std::pair<std::pair<TR::TreeTop*, TR::Block*>, int32_t>, TR::Region &> RecompilationTestLocationAllocator;
+   typedef std::list<std::pair<std::pair<TR::TreeTop*, TR::Block*>, int32_t>, RecompilationTestLocationAllocator> RecompilationTestLocations;
+   TR_JProfilingRecompLoopTest(TR::OptimizationManager *manager)
+      : TR::Optimization(manager)
+      {}
+   static TR::Optimization *create(TR::OptimizationManager *manager)
+      {
+      return new (manager->allocator()) TR_JProfilingRecompLoopTest(manager);
+      }
+   virtual int32_t perform();
+   virtual const char *optDetailString() const throw();
+   void addRecompilationTests(TR::Compilation *comp, RecompilationTestLocations &testLocations);
+   int32_t getLoopNestingDepth(TR::Compilation *comp, TR::Block *block);
+   bool isByteCodeInfoInCurrentTestLocationList(TR_ByteCodeInfo &bci, TR::list<TR_ByteCodeInfo, TR::Region&> &addedLocationBCIList);
+   };

--- a/runtime/compiler/optimizer/Optimizations.enum
+++ b/runtime/compiler/optimizer/Optimizations.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,3 +33,4 @@
    OPTIMIZATION(osrGuardRemoval)
    OPTIMIZATION(jProfilingBlock)
    OPTIMIZATION(jProfilingValue)
+   OPTIMIZATION(jProfilingRecompLoopTest)

--- a/runtime/compiler/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilation.cpp
@@ -167,7 +167,7 @@ TR::Instruction *TR_PPCRecompilation::generatePrologue(TR::Instruction *cursor)
       else
          {
          // This only applies to JitProfiling, as JProfiling uses sampling
-         TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
+         //TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
 
          cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, firstNode, cr0, gr0,   0, cursor);
          // this is just padding for consistent code length

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1929,6 +1929,39 @@ TR_BlockFrequencyInfo::getRawCount(TR::ResolvedMethodSymbol *resolvedMethod, TR_
       frequency = getRawCount(searchBCI, callSiteInfo, maxCount, comp);
       }
    return frequency;
+   }
+
+/**   \brief Returns block number of the original block in which current byteCodeInfo was created.
+ *    \details
+ *          It finds the byte code info of the start of the block in which passed bci was originally
+ *          created and returns the block number of that block from the stored information.
+ *          It is useful when we are trying to associate the profiling information with the node which might
+ *          have moved to different blocks with different bci
+ *    \param bci TR_ByteCodeInfo for which original block number is searched for
+ *    \param comp Current compilation object
+ *    \return block number of the original block bci belongs to.
+ *            WARNING: If consumer of this API uses this to to get the profiled data in later compilation and
+ *            requested BCI was not inlined before, it returns -1.
+ */
+int32_t
+TR_BlockFrequencyInfo::getOriginalBlockNumberToGetRawCount(TR_ByteCodeInfo &bci, TR::Compilation *comp)
+   {
+   int32_t callerIndex = bci.getCallerIndex();
+   TR::ResolvedMethodSymbol *resolvedMethod = callerIndex < 0 ? comp->getMethodSymbol() : comp->getInlinedResolvedMethodSymbol(callerIndex);
+   int32_t byteCodeToSearch = resolvedMethod->getProfilingByteCodeIndex(bci.getByteCodeIndex());
+   TR_ByteCodeInfo searchBCI = bci;
+   searchBCI.setByteCodeIndex(byteCodeToSearch);
+   bool currentCallSiteInfo = TR_CallSiteInfo::getCurrent(comp) == _callSiteInfo; 
+   for (auto i=0; i < _numBlocks; ++i)
+      {
+      if (currentCallSiteInfo && _callSiteInfo->hasSameBytecodeInfo(_blocks[i], searchBCI, comp) ||
+            (!currentCallSiteInfo && _blocks[i].getCallerIndex() == searchBCI.getCallerIndex() && _blocks[i].getByteCodeIndex() == searchBCI.getByteCodeIndex()))
+         {
+         traceMsg(comp, "Get frequency from original block_%d\n", i);
+         return i;
+         }
+      }
+   return -1;
    }
 
 int32_t

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1643,7 +1643,9 @@ TR_BlockFrequencyInfo::TR_BlockFrequencyInfo(TR_CallSiteInfo *callSiteInfo, int3
    _blocks(blocks),
    _frequencies(frequencies),
    _counterDerivationInfo(NULL),
-   _entryBlockNumber(-1)
+   _entryBlockNumber(-1),
+   _isQueuedForRecompilation(0),
+   _isQueuedForRecompilationSymRef(NULL)
    {
    }
 
@@ -1668,7 +1670,9 @@ TR_BlockFrequencyInfo::TR_BlockFrequencyInfo(
       NULL
       ),
    _counterDerivationInfo(NULL),
-   _entryBlockNumber(-1)
+   _entryBlockNumber(-1),
+   _isQueuedForRecompilation(0),
+   _isQueuedForRecompilationSymRef(NULL)
    {
    for (size_t i = 0; i < _numBlocks; ++i)
       {
@@ -1697,6 +1701,14 @@ TR_BlockFrequencyInfo::TR_BlockFrequencyInfo(
             );
          }
       }
+   }
+
+TR::SymbolReference *
+TR_BlockFrequencyInfo::getOrCreateSymRefForIsQueuedForRecompilation(TR::Compilation *comp)
+   {
+   if (_isQueuedForRecompilationSymRef == NULL)
+      _isQueuedForRecompilationSymRef = comp->getSymRefTab()->createKnownStaticDataSymbolRef(&_isQueuedForRecompilation, TR::Int32);
+   return _isQueuedForRecompilationSymRef;
    }
 
 TR_BlockFrequencyInfo::~TR_BlockFrequencyInfo()

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -633,6 +633,7 @@ class TR_BlockFrequencyInfo
    int32_t getFrequencyInfo(TR::Block *block, TR::Compilation *comp);
    int32_t getFrequencyInfo(TR_ByteCodeInfo &bci, TR::Compilation *comp, bool normalizeForCallers = true, bool trace = true);
    void    setCounterDerivationInfo(TR_BitVector **counterDerivationInfo) { _counterDerivationInfo = counterDerivationInfo; }
+   TR_BitVector ** getCounterDerivativeInfo() { return _counterDerivationInfo; }
    void    setEntryBlockNumber(int32_t number) { _entryBlockNumber = number; }
    bool    isJProfilingData() { return _counterDerivationInfo != NULL; }
    static int32_t *getEnableJProfilingRecompilation() { return &_enableJProfilingRecompilation; }
@@ -643,7 +644,7 @@ class TR_BlockFrequencyInfo
    int32_t getCallCount();
    int32_t getMaxRawCount(int32_t callerIndex);
    int32_t getMaxRawCount();
-
+   int32_t getOriginalBlockNumberToGetRawCount(TR_ByteCodeInfo &bci, TR::Compilation *comp);
    private:
    int32_t getRawCount(TR::ResolvedMethodSymbol *resolvedMethod, TR_ByteCodeInfo &bci, TR_CallSiteInfo *callSiteInfo, int64_t maxCount, TR::Compilation *comp);
    int32_t getRawCount(TR_ByteCodeInfo &bci, TR_CallSiteInfo *callSiteInfo, int64_t maxCount, TR::Compilation *comp);

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -638,6 +638,9 @@ class TR_BlockFrequencyInfo
    bool    isJProfilingData() { return _counterDerivationInfo != NULL; }
    static int32_t *getEnableJProfilingRecompilation() { return &_enableJProfilingRecompilation; }
    static void    enableJProfilingRecompilation() { _enableJProfilingRecompilation = -1; }
+   void setIsQueuedForRecompilation() { _isQueuedForRecompilation = -1; }
+   int32_t *getIsQueuedForRecompilation() { return &_isQueuedForRecompilation; }
+   TR::SymbolReference *getOrCreateSymRefForIsQueuedForRecompilation(TR::Compilation *comp);
 
    void dumpInfo(TR::FILE *);
 
@@ -661,6 +664,9 @@ class TR_BlockFrequencyInfo
    TR_BitVector    ** _counterDerivationInfo;
    int32_t         _entryBlockNumber;
    static int32_t  _enableJProfilingRecompilation;
+   // Following flag is checked at runtime to know if we have queued this method for recompilation and skip the profiling code
+   int32_t         _isQueuedForRecompilation;
+   TR::SymbolReference *_isQueuedForRecompilationSymRef;
    };
 
 TR_BlockFrequencyInfo * TR_BlockFrequencyInfo::get(TR_PersistentProfileInfo * profileInfo)

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -462,7 +462,7 @@ createInternalPtrStackMapInJ9Format(
       totalPointers++;
       }
 
-   if (totalPointers >= fej9->maxInternalPlusPinningArrayPointers(comp))
+   if (totalPointers >= fej9->maxInternalPlusPinningArrayPointers(comp) && !comp->isProfilingCompilation())
       {
       comp->failCompilation<TR::ExcessiveComplexity>("Failed to create Internal Ptr Stack Map in J9 Format");
       }

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -182,7 +182,7 @@ TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
          else
             {
             // This only applies to JitProfiling, as JProfiling uses sampling
-            TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
+            //TR_ASSERT(_compilation->getProfilingMode() == JitProfiling, "JProfiling should use sampling to trigger recompilation");
             cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, CMP4MemImms, mRef, 0, cg());
             }
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -12311,6 +12311,8 @@ TR_J9VMBase::generateBinaryEncodingPrologue(
 
    data->jitTojitStart = data->preProcInstruction->getNext();
 
+   if (comp->isProfilingCompilation())
+      cg->generateDebugCounter(data->jitTojitStart, TR::DebugCounter::debugCounterName(comp, "profiledMethodCall/(%s)/", comp->signature()));
    // Generate code to setup argument registers for interpreter to JIT transfer
    // This piece of code is right before JIT-JIT entry point
    //


### PR DESCRIPTION
When jProfiling in compilation is enabled, add a test after aynchcheck node
in loop to calculate the frequency and trip up recompilation of the method
if reached certain threshold.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>