### PR TITLE
Fix shared cache modlevel for Java 10 and 11

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassCacheInfo.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassCacheInfo.java
@@ -161,7 +161,10 @@ public class SharedClassCacheInfo {
 	}
 	
 	/**
-	 * Gets the JVM level for the shared class cache. 
+	 * Gets the JVM level for the shared class cache.  
+	/*[IF Java10] 
+	 * Starting from Java 10, the JVM LEVEL equals to the java version number on which the share class cache is created.
+	/*[ENDIF]
 	 *
 	 * @return		A JVMLEVEL constant.
 	 */					

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -536,10 +536,6 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 		translationFlags |= BCT_Java9MajorVersionShifted;
 	} else if (J2SE_VERSION(vm) >= J2SE_18) {
 		translationFlags |= BCT_Java8MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_17) {
-		translationFlags |= BCT_Java7MajorVersionShifted;
-	} else if (J2SE_VERSION(vm) >= J2SE_16) {
-		translationFlags |= BCT_Java6MajorVersionShifted;
 	}
 #endif
 

--- a/runtime/include/ibmjvmti.h
+++ b/runtime/include/ibmjvmti.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,6 +105,10 @@
 #define COM_IBM_SHARED_CACHE_MODLEVEL_JAVA7 3
 #define COM_IBM_SHARED_CACHE_MODLEVEL_JAVA8 4
 #define COM_IBM_SHARED_CACHE_MODLEVEL_JAVA9 5
+/* 
+ * No macro is defined for shared cache modLevel starting from Java 10. The value of modLevel equals to the java version number
+ * on which the shared cache is created.
+ */
 
 #define COM_IBM_SHARED_CACHE_ADDRMODE_32 32
 #define COM_IBM_SHARED_CACHE_ADDRMODE_64 64

--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -24,20 +24,21 @@
 
 /**
  * Constants for supported J2SE versions.
- * note: J2SE_15 needed for shared classes cache introspection but not supported by JVM.
  */
 /*
  * Note: J2SE_LATEST is the highest Java version supported by VM for a JCL level.
  *       This allows JVM operates with latest version when neither classlib.properties
  *       nor release file presents.
  */
-#define J2SE_15   0x1500
-#define J2SE_16   0x1600
-#define J2SE_17   0x1700
-#define J2SE_18   0x1800
-#define J2SE_19   0x1900
-#define J2SE_V10  0x1A00            /* This refers Java 10 */
-#define J2SE_V11  0x1B00            /* This refers Java 11 */
+#define J2SE_18   0x0800
+#define J2SE_19   0x0900
+#define J2SE_V10  0x0A00            /* This refers Java 10 */
+#define J2SE_V11  0x0B00            /* This refers Java 11 */
+/* Shared class cache is using JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) to get the Java version.
+ * So bits 9 to 16 of the J2SE constant should match the java version number.
+ */
+
+
 #if JAVA_SPEC_VERSION == 8
 	#define J2SE_LATEST  J2SE_18
 #elif JAVA_SPEC_VERSION == 9
@@ -84,6 +85,7 @@
 #define J2SE_SHAPE_RAW	 		0x90000
 #define J2SE_SHAPE_MASK 		0xF0000
 #define J2SE_SHAPE_SHIFT		16
+#define J2SE_JAVA_SPEC_VERSION_SHIFT 8
 
 /**
  * Masks and constants for describing J2SE shapes.
@@ -111,6 +113,11 @@
  * Macro to extract J2SE shape given a JNIEnv.
  */ 
 #define J2SE_SHAPE_FROM_ENV(env) J2SE_SHAPE(((J9VMThread*)env)->javaVM)
+
+/**
+ * Macro to extract java spec version from J2SE version.
+ */
+#define JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) 	((j2seVersion) >> J2SE_JAVA_SPEC_VERSION_SHIFT)
 
 #endif     /* j2sever_h */
 

--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -36,8 +36,11 @@ extern "C" {
 #define J9SH_MODLEVEL_JAVA7  3
 #define J9SH_MODLEVEL_JAVA8  4
 #define J9SH_MODLEVEL_JAVA9  5
-#define J9SH_MODLEVEL_JAVA10 6
-#define J9SH_MODLEVEL_JAVA11 7
+/*
+ * From Java 10, modLevel equals to java version number. But there might be Java 10 shared cache that has modLevel 6
+ * created before this change. Define J9SH_MODLEVEL_JAVA10 to handle them
+ */
+#define J9SH_MODLEVEL_JAVA10  6
 
 /*	JVM feature bit flag(s)	*/
 /*
@@ -74,8 +77,9 @@ extern "C" {
 #define J9SH_VERSION_STRING_G07ANDLOWER_SPEC "C%dD%dA%d"
 #define J9SH_VERSION_STRING_G07TO29_SPEC "C%dM%dA%d"
 #define J9SH_VERSION_STRING_SPEC "C%dM%dF%xA%d"
-#define J9SH_VERSION_STRING_LEN 12
+#define J9SH_VERSION_STRING_LEN 13
 #define J9SH_VERSTRLEN_INCREASED_SINCEG29 2
+#define J9SH_VERSTRLEN_INCREASED_SINCEJAVA10 1
 
 typedef struct J9PortShcVersion {
     uint32_t esVersionMajor;
@@ -102,16 +106,18 @@ uint32_t
 getJCLForShcModlevel(uintptr_t modlevel);
 
 uintptr_t
-isCompatibleShcFilePrefix(J9PortLibrary* portlib, uint32_t j2seVersion, uint32_t feature, const char* filename);
+isCompatibleShcFilePrefix(J9PortLibrary* portlib, uint32_t javaVersion, uint32_t feature, const char* filename);
 
 void
-getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer);
+getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer, uint32_t buffSize);
 
 void
 getStringForShcAddrmode(J9PortLibrary* portlib, uint32_t addrmode, char* buffer);
 
 uintptr_t
 isCacheFileName(J9PortLibrary* portlib, const char* nameToTest, uintptr_t expectPersistent, const char* optionalExtraID);
+
+uintptr_t getModLevelFromName(const char* cacheNameWithVGen);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -237,7 +237,6 @@ printSharedCache(void* element, void* param)
 	SH_OSCache_Info* currentItem = (SH_OSCache_Info*) element;
 	if (((state->printCompatibleCache == true) && (currentItem->isCompatible))
 			|| ((state->printIncompatibleCache == true) && (!currentItem->isCompatible))) {
-		char jclLevelStr[10];
 		char addrmodeStr[10];
 
 		PORT_ACCESS_FROM_JAVAVM(state->vm);
@@ -286,9 +285,10 @@ printSharedCache(void* element, void* param)
 			j9tty_printf(PORTLIB, "\nIncompatible shared caches\n");
 			state->printIncompatibleHeader = 2;
 		}
-
 		j9tty_printf(PORTLIB, "%-16s\t", currentItem->name);
-		getStringForShcModlevel(PORTLIB, currentItem->versionData.modlevel, (char*)&jclLevelStr);
+		char jclLevelStr[10];
+		memset(jclLevelStr, 0, sizeof(jclLevelStr));
+		getStringForShcModlevel(PORTLIB, currentItem->versionData.modlevel, (char*)&jclLevelStr, sizeof(jclLevelStr));
 		getStringForShcAddrmode(PORTLIB, currentItem->versionData.addrmode, (char*)&addrmodeStr);
 		j9tty_printf(PORTLIB, "%s %s  ", jclLevelStr, addrmodeStr);
 		if (J9PORT_SHR_CACHE_TYPE_PERSISTENT == currentItem->versionData.cacheType) {

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,12 +69,16 @@
 											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN, J9SH_VERSION_STRING_SPEC,\
 											 version, modlevel, feature, addrmode)
 
+#define J9SH_GET_VERSION_STRING_JAVA9ANDLOWER(portLib, versionStr, version, modlevel, feature, addrmode)\
+											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_SPEC,\
+											 version, modlevel, feature, addrmode)
+
 #define J9SH_GET_VERSION_G07TO29_STRING(portLib, versionStr, version, modlevel, addrmode)\
-											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29, J9SH_VERSION_STRING_G07TO29_SPEC,\
+											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29 - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_G07TO29_SPEC,\
 											 version, modlevel, addrmode)
 
 #define J9SH_GET_VERSION_G07ANDLOWER_STRING(portLib, versionStr, version, modlevel, addrmode)\
-											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29, J9SH_VERSION_STRING_G07ANDLOWER_SPEC,\
+											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29 - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_G07ANDLOWER_SPEC,\
 											 version, modlevel, addrmode)
 
 #define OSC_TRACE(var) if (_verboseFlags) j9nls_printf(PORTLIB, J9NLS_INFO, var)

--- a/runtime/tests/shared/OSCacheTestMmap.cpp
+++ b/runtime/tests/shared/OSCacheTestMmap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ SH_OSCacheTestMmap::testBasic(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	char *q;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 	
 	rc = j9shmem_getDir(NULL, TRUE, cacheDir, J9SH_MAXPATH);
@@ -136,7 +136,7 @@ SH_OSCacheTestMmap::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	J9SharedClassPreinitConfig *piconfig = NULL;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	rc = j9shmem_getDir(NULL, TRUE, cacheDir, J9SH_MAXPATH);
@@ -203,7 +203,7 @@ SH_OSCacheTestMmap::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	J9SharedClassPreinitConfig *piconfig;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -297,7 +297,7 @@ SH_OSCacheTestMmap::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -430,7 +430,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 	UDATA numCacheBeforeTest = 0;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if(NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -473,7 +473,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_16, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat != NULL) {
 		numCacheBeforeTest += pool_numElements(cacheStat);
@@ -495,7 +495,7 @@ SH_OSCacheTestMmap::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_16, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
 	if(cacheStat == NULL) {
 		j9tty_printf(PORTLIB, "testGetAllCacheStatistics: failed to get cache statistics - there should be at least one cache!\n");
 		goto cleanup;
@@ -544,7 +544,7 @@ SH_OSCacheTestMmap::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (osc = (SH_OSCachemmap *)j9mem_allocate_memory(SH_OSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
@@ -632,7 +632,7 @@ SH_OSCacheTestMmap::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -721,7 +721,7 @@ SH_OSCacheTestMmap::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ SH_OSCacheTestSysv::testBasic(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	J9PortShcVersion versionData;
 	char cacheDir[J9SH_MAXPATH];
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	rc = j9shmem_getDir(NULL, TRUE, cacheDir, J9SH_MAXPATH);
@@ -180,7 +180,7 @@ SH_OSCacheTestSysv::testMultipleCreate(J9PortLibrary* portLibrary, J9JavaVM *vm,
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 	
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -312,7 +312,7 @@ SH_OSCacheTestSysv::testConstructor(J9PortLibrary *portLibrary, J9JavaVM *vm)
 	J9SharedClassPreinitConfig *piconfig;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -392,7 +392,7 @@ SH_OSCacheTestSysv::testFailedConstructor(J9PortLibrary *portLibrary, J9JavaVM *
 	J9SharedClassPreinitConfig *piconfig;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -472,7 +472,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	UDATA numCacheBeforeTest = 0;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if(NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -515,7 +515,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 		}
 	}
 
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_16, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat != NULL) {
 		numCacheBeforeTest += pool_numElements(cacheStat);
@@ -539,7 +539,7 @@ SH_OSCacheTestSysv::testGetAllCacheStatistics(J9JavaVM* vm)
 	}
 
 	/* Search for caches in "/tmp/javasharedresources". */
-	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_16, false, false, SHR_STATS_REASON_TEST, true);
+	cacheStat = SH_OSCache::getAllCacheStatistics(vm, ctrlDirName, 0, 1, J2SE_LATEST, false, false, SHR_STATS_REASON_TEST, true);
 
 	if(cacheStat == NULL) {
 		j9tty_printf(PORTLIB, "testGetAllCacheStatistics: failed to get cache statistics - there should be at least one cache!\n");
@@ -588,7 +588,7 @@ SH_OSCacheTestSysv::testMutex(J9PortLibrary *portLibrary, J9JavaVM *vm, struct j
 	UDATA childargc = 0;
 	IDATA rc;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (osc = (SH_OSCachesysv *)j9mem_allocate_memory(SH_OSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
@@ -679,7 +679,7 @@ SH_OSCacheTestSysv::testMutexHang(J9PortLibrary *portLibrary, J9JavaVM *vm, stru
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -768,7 +768,7 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 	J9SharedClassPreinitConfig *piconfig;
 	J9PortShcVersion versionData;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {
@@ -910,7 +910,7 @@ SH_OSCacheTestSysv::testDestroy (J9PortLibrary* portLibrary, J9JavaVM *vm, struc
 	char * childargv[SHRTEST_MAX_CMD_OPTS];
 	UDATA childargc = 0;
 	
-	setCurrentCacheVersion(vm, J2SE_16, &versionData);
+	setCurrentCacheVersion(vm, J2SE_LATEST, &versionData);
 	versionData.cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 
 	if (NULL == (piconfig = (J9SharedClassPreinitConfig *)j9mem_allocate_memory(sizeof(J9SharedClassPreinitConfig), J9MEM_CATEGORY_CLASSES))) {

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -130,6 +130,29 @@ getGenerationFromName(const char* cacheNameWithVGen)
 }
 
 /**
+ * Return the value of the modLevel from the cache filename
+ *
+ * @param [in] cacheNameWithVGen  the cache file name
+ *
+ * @return the modeLevel number or 0 if an error occurred
+ */
+uintptr_t
+getModLevelFromName(const char* cacheNameWithVGen)
+{
+	char* cursor = (char*)cacheNameWithVGen;
+	uintptr_t modLevel = 0;
+	
+	cursor = strchr(cursor, J9SH_MODLEVEL_PREFIX_CHAR);
+	if (NULL != cursor) {
+		cursor += 1;
+		if (0 != scan_udata(&cursor, &modLevel)) {
+			modLevel = 0;
+		}
+	}
+	return modLevel;
+}
+
+/**
  * Return the modification level for a given j2se version
  * 
  * @param [in] j2seVersion  The j2se version
@@ -141,34 +164,21 @@ getShcModlevelForJCL(uintptr_t j2seVersion)
 {
 	uint32_t modLevel = 0;
 	switch (j2seVersion) {
-	case J2SE_15 :
-		modLevel = J9SH_MODLEVEL_JAVA5;
-		break;
-	case J2SE_16 :
-		modLevel = J9SH_MODLEVEL_JAVA6;
-		break;
-	case J2SE_17 :
-		modLevel = J9SH_MODLEVEL_JAVA7;
-		break;
 	case J2SE_18 :
 		modLevel = J9SH_MODLEVEL_JAVA8;
 		break;
 	case J2SE_19 :
 		modLevel = J9SH_MODLEVEL_JAVA9;
 		break;
-	case J2SE_V10 :
-		modLevel = J9SH_MODLEVEL_JAVA10;
-		break;
-	case J2SE_V11 :
-		modLevel = J9SH_MODLEVEL_JAVA11;
+	default: 
+		modLevel = JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion);
 		break;
 	}
 	return modLevel;
 }
 
 /**
- * Return the j2se version for a given modification level
- * 
+ * Return the java spec version for a given modification level
  * @param [in] modlevel  The modification level
  * 
  * @return the j2se version or 0 if one cannot be found
@@ -176,45 +186,51 @@ getShcModlevelForJCL(uintptr_t j2seVersion)
 uint32_t
 getJCLForShcModlevel(uintptr_t modlevel)
 {
-	uint32_t j2seVersion = 0;
+	uint32_t javaVersion = 0;
 	switch (modlevel) {
 	case J9SH_MODLEVEL_JAVA5 :
-		j2seVersion = J2SE_15;
+		javaVersion = 5;
 		break;
 	case J9SH_MODLEVEL_JAVA6 :
-		j2seVersion = J2SE_16;
+		javaVersion = 6;
 		break;
 	case J9SH_MODLEVEL_JAVA7 :
-		j2seVersion = J2SE_17;
+		javaVersion = 7;
 		break;
 	case J9SH_MODLEVEL_JAVA8 :
-		j2seVersion = J2SE_18;
+		javaVersion = 8;
 		break;
 	case J9SH_MODLEVEL_JAVA9 :
-		j2seVersion = J2SE_19;
+		javaVersion = 9;
 		break;
-	case J9SH_MODLEVEL_JAVA10 :
-		j2seVersion = J2SE_V10;
+	case J9SH_MODLEVEL_JAVA10:
+		/* From Java 10, modLevel equals to java version number. But there might be Java 10 shared cache that has modLevel 6
+		 * created before this change.
+		 */
+		javaVersion = 10;
 		break;
-	case J9SH_MODLEVEL_JAVA11 :
-		j2seVersion = J2SE_V11;
+	default:
+		if (modlevel >= 10) {
+			/* J9SH_MODLEVEL_JAVA9 is 5. Does not have modlevel that is 7,8,9 */
+			javaVersion = modlevel;
+		}
 		break;
 	}
-	return j2seVersion;
+	return javaVersion;
 }
 
 /**
  * Given a cache filename and a j2se version, is the filename compatible with this running JVM
  * 
  * @param [in] portlib  A port library
- * @param [in] j2seVersion  The j2se version the JVM is running
+ * @param [in] javaVersion  The java version the JVM is running
  * @param [in] feature  this running JVM feature
  * @param [in] filename  The cache filename
  * 
  * @return 1 if the cache is compatible or 0 otherwise
  */
 uintptr_t 
-isCompatibleShcFilePrefix(J9PortLibrary* portlib, uint32_t j2seVersion, uint32_t feature, const char* filename)
+isCompatibleShcFilePrefix(J9PortLibrary* portlib, uint32_t javaVersion, uint32_t feature, const char* filename)
 {
 	J9PortShcVersion versionData;
 	uint32_t jclLevel;
@@ -224,7 +240,7 @@ isCompatibleShcFilePrefix(J9PortLibrary* portlib, uint32_t j2seVersion, uint32_t
 
 	if ((versionData.esVersionMajor == EsVersionMajor) &&
 			(versionData.esVersionMinor == EsVersionMinor) &&
-			(jclLevel == j2seVersion) &&
+			(jclLevel == javaVersion) &&
 			(versionData.addrmode == J9SH_ADDRMODE) &&
 			(versionData.feature == feature)) {
 		return 1;
@@ -240,32 +256,38 @@ isCompatibleShcFilePrefix(J9PortLibrary* portlib, uint32_t j2seVersion, uint32_t
  * @param [out] buffer  The buffer to copy the string into
  */
 void
-getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer)
+getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer, uint32_t buffSize)
 {
+	PORT_ACCESS_FROM_PORT(portlib);
 	switch (modlevel) {
 	case J9SH_MODLEVEL_JAVA5 :
-		strcpy(buffer, "Java5");
+		strncpy(buffer, "Java5", buffSize);
 		break;
 	case J9SH_MODLEVEL_JAVA6 :
-		strcpy(buffer, "Java6");
+		strncpy(buffer, "Java6", buffSize);
 		break;
 	case J9SH_MODLEVEL_JAVA7 :
-		strcpy(buffer, "Java7");
+		strncpy(buffer, "Java7", buffSize);
 		break;
 	case J9SH_MODLEVEL_JAVA8 :
-		strcpy(buffer, "Java8");
+		strncpy(buffer, "Java8", buffSize);
 		break;
 	case J9SH_MODLEVEL_JAVA9 :
-		strcpy(buffer, "Java9");
+		strncpy(buffer, "Java9", buffSize);
 		break;
 	case J9SH_MODLEVEL_JAVA10 :
-		strcpy(buffer, "Java10");
-		break;
-	case J9SH_MODLEVEL_JAVA11 :
-		strcpy(buffer, "Java11");
+		/* From Java 10, modLevel equals to java version number. But there might be Java 10 shared cache that has modLevel 6
+		 * created before this change.
+		 */
+		strncpy(buffer, "Java10", buffSize);
 		break;
 	default :
-		strcpy(buffer, "Unknown");
+		if (modlevel >= 10) {
+			j9str_printf(portlib, buffer, buffSize, "%s%u", "Java", modlevel);
+		} else {
+			/* J9SH_MODLEVEL_JAVA9 is 5. Does not have modlevel that is 7,8,9 */
+			strncpy(buffer, "Unknown", buffSize);
+		}
 		break;
 	}
 }
@@ -310,6 +332,7 @@ isCacheFileName(J9PortLibrary* portlib, const char* nameToTest, uintptr_t expect
 	intptr_t nameToTestLen = 0;
 	intptr_t expectedVersionLen = ((expectCacheType == J9PORT_SHR_CACHE_TYPE_PERSISTENT) || (J9PORT_SHR_CACHE_TYPE_SNAPSHOT == expectCacheType)) ? J9SH_VERSION_STRING_LEN + 1 : J9SH_VERSION_STRING_LEN;
 	uintptr_t generation = getGenerationFromName(nameToTest);
+	uintptr_t modLevel = 0;
 
 	/*
 	 * cache names generated by earlier JVMs (generation <=29) don't have feature prefix char 'F' and the value
@@ -320,6 +343,14 @@ isCacheFileName(J9PortLibrary* portlib, const char* nameToTest, uintptr_t expect
 	}
 	if (nameToTest == NULL) {
 		return 0;
+	}
+	modLevel = getModLevelFromName(nameToTest);
+	if (0 == modLevel) {
+		return 0;
+	}
+	/* modLevel becomes 2 digits from Java 10 */
+	if (modLevel < 10) {
+		expectedVersionLen -= J9SH_VERSTRLEN_INCREASED_SINCEJAVA10;
 	}
 	if (optionalExtraID != NULL) {
 		const char* temp1 = strstr(nameToTest, optionalExtraID);

--- a/test/functional/VM_Test/src/com/ibm/j9/sharedCacheAPI/tests/SharedUtilsTest.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/sharedCacheAPI/tests/SharedUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2008 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@ import java.lang.reflect.Field;
 public class SharedUtilsTest 
 {
     private String cacheName = "ShareClassesUtilities";
+    private int TEMP_JAVA10_SHARED_CACHE_MODLEVEL = 6;
     
     public static void main(String args[]) {
 	SharedUtilsTest obj = new SharedUtilsTest();
@@ -112,7 +113,12 @@ public class SharedUtilsTest
 				}
 			}
 			int level = obj.getCacheJVMLevel();
-			rc = (level >= min && level <= max);
+			if (level >= min && level <= max) {
+				rc = true;
+			} else if (level >= 10 || TEMP_JAVA10_SHARED_CACHE_MODLEVEL == level) {
+				/* mod level equals to java version number from Java 10. There might be an exiting java10 shared cache that has modLevel 6 created before this change */
+				rc = true;
+			}
 		}
 		catch (IllegalAccessException e) {
 		    System.out.println("IllegalStateException by getSharedCacheInfo");

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
@@ -81,30 +81,6 @@
 	<exclude id="Test 17: JAZZ 31726 test 7 ensure -Xzero -Xzero:describe shows sharebootzip" platform="SE[^8]\d+">
 		<reason>Java 9 removed option -Xzero</reason>
 	</exclude>
-	<exclude id="Test 86: utilities test: iterate and destroy cache" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 87: utilities test: validate that the cache is destroyed" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 91: utilities test: iterate and destroy cache with multiple -Xshareclasses option" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 92: utilities test: validate that cache is destroyed" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 116: utilities test: iterate and destroy cache when running with different cacheDir option" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 117: utilities test: validate that the cache is destroyed" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 118: utilities test: validate that previous tests created a cache" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
-	<exclude id="Test 119: utilities test: delete the cache created in previous test" platform="SE100">
-		<reason>SharedClassCacheInfo is missing constants for Java 10 &amp; 11 #1288</reason>
-	</exclude>
 	<exclude id="Test 133: Test -Xshareclasses:printallstats=zipcache" platform="SE[^8]\d+" shouldFix="yes">
 		<reason>JCL team has not yet added JVM_ZipHook() in Java 9</reason>
 	</exclude>


### PR DESCRIPTION
1. Remove J2SE_15, J2SE_16, J2SE_17
2. Change J2SE_18 to 0x0800, J2SE_19 to 0x0900, J2SE_V10 to 0x0A00
J2SE_V11 to 0x0B00
3. Starting from Java 10, shared cache modlevel will be set to java
version number
4. Re-enable tests in testSCCMLTests2

Fixes #1288

Signed-off-by: hangshao <hangshao@ca.ibm.com>