### PR TITLE
Update JVM_*Signal functions

### DIFF
--- a/runtime/j9vm/j9scar.tdf
+++ b/runtime/j9vm/j9scar.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2017 IBM Corp. and others
+// Copyright (c) 2006, 2018 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -334,3 +334,7 @@ TraceExit=Trc_SC_GCNoCompact_Exit Overhead=1 Level=1 Template="JVM_GCNoCompact()
 TraceEntry=Trc_SC_LoadSystemLibrary_Entry NoEnv Overhead=1 Level=1 Template="JVM_LoadSystemLibrary(name=%s)"
 TraceExit=Trc_SC_LoadSystemLibrary_Exit NoEnv Overhead=1 Level=1 Template="JVM_LoadSystemLibrary -- return 0x%zx"
 TraceEvent=Trc_SC_LoadSystemLibrary_LoadFailed NoEnv Overhead=1 Level=1 Template="JVM_LoadSystemLibrary(name=%s) failed to load"
+
+TraceEntry=Trc_SC_RegisterSignal_Entry Overhead=1 Level=1 Template="JVM_RegisterSignal(signal=%d, handler=%p)"
+TraceExit=Trc_SC_RegisterSignal_Exit Overhead=1 Level=1 Template="JVM_RegisterSignal -- return old OS handler = %p"
+TraceException=Trc_SC_RegisterSignal_FailedToRegisterHandler Overhead=1 Level=1 Template="Failed to register handler: OS signal value = %d, new signal handler = %p, old signal handler = %p"


### PR DESCRIPTION
1) Add a macro to reflect if a signal is ignored (`J9_SIG_IGNORED`).

2) Rename `isSignalSpecial` to `isSignalReservedByJVM`, and `isSignalSpecial`
to `isSignalUsedForShutdown`.

3) Add function `isSignalIgnored` to check if a signal is ignored.

4) Move `SIGQUIT` check from `isSignalUsedForShutdown` to
`isSignalReservedByJVM`. Add more signals to `isSignalReservedByJVM` using
IBM signal documentation.

5) Update `JVM_RaiseSignal`: Ignore shutdown signals if `-Xrs` is present or
if a shutdown signal is ignored. Ignore `SIGQUIT` if `-Xrs` is present.

6) Update `JVM_RegisterSignal`: Add better comments. Return immediately
for error cases. Check for ignored shutdown signals. Use `sigemptyset` to
avoid blocking any signals. Set `SA_NODEFER` in `sigaction.sa_flags`.
`SA_NODEFER` doesn't prevent the signal from being received from within
its own signal handler.

7) Fix `JVM_RegisterSignal` and `JVM_RaiseSignal` w.r.t -Xrs cmdline option.

8) Add `SIGRECONFIG` to `jvm.c::signalMap`.

9) Added new trace points for `JVM_RegisterSignal` in `j9scar.tdf`.

10) Removed function `dummySignalHandler` in `jvm.c`.

11) In `JVM_RegisterSignal`, `registerPredefinedHandler` is invoked to
register the pre-defined signal handler. Link `JVM_RegisterSignal`
function with OMR Signal API.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>