### PR TITLE
Unexclude shared classes jdk10 test failures

### DIFF
--- a/test/cmdLineTests/URLClassLoaderTests/exclude.xml
+++ b/test/cmdLineTests/URLClassLoaderTests/exclude.xml
@@ -27,16 +27,6 @@
 <suite id="URLClassLoader Excluded Test Case List">
 	<platform id="none"/>
 	<platform id="all"/>
-	<exclude id="Sanity.verifySuccess" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="FindStore.FindExplicit" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="FindStore.FindRelative" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="FindStore.FindNetUse" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="FindStore.FindClassfile" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="FindStore.FindDiffcpClassfile" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="JarExtensionsTests.SingleJarInManifest.Verify1" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="JarExtensionsTests.MultipleJarsInManifests.Verify1" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="JarExtensionsTests.SingleJarInManifestWithIndex.Verify1" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
-	<exclude id="JarExtensionsTests.MultipleJarsInManifestsWithIndex.Verify1" platform="SE100"><reason>JDK10 cmdLineTester_SCURLClassLoaderTests FAILED #1623</reason></exclude>
 	<exclude id="FindStore.FindDiffcpExplicit" platform="all"><reason>noTimestampChecks does not work properly</reason></exclude>
 	<exclude id="FindStore.FindDiffcpRelative" platform="all"><reason>noTimestampChecks does not work properly</reason></exclude>
 	<exclude id="FindStore.FindDiffcpNetUse" platform="all"><reason>noTimestampChecks does not work properly</reason></exclude>

--- a/test/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
+++ b/test/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
@@ -29,15 +29,6 @@
 	<platform id="none"/>
 	<platform id="all"/>
 	
-	<exclude id="Test 1: Test --patch-module for Bootstrap ClassLoader and Builtin ClassLoader. Patched classes should not be stored to the cache. Other classes from the patched module should still be stored" platform="SE100">
-		<reason>JDK10 testSCCMLModularity_1 FAILED #1625</reason>
-	</exclude>
-	<exclude id="Test 3: Jimage and module path should be stored into the cache. Patch paths should not be stored" platform="SE100">
-		<reason>JDK10 testSCCMLModularity_1 FAILED #1625</reason>
-	</exclude>
-	<exclude id="Test 4: Test classes are being found in the shared cache when running an application module" platform="SE100">
-		<reason>JDK10 testSCCMLModularity_1 FAILED #1625</reason>
-	</exclude>
 	<exclude id="Test 4s: Setup for test 4 and test 5, create a Java 6 cache" platform="zos_390-31.*" shouldFix="yes">
 		<reason>Java 6 SDK is missing for the platform</reason>
 	</exclude>
@@ -89,12 +80,6 @@
 	</exclude>
 	<exclude id="Test 17: JAZZ 31726 test 7 ensure -Xzero -Xzero:describe shows sharebootzip" platform="SE[^8]\d+">
 		<reason>Java 9 removed option -Xzero</reason>
-	</exclude>
-	<exclude id="Test 53: Make sure classes are being stored to the shared cache" platform="SE100">
-		<reason>JDK10 testSCCMLTests1_1 FAILED #1624</reason>
-	</exclude>
-	<exclude id="Test 54: Make sure classes are being found in the shared cache" platform="SE100">
-		<reason>JDK10 testSCCMLTests1_1 FAILED #1624</reason>
 	</exclude>
 	<exclude id="Test 133: Test -Xshareclasses:printallstats=zipcache" platform="SE[^8]\d+" shouldFix="yes">
 		<reason>JCL team has not yet added JVM_ZipHook() in Java 9</reason>


### PR DESCRIPTION
Problems are resolved by ibmruntimes/openj9-openjdk-jdk10#16

Fixes #1623 
Fixes #1624 
Fixes #1625

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>