### PR TITLE
Use the Runtime.Version API to get Java version

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
@@ -32,5 +32,3 @@ org.openj9.test.attachAPI.TestAttachAPI:test_agntld02																	238 generi
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld03																	238 generic-all
 org.openj9.test.attachAPI.TestSunAttachClasses:testAgentLoading															238 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
-org.openj9.test.vmArguments.VmArgumentTests:testExecutableJarArguments													1659 generic-all
-org.openj9.test.vmArguments.VmArgumentTests:testJarArguments															1659 generic-all

--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -255,7 +255,7 @@
 		<jar jarfile="${DEST}/TestResources.jar" filesonly="true">
 			<fileset dir="${build_resource}" />
 		</jar>
-		<jar jarfile="${RESOURCES_DIR}/vmargs_${JAVA_VERSION}.jar" filesonly="true" manifest="./META-INF/MANIFEST.MF">
+		<jar jarfile="${RESOURCES_DIR}/vmargs.jar" filesonly="true" manifest="./META-INF/MANIFEST.MF">
 			<fileset dir="${build}" includes="org/openj9/test/vmArguments/*.class"/>
 		</jar>
 		<copy todir="${DEST}">

--- a/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openj9.test.util.StringPrintStream;
+import org.openj9.test.util.VersionCheck;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
@@ -101,7 +102,6 @@ public class VmArgumentTests {
 	private static final String JAVA_COMPILER_VALUE=System.getProperty("java.compiler");
 	private static final String SYSPROP_DJAVA_COMPILER_EQUALS = "-Djava.compiler="+JAVA_COMPILER_VALUE;
 
-	private static final String JAVA_VERSION;
 	private static final boolean isJava8;
 
 	private static final String IBM_NOSIGHANDLER = "IBM_NOSIGHANDLER";
@@ -145,9 +145,9 @@ public class VmArgumentTests {
 						"-Dsun.java.command",
 						"-Dsun.java.launcher"
 		};	
-		JAVA_VERSION=System.getProperty("java.version");
-		isJava8 = JAVA_VERSION.startsWith("1.8.0");
-		vmargsJarFilename = isJava8? "vmargs_SE80.jar": "vmargs_SE90.jar";
+		int javaMajorVersion = VersionCheck.major();
+		isJava8 = (8 == javaMajorVersion);
+		vmargsJarFilename = "vmargs.jar";
 	}
 
 	/* 


### PR DESCRIPTION
Update the VmArgumentTests to create the test jar filename using the Version
API where possible.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>