### PR TITLE
Improve start-up time when not using AOT

### DIFF
--- a/runtime/compiler/trj9/control/CompilationThread.cpp
+++ b/runtime/compiler/trj9/control/CompilationThread.cpp
@@ -486,7 +486,10 @@ bool TR::CompilationInfo::shouldDowngradeCompReq(TR_MethodToBeCompiled *entry)
                  // Downgrade if compilation queue is too large
                 (TR::Options::getCmdLineOptions()->getOption(TR_EnableDowngradeOnHugeQSZ) &&
                  getMethodQueueSize() >= TR::Options::_qszThresholdToDowngradeOptLevel) ||
-                 // Downgrade if AOT and startup
+                 // Downgrade if compilation queue grows too much during startup
+                (_jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP &&
+                 getMethodQueueSize() >= TR::Options::_qszThresholdToDowngradeOptLevelDuringStartup) ||
+                 // Downgrade if AOT and startup, 
                 (TR::Options::getCmdLineOptions()->sharedClassCache() &&
                  _jitConfig->javaVM->phase == J9VM_PHASE_STARTUP &&
                  !TR::Options::getCmdLineOptions()->getOption(TR_DisableDowngradeToColdOnVMPhaseStartup))

--- a/runtime/compiler/trj9/control/HookedByTheJit.cpp
+++ b/runtime/compiler/trj9/control/HookedByTheJit.cpp
@@ -564,7 +564,11 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
          } // if (TR::Options::sharedClassCache())
       if (count == -1) // count didn't change yet
          {
-         count = getCount(romMethod, optionsJIT, optionsAOT);
+         if (!TR::Options::getCountsAreProvidedByUser() &&
+            fe->isClassLibraryMethod((TR_OpaqueMethodBlock *)method))
+            count = J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod) ? TR::Options::getCountForLoopyBootstrapMethods() : TR::Options::getCountForLooplessBootstrapMethods();
+         if (count == -1)
+            count = getCount(romMethod, optionsJIT, optionsAOT);
 
          // If add-spreading-invocation mode is enabled, add a hash value (hashed from method name) to count
          if (optionsAOT->getOption(TR_EnableCompilationSpreading) || optionsJIT->getOption(TR_EnableCompilationSpreading))
@@ -578,7 +582,6 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
                count = count * TR::Options::_countPercentageForEarlyCompilation / 100;
             // TODO: disable this mechanism after an hour or so to conserve idle time
             }
-
          }
       }
 

--- a/runtime/compiler/trj9/control/J9Options.hpp
+++ b/runtime/compiler/trj9/control/J9Options.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,6 +113,11 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _countForMethodsCompiledDuringStartup;
    static int32_t getCountForMethodsCompiledDuringStartup() { return _countForMethodsCompiledDuringStartup; }
 
+   static int32_t _countForLoopyBootstrapMethods;
+   static int32_t _countForLooplessBootstrapMethods;
+   static int32_t getCountForLoopyBootstrapMethods() { return _countForLoopyBootstrapMethods; }
+   static int32_t getCountForLooplessBootstrapMethods() { return _countForLooplessBootstrapMethods; }
+
    // fast JNI option
    static TR::SimpleRegex *_jniAccelerator;
    static TR::SimpleRegex * getJniAccelerator() { return _jniAccelerator; }
@@ -210,6 +215,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _numQueuedInvReqToDowngradeOptLevel;
    static int32_t _qszThresholdToDowngradeOptLevel;
    static int32_t _qsziThresholdToDowngradeDuringCLP;
+   static int32_t _qszThresholdToDowngradeOptLevelDuringStartup;
    static int32_t _cpuUtilThresholdForStarvation;
    static int32_t _compPriorityQSZThreshold;
    static int32_t _GCRQueuedThresholdForCounting; // if too many GCR are queued we stop counting


### PR DESCRIPTION
There are two changes implemented by this commit:
1) Reduce the invocation counts for methods belonging to bootstrap classes
2) Downgrade to cold compilations performed during start-up phase

The motivation for change (1) is to get out of interpreter sooner (the
invocation count is the number of times an interpreted method needs to
be invoked to be JIT compiled). The main problem is that a lower
invocation count reduces the number of interpreter profiling samples
which in turn may affect throughput. One way around this issue is to restrict
this change to methods belonging to bootstrap classes that are executed a
lot during start-up but to a lesser degree during stready state.

The motivation for change (2) is that, with a lower invocation count more
methods are going to be compiled and the extra compilation overhead may
affect start-up time. Thus, we need to reduce the compilation overhead
by using lower optimization levels (i.e. "cold"). Methods compiled at
"cold" will be upgraded through the GCR mechanism if they are executed
enough times.

There are two new options to control change (1)
-Xjit:bcountForBootstrapMethods=<nnn>   // for methods with loops
-Xjit:countForBootstrapMethods=<nnn>    // for methods without loops
and one new option to control change (2)
-Xjit:queueSizeThresholdToDowngradeOptLevelDuringStartup=<nnn>

Performance experiments on x86 showed good startup improvements for
Liberty Application Server (6-7%) and no throughput regressions for a
few Liberty based benchmarks.

In this commit the feature will be disabled to allow for more performance
testing on other platforms.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>