### PR TITLE
Add isAccessUserOnly0 for FileSystem

### DIFF
--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -96,7 +96,7 @@ Java_com_ibm_oti_vm_BootstrapClassLoader_addJar(JNIEnv *env, jobject receiver, j
 	}
 	/* If any error occcurred, throw OutOfMemoryError */
 	if (0 == newCount) {
-		throwNativeOOMError(env, J9NLS_JCL_UNABLE_TO_CREATE_CLASS_PATH_ENTRY);
+		vmFuncs->throwNativeOOMError(env, J9NLS_JCL_UNABLE_TO_CREATE_CLASS_PATH_ENTRY);
 	}
 	return newCount;
 }

--- a/runtime/jcl/common/exhelp.c
+++ b/runtime/jcl/common/exhelp.c
@@ -39,21 +39,6 @@ throwNewIndexOutOfBoundsException(JNIEnv *env, char *message)
 
 
 /**
-  * Throw java.io.IOException with the message provided
-  */
-void
-throwNewJavaIoIOException(JNIEnv *env, const char *message)
-{
-	jclass exceptionClass = (*env)->FindClass(env, "java/io/IOException");
-	if (exceptionClass == 0) {
-		/* Just return if we can't load the exception class. */
-		return;
-	}
-	(*env)->ThrowNew(env, exceptionClass, message);
-}
-
-
-/**
   * Throw java.lang.InternalError
   */
 void
@@ -65,21 +50,6 @@ throwNewInternalError(JNIEnv *env, char *message)
 		return;
 	}
 	(*env)->ThrowNew(env, exceptionClass, message);
-}
-
-
-/**
-  * Throw java.lang.OutOfMemoryError
-  */
-void
-throwNativeOOMError(JNIEnv *env, U_32 moduleName, U_32 messageNumber)
-{
-	J9VMThread *currentThread = (J9VMThread *)env;
-	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	vmFuncs->internalEnterVMFromJNI(currentThread);
-	vmFuncs->setNativeOutOfMemoryError(currentThread, moduleName, messageNumber);
-	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 

--- a/runtime/jcl/common/extendedosmbean.c
+++ b/runtime/jcl/common/extendedosmbean.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -129,7 +129,7 @@ handle_error(JNIEnv *env, IDATA error, jint type)
 
 	/* If out of memory setup a pending OutOfMemoryError */
 	if (J9PORT_ERROR_SYSINFO_MEMORY_ALLOC_FAILED == error) {
-		throwNativeOOMError(env, J9NLS_PORT_SYSINFO_OUT_OF_MEMORY_ERROR_MSG);
+		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, J9NLS_PORT_SYSINFO_OUT_OF_MEMORY_ERROR_MSG);
 		return 0;
 	}
 

--- a/runtime/jcl/common/gpu.c
+++ b/runtime/jcl/common/gpu.c
@@ -48,7 +48,7 @@ extractArguments(JNIEnv *env, jintArray argSizes, jlongArray argValues) {
 		jsize i = 0;
 
 		if (NULL == args) {
-			throwNativeOOMError(env, 0, 0);
+			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 			return NULL;
 		}
 		/* gather addresses of parameters */

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -77,7 +77,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 		}
 		classBytes = j9mem_allocate_memory(length, J9MEM_CATEGORY_CLASSES);
 		if (classBytes == NULL) {
-			throwNativeOOMError(env, 0, 0);
+			vmFuncs->throwNativeOOMError(env, 0, 0);
 			return NULL;
 		}
 		(*env)->GetByteArrayRegion(env, classRep, offset, length, (jbyte *)classBytes);

--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -458,6 +458,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 {
 	UDATA i = 0;
 	UDATA rc = 0;
+	J9InternalVMFunctions *vmFuncs = ((J9VMThread *)env)->javaVM->internalVMFunctions;
 
 	PORT_ACCESS_FROM_ENV(env);
 
@@ -471,7 +472,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 	*formatStringsArray = (char **)j9mem_allocate_memory(sizeof(char *) * (*tracePointCount + 1), J9MEM_CATEGORY_VM_JCL);
 
 	if (NULL == *formatStringsArray) {
-		throwNativeOOMError(env, 0, 0);
+		vmFuncs->throwNativeOOMError(env, 0, 0);
 		rc = 2;
 		goto fail;
 	}
@@ -481,7 +482,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 	*callPatternsArray = (UDATA *) j9mem_allocate_memory(sizeof(UDATA) * *tracePointCount, J9MEM_CATEGORY_VM_JCL);
 
 	if (NULL == *callPatternsArray) {
-		throwNativeOOMError(env, 0, 0);
+		vmFuncs->throwNativeOOMError(env, 0, 0);
 		rc = 2;
 		goto fail;
 	}
@@ -522,7 +523,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 		(*formatStringsArray)[i] = (char *)j9mem_allocate_memory(strlen(jniStringCharacters) + 1, J9MEM_CATEGORY_VM_JCL);
 
 		if (NULL == (*formatStringsArray)[i]) {
-			throwNativeOOMError(env, 0, 0);
+			vmFuncs->throwNativeOOMError(env, 0, 0);
 			(*env)->ReleaseStringUTFChars(env, thisString, jniStringCharacters);
 			rc = 6;
 			goto fail;
@@ -603,6 +604,7 @@ buildModInfo(JNIEnv *const env, const char *const applicationName, const UDATA t
 {
 	UtModuleInfo *toReturn = NULL;
 	UDATA arraySize = sizeof(unsigned char) * tracePointCount;
+	J9InternalVMFunctions *vmFuncs = ((J9VMThread *)env)->javaVM->internalVMFunctions;
 
 	PORT_ACCESS_FROM_ENV(env);
 
@@ -617,7 +619,7 @@ buildModInfo(JNIEnv *const env, const char *const applicationName, const UDATA t
 	toReturn->namelength = (I_32)strlen(applicationName);
 	toReturn->name = j9mem_allocate_memory( toReturn->namelength + 1, J9MEM_CATEGORY_VM_JCL);
 	if (NULL == toReturn->name) {
-		throwNativeOOMError(env, 0, 0);
+		vmFuncs->throwNativeOOMError(env, 0, 0);
 		goto error;
 	}
 	strcpy(toReturn->name, applicationName);
@@ -628,7 +630,7 @@ buildModInfo(JNIEnv *const env, const char *const applicationName, const UDATA t
 
 	toReturn->active = (unsigned char *)j9mem_allocate_memory( arraySize, J9MEM_CATEGORY_VM_JCL);
 	if (NULL == toReturn->active) {
-		throwNativeOOMError(env, 0, 0);
+		vmFuncs->throwNativeOOMError(env, 0, 0);
 		goto error;
 	}
 
@@ -636,7 +638,7 @@ buildModInfo(JNIEnv *const env, const char *const applicationName, const UDATA t
 
 	toReturn->traceVersionInfo = (UtTraceVersionInfo *)j9mem_allocate_memory( sizeof(UtTraceVersionInfo), J9MEM_CATEGORY_VM_JCL);
 	if (NULL == toReturn->traceVersionInfo) {
-		throwNativeOOMError(env, 0, 0);
+		vmFuncs->throwNativeOOMError(env, 0, 0);
 		goto error;
 	}
 
@@ -644,7 +646,7 @@ buildModInfo(JNIEnv *const env, const char *const applicationName, const UDATA t
 
 	toReturn->levels = (unsigned char *)j9mem_allocate_memory( arraySize, J9MEM_CATEGORY_VM_JCL);
 	if (NULL == toReturn->levels) {
-		throwNativeOOMError(env, 0, 0);
+		vmFuncs->throwNativeOOMError(env, 0, 0);
 		goto error;
 	}
 	memset(toReturn->levels, 3, arraySize);
@@ -1798,7 +1800,7 @@ allocArrayList(JNIEnv *const env, const UDATA slabSize)
 
 	if (NULL == toReturn) {
 		/*Malloc failure*/
-		throwNativeOOMError(env, 0, 0);
+		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 		return NULL;
 	}
 
@@ -1818,7 +1820,7 @@ arrayListAllocateSlab(JNIEnv *const env, const struct ArrayList *const list)
 	void **toReturn = j9mem_allocate_memory(allocSize, J9MEM_CATEGORY_VM_JCL);
 
 	if (NULL == toReturn) {
-		throwNativeOOMError(env, 0, 0);
+		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 		return NULL;
 	}
 

--- a/runtime/jcl/common/jniidcacheinit.c
+++ b/runtime/jcl/common/jniidcacheinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ initializeJavaLangStringIDCache(JNIEnv* env)
 		globalStringRef = (*env)->NewGlobalRef(env, jStringClass);
 		if (globalStringRef == NULL) {
 			/* out of memory exception thrown */
-			throwNativeOOMError(env, 0, 0);
+			javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 			return FALSE; 
 		}
 		
@@ -148,7 +148,7 @@ initializeSunReflectConstantPoolIDCache(JNIEnv* env)
 		globalClassRef = (*env)->NewGlobalRef(env, sunReflectConstantPool);
 		if (globalClassRef == NULL) {
 			/* out of memory exception thrown */
-			throwNativeOOMError(env, 0, 0);
+			javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 			return FALSE; 
 		}
 		

--- a/runtime/jcl/common/log.c
+++ b/runtime/jcl/common/log.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ Java_com_ibm_jvm_Log_QueryOptionsImpl(JNIEnv *env, jclass clazz)
 	/* allocate enough memory for the options string */
 	nativeOptions = j9mem_allocate_memory(LOG_OPTION_DATA_SIZE, J9MEM_CATEGORY_VM_JCL);
 	if (NULL == nativeOptions) {
-		throwNativeOOMError(env, 0, 0);
+		vm->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 		return NULL;
 	}
 

--- a/runtime/jcl/common/mgmthypervisor.c
+++ b/runtime/jcl/common/mgmthypervisor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,7 +116,7 @@ handle_error(JNIEnv *env, IDATA error, jint type)
 
 	/* If out of memory setup a pending OutOfMemoryError */
 	if (J9PORT_ERROR_HYPERVISOR_MEMORY_ALLOC_FAILED == error) {
-		throwNativeOOMError(env, J9NLS_PORT_HYPERVISOR_OUT_OF_MEMORY_ERROR_MSG);
+		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, J9NLS_PORT_HYPERVISOR_OUT_OF_MEMORY_ERROR_MSG);
 		return 0;
 	}
 

--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -2618,7 +2618,7 @@ Java_com_ibm_java_lang_management_internal_ThreadMXBeanImpl_getNativeThreadIdsIm
 	nativeIds = j9mem_allocate_memory(arrLen * sizeof(jlong), J9MEM_CATEGORY_VM_JCL);
 	if (NULL == nativeIds) {
 		Trc_JCL_threadmxbean_getNativeThreadIdsImpl_outOfMemory(env, arrLen);
-		throwNativeOOMError(env, 0, 0);
+		javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 		goto _exit;
 	}
 	/* Extract primitive (jlong) array from the jlongArray passed by JNI.  Examine its elements for TIDs. */

--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -412,7 +412,7 @@ getURLMethodIDs(JNIEnv* env)
 			(*env)->DeleteLocalRef(env, javaNetURLClassLocalRef);
 			if (NULL == javaNetURLClass) {
 				omrthread_monitor_exit(vm->jclCacheMutex);
-				throwNativeOOMError(env, J9NLS_JCL_OOM_NEW_GLOBAL_REF);
+				vm->internalVMFunctions->throwNativeOOMError(env, J9NLS_JCL_OOM_NEW_GLOBAL_REF);
 				goto _exit;
 			}
 			JCL_CACHE_SET(env, CLS_java_net_URL, javaNetURLClass);
@@ -2226,7 +2226,7 @@ Java_com_ibm_oti_shared_SharedClassUtilities_getSharedCacheInfoImpl(JNIEnv *env,
 		dir = (const jbyte *)(*env)->GetStringUTFChars(env, cacheDir, NULL);
 		if (NULL == dir) {
 			(*env)->ExceptionClear(env);
-			throwNativeOOMError(env, 0, 0);
+			vm->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 			result = -1;
 			goto exit;
 		}
@@ -2267,7 +2267,7 @@ Java_com_ibm_oti_shared_SharedClassUtilities_destroySharedCacheImpl(JNIEnv *env,
 			dir = (const jbyte *)(*env)->GetStringUTFChars(env, cacheDir, NULL);
 			if (NULL == dir) {
 				(*env)->ExceptionClear(env);
-				throwNativeOOMError(env, 0, 0);
+				vm->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 				result = -1;
 				goto exit;
 			}
@@ -2277,7 +2277,7 @@ Java_com_ibm_oti_shared_SharedClassUtilities_destroySharedCacheImpl(JNIEnv *env,
 			name = (const jbyte *)(*env)->GetStringUTFChars(env, cacheName, NULL);
 			if (NULL == name) {
 				(*env)->ExceptionClear(env);
-				throwNativeOOMError(env, 0, 0);
+				vm->internalVMFunctions->throwNativeOOMError(env, 0, 0);
 				result = -1;
 				goto exit;
 			}

--- a/runtime/jcl/common/sun_reflect_ConstantPool.c
+++ b/runtime/jcl/common/sun_reflect_ConstantPool.c
@@ -265,7 +265,7 @@ getMethodAt(JNIEnv *env, jobject constantPoolOop, jint cpIndex, UDATA resolveFla
 				const jboolean isStatic = (J9CPTYPE_STATIC_METHOD == cpType) || (J9CPTYPE_INTERFACE_STATIC_METHOD == cpType);
 				returnValue = (*env)->ToReflectedMethod(env, jlClass, methodID, isStatic);
 			} else {
-				throwNativeOOMError(env, 0, 0);
+				vmFunctions->throwNativeOOMError(env, 0, 0);
 			}
 		}
 
@@ -342,7 +342,7 @@ retry:
 				/* The isStatic argument is ignored. */
 				returnValue = (*env)->ToReflectedField(env, jlClass, fieldID, FALSE);
 			} else {
-				throwNativeOOMError(env, 0, 0);
+				vmFunctions->throwNativeOOMError(env, 0, 0);
 			}
 		}
 	}

--- a/runtime/mgmt/mgmtinit.c
+++ b/runtime/mgmt/mgmtinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,8 @@
  *******************************************************************************/
 
 #include "jni.h"
+#include "j9port.h"
+#include "jclprots.h"
 
 /*
  * Invoked immediately after this shared library has been loaded.
@@ -30,4 +32,94 @@ jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
 {
 	return JNI_VERSION_1_8;
+}
+
+/* Convert path to platform encoding.
+ * It is the callers responsibility for freeing the returned memory.
+ *
+ * @return NULL on error, otherwise return converted string
+ */
+static const char*
+translatePathToPlatform(JNIEnv *env, const char* pathUTF)
+{
+	char *result = NULL;
+	int32_t bufferLength = 0;
+	uintptr_t pathUTFSize = strlen(pathUTF);
+
+	PORT_ACCESS_FROM_ENV(env);
+
+	bufferLength = 	j9str_convert(J9STR_CODE_MUTF8, J9STR_CODE_PLATFORM_OMR_INTERNAL, pathUTF, pathUTFSize, NULL, 0);
+
+	if (bufferLength >= 0) {
+		bufferLength += MAX_STRING_TERMINATOR_LENGTH;
+
+		result = (char*)j9mem_allocate_memory(bufferLength, OMRMEM_CATEGORY_PORT_LIBRARY);
+		if (NULL != result)  {
+			int32_t resultLength = j9str_convert(J9STR_CODE_MUTF8, J9STR_CODE_PLATFORM_OMR_INTERNAL, pathUTF, pathUTFSize, result, bufferLength);
+			if ((resultLength < 0) ||  (resultLength + MAX_STRING_TERMINATOR_LENGTH != bufferLength)) {
+				j9mem_free_memory(result);
+				result = NULL; /* error occured */
+			} else {
+				/* add terminator */
+				memset(result + resultLength, 0, MAX_STRING_TERMINATOR_LENGTH);
+			}
+		}
+	}
+
+	return (const char*)result;
+
+}
+
+/**
+ * Determines whether file path has user permissions only.
+ *
+ * @param path file path
+ * @return Returns true if the file has only user permissions,
+ * false otherwise. Always returns false on Windows.
+ *
+ * Note: Windows permission bits are not set to differentiate between users.
+ */
+JNIEXPORT jboolean JNICALL 
+Java_sun_management_FileSystemImpl_isAccessUserOnly0(JNIEnv *env, jclass c, jstring path)
+{
+	const char* pathUTF = NULL;
+	jboolean result = JNI_FALSE;
+
+	PORT_ACCESS_FROM_ENV(env);
+
+	pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
+	if (NULL == pathUTF) {
+		((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
+	} else {
+		struct J9FileStat buf;
+		I_32 status = -1;
+		const char* pathConvert = pathUTF;
+#if !defined(WIN32) && !defined(WIN64)
+		pathConvert = (char*)translatePathToPlatform(env, pathUTF);
+		if (NULL == pathConvert) {
+			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNativeOOMError(env, 0, 0);
+			(*env)->ReleaseStringUTFChars(env, path, pathUTF);
+			return result;
+		}
+#endif /* skip on windows */
+		/* retrieve file information */
+		status = j9file_stat(pathConvert, 0, &buf);
+
+		if (0 == status) {
+			/* if any permissions are set other than user, fail */
+			if (!buf.perm.isGroupWriteable && !buf.perm.isGroupReadable && !buf.perm.isOtherWriteable && !buf.perm.isOtherReadable) {
+				result = JNI_TRUE;
+			}
+		} else {
+			/* failed to retrieve statistics */
+			((J9VMThread *)env)->javaVM->internalVMFunctions->throwNewJavaIoIOException(env, NULL);
+		}
+
+		if (pathConvert != pathUTF) {
+			j9mem_free_memory((void*)pathConvert);
+		}
+		(*env)->ReleaseStringUTFChars(env, path, pathUTF);
+	}
+
+	return result;
 }

--- a/runtime/mgmt/module.xml
+++ b/runtime/mgmt/module.xml
@@ -24,6 +24,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 	<exports group="all">
 		<export name="JNI_OnLoad" />
+		<export name="Java_sun_management_FileSystemImpl_isAccessUserOnly0" />
 	</exports>
 
 	<artifact type="shared" name="management" loadgroup="" appendrelease="false">

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4818,6 +4818,8 @@ typedef struct J9InternalVMFunctions {
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 	IDATA ( *registerPredefinedHandler)(struct J9JavaVM *vm, U_32 signal, void **oldOSHandler);
 	IDATA ( *registerOSHandler)(struct J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
+	void ( *throwNativeOOMError)(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
+	void ( *throwNewJavaIoIOException)(JNIEnv *env, const char *message);
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -301,8 +301,6 @@ J9SigQuitStartup (J9JavaVM * vm);
 
 /* BBjclNativesCommonExceptionHelpers*/
 void
-throwNativeOOMError (JNIEnv *env, U_32 moduleName, U_32 messageNumber);
-void
 throwNewNullPointerException (JNIEnv *env, char *message);
 void
 throwNewIllegalStateException (JNIEnv *env, char *message);
@@ -312,8 +310,6 @@ void
 throwNewIndexOutOfBoundsException (JNIEnv *env, char *message);
 void
 throwNewInternalError (JNIEnv *env, char *message);
-void
-throwNewJavaIoIOException (JNIEnv *env, const char *message);
 void
 throwNewIllegalArgumentException (JNIEnv *env, char *message);
 void

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4185,6 +4185,12 @@ typedef struct J9ThreadEnv {
 
 void flushProcessWriteBuffers(J9JavaVM *vm);
 
+/* throwexception.c */
+void
+throwNativeOOMError(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
+void
+throwNewJavaIoIOException(JNIEnv *env, const char *message);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -363,4 +363,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 	registerPredefinedHandler,
 	registerOSHandler,
+	throwNativeOOMError,
+	throwNewJavaIoIOException,
 };

--- a/runtime/vm/throwexception.c
+++ b/runtime/vm/throwexception.c
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "j9.h"
+
+/**
+  * Throw java.lang.OutOfMemoryError
+  */
+void
+throwNativeOOMError(JNIEnv *env, U_32 moduleName, U_32 messageNumber)
+{
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->setNativeOutOfMemoryError(currentThread, moduleName, messageNumber);
+	vmFuncs->internalReleaseVMAccess(currentThread);
+}
+
+
+/**
+  * Throw java.io.IOException with the message provided
+  */
+void
+throwNewJavaIoIOException(JNIEnv *env, const char *message)
+{
+	jclass exceptionClass = (*env)->FindClass(env, "java/io/IOException");
+	if (exceptionClass == 0) {
+		/* Just return if we can't load the exception class. */
+		return;
+	}
+	(*env)->ThrowNew(env, exceptionClass, message);
+}


### PR DESCRIPTION
libmanagement natives were replaced by a stub in openj9. isAccessUserOnly0 is required for the security enabled SVT JLM tests to pass on Java 8.

Depends on: https://github.com/eclipse/omr/pull/2536

Fixes: #1520

Test PR: #1656

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>