### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -765,3 +765,5 @@ TraceException=Trc_VM_sendResolveMethodTypeRefInto_Exception Overhead=1 Level=1 
 TraceExit=Trc_VM_sendResolveMethodTypeRefInto_Exit Overhead=1 Level=5 Template="sendResolveMethodTypeRefInto methodType=%p."
 
 TraceException=Trc_VM_CgroupSubsystemsNotEnabled Overhead=1 Level=1 Template="Cgroup subsystems available: 0x%llx, enabled: 0x%llx"
+
+TraceException=Trc_VM_failedtoAllocateGuardPage noEnv Overhead=1 Level=1 Template="Failed to allocate exclusive guard page of size %lld"


### PR DESCRIPTION
- tracepoint for guard page allocation failure
- remove prints from startup

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>