### PR TITLE
Optimized Unsafe getAndAdd and getAndSet on X86

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -371,6 +371,10 @@
    sun_misc_Unsafe_staticFieldBase,
    sun_misc_Unsafe_staticFieldOffset,
    sun_misc_Unsafe_objectFieldOffset,
+   sun_misc_Unsafe_getAndAddInt,
+   sun_misc_Unsafe_getAndSetInt,
+   sun_misc_Unsafe_getAndAddLong,
+   sun_misc_Unsafe_getAndSetLong,
 
    sun_misc_Unsafe_putBooleanOrdered_jlObjectJZ_V,
    sun_misc_Unsafe_putByteOrdered_jlObjectJB_V,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3150,6 +3150,10 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {x(TR::sun_misc_Unsafe_staticFieldBase,               "staticFieldBase",   "(Ljava/lang/reflect/Field;)Ljava/lang/Object")},
       {x(TR::sun_misc_Unsafe_staticFieldOffset,             "staticFieldOffset", "(Ljava/lang/reflect/Field;)J")},
       {x(TR::sun_misc_Unsafe_objectFieldOffset,             "objectFieldOffset", "(Ljava/lang/reflect/Field;)J")},
+      {x(TR::sun_misc_Unsafe_getAndAddInt,                  "getAndAddInt",      "(Ljava/lang/Object;JI)I")},
+      {x(TR::sun_misc_Unsafe_getAndSetInt,                  "getAndSetInt",      "(Ljava/lang/Object;JI)I")},
+      {x(TR::sun_misc_Unsafe_getAndAddLong,                 "getAndAddLong",     "(Ljava/lang/Object;JJ)J")},
+      {x(TR::sun_misc_Unsafe_getAndSetLong,                 "getAndSetLong",     "(Ljava/lang/Object;JJ)J")},
 
       {x(TR::sun_misc_Unsafe_putBooleanOrdered_jlObjectJZ_V,       "putOrderedBoolean", "(Ljava/lang/Object;JZ)V")},
       {x(TR::sun_misc_Unsafe_putByteOrdered_jlObjectJB_V,          "putOrderedByte",    "(Ljava/lang/Object;JB)V")},
@@ -4734,8 +4738,11 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
             case TR::sun_misc_Unsafe_loadFence:
             case TR::sun_misc_Unsafe_storeFence:
             case TR::sun_misc_Unsafe_fullFence:
-
             case TR::sun_misc_Unsafe_ensureClassInitialized:
+            case TR::sun_misc_Unsafe_getAndAddInt:
+            case TR::sun_misc_Unsafe_getAndSetInt:
+            case TR::sun_misc_Unsafe_getAndAddLong:
+            case TR::sun_misc_Unsafe_getAndSetLong:
 
             case TR::java_lang_Math_sqrt:
             case TR::java_lang_StrictMath_sqrt:

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -366,6 +366,9 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
 
    switch (calleeMethod->getRecognizedMethod())
       {
+      case TR::sun_misc_Unsafe_getAndAddLong:
+      case TR::sun_misc_Unsafe_getAndSetLong:
+         return TR::Compiler->target.is32Bit();
       case TR::java_lang_J9VMInternals_fastIdentityHashCode:
       case TR::java_lang_Class_getSuperclass:
       case TR::java_lang_String_regionMatchesInternal:
@@ -410,6 +413,11 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
          return !calleeMethod->isNative();
       default:
          break;
+      }
+
+   if (!strncmp(calleeMethod->classNameChars(), "java/util/concurrent/atomic/", strlen("java/util/concurrent/atomic/")))
+      {
+      return true;
       }
 
    return false;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -24,6 +24,7 @@
 #define J9RECOGNIZEDCALLTRANSFORMER_INCL
 
 #include "optimizer/OMRRecognizedCallTransformer.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 
 namespace J9
 {
@@ -76,6 +77,20 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     *     \endcode
     */
    void process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node);
+   /** \brief
+    *     Transforms certain Unsafe atomic helpers into a CodeGen inlined helper with equivalent semantics.
+    *
+    *  \param treetop
+    *     The treetop which anchors the call node.
+    
+    *  \param node
+    *     The call node representing the Unsafe call
+    *
+    *  \param helper
+    *     The CodeGen inlined helper being transformed into
+    *
+    */
+   void processUnsafeAtomicCall(TR::TreeTop* treetop, TR::Node* node, TR::SymbolReferenceTable::CommonNonhelperSymbol helper);
    };
 
 }

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1706,6 +1706,32 @@ TR::Node * J9::TransformUtil::calculateIndexFromOffsetInContiguousArray(TR::Comp
 
 /**
  * \brief
+ *    Save a node to temp slot
+ *
+ * \parm comp
+ *    The compilation object asking for the transformation
+ *
+ * \parm node
+ *    The node to be saved
+ *
+ * \parm insertTreeTop
+ *    The treetop containing the node
+ *
+ * \return
+ *    A node that loads the saved node from the temp slot
+ */
+TR::Node*
+J9::TransformUtil::saveNodeToTempSlot(TR::Compilation* comp, TR::Node* node, TR::TreeTop* insertTreeTop)
+   {
+   auto type = node->getDataType();
+   auto symRef = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), type);
+   insertTreeTop->insertBefore(TR::TreeTop::create(comp, TR::Node::createWithSymRef(comp->il.opCodeForDirectStore(type), 1, 1, node, symRef)));
+   return TR::Node::createWithSymRef(comp->il.opCodeForDirectLoad(type), 0, symRef);
+   }
+
+
+/**
+ * \brief
  *    Create temps for a call's children and replace the call's children with loads from the newly created temps.
  *
  * \parm opt
@@ -1817,5 +1843,137 @@ J9::TransformUtil::createDiamondForCall(TR::Optimization* opt, TR::TreeTop *call
       elseTree->insertAfter(elseStoreTree);
       if (opt->trace())
          traceMsg(comp, "Two store nodes %p and %p are inserted in the diamond\n", ifStoreNode, elseStoreNode);
+      }
+   }
+
+
+/**
+ * \brief
+ *    Generate a diamond to calculate the address for an Unsafe node
+ *
+ * \parm treetop
+ *    The treetop containing the Unsafe node
+ *
+ * \parm objectNode
+ *    The node representing target object
+ *
+ * \parm offsetNode
+ *    The node representing the offset of the targte object
+ *
+ * \parm needsNullCheck
+ *    Whether a NULLCHK should be generated
+ *
+ * \parm isNotStaticField
+ *    Whether the field is known as non-static
+ *
+ * \return
+ *    A node that loads the saved node from the temp slot
+ */
+TR::Node*
+J9::TransformUtil::calculateUnsafeAddress(TR::TreeTop* treetop, TR::Node* objectNode, TR::Node* offsetNode, TR::Compilation* comp, bool needsNullCheck, bool isNotStaticField)
+   {
+   if (!objectNode)
+      {
+      // If object is null, the offset is an absolute address. No need for calculation.
+      return TR::Node::create(TR::l2a, 1, offsetNode);
+      }
+   else if (isNotStaticField)
+      {
+      // If it is safe to skip diamond, the address can be calaulated directly via [object+offset]
+      return TR::Compiler->target.is32Bit() ? TR::Node::create(TR::aiadd, 2, objectNode, TR::Node::create(TR::l2i, 1, offsetNode)) :
+                                              TR::Node::create(TR::aladd, 2, objectNode, offsetNode);
+      }
+   else
+      {
+      auto cfg = comp->getMethodSymbol()->getFlowGraph();
+      // Otherwise, the address is [object+offset] for non-static field,
+      //            or [object's ramStaticsFromClass + (offset & ~mask)] for static field
+      objectNode = TR::TransformUtil::saveNodeToTempSlot(comp, objectNode, treetop);
+      offsetNode = TR::TransformUtil::saveNodeToTempSlot(comp, offsetNode, treetop);
+
+      // Null Check
+      if (needsNullCheck)
+         {
+         auto NULLCHKNode = TR::Node::createWithSymRef(TR::NULLCHK, 1, 1,
+                                                       TR::Node::create(TR::PassThrough, 1, objectNode->duplicateTree()),
+                                                       comp->getSymRefTab()->findOrCreateNullCheckSymbolRef(comp->getMethodSymbol()));
+         NULLCHKNode->getByteCodeInfo().setCallerIndex(comp->getCurrentInlinedSiteIndex());
+         treetop->insertBefore(TR::TreeTop::create(comp, NULLCHKNode));
+         }
+
+      // Test if object is null
+      auto testNullNode = TR::Node::createif(TR::ifacmpeq, objectNode->duplicateTree(), TR::Node::aconst(0), NULL);
+      auto testNullTreeTop = TR::TreeTop::create(comp, testNullNode);
+      treetop->insertBefore(testNullTreeTop);
+      treetop->getEnclosingBlock()->split(treetop, cfg);
+
+      // Test if low tag is set
+      auto testLowTagNode = TR::Node::createif(TR::iflcmpeq, 
+                                               TR::Node::create(TR::land, 2, offsetNode->duplicateTree(), TR::Node::lconst(1)),
+                                               TR::Node::lconst(0),
+                                               NULL);
+      auto testLowTagTreeTop = TR::TreeTop::create(comp, testLowTagNode);
+      treetop->insertBefore(testLowTagTreeTop);
+      treetop->getEnclosingBlock()->split(treetop, cfg);
+
+      // Test if field is static / non-array
+      auto jlClass = comp->getClassClassPointer(true); jlClass = NULL;
+      auto checkStaticNode = jlClass ? TR::Node::createif(TR::ificmpeq,
+                                                          TR::Node::createWithSymRef(TR::instanceof, 2, 2,
+                                                                                     objectNode->duplicateTree(),
+                                                                                     TR::Node::createWithSymRef(TR::loadaddr, 0, comp->getSymRefTab()->findOrCreateClassSymbol(comp->getMethodSymbol(), -1, jlClass)),
+                                                                                     comp->getSymRefTab()->findOrCreateInstanceOfSymbolRef(comp->getMethodSymbol())),
+                                                          TR::Node::iconst(0),
+                                                          NULL)
+                                     : TR::Compiler->target.is32Bit() ? TR::Node::createif(TR::ificmpne,
+                                                                                           TR::Node::create(TR::iand, 2,
+                                                                                                            TR::Node::createWithSymRef(TR::iloadi, 1, 1,
+                                                                                                                                       TR::Node::createWithSymRef(TR::aloadi, 1, 1,
+                                                                                                                                                                  objectNode->duplicateTree(),
+                                                                                                                                                                  comp->getSymRefTab()->findOrCreateVftSymbolRef()),
+                                                                                                                                       comp->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef()),
+                                                                                                            TR::Node::iconst(TR::Compiler->cls.flagValueForArrayCheck(comp))),
+                                                                                           TR::Node::iconst(0),
+                                                                                           NULL)
+                                                                      : TR::Node::createif(TR::iflcmpne,
+                                                                                           TR::Node::create(TR::land, 2,
+                                                                                                            TR::Node::createWithSymRef(TR::lloadi, 1, 1,
+                                                                                                                                       TR::Node::createWithSymRef(TR::aloadi, 1, 1,
+                                                                                                                                                                  objectNode->duplicateTree(),
+                                                                                                                                                                  comp->getSymRefTab()->findOrCreateVftSymbolRef()),
+                                                                                                                                       comp->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef()),
+                                                                                                            TR::Node::lconst(TR::Compiler->cls.flagValueForArrayCheck(comp))),
+                                                                                           TR::Node::lconst(0),
+                                                                                           NULL);
+      auto checkStaticNodeTreeTop = TR::TreeTop::create(comp, checkStaticNode);
+      treetop->insertBefore(checkStaticNodeTreeTop);
+      treetop->getEnclosingBlock()->split(treetop, cfg);
+
+      // Calculate static address
+      auto objectAdjustmentNode = TR::Node::createWithSymRef(TR::astore, 1, 1,
+                                                             TR::Node::createWithSymRef(TR::aloadi, 1, 1, 
+                                                                                        TR::Node::createWithSymRef(TR::aloadi, 1, 1,
+                                                                                                                   objectNode->duplicateTree(),
+                                                                                                                   comp->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef()),
+                                                                                        comp->getSymRefTab()->findOrCreateRamStaticsFromClassSymbolRef()),
+                                                             objectNode->getSymbolReference());
+      auto offsetAdjustmentNode = TR::Node::createWithSymRef(TR::lstore, 1, 1,
+                                                             TR::Node::create(TR::land, 2,
+                                                                              offsetNode->duplicateTree(),
+                                                                              TR::Node::lconst(~J9_SUN_FIELD_OFFSET_MASK)),
+                                                             offsetNode->getSymbolReference());
+      treetop->insertBefore(TR::TreeTop::create(comp, objectAdjustmentNode));
+      treetop->insertBefore(TR::TreeTop::create(comp, offsetAdjustmentNode));
+      treetop->getEnclosingBlock()->split(treetop, cfg);
+
+      // Setup CFG edges
+      testNullNode->setBranchDestination(treetop->getEnclosingBlock()->getEntry());
+      cfg->addEdge(TR::CFGEdge::createEdge(testNullTreeTop->getEnclosingBlock(), treetop->getEnclosingBlock(), comp->trMemory()));
+      testLowTagNode->setBranchDestination(treetop->getEnclosingBlock()->getEntry());
+      cfg->addEdge(TR::CFGEdge::createEdge(testLowTagTreeTop->getEnclosingBlock(), treetop->getEnclosingBlock(), comp->trMemory()));
+      checkStaticNode->setBranchDestination(treetop->getEnclosingBlock()->getEntry());
+      cfg->addEdge(TR::CFGEdge::createEdge(checkStaticNodeTreeTop->getEnclosingBlock(), treetop->getEnclosingBlock(), comp->trMemory()));
+      return TR::Compiler->target.is32Bit() ? TR::Node::create(TR::aiadd, 2, objectNode->duplicateTree(), TR::Node::create(TR::l2i, 1, offsetNode->duplicateTree())) :
+                                              TR::Node::create(TR::aladd, 2, objectNode->duplicateTree(), offsetNode->duplicateTree());
       }
    }

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -57,26 +57,24 @@ public:
    static TR::Node *transformStringIndexOfCall( TR::Compilation *, TR::Node *callNode);
    
    static TR::Node *transformIndirectLoad(TR::Compilation *, TR::Node *node);
-
    static bool transformDirectLoad(TR::Compilation *, TR::Node *node);
 
    static bool transformIndirectLoadChain(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, TR::KnownObjectTable::Index baseKnownObject, TR::Node **removedNode);
-
    static bool transformIndirectLoadChainAt(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, uintptrj_t *baseReferenceLocation, TR::Node **removedNode);
-
    static bool transformIndirectLoadChainImpl( TR::Compilation *, TR::Node *node, TR::Node *baseExpression, void *baseAddress, TR::Node **removedNode);
 
    static bool fieldShouldBeCompressed(TR::Node *node, TR::Compilation *comp);
 
    static TR::Block *insertNewFirstBlockForCompilation(TR::Compilation *comp);
-
    static TR::Node *calculateOffsetFromIndexInContiguousArray(TR::Compilation *, TR::Node * index, TR::DataType type);
-
    static TR::Node *calculateElementAddress(TR::Compilation *, TR::Node *array, TR::Node * index, TR::DataType type);
-
    static TR::Node *calculateIndexFromOffsetInContiguousArray(TR::Compilation *, TR::Node * offset, TR::DataType type);
+
+   static TR::Node* saveNodeToTempSlot(TR::Compilation* comp, TR::Node* node, TR::TreeTop* insertTreeTop);
    static void createTempsForCall(TR::Optimization* opt, TR::TreeTop *callTree);
    static void createDiamondForCall(TR::Optimization* opt, TR::TreeTop *callTree, TR::TreeTop *compareTree, TR::TreeTop *ifTree, TR::TreeTop *elseTree, bool changeBlockExtensions = false, bool markCold = false);
+
+   static TR::Node* calculateUnsafeAddress(TR::TreeTop* treetop, TR::Node* objectNode, TR::Node* offsetNode, TR::Compilation* comp, bool needsNullCheck, bool isNotStaticField);
    };
 
 }


### PR DESCRIPTION
Unsafe's methods getAndAdd and getAndSet are recognized and
transformed into OMR's corresponding helpers, allowing being
inlined by the CodeGen.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>