### PR TITLE
Remove obsolete pdremSelect and isPackedArithmeticSelect

### DIFF
--- a/runtime/compiler/trj9/arm/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/arm/codegen/TreeEvaluatorTable.hpp
@@ -458,7 +458,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
 
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
 

--- a/runtime/compiler/trj9/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/trj9/codegen/CodeGenGPU.cpp
@@ -1270,7 +1270,6 @@ static const char * nvvmOpCodeNames[] =
    NULL,          // TR::pdclearSetSign
    NULL,          // TR::pdSetSign
    NULL,          // TR::pddivrem
-   NULL,          // TR::pdremSelect
    NULL,          // TR::pdModifyPrecision
    NULL,          // TR::pd2df
    NULL,          // TR::pd2dfAbs

--- a/runtime/compiler/trj9/il/ILOpCodeProperties.hpp
+++ b/runtime/compiler/trj9/il/ILOpCodeProperties.hpp
@@ -6193,22 +6193,6 @@
    },
 
    {
-   /* .opcode               = */ TR::pdremSelect,
-   /* .name                 = */ "pdremSelect",
-   /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
-   /* .properties3          = */ 0,
-   /* .properties4          = */ ILProp4::BinaryCodedDecimalOp | ILProp4::PackedArithmeticSelect | ILProp4::CanHaveStorageReferenceHint,
-   /* .dataType             = */ TR::PackedDecimal,
-   /* .typeProperties       = */ ILTypeProp::PackedDecimal,
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType),
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::pdModifyPrecision,
    /* .name                 = */ "pdModifyPrecision",
    /* .properties1          = */ 0,

--- a/runtime/compiler/trj9/il/ILProps.hpp
+++ b/runtime/compiler/trj9/il/ILProps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ namespace ILProp4
       ModifyPrecision                  = 0x00000008,
       BinaryCodedDecimalOp             = 0x00000010,
       ConversionHasFraction            = 0x00000020,
-      PackedArithmeticSelect           = 0x00000040,
+      // Available                     = 0x00000040,
       PackedArithmeticOverflowMessage  = 0x00000080,
       DFPTestDataClass                 = 0x00000100,
       CanHaveStorageReferenceHint      = 0x00000200,

--- a/runtime/compiler/trj9/il/J9ILOpCodesEnum.hpp
+++ b/runtime/compiler/trj9/il/J9ILOpCodesEnum.hpp
@@ -460,7 +460,6 @@
    pdSetSign,      // packed decimal forced sign code setting
 
    pddivrem,            // packed decimal fused divide and remainder
-   pdremSelect,         // packed decimal select remainder from pddivrem
 
    pdModifyPrecision,      // packed decimal modify precision
 

--- a/runtime/compiler/trj9/il/J9ILOps.hpp
+++ b/runtime/compiler/trj9/il/J9ILOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,9 +70,8 @@ public:
    bool isBinaryCodedDecimalOp()            const { return properties4().testAny(ILProp4::BinaryCodedDecimalOp); }
    bool isAnyBCDCompareOp()                 const { return isBinaryCodedDecimalOp() && isBooleanCompare(); } // isAnyBCDCompareOp is true for all BCD nodes that do some type of compare e.g. pdcmpxx
    bool isBCDToNonBCDConversion()           const { return isConversion() && isBinaryCodedDecimalOp() && !getType().isBCD(); }
-   bool isPackedArithmeticSelect()          const { return properties4().testAny(ILProp4::PackedArithmeticSelect); }
    bool isPackedArithmeticOverflowMessage() const { return properties4().testAny(ILProp4::PackedArithmeticOverflowMessage); }
-   bool isBasicOrSpecialPackedArithmetic()  const { return isBasicPackedArithmetic() || isPackedArithmeticOverflowMessage() || isPackedArithmeticSelect(); }
+   bool isBasicOrSpecialPackedArithmetic()  const { return isBasicPackedArithmetic() || isPackedArithmeticOverflowMessage(); }
    bool isAnyBCDArithmetic()                const { return isBasicOrSpecialPackedArithmetic(); }
    bool isDFPTestDataClass()                const { return properties4().testAny(ILProp4::DFPTestDataClass); }
    bool trackLineNo()                       const { return properties4().testAny(ILProp4::TrackLineNo); }

--- a/runtime/compiler/trj9/il/J9Node.hpp
+++ b/runtime/compiler/trj9/il/J9Node.hpp
@@ -196,12 +196,6 @@ public:
    void    setSourcePrecision(int32_t prec);
    int32_t getSourcePrecision();
 
-   // Dividend/Divisor Tracking on pdremSelect nodes
-   void    setSelectDivisorPrecision(int32_t p);
-   int32_t getSelectDivisorPrecision();
-   void    setSelectDividendPrecision(int32_t p);
-   int32_t getSelectDividendPrecision();
-
    int32_t getDecimalAdjustOrFractionOrDivisor();
    int32_t getDecimalRoundOrDividend();
 
@@ -231,7 +225,6 @@ public:
    bool hasAssumedPreferredSign();
    void setHasAssumedPreferredSign(bool v);
    bool hasKnownOrAssumedPreferredSign();
-   void setHasKnownAndAssumedPreferredSign(bool v);
 
    bool              hasKnownSignCode();
    TR_RawBCDSignCode getKnownSignCode();

--- a/runtime/compiler/trj9/optimizer/J9SimplifierTableEnum.hpp
+++ b/runtime/compiler/trj9/optimizer/J9SimplifierTableEnum.hpp
@@ -458,7 +458,6 @@
    pdSetSignSimplifier,         // TR::pdSetSign
 
    dftSimplifier,               // TR::pddivrem
-   dftSimplifier,               // TR::pdremSelect
 
    pdshlSimplifier,             // TR::pdModifyPrecision
 

--- a/runtime/compiler/trj9/p/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/p/codegen/TreeEvaluatorTable.hpp
@@ -449,7 +449,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdclearSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
    TR::TreeEvaluator::badILOpEvaluator,          // TR::countDigits
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pd2df

--- a/runtime/compiler/trj9/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -450,7 +450,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdclearSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
    TR::TreeEvaluator::badILOpEvaluator,          // TR::countDigits
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pd2df

--- a/runtime/compiler/trj9/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -450,7 +450,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdclearSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdSetSign
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pddivrem
-   TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdremSelect
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pdModifyPrecision
    TR::TreeEvaluator::badILOpEvaluator,          // TR::countDigits
    TR::TreeEvaluator::unImpOpEvaluator,          // TR::pd2df

--- a/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.hpp
@@ -152,7 +152,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *pddivremEvaluatorHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *pddivremVectorEvaluatorHelper(TR::Node *node, TR::CodeGenerator *cg);
 
-   static TR::Register *pdremSelectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *pdnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static void clearAndSetSign(TR::Node *node,

--- a/runtime/compiler/trj9/z/codegen/TreeEvaluatorTable.hpp
+++ b/runtime/compiler/trj9/z/codegen/TreeEvaluatorTable.hpp
@@ -459,7 +459,6 @@
    TR::TreeEvaluator::pdSetSignEvaluator,    // TR::pdSetSign
 
    TR::TreeEvaluator::pddivremEvaluator,    // TR::pddivrem
-   TR::TreeEvaluator::pdremSelectEvaluator, // TR::pdremSelect
 
    TR::TreeEvaluator::pdModifyPrecisionEvaluator,       // TR::pdModifyPrecision
 


### PR DESCRIPTION
Remove the obsolete pdremSelect opCode.

With pdremSelect and pddivSelect removed. The isPackedArithmeticSelect
IL property is useless. Remove this property from the code base, too.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>