### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.cpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +110,6 @@ MM_EnvironmentDelegate::attachVMThread(OMR_VM *omrVM, const char  *threadName, u
 	if (JNI_OK != javaVM->internalVMFunctions->attachSystemDaemonThread(javaVM, &vmThread, threadName)) {
 		return NULL;
 	}
-	javaVM->internalVMFunctions->internalReleaseVMAccessInJNI(vmThread);
 
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
 	if ((MM_EnvironmentBase::ATTACH_THREAD != reason) &&  (NULL != javaVM->javaOffloadSwitchOnWithReasonFunc)) {

--- a/runtime/jcl/common/compiler.c
+++ b/runtime/jcl/common/compiler.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,11 +29,14 @@ void JNICALL Java_java_lang_Compiler_enable(JNIEnv *env, jclass clazz)
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	J9VMThread *currentThread = (J9VMThread *) env;
 	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9JITConfig * jitConfig = vm->jitConfig;
 
 	if ((jitConfig != NULL) && (jitConfig->enableJit != NULL)) {
-		vmFuncs->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+		vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		jitConfig->enableJit(jitConfig);
 	}
 #endif
@@ -45,11 +48,14 @@ void JNICALL Java_java_lang_Compiler_disable(JNIEnv *env, jclass clazz)
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	J9VMThread *currentThread = (J9VMThread *) env;
 	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9JITConfig * jitConfig = vm->jitConfig;
 
 	if ((jitConfig != NULL) && (jitConfig->disableJit != NULL)) {
-		vmFuncs->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+		vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		jitConfig->disableJit(jitConfig);
 	}
 #endif
@@ -61,7 +67,6 @@ jobject JNICALL Java_java_lang_Compiler_commandImpl(JNIEnv *env, jclass clazz, j
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	J9VMThread *currentThread = (J9VMThread *) env;
 	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9JITConfig * jitConfig = vm->jitConfig;
 
 	if ((cmd != NULL) && (jitConfig != NULL) && (jitConfig->command != NULL)) {
@@ -79,7 +84,11 @@ jobject JNICALL Java_java_lang_Compiler_commandImpl(JNIEnv *env, jclass clazz, j
 
 						if (commandString != NULL) {
 							I_32 result = 0;
-							vmFuncs->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+							J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+							vmFuncs->internalEnterVMFromJNI(currentThread);
+							vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 							result = jitConfig->command(currentThread, commandString);
 							(*env)->ReleaseStringUTFChars(env, cmd, commandString);
 							return (*env)->NewObject(env, intClass, mid, result);
@@ -100,11 +109,14 @@ jboolean JNICALL Java_java_lang_Compiler_compileClassImpl(JNIEnv *env, jclass cl
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	J9VMThread *currentThread = (J9VMThread *) env;
 	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9JITConfig * jitConfig = vm->jitConfig;
 
 	if ((compileClass != NULL) && (jitConfig != NULL) && (jitConfig->compileClass != NULL)) {
-		vmFuncs->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+		vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		rc = (jboolean)jitConfig->compileClass(currentThread, compileClass);
 	}
 #endif
@@ -117,7 +129,6 @@ jboolean JNICALL Java_java_lang_Compiler_compileClassesImpl(JNIEnv *env, jclass 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	J9VMThread *currentThread = (J9VMThread *) env;
 	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9JITConfig * jitConfig = vm->jitConfig;
 
 	if ((nameRoot != NULL) && (jitConfig != NULL) && (jitConfig->compileClasses != NULL)) {
@@ -127,7 +138,11 @@ jboolean JNICALL Java_java_lang_Compiler_compileClassesImpl(JNIEnv *env, jclass 
 		if (pattern != NULL) {
 			jboolean rc;
 
-			vmFuncs->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+			J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+			vmFuncs->internalEnterVMFromJNI(currentThread);
+			vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 			rc = (jboolean) jitConfig->compileClasses(currentThread, pattern);
 			(*env)->ReleaseStringUTFChars(env, nameRoot, pattern);
 			return rc;

--- a/runtime/jcl/common/java_lang_ref_Finalizer.c
+++ b/runtime/jcl/common/java_lang_ref_Finalizer.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,11 @@ Java_java_lang_ref_Finalizer_runAllFinalizersImpl(JNIEnv *env, jclass recv)
 	J9VMThread *currentThread = (J9VMThread*)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
-	vm->internalVMFunctions->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	mmFuncs->j9gc_runFinalizersOnExit(currentThread, TRUE);
 	mmFuncs->j9gc_finalizer_completeFinalizersOnExit(currentThread);
 }
@@ -46,6 +50,10 @@ Java_java_lang_ref_Finalizer_runFinalizationImpl(JNIEnv *env, jclass recv)
 	J9VMThread *currentThread = (J9VMThread*)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
-	vm->internalVMFunctions->internalReleaseVMAccessInJNI(currentThread);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->internalReleaseVMAccess(currentThread);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	mmFuncs->runFinalization(currentThread);
 }

--- a/runtime/jcl/common/thread.cpp
+++ b/runtime/jcl/common/thread.cpp
@@ -212,7 +212,7 @@ Java_java_lang_Thread_suspendImpl(JNIEnv *env, jobject rcv)
 				 */
 				vmFuncs->setHaltFlag(targetThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 			} else {
-				vmFuncs->internalReleaseVMAccessInJNI(currentThread);
+				vmFuncs->internalExitVMToJNI(currentThread);
 				omrthread_monitor_enter(targetThread->publicFlagsMutex);
 				VM_VMAccess::setHaltFlagForVMAccessRelease(targetThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 				if (VM_VMAccess::mustWaitForVMAccessRelease(targetThread)) {

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -880,11 +880,8 @@ jnichk_getObjectClazz(JNIEnv* env, jobject objRef)
 {
 	J9VMThread* vmThread = (J9VMThread*)env;
 	J9Class* clazz = NULL;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
-	
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+
+	enterVM(vmThread);
 
 	if (objRef != NULL) {
 		j9object_t obj = *(j9object_t*)objRef;
@@ -894,9 +891,7 @@ jnichk_getObjectClazz(JNIEnv* env, jobject objRef)
 		}
 	}
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return clazz;
 }
@@ -906,11 +901,8 @@ static BOOLEAN jnichk_isObjectArray(JNIEnv* env, jobject obj) {
 	J9JavaVM* vm = vmThread->javaVM;
 	J9Class* clazz = NULL;
 	BOOLEAN result = FALSE;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 	clazz = J9OBJECT_CLAZZ(vmThread, *(j9object_t*)obj);
 
@@ -919,9 +911,7 @@ static BOOLEAN jnichk_isObjectArray(JNIEnv* env, jobject obj) {
 
 	}
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return result;
 }
@@ -931,18 +921,13 @@ static BOOLEAN jnichk_isIndexable(JNIEnv* env, jobject obj) {
 	J9JavaVM* vm = vmThread->javaVM;
 	J9Class* clazz = NULL;
 	BOOLEAN result;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 	clazz = J9OBJECT_CLAZZ(vmThread, *(j9object_t*)obj);
 	result = J9CLASS_IS_ARRAY(clazz);
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return result;
 }
@@ -955,17 +940,12 @@ jniVerboseGetID(const char *function, JNIEnv *env, jclass classRef, const char *
 	if ( vmThread->javaVM->checkJNIData.options & JNICHK_VERBOSE) {
 		J9UTF8 *className;
 		PORT_ACCESS_FROM_VMC(vmThread);
-		BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
-	
-		if (enteredWithoutVMAccess) {
-			acquireVMAccess(vmThread);
-		}
+
+		enterVM(vmThread);
 
 		className = J9ROMCLASS_CLASSNAME(J9VM_J9CLASS_FROM_JCLASS(vmThread, classRef)->romClass);
 
-		if (enteredWithoutVMAccess) {
-			releaseVMAccess(vmThread);
-		}
+		exitVM(vmThread);
 
 		Trc_JNI_GetID(env, function, J9UTF8_DATA(className), name, sig);
 		j9tty_printf(PORTLIB, "<JNI %s: %.*s.%s %s>\n",
@@ -1091,7 +1071,8 @@ static UDATA jniIsLocalRef(JNIEnv * currentEnv, JNIEnv* env, jobject reference)
 			return ((UDATA) reference & (sizeof(UDATA) - 1)) == 0 && *(j9object_t*) reference != NULL;
 		} else {
 			J9StackWalkState walkState;
-			UDATA releaseAccess = FALSE;
+
+			enterVM(vmThread);
 
 			walkState.userData1 = reference;
 			walkState.userData2 = vmThread->jniLocalReferences;
@@ -1102,14 +1083,9 @@ static UDATA jniIsLocalRef(JNIEnv * currentEnv, JNIEnv* env, jobject reference)
 			walkState.objectSlotWalkFunction = jniIsLocalRefOSlotWalkFunction;
 			walkState.walkThread = vmThread;
 
-			if ((vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) == 0) {
-				vmThread->javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
-				releaseAccess = TRUE;
-			}
 			vmThread->javaVM->walkStackFrames(vmThread, &walkState);
-			if (releaseAccess) {
-				vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
-			}
+
+			exitVM(vmThread);
 
 			return walkState.userData3 == reference;
 		}
@@ -1129,11 +1105,7 @@ static UDATA jniIsLocalRef(JNIEnv * currentEnv, JNIEnv* env, jobject reference)
 		/* is it in the local references? */
 		frame = (J9JNIReferenceFrame*)vmThread->jniLocalReferences;
 		if (frame != NULL) {
-			BOOLEAN hasNoVMAccess = !HAS_VM_ACCESS(currentThread);
-
-			if (hasNoVMAccess) {
-				acquireVMAccess(currentThread);
-			}
+			enterVM(vmThread);
 			while (frame != NULL) {
 				/* walk the pool */
 				if (pool_includesElement(frame->references, reference)) {
@@ -1142,9 +1114,7 @@ static UDATA jniIsLocalRef(JNIEnv * currentEnv, JNIEnv* env, jobject reference)
 				}
 				frame = frame->previous;
 			}
-			if (hasNoVMAccess) {
-				releaseVMAccess(currentThread);
-			}
+			exitVM(vmThread);
 		}
 
 		return rc;
@@ -1161,11 +1131,8 @@ jniIsGlobalRef(JNIEnv* env, jobject reference)
 	UDATA rc;
 	JNICHK_GREF_HASHENTRY entry;
 	JNICHK_GREF_HASHENTRY* actualResult;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
-	
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+
+	enterVM(vmThread);
 
 #ifdef J9VM_THR_PREEMPTIVE
 	omrthread_monitor_enter(vm->jniFrameMutex);
@@ -1193,9 +1160,7 @@ jniIsGlobalRef(JNIEnv* env, jobject reference)
 	omrthread_monitor_exit(vm->jniFrameMutex);
 #endif
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return rc;
 }
@@ -1230,12 +1195,9 @@ static UDATA jniIsLocalRefFrameWalkFunction(J9VMThread* vmThread, J9StackWalkSta
 		case J9SF_FRAME_TYPE_JNI_NATIVE_METHOD:
 			if (walkState->frameFlags & J9_SSF_CALL_OUT_FRAME_ALLOC) {
 				J9JNIReferenceFrame* frame = walkState->userData2;
-				BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 				UDATA frameType = 0;
 
-				if (enteredWithoutVMAccess) {
-					acquireVMAccess(vmThread);
-				}
+				enterVM(vmThread);
 
 				/* Walk the pools - each native frame with J9_SSF_CALL_OUT_FRAME_ALLOC set pushes
 				 * and internal reference frame first, so stop once that one has been inspected.
@@ -1252,9 +1214,7 @@ static UDATA jniIsLocalRefFrameWalkFunction(J9VMThread* vmThread, J9StackWalkSta
 				} while (frameType != JNIFRAME_TYPE_INTERNAL);
 				walkState->userData2 = frame;
 
-				if (enteredWithoutVMAccess) {
-					releaseVMAccess(vmThread);
-				}
+				exitVM(vmThread);
 			}
 	}
 
@@ -1297,12 +1257,9 @@ jniCheckRef(JNIEnv* env,  const char* function, IDATA argNum, jobject reference)
 static UDATA jniIsWeakGlobalRef(JNIEnv* env, jobject reference) {
 	J9VMThread* vmThread = (J9VMThread*)env;
 	J9JavaVM* vm = vmThread->javaVM;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 	UDATA rc;
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 #ifdef J9VM_THR_PREEMPTIVE
 	omrthread_monitor_enter(vm->jniFrameMutex);
@@ -1313,9 +1270,7 @@ static UDATA jniIsWeakGlobalRef(JNIEnv* env, jobject reference) {
 	omrthread_monitor_exit(vm->jniFrameMutex);
 #endif
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return rc;
 }
@@ -1326,7 +1281,6 @@ getRefType(JNIEnv* env, jobject reference)
 {
 	JNIEnv* thread;
 	J9VMThread *vmThread = (J9VMThread *) env;
-	UDATA releaseAccess = FALSE;
 	PORT_ACCESS_FROM_ENV(env);
 
 	if (reference == NULL) {
@@ -1342,25 +1296,20 @@ getRefType(JNIEnv* env, jobject reference)
 		return j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_JNICHK_WEAK_GLOBAL_REF, NULL);
 	}
 
-	if ((vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) == 0) {
-		vmThread->javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
-		releaseAccess = TRUE;
-	}
-	omrthread_monitor_enter( vmThread->javaVM->vmThreadListMutex );
-	thread = (JNIEnv*)((J9VMThread*)env)->linkNext;
-	while (thread != env) {
-		if (jniIsLocalRef(env, thread, reference)) {
-			omrthread_monitor_exit( vmThread->javaVM->vmThreadListMutex );
-			if (releaseAccess) {
-				vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	{
+		enterVM(vmThread);
+		omrthread_monitor_enter( vmThread->javaVM->vmThreadListMutex );
+		thread = (JNIEnv*)((J9VMThread*)env)->linkNext;
+		while (thread != env) {
+			if (jniIsLocalRef(env, thread, reference)) {
+				omrthread_monitor_exit( vmThread->javaVM->vmThreadListMutex );
+				exitVM(vmThread);
+				return j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_JNICHK_BAD_LOCAL_REF, NULL);
 			}
-			return j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_JNICHK_BAD_LOCAL_REF, NULL);
+			thread = (JNIEnv*)((J9VMThread*)thread)->linkNext;
 		}
-		thread = (JNIEnv*)((J9VMThread*)thread)->linkNext;
-	}
-	omrthread_monitor_exit( vmThread->javaVM->vmThreadListMutex );
-	if (releaseAccess) {
-		vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+		omrthread_monitor_exit( vmThread->javaVM->vmThreadListMutex );
+		exitVM(vmThread);
 	}
 
 	if (*(j9object_t*)reference == NULL) {
@@ -1407,7 +1356,6 @@ jniTraceObject(JNIEnv* env, jobject aJobject)
 	J9VMThread *vmThread = (J9VMThread*)env;
 	J9JavaVM * vm = vmThread->javaVM;
 	J9Class* jlClass, *clazz;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 	PORT_ACCESS_FROM_VMC(vmThread);
 
 	jlClass = J9VMJAVALANGCLASS_OR_NULL(vm);
@@ -1419,15 +1367,11 @@ jniTraceObject(JNIEnv* env, jobject aJobject)
 	} else if (clazz == jlClass) {
 		J9UTF8* utf8;
 
-		if (enteredWithoutVMAccess) {
-			acquireVMAccess(vmThread);
-		}
+		enterVM(vmThread);
 
 		utf8 = J9ROMCLASS_CLASSNAME(J9VM_J9CLASS_FROM_JCLASS(vmThread, aJobject)->romClass);
 
-		if (enteredWithoutVMAccess) {
-			releaseVMAccess(vmThread);
-		}
+		exitVM(vmThread);
 
 		j9tty_printf(PORTLIB, "%.*s", J9UTF8_LENGTH(utf8), J9UTF8_DATA(utf8));
 	} else {
@@ -1528,7 +1472,6 @@ jniCheckStringUTFRange(JNIEnv* env, const char* function, jstring string, jint s
 static void jniCheckValidClass(JNIEnv* env, const char* function, UDATA argNum, jobject obj) {
 	J9VMThread *vmThread = (J9VMThread*)env;
 	J9JavaVM *vm = vmThread->javaVM;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 	UDATA classDepthAndFlags;
 	UDATA options = vm->checkJNIData.options;
 	J9ROMClass * romClass;
@@ -1541,15 +1484,11 @@ static void jniCheckValidClass(JNIEnv* env, const char* function, UDATA argNum, 
 		}
 	}
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 	clazz = J9VM_J9CLASS_FROM_JCLASS((J9VMThread *)env, obj);
 	classDepthAndFlags = J9CLASS_FLAGS(clazz);
 	romClass = clazz->romClass;
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	if (classDepthAndFlags & J9_JAVA_CLASS_HOT_SWAPPED_OUT) {
 		J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
@@ -2039,12 +1978,9 @@ jniCheckPrintJNIOnLoad(JNIEnv *env, U_32 level)
 	UDATA alloc = FALSE;
 	char *data;
 	J9VMThread *vmThread = (J9VMThread*)env;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 	PORT_ACCESS_FROM_VMC(vmThread);
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 	/* loadLibrary is a static method, and its first argument is the name of the library */
 	libName = (j9array_t *)vmThread->arg0EA;
@@ -2086,9 +2022,7 @@ jniCheckPrintJNIOnLoad(JNIEnv *env, U_32 level)
 		j9mem_free_memory(data);
 	}
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 }
 
 

--- a/runtime/jnichk/jnichk_internal.h
+++ b/runtime/jnichk/jnichk_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,31 @@ typedef struct JNICHK_GREF_HASHENTRY {
 	BOOLEAN alive;
 } JNICHK_GREF_HASHENTRY;		
 
-#define HAS_VM_ACCESS(vmThread) ((vmThread)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)
+
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+
+#define enterVM(currentThread) enterVMFromJNI(currentThread)
+
+#define exitVM(currentThread) exitVMToJNI(currentThread)
+
+#else /* J9VM_INTERP_ATOMIC_FREE_JNI */
+
+#define enterVM(currentThread) \
+	BOOLEAN hasNoVMAccess = J9_ARE_NO_BITS_SET((currentThread)->publicFlags, J9_PUBLIC_FLAGS_VM_ACCESS); \
+	do { \
+		if (hasNoVMAccess) { \
+			acquireVMAccess(currentThread); \
+		} \
+	} while(0)
+
+#define exitVM(currentThread) \
+	do { \
+		if (hasNoVMAccess) { \
+			releaseVMAccess(currentThread); \
+		} \
+	} while(0)
+
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/jnichk/jnicmem.c
+++ b/runtime/jnichk/jnicmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,17 +84,12 @@ jniRecordMemoryAcquire(JNIEnv* env, const char* functionName, jobject object, co
 	if (recordCRC) {
 		U_32 length;
 		J9IndexableObject *arrayPtr;
-		BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 
-		if (enteredWithoutVMAccess) {
-			acquireVMAccess(vmThread);
-		}
+		enterVM(vmThread);
 		arrayPtr = *(J9IndexableObject**)object;
 		length = J9INDEXABLEOBJECT_SIZE(vmThread, arrayPtr);
 		length <<= ((J9ROMArrayClass*)(J9OBJECT_CLAZZ(vmThread, arrayPtr)->romClass))->arrayShape & 0x0000FFFF;
-		if (enteredWithoutVMAccess) {
-			releaseVMAccess(vmThread);
-		}
+		exitVM(vmThread);
 		crc = j9crc32(j9crc32(0, NULL, 0), (U_8*)memory, length);
 	}
 
@@ -238,7 +233,6 @@ checkArrayCrc(JNIEnv * env, const char *acquireFunction, const char *releaseFunc
 	const void *memory, jint mode, MemRecord * poolElement)
 {
 	J9VMThread *vmThread = (J9VMThread *)env;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 	PORT_ACCESS_FROM_VMC(vmThread);
 
 	U_32 length;
@@ -247,9 +241,7 @@ checkArrayCrc(JNIEnv * env, const char *acquireFunction, const char *releaseFunc
 	J9IndexableObject *arrayPtr;
 	UDATA isContiguousArray = 0;
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 	arrayPtr = *(J9IndexableObject**)object;
 	length = J9INDEXABLEOBJECT_SIZE(vmThread, arrayPtr);
 	length <<= ((J9ROMArrayClass*)(J9OBJECT_CLAZZ(vmThread, arrayPtr)->romClass))->arrayShape & 0x0000FFFF;
@@ -264,9 +256,7 @@ checkArrayCrc(JNIEnv * env, const char *acquireFunction, const char *releaseFunc
 		arrayCrc = calculateArrayCrc(vmThread, arrayPtr);	
 	}
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 	bufCrc = isCopy ? j9crc32(j9crc32(0, NULL, 0), (U_8 *) memory, length) : arrayCrc;
 
 	if (!isCopy) {
@@ -353,18 +343,13 @@ static jobject
 jniCheckNewGlobalRef(JNIEnv * env, jobject ref)
 {
 	J9VMThread *vmThread = (J9VMThread *)env;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 	jobject globalRef;
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 	globalRef = vmThread->javaVM->internalVMFunctions->j9jni_createGlobalRef(env, *(j9object_t*)ref, JNI_FALSE);
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return globalRef;
 }
@@ -375,17 +360,12 @@ static void
 jniCheckDeleteGlobalRef(JNIEnv * env, jobject ref)
 {
 	J9VMThread *vmThread = (J9VMThread *) env;
-	BOOLEAN enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
 
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 	vmThread->javaVM->internalVMFunctions->j9jni_deleteGlobalRef(env, ref, JNI_FALSE);
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 }
 
 
@@ -394,7 +374,6 @@ static jboolean
 jniCheckIsSameObject(JNIEnv * env, jobject ref1, jobject ref2)
 {
 	J9VMThread *vmThread = (J9VMThread *) env;
-	BOOLEAN enteredWithoutVMAccess;
 	jboolean same;
 
 	if ((ref1 == NULL) || (ref2 == NULL)) {
@@ -404,16 +383,11 @@ jniCheckIsSameObject(JNIEnv * env, jobject ref1, jobject ref2)
 		return JNI_TRUE;
 	}
 
-	enteredWithoutVMAccess = !HAS_VM_ACCESS(vmThread);
-	if (enteredWithoutVMAccess) {
-		acquireVMAccess(vmThread);
-	}
+	enterVM(vmThread);
 
 	same = *(j9object_t*)ref1 == *(j9object_t*)ref2;
 
-	if (enteredWithoutVMAccess) {
-		releaseVMAccess(vmThread);
-	}
+	exitVM(vmThread);
 
 	return same;
 }

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -777,11 +777,17 @@ getThreadState(J9VMThread *currentThread, j9object_t threadObject)
 		if (vmstate & J9VMTHREAD_STATE_INTERRUPTED) {
 			state |= JVMTI_THREAD_STATE_INTERRUPTED;
 		}
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+		if (vmThread->inNative) {
+			state |= JVMTI_THREAD_STATE_IN_NATIVE;
+		}
+#else /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		if ( (vmThread->omrVMThread->vmState & J9VMSTATE_MAJOR) == J9VMSTATE_JNI ) {
 			if (!(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)) {
 				state |= JVMTI_THREAD_STATE_IN_NATIVE;
 			}
 		}
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		if (vmstate & J9VMTHREAD_STATE_BLOCKED) {
 			state |= JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER;
 		/* Object.wait() */

--- a/runtime/oti/VMAccess.hpp
+++ b/runtime/oti/VMAccess.hpp
@@ -366,20 +366,6 @@ public:
 #define inlineExitVMToJNI inlineReleaseVMAccess
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 
-	static VMINLINE void
-	inlineReleaseVMAccessInJNI(J9VMThread* const currentThread)
-	{
-#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
-		VM_AtomicSupport::writeBarrier();
-		currentThread->inNative = FALSE;
-		VM_AtomicSupport::readWriteBarrier(); // necessary?
-		if (J9_EXPECTED(J9_ARE_ANY_BITS_SET(currentThread->publicFlags, J9_PUBLIC_FLAGS_VM_ACCESS)))
-#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-		{
-			J9_VM_FUNCTION(currentThread, internalReleaseVMAccessInJNI)(currentThread);
-		}
-	}
-
 	// assumes PFM is held
 	static VMINLINE void
 	backOffFromSafePoint(J9VMThread* const vmThread)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4786,7 +4786,6 @@ typedef struct J9InternalVMFunctions {
 	void  ( *internalEnterVMFromJNI)(struct J9VMThread * currentThread) ;
 	void  ( *internalExitVMToJNI)(struct J9VMThread * currentThread) ;
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-	void  ( *internalReleaseVMAccessInJNI)(struct J9VMThread * currentThread) ;
 	struct J9HashTable* ( *hashModuleTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashPackageTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;
 	struct J9HashTable* ( *hashModuleExtraInfoTableNew)(struct J9JavaVM * vm, U_32 initialSize) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -240,7 +240,6 @@ I_32 numCodeSets (void);
 #define _J9VMACCESSCONTROL_
 extern J9_CFUNC void  internalExitVMToJNI (J9VMThread *currentThread);
 extern J9_CFUNC void  internalEnterVMFromJNI (J9VMThread *currentThread);
-extern J9_CFUNC void  internalReleaseVMAccessInJNI (J9VMThread *vmThread);
 extern J9_CFUNC void  internalReleaseVMAccess (J9VMThread *vmThread);
 extern J9_CFUNC void  internalAcquireVMAccess (J9VMThread *vmThread);
 extern J9_CFUNC IDATA  internalTryAcquireVMAccess (J9VMThread *vmThread);

--- a/runtime/oti/vmaccess.h
+++ b/runtime/oti/vmaccess.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,11 +37,9 @@
 #endif
 #define releaseVMAccess(vmThread) internalReleaseVMAccess(vmThread)
 #define acquireVMAccess(vmThread) internalAcquireVMAccess(vmThread)
-#define releaseVMAccessInJNI(vmThread) internalReleaseVMAccessInJNI(vmThread)
 #else
 #define exitVMToJNI(vmThread) (vmThread)->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread)
 #define enterVMFromJNI(vmThread) (vmThread)->javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread)
-#define releaseVMAccessInJNI(vmThread) (vmThread)->javaVM->internalVMFunctions->internalReleaseVMAccessInJNI(vmThread)
 #define releaseVMAccess(vmThread) (vmThread)->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread)
 #define acquireVMAccess(vmThread) (vmThread)->javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread)
 #endif

--- a/runtime/tests/shared/AttachedDataTest.cpp
+++ b/runtime/tests/shared/AttachedDataTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2016 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1508,7 +1508,7 @@ startReader(void *entryArg) {
 	J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	vm->internalVMFunctions->internalAcquireVMAccess(currentThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 	/* writer thread must have failed, no need to proceed */
 	if (true == adt->cancelThread) {
@@ -1547,7 +1547,7 @@ startReader(void *entryArg) {
 
 _exitCloseCache:
 	adt->closeTestCache(vm, false);
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	UnitTest::unitTest = UnitTest::NO_TEST;
 	vm->internalVMFunctions->threadCleanup(currentThread, 0);
 	INFOPRINTF("Reader thread exited\n");
@@ -1564,7 +1564,7 @@ startWriter(void *entryArg) {
 	J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	vm->internalVMFunctions->internalAcquireVMAccess(currentThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
     rc = adt->openTestCache(vm, NULL, 0, J9PORT_SHR_CACHE_TYPE_PERSISTENT, 0, 0);
     if (FAIL == rc) {
@@ -1631,7 +1631,7 @@ startWriter(void *entryArg) {
 
 _exitCloseCache:
 	adt->closeTestCache(vm, true);
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	vm->internalVMFunctions->threadCleanup(currentThread, 0);
 	INFOPRINTF("Writer thread exited\n");
 	adt->threadExited = true;
@@ -1809,7 +1809,7 @@ testAttachedData(J9JavaVM* vm)
 	REPORT_START("AttachedDataTest");
 
 	currentThread = vm->internalVMFunctions->currentVMThread(vm);
-	vm->internalVMFunctions->internalAcquireVMAccess(currentThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 	for(i = 0; i < 4; i++) {
 		U_64 extraRuntimeFlag = 0;
@@ -1965,7 +1965,7 @@ _exitCloseCache:
 	UnitTest::cacheSize = 0;
 	UnitTest::cacheMemory = NULL;
 
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	REPORT_SUMMARY("AttachedDataTest", rc);
 	return rc;
 

--- a/runtime/tests/shared/CacheFullTests.cpp
+++ b/runtime/tests/shared/CacheFullTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2016 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,7 @@ testCacheFull(J9JavaVM* vm)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	REPORT_START("testCacheFull");
 
-	vm->internalVMFunctions->internalAcquireVMAccess(currentThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 	rc |= test1(vm);
 	rc |= test2(vm);
@@ -123,7 +123,7 @@ testCacheFull(J9JavaVM* vm)
 	rc |= test8(vm);
 	rc |= test9(vm);
 
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	REPORT_SUMMARY("testCacheFull", rc);
 	return rc;

--- a/runtime/tests/shared/CompositeCacheSizesTests.cpp
+++ b/runtime/tests/shared/CompositeCacheSizesTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,7 +103,7 @@ testCompositeCacheSizes(J9JavaVM* vm)
 
 	IDATA rc = TEST_PASS;
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 	UnitTest::unitTest = UnitTest::COMPOSITE_CACHE_SIZES_TEST;
 	rc |= test1(vm);
 	rc |= test2(vm);
@@ -124,7 +124,7 @@ testCompositeCacheSizes(J9JavaVM* vm)
 	rc |= test14(vm);
 	UnitTest::unitTest = UnitTest::NO_TEST;
 
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 
 	j9tty_printf(PORTLIB, "%s: %s\n", testName, TEST_PASS==rc?"PASS":"FAIL");
 	if (rc == TEST_ERROR) {

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1026,7 +1026,7 @@ testCorruptCache(J9JavaVM* vm)
 	REPORT_START("CorruptCacheTest");
 
 	UnitTest::unitTest = UnitTest::CORRUPT_CACHE_TEST;
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 
 	for(i = 0; i < 6; i++) {
 		CorruptCacheTest corruptCacheTest;
@@ -1375,7 +1375,7 @@ testCorruptCache(J9JavaVM* vm)
 
 	UnitTest::unitTest = UnitTest::NO_TEST;
 
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 	REPORT_SUMMARY("CorruptCacheTest", rc);
 	return rc;
 }

--- a/runtime/tests/shared/ProtectNewROMClassDataTests.cpp
+++ b/runtime/tests/shared/ProtectNewROMClassDataTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,7 +113,7 @@ IDATA testProtectNewROMClassData_test1(J9JavaVM* vm) {
 	char * OSCacheMem;
 	FakeOSCache *myfakeoscache;
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 
 	if (NULL == (OSCacheMem = (char *)j9mem_allocate_memory(FakeOSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
 		ERRPRINTF("Failed to allocate memory for testProtectNewROMClassData_test1");
@@ -245,6 +245,6 @@ done:
 	if (NULL != OSCacheMem) {
 		j9mem_free_memory(OSCacheMem);
 	}
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 	return rc;
 }

--- a/runtime/tests/shared/ProtectSharedCacheDataTests.cpp
+++ b/runtime/tests/shared/ProtectSharedCacheDataTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,7 +137,7 @@ testProtectSharedCacheData_test1(J9JavaVM* vm)
 	INFOPRINTF("Case mprotect=nopartialpages\n");
 #endif
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 
 	if (NULL == (osCacheMem = (char *)j9mem_allocate_memory(ProtectSharedCacheDataOSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
 		ERRPRINTF("Failed to allocate memory for testProtectNewROMClassData_test1");
@@ -340,7 +340,7 @@ done:
 	if (NULL != osCacheMem) {
 		j9mem_free_memory(osCacheMem);
 	}
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 	return rc;
 }
 
@@ -384,7 +384,7 @@ testProtectSharedCacheData_test2(J9JavaVM* vm)
 	INFOPRINTF("Case mprotect=default or mprotect=partialpages\n");
 #endif
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 
 	if (NULL == (osCacheMem = (char *)j9mem_allocate_memory(ProtectSharedCacheDataOSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
 		ERRPRINTF("Failed to allocate memory for testProtectNewROMClassData_test2");
@@ -628,7 +628,7 @@ done:
 	if (NULL != osCacheMem) {
 		j9mem_free_memory(osCacheMem);
 	}
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 	return rc;
 }
 
@@ -665,7 +665,7 @@ testProtectSharedCacheData_test3(J9JavaVM* vm)
 
 	INFOPRINTF("Case mprotect=onfind\n");
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 
 	if (NULL == (osCacheMem = (char *)j9mem_allocate_memory(ProtectSharedCacheDataOSCache::getRequiredConstrBytes(), J9MEM_CATEGORY_CLASSES))) {
 		ERRPRINTF("Failed to allocate memory for testProtectNewROMClassData_test1");
@@ -739,6 +739,6 @@ done:
 	if (NULL != osCacheMem) {
 		j9mem_free_memory(osCacheMem);
 	}
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 	return rc;
 }

--- a/runtime/tests/shared/SCStoreTransactionTests.cpp
+++ b/runtime/tests/shared/SCStoreTransactionTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,7 +102,7 @@ testSCStoreTransaction(J9JavaVM* vm)
 		return TEST_ERROR;
 	}
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 	rc |= test1(vm);
 	rc |= test2(vm);
 	rc |= test3(vm);
@@ -139,7 +139,7 @@ testSCStoreTransaction(J9JavaVM* vm)
 		j9tty_printf(PORTLIB, "%s: Skipping some tests b/c the cache has class debug area size of 0 bytes.\n", testName);
 	}
 	
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 
 	j9tty_printf(PORTLIB, "%s: %s\n", testName, TEST_PASS==rc?"PASS":"FAIL");
 	if (rc == TEST_ERROR) {

--- a/runtime/tests/shared/SCStoreWithBCITests.cpp
+++ b/runtime/tests/shared/SCStoreWithBCITests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,14 +97,14 @@ testSCStoreWithBCITests(J9JavaVM* vm)
 		return TEST_ERROR;
 	}
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 	
 	rc |= test1(vm);
 	for (i = 0; i < sizeof(tests)/sizeof(TestInfo); i += 1) {
 		rc |= testRunner(vm, tests[i]);
 	}
 	
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 
 	j9tty_printf(PORTLIB, "%s: %s\n", testName, TEST_PASS==rc?"PASS":"FAIL");
 	if (rc == TEST_ERROR) {

--- a/runtime/tests/shared/SCStringTransactionTests.cpp
+++ b/runtime/tests/shared/SCStringTransactionTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,11 +75,11 @@ testSCStringTransaction(J9JavaVM* vm)
 		return TEST_ERROR;
 	}
 
-	vm->internalVMFunctions->internalAcquireVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalEnterVMFromJNI(vm->mainThread);
 	rc |= test1(vm);
 	rc |= test2(vm);
 	rc |= test3(vm);
-	vm->internalVMFunctions->internalReleaseVMAccess(vm->mainThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vm->mainThread);
 
 
 	j9tty_printf(PORTLIB, "%s: %s\n", testName, TEST_PASS==rc?"PASS":"FAIL");

--- a/runtime/tests/thread/testnatives/testnatives.c
+++ b/runtime/tests/thread/testnatives/testnatives.c
@@ -231,12 +231,12 @@ Java_j9vm_test_thread_TestNatives_getSchedulingPolicy(JNIEnv* env, jclass clazz,
 	J9VMThread *targetVMThread = NULL;
 	jint schedulingPolicy = -1;
 
-	javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
+	javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 
 	javaThreadObject = J9_JNI_UNWRAP_REFERENCE(javaThread);
 	targetVMThread = (J9VMThread *)J9VMJAVALANGTHREAD_THREADREF(vmThread, javaThreadObject);
 	
-	javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (NULL != targetVMThread) {
 		schedulingPolicy = getSchedulingPolicy(targetVMThread);
@@ -264,12 +264,12 @@ Java_j9vm_test_thread_TestNatives_getSchedulingPriority(JNIEnv* env, jclass claz
 	J9VMThread *targetVMThread = NULL;
 	jint schedulingPriority = -1;
 
-	javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
+	javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 
 	javaThreadObject = J9_JNI_UNWRAP_REFERENCE(javaThread);
 	targetVMThread = (J9VMThread *)J9VMJAVALANGTHREAD_THREADREF(vmThread, javaThreadObject);
 
-	javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (NULL != targetVMThread) {
 		schedulingPriority = getSchedulingPriority(targetVMThread);
@@ -539,7 +539,7 @@ Java_com_ibm_j9_monitor_tests_TestNatives_getLockWordValue(JNIEnv* env, jobject 
 	j9objectmonitor_t lock;
 	J9JavaVM *vm = ((J9VMThread *) env)->javaVM;
 
-	vm->internalVMFunctions->internalAcquireVMAccess((J9VMThread *)env);
+	vm->internalVMFunctions->internalEnterVMFromJNI((J9VMThread *)env);
 
 	obj = J9_JNI_UNWRAP_REFERENCE(lockwordObj);
 #if defined( J9VM_THR_LOCK_NURSERY )
@@ -553,7 +553,7 @@ Java_com_ibm_j9_monitor_tests_TestNatives_getLockWordValue(JNIEnv* env, jobject 
 		lock = *lockEA;
 	}
 
-	vm->internalVMFunctions->internalReleaseVMAccess((J9VMThread *)env);
+	vm->internalVMFunctions->internalExitVMToJNI((J9VMThread *)env);
 
 	return (jlong) lock;
 }
@@ -565,12 +565,12 @@ Java_com_ibm_j9_monitor_tests_TestNatives_getLockWordOffset(JNIEnv* env, jobject
 	J9JavaVM *vm = ((J9VMThread *) env)->javaVM;
 	jlong result = -1;
 
-	vm->internalVMFunctions->internalAcquireVMAccess((J9VMThread *)env);
+	vm->internalVMFunctions->internalEnterVMFromJNI((J9VMThread *)env);
 
 	obj = J9_JNI_UNWRAP_REFERENCE(lockwordObj);
 	result = (jlong) J9OBJECT_MONITOR_OFFSET((J9VMThread *) env,obj);
 
-	vm->internalVMFunctions->internalReleaseVMAccess((J9VMThread *)env);
+	vm->internalVMFunctions->internalExitVMToJNI((J9VMThread *)env);
 
 	return result;
 }
@@ -600,11 +600,11 @@ Java_j9vm_test_softmx_TestNatives_setAggressiveGCPolicy(JNIEnv* env, jclass claz
 	J9VMThread *vmThread = (J9VMThread *) env;
 	J9JavaVM *javaVM = vmThread->javaVM;
 
-	javaVM->internalVMFunctions->internalAcquireVMAccess(vmThread);
+	javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 
 	javaVM->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(vmThread, J9MMCONSTANT_IMPLICIT_GC_AGGRESSIVE);
 
-	javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 }
 

--- a/runtime/tests/thread/thrstate/testsetup.c
+++ b/runtime/tests/thread/thrstate/testsetup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2008 IBM Corp. and others
+ * Copyright (c) 2008, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -407,7 +407,7 @@ test_setup(JNIEnv *env, BOOLEAN ignoreExpectedFailures)
 	}
 
 	j9tty_printf(PORTLIB, "acquiring VM access\n");
-	vmFuncs->internalAcquireVMAccess(currentThread); /* prevent the GC from moving objects */
+	vmFuncs->internalEnterVMFromJNI(currentThread); /* prevent the GC from moving objects */
 
 	if (initObject(env, &TESTDATA(blockingObject), TESTDATA(blockingObjectRef), &TESTDATA(objMonitor))) {
 		j9tty_printf(PORTLIB, "test_setup: unable to create object\n");

--- a/runtime/util/cphelp.c
+++ b/runtime/util/cphelp.c
@@ -30,7 +30,8 @@ getClassPathEntry(J9VMThread * currentThread, J9ClassLoader * classLoader, IDATA
 	UDATA vmAccess = currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS;
 
 	if (vmAccess == 0) {
-		currentThread->javaVM->internalVMFunctions->internalAcquireVMAccess(currentThread);
+		/* The only callers without VM access are in the JNI context */
+		currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	}
 	if ((cpIndex < 0) || ((UDATA)cpIndex >= classLoader->classPathEntryCount)) {
 		rc = 1;
@@ -39,7 +40,7 @@ getClassPathEntry(J9VMThread * currentThread, J9ClassLoader * classLoader, IDATA
 		rc = 0;
 	}
 	if (vmAccess == 0) {
-		currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 	return rc;
 }

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -1223,7 +1223,7 @@ jitFillOSRBuffer(struct J9VMThread *currentThread, void *osrBlock, UDATA reserve
 void JNICALL
 initializeAttachedThread(J9VMThread *currentThread, const char *name, j9object_t *group, UDATA daemon, J9VMThread *initializee)
 {
-	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
+	VM_VMAccess::inlineAcquireVMAccess(currentThread);
 	initializeAttachedThreadImpl(currentThread, name, group, daemon, initializee);
 	VM_VMAccess::inlineReleaseVMAccess(currentThread);
 }

--- a/runtime/vm/classloadersearch.c
+++ b/runtime/vm/classloadersearch.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -198,9 +198,9 @@ addZipToLoader(J9JavaVM * vm, const char * filename, J9ClassLoader * classLoader
 			jclass classLoaderClass = NULL;
 			jmethodID mid;
 
-			internalAcquireVMAccess(currentThread);
+			internalEnterVMFromJNI(currentThread);
 			classLoaderRef = j9jni_createLocalRef(env, classLoader->classLoaderObject);
-			internalReleaseVMAccess(currentThread);
+			internalExitVMToJNI(currentThread);
 			if (classLoaderRef == NULL) {
 				rc = CLS_ERROR_OUT_OF_MEMORY;
 				goto cleanup;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -336,7 +336,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	internalEnterVMFromJNI,
 	internalExitVMToJNI,
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-	internalReleaseVMAccessInJNI,
 	hashModuleTableNew,
 	hashPackageTableNew,
 	hashModuleExtraInfoTableNew,

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -369,14 +369,14 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 {
 	J9JavaVM * vm = vmThread->javaVM;
 
+	enterVMFromJNI(vmThread);
 	/* Inform ThreadGroup about any uncaught exception.  Tiny VMs do not have ThreadGroup, so they just dump the exception. */
 	if (vmThread->currentException) {
-		enterVMFromJNI(vmThread);
 		handleUncaughtException(vmThread, 0, 0, 0, 0);
 		/* Safe to call this whether handleUncaughtException clears the exception or not */
 		internalExceptionDescribe(vmThread);
-		releaseVMAccess(vmThread);
 	}
+	releaseVMAccess(vmThread);
 	
 	/* Mark this thread as dead */
 	setEventFlag(vmThread, J9_PUBLIC_FLAGS_STOPPED);
@@ -402,7 +402,7 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 
 	/* Do the java dance to indicate thread death */
 
-	enterVMFromJNI(vmThread);
+	acquireVMAccess(vmThread);
 	cleanUpAttachedThread(vmThread, 0, 0, 0, 0);
 	releaseVMAccess(vmThread);
 	


### PR DESCRIPTION
- disallow direct VM access acquire/release when in JNI
- fix all the offenders to avoid assertions

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>