### PR TITLE
exclude cmdLineTester_verbosetest on Windows temporarily

### DIFF
--- a/test/cmdLineTests/verbosetest/playlist.xml
+++ b/test/cmdLineTests/verbosetest/playlist.xml
@@ -36,7 +36,8 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DTESTNG=$(Q)$(TESTNG)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) -DJAVA_VERSION=$(Q)$(JAVA_VERSION)$(Q) -DREPORTDIR=$(REPORTDIR) -DTEST_GROUP=$(Q)$(TEST_GROUP)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)verbosetests.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^arch.arm</platformRequirements>
+		<!-- https://github.com/eclipse/openj9/issues/1608, exclude test on Win temporarily -->
+		<platformRequirements>^arch.arm,^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
* exclude cmdLineTester_verbosetest on Windows temporarily
* applying for a windows machine to triage

Issue:#1608

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>