### PR TITLE
Makefile update to make use of ELFGenerator

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -66,7 +66,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/CodeGenGC.cpp \
     omr/compiler/codegen/CodeGenPrep.cpp \
     omr/compiler/codegen/CodeGenRA.cpp \
-    omr/compiler/codegen/ELFObjectFileGenerator.cpp \
+    omr/compiler/codegen/ELFGenerator.cpp \
     omr/compiler/codegen/FrontEnd.cpp \
     omr/compiler/codegen/LiveRegister.cpp \
     omr/compiler/codegen/NodeEvaluation.cpp \


### PR DESCRIPTION
ELF generating capabilities in OMR are now handled by
ELFGenerator and its derived classes, all defined in
ELFGenerator.cpp.

Depends on: eclipse/omr#2321

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>