### PR TITLE
Exclude cmdLineTester_getPid on windows

### DIFF
--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -46,7 +46,7 @@ include $(TEST_ROOT)$(D)TestConfig$(D)utils.mk
 ifndef JAVA_BIN
 $(error Please provide JAVA_BIN value.)
 else
-export JAVA_BIN:=$(JAVA_BIN)
+export JAVA_BIN:=$(subst \,/,$(JAVA_BIN))
 endif
 
 ifndef SPEC

--- a/test/cmdLineTests/runtimemxbeanTests/exclude.xml
+++ b/test/cmdLineTests/runtimemxbeanTests/exclude.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2018, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,24 +21,10 @@
 
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
-<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
-	<test>
-		<testCaseName>cmdLineTester_getPid</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)runtimemxbeanTests.jar$(Q) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)getPidTest.xml$(Q) \
-		-explainExcludes -xids all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) -nonZeroExitWhenError; \
-		$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>SE100</subset>
-		</subsets>
-	</test>
-</playlist>
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+<suite id="getPid test">
+    <exclude id="Compare RuntimeMXBean.getPid() with getting PID from system" platform="win_x86-64_cr" shouldFix="true">
+        <reason>https://github.com/eclipse/openj9/issues/1630</reason>
+    </exclude>
+</suite>


### PR DESCRIPTION
Issue: https://github.com/eclipse/openj9/issues/1630
[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>