### PR TITLE
X86 CG inlines isAssignableFrom for abstract class

### DIFF
--- a/runtime/compiler/trj9/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/x/codegen/J9TreeEvaluator.cpp
@@ -13563,7 +13563,7 @@ inlineIsAssignableFrom(
       {
       TR::SymbolReference *thisClassSymRef = thisClass->getFirstChild()->getSymbolReference();
 
-      if (thisClassSymRef->isClassInterface(comp) || thisClassSymRef->isClassAbstract(comp))
+      if (thisClassSymRef->isClassInterface(comp))
          {
          return false;
          }


### PR DESCRIPTION
java.lang.Class.isAssignableFrom() for abstract class is now inlined by CG on X86.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>