### PR TITLE
Run local CSE to aid idiom recognition at warm

### DIFF
--- a/runtime/compiler/trj9/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/trj9/optimizer/J9Optimizer.cpp
@@ -670,6 +670,7 @@ static const OptimizationStrategy cheapWarmStrategyOpts[] =
    { OMR::loopReduction                                                              },
    { OMR::blockShuffling                                                             },
 #endif
+   { OMR::localCSE,                                  OMR::IfLoopsAndNotProfiling     },
    { OMR::idiomRecognition,                          OMR::IfLoopsAndNotProfiling     },
    { OMR::blockSplitter                                                         },
    { OMR::treeSimplification                                                    }, // revisit; not really required ?


### PR DESCRIPTION
An extra pass of local common subexpression elimination (CSE) before
idiom recognition allows the latter to recognize arraycmp in
String.equals at warm.