### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/oti/VMAccess.hpp
+++ b/runtime/oti/VMAccess.hpp
@@ -335,13 +335,7 @@ public:
 	{
 		currentThread->inNative = FALSE;
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-#if defined(LINUX)
-#if !defined(TYPESTUBS_H)
-		asm volatile ("" : : : "memory");
-#endif /* !TYPESTUBS_H */
-#else /* LINUX */
-#error compiler barrier unimplemented
-#endif /* LINUX */
+		VM_AtomicSupport::compilerReorderingBarrier();
 #else /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 		VM_AtomicSupport::readWriteBarrier(); // necessary?
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -354,14 +348,9 @@ public:
 	inlineExitVMToJNI(J9VMThread* const currentThread)
 	{
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
+		VM_AtomicSupport::compilerReorderingBarrier();
 		currentThread->inNative = TRUE;
-#if defined(LINUX)
-#if !defined(TYPESTUBS_H)
-		asm volatile ("" : : : "memory");
-#endif /* !TYPESTUBS_H */
-#else /* LINUX */
-#error compiler barrier unimplemented
-#endif /* LINUX */
+		VM_AtomicSupport::compilerReorderingBarrier();
 #else /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 		VM_AtomicSupport::writeBarrier();
 		currentThread->inNative = TRUE;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5488,7 +5488,11 @@ typedef struct J9JavaVM {
 	UDATA safePointResponseCount;
 	struct J9VMRuntimeStateListener vmRuntimeStateListener;
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
+#if defined(LINUX)
 	J9PortVmemIdentifier exclusiveGuardPage;
+#elif defined(WIN32) /* LINUX */
+	void *flushFunction;
+#endif /* WIN32 */
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 } J9JavaVM;
 


### PR DESCRIPTION
- use FlushProcessWriteBuffers on windows
- use atomic compiler barrier

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>