### PR TITLE
Fix order of exceptions for method sends

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6358,8 +6358,15 @@ done:
 		UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
 		UDATA methodIndex = methodIndexAndArgCount >> 8;
 		j9object_t receiver = ((j9object_t*)_sp)[methodIndexAndArgCount & 0xFF];
-		if (fromBytecode && J9_UNEXPECTED(NULL == receiver)) {
-			rc = THROW_NPE;
+		if (J9_UNEXPECTED(NULL == receiver)) {
+			/* Resolution exceptions must be thrown first, so check if methodRef 
+			 * is resolved before throwing NPE on receiver.
+			 */
+			if (methodIndex != (sizeof(J9Class) + sizeof(UDATA))) {
+				rc = THROW_NPE;
+			} else {
+				_sendMethod = (J9Method *)_vm->initialMethods.initialVirtualMethod;
+			}
 		} else {
 			J9Class *receiverClass = J9OBJECT_CLAZZ(_currentThread, receiver);
 			_sendMethod = *(J9Method**)((UDATA)receiverClass + methodIndex);


### PR DESCRIPTION
Fix order of exceptions for method sends

Resolution must occur before checking the receiver for NPE

Signed-off-by: tajila <atobia@ca.ibm.com>

Reviewer: @gacholio 