### PR TITLE
Check and delete gits index.lock file

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -21,10 +21,11 @@
  *******************************************************************************/
 
 def git_clean() {
-    script {
-        if (fileExists('.git')) {
+    if (fileExists('.git')) {
             sh "git clean -ffxd"
-        }
+    }
+    if (fileExists('.git/index.lock')) {
+            sh "rm -f .git/index.lock"
     }
 }
 


### PR DESCRIPTION
* [skip ci]
* a lock file is occassionally left behind when the jenkins job is terminated

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>