### PR TITLE
Add functions for JVM signal support

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4811,11 +4811,12 @@ typedef struct J9InternalVMFunctions {
 	BOOLEAN ( *updateVMRuntimeState)(struct J9JavaVM *vm, U_32 newState);
 	U_32 ( *getVMMinIdleWaitTime)(struct J9JavaVM *vm);
 #if defined(J9VM_RAS_EYECATCHERS)
-	void (*rasSetServiceLevel)(struct J9JavaVM *vm, const char *runtimeVersion);
+	void ( *rasSetServiceLevel)(struct J9JavaVM *vm, const char *runtimeVersion);
 #endif /* J9VM_RAS_EYECATCHERS */
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-	void (*flushProcessWriteBuffers)(struct J9JavaVM *vm);
+	void ( *flushProcessWriteBuffers)(struct J9JavaVM *vm);
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
+	IDATA ( *registerPredefinedHandler)(struct J9JavaVM *vm, U_32 signal, void **oldOSHandler);
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -781,6 +781,9 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sig_protect(param1,param2,param3,param4,param5,param6) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_protect((OMRPortLibrary*)privatePortLibrary,(omrsig_protected_fn)param1,param2,(omrsig_handler_fn)param3,param4,param5,param6)
 #define j9sig_can_protect(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_can_protect(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #define j9sig_set_async_signal_handler(param1,param2,param3) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_async_signal_handler((OMRPortLibrary*)privatePortLibrary,(omrsig_handler_fn)param1,param2,param3)
+#define j9sig_set_single_async_signal_handler(param1,param2,param3,param4) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_single_async_signal_handler((OMRPortLibrary*)privatePortLibrary,(omrsig_handler_fn)param1,param2,param3,param4)
+#define j9sig_map_os_signal_to_portlib_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_os_signal_to_portlib_signal((OMRPortLibrary*)privatePortLibrary,param1)
+#define j9sig_map_portlib_signal_to_os_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_portlib_signal_to_os_signal((OMRPortLibrary*)privatePortLibrary,param1)
 #define j9sig_info(param1,param2,param3,param4,param5) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4,param5)
 #define j9sig_info_count(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info_count(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9sig_set_options(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_options(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1580,6 +1580,18 @@ initializeClassPathEntry (J9JavaVM * javaVM, J9ClassPathEntry *cpEntry);
 BOOLEAN
 setBootLoaderModulePatchPaths(J9JavaVM * javaVM, J9Module * j9module, const char * moduleName);
 
+/**
+ * @brief Register jvminit.c::predefinedHandlerWrapper using j9sig_set_*async_signal_handler
+ * for the specified signal
+ *
+ * @param vm pointer to a J9JavaVM
+ * @param signal integer value of the signal
+ * @param oldOSHandler points to the old signal handler function
+ *
+ * @return 0 on success and non-zero on failure
+ */
+IDATA
+registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler);
 
 /* ---------------- romutil.c ---------------- */
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -361,4 +361,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
 	flushProcessWriteBuffers,
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
+	registerPredefinedHandler,
 };

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -767,3 +767,6 @@ TraceExit=Trc_VM_sendResolveMethodTypeRefInto_Exit Overhead=1 Level=5 Template="
 TraceException=Trc_VM_CgroupSubsystemsNotEnabled Overhead=1 Level=1 Template="Cgroup subsystems available: 0x%llx, enabled: 0x%llx"
 
 TraceException=Trc_VM_failedtoAllocateGuardPage noEnv Overhead=1 Level=1 Template="Failed to allocate exclusive guard page of size %zu"
+
+TraceException=Trc_VM_registerPredefinedHandler_invalidPortlibSignalFlag NoEnv Overhead=1 Level=1 Template="registerPredefinedHandler - invalid portlib signal flag: %zu"
+TraceEvent=Trc_VM_signalDispatch_signalValue Overhead=1 Level=3 Template="signalDispatch - signal value: %d"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -317,6 +317,12 @@ static BOOLEAN isSSE2SupportedOnX86();
 static BOOLEAN isPPC64bit(void);
 #endif /* (AIXPPC || LINUXPPC) & !J9OS_I5 */
 
+static UDATA predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *userData);
+static void signalDispatch(J9VMThread *vmThread, I_32 sigNum);
+
+J9_DECLARE_CONSTANT_UTF8(j9_int_void, "(I)V");
+J9_DECLARE_CONSTANT_UTF8(j9_dispatch, "dispatch");
+
 #if defined(COUNT_BYTECODE_PAIRS)
 static jint
 initializeBytecodePairs(J9JavaVM *vm)
@@ -602,9 +608,11 @@ freeJavaVM(J9JavaVM * vm)
 	j9sig_set_async_signal_handler(sigxfszHandler, NULL, 0);
 #endif
 
+	/* Remove the predefinedHandlerWrapper. */
+	j9sig_set_async_signal_handler(predefinedHandlerWrapper, vm, 0);
+
 	/* Unload before trace engine exits */
 	UT_MODULE_UNLOADED(J9_UTINTERFACE_FROM_VM(vm));
-
 
 	if (0 != vm->vmRuntimeStateListener.minIdleWaitTime) {
 		stopVMRuntimeStateListener(vm);
@@ -6202,6 +6210,118 @@ shutDownHookWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo
 
 }
 #endif
+
+/**
+ * Invoke jdk.internal.misc.Signal.dispatch(int number) in Java 9 and
+ * onwards. Invoke sun.misc.Signal.dispatch(int number) in Java 8.
+ *
+ * @param vmThread pointer to a J9VMThread
+ * @param signal integer value of the signal
+ *
+ * @return void
+ */
+static void
+signalDispatch(J9VMThread *vmThread, I_32 signal) {
+	J9JavaVM *vm = vmThread->javaVM;
+	J9NameAndSignature nas = {0};
+	I_32 args[] = {signal};
+
+	Trc_VM_signalDispatch_signalValue(vmThread, signal);
+
+	nas.name = (J9UTF8 *)&j9_dispatch;
+	nas.signature = (J9UTF8 *)&j9_int_void;
+
+	enterVMFromJNI(vmThread);
+
+	if (J2SE_VERSION(vm) >= J2SE_19) {
+		runStaticMethod(vmThread, (U_8 *)"jdk/internal/misc/Signal", &nas, 1, (UDATA *)args);
+	} else {
+		runStaticMethod(vmThread, (U_8 *)"sun/misc/Signal", &nas, 1, (UDATA *)args);
+	}
+
+	/* An exception shouldn't happen over here. */
+	Assert_VM_true(NULL == vmThread->currentException);
+
+	releaseVMAccess(vmThread);
+}
+
+/* @brief This handler will be invoked by the asynchSignalReporterThread
+ * in omrsignal.c once registered using j9sig_set_*async_signal_handler
+ * for a specific signal.
+ *
+ * @param portLibrary the port library
+ * @param gpType port library signal flag
+ * @param gpInfo GPF information (will be NULL in this case)
+ * @param userData user data (will be a pointer to J9JavaVM in this case)
+ *
+ * @return 0 on success and non-zero on failure
+ *
+ */
+static UDATA
+predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *userData) {
+	J9JavaVM *vm = (J9JavaVM *)userData;
+	J9JavaVMAttachArgs attachArgs = {0};
+	J9VMThread *vmThread = NULL;
+	IDATA result = JNI_ERR;
+	BOOLEAN shutdownStarted = FALSE;
+	I_32 signal = 0;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	signal = j9sig_map_portlib_signal_to_os_signal(gpType);
+	/* Don't invoke handler if signal is 0 or negative, or if -Xrs or -Xrs:async is specified */
+	if ((signal <= 0) || J9_ARE_ANY_BITS_SET(vm->sigFlags, J9_SIG_XRS_ASYNC)) {
+		return 1;
+	}
+
+	/* Don't invoke handler if JVM exit or shutdown has started. */
+	omrthread_monitor_enter(vm->runtimeFlagsMutex);
+	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED | J9_RUNTIME_SHUTDOWN_STARTED)) {
+		shutdownStarted = TRUE;
+	}
+	omrthread_monitor_exit(vm->runtimeFlagsMutex);
+
+	if (shutdownStarted) {
+		return 1;
+	}
+
+	attachArgs.version = JNI_VERSION_1_8;
+	attachArgs.name = "JVM Signal Thread";
+	attachArgs.group = vm->systemThreadGroupRef;
+
+	/* Attach current thread as a daemon thread */
+	result = internalAttachCurrentThread(vm, &vmThread, &attachArgs,
+				J9_PRIVATE_FLAGS_DAEMON_THREAD | J9_PRIVATE_FLAGS_SYSTEM_THREAD | J9_PRIVATE_FLAGS_ATTACHED_THREAD,
+				omrthread_self());
+
+	if (JNI_OK != result) {
+		/* Thread couldn't be attached. So, we can't run Java code. */
+		return 1;
+	}
+
+	/* Run handler (Java code). */
+	signalDispatch(vmThread, signal);
+
+	DetachCurrentThread((JavaVM *)vm);
+
+	return 0;
+}
+
+IDATA
+registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler) {
+	IDATA rc = 0;
+	U_32 portlibSignalFlag = 0;
+
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	portlibSignalFlag = j9sig_map_os_signal_to_portlib_signal(signal);
+	if (0 != portlibSignalFlag) {
+		rc = j9sig_set_single_async_signal_handler(predefinedHandlerWrapper, vm, portlibSignalFlag, oldOSHandler);
+	} else {
+		Trc_VM_registerPredefinedHandler_invalidPortlibSignalFlag(portlibSignalFlag);
+	}
+
+	return rc;
+}
 
 static jint
 initializeDDR(J9JavaVM * vm)


### PR DESCRIPTION
Two static functions added in `jvminit.c`:
1) `signalDispatch`: Invoke `jdk.internal.misc.Signal.dispatch(int number)`
in Java 9 and onwards. Invoke `sun.misc.Signal.dispatch(int number)` in
Java 8.
2) `predefinedHandlerWrapper`: When a signal is raised, this handler will
be invoked by the `asynchSignalReporterThread` in `omrsignal.c` if it is
registered using `omrsig_set_*async_signal_handler` with a specific
signal.

One function introduced in `vm_api.h` and defined in `jvminit.c`:
1) `registerPredefinedHandler`: Registers `predefinedHandlerWrapper` using
`omrsig_set_*async_signal_handler` for a specified signal. Old OS handler is 
passed via an input reference variable.

`registerPredefinedHandler` is also added to `J9InternalFunctions` since it
will be invoked from `jvm.c::JVM_RegisterSignal`.

`freeJavaVM` invokes `j9sig_set_async_signal_handler(predefinedHandlerWrapper...` 
to unregister the pre-defined signal handler during shutdown.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>