### PR TITLE
Tests for isAccessUserOnly0 native

### DIFF
--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -40,7 +40,18 @@
 	<property name="build_resource" location="./resource" />
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src"/>
 	<property name="TestUtilities" location="../TestUtilities/src"/>
-
+	<if>
+		<equals arg1="${JCL_VERSION}" arg2="current"/>
+		<then>
+			<property name="src_90_jcl" location="./src_90_current" />
+			<property name="addExports_90_jcl" value="--add-exports java.management/sun.management=ALL-UNNAMED" />
+		</then>
+		<else>
+			<property name="src_90_jcl" location="./src_90_latest" />
+			<property name="addExports_90_jcl" value="--add-exports jdk.management.agent/jdk.internal.agent=ALL-UNNAMED" />
+		</else>
+	</if>	
+		
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build}" />
@@ -154,9 +165,11 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${src_90}" />
+					<src path="${src_90_jcl}" />
 					<src path="${TestUtilities}" />
 					<src path="${transformerListener}" />
 					<compilerarg line='${addExports}' />
+					<compilerarg line='${addExports_90_jcl}' />
 					<compilerarg line='${addModules}' />
 					<!-- PR117298-->
 					<exclude name="**/Cmvc194280.java" />

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1959,5 +1959,48 @@
 			<subset>SE110</subset>
 		</subsets>
 	</test>
+	
+	<test>
+		<testCaseName>FileSystem-isAccessUserOnlyTests</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			--add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+			-testnames FileSystem-isAccessUserOnlyTests \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+	
+	<test>
+		<testCaseName>FileSystem-isAccessUserOnlyTests_SE80</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+			-testnames FileSystem-isAccessUserOnlyTests \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+	</test>
 
 </playlist>

--- a/test/functional/Java8andUp/src_80/org/openj9/test/jdk/internal/agent/Test_FileSystem.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/jdk/internal/agent/Test_FileSystem.java
@@ -1,0 +1,98 @@
+package org.openj9.test.jdk.internal.agent;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.jdk.internal.agent.Test_FileSystem_Base;
+import sun.management.FileSystem;
+import java.io.File;
+import org.testng.Assert;
+import java.io.IOException;
+
+public class Test_FileSystem extends Test_FileSystem_Base {
+	
+	/**
+	 * @tests sun.management.FileSystem#isAccessUserOnly(java.io.File f)
+	 */
+	public void test_fileHasUserAccessOnly() {
+		File file = testSetup();
+		if (null == file) {
+			return; /* skip test */
+		}
+		FileSystem fs = FileSystem.open();
+		
+		/* set write permissions for user access only */
+		logger.debug("Write permissions for user access only");
+		resetPermissions(file);
+		file.setWritable(true, true);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), true);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		/* set read permissions for user access only */
+		logger.debug("Read permissions for user access only");
+		resetPermissions(file);
+		file.setReadable(true, true);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), true);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		file.delete();
+	}
+	
+	/**
+	 * @tests sun.management.FileSystem#isAccessUserOnly(java.io.File f)
+	 */
+	public void test_fileHasOtherAccess() {
+		File file = testSetup();
+		if (null == file) {
+			return; /* skip test */
+		}
+		FileSystem fs = FileSystem.open();
+		
+		/* set write permissions for all users */
+		logger.debug("Write permissions set for all users.");
+		resetPermissions(file);
+		file.setWritable(true, false);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), false);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		/* set read permissions for all users */
+		logger.debug("Read permissions for all users");
+		resetPermissions(file);
+		file.setReadable(true, false);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), false);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		file.delete();
+	}
+}

--- a/test/functional/Java8andUp/src_90_current/org/openj9/test/jdk/internal/agent/Test_FileSystem.java
+++ b/test/functional/Java8andUp/src_90_current/org/openj9/test/jdk/internal/agent/Test_FileSystem.java
@@ -1,0 +1,98 @@
+package org.openj9.test.jdk.internal.agent;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.jdk.internal.agent.Test_FileSystem_Base;
+import sun.management.FileSystem;
+import java.io.File;
+import org.testng.Assert;
+import java.io.IOException;
+
+public class Test_FileSystem extends Test_FileSystem_Base {
+	
+	/**
+	 * @tests sun.management.FileSystem#isAccessUserOnly(java.io.File f)
+	 */
+	public void test_fileHasUserAccessOnly() {
+		File file = testSetup();
+		if (null == file) {
+			return; /* skip test */
+		}
+		FileSystem fs = FileSystem.open();
+		
+		/* set write permissions for user access only */
+		logger.debug("Write permissions for user access only");
+		resetPermissions(file);
+		file.setWritable(true, true);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), true);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		/* set read permissions for user access only */
+		logger.debug("Read permissions for user access only");
+		resetPermissions(file);
+		file.setReadable(true, true);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), true);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		file.delete();
+	}
+	
+	/**
+	 * @tests sun.management.FileSystem#isAccessUserOnly(java.io.File f)
+	 */
+	public void test_fileHasOtherAccess() {
+		File file = testSetup();
+		if (null == file) {
+			return; /* skip test */
+		}
+		FileSystem fs = FileSystem.open();
+		
+		/* set write permissions for all users */
+		logger.debug("Write permissions set for all users.");
+		resetPermissions(file);
+		file.setWritable(true, false);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), false);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		/* set read permissions for all users */
+		logger.debug("Read permissions for all users");
+		resetPermissions(file);
+		file.setReadable(true, false);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), false);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		file.delete();
+	}
+}

--- a/test/functional/Java8andUp/src_90_latest/org/openj9/test/jdk/internal/agent/Test_FileSystem.java
+++ b/test/functional/Java8andUp/src_90_latest/org/openj9/test/jdk/internal/agent/Test_FileSystem.java
@@ -1,0 +1,98 @@
+package org.openj9.test.jdk.internal.agent;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.openj9.test.jdk.internal.agent.Test_FileSystem_Base;
+import jdk.internal.agent.FileSystem;
+import java.io.File;
+import org.testng.Assert;
+import java.io.IOException;
+
+public class Test_FileSystem extends Test_FileSystem_Base {
+	
+	/**
+	 * @tests sun.management.FileSystem#isAccessUserOnly(java.io.File f)
+	 */
+	public void test_fileHasUserAccessOnly() {
+		File file = testSetup();
+		if (null == file) {
+			return; /* skip test */
+		}
+		FileSystem fs = FileSystem.open();
+		
+		/* set write permissions for user access only */
+		logger.debug("Write permissions for user access only");
+		resetPermissions(file);
+		file.setWritable(true, true);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), true);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		/* set read permissions for user access only */
+		logger.debug("Read permissions for user access only");
+		resetPermissions(file);
+		file.setReadable(true, true);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), true);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		file.delete();
+	}
+	
+	/**
+	 * @tests sun.management.FileSystem#isAccessUserOnly(java.io.File f)
+	 */
+	public void test_fileHasOtherAccess() {
+		File file = testSetup();
+		if (null == file) {
+			return; /* skip test */
+		}
+		FileSystem fs = FileSystem.open();
+		
+		/* set write permissions for all users */
+		logger.debug("Write permissions set for all users.");
+		resetPermissions(file);
+		file.setWritable(true, false);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), false);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		/* set read permissions for all users */
+		logger.debug("Read permissions for all users");
+		resetPermissions(file);
+		file.setReadable(true, false);
+		try {
+			resolveTest(fs.isAccessUserOnly(file), false);
+		} catch(IOException e) {
+			Assert.fail();
+		}
+		
+		file.delete();
+	}
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -387,5 +387,10 @@
 			<class name="org.openj9.test.floatsanity.TestFactory" />
 		</classes>
 	</test>
+	<test name="FileSystem-isAccessUserOnlyTests">
+		<classes>
+			<class name="org.openj9.test.jdk.internal.agent.Test_FileSystem"/>
+		</classes>
+	</test>
 </suite>
 <!-- Suite -->

--- a/test/functional/TestUtilities/src/org/openj9/test/jdk/internal/agent/Test_FileSystem_Base.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/jdk/internal/agent/Test_FileSystem_Base.java
@@ -1,0 +1,71 @@
+package org.openj9.test.jdk.internal.agent;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.log4testng.Logger;
+import java.io.File;
+
+@Test(groups = { "level.sanity" })
+public abstract class Test_FileSystem_Base {
+	protected Logger logger = Logger.getLogger(getClass());
+
+	protected File testSetup() {
+		File file = null;
+		
+		/* method is not supported on windows */
+		if (isWindows()) {
+			logger.debug("skipping  test on Windows");
+		} else {
+		
+			try {
+				file = File.createTempFile("test", null);
+				file.deleteOnExit();
+			} catch (Exception e) {
+				logger.debug("Exception thrown in creating file.");
+				Assert.fail();
+			}
+		}
+		
+		return file;
+	}
+	
+	protected boolean isWindows() {
+		String osName = System.getProperty("os.name");
+		if ((null != osName) && osName.startsWith("Windows")) {
+			return true;
+		}
+		return false;
+	}
+	
+	protected void resetPermissions(File file) {
+		file.setReadable(false, false);
+		file.setWritable(false, false);
+	}
+	
+	protected void resolveTest(boolean actualResult, boolean expectedResult) {
+		logger.debug("Test passed: " + (expectedResult == actualResult));
+		Assert.assertEquals(expectedResult, actualResult);
+	}
+}

--- a/test/functional/TestUtilities/src/org/openj9/test/jdk/internal/agent/Test_FileSystem_Base.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/jdk/internal/agent/Test_FileSystem_Base.java
@@ -65,7 +65,6 @@ public abstract class Test_FileSystem_Base {
 	}
 	
 	protected void resolveTest(boolean actualResult, boolean expectedResult) {
-		logger.debug("Test passed: " + (expectedResult == actualResult));
 		Assert.assertEquals(expectedResult, actualResult);
 	}
 }


### PR DESCRIPTION
- includes tests for isAccessUserOnly0 in Java8 and Java9
- expanded test infra to have src_90_current and src_90_latest files for different JCL versions in Java 9

Relies on: #1655 

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>