### PR TITLE
Clean up pddivSelect

### DIFF
--- a/runtime/compiler/trj9/arm/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/arm/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -458,7 +458,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision

--- a/runtime/compiler/trj9/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/trj9/codegen/CodeGenGPU.cpp
@@ -1270,7 +1270,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::pdclearSetSign
    NULL,          // TR::pdSetSign
    NULL,          // TR::pddivrem
-   NULL,          // TR::pddivSelect
    NULL,          // TR::pdremSelect
    NULL,          // TR::pdModifyPrecision
    NULL,          // TR::pd2df

--- a/runtime/compiler/trj9/il/ILOpCodeProperties.hpp
+++ b/runtime/compiler/trj9/il/ILOpCodeProperties.hpp
@@ -6193,22 +6193,6 @@
    },
 
    {
-   /* .opcode               = */ TR::pddivSelect,
-   /* .name                 = */ "pddivSelect",
-   /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
-   /* .properties3          = */ 0,
-   /* .properties4          = */ ILProp4::BinaryCodedDecimalOp | ILProp4::PackedArithmeticSelect | ILProp4::CanHaveStorageReferenceHint,
-   /* .dataType             = */ TR::PackedDecimal,
-   /* .typeProperties       = */ ILTypeProp::PackedDecimal,
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType),
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::pdremSelect,
    /* .name                 = */ "pdremSelect",
    /* .properties1          = */ 0,

--- a/runtime/compiler/trj9/il/J9ILOpCodesEnum.hpp
+++ b/runtime/compiler/trj9/il/J9ILOpCodesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -460,7 +460,6 @@
    pdSetSign,      // packed decimal forced sign code setting
 
    pddivrem,            // packed decimal fused divide and remainder
-   pddivSelect,         // packed decimal select divide from pddivrem
    pdremSelect,         // packed decimal select remainder from pddivrem
 
    pdModifyPrecision,      // packed decimal modify precision

--- a/runtime/compiler/trj9/il/J9Node.cpp
+++ b/runtime/compiler/trj9/il/J9Node.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1481,7 +1481,7 @@ J9::Node::getSourcePrecision()
 
 
 
-// Dividend/Divisor Tracking on pddivSelect/pdremSelect nodes
+// Dividend/Divisor Tracking on pdremSelect nodes
 void
 J9::Node::setSelectDivisorPrecision(int32_t p)
    {

--- a/runtime/compiler/trj9/il/J9Node.hpp
+++ b/runtime/compiler/trj9/il/J9Node.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -196,7 +196,7 @@ public:
    void    setSourcePrecision(int32_t prec);
    int32_t getSourcePrecision();
 
-   // Dividend/Divisor Tracking on pddivSelect/pdremSelect nodes
+   // Dividend/Divisor Tracking on pdremSelect nodes
    void    setSelectDivisorPrecision(int32_t p);
    int32_t getSelectDivisorPrecision();
    void    setSelectDividendPrecision(int32_t p);

--- a/runtime/compiler/trj9/optimizer/J9SimplifierHandlers.cpp
+++ b/runtime/compiler/trj9/optimizer/J9SimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2454,36 +2454,6 @@ TR::Node *pddivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    if (newNode != NULL)
       return newNode;
 
-   return node;
-   }
-
-TR::Node *pddivSelectSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
-   {
-   simplifyChildren(node, block, s);
-   TR::Node *firstChild = node->getFirstChild();
-#ifdef TR_TARGET_S390
-   // a pddivSelect with a single use pddivrem child is equivalent to a pddiv
-   if (firstChild->getOpCodeValue() == TR::pddivrem &&
-       firstChild->getReferenceCount() == 1 &&
-       NUM_DEFAULT_CHILDREN >= 2 &&
-       firstChild->getDecimalPrecision() >= s->cg()->getPDDivEncodedPrecision(firstChild) &&   // make sure pddivrem doesn't truncate
-       performTransformation(s->comp(),"%sModify pddivSelect [" POINTER_PRINTF_FORMAT "] with child %s [" POINTER_PRINTF_FORMAT "] to ",s->optDetailString(),node,firstChild->getOpCode().getName(),firstChild))
-      {
-      TR::Node *dividend = firstChild->getFirstChild();
-      TR::Node *divisor = firstChild->getSecondChild();
-      dividend->incReferenceCount();  // retaining the dividend
-      divisor->incReferenceCount(); // retaining the divisor
-      node->setSelectDividendPrecision(0);
-      node->setSelectDivisorPrecision(0);
-      s->prepareToReplaceNode(node, TR::pddiv);
-      node->setNumChildren(2);
-      node->setChild(0, dividend);
-      node->setChild(1, divisor);
-      dumpOptDetails(s->comp(),"%s [" POINTER_PRINTF_FORMAT "] : child1 %s [" POINTER_PRINTF_FORMAT "], child2 %s [" POINTER_PRINTF_FORMAT "]\n",
-         node->getOpCode().getName(),node,dividend->getOpCode().getName(),dividend,divisor->getOpCode().getName(),divisor);
-      return node;
-      }
-#endif
    return node;
    }
 

--- a/runtime/compiler/trj9/optimizer/J9SimplifierHandlers.hpp
+++ b/runtime/compiler/trj9/optimizer/J9SimplifierHandlers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,6 @@ TR::Node * pdaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
 TR::Node * pdsubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * pdmulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * pddivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * pddivSelectSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * pdshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * pdloadSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * pdSetSignSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);

--- a/runtime/compiler/trj9/optimizer/J9SimplifierTableEnum.hpp
+++ b/runtime/compiler/trj9/optimizer/J9SimplifierTableEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -458,7 +458,6 @@
    pdSetSignSimplifier,         // TR::pdSetSign
 
    dftSimplifier,               // TR::pddivrem
-   pddivSelectSimplifier,       // TR::pddivSelect
    dftSimplifier,               // TR::pdremSelect
 
    pdshlSimplifier,             // TR::pdModifyPrecision

--- a/runtime/compiler/trj9/p/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/p/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -449,7 +449,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdclearSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
    TR::TreeEvaluator::badILOpEvaluator,          // TR::countDigits

--- a/runtime/compiler/trj9/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -450,7 +450,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdclearSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
    TR::TreeEvaluator::badILOpEvaluator,          // TR::countDigits

--- a/runtime/compiler/trj9/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -450,7 +450,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdclearSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
    TR::TreeEvaluator::badILOpEvaluator,          // TR::countDigits

--- a/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.hpp
@@ -154,7 +154,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
 
    static TR::Register *pdremSelectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *pdnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *pddivSelectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static void clearAndSetSign(TR::Node *node,
                                TR_PseudoRegister *targetReg,

--- a/runtime/compiler/trj9/z/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/z/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -459,7 +459,6 @@
    TR::TreeEvaluator::pdSetSignEvaluator,    // TR::pdSetSign
 
    TR::TreeEvaluator::pddivremEvaluator,    // TR::pddivrem
-   TR::TreeEvaluator::pddivSelectEvaluator, // TR::pddivSelect
    TR::TreeEvaluator::pdremSelectEvaluator, // TR::pdremSelect
 
    TR::TreeEvaluator::pdModifyPrecisionEvaluator,       // TR::pdModifyPrecision


### PR DESCRIPTION
Remove the obsolete pddivSelect opCode from OMR.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>