### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/compiler/trj9/p/codegen/PPCJNILinkage.cpp
+++ b/runtime/compiler/trj9/p/codegen/PPCJNILinkage.cpp
@@ -725,12 +725,17 @@ void TR::PPCJNILinkage::releaseVMAccessAtomicFree(TR::Node* callNode, TR::Regist
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
    generateInstruction(cg(), TR::InstOpCode::lwsync, callNode);
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
+   generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, callNode, tempReg1, 1);
+   generateMemSrc1Instruction(cg(), TR::InstOpCode::Op_st, callNode, new (trHeapMemory()) TR::MemoryReference(metaReg, (int32_t)offsetof(struct J9VMThread, inNative), TR::Compiler->om.sizeofReferenceAddress(), cg()), tempReg1);
+#if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
+	generateInstruction(cg(), TR::InstOpCode::sync, callNode); // Necessary?
+#endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
    generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, tempReg1, new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetPublicFlagsOffset(), TR::Compiler->om.sizeofReferenceAddress(), cg()));
-   if (J9_PUBLIC_FLAGS_HALT_THREAD_ANY >= LOWER_IMMED && J9_PUBLIC_FLAGS_HALT_THREAD_ANY <= UPPER_IMMED)
-      generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::andi_r, callNode, tempReg2, tempReg1, cr0Reg, J9_PUBLIC_FLAGS_HALT_THREAD_ANY);
+   if (J9_PUBLIC_FLAGS_VM_ACCESS >= LOWER_IMMED && J9_PUBLIC_FLAGS_VM_ACCESS <= UPPER_IMMED)
+      generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::andi_r, callNode, tempReg2, tempReg1, cr0Reg, J9_PUBLIC_FLAGS_VM_ACCESS);
    else
       {
-      loadConstant(cg(), callNode, J9_PUBLIC_FLAGS_HALT_THREAD_ANY, tempReg2);
+      loadConstant(cg(), callNode, J9_PUBLIC_FLAGS_VM_ACCESS, tempReg2);
       // FIXME: Apparently I'm the first one to ever use a Trg1Src2 record-form instruction...
       // ctor for Trg1Src2 + condReg only has the preced form, if you don't pass a preceding instruction the following instruction will end up as the first instruction after the prologue
       generateTrg1Src2Instruction(cg(), TR::InstOpCode::and_r, callNode, tempReg2, tempReg1, tempReg2, cr0Reg, /* FIXME */ cg()->getAppendInstruction());
@@ -748,12 +753,6 @@ void TR::PPCJNILinkage::releaseVMAccessAtomicFree(TR::Node* callNode, TR::Regist
       generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, PPCOpProp_BranchUnlikely, callNode, releaseVMAcessSnippetLabel, cr0Reg);
    else
       generateConditionalBranchInstruction(cg(), TR::InstOpCode::bnel, callNode, releaseVMAcessSnippetLabel, cr0Reg);
-
-   generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, callNode, tempReg1, 1);
-   generateMemSrc1Instruction(cg(), TR::InstOpCode::Op_st, callNode, new (trHeapMemory()) TR::MemoryReference(metaReg, (int32_t)offsetof(struct J9VMThread, inNative), TR::Compiler->om.sizeofReferenceAddress(), cg()), tempReg1);
-#if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-	generateInstruction(cg(), TR::InstOpCode::lwsync, callNode); // Necessary?
-#endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
    }
 
 void TR::PPCJNILinkage::acquireVMAccessAtomicFree(TR::Node* callNode, TR::RegisterDependencyConditions* deps, TR::RealRegister* metaReg, TR::Register* cr0Reg, TR::Register* tempReg1, TR::Register* tempReg2)

--- a/runtime/oti/VMAccess.hpp
+++ b/runtime/oti/VMAccess.hpp
@@ -457,7 +457,7 @@ public:
 		setPublicFlags(vmThread, flags, true);
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-		// TODO: flush
+		J9_VM_FUNCTION(vmThread, flushProcessWriteBuffers)(vmThread->javaVM);
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 		VM_AtomicSupport::readWriteBarrier(); // necessary?
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -277,7 +277,7 @@ static const struct { \
 
 #define J9_ARE_MODULES_ENABLED(vm) (J2SE_VERSION(vm) >= J2SE_19)
 
-/* Macrco for VM internalVMFunctions */
+/* Macro for VM internalVMFunctions */
 #if defined(J9_INTERNAL_TO_VM)
 #define J9_VM_FUNCTION(currentThread, function) function
 #define J9_VM_FUNCTION_VIA_JAVAVM(javaVM, function) function

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4793,6 +4793,9 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_RAS_EYECATCHERS)
 	void (*rasSetServiceLevel)(struct J9JavaVM *vm, const char *runtimeVersion);
 #endif /* J9VM_RAS_EYECATCHERS */
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
+	void (*flushProcessWriteBuffers)(struct J9JavaVM *vm);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4197,6 +4197,11 @@ typedef struct J9ThreadEnv {
 
 } J9ThreadEnv;
 
+
+/* FlushProcessWriteBuffers.cpp */
+
+void flushProcessWriteBuffers(J9JavaVM *vm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/vm/FlushProcessWriteBuffers.cpp
+++ b/runtime/vm/FlushProcessWriteBuffers.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if defined(WIN32)
+#include <windows.h>
+VOID WINAPI FlushProcessWriteBuffers(void);
+#elif defined(LINUX) /* WIN32 */
+#include <sys/mman.h>
+#endif /* LINUX */
+
+#include "vm_internal.h"
+#include "ut_j9vm.h"
+#include "AtomicSupport.hpp"
+
+extern "C" {
+
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
+
+void
+flushProcessWriteBuffers(J9JavaVM *vm)
+{
+#if defined(WIN32)
+	FlushProcessWriteBuffers();
+#elif defined(LINUX) /* WIN32 */
+	int mprc = mprotect(vm->exclusiveGuardPage.address, vm->exclusiveGuardPage.pageSize, PROT_READ | PROT_WRITE);
+	Assert_VM_true(0 == mprc);
+	VM_AtomicSupport::add((UDATA*)vm->exclusiveGuardPage.address, 1);
+	mprc = mprotect(vm->exclusiveGuardPage.address, vm->exclusiveGuardPage.pageSize, PROT_NONE);
+	Assert_VM_true(0 == mprc);
+#else /* LINUX */
+#error flushProcessWriteBuffers unimplemented
+#endif /* LINUX */
+}
+
+UDATA
+initializeExclusiveAccess(J9JavaVM *vm)
+{
+#if defined(LINUX)
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	UDATA rc = 1;
+	UDATA pageSize = j9vmem_supported_page_sizes()[0];
+	void *addr = j9vmem_reserve_memory(
+		NULL,
+		pageSize,
+		&vm->exclusiveGuardPage,
+		J9PORT_VMEM_MEMORY_MODE_READ | J9PORT_VMEM_MEMORY_MODE_WRITE | J9PORT_VMEM_MEMORY_MODE_COMMIT,
+		pageSize, OMRMEM_CATEGORY_VM);
+	if (NULL != addr) {
+		if (0 == mlock(addr, pageSize)) {
+			if (0 == mprotect(vm->exclusiveGuardPage.address, vm->exclusiveGuardPage.pageSize, PROT_NONE)) {
+				rc = 0;
+			} else {
+				j9tty_printf(PORTLIB, "mrprotect bad\n");				
+			}
+		} else {
+			j9tty_printf(PORTLIB, "mlock bad\n");
+			/* free mem */
+		}
+	} else {
+		j9tty_printf(PORTLIB, "vmem bad\n");		
+	}
+	return rc;
+#else /* LINUX */
+	return 0;
+#endif /* LINUX */
+}
+
+void
+shutDownExclusiveAccess(J9JavaVM *vm)
+{
+#if defined(LINUX)
+	if (NULL != vm->exclusiveGuardPage.address) {
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		j9vmem_free_memory(vm->exclusiveGuardPage.address, vm->exclusiveGuardPage.pageSize, &vm->exclusiveGuardPage);
+		vm->exclusiveGuardPage.address = NULL;
+	}
+#endif /* LINUX */
+}
+
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
+
+} /* extern "C" */

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -361,4 +361,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 #if defined(J9VM_RAS_EYECATCHERS)
 	j9rasSetServiceLevel,
 #endif /* J9VM_RAS_EYECATCHERS */
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
+	flushProcessWriteBuffers,
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 };

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -389,7 +389,7 @@ int32_t
 j9gs_deinitializeThread(struct J9VMThread *vmThread);
 #endif
 
-/* VMAccess.cpp */
+/* FlushProcessWriteBuffers.cpp */
 
 UDATA initializeExclusiveAccess(J9JavaVM *vm);
 void shutDownExclusiveAccess(J9JavaVM *vm);


### PR DESCRIPTION
- fix PPC JIT direct JNI for atomic-free
- refactor FlushProcessWriteBuffers code

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>