### PR TITLE
Clean up x86 platform specific code in TR_J9VMBase

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1098,10 +1098,6 @@ onLoadInternal(
    if (!TR::CompilationInfo::createCompilationInfo(jitConfig))
       return -1;
 
-#if defined(TR_TARGET_X86)
-   TR_J9VM::initializeX86ProcessorInfo(jitConfig);
-#endif
-
    if (!TR_J9VMBase::createGlobalFrontEnd(jitConfig, TR::CompilationInfo::get()))
       return -1;
 

--- a/runtime/compiler/env/J9CPU.hpp
+++ b/runtime/compiler/env/J9CPU.hpp
@@ -34,6 +34,7 @@ namespace J9 { typedef CPU CPUConnector; }
 
 #include "env/OMRCPU.hpp"
 #include "j9port.h"
+#include "infra/Assert.hpp"                         // for TR_ASSERT
 
 namespace J9
 {
@@ -45,6 +46,9 @@ protected:
 public:
 
    J9ProcessorDesc *TO_PORTLIB_getJ9ProcessorDesc();
+
+   const char *getProcessorVendorId() { TR_ASSERT(false, "Vendor ID not defined for this platform!"); return NULL; }
+   uint32_t getProcessorSignature() { TR_ASSERT(false, "Processor Signature not defined for this platform!"); return 0; }
    };
 }
 

--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -574,108 +574,6 @@ TR_J9VMBase::getPPCSupportsVSXRegisters()
 
 // -----------------------------------------------------------------------------
 
-extern TR_X86CPUIDBuffer *queryX86TargetCPUID(void * javaVM);
-
-char TR_J9VMBase::x86VendorID[] = {'U','n','k','n','o','w','n','B','r','a','n','d','\0'};
-bool TR_J9VMBase::x86VendorIDInitialized = false;
-
-void
-TR_J9VMBase::initializeX86ProcessorInfo(J9JITConfig *jitConfig)
-   {
-   TR_ASSERT(jitConfig, "jitConfig is not defined!");
-   TR_ASSERT(jitConfig->javaVM, "jitConfig->javaVM is not defined!");
-
-   // Terminate the vendor ID with NULL before returning.
-   //
-   strncpy(x86VendorID, queryX86TargetCPUID(jitConfig->javaVM)->_vendorId, 12);
-   x86VendorID[12] = '\0';
-   x86VendorIDInitialized = true;
-
-   // Initialize processorFeatureFlags
-   //
-#if defined(TR_TARGET_X86)
-   TR::Compiler->target.cpu.setX86ProcessorFeatureFlags(queryX86TargetCPUID(jitConfig->javaVM)->_featureFlags);
-   TR::Compiler->target.cpu.setX86ProcessorFeatureFlags2(queryX86TargetCPUID(jitConfig->javaVM)->_featureFlags2);
-   TR::Compiler->target.cpu.setX86ProcessorFeatureFlags8(queryX86TargetCPUID(jitConfig->javaVM)->_featureFlags8);
-#endif // TR_TARGET_X86
-   }
-
-
-const char *
-TR_J9VMBase::getX86ProcessorVendorId()
-   {
-   TR_ASSERT(x86VendorIDInitialized, "X86 Vendor ID has not yet been initialized");
-   return x86VendorID;
-   }
-
-uint32_t
-TR_J9VMBase::getX86ProcessorSignature()
-   {
-   TR_ASSERT(_jitConfig, "jitConfig is not defined!");
-   TR_ASSERT(_jitConfig->javaVM, "jitConfig->javaVM is not defined!");
-   return queryX86TargetCPUID(_jitConfig->javaVM)->_processorSignature;
-   }
-
-uint32_t
-TR_J9VMBase::getX86ProcessorFeatureFlags()
-   {
-   TR_ASSERT(_jitConfig, "jitConfig is not defined!");
-   TR_ASSERT(_jitConfig->javaVM, "jitConfig->javaVM is not defined!");
-   return queryX86TargetCPUID(_jitConfig->javaVM)->_featureFlags;
-   }
-
-uint32_t
-TR_J9VMBase::getX86ProcessorFeatureFlags2()
-   {
-   TR_ASSERT(_jitConfig, "jitConfig is not defined!");
-   TR_ASSERT(_jitConfig->javaVM, "jitConfig->javaVM is not defined!");
-   return queryX86TargetCPUID(_jitConfig->javaVM)->_featureFlags2;
-   }
-
-uint32_t
-TR_J9VMBase::getX86ProcessorFeatureFlags8()
-   {
-   TR_ASSERT(_jitConfig, "jitConfig is not defined!");
-   TR_ASSERT(_jitConfig->javaVM, "jitConfig->javaVM is not defined!");
-   return queryX86TargetCPUID(_jitConfig->javaVM)->_featureFlags8;
-   }
-
-bool
-TR_J9VMBase::testOSForSSESupport()
-   {
-   return true; // VM guarantees SSE/SSE2 are available
-   }
-
-bool
-TR_J9VMBase::getX86SupportsSSE4_1()
-   {
-   uint32_t flags = getX86ProcessorFeatureFlags2();
-   if ((flags & 0x00080000) != 0x00080000)
-      return false;
-   return true;
-   }
-
-bool
-TR_J9VMBase::getX86SupportsHLE()
-   {
-   uint32_t flags8 = getX86ProcessorFeatureFlags8();
-   if ((flags8 & TR_HLE) != 0x00000000)
-      return true;
-   else return false;
-   }
-
-bool
-TR_J9VMBase::getX86SupportsPOPCNT()
-   {
-   uint32_t flags2 = getX86ProcessorFeatureFlags2();
-   if ((flags2 & TR_POPCNT) != 0x00000000)
-      return true;
-   else return false;
-   }
-
-
-// -----------------------------------------------------------------------------
-
 // For Verbose Log
 int32_t TR_J9VM::getCompInfo(char *processorName, int32_t stringLength)
    {
@@ -938,10 +836,11 @@ TR_J9VM::initializeProcessorType()
       }
    else if (TR::Compiler->target.cpu.isX86())
       {
-      const char *vendor = getX86ProcessorVendorId();
-      uint32_t processorSignature = getX86ProcessorSignature();
+      const char *vendor = TR::Compiler->target.cpu.getProcessorVendorId();
+      uint32_t processorSignature = TR::Compiler->target.cpu.getProcessorSignature();
 
       TR::Compiler->target.cpu.setProcessor(portLibCall_getX86ProcessorType(vendor, processorSignature));
+
       TR_ASSERT(TR::Compiler->target.cpu.id() >= TR_FirstX86Processor
              && TR::Compiler->target.cpu.id() <= TR_LastX86Processor, "Not a valid X86 Processor Type");
       }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1380,7 +1380,7 @@ void TR_J9VMBase::printVerboseLogHeader(TR::Options *cmdLineOptions)
    char processorName[size] = {0};
 
 #if defined(TR_TARGET_X86)
-   vendorId =  getX86ProcessorVendorId();
+   vendorId =  TR::Compiler->target.cpu.getX86ProcessorVendorId();
    getCompInfo(processorName, size);
    TR_VerboseLog::writeLine(TR_Vlog_INFO,"Processor Information:");
    TR_VerboseLog::writeLine(TR_Vlog_INFO,"     Platform Info:%s",processorName);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -275,7 +275,6 @@ public:
    static char *getJ9FormattedName(J9JITConfig *, J9PortLibrary *, char *, int32_t, char *, char *, bool suffix=false);
    static TR_Processor getPPCProcessorType();
    virtual bool getPPCSupportsVSXRegisters();
-   static void initializeX86ProcessorInfo(J9JITConfig *);
 
    static bool isBigDecimalClass(J9UTF8 * className);
    bool isCachedBigDecimalClassFieldAddr(){ return cachedStaticDFPAvailField; }
@@ -386,10 +385,6 @@ public:
    virtual bool               hasResumableTrapHandler();
    virtual bool               hasFixedFrameC_CallingConvention();
    virtual bool               pushesOutgoingArgsAtCallSite( TR::Compilation *comp);
-
-
-   bool                       getX86SupportsHLE();
-   virtual bool               getX86SupportsPOPCNT();
 
    virtual TR::PersistentInfo * getPersistentInfo()  { return ((TR_PersistentMemory *)_jitConfig->scratchSegment)->getPersistentInfo(); }
    void                       unknownByteCode( TR::Compilation *, uint8_t opcode);
@@ -717,13 +712,6 @@ public:
    virtual bool               isClassArray(TR_OpaqueClassBlock *);
    virtual bool               isFinalFieldPointingAtJ9Class(TR::SymbolReference *symRef, TR::Compilation *comp);
 
-   virtual const char * getX86ProcessorVendorId();
-   virtual uint32_t     getX86ProcessorSignature();
-   virtual uint32_t     getX86ProcessorFeatureFlags();
-   virtual uint32_t     getX86ProcessorFeatureFlags2();
-   virtual uint32_t     getX86ProcessorFeatureFlags8();
-   virtual bool         getX86SupportsSSE4_1();
-
    virtual void *getJ2IThunk(char *signatureChars, uint32_t signatureLength,  TR::Compilation *comp);
    virtual void *setJ2IThunk(char *signatureChars, uint32_t signatureLength, void *thunkptr,  TR::Compilation *comp);
    virtual void *setJ2IThunk(TR_Method *method, void *thunkptr, TR::Compilation *comp);  // DMDM: J9 now
@@ -902,7 +890,6 @@ public:
 
    TR::Node * initializeLocalObjectFlags( TR::Compilation *, TR::Node * allocationNode, J9Class * ramClass);
 
-   virtual bool             testOSForSSESupport();
    virtual J9JITConfig *getJ9JITConfig() { return _jitConfig; }
 
    virtual int32_t getCompThreadIDForVMThread(void *vmThread);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4294,9 +4294,7 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
             opcode = TR::inotz;
             break;
          case TR::java_lang_Integer_bitCount:
-            if(TR::Compiler->target.cpu.isX86() && fej9()->getX86SupportsPOPCNT())
-               opcode = TR::ipopcnt;
-            else if (TR::Compiler->target.cpu.hasPopulationCountInstruction())
+            if (TR::Compiler->target.cpu.hasPopulationCountInstruction())
                opcode = TR::ipopcnt;
             else
                opcode = TR::BadILOp;
@@ -4317,9 +4315,7 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
             opcode = TR::lnotz;
             break;
          case TR::java_lang_Long_bitCount:
-            if(TR::Compiler->target.cpu.isX86() && fej9()->getX86SupportsPOPCNT())
-               opcode = TR::lpopcnt;
-            else if (TR::Compiler->target.cpu.hasPopulationCountInstruction())
+            if (TR::Compiler->target.cpu.hasPopulationCountInstruction())
                opcode = TR::lpopcnt;
             else
                opcode = TR::BadILOp;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -4476,7 +4476,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
          }
       }
 
-   if (TR::Compiler->target.is64Bit() && fej9->getX86SupportsHLE() && comp->getOption(TR_X86HLE))
+   if (TR::Compiler->target.is64Bit() && cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
       {
       TR::LabelSymbol *JITMonitorEntrySnippetLabel = generateLabelSymbol(cg);
       TR::TreeEvaluator::transactionalMemoryJITMonitorEntry(node, cg, startLabel, snippetLabel, JITMonitorEntrySnippetLabel, objectReg, lwOffset);
@@ -4531,13 +4531,13 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    if (TR::Compiler->target.is64Bit() && !fej9->generateCompressedLockWord())
       {
       op = TR::Compiler->target.isSMP() ? LCMPXCHG8MemReg : CMPXCHG8MemReg;
-      if (fej9->getX86SupportsHLE() && comp->getOption(TR_X86HLE))
+      if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
          op = TR::Compiler->target.isSMP() ? XALCMPXCHG8MemReg : XACMPXCHG8MemReg;
       }
    else
       {
       op = TR::Compiler->target.isSMP() ? LCMPXCHG4MemReg : CMPXCHG4MemReg;
-      if (fej9->getX86SupportsHLE() && comp->getOption(TR_X86HLE))
+      if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
          op = TR::Compiler->target.isSMP() ? XALCMPXCHG4MemReg : XACMPXCHG4MemReg;
       }
 
@@ -5364,7 +5364,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
 #ifdef J9VM_TASUKI_LOCKS_DOUBLE_SLOT
       TR_ASSERT(TR::Compiler->target.is32Bit(), "This code-piece should never be reached");
 #endif
-      if (fej9->getX86SupportsHLE() && comp->getOption(TR_X86HLE))
+      if (cg->getX86ProcessorInfo().supportsHLE() && comp->getOption(TR_X86HLE))
          generateMemImmInstruction(XRSMemImm4(gen64BitInstr),
             node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
       else

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -35,6 +35,7 @@ namespace J9 { typedef J9::X86::CPU CPUConnector; }
 #endif
 
 #include "compiler/env/J9CPU.hpp"
+#include "env/ProcessorInfo.hpp"
 
 namespace TR { class Compilation; }
 
@@ -62,33 +63,21 @@ class CPU : public J9::CPU
 protected:
 
    CPU() :
-         J9::CPU(),
-         _featureFlags(0),
-         _featureFlags2(0),
-         _featureFlags8(0)
-      {}
+         J9::CPU()
+      {
+      }
 
 public:
 
-   const char *getX86ProcessorVendorId(TR::Compilation *comp);
-   uint32_t getX86ProcessorSignature(TR::Compilation *comp);
-   uint32_t getX86ProcessorFeatureFlags(TR::Compilation *comp);
-   uint32_t getX86ProcessorFeatureFlags2(TR::Compilation *comp);
-   uint32_t getX86ProcessorFeatureFlags8(TR::Compilation *comp);
+   TR_X86CPUIDBuffer *queryX86TargetCPUID();
+   const char * getProcessorVendorId();
+   uint32_t getProcessorSignature();
+
+   bool testOSForSSESupport();
+   bool hasPopulationCountInstruction();
 
    TR_ProcessorFeatureFlags getProcessorFeatureFlags();
    bool isCompatible(TR_Processor processorSignature, TR_ProcessorFeatureFlags processorFeatureFlags);
-
-   bool testOSForSSESupport(TR::Compilation *comp);
-
-   void setX86ProcessorFeatureFlags(uint32_t flags);
-   void setX86ProcessorFeatureFlags2(uint32_t flags2);
-   void setX86ProcessorFeatureFlags8(uint32_t flags8);
-
-private:
-   uint32_t _featureFlags;
-   uint32_t _featureFlags2;
-   uint32_t _featureFlags8;
 
    };
 


### PR DESCRIPTION
- Move the x86 platform specific code out of the TR_J9VMBase top level api and to x/J9CPU class
- Remove redundant code in J9CPU and TR_J9VMBase
- Rewrite and simplify some of the APIs inside x/J9CPU
- Depends on https://github.com/eclipse/omr/pull/2425

Issue: #1612 
Signed-off-by: Harry Yu <harryyu1994@gmail.com>