### PR TITLE
Specify heap limits as percentage of total memory

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -256,10 +256,8 @@ MM_GCExtensions::computeDefaultMaxHeap(MM_EnvironmentBase *env)
 
 #if defined(OMR_ENV_DATA64)
 	if (J2SE_VERSION((J9JavaVM *)getOmrVM()->_language_vm) >= J2SE_19) {
-		uint64_t usableMemory = omrsysinfo_get_addressable_physical_memory();
-
-		/* extend java default max memory to 25% of physical RAM */
-		memoryMax = OMR_MAX(memoryMax, usableMemory / 4);
+		/* extend java default max memory to 25% of usable RAM */
+		memoryMax = OMR_MAX(memoryMax, usablePhysicalMemory / 4);
 	}
 
 	/* limit maxheapsize up to MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_3BIT_SHIFT_COMPRESSEDREFS, then can set 3bit compressedrefs as the default */

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -183,6 +183,9 @@ public:
 	MM_IdleGCManager* idleGCManager; /**< Manager which registers for VM Runtime State notification & manages free heap on notification */
 #endif
 
+	double maxRAMPercent; /**< Value of -XX:MaxRAMPercentage specified by the user */
+	double initialRAMPercent; /**< Value of -XX:InitialRAMPercentage specified by the user */
+
 protected:
 private:
 protected:
@@ -299,6 +302,8 @@ public:
 #if defined(J9VM_GC_IDLE_HEAP_MANAGER)
 		, idleGCManager(NULL)
 #endif
+		, maxRAMPercent(0.0) /* this would get overwritten by user specified value */
+		, initialRAMPercent(0.0) /* this would get overwritten by user specified value */
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -144,6 +144,9 @@ static void hookValidatorVMThreadCrash(J9HookInterface * * hookInterface, UDATA 
 static bool gcInitializeVMHooks(MM_GCExtensionsBase *extensions);
 static void gcCleanupVMHooks(MM_GCExtensionsBase *extensions);
 
+static const char * displayXmxOrMaxRAMPercentage(IDATA* memoryParameters);
+static const char * displayXmsOrInitialRAMPercentage(IDATA* memoryParameters);
+
 /**
  * Initialize the threads mutator information (RS pointers, reference list pointers etc) for GC/MM purposes.
  *
@@ -304,7 +307,7 @@ gcCleanupHeapStructures(J9JavaVM * vm)
  * Initialized passive and active heap components
  */
 IDATA
-j9gc_initialize_heap(J9JavaVM *vm, UDATA heapBytesRequested)
+j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesRequested)
 {
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(vm);
 	MM_EnvironmentBase env(vm->omrVM);
@@ -448,7 +451,7 @@ j9gc_initialize_heap(J9JavaVM *vm, UDATA heapBytesRequested)
 	globalCollector = extensions->configuration->createGlobalCollector(&env);
 	if (NULL == globalCollector) {
 		if(MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_METRONOME_DOES_NOT_SUPPORT_4BIT_SHIFT == extensions->heapInitializationFailureReason) {
-			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, "-Xmx");
+			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, displayXmxOrMaxRAMPercentage(memoryParameterTable));
 		}
 		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INSTANTIATE_GLOBAL_GARBAGE_COLLECTOR, "Failed to instantiate global garbage collector.");
 		goto error_no_memory;
@@ -902,6 +905,44 @@ setConfigurationSpecificMemoryParameters(J9JavaVM *javaVM, IDATA* memoryParamete
  *
  * Determine which memory parameter to display to the user in the event of an error.
  * @param memoryParameters array of parameter values
+ * @return pointer to "-Xmx" or "-XX:MaxRAMPercentage"
+ */
+static const char *
+displayXmxOrMaxRAMPercentage(IDATA* memoryParameters)
+{
+	if ((-1 != memoryParameters[opt_maxRAMPercent])
+		&& (memoryParameters[opt_Xmx] == memoryParameters[opt_maxRAMPercent])
+	) {
+		return "-Xmx (as set by -XX:MaxRAMPercentage)";
+	} else {
+		return "-Xmx";
+	}
+}
+
+/**
+ * Verify memory parameters.
+ *
+ * Determine which memory parameter to display to the user in the event of an error.
+ * @param memoryParameters array of parameter values
+ * @return pointer to "-Xms" or "-XX:InitialRAMPercentage"
+ */
+static const char *
+displayXmsOrInitialRAMPercentage(IDATA* memoryParameters)
+{
+	if ((-1 != memoryParameters[opt_initialRAMPercent])
+		&& (memoryParameters[opt_Xms] == memoryParameters[opt_initialRAMPercent])
+	) {
+		return "-Xms (as set by -XX:InitialRAMPercentage)";
+	} else {
+		return "-Xms";
+	}
+}
+
+/**
+ * Verify memory parameters.
+ *
+ * Determine which memory parameter to display to the user in the event of an error.
+ * @param memoryParameters array of parameter values
  * @return pointer to "-Xmn" or "-Xmns"
  */
 const char *
@@ -1034,7 +1075,7 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 #endif /* defined(J9ZOS39064) */
 
 	if (extensions->memoryMax > (extensions->heapCeiling - J9GC_COMPRESSED_POINTER_NULL_REGION_SIZE)) {
-		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, "-Xmx");
+		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_OVERFLOW, displayXmxOrMaxRAMPercentage(memoryParameters));
 		return JNI_ERR;
 	}
 #endif /* defined (J9VM_GC_COMPRESSED_POINTERS) */
@@ -1042,12 +1083,12 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 	/* Verify Xmx is too small */
 	if (extensions->memoryMax < minimumSizeValue) {
 		if (NULL == memoryOption1) {
-			memoryOption1 = "-Xmx";
+			memoryOption1 = displayXmxOrMaxRAMPercentage(memoryParameters);
 			memoryOption2 = NULL;
 			goto _subSpaceTooSmallForValue;
 		} else {
 			if (opt_XmxSet) {
-				subSpaceTooLargeOption = "-Xmx";
+				subSpaceTooLargeOption = displayXmxOrMaxRAMPercentage(memoryParameters);
 				goto _subSpaceTooLarge;
 			}
 			goto _subSpaceTooLargeForHeap;
@@ -1071,7 +1112,7 @@ gcInitializeXmxXmdxVerification(J9JavaVM *javaVM, IDATA* memoryParameters, bool 
 			memoryOption1 = "-Xmdx";
 			memoryOption2 = NULL;
 			if (opt_XmxSet) {
-				subSpaceTooLargeOption = "-Xmx";
+				subSpaceTooLargeOption = displayXmxOrMaxRAMPercentage(memoryParameters);
 				goto _subSpaceTooLarge;
 			}
 			goto _subSpaceTooLargeForHeap;
@@ -1180,8 +1221,8 @@ independentMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 	 * Can not verify minimum values until Xmns/Xmos have been verified.
 	 */
 	if (opt_XmxSet) {
-		maximumXmdxValueParameter = "-Xmx";
-		maximumXmsValueParameter = "-Xmx";
+		maximumXmdxValueParameter = displayXmxOrMaxRAMPercentage(memoryParameters);
+		maximumXmsValueParameter = displayXmxOrMaxRAMPercentage(memoryParameters);
 	}
 
 	if (opt_XmdxSet) {
@@ -1210,7 +1251,7 @@ independentMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		}
 
 		if (extensions->initialMemorySize > maximumXmsValue) {
-			memoryOption = "-Xms";
+			memoryOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 			if (maximumXmsValueParameter) {
 				subSpaceTooLargeOption = maximumXmsValueParameter;
 				goto _subSpaceTooLarge;
@@ -1220,7 +1261,7 @@ independentMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 
 		/* When comparing to maximum boundary use the Xms value */
 		maximumXmsValue = extensions->initialMemorySize;
-		maximumXmsValueParameter = "-Xms";
+		maximumXmsValueParameter = displayXmsOrInitialRAMPercentage(memoryParameters);
 	}
 
 	/* verify -Xsoftmx is set between -Xms and -Xmx */
@@ -1399,11 +1440,11 @@ independentMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 
 	if (opt_XmsSet && (extensions->initialMemorySize < XmsMinimumValue)) {
 		if (NULL == memoryOption) {
-			memoryOption = "-Xms";
+			memoryOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 			minimumSizeValue = XmsMinimumValue; /* display min size */
 			goto _subSpaceTooSmallForValue;
 		} else {
-			subSpaceTooLargeOption = "-Xms";
+			subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 			goto _subSpaceTooLarge;
 		}
 	}
@@ -1543,7 +1584,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		assume0(extensions->initialMemorySize <= extensions->maxSizeDefaultMemorySpace);
 
 		maximumXmsValue = extensions->initialMemorySize;
-		maximumXmsValueParameter = "-Xms";
+		maximumXmsValueParameter = displayXmsOrInitialRAMPercentage(memoryParameters); 
 		break;
 
 	case XMDX:
@@ -1567,7 +1608,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		}
 
 		maximumXmsValue = extensions->initialMemorySize;
-		maximumXmsValueParameter = "-Xms";
+		maximumXmsValueParameter = displayXmsOrInitialRAMPercentage(memoryParameters);
 		break;
 
 	case NONE:
@@ -1578,7 +1619,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 
 		maximumXmsValue = extensions->memoryMax;
 		if (opt_XmxSet) {
-			maximumXmsValueParameter = "-Xmx";
+			maximumXmsValueParameter = displayXmxOrMaxRAMPercentage(memoryParameters);
 		}
 		break;
 
@@ -1622,7 +1663,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 			 */
 			if (extensions->oldSpaceSize != extensions->initialMemorySize) {
 				memoryOption = displayXmoOrXmos(memoryParameters);
-				memoryOption2 = "-Xms";
+				memoryOption2 = displayXmsOrInitialRAMPercentage(memoryParameters);
 				goto _subSpaceNotEqualError;
 			}
 			break;
@@ -1658,7 +1699,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 
 			if (opt_XmoxSet && (extensions->oldSpaceSize > extensions->maxOldSpaceSize)) {
 				memoryOption = displayXmoOrXmox(memoryParameters);
-				subSpaceTooSmallOption = "-Xms";
+				subSpaceTooSmallOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 				goto _subSpaceTooSmall;
 			}
 			break;
@@ -1758,7 +1799,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 			if (opt_XmsSet && ((extensions->oldSpaceSize + extensions->newSpaceSize) != extensions->initialMemorySize)) {
 				memoryOption = displayXmoOrXmos(memoryParameters);
 				memoryOption2 =  displayXmnOrXmns(memoryParameters);
-				subSpaceTooLargeOption = "-Xms";
+				subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 				goto _subSpaceCombinationNotEqual;
 			}
 			break;
@@ -1781,21 +1822,21 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 				/* Verify not too small */
 				if (candidateXmnsValue < newSpaceSizeMinimum) {
 					memoryOption = displayXmoOrXmos(memoryParameters);
-					subSpaceTooLargeOption = "-Xms";
+					subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceTooLarge;
 				}
 
 				/* Ensure Xmns <= Xmnx */
 				if (opt_XmnxSet && (candidateXmnsValue > extensions->maxNewSpaceSize)) {
 					memoryOption = displayXmnOrXmnx(memoryParameters);
-					subSpaceTooSmallOption = "-Xms";
+					subSpaceTooSmallOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceTooSmall;
 				}
 
 				/* Enforce Xms = Xmns + Xmos */
 				if ((extensions->oldSpaceSize + candidateXmnsValue) != extensions->initialMemorySize) {
 					memoryOption = displayXmoOrXmos(memoryParameters);
-					subSpaceTooLargeOption = "-Xms";
+					subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceTooLarge;
 				}
 			} else {
@@ -1854,21 +1895,21 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 				/* Verify not too small */
 				if (candidateXmosValue < oldSpaceSizeMinimum) {
 					memoryOption = displayXmnOrXmns(memoryParameters);
-					subSpaceTooLargeOption = "-Xms";
+					subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceTooLarge;
 				}
 
 				/* Ensure Xmos <= Xmox */
 				if (opt_XmoxSet && (candidateXmosValue > extensions->maxOldSpaceSize)) {
 					memoryOption = displayXmoOrXmox(memoryParameters);
-					subSpaceTooSmallOption = "-Xms";
+					subSpaceTooSmallOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceTooSmall;
 				}
 
 				/* Enforce Xms = Xmns + Xmos */
 				if ((candidateXmosValue + extensions->newSpaceSize) != extensions->initialMemorySize) {
 					memoryOption = displayXmnOrXmns(memoryParameters);
-					subSpaceTooLargeOption = "-Xms";
+					subSpaceTooLargeOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceTooLarge;
 				}
 			} else {
@@ -1966,7 +2007,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 					 */
 					memoryOption = "-Xmox";
 					memoryOption2 = "-Xmnx";
-					subSpaceTooSmallOption = "-Xms";
+					subSpaceTooSmallOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 					goto _subSpaceCombinationTooSmall;
 				}
 			} else {
@@ -2032,7 +2073,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 				extensions->initialMemorySize = combinedXmosXmnsSize;
 			} else {
 				assume0(0); /* Previous stage checked Xms > minConfiguration */
-				memoryOption = "-Xms";
+				memoryOption = displayXmsOrInitialRAMPercentage(memoryParameters);
 				minimumSizeValue = extensions->absoluteMinimumOldSubSpaceSize + (2*extensions->absoluteMinimumNewSubSpaceSize); /* smallest configuration */
 				goto _subSpaceTooSmallForValue;
 			}
@@ -2077,7 +2118,7 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 					goto _subSpaceCombinationTooLarge;
 				}
 				if (opt_XmxSet) {
-					subSpaceTooLargeOption = "-Xmx";
+					subSpaceTooLargeOption = displayXmxOrMaxRAMPercentage(memoryParameters);
 					goto _subSpaceCombinationTooLarge;
 				}
 				goto _subSpaceCombinationTooLargeForHeap;
@@ -2164,17 +2205,17 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		/* first, the error checking */
 		if (!isLessThanEqualOrUnspecifiedAgainstFixed(&extensions->userSpecifiedParameters._Xmn, mx)) {
 			memoryOption = "-Xmn";
-			subSpaceTooLargeOption = "-Xmx";
+			subSpaceTooLargeOption = displayXmxOrMaxRAMPercentage(memoryParameters);
 			goto _subSpaceTooLarge;
 		}
 		if (!isLessThanEqualOrUnspecifiedAgainstFixed(&extensions->userSpecifiedParameters._Xmns, mx)) {
 			memoryOption = "-Xmns";
-			subSpaceTooLargeOption = "-Xmx";
+			subSpaceTooLargeOption = displayXmxOrMaxRAMPercentage(memoryParameters);
 			goto _subSpaceTooLarge;
 		}
 		if (!isLessThanEqualOrUnspecifiedAgainstFixed(&extensions->userSpecifiedParameters._Xmnx, mx)) {
 			memoryOption = "-Xmnx";
-			subSpaceTooLargeOption = "-Xmx";
+			subSpaceTooLargeOption = displayXmxOrMaxRAMPercentage(memoryParameters);
 			goto _subSpaceTooLarge;
 		}
 		if (!isLessThanEqualOrUnspecifiedAgainstOption(&extensions->userSpecifiedParameters._Xmns, &extensions->userSpecifiedParameters._Xmnx)) {
@@ -2741,6 +2782,17 @@ gcInitializeDefaults(J9JavaVM* vm)
 		goto error;
 	}
 
+	if ((-1 == memoryParameterTable[opt_Xms]) && (-1 != memoryParameterTable[opt_initialRAMPercent])) {
+		extensions->initialMemorySize = (uintptr_t)(((double)extensions->usablePhysicalMemory / 100.0) * extensions->initialRAMPercent);
+		/* Update memory parameter table to appear that -Xms was specified */
+		memoryParameterTable[opt_Xms] = memoryParameterTable[opt_initialRAMPercent];
+	}
+	if ((-1 == memoryParameterTable[opt_Xmx]) && (-1 != memoryParameterTable[opt_maxRAMPercent])) {
+		extensions->memoryMax = (uintptr_t)(((double)extensions->usablePhysicalMemory / 100.0) * extensions->maxRAMPercent);
+		/* Update memory parameter table to appear that -Xmx was specified */
+		memoryParameterTable[opt_Xmx] = memoryParameterTable[opt_maxRAMPercent];
+	}	
+
 	if (gc_policy_metronome == extensions->configurationOptions._gcPolicy) {
 		/* Heap is segregated; take into account segregatedAllocationCache. */
 		vm->segregatedAllocationCacheSize = (J9VMGC_SIZECLASSES_NUM_SMALL + 1)*sizeof(J9VMGCSegregatedAllocationCacheEntry);
@@ -2818,7 +2870,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 		}
 
 		/* Try to initialize basic heap structures with the memory parameters we currently have */
-		if (JNI_OK == j9gc_initialize_heap(vm, extensions->memoryMax)) {
+		if (JNI_OK == j9gc_initialize_heap(vm, memoryParameterTable, extensions->memoryMax)) {
 			break;
 		}
 

--- a/runtime/gc_modron_startup/mmparse.h
+++ b/runtime/gc_modron_startup/mmparse.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,8 @@ typedef enum {
 	opt_Xmr,
 	opt_Xmdx,
 	opt_Xsoftmx,
+	opt_maxRAMPercent,
+	opt_initialRAMPercent,
 	opt_none
 } gcMemoryParameters;
 

--- a/runtime/oti/j9argscan.h
+++ b/runtime/oti/j9argscan.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,6 +103,17 @@ uintptr_t scan_idata(char **scan_start, intptr_t *result);
 */
 char *scan_to_delim(J9PortLibrary *portLibrary, char **scan_start, char delimiter);
 
+/** 
+ * Scan the next double number off of the argument string.
+ * Store the scanned double value in *result
+ *
+ * @param[in/out] scan_start pointer to char * representing the string to be scanned,
+                  on success, *scan_start is updated to point to the character after the last character converted to double
+ * @param[out] result pointer to double, on success contains the scanned double value
+ * @return on success returns OPTION_OK, on overflow returns OPTION_OVERFLOW,
+ *         if no conversion is performed return OPTION_MALFORMED
+ */
+uintptr_t scan_double(char **scan_start, double *result);
 
 /**
 * @brief

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -96,6 +96,7 @@ extern "C" {
 #define GET_PRC_VALUE 7
 #define GET_COMPOUND 8
 #define GET_COMPOUND_OPTS 9
+#define GET_DBL_VALUE 10
 
 #define OPTION_OK 0
 #define OPTION_MALFORMED -1
@@ -124,10 +125,11 @@ extern "C" {
 #define GET_OPTION_VALUES(element, delimChar, sepChar, buffer, bufSize) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_OPTIONS, buffer, bufSize, delimChar, sepChar, NULL)
 #define GET_COMPOUND_VALUE(element, delimChar, buffer, bufSize) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_COMPOUND, buffer, bufSize, delimChar, 0, NULL)
 #define GET_COMPOUND_VALUES(element, delimChar, sepChar, buffer, bufSize) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_COMPOUND_OPTS, buffer, bufSize, delimChar, sepChar, NULL)
-#define GET_MEMORY_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_MEM_VALUE, (char **)&optname, 0, 0, 0, &result)
-#define GET_INTEGER_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_INT_VALUE, (char **)&optname, 0, 0, 0, &result)
-#define GET_PERCENT_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_PRC_VALUE,(char **) &optname, 0, 0, 0, &result)
-#define GET_OPTION_OPTION(element, delimChar, delimChar2, resultPtr) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, element, GET_OPTION_OPT, resultPtr, 0, delimChar, delimChar2, NULL)
+#define GET_MEMORY_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, (element), GET_MEM_VALUE, (char **)&(optname), 0, 0, 0, &(result))
+#define GET_INTEGER_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, (element), GET_INT_VALUE, (char **)&(optname), 0, 0, 0, &(result))
+#define GET_PERCENT_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, (element), GET_PRC_VALUE,(char **) &(optname), 0, 0, 0, &(result))
+#define GET_OPTION_OPTION(element, delimChar, delimChar2, resultPtr) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, (element), GET_OPTION_OPT, (resultPtr), 0, (delimChar), (delimChar2), NULL)
+#define GET_DOUBLE_VALUE(element, optname, result) vm->internalVMFunctions->optionValueOperations(vm->portLibrary, vm->vmArgsArray, (element), GET_DBL_VALUE, (char **) &(optname), 0, 0, 0, &(result))
 #define HAS_MAPPING(args, element) (args->j9Options[element].mapping!=NULL)
 #define MAPPING_FLAGS(args, element) (args->j9Options[element].mapping->flags)
 #define MAPPING_J9NAME(args, element) (args->j9Options[element].mapping->j9Name)


### PR DESCRIPTION
Add options for specifying heap limits in terms of percentage of
total memory available to the JVM.
Following options are added:
1. -XX:MaxRAMPercentage=N where 0 <= N <= 100.0
This option specifies maximum heap size. If -Xmx is specified, this
option is ignored.
2. -XX:InitialRAMPercentage=N where 0 <= N <= 100.0
This option specifies initial heap size. If -Xms is specified, this
option is ignored.

Closes: #1428

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>