### PR TITLE
Preserved original pointer in getCustomFFIType

### DIFF
--- a/runtime/vm/FFITypeHelpers.hpp
+++ b/runtime/vm/FFITypeHelpers.hpp
@@ -112,17 +112,20 @@ public:
 
 		*typeFFI = NULL;
 		UDATA structSize = UDATA_MAX;
-		char bufOnStackLocal[J9VM_LAYOUT_STRING_ON_STACK_LIMIT];
-		char *layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, bufOnStackLocal, J9VM_LAYOUT_STRING_ON_STACK_LIMIT, NULL);
+		char layoutBuffer[J9VM_LAYOUT_STRING_ON_STACK_LIMIT];
+		char* layout = copyStringToUTF8WithMemAlloc(_currentThread, layoutStringObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, layoutBuffer, sizeof(layoutBuffer), NULL);
+
+		/* Subsequent calls will modify the contents of this pointer, so preserve the original pointer for j9mem_free_memory */
+		char* layoutTemp = layout;
 
 		if (NULL == layout) {
 			goto doneGetCustomFFIType;
 		}
 
-		structSize = getIntFromLayout(&layout);
-		*typeFFI = getStructFFIType(&layout, false);
+		structSize = getIntFromLayout(&layoutTemp);
+		*typeFFI = getStructFFIType(&layoutTemp, false);
 doneGetCustomFFIType:
-		if (layout != bufOnStackLocal) {
+		if (layout != layoutBuffer) {
 			j9mem_free_memory(layout);
 		}
 		return structSize;

--- a/runtime/vm/OutOfLineINL_java_lang_invoke_NativeMethodHandle.cpp
+++ b/runtime/vm/OutOfLineINL_java_lang_invoke_NativeMethodHandle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,11 +66,17 @@ OutOfLineINL_java_lang_invoke_NativeMethodHandle_initJ9NativeCalloutDataRef(J9VM
 	 */
 	U_32 typeCount = J9INDEXABLEOBJECT_SIZE(currentThread, argTypesObject) + 1;
 	args = (ffi_type **)j9mem_allocate_memory(sizeof(ffi_type *) * typeCount, OMRMEM_CATEGORY_VM);
+
 	if (NULL == args) {
 		rc = GOTO_THROW_CURRENT_EXCEPTION;
 		setNativeOutOfMemoryError(currentThread, 0, 0);
 		goto done;
 	}
+
+	/* Zero out the memory because if an error occurs before all the entries in this array are initialized then the error
+	* handling code at freeAllMemoryThenExit will attempt to free all the pointers, some of which will not be initialized.
+	*/
+	memset(args, 0, sizeof(ffi_type *) * typeCount);
 
 	cif = (ffi_cif *)j9mem_allocate_memory(sizeof(ffi_cif), OMRMEM_CATEGORY_VM);
 	if (NULL == cif) {


### PR DESCRIPTION
The getIntFromLayout and getStructFFIType APIs take a reference to the
array returned by copyStringToUTF8WithMemAlloc and they modify the
pointer value. Subsequent calls to j9mem_free_memory will fail due to
metadata not being present.

We preserve the original array pointer and pass a temporary to the
aforementioned APIs to avoid these problems.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>