### PR TITLE
Run redundant goto elimination before codegen

### DIFF
--- a/runtime/compiler/trj9/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/trj9/optimizer/J9Optimizer.cpp
@@ -712,6 +712,7 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::compactNullChecks,                         OMR::IfEnabled                  }, // cleanup at the end
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead anchors created by check/store removal
    { OMR::deadTreesElimination,                      OMR::IfEnabled                  }, // remove dead RegStores produced by previous deadTrees pass
+   { OMR::redundantGotoElimination,                  OMR::IfEnabledAndNotJitProfiling }, // dead store and dead tree elimination may have left empty blocks
    { OMR::compactLocals,                             OMR::IfNotJitProfiling          }, // analysis results are invalidated by profilingGroup
    { OMR::globalLiveVariablesForGC                                              },
    { OMR::profilingGroup,                            OMR::IfProfiling                },


### PR DESCRIPTION
After global dead store elimination and dead trees elimination, there
may be blocks containing nothing but goto. This commit gives redundant
goto elimination a chance to look at any such blocks detected by the
preceding pass(es) of dead trees elimination.