### PR TITLE
Enable CMake builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ addons:
 before_install:
   - jdk_switcher use oraclejdk8
 before_script:
-  # - ccache -s -z
+  - ccache -s -z
   # Exit immediately if any unexpected error occurs.
   - set -e
   - if [ ! `wget https://ci.eclipse.org/openj9/userContent/freemarker-2.3.8.jar -O freemarker.jar` ]; then
@@ -83,9 +83,9 @@ script:
   # builds have 2 cores and 4 gigs of memory.  Attempt to double provision the number of cores for the make...
   # Limit number of jobs to work around g++ internal compiler error.
   - export UMA_WINDOWS_PARRALLEL_HACK=-j4
-  - bash configure --with-freemarker-jar=$TRAVIS_BUILD_DIR/freemarker.jar --with-jobs=4 --with-num-cores=4 --with-cmake --disable-ddr
+  - bash configure --with-freemarker-jar=$TRAVIS_BUILD_DIR/freemarker.jar --with-jobs=4 --with-num-cores=4 --enable-ccache --with-cmake --disable-ddr
   - make images EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"
   # Minimal sniff test - ensure java -version works.
   - ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -version
 after_script:
-  # - ccache -s
+  - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,6 @@ addons:
       - zip
 before_install:
   - jdk_switcher use oraclejdk8
-env:
-    - env BUILD_CMAKE=true EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"
-    - env BUILD_CMAKE=false
 before_script:
   # - ccache -s -z
   # Exit immediately if any unexpected error occurs.
@@ -86,8 +83,8 @@ script:
   # builds have 2 cores and 4 gigs of memory.  Attempt to double provision the number of cores for the make...
   # Limit number of jobs to work around g++ internal compiler error.
   - export UMA_WINDOWS_PARRALLEL_HACK=-j4
-  - bash configure --with-freemarker-jar=$TRAVIS_BUILD_DIR/freemarker.jar --with-jobs=4 --with-num-cores=4 $( [[ $BUILD_CMAKE == "true" ]] && echo "--with-cmake --disable-ddr")
-  - make images
+  - bash configure --with-freemarker-jar=$TRAVIS_BUILD_DIR/freemarker.jar --with-jobs=4 --with-num-cores=4 --with-cmake --disable-ddr
+  - make images EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"
   # Minimal sniff test - ensure java -version works.
   - ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -version
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ addons:
 before_install:
   - jdk_switcher use oraclejdk8
 env:
-  global:
+    - env BUILD_CMAKE=true EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"
+    - env BUILD_CMAKE=false
 before_script:
   # - ccache -s -z
   # Exit immediately if any unexpected error occurs.
@@ -85,7 +86,7 @@ script:
   # builds have 2 cores and 4 gigs of memory.  Attempt to double provision the number of cores for the make...
   # Limit number of jobs to work around g++ internal compiler error.
   - export UMA_WINDOWS_PARRALLEL_HACK=-j4
-  - bash configure --with-freemarker-jar=$TRAVIS_BUILD_DIR/freemarker.jar --with-jobs=4 --with-num-cores=4
+  - bash configure --with-freemarker-jar=$TRAVIS_BUILD_DIR/freemarker.jar --with-jobs=4 --with-num-cores=4 $( [[ $BUILD_CMAKE == "true" ]] && echo "--with-cmake --disable-ddr")
   - make images
   # Minimal sniff test - ensure java -version works.
   - ./build/linux-x86_64-normal-server-release/images/jdk/bin/java -version

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -29,6 +29,7 @@ cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 ###
 
 include(cmake/version.cmake)
+
 project(j9vm VERSION ${J9VM_VERSION} LANGUAGES CXX C)
 
 set(J9VM_OMR_DIR "${CMAKE_CURRENT_SOURCE_DIR}/omr" CACHE PATH "Path to the OMR directory")
@@ -68,6 +69,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 set(OMR_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING "")
 set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING "" FORCE)
+
+# Generic configuration for omr
+include(cmake/omr_config.cmake)
 
 
 #clean up the variables we used

--- a/runtime/cmake/omr_config.cmake
+++ b/runtime/cmake/omr_config.cmake
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+################################################################################
+
+# Various config options we apply to OMR
+
+set(OMR_EXAMPLE OFF CACHE INTERNAL "")
+set(OMR_FVTEST OFF CACHE INTERNAL "")
+set(OMR_GC ON CACHE INTERNAL "")

--- a/runtime/gc/CMakeLists.txt
+++ b/runtime/gc/CMakeLists.txt
@@ -76,6 +76,11 @@ target_link_libraries(j9gc
 		rt
 )
 
+target_include_directories(j9gc
+	PUBLIC
+		$<TARGET_PROPERTY:omrgc,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
 install(
 	TARGETS j9gc
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}

--- a/runtime/jsigWrapper/CMakeLists.txt
+++ b/runtime/jsigWrapper/CMakeLists.txt
@@ -24,13 +24,16 @@
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
 add_library(jsig SHARED
-    jsig.c
+	jsig.c
 )
 
 target_link_libraries(jsig
-    PRIVATE
-        omrutil
-        dl
+	PRIVATE
+		j9vm_interface
+
+		omrsig
+		omrutil
+		dl
 )
 
 target_include_directories(jsig PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/runtime/port/CMakeLists.txt
+++ b/runtime/port/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(j9prt
 		j9vm_interface
 
 	PRIVATE
+		omrsig
 		j9utilcore
 		j9pool
 		j9hashtable

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(j9vm SHARED
 	swalk.c
 	threadhelp.cpp
 	threadpark.c
+	throwexception.c
 	visible.c
 	VMAccess.cpp
 	vmbootlib.c


### PR DESCRIPTION
Note: currently depends on #52 

Also, currently the omr repo is hacked in, until eclipse/omr#2477 and eclipse/omr#2478 land