### PR TITLE
Add timeout to pipeline builds

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -229,21 +229,23 @@ def add_node_to_description() {
 def build_all() {
 
     // Typically called by Build jobs and Compile only PRs
-
-    add_node_to_description()
-    get_source()
-    build()
-    archive()
-    git_clean()
+    timeout(time: 6, unit: 'HOURS') {
+        add_node_to_description()
+        get_source()
+        build()
+        archive()
+        git_clean()
+    }
 }
 
 def build_pr() {
 
     // Called by PR Compile & Test jobs
     // Does not cleanup as it is expected testing will occur, followed by cleanup
-
-    get_source()
-    build()
+    timeout(time: 6, unit: 'HOURS') {
+        get_source()
+        build()
+    }
 }
 
 return this

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -107,12 +107,14 @@ def add_node_to_description() {
 }
 
 def test_all() {
-    add_node_to_description()
-    configure()
-    get_dependencies()
-    compile()
-    test()
-    publish()
+    timeout(time: 8, unit: 'HOURS') {
+        add_node_to_description()
+        configure()
+        get_dependencies()
+        compile()
+        test()
+        publish()
+    }
 }
 
 def test_all_with_fetch() {


### PR DESCRIPTION
Set timeout for build pipeline builds to 6 hours and to 8 hours 
for test pipeline builds. 

Issue: https://github.com/eclipse/openj9/issues/974

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>