### PR TITLE
Corrects typo from 'Disallow nestmate changes during class redefinition'

### DIFF
--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3109,7 +3109,7 @@ verifyClassesAreCompatible(J9VMThread * currentThread, jint class_count, J9JVMTI
 
 			/* Nest hosts must both be null or must both contain the same string */
 			if ((NULL != originalNestHostName) || (NULL != replacementNestHostName)) {
-				if ((NULL == originalNestHostName) || (NULL == replacementNestHostName) {
+				if ((NULL == originalNestHostName) || (NULL == replacementNestHostName)) {
 					return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;
 				} else if (!J9UTF8_EQUALS(originalNestHostName, replacementNestHostName)) {
 					return JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED;


### PR DESCRIPTION
An accidental missed bracket from 'Disallow nestmate changes during
class redefinition' (PR # 1412, commit 320f56d) during PR review causes
compilation failure when J9VM_OPT_VALHALLA_NESTMATES build flag is
enabled. This commit adds the missing bracket.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>