### PR TITLE
Refactor Valhalla nestmates tests

### DIFF
--- a/test/docs/DependentLibs.md
+++ b/test/docs/DependentLibs.md
@@ -34,9 +34,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 These libs will be downloaded automatically as part of `make compile` 
 process.
 
-Valhalla tests currently make use of the nestmates capabilities which 
-are available starting in asm version 7. In order to run the Valhalla 
-nestmates on a local machine, you must manually get the asm-7.0.jar and
-put it in TestConfig/lib/. Avoid using asm 7 in other tests as this is 
-a temporary solution.
 

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -57,7 +57,7 @@
 			<classpath>
 				<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar"/>
 				<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar"/>
-				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar"/>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar"/>
 			</classpath>
 		</javac>
 	</target>

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -25,7 +25,7 @@
 	<test>
 		<testCaseName>NestAttributeTest</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(LIB_DIR)$(D)asm-7.0.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+	-cp $(Q)$(LIB_DIR)$(D)asm-all.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames NestAttributeTest \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -30,7 +30,6 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/Valhalla/src/org/openj9/test/valhalla/ClassGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/valhalla/ClassGenerator.java
@@ -24,137 +24,72 @@ package org.openj9.test.valhalla;
 import org.objectweb.asm.*;
 
 public class ClassGenerator implements Opcodes {
+	
+	public static byte[] generateClass(String name, Attribute[] attributes) {
+		ClassWriter classWriter = new ClassWriter(0);
+		classWriter.visit(55, ACC_PUBLIC | ACC_SUPER, name, null, "java/lang/Object", null);
+		
+		/* Generate base constructor which just calls super.<init>() */
+		MethodVisitor methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+		methodVisitor.visitCode();
+		methodVisitor.visitVarInsn(ALOAD, 0);
+		methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+		methodVisitor.visitInsn(RETURN);
+		methodVisitor.visitMaxs(1, 1);
+		methodVisitor.visitEnd();
+
+		/* Generate passed in attributes if there are any */
+		if (null != attributes) {
+			for (Attribute attr : attributes) {
+				classWriter.visitAttribute(attr);
+			}
+		}
+
+		classWriter.visitEnd();
+		return classWriter.toByteArray();
+	}
 
 	public static byte[] MultipleNestMembersAttributesdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestMembersAttributes", null, "java/lang/Object", null);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		/* Classwriter will automatically correct the existence of two nest members
-		 * attributes, so they are generated separately  */
-		{
-			String[] nestmems = {};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		{
-			String[] nestmems = {};
-			NestMembersAttribute attr = new NestMembersAttribute(nestmems);
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
+		String[] nestMembersList = {};
+		NestMembersAttribute attr1 = new NestMembersAttribute(nestMembersList);
+		NestMembersAttribute attr2 = new NestMembersAttribute(nestMembersList);
+		return generateClass("MultipleNestMembersAttributes", new Attribute[]{ attr1, attr2});
 	}
 
 	public static byte[] MultipleNestHostAttributesdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		
-		cw.visit(52, ACC_PUBLIC + ACC_SUPER, "MultipleNestHostAttributes", null, "java/lang/Object", null);
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		{
-			mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "main", "([Ljava/lang/String;)V", null, new String[] { "java/lang/Exception" });
-			mv.visitCode();
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(0, 1);
-			mv.visitEnd();
-		}
-		/* Classwriter will automatically correct the existence of two nest host
-		 * attributes, so they are generated separately  */
-		{
-			NestHostAttribute attr = new NestHostAttribute("clazzname");
-			cw.visitAttribute(attr);
-		}
-		{
-			NestHostAttribute attr = new NestHostAttribute("clazzname");
-			cw.visitAttribute(attr);
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
+		NestHostAttribute attr1 = new NestHostAttribute("clazzname");
+		NestHostAttribute attr2 = new NestHostAttribute("clazzname");
+		return generateClass("MultipleNestHostAttributes", new Attribute[]{ attr1, attr2 });
 	}
 
 	public static byte[] MultipleNestAttributesdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "MultipleNestAttributes", null, "java/lang/Object", null);
-		cw.visitNestMember("DoesNotExist");
-		cw.visitNestHost("DoesNotExist");
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
+		String[] nestMembersList = { "DoesNotExist" };
+		NestMembersAttribute nestMembersAttribute = new NestMembersAttribute(nestMembersList);
+		NestHostAttribute nestHostAttribute = new NestHostAttribute("DoesNotExist");
+		return generateClass("MultipleNestAttributes", new Attribute[]{ nestMembersAttribute, nestHostAttribute });
 	}
 
 	public static byte[] ClassIsOwnNestHostdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "ClassIsOwnNestHost", null, "java/lang/Object", null);
-		cw.visitNestHost("ClassIsOwnNestHost");
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
+		NestHostAttribute nestHostAttribute = new NestHostAttribute("DoesNotExist");
+		return generateClass("ClassIsOwnNestHost", new Attribute[]{ nestHostAttribute });
 	}
 
 	public static byte[] NestMemberIsItselfdump () throws Exception {
-		ClassWriter cw = new ClassWriter(0);
-		MethodVisitor mv;
-		
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "NestMemberIsItself", null, "java/lang/Object", null);
-		cw.visitNestMember("NestMemberIsItself");
-		{
-			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-			mv.visitCode();
-			mv.visitVarInsn(ALOAD, 0);
-			mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-			mv.visitInsn(RETURN);
-			mv.visitMaxs(1, 1);
-			mv.visitEnd();
-		}
-		cw.visitEnd();
-		return cw.toByteArray();
+		String[] nestMembersList = { "NestMemberIsItself" };
+		NestMembersAttribute nestMembersAttribute = new NestMembersAttribute(nestMembersList);
+		return generateClass("NestMemberIsItself", new Attribute[]{ nestMembersAttribute });
 	}	
 
 	public static byte[] fieldAccessDump () throws Exception {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 		
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visit(55, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
 		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
-		cw.visitNestMember("FieldAccess$Inner");
+		String[] nestMembersList = { "FieldAccess$Inner" };
+		NestMembersAttribute nestMembersAttribute = new NestMembersAttribute(nestMembersList);
+		cw.visitAttribute(nestMembersAttribute);
+
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -181,8 +116,10 @@ public class ClassGenerator implements Opcodes {
 		FieldVisitor fv;
 		MethodVisitor mv;
 		
-		cw.visit(V1_8, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
-		cw.visitNestHost("FieldAccess");
+		cw.visit(55, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
+		NestHostAttribute nestHostAttribute = new NestHostAttribute("FieldAccess");
+		cw.visitAttribute(nestHostAttribute);
+		
 		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
@@ -214,8 +151,11 @@ public class ClassGenerator implements Opcodes {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 		
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "MethodAccess", null, "java/lang/Object", null);
-		cw.visitNestMember("MethodAccess$Inner");
+		cw.visit(55, ACC_PUBLIC | ACC_SUPER, "MethodAccess", null, "java/lang/Object", null);
+		String[] nestMembersList = { "MethodAccess$Inner" };
+		NestMembersAttribute nestMembersAttribute = new NestMembersAttribute(nestMembersList);
+		cw.visitAttribute(nestMembersAttribute);
+		
 		cw.visitInnerClass("MethodAccess$Inner", "MethodAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
@@ -242,8 +182,9 @@ public class ClassGenerator implements Opcodes {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 		
-		cw.visit(V1_8, ACC_SUPER, "MethodAccess$Inner", null, "java/lang/Object", null);
-		cw.visitNestHost("MethodAccess");
+		cw.visit(55, ACC_SUPER, "MethodAccess$Inner", null, "java/lang/Object", null);
+		NestHostAttribute nestHostAttribute = new NestHostAttribute("MethodAccess");
+		cw.visitAttribute(nestHostAttribute);
 		cw.visitInnerClass("MethodAccess$Inner", "MethodAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			mv = cw.visitMethod(ACC_PRIVATE, "<init>", "()V", null, null);
@@ -270,9 +211,12 @@ public class ClassGenerator implements Opcodes {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 		
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visit(55, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
 		cw.visitInnerClass("pkg/FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
-		cw.visitNestMember("pkg/FieldAccess$Inner");
+		String[] nestMembersList = { "pkg/FieldAccess$Inner" };
+		NestMembersAttribute nestMembersAttribute = new NestMembersAttribute(nestMembersList);
+		cw.visitAttribute(nestMembersAttribute);
+		
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -299,8 +243,9 @@ public class ClassGenerator implements Opcodes {
 		FieldVisitor fv;
 		MethodVisitor mv;
 
-		cw.visit(V1_8, ACC_SUPER, "pkg/FieldAccess$Inner", null, "java/lang/Object", null);
-		cw.visitNestHost("FieldAccess");
+		cw.visit(55, ACC_SUPER, "pkg/FieldAccess$Inner", null, "java/lang/Object", null);
+		NestHostAttribute nestHostAttribute = new NestHostAttribute("FieldAccess");
+		cw.visitAttribute(nestHostAttribute);
 		cw.visitInnerClass("pkg/FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
@@ -332,7 +277,7 @@ public class ClassGenerator implements Opcodes {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visit(55, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
 		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
@@ -360,8 +305,10 @@ public class ClassGenerator implements Opcodes {
 		FieldVisitor fv;
 		MethodVisitor mv;
 
-		cw.visit(V1_8, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
-		cw.visitNestHost("FieldAccess");
+		cw.visit(55, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
+		NestHostAttribute nestHostAttribute = new NestHostAttribute("FieldAccess");
+		cw.visitAttribute(nestHostAttribute);
+		
 		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);
@@ -393,9 +340,12 @@ public class ClassGenerator implements Opcodes {
 		ClassWriter cw = new ClassWriter(0);
 		MethodVisitor mv;
 
-		cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
+		cw.visit(55, ACC_PUBLIC | ACC_SUPER, "FieldAccess", null, "java/lang/Object", null);
 		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
-		cw.visitNestMember("FieldAccess$Inner");
+		String[] nestMembersList = { "FieldAccess$Inner" };
+		NestMembersAttribute nestMembersAttribute = new NestMembersAttribute(nestMembersList);
+		cw.visitAttribute(nestMembersAttribute);
+		
 		{
 			mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
 			mv.visitCode();
@@ -422,7 +372,7 @@ public class ClassGenerator implements Opcodes {
 		FieldVisitor fv;
 		MethodVisitor mv;
 
-		cw.visit(V1_8, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
+		cw.visit(55, ACC_SUPER, "FieldAccess$Inner", null, "java/lang/Object", null);
 		cw.visitInnerClass("FieldAccess$Inner", "FieldAccess", "Inner", ACC_PRIVATE | ACC_STATIC);
 		{
 			fv = cw.visitField(ACC_PRIVATE | ACC_STATIC, "f", "I", null, null);


### PR DESCRIPTION
- Revert from asm6 to asm7
- Refactor class generator to reduce code duplication

Precursor to https://github.com/eclipse/openj9/pull/1703 - external PR build does not allow use of asm7.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>