### PR TITLE
Remove duplicate flag (J9_SIG_XRS) and fix dependencies

### DIFF
--- a/runtime/compiler/trj9/control/J9Options.cpp
+++ b/runtime/compiler/trj9/control/J9Options.cpp
@@ -2230,13 +2230,17 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       doAOT = false;
       }
 
-   // If the VM -Xrs option has been specified the user is requesting that
-   // we remove signals. Set the noResumableTrapHandler option to note this
+   // If the VM -Xrs or -Xrs:sync option has been specified the user is requesting
+   // that we remove signals. Set the noResumableTrapHandler option to note this
    // request.
    // Also disable the packed decimal part of DAA because some PD instructions
-   // trigger hardward exceptions. A new option has been added to disable traps
+   // trigger hardware exceptions. A new option has been added to disable traps
    // Which allows the disabling of DAA and traps to be decoupled from the handler
-   if (javaVM->sigFlags & J9_SIG_XRS)
+   // Multiple variants of -Xrs option are available now:
+   // -Xrs Ignore all signals (J9_SIG_XRS_SYNC, J9_SIG_XRS_ASYNC)
+   // -Xrs:sync Ignore synchronous signals (J9_SIG_XRS_SYNC)
+   // -Xrs:async Ignore asynchronous signals (J9_SIG_XRS_ASYNC)
+   if (J9_ARE_ALL_BITS_SET(javaVM->sigFlags, J9_SIG_XRS_SYNC))
       {
       self()->setOption(TR_NoResumableTrapHandler);
       self()->setOption(TR_DisablePackedDecimalIntrinsics);

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -4477,7 +4477,7 @@ JVM_RaiseSignal(jint sigNum)
 
 	Trc_SC_RaiseSignal_Entry(sigNum);
 
-	if (J9_ARE_ALL_BITS_SET(javaVM->sigFlags, J9_SIG_XRS)
+	if (J9_ARE_ALL_BITS_SET(javaVM->sigFlags, J9_SIG_XRS_SYNC)
 			&& isSignalSpecial(sigNum)) {
 		/* Ignore signal */
 	} else {
@@ -4548,7 +4548,7 @@ JVM_RegisterSignal(jint sigNum, void* handler)
 		/* Don't allow user to register a native handler since
 		 * the signal is already used by the VM.
 		 */
-	} else if (J9_ARE_NO_BITS_SET(javaVM->sigFlags, J9_SIG_XRS)
+	} else if (J9_ARE_NO_BITS_SET(javaVM->sigFlags, J9_SIG_XRS_SYNC)
 			&& isSignalSpecial(sigNum)) {
 		/* Don't allow user to register a native handler since
 		 * the signal is already used by the VM.

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -280,7 +280,7 @@ jobject getPropertyList(JNIEnv *env)
 	 * 	we consider to be asynchronous signals.
 	 * The JCLs do not install handlers for any synchronous signals */
 	strings[propIndex++] = "ibm.signalhandling.rs";
-	if (javaVM->sigFlags & J9_SIG_XRS_ASYNC) {
+	if (J9_ARE_ALL_BITS_SET(javaVM->sigFlags, J9_SIG_XRS_ASYNC)) {
 		strings[propIndex++] = "true";
 	} else {
 		strings[propIndex++] = "false";

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -619,7 +619,6 @@ extern "C" {
 #define J9_SIG_NO_SIG_QUIT 0x1
 #define J9_SIG_NO_SIG_CHAIN 0x4
 #define J9_SIG_NO_SIG_INT 0x8
-#define J9_SIG_XRS 0x10
 #define J9_SIG_XRS_SYNC 0x10
 #define J9_SIG_XRS_ASYNC 0x20
 #define J9_SIG_ZOS_CEEHDLR 0x40

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5904,10 +5904,10 @@ setSignalOptions(J9JavaVM* vm)
 
 		GET_OPTION_VALUE(argIndex, ':', &optionValue);
 
-		if (optionValue && 0 == strcmp(optionValue, "sync")) {
+		if ((NULL != optionValue) && (0 == strcmp(optionValue, "sync"))) {
 			vm->sigFlags |= J9_SIG_XRS_SYNC;
 			sigOptions |= J9PORT_SIG_OPTIONS_REDUCED_SIGNALS_SYNCHRONOUS;
-		} else if (optionValue && 0 == strcmp(optionValue, "async")) {
+		} else if ((NULL != optionValue) && (0 == strcmp(optionValue, "async"))) {
 			vm->sigFlags |= (J9_SIG_XRS_ASYNC | J9_SIG_NO_SIG_QUIT);
 			sigOptions |= J9PORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS;
 		} else {


### PR DESCRIPTION
1) `J9_SIG_XRS` has been removed since it is a duplicate of 
`J9_SIG_XRS_SYNC`.

2) Update VM's and JIT's processing of `-Xrs` option since they use 
`J9_SIG_XRS`.

3) Fix code formatting.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>