### PR TITLE
Do not return 0 from isCacheFileName() based on modLevel

### DIFF
--- a/runtime/oti/shchelp.h
+++ b/runtime/oti/shchelp.h
@@ -81,6 +81,8 @@ extern "C" {
 #define J9SH_VERSTRLEN_INCREASED_SINCEG29 2
 #define J9SH_VERSTRLEN_INCREASED_SINCEJAVA10 1
 
+#define J9SH_MODLEVEL_PREFIX_CHAR_OFFSET 4
+
 typedef struct J9PortShcVersion {
     uint32_t esVersionMajor;
     uint32_t esVersionMinor;

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -135,24 +135,21 @@ getGenerationFromName(const char* cacheNameWithVGen)
  * @param [in] cacheNameWithVGen  the cache file name
  *
  * @return the modeLevel number,
- * 		   0 if it is an old cache name that does not have modlLevel,
- * 		   -1 if there is an error.
+ * 		   -1 if it is an old cache name that does not have modlLevel, or an error occurred.
  */
 intptr_t
 getModLevelFromName(const char* cacheNameWithVGen)
 {
 	char* cursor = (char*)cacheNameWithVGen;
-	intptr_t modLevel = 0;
-	
-	cursor = strchr(cursor, J9SH_MODLEVEL_PREFIX_CHAR);
-	if (NULL != cursor) {
-		cursor += 1;
+	intptr_t modLevel = -1;
+
+	if ((strlen(cacheNameWithVGen) > (J9SH_MODLEVEL_PREFIX_CHAR_OFFSET + 2))
+		 && (J9SH_MODLEVEL_PREFIX_CHAR == cursor[J9SH_MODLEVEL_PREFIX_CHAR_OFFSET])
+	) {
+		cursor += (J9SH_MODLEVEL_PREFIX_CHAR_OFFSET + 1);
 		if (0 != scan_idata(&cursor, &modLevel)) {
 			modLevel = -1;
 		}
-	} else {
-		/* old cache name that does not have J9SH_MODLEVEL_PREFIX_CHAR */
-		modLevel = 0;
 	}
 	return modLevel;
 }
@@ -350,9 +347,7 @@ isCacheFileName(J9PortLibrary* portlib, const char* nameToTest, uintptr_t expect
 		return 0;
 	}
 	modLevel = getModLevelFromName(nameToTest);
-	if (-1 == modLevel) {
-		return 0;
-	}
+
 	/* modLevel becomes 2 digits from Java 10 */
 	if (modLevel < 10) {
 		expectedVersionLen -= J9SH_VERSTRLEN_INCREASED_SINCEJAVA10;


### PR DESCRIPTION
We cannot determine whether a file is cache file simply base on
J9SH_MODLEVEL_PREFIX_CHAR, as old cache file name has no
J9SH_MODLEVEL_PREFIX_CHAR in its prefix string. Do not use strchr() to
search for J9SH_MODLEVEL_PREFIX_CHAR as old cache file name could have
"M" in its cache name. 

Signed-off-by: hangshao <hangshao@ca.ibm.com>