### PR TITLE
Fix an issue with instanceof and multi-dimensional arrays

### DIFF
--- a/runtime/compiler/trj9/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -368,22 +368,23 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
             if (TR::Compiler->cls.isReferenceArray(cg->comp(), castClass))
                {
                TR_OpaqueClassBlock *componentClass = fej9->getComponentClassFromArrayClass(castClass);
+               TR_OpaqueClassBlock *leafClass = fej9->getLeafComponentClassFromArrayClass(castClass);
 
-               // Cast class is an array of java/lang/Object, all we need to do is check if the object is an array of non-primitives.
+               // Cast class is a single dim array of java/lang/Object, all we need to do is check if the object is an array of non-primitives.
                //
-               if (cg->comp()->getObjectClassPointer() == componentClass)
+               if (cg->comp()->getObjectClassPointer() == componentClass && componentClass == leafClass)
                   {
                   sequences[i++] = ArrayOfJavaLangObjectTest;
                   sequences[i++] = GoToFalse;
                   }
-               // Cast class is an array of a final class, all we need to do is check if the object is of this type, anything else is false.
+               // Cast class is a single dim array of a final class, all we need to do is check if the object is of this type, anything else is false.
                //
-               else if (fej9->isClassFinal(componentClass))
+               else if (fej9->isClassFinal(componentClass) && componentClass == leafClass)
                   {
                   sequences[i++] = ClassEqualityTest;
                   sequences[i++] = GoToFalse;
                   }
-               // Cast class is an array of some non-final class.
+               // Cast class is an array of some non-final class or multiple dimensions.
                //
                else
                   {


### PR DESCRIPTION
When using instanceof for a multi-dimension array of Objects
(i.e. Object[][]) the JIT would fail to verify the number of
dimensions and only insure that the object is non-null and is
not an array of primitives. This fix will cause the JIT to
emit a proper set of tests and fall back to a helper routine
after the fast path tests. This change only effects Power and
ZSeries as this common code facility is not used on X86.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>