### PR TITLE
Update test names for JDK10

### DIFF
--- a/test/JLM_Tests/playlist.xml
+++ b/test/JLM_Tests/playlist.xml
@@ -59,7 +59,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JLM_Tests_interface_SE90</testCaseName>
+		<testCaseName>JLM_Tests_interface</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -122,7 +122,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JLM_Tests_class_SE90</testCaseName>
+		<testCaseName>JLM_Tests_class</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -177,7 +177,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JLM_Tests_IBMinternal_SE90</testCaseName>
+		<testCaseName>JLM_Tests_IBMinternal</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:+HeapManagementMXBeanCompatibility</variation>
@@ -1038,7 +1038,7 @@
 	</test>
 
 	<test>
-		<testCaseName>testJCMMXBeanLocal_SE90</testCaseName>
+		<testCaseName>testJCMMXBeanLocal</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode101</variation>
@@ -1093,7 +1093,7 @@
 	</test>
 
 	<test>
-		<testCaseName>testJCMMXBeanRemote_SE90</testCaseName>
+		<testCaseName>testJCMMXBeanRemote</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode101</variation>

--- a/test/Java8andUp/playlist.xml
+++ b/test/Java8andUp/playlist.xml
@@ -43,7 +43,7 @@
 	</test>
 
 	<test>
-		<testCaseName>generalSanityTest_SE90</testCaseName>
+		<testCaseName>generalSanityTest</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames generalTest \
@@ -209,7 +209,7 @@
 	</test>
 
 	<test>
-		<testCaseName>AttachAPISanity_SE90</testCaseName>
+		<testCaseName>AttachAPISanity</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -256,7 +256,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestAttachAPI_SE90</testCaseName>
+		<testCaseName>TestAttachAPI</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -300,7 +300,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestAttachAPIEnabling_SE90</testCaseName>
+		<testCaseName>TestAttachAPIEnabling</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -347,7 +347,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestAttachErrorHandling_SE90</testCaseName>
+		<testCaseName>TestAttachErrorHandling</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -393,7 +393,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestSunAttachClasses_SE90</testCaseName>
+		<testCaseName>TestSunAttachClasses</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -440,7 +440,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestManagementAgent_SE90</testCaseName>
+		<testCaseName>TestManagementAgent</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -486,7 +486,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestFileLocking_SE90</testCaseName>
+		<testCaseName>TestFileLocking</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -719,7 +719,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JCL_Test_SE90+</testCaseName>
+		<testCaseName>JCL_Test</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
@@ -774,7 +774,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JCL_Test_OutOfMemoryError_SE90+</testCaseName>
+		<testCaseName>JCL_Test_OutOfMemoryError</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
@@ -887,7 +887,7 @@
 	</test>
 
 	<test>
-		<testCaseName>J9VMInternals_Test_SE90</testCaseName>
+		<testCaseName>J9VMInternals_Test</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1040,7 +1040,7 @@
 	</test>
 
 	<test>
-		<testCaseName>JCL_Test_JIT_Helper_SE90</testCaseName>
+		<testCaseName>JCL_Test_JIT_Helper</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) --add-exports=java.base/com.ibm.jit=ALL-UNNAMED \
 	-Xbootclasspath/a:$(Q)$(TEST_RESROOT)$(D)TestResources.jar$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \

--- a/test/JavaAgentTest/playlist.xml
+++ b/test/JavaAgentTest/playlist.xml
@@ -24,7 +24,7 @@
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>TestFlushReflectionCache_SE90</testCaseName>
+		<testCaseName>TestFlushReflectionCache</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode100</variation>
@@ -53,7 +53,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestRefreshGCSpecialClassesCache_NOBCI_SE90</testCaseName>
+		<testCaseName>TestRefreshGCSpecialClassesCache_NOBCI</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode100</variation>
@@ -81,7 +81,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestRefreshGCSpecialClassesCache_NOBCI_JIT_ON_SE90</testCaseName>
+		<testCaseName>TestRefreshGCSpecialClassesCache_NOBCI_JIT_ON</testCaseName>
 		<variations>
 			<variation>Mode107</variation>
 		</variations>
@@ -108,7 +108,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestRefreshGCSpecialClassesCache_BCI_FAST_HCR_SE90</testCaseName>
+		<testCaseName>TestRefreshGCSpecialClassesCache_BCI_FAST_HCR</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode100</variation>
@@ -137,7 +137,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestRefreshGCSpecialClassesCache_BCI_EXTENDED_HCR_SE90</testCaseName>
+		<testCaseName>TestRefreshGCSpecialClassesCache_BCI_EXTENDED_HCR</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode107</variation>
@@ -165,7 +165,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestGCClassWithStaticRetransformInGencon_SE90</testCaseName>
+		<testCaseName>TestGCClassWithStaticRetransformInGencon</testCaseName>
 		<variations>
 			<variation>Mode109</variation>
 		</variations>
@@ -192,7 +192,7 @@
 	</test>
 
 	<test>
-		<testCaseName>TestGCClassWithStaticRetransformInBalanced_SE90</testCaseName>
+		<testCaseName>TestGCClassWithStaticRetransformInBalanced</testCaseName>
 		<variations>
 			<variation>Mode550</variation>
 		</variations>

--- a/test/Jsr292/playlist.xml
+++ b/test/Jsr292/playlist.xml
@@ -49,7 +49,7 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr292Test_SE90</testCaseName>
+		<testCaseName>jsr292Test</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>
@@ -102,7 +102,7 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr292Test_JitCount0_SE90</testCaseName>
+		<testCaseName>jsr292Test_JitCount0</testCaseName>
 		<variations>
 			<variation>-Xjit:count=0</variation>
 		</variations>
@@ -155,7 +155,7 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr292BootstrapTest_SE90</testCaseName>
+		<testCaseName>jsr292BootstrapTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>

--- a/test/Jsr335/playlist.xml
+++ b/test/Jsr335/playlist.xml
@@ -52,7 +52,7 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr335tests_SE90</testCaseName>
+		<testCaseName>jsr335tests</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode101</variation>
@@ -102,7 +102,7 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr335tests_defendersupersends_SE90</testCaseName>
+		<testCaseName>jsr335tests_defendersupersends</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 		</variations>

--- a/test/NativeTest/playlist.xml
+++ b/test/NativeTest/playlist.xml
@@ -176,7 +176,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>shrtest_linux_SE90</testCaseName>
+		<testCaseName>shrtest_linux</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -199,7 +199,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>shrtest_zos_SE90</testCaseName>
+		<testCaseName>shrtest_zos</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -222,7 +222,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>shrtest_aix_SE90</testCaseName>
+		<testCaseName>shrtest_aix</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -245,7 +245,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>shrtest_win_SE90</testCaseName>
+		<testCaseName>shrtest_win</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/test/OpenJ9_Jsr_292_API/playlist.xml
+++ b/test/OpenJ9_Jsr_292_API/playlist.xml
@@ -24,7 +24,7 @@
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>openj9_jsr292Test_SE90</testCaseName>
+		<testCaseName>openj9_jsr292Test</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	--add-modules mods.modulea,mods.moduleb,mods.modulec --module-path $(Q)$(TEST_RESROOT)$(D)mods$(Q) \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
@@ -48,7 +48,7 @@
 	</test>
 	
 	<test>
-		<testCaseName>openj9_jsr292Test_JitCount0_SE90</testCaseName>
+		<testCaseName>openj9_jsr292Test_JitCount0</testCaseName>
 		<variations>
 			<variation>-Xjit:count=0</variation>
 		</variations>

--- a/test/UnsafeTest/playlist.xml
+++ b/test/UnsafeTest/playlist.xml
@@ -48,7 +48,7 @@
 	</test>
 
 	<test>
-		<testCaseName>UnsafeTests_SE90</testCaseName>
+		<testCaseName>UnsafeTests</testCaseName>
 		<variations>
 			<variation>-DScenario=Regular</variation>
 			<variation>-DScenario=Compiled</variation>

--- a/test/cmdLineTests/URLClassLoaderTests/playlist.xml
+++ b/test/cmdLineTests/URLClassLoaderTests/playlist.xml
@@ -51,7 +51,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_SCURLClassLoaderTests_SE90</testCaseName>
+		<testCaseName>cmdLineTester_SCURLClassLoaderTests</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -107,7 +107,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_SCURLClassLoaderNPTests_SE90</testCaseName>
+		<testCaseName>cmdLineTester_SCURLClassLoaderNPTests</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>

--- a/test/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -44,7 +44,7 @@
 	</test>
 	
 	<test>
-		<testCaseName>cmdLineTest_J9test_SE90</testCaseName>
+		<testCaseName>cmdLineTest_J9test</testCaseName>
 		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' \
 	-Xint -jar $(CMDLINETESTER_JAR) \

--- a/test/cmdLineTests/getCallerClassTests/playlist.xml
+++ b/test/cmdLineTests/getCallerClassTests/playlist.xml
@@ -42,7 +42,7 @@
 		</subsets>
 	</test>
 		<test>
-		<testCaseName>cmdLineTester_getCallerClassTests_SE90</testCaseName>
+		<testCaseName>cmdLineTester_getCallerClassTests</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/test/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -54,7 +54,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_jep178_staticLinking_SE90</testCaseName>
+		<testCaseName>cmdLineTester_jep178_staticLinking</testCaseName>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
 	-DJAVATEST_ROOT="$(JAVATEST_ROOT)" \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \

--- a/test/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/cmdLineTests/jvmtitests/playlist.xml
@@ -98,7 +98,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_jvmtitests_hcr_SE90</testCaseName>
+		<testCaseName>cmdLineTester_jvmtitests_hcr</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode101</variation>
@@ -249,7 +249,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_jvmtitests_hcr_nongold_SE90</testCaseName>
+		<testCaseName>cmdLineTester_jvmtitests_hcr_nongold</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode101</variation>
@@ -318,7 +318,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_jvmtitests_hcr_OSRG_nongold_SE90</testCaseName>
+		<testCaseName>cmdLineTester_jvmtitests_hcr_OSRG_nongold</testCaseName>
 		<variations>
 			<variation>Mode107-OSRG</variation>
 			<variation>Mode110-OSRG</variation>

--- a/test/cmdLineTests/lockWordAlignment/playlist.xml
+++ b/test/cmdLineTests/lockWordAlignment/playlist.xml
@@ -42,7 +42,7 @@
 		</subsets>
 	</test>
 		<test>
-		<testCaseName>cmdLineTester_lockWordAlignment_Object_Standard_SE90</testCaseName>
+		<testCaseName>cmdLineTester_lockWordAlignment_Object_Standard</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/test/cmdLineTests/proxyFieldAccess/playlist.xml
+++ b/test/cmdLineTests/proxyFieldAccess/playlist.xml
@@ -41,7 +41,7 @@
 		</subsets>
 	</test>
 		<test>
-		<testCaseName>cmdLineTester_ProxyFieldAccess_SE90</testCaseName>
+		<testCaseName>cmdLineTester_ProxyFieldAccess</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Remove SE90 from test that runs on JDK10.


[ci skip]


Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>