### PR TITLE
Prefetching, checkcasts and profiled compile changes

### DIFF
--- a/runtime/compiler/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.cpp
@@ -353,6 +353,8 @@ J9::MethodSymbol::safeToSkipDivChecks()
 static TR::RecognizedMethod canSkipCheckCasts[] =
    {
    TR::java_util_ArrayList_ensureCapacity,
+   TR::java_util_HashMap_resize,
+   TR::java_util_HashMapHashIterator_nextNode,
    TR::java_util_Hashtable_clone,
    TR::java_util_Hashtable_putAll,
    TR::unknownMethod

--- a/runtime/compiler/optimizer/ProfileGenerator.cpp
+++ b/runtime/compiler/optimizer/ProfileGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@
 #include "optimizer/TransformUtil.hpp"         // for calculateElementAddress
 
 #define OPT_DETAILS "O^O PROFILE GENERATOR: "
-#define MAX_NUMBER_OF_ALLOWED_NODES 30000
+#define MAX_NUMBER_OF_ALLOWED_NODES 90000
 
 #ifdef DEBUG
 // Define range of asyncs to become split points, for debugging.

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -372,3 +372,368 @@ J9::Power::CodeGenerator::enableAESInHardwareTransformations()
       return false;
    }
 
+void
+J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register *targetRegister)
+   {
+   static bool disableHotFieldPrefetch = (feGetEnv("TR_DisableHotFieldPrefetch") != NULL);
+   static bool disableHotFieldNextElementPrefetch  = (feGetEnv("TR_DisableHotFieldNextElementPrefetch") != NULL);
+   static bool disableTreeMapPrefetch  = (feGetEnv("TR_DisableTreeMapPrefetch") != NULL);
+   static bool disableStringObjPrefetch = (feGetEnv("TR_DisableStringObjPrefetch") != NULL);
+   bool optDisabled = false;
+
+   if (node->getOpCodeValue() == TR::aloadi ||
+        (TR::Compiler->target.is64Bit() &&
+         comp()->useCompressedPointers() &&
+         node->getOpCodeValue() == TR::l2a &&
+         comp()->getMethodHotness() >= scorching &&
+         TR::Compiler->om.compressedReferenceShiftOffset() == 0 &&
+         TR::Compiler->target.cpu.id() >= TR_PPCp6)
+      )
+      {
+      int32_t prefetchOffset = comp()->findPrefetchInfo(node);
+      TR::Node *firstChild = node->getFirstChild();
+
+      if (!disableHotFieldPrefetch && prefetchOffset >= 0) // Prefetch based on hot field information
+         {
+         bool canSkipNullChk = false;
+         static bool disableDelayPrefetch = (feGetEnv("TR_DisableDelayPrefetch") != NULL);
+         TR::LabelSymbol *endCtrlFlowLabel = generateLabelSymbol(self());
+         TR::Node *topNode = self()->getCurrentEvaluationTreeTop()->getNode();
+         // Search the current block for a check for NULL
+         TR::TreeTop *tt = self()->getCurrentEvaluationTreeTop()->getNextTreeTop();
+         TR::Node *checkNode = NULL;
+
+         while (!disableDelayPrefetch && tt && (tt->getNode()->getOpCodeValue() != TR::BBEnd))
+            {
+            checkNode = tt->getNode();
+            if (checkNode->getOpCodeValue() == TR::ifacmpeq &&
+                checkNode->getFirstChild() == node &&
+                checkNode->getSecondChild()->getDataType() == TR::Address &&
+                checkNode->getSecondChild()->isZero())
+               {
+               canSkipNullChk = true;
+               }
+            tt = tt->getNextTreeTop();
+            }
+
+         if (!canSkipNullChk)
+            {
+            TR::Register *condReg = self()->allocateRegister(TR_CCR);
+            TR::LabelSymbol *startCtrlFlowLabel = generateLabelSymbol(self());
+            startCtrlFlowLabel->setStartInternalControlFlow();
+            endCtrlFlowLabel->setEndInternalControlFlow();
+            generateLabelInstruction(self(), TR::InstOpCode::label, node, startCtrlFlowLabel);
+
+            // check for null
+            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::cmpli4, node, condReg, targetRegister, NULLVALUE);
+            generateConditionalBranchInstruction(self(), TR::InstOpCode::beql, node, endCtrlFlowLabel, condReg);
+
+            TR::Register *tempReg = self()->allocateRegister();
+            TR::RegisterDependencyConditions *deps = new (self()->trHeapMemory()) TR::RegisterDependencyConditions(1, 2, self()->trMemory());
+            deps->addPostCondition(tempReg, TR::RealRegister::NoReg);
+            addDependency(deps, condReg, TR::RealRegister::NoReg, TR_CCR, self());
+
+            if (TR::Compiler->target.is64Bit() && !comp()->useCompressedPointers())
+               {
+               TR::MemoryReference *tempMR = new (self()->trHeapMemory()) TR::MemoryReference(targetRegister, prefetchOffset, 8, self());
+               generateTrg1MemInstruction(self(), TR::InstOpCode::ld, node, tempReg, tempMR);
+               }
+            else
+               {
+               TR::MemoryReference *tempMR = new (self()->trHeapMemory()) TR::MemoryReference(targetRegister, prefetchOffset, 4, self());
+               generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, tempReg, tempMR);
+               }
+
+            TR::MemoryReference *targetMR = new (self()->trHeapMemory()) TR::MemoryReference(tempReg, (int32_t)0, 4, self());
+            targetMR->forceIndexedForm(node, self());
+            generateMemInstruction(self(), TR::InstOpCode::dcbt, node, targetMR);
+
+            self()->stopUsingRegister(tempReg);
+            self()->stopUsingRegister(condReg);
+            }
+         else
+            {
+            // Delay the dcbt to after the null check and fall through to the next block's treetop.
+            TR::TreeTop *useTree = tt->getNextTreeTop();
+            TR_ASSERT(useTree->getNode()->getOpCodeValue() == TR::BBStart, "Expecting a BBStart on the fall through\n");
+            TR::Node *useNode = useTree->getNode();
+            TR::Block *bb = useNode->getBlock();
+            if (bb->isExtensionOfPreviousBlock()) // Survived the null check
+               {
+               TR_PrefetchInfo *pf = new (self()->trHeapMemory())TR_PrefetchInfo(self()->getCurrentEvaluationTreeTop(), useTree, node, useNode, prefetchOffset, false);
+               comp()->removeExtraPrefetchInfo(useNode);
+               comp()->getExtraPrefetchInfo().push_front(pf);
+               }
+            }
+
+         // Do a prefetch on the next element of the array
+         // if the pointer came from an array.  Seems to give no gain at all, disabled until later
+         TR::Register *pointerReg = NULL;
+         bool fromRegLoad = false;
+         if (!disableHotFieldNextElementPrefetch)
+            {
+            // 32bit
+            if (TR::Compiler->target.is32Bit())
+               {
+               if (!(firstChild->getOpCodeValue() == TR::aiadd &&
+                     firstChild->getFirstChild() &&
+                     firstChild->isInternalPointer()) &&
+                   !(firstChild->getOpCodeValue() == TR::aRegLoad &&
+                     firstChild->getSymbolReference()->getSymbol()->isInternalPointer()))
+                  {
+                  optDisabled = true;
+                  }
+               else
+                  {
+                  fromRegLoad = (firstChild->getOpCodeValue() == TR::aRegLoad);
+                  pointerReg = fromRegLoad ? firstChild->getRegister() : self()->allocateRegister();
+                  if (!fromRegLoad)
+                     {
+                     // Case for aiadd, there should be 2 children
+                     TR::Node *baseObject = firstChild->getFirstChild();
+                     TR::Register *baseReg = (baseObject) ? baseObject->getRegister() : NULL;
+                     TR::Node *indexObject = firstChild->getSecondChild();
+                     TR::Register *indexReg = (indexObject) ? indexObject->getRegister() : NULL;
+                     // If the index is constant we just grab it
+                     if (indexObject->getOpCode().isLoadConst())
+                        {
+                        int32_t len = indexObject->getInt();
+                        if (len >= LOWER_IMMED && len <= UPPER_IMMED)
+                           generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, pointerReg, baseReg, len);
+                        else
+                           {
+                           indexReg = self()->allocateRegister();
+                           loadConstant(self(), node, len, indexReg);
+                           generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, pointerReg, baseReg, indexReg);
+                           self()->stopUsingRegister(indexReg);
+                           }
+                        }
+                     else
+                        generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, pointerReg, baseReg, indexReg);
+                     }
+                  }
+               }
+            // 64bit CR
+            else if (TR::Compiler->target.is64Bit() && comp()->useCompressedPointers())
+               {
+               if (!(firstChild->getOpCodeValue() == TR::iu2l &&
+                     firstChild->getFirstChild() &&
+                     firstChild->getFirstChild()->getOpCodeValue() == TR::iloadi &&
+                     firstChild->getFirstChild()->getNumChildren() == 1))
+                  {
+                  optDisabled = true;
+                  }
+               else
+                  {
+                  fromRegLoad = true;
+                  pointerReg = firstChild->getFirstChild()->getFirstChild()->getRegister();
+                  }
+               }
+            // 64bit - TODO
+            else
+               optDisabled = true;
+            }
+
+         if (!optDisabled)
+            {
+            TR::Register *condReg = self()->allocateRegister(TR_CCR);
+            TR::Register *tempReg = self()->allocateRegister();
+
+            // 32 bit only.... For -Xgc:noconcurrentmark, heapBase will be 0 and heapTop will be ok
+            // Otherwise, for a 2.25Gb or bigger heap, heapTop will be 0.  Relying on correct JIT initialization
+            uintptr_t heapTop = comp()->getOptions()->getHeapTop() ? comp()->getOptions()->getHeapTop() : 0xFFFFFFFF;
+
+            if (pointerReg && (heapTop > comp()->getOptions()->getHeapBase()))  // Check for gencon
+               {
+               TR::Register *temp3Reg = self()->allocateRegister();
+               static bool prefetch2Ahead = (feGetEnv("TR_Prefetch2Ahead") != NULL);
+               if (TR::Compiler->target.is64Bit() && !comp()->useCompressedPointers())
+                  {
+                  if (!prefetch2Ahead)
+                     generateTrg1MemInstruction(self(), TR::InstOpCode::ld, node, temp3Reg, new (self()->trHeapMemory()) TR::MemoryReference(pointerReg, (int32_t)TR::Compiler->om.sizeofReferenceField(), 8, self()));
+                  else
+                     generateTrg1MemInstruction(self(), TR::InstOpCode::ld, node, temp3Reg, new (self()->trHeapMemory()) TR::MemoryReference(pointerReg, (int32_t)(TR::Compiler->om.sizeofReferenceField()*2), 8, self()));
+                  }
+               else
+                  {
+                  if (!prefetch2Ahead)
+                     generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, temp3Reg, new (self()->trHeapMemory()) TR::MemoryReference(pointerReg, (int32_t)TR::Compiler->om.sizeofReferenceField(), 4, self()));
+                  else
+                     generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, temp3Reg, new (self()->trHeapMemory()) TR::MemoryReference(pointerReg, (int32_t)(TR::Compiler->om.sizeofReferenceField()*2), 4, self()));
+                  }
+
+               if (comp()->getOptions()->getHeapBase() != NULL)
+                  {
+                  loadAddressConstant(self(), node, (intptrj_t)(comp()->getOptions()->getHeapBase()), tempReg);
+                  generateTrg1Src2Instruction(self(), TR::InstOpCode::cmpl4, node, condReg, temp3Reg, tempReg);
+                  generateConditionalBranchInstruction(self(), TR::InstOpCode::blt, node, endCtrlFlowLabel, condReg);
+                  }
+               if (heapTop != 0xFFFFFFFF)
+                  {
+                  loadAddressConstant(self(), node, (intptrj_t)(heapTop-prefetchOffset), tempReg);
+                  generateTrg1Src2Instruction(self(), TR::InstOpCode::cmpl4, node, condReg, temp3Reg, tempReg);
+                  generateConditionalBranchInstruction(self(), TR::InstOpCode::bgt, node, endCtrlFlowLabel, condReg);
+                  }
+               TR::MemoryReference *targetMR = new (self()->trHeapMemory()) TR::MemoryReference(temp3Reg, (int32_t)0, 4, self());
+               targetMR->forceIndexedForm(node, self());
+               generateMemInstruction(self(), TR::InstOpCode::dcbt, node, targetMR); // use dcbt for prefetch next element
+
+               self()->stopUsingRegister(temp3Reg);
+               }
+
+            if (!fromRegLoad)
+               self()->stopUsingRegister(pointerReg);
+            self()->stopUsingRegister(tempReg);
+            self()->stopUsingRegister(condReg);
+            }
+            generateLabelInstruction(self(), TR::InstOpCode::label, node, endCtrlFlowLabel);
+         }
+
+      // Try prefetch all string objects, no apparent gain.  Disabled for now.
+      if (!disableStringObjPrefetch && 0 &&
+         node->getSymbolReference() &&
+         !node->getSymbolReference()->isUnresolved() &&
+         (node->getSymbolReference()->getSymbol()->getKind() == TR::Symbol::IsShadow) &&
+         (node->getSymbolReference()->getCPIndex() >= 0))
+         {
+         int32_t len;
+         const char *fieldName = node->getSymbolReference()->getOwningMethod(comp())->fieldSignatureChars(
+            node->getSymbolReference()->getCPIndex(), len);
+
+         if (fieldName && strstr(fieldName, "Ljava/lang/String;"))
+            {
+            TR::MemoryReference *targetMR = new (self()->trHeapMemory()) TR::MemoryReference(targetRegister, (int32_t)0, 4, self());
+            targetMR->forceIndexedForm(node, self());
+            generateMemInstruction(self(), TR::InstOpCode::dcbt, node, targetMR);
+            }
+         }
+      }
+
+   if (node->getOpCodeValue() == TR::aloadi ||
+      (TR::Compiler->target.is64Bit() && comp()->useCompressedPointers() && node->getOpCodeValue() == TR::iloadi && comp()->getMethodHotness() >= hot))
+      {
+      TR::Node *firstChild = node->getFirstChild();
+      optDisabled = false;
+      if (!disableTreeMapPrefetch)
+         {
+         // 32bit
+         if (TR::Compiler->target.is32Bit())
+            {
+            if (!(firstChild &&
+                firstChild->getOpCodeValue() == TR::aiadd &&
+                firstChild->isInternalPointer() &&
+                (strstr(comp()->fe()->sampleSignature(node->getOwningMethod(), 0, 0, self()->trMemory()),"java/util/TreeMap$UnboundedValueIterator.next()")
+                || strstr(comp()->fe()->sampleSignature(node->getOwningMethod(), 0, 0, self()->trMemory()),"java/util/ArrayList$Itr.next()"))
+               ))
+               {
+               optDisabled = true;
+               }
+            }
+         // 64bit cr
+         else if (TR::Compiler->target.is64Bit() && comp()->useCompressedPointers())
+            {
+            if (!(firstChild &&
+                firstChild->getOpCodeValue() == TR::aladd &&
+                firstChild->isInternalPointer() &&
+                (strstr(comp()->fe()->sampleSignature(node->getOwningMethod(), 0, 0, self()->trMemory()),"java/util/TreeMap$UnboundedValueIterator.next()")
+                || strstr(comp()->fe()->sampleSignature(node->getOwningMethod(), 0, 0, self()->trMemory()),"java/util/ArrayList$Itr.next()"))
+               ))
+               {
+               optDisabled = true;
+               }
+            }
+         }
+
+      if (!optDisabled)
+         {
+         int32_t loopSize = 0;
+         int32_t prefetchElementStride = 1;
+         TR::Block *b = self()->getCurrentEvaluationBlock();
+         TR_BlockStructure *blockStructure = b->getStructureOf();
+         if (blockStructure)
+            {
+            TR_Structure *containingLoop = blockStructure->getContainingLoop();
+            if (containingLoop)
+               {
+               TR_ScratchList<TR::Block> blocksInLoop(comp()->trMemory());
+
+               containingLoop->getBlocks(&blocksInLoop);
+               ListIterator<TR::Block> blocksIt(&blocksInLoop);
+               TR::Block *nextBlock;
+               for (nextBlock = blocksIt.getCurrent(); nextBlock; nextBlock=blocksIt.getNext())
+                  {
+                  loopSize += nextBlock->getNumberOfRealTreeTops();
+                  }
+               }
+            }
+
+         if (comp()->useCompressedPointers())
+            {
+            prefetchElementStride = 2;
+            }
+         else
+            {
+            if (loopSize < 200) //comp()->useCompressedPointers() is false && loopSize < 200.
+               {
+               prefetchElementStride = 4;
+               }
+            else if (loopSize < 300) //comp()->useCompressedPointers() is false && loopsize >=200 && loopsize < 300.
+               {
+               prefetchElementStride = 2;
+               }
+            //If comp()->useCompressedPointers() is false and loopsize >= 300, prefetchElementStride does not get changed.
+            }
+
+         // Look at the aiadd's children
+         TR::Node *baseObject = firstChild->getFirstChild();
+         TR::Register *baseReg = (baseObject) ? baseObject->getRegister() : NULL;
+         TR::Node *indexObject = firstChild->getSecondChild();
+         TR::Register *indexReg = (indexObject) ? indexObject->getRegister() : NULL;
+         if (baseReg && indexReg && loopSize > 0)
+            {
+            TR::Register *tempReg = self()->allocateRegister();
+            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, tempReg, indexReg, (int32_t)(prefetchElementStride * TR::Compiler->om.sizeofReferenceField()));
+            if (TR::Compiler->target.is64Bit() && !comp()->useCompressedPointers())
+               {
+               TR::MemoryReference *targetMR = new (self()->trHeapMemory()) TR::MemoryReference(baseReg, tempReg, 8, self());
+               generateTrg1MemInstruction(self(), TR::InstOpCode::ld, node, tempReg, targetMR);
+               }
+            else
+               {
+               TR::MemoryReference *targetMR = new (self()->trHeapMemory()) TR::MemoryReference(baseReg, tempReg, 4, self());
+               generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, tempReg, targetMR);
+               }
+
+            if (comp()->useCompressedPointers())
+               {
+               generateShiftLeftImmediateLong(self(), node, tempReg, tempReg, TR::Compiler->om.compressedReferenceShiftOffset());
+               }
+            TR::MemoryReference *target2MR =  new (self()->trHeapMemory()) TR::MemoryReference(tempReg, 0, 4, self());
+            target2MR->forceIndexedForm(node, self());
+            generateMemInstruction(self(), TR::InstOpCode::dcbt, node, target2MR);
+            self()->stopUsingRegister(tempReg);
+            }
+         }
+      }
+   else if (node->getOpCodeValue() == TR::wrtbari &&
+            comp()->getMethodHotness() >= scorching &&
+            TR::Compiler->target.cpu.id() >= TR_PPCp6 &&
+              (TR::Compiler->target.is32Bit() ||
+                (TR::Compiler->target.is64Bit() &&
+                 comp()->useCompressedPointers() &&
+                 TR::Compiler->om.compressedReferenceShiftOffset() == 0
+                )
+              )
+           )
+      {
+      // Take the source register of the store and apply on the prefetchOffset right away
+      int32_t prefetchOffset = comp()->findPrefetchInfo(node);
+      if (prefetchOffset >= 0)
+         {
+         TR::MemoryReference *targetMR = new (self()->trHeapMemory()) TR::MemoryReference(targetRegister, prefetchOffset, TR::Compiler->om.sizeofReferenceAddress(), self());
+         targetMR->forceIndexedForm(node, self());
+         generateMemInstruction(self(), TR::InstOpCode::dcbt, node, targetMR);
+         }
+      }
+   }
+

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -89,6 +89,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    bool enableAESInHardwareTransformations();
 
+   void insertPrefetchIfNecessary(TR::Node *node, TR::Register *targetRegister);
+
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    bool suppressInliningOfCryptoMethod(TR::RecognizedMethod method);
    bool inlineCryptoMethod(TR::Node *node, TR::Register *&resultReg);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -74,7 +74,6 @@
 
 extern TR::Register *addConstantToLong(TR::Node * node, TR::Register *srcReg, int64_t value, TR::Register *trgReg, TR::CodeGenerator *cg);
 extern TR::Register *addConstantToInteger(TR::Node * node, TR::Register *trgReg, TR::Register *srcReg, int32_t value, TR::CodeGenerator *cg);
-extern void addPrefetch(TR::CodeGenerator *cg, TR::Node *node, TR::Register *targetRegister);
 
 static const char *ppcSupportsReadMonitors = feGetEnv("TR_ppcSupportReadMonitors");
 
@@ -1171,11 +1170,7 @@ TR::Register *J9::Power::TreeEvaluator::iwrtbarEvaluator(TR::Node *node, TR::Cod
             postSyncConditions(node, cg, sourceRegister, tempMR, TR::InstOpCode::sync, lazyVolatile);
          }
 
-      if ((TR::Compiler->target.is32Bit() || (TR::Compiler->target.is64Bit() && comp->useCompressedPointers() && (TR::Compiler->om.compressedReferenceShiftOffset() == 0))) && comp->getMethodHotness() >= scorching
-            && TR::Compiler->target.cpu.id() >= TR_PPCp6)
-         {
-         addPrefetch(cg, node, sourceRegister);
-         }
+      cg->insertPrefetchIfNecessary(node, sourceRegister);
 
       VMwrtbarEvaluator(node, sourceRegister, destinationRegister, NULL, NULL, NULL, secondChild->isNonNull(), true, usingCompressedPointers, cg, flagsReg);
       }


### PR DESCRIPTION
HashMap.resize and HashMapHashIterator.nextNode were added to
canSkipCheckCasts since they don't need check casts.

Node threshold inside ProfileGenerator was changed to 90000. This will
promote more profiled compilations and was shown to improve the throughput
of an internal appserver benchmark.

addPrefetch was moved from OMR to OpenJ9 and renamed to
insertPrefetchIfNecessary.

It was also modified to work on Itr.next in ArrayList and the prefetching
stride distance was also changed. The new value was found through testing
and displayed an improvement in throughput in the previously mentioned
internal appserver benchmark.

Also during the move, an bug in insertPrefetchIfNecessary where
compressedrefs decompression was not occuring was fixed.

iwrtbarEvaluator was modified to now use insertPrefetchIfNecessary instead
of addPrefetch.

Signed-off-by: jimmyk <jimmyk@ca.ibm.com>