### PR TITLE
Changes to allow code to build on z/OS platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Copyright (c) 2000, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+# This .gitattributes file will cause all text files EXCEPT for
+# those specifically listed below to be encoded as EBCDIC.
+# Selected binary files will not be translated at all.
+
+# The default for text files
+* git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+
+# Specific types of files remain as ASCII
+*.xml git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+*.dtd git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+*.xsd git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+buildspecs/* git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# git's files (which MUST be ASCII)
+.gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+.gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# Binary files
+*.jpg git-encoding=BINARY working-tree-encoding=BINARY
+*.png git-encoding=BINARY working-tree-encoding=BINARY
+*.gif git-encoding=BINARY working-tree-encoding=BINARY
+*.zip git-encoding=BINARY working-tree-encoding=BINARY

--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -101,7 +101,7 @@ TRACEGEN_DEFINITION_SENTINELS := $(patsubst %.tdf,%.tracesentinel,$(TRACEGEN_DEF
 
 # process TDF files to generate RAS tracing headers and C files
 trace_merge : buildtrace
-	@$(MAKE) -f buildtools.mk $(TRACEGEN_DEFINITION_SENTINELS)
+	@$(MAKE) -f buildtools.mk 'SPEC=$(SPEC)' $(TRACEGEN_DEFINITION_SENTINELS)
 	./tracemerge -majorversion 5 -minorversion 1 -root .
 	touch $@
 
@@ -123,7 +123,7 @@ HOOK_DEFINITION_SENTINELS := $(patsubst %.hdf,%.hooksentinel, $(HOOK_DEFINITION_
 	touch $@
 
 hooktool : buildhook
-	@$(MAKE) -f buildtools.mk $(HOOK_DEFINITION_SENTINELS)
+	@$(MAKE) -f buildtools.mk 'SPEC=$(SPEC)' $(HOOK_DEFINITION_SENTINELS)
 
 # run configure to generate makefile
 OMRGLUE = ../gc_glue_java

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1999, 2017 IBM Corp. and others
+ * Copyright (c) 1999, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,7 +70,7 @@ import java.util.StringTokenizer;
  */
 public class JavaPreprocessor {
 
-	private static final Charset ASCII = Charset.forName("US-ASCII");
+	private final Charset charset;
 
 	private final File inFile;
 	private BufferedReader in;
@@ -171,12 +171,20 @@ public class JavaPreprocessor {
 	 */
 	public JavaPreprocessor(OutputStream metadataOut, File inputFile, OutputStream out, File outputFile) {
 		super();
+		
+		String osname = System.getProperty("os.name");
+		if ("z/OS".equalsIgnoreCase(osname)) {
+			charset = Charset.forName("IBM-1047");
+		} else {
+			charset = Charset.forName("US-ASCII");
+		}
+		
 		this.inStack = new Stack<>();
 		this.inFile = inputFile;
-		this.out = new OutputStreamWriter(out, ASCII);
+		this.out = new OutputStreamWriter(out, charset);
 
 		if (metadataOut != null) {
-			this.metadataOut = new OutputStreamWriter(metadataOut, ASCII);
+			this.metadataOut = new OutputStreamWriter(metadataOut, charset);
 			try {
 				this.metadataOut.write(inputFile.getAbsolutePath());
 				this.metadataOut.write(newLine);
@@ -503,7 +511,7 @@ public class JavaPreprocessor {
 		}
 
 		try {
-			BufferedReader includeReader = new BufferedReader(new InputStreamReader(new FileInputStream(arg), ASCII));
+			BufferedReader includeReader = new BufferedReader(new InputStreamReader(new FileInputStream(arg), charset));
 
 			includeReader.mark(1024);
 
@@ -1287,7 +1295,7 @@ public class JavaPreprocessor {
 
 		try {
 			fis = new FileInputStream(inFile);
-			this.in = new BufferedReader(new InputStreamReader(fis, ASCII));
+			this.in = new BufferedReader(new InputStreamReader(fis, charset));
 		} catch (FileNotFoundException e) {
 			error("File not found: " + inFile.getAbsolutePath());
 		}


### PR DESCRIPTION
Changes required for building OpenJDK with OpenJ9 on z/OS

* Ensure preprocessor works on z/OS by using EBCDIC as the
default charset.
* Add a .gitattributes file to enable files to be cloned to
z/OS in charset as defined in the file.
* Add definition of SPEC in the buildtools.mk file

Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>