### PR TITLE
Make spelling of "initialize" consistent

### DIFF
--- a/debugtools/DDR_Artifacts/specs/29/aix_ppc
+++ b/debugtools/DDR_Artifacts/specs/29/aix_ppc
@@ -11786,7 +11786,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -11843,7 +11843,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -11877,7 +11877,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/aix_ppc-64
+++ b/debugtools/DDR_Artifacts/specs/29/aix_ppc-64
@@ -1051,7 +1051,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1108,7 +1108,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1142,7 +1142,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/aix_ppc-64_cmprssptrs
+++ b/debugtools/DDR_Artifacts/specs/29/aix_ppc-64_cmprssptrs
@@ -11777,7 +11777,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -11834,7 +11834,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -11868,7 +11868,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/aix_ppc-64_cmprssptrs_purec
+++ b/debugtools/DDR_Artifacts/specs/29/aix_ppc-64_cmprssptrs_purec
@@ -11692,7 +11692,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -11749,7 +11749,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -11783,7 +11783,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/aix_ppc-64_purec
+++ b/debugtools/DDR_Artifacts/specs/29/aix_ppc-64_purec
@@ -2609,7 +2609,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2666,7 +2666,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2700,7 +2700,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/aix_ppc_purec
+++ b/debugtools/DDR_Artifacts/specs/29/aix_ppc_purec
@@ -1050,7 +1050,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1107,7 +1107,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1141,7 +1141,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390
@@ -13632,7 +13632,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13689,7 +13689,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13723,7 +13723,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64
@@ -13610,7 +13610,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13667,7 +13667,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13701,7 +13701,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64_cmprssptrs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64_cmprssptrs
@@ -13611,7 +13611,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13668,7 +13668,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13702,7 +13702,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64_cmprssptrs_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64_cmprssptrs_cs
@@ -2646,7 +2646,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2703,7 +2703,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2737,7 +2737,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64_cmprssptrs_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64_cmprssptrs_purec
@@ -1463,7 +1463,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1520,7 +1520,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1554,7 +1554,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64_cs
@@ -11723,7 +11723,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -11780,7 +11780,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -11814,7 +11814,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64_purec
@@ -13458,7 +13458,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13515,7 +13515,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13549,7 +13549,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390-64_purec_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390-64_purec_cs
@@ -1044,7 +1044,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1101,7 +1101,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1135,7 +1135,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_390_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_390_purec
@@ -2607,7 +2607,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2664,7 +2664,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2698,7 +2698,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_arm
+++ b/debugtools/DDR_Artifacts/specs/29/linux_arm
@@ -2854,7 +2854,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2911,7 +2911,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2945,7 +2945,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc
@@ -13624,7 +13624,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13681,7 +13681,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13715,7 +13715,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64
@@ -13619,7 +13619,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13676,7 +13676,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13710,7 +13710,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs
@@ -1463,7 +1463,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1520,7 +1520,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1554,7 +1554,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le
@@ -2740,7 +2740,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2797,7 +2797,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2831,7 +2831,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le_cs
@@ -13628,7 +13628,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13685,7 +13685,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13719,7 +13719,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le_purec
@@ -2700,7 +2700,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2757,7 +2757,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2791,7 +2791,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le_purec_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_le_purec_cs
@@ -11576,7 +11576,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -11633,7 +11633,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -11667,7 +11667,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cmprssptrs_purec
@@ -2825,7 +2825,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2882,7 +2882,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2916,7 +2916,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_cs
@@ -13544,7 +13544,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13601,7 +13601,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13635,7 +13635,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_le
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_le
@@ -2740,7 +2740,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2797,7 +2797,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2831,7 +2831,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_le_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_le_purec
@@ -13573,7 +13573,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13630,7 +13630,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13664,7 +13664,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_purec
@@ -13488,7 +13488,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13545,7 +13545,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13579,7 +13579,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_purec_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc-64_purec_cs
@@ -1280,7 +1280,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1337,7 +1337,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1371,7 +1371,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_ppc_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_ppc_purec
@@ -1280,7 +1280,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1337,7 +1337,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1371,7 +1371,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86
@@ -2794,7 +2794,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2851,7 +2851,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2885,7 +2885,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64
@@ -11922,7 +11922,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -11979,7 +11979,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -12013,7 +12013,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs
@@ -13672,7 +13672,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13729,7 +13729,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13763,7 +13763,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_cs
@@ -12224,7 +12224,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -12281,7 +12281,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -12315,7 +12315,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_panama
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_panama
@@ -13706,7 +13706,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13763,7 +13763,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13797,7 +13797,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_purec
@@ -2693,7 +2693,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2750,7 +2750,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2784,7 +2784,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_purec_cs
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64_cmprssptrs_purec_cs
@@ -12042,7 +12042,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -12099,7 +12099,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -12133,7 +12133,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86-64_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86-64_purec
@@ -2693,7 +2693,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2750,7 +2750,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2784,7 +2784,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/linux_x86_purec
+++ b/debugtools/DDR_Artifacts/specs/29/linux_x86_purec
@@ -2607,7 +2607,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2664,7 +2664,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2698,7 +2698,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/win_x86
+++ b/debugtools/DDR_Artifacts/specs/29/win_x86
@@ -2680,7 +2680,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2737,7 +2737,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2771,7 +2771,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/win_x86-64
+++ b/debugtools/DDR_Artifacts/specs/29/win_x86-64
@@ -12285,7 +12285,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -12342,7 +12342,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -12376,7 +12376,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/win_x86-64_cmprssptrs
+++ b/debugtools/DDR_Artifacts/specs/29/win_x86-64_cmprssptrs
@@ -13736,7 +13736,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13793,7 +13793,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13827,7 +13827,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/win_x86-64_cmprssptrs_purec
+++ b/debugtools/DDR_Artifacts/specs/29/win_x86-64_cmprssptrs_purec
@@ -13600,7 +13600,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13657,7 +13657,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13691,7 +13691,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/win_x86-64_purec
+++ b/debugtools/DDR_Artifacts/specs/29/win_x86-64_purec
@@ -2728,7 +2728,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2785,7 +2785,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2819,7 +2819,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/win_x86_purec
+++ b/debugtools/DDR_Artifacts/specs/29/win_x86_purec
@@ -2841,7 +2841,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2898,7 +2898,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2932,7 +2932,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390
@@ -2876,7 +2876,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2933,7 +2933,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2967,7 +2967,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390-64
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390-64
@@ -1051,7 +1051,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1108,7 +1108,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1142,7 +1142,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390-64_cmprssptrs
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390-64_cmprssptrs
@@ -13552,7 +13552,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13609,7 +13609,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13643,7 +13643,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390-64_cmprssptrs_cs
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390-64_cmprssptrs_cs
@@ -13543,7 +13543,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13600,7 +13600,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13634,7 +13634,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390-64_cmprssptrs_purec
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390-64_cmprssptrs_purec
@@ -1053,7 +1053,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -1110,7 +1110,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -1144,7 +1144,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390-64_cs
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390-64_cs
@@ -13542,7 +13542,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -13599,7 +13599,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -13633,7 +13633,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390-64_purec
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390-64_purec
@@ -2610,7 +2610,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2667,7 +2667,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2701,7 +2701,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/specs/29/zos_390_purec
+++ b/debugtools/DDR_Artifacts/specs/29/zos_390_purec
@@ -2816,7 +2816,7 @@ F|_reduceStoreContentionDisabled|_reduceStoreContentionDisabled|bool|bool
 F|_debugData|_debugData|class ClassDebugDataProvider*|class ClassDebugDataProvider*
 F|_commonCCInfo|_commonCCInfo|struct J9ShrCompositeCacheCommonInfo*|struct J9ShrCompositeCacheCommonInfo*
 F|_newHdrPtr|_newHdrPtr|class SH_CompositeCacheImpl$SH_SharedCacheHeaderInit*|class SH_CompositeCacheImpl::SH_SharedCacheHeaderInit*
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_Manager|SH_ManagerPointer|
 F|_hashTable|_hashTable|struct J9HashTable*|struct J9HashTable*
 F|_cache|_cache|class SH_SharedCache*|class SH_SharedCache*
@@ -2873,7 +2873,7 @@ F|_doCheckBuildID|_doCheckBuildID|bool|bool
 F|_corruptionCode|_corruptionCode|IDATA|IDATA
 F|_corruptValue|_corruptValue|UDATA|UDATA
 F|_isUserSpecifiedCacheDir|_isUserSpecifiedCacheDir|bool|bool
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -2907,7 +2907,7 @@ F|_semFileName|_semFileName|U8*|char*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_storageKeyTesting|_storageKeyTesting|UDATA|UDATA
 F|config|config|struct J9SharedClassPreinitConfig*|const struct J9SharedClassPreinitConfig*
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_groupPerm|_groupPerm|UDATA|UDATA
 F|_semid|_semid|I32|I32
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess

--- a/debugtools/DDR_Artifacts/supersets/29/superset.ibuild.dat
+++ b/debugtools/DDR_Artifacts/supersets/29/superset.ibuild.dat
@@ -17612,7 +17612,7 @@ F|_dataSize|_dataSize|U32|const U32
 F|_dataStart|_dataStart|U8*|const U8*
 S|SH_CompiledMethodManagerImpl|SH_CompiledMethodManagerImplPointer|SH_CompiledMethodManager
 S|SH_CompiledMethodManager|SH_CompiledMethodManagerPointer|SH_ROMClassResourceManager
-S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitialiser
+S|SH_CompositeCacheImpl$SH_SharedCacheHeaderInit|SH_CompositeCacheImpl$SH_SharedCacheHeaderInitPointer|SH_OSCache$SH_OSCacheInitializer
 S|SH_CompositeCacheImpl|SH_CompositeCacheImplPointer|AbstractMemoryPermission
 F|_cacheFullFlags|_cacheFullFlags|UDATA|UDATA
 F|_cacheHeaderPageBytes|_cacheHeaderPageBytes|U32|U32
@@ -17712,7 +17712,7 @@ F|_portlib|_portlib|struct J9PortLibrary*|struct J9PortLibrary*
 F|_runtimeFlagsPtr|_runtimeFlagsPtr|U64*|U64*
 F|_state|_state|UDATA|UDATA
 F|_verboseFlags|_verboseFlags|UDATA|UDATA
-S|SH_OSCache$SH_OSCacheInitialiser|SH_OSCache$SH_OSCacheInitialiserPointer|
+S|SH_OSCache$SH_OSCacheInitializer|SH_OSCache$SH_OSCacheInitializerPointer|
 S|SH_OSCacheFile|SH_OSCacheFilePointer|SH_OSCache
 F|_fileHandle|_fileHandle|IDATA|IDATA
 S|SH_OSCache_Info|SH_OSCache_InfoPointer|
@@ -17739,7 +17739,7 @@ S|SH_OSCachesysv|SH_OSCachesysvPointer|SH_OSCache
 F|_attach_count|_attach_count|IDATA|IDATA
 F|_controlFileStatus|_controlFileStatus|struct J9ControlFileStatus|struct J9ControlFileStatus
 F|_groupPerm|_groupPerm|UDATA|UDATA
-F|_initialiser|_initialiser|class SH_OSCache$SH_OSCacheInitialiser*|class SH_OSCache::SH_OSCacheInitialiser*
+F|_initializer|_initializer|class SH_OSCache$SH_OSCacheInitializer*|class SH_OSCache::SH_OSCacheInitializer*
 F|_openSharedMemory|_openSharedMemory|bool|bool
 F|_semAccess|_semAccess|enum SH_SysvSemAccess|enum SH_SysvSemAccess
 F|_semFileName|_semFileName|U8*|char*

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -192,7 +192,7 @@ public class J9DDRClassLoader extends SecureClassLoader {
 	private byte[] getClazz(String binaryName) throws ClassNotFoundException {
 		//make sure that we have a reader available
 		if(reader == null) {		
-			throw new IllegalStateException("The structure reader has not been initialised");
+			throw new IllegalStateException("The structure reader has not been initialized");
 		}
 		
 		try {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -420,7 +420,7 @@ public class StructureReader {
 		logger.logp(FINER,null,null,"ddrStringTableStart=0x{0}",Long.toHexString(ddrStringTableStart));
 
 		if(structures == null) {
-			//initialise the structure map with a sensible initial capacity
+			//initialize the structure map with a sensible initial capacity
 			structures = new HashMap<String, StructureDescriptor>(header.getStructureCount());
 		}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/elf/ELFFileReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 IBM Corp. and others
+ * Copyright (c) 2004, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -156,7 +156,7 @@ public abstract class ELFFileReader
 			this._file = file;
 			sourceName = file.getAbsolutePath();
 			this.baseOffset = offset;
-			initialiseReader(offset);
+			initializeReader(offset);
 		} catch ( IOException e ) {
 			// Don't leak file handles if we fail to create this reader.
 			if( is != null ) {
@@ -183,14 +183,14 @@ public abstract class ELFFileReader
 		is = in;
 		this.baseOffset = offset;
 		sourceName = "internal data stream";
-		initialiseReader(offset);
+		initializeReader(offset);
 	}
 	
 	public String getSourceName() {
 		return sourceName;
 	}
 	
-	private void initialiseReader(long offset) throws IOException, InvalidDumpFormatException {
+	private void initializeReader(long offset) throws IOException, InvalidDumpFormatException {
 		is.seek(offset);
 		readHeader();
 		readSectionHeader();
@@ -499,7 +499,7 @@ public abstract class ELFFileReader
 			
 			// - Sections are only loaded if they are contained in a program header.
 			// - NOBITS sections (.bss) occupy space in memory but not in the library
-			//   (since they define sections that are generally initialised to 0's).
+			//   (since they define sections that are generally initialized to 0's).
 			// - entry.address == 0 (sh_addr) also indicates a section that isn't loaded
 			// - entry.size == 0 is always true for the first (null) section header
 			if (!sectionHeaderMapsToProgramHeader(entry) || entry.isNoBits()

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/MiniDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/MiniDumpReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 IBM Corp. and others
+ * Copyright (c) 2004, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -520,7 +520,7 @@ public class MiniDumpReader extends AbstractCoreReader implements ICoreFileReade
 				}
 			}
 			/* Add thread info (may or may not be in the dump) */
-			/* Relies on threads having been initialised as it adds properties so must be done second. */
+			/* Relies on threads having been initialized as it adds properties so must be done second. */
 			for (ThreadInfoStream stream : threadInfoStreams) {
 				try {
 					stream.readFrom(this, this.getAddressSpaces().get(0), is64Bit(), threads);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/TDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/TDumpReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2015 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -649,7 +649,7 @@ public class TDumpReader implements ICoreFileReader
 					long usedTextRangeLimits[][] = new long[rr.length][2];
 					long usedDataRangeLimits[][] = new long[rr.length][2];
 					for (int i = 0; i < rr.length; ++i) {
-						// initialise lower limit addresses to high value
+						// initialize lower limit addresses to high value
 						usedTextRangeLimits[i][0] = Long.MAX_VALUE;
 						usedDataRangeLimits[i][0] = Long.MAX_VALUE;
 					}
@@ -735,7 +735,7 @@ public class TDumpReader implements ICoreFileReader
 					List<ISymbol> symbols = new ArrayList<ISymbol>();
 					// Array of lowest and highest symbol addresses found in each contiguous memory range
 					long usedTextRangeLimits[][] = new long[rr.length][2];
-					// initialise start address to high
+					// initialize start address to high
 					for (int i = 0; i < rr.length; ++i) {
 						usedTextRangeLimits[i][0] = Long.MAX_VALUE;
 					}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/Footer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/libraries/Footer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,7 +66,7 @@ public class Footer implements Serializable {
 		data.append(version);
 		data.append("\n");
 		for(int i = 0; i < entries.length; i++) {
-			if(entries[i] != null) {		//skip over entries that have not been initialised
+			if(entries[i] != null) {		//skip over entries that have not been initialized
 				data.append(entries[i].toString());
 			}
 		}
@@ -76,7 +76,7 @@ public class Footer implements Serializable {
 	public FooterLibraryEntry findEntry(String path) {
 		FooterLibraryEntry namematch = null;			//match against the name  
 		for(int i = 0; i < entries.length; i++) {
-			if(entries[i] != null) {		//skip over entries that have not been initialised
+			if(entries[i] != null) {		//skip over entries that have not been initialized
 				if(entries[i].getPath().equals(path)) {
 					return entries[i];
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/SnapFormatCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/SnapFormatCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 IBM Corp. and others
+ * Copyright (c) 2013, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -627,7 +627,7 @@ public class SnapFormatCommand extends SnapBaseCommand
 		} catch (CorruptDataException e) {
 			// Although we got a CDE some data may have been copied to the buffer.
 			// This appears to happen on z/OS when some of the buffer space is in a page of
-			// uninitialised memory. (See defect 185780.) In that case the missing data is
+			// uninitialized memory. (See defect 185780.) In that case the missing data is
 			// all 0's anyway.
 			out.println("Problem reading " + bufferSize + " bytes from 0x" +  Long.toHexString(address) + ". Trace file may contain partial or damaged data.");
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/SnapTraceCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/SnapTraceCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,7 @@ public class SnapTraceCommand extends SnapBaseCommand {
 			} catch (CorruptDataException e) {
 				// Although we got a CDE some data may have been copied to the buffer.
 				// This appears to happen on z/OS when some of the buffer space is in a page of
-				// uninitialised memory. (See defect 185780.) In that case the missing data is
+				// uninitialized memory. (See defect 185780.) In that case the missing data is
 				// all 0's anyway.
 				out.println("Problem reading " + bufferSize + " bytes from 0x" +  Long.toHexString(address) + ". Trace file may contain partial or damaged data.");
 			}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/TraceFileHeaderWriter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/TraceFileHeaderWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ public class TraceFileHeaderWriter {
 	/**
 	 * This class generates a trace file header. It is intended to be used when
 	 * a core dump has been taken before the JVM has written out any trace, the
-	 * trace header is not initialised until that happens.
+	 * trace header is not initialized until that happens.
 	 * 
 	 * There are a lot of arguments to pass but this data can be obtained from
 	 * the dump and prevents this code needing to exist in 23, 24 and 26

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageProcess.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/view/dtfj/image/J9DDRImageProcess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -430,7 +430,7 @@ public class J9DDRImageProcess implements ImageProcess {
 			Object[] passbackArray = new Object[1];
 			
 			try {
-				//attempt to load a default bootstrap class which will allow different implementations to provide their own initialisers
+				//attempt to load a default bootstrap class which will allow different implementations to provide their own initializers
 				data.bootstrapRelative("view.dtfj.DTFJBootstrapShim", (Object)passbackArray, this);
 			} catch (ClassNotFoundException e) {
 				//no specific class was found, so use a generic native one instead

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/StringTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/StringTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -188,7 +188,7 @@ public class StringTable
 			private PointerPointer cache;
 
 			{
-				// Instance initialiser
+				// Instance initializer
 				cacheTableIndex = new UDATA(0);
 				try {
 					cacheSize = getCacheSize();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaClassloader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaClassloader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,7 +107,7 @@ public class DTFJJavaClassloader implements JavaClassLoader {
 		cache = softReferenceToClassCache.get();
 		/* 
 		 * On the first time through, cache will be null because we created the soft reference that 
-		 * way so that we only initialise the class cache if needed.
+		 * way so that we only initialize the class cache if needed.
 		 * On subsequent occasions, the cache may be null if memory pressure caused GC
 		 * to clear the soft reference.
 		 */

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/JavaObject.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/java/j9/JavaObject.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -397,7 +397,7 @@ public class JavaObject implements com.ibm.dtfj.java.JavaObject
 						//				when it is given an invalid address and when it is copying array slots that do not yet contain
 						//				an object.
 						if(pointer.getAddress() == 0) {
-							//CMVC 175864 : the getObjectAtAddress function enforces stricter address checking, so need to exclude uninitialised slots up front
+							//CMVC 175864 : the getObjectAtAddress function enforces stricter address checking, so need to exclude uninitialized slots up front
 							intermediateArray[x] = null;
 						} else {
 							try {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/framework/input/LineJavaCoreInputBuffer.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/framework/input/LineJavaCoreInputBuffer.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ public class LineJavaCoreInputBuffer extends OffsetBasedJavaCoreInputBuffer {
 	}
 	
 	/**
-	 * Initialise fields and read the first line.
+	 * Initialize fields and read the first line.
 	 * @param reader
 	 * @param lineDelimiter
 	 */

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/framework/tag/LineRule.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/framework/tag/LineRule.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ public abstract class LineRule implements ILineRule {
 	}
 	
 	/**
-	 * Initialises buffer, token list, and other fields prior to parsing and tokenising a line.
+	 * Initializes buffer, token list, and other fields prior to parsing and tokenising a line.
 	 * The user-implemented method that parses the line is called here. This method is called
 	 * internally by the framework, so the user never needs to explicitly call this method.
 	 * 

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/environment/EnvironmentTagParser.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/environment/EnvironmentTagParser.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ public class EnvironmentTagParser extends TagParser implements
 	}
 	
 	/**
-	 * Initialise parser with rules for lines in the environment (CI) section in 
+	 * Initialize parser with rules for lines in the environment (CI) section in 
 	 * the javacore
 	 */
 	protected void initTagAttributeRules() {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/memory/MemoryTagParser.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/memory/MemoryTagParser.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ public class MemoryTagParser extends TagParser implements IMemoryTypes {
 	}
 
 	/**
-	 * Initialise parser with rules for lines in the host platform (XH) section in 
+	 * Initialize parser with rules for lines in the host platform (XH) section in 
 	 * the javacore
 	 */
 	protected void initTagAttributeRules() {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/title/TitleTagParser.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/title/TitleTagParser.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ public class TitleTagParser extends TagParser implements ITitleTypes {
 	}
 
 	/**
-	 * Initialise parser with rules for the TITLE section in the javacore
+	 * Initialize parser with rules for the TITLE section in the javacore
 	 */
 	protected void initTagAttributeRules() {
 

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaClass.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaClass.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,7 +94,7 @@ class PHDJavaClass implements JavaClass {
 		private JavaClass componentType = null;
 
 		/**
-		 * Initialise a Builder for a PHDJavaClass with the six required parameters.
+		 * Initialize a Builder for a PHDJavaClass with the six required parameters.
 		 * @param space
 		 * @param runtime
 		 * @param loader

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaObject.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/phd/PHDJavaObject.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corp. and others
+ * Copyright (c) 2008, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,7 +93,7 @@ public class PHDJavaObject implements JavaObject {
 		private long instanceSize = UNSPECIFIED_INSTANCE_SIZE;
 		
 		/**
-		 * Initialise a Builder for a PHDJavaClass with the five required parameters.
+		 * Initialize a Builder for a PHDJavaClass with the five required parameters.
 		 * @param heap
 		 * @param address
 		 * @param cls

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/JdmpviewInitException.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/JdmpviewInitException.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2011, 2017 IBM Corp. and others
+ * Copyright (c) 2011, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 package com.ibm.jvm.dtfjview;
 
 /**
- * Indicates that jdmpview failed to initialise
+ * Indicates that jdmpview failed to initialize
  * 
  * @author adam
  *

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -216,7 +216,7 @@ public class Session implements ISession {
 		isInteractiveSession = (args.get(ARG_CMDFILE) == null) && (commands.isEmpty());		//interactive if no commands have been supplied
 		//create a console context which will allow other commands such as the open command to function
 		ctxroot = new CombinedContext(0, 0, null, null, null, null, -1);
-		initialiseContext(ctxroot);
+		initializeContext(ctxroot);
 		currentContext = ctxroot;			//default to the root context at startup
 	
 		// Set system property to switch off additional DDR processing for Node.JS
@@ -231,7 +231,7 @@ public class Session implements ISession {
 	}
 	
 	//initializes the supplied context with its starting parameters and property values
-	private void initialiseContext(IDTFJContext ctx) {
+	private void initializeContext(IDTFJContext ctx) {
 		ctx.refresh();
 		ctx.getProperties().put(SESSION_PROPERTY, this);
 		for(String key : variables.keySet()) {

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceArgs.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceArgs.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@ final public class TraceArgs {
     public      static            boolean              override;
     public      static            String               datFileDirectory = null;
     
-   /** Initialises static variables.
+   /** Initializes static variables.
     *
     *  <p>This is called each time the TraceFormatter is started, from the initStatics()
     *     method in TraceFormat.java</p>

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceFormat.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceFormat.java
@@ -220,7 +220,7 @@ final public class TraceFormat
 				"  ThreadID         TP id  Type         TraceEntry ");
 		expectedRecords = 0;
 
-		// initialise statics in other classes
+		// initialize statics in other classes
 		Util.initStatics();
 		TraceArgs.initStatics();
 		TraceRecord.initStatics();
@@ -489,7 +489,7 @@ final public class TraceFormat
 
 	private void prime() throws IOException
 	{
-		/* reinitialise class variables to allow reuse */
+		/* reinitialize class variables to allow reuse */
 		globalNumberOfBuffers = 0;
 		tempThreadArray = null;
 		tracedThreads = null;

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecord.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceRecord.java
@@ -240,7 +240,7 @@ public class TraceRecord implements Comparable {
         traceThread.addElement(this);
     }
 
-    /** Initialises static variables.
+    /** Initializes static variables.
      *
      *  <p>This is called each time the TraceFormatter is started, from the initStatics()
      *     method in TraceFormat.java</p>

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/Util.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/Util.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,7 @@ final public class Util {
     {
     }
 
-    /** Initialises static variables.
+    /** Initializes static variables.
      *
      *  <p>This is called each time the TraceFormatter is started, from the initStatics()
      *     method in TraceFormat.java</p>

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/trace/format/api/TraceContext.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/trace/format/api/TraceContext.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,7 +81,7 @@ public class TraceContext {
 	protected MessageFile messageFile;
 	protected Vector auxiliaryMessageFiles;
 
-	/* The trace headers used to initialise this context */
+	/* The trace headers used to initialize this context */
 	TraceFileHeader metadata;
 
 	PrintStream errorStream = System.out;

--- a/runtime/bcutil/test/dyntest/intern_tests.cpp
+++ b/runtime/bcutil/test/dyntest/intern_tests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2014 IBM Corp. and others
+ * Copyright (c) 2008, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -622,7 +622,7 @@ testStringInternTableStressLocal(J9PortLibrary *portLib, UDATA numIterations)
 	J9UTF8 *utf8s[5000];
 	const UDATA utfs8Count = sizeof(utf8s)/sizeof(utf8s[0]);
 
-	/* Class loaders are not initialised as currently the StringInternTable only uses their addresses. */
+	/* Class loaders are not initialized as currently the StringInternTable only uses their addresses. */
 	J9ClassLoader classLoaders[25];
 	const UDATA classLoadersCount = sizeof(classLoaders)/sizeof(classLoaders[0]);
 
@@ -764,7 +764,7 @@ testStringInternTableStressShared(J9PortLibrary *portLib, UDATA numIterations)
 	J9UTF8 *utf8s[5000];
 	const UDATA utfs8Count = sizeof(utf8s)/sizeof(utf8s[0]);
 
-	/* Class loaders are not initialised as currently the StringInternTable only uses their addresses. */
+	/* Class loaders are not initialized as currently the StringInternTable only uses their addresses. */
 	J9ClassLoader classLoaders[25];
 	const UDATA classLoadersCount = sizeof(classLoaders)/sizeof(classLoaders[0]);
 

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,14 +85,14 @@ void J9::ARM::AheadOfTimeCompile::processRelocations()
       *(uint32_t *)relocationDataCursor = self()->getSizeOfAOTRelocations() + 4;
       relocationDataCursor += 4;
 
-      // set up pointers for each iterated relocation and initialise header
+      // set up pointers for each iterated relocation and initialize header
       TR::IteratedExternalRelocation *s;
       for (s = self()->getAOTRelocationTargets().getFirst();
            s != NULL;
            s = s->getNext())
          {
          s->setRelocationData(relocationDataCursor);
-         s->initialiseRelocation(_cg);
+         s->initializeRelocation(_cg);
          relocationDataCursor += s->getSizeOfRelocationData();
          }
       }
@@ -100,7 +100,7 @@ void J9::ARM::AheadOfTimeCompile::processRelocations()
 
 uintptr_t findCorrectInlinedSiteIndex(void *constantPool, TR::Compilation *comp, uintptr_t currentInlinedSiteIndex);
 
-uint8_t *J9::ARM::AheadOfTimeCompile::initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
+uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR::Compilation* comp = TR::comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
@@ -55,7 +55,7 @@ public:
    AheadOfTimeCompile(TR::CodeGenerator *cg);
 
    virtual void     processRelocations();
-   virtual uint8_t *initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
+   virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
    List<TR::ARMRelocation>& getRelocationList() {return _relocationList;}
 

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -157,7 +157,7 @@ int32_t CpuUtilization::updateCpuUsageCircularBuffer(J9JITConfig *jitConfig)
 
 CpuUtilization::CpuUtilization(J9JITConfig *jitConfig):
 
-   // initialise usage to INITIAL_USAGE
+   // initialize usage to INITIAL_USAGE
    _cpuUsage    (INITIAL_USAGE),
    _vmCpuUsage  (INITIAL_USAGE),
    _avgCpuUsage (INITIAL_USAGE),

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,12 +88,12 @@ void J9::Power::AheadOfTimeCompile::processRelocations()
          *(uint32_t *) relocationDataCursor = getSizeOfAOTRelocations() + 4;
          relocationDataCursor += 4;
          }
-      // set up pointers for each iterated relocation and initialise header
+      // set up pointers for each iterated relocation and initialize header
       TR::IteratedExternalRelocation *s;
       for (s = getAOTRelocationTargets().getFirst(); s != NULL; s = s->getNext())
          {
          s->setRelocationData(relocationDataCursor);
-         s->initialiseRelocation(_cg);
+         s->initializeRelocation(_cg);
          relocationDataCursor += s->getSizeOfRelocationData();
          }
       }
@@ -101,7 +101,7 @@ void J9::Power::AheadOfTimeCompile::processRelocations()
 
 uintptr_t findCorrectInlinedSiteIndex(void *constantPool, TR::Compilation *comp, uintptr_t currentInlinedSiteIndex);
 
-uint8_t *J9::Power::AheadOfTimeCompile::initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
+uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR::Compilation* comp = TR::comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
@@ -53,7 +53,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
    AheadOfTimeCompile(TR::CodeGenerator *cg);
 
    virtual void     processRelocations();
-   virtual uint8_t *initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
+   virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
    private:
    TR::CodeGenerator *_cg;

--- a/runtime/compiler/runtime/DataCache.cpp
+++ b/runtime/compiler/runtime/DataCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,7 +153,7 @@ TR_DataCacheManager::TR_DataCacheManager(J9JITConfig *jitConfig, TR::Monitor *mo
 #if defined(DATA_CACHE_DEBUG)
    if (!_newImplementation)
       fprintf(stderr, "Old data cache implementation enabled");
-   fprintf(stderr, "Initialised the data cache manager with a quantum size of %d with a minimum of %d quanta per allocation.\n", _quantumSize, _minQuanta);
+   fprintf(stderr, "Initialized the data cache manager with a quantum size of %d with a minimum of %d quanta per allocation.\n", _quantumSize, _minQuanta);
 #endif
    }
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,14 +76,14 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
       // set up the size for the region
       *(uint64_t *)relocationDataCursor = self()->getSizeOfAOTRelocations() + SIZEPOINTER;
       relocationDataCursor += SIZEPOINTER;
-      // set up pointers for each iterated relocation and initialise header
+      // set up pointers for each iterated relocation and initialize header
       TR::IteratedExternalRelocation *s;
       for (s = self()->getAOTRelocationTargets().getFirst();
            s != 0;
            s = s->getNext())
          {
          s->setRelocationData(relocationDataCursor);
-         s->initialiseRelocation(_cg);
+         s->initializeRelocation(_cg);
          relocationDataCursor += s->getSizeOfRelocationData();
          }
       }
@@ -91,7 +91,7 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
 
 uintptr_t findCorrectInlinedSiteIndex(void *constantPool, TR::Compilation *comp, uintptr_t currentInlinedSiteIndex);
 
-uint8_t *J9::X86::AheadOfTimeCompile::initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
+uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
    TR_SharedCache *sharedCache = fej9->sharedCache();

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.hpp
@@ -51,7 +51,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile  : public J9::AheadOfTimeCompile
       }
 
    virtual void     processRelocations();
-   virtual uint8_t *initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
+   virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
    private:
    static uint32_t _relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds];

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,14 +99,14 @@ void J9::Z::AheadOfTimeCompile::processRelocations()
          relocationDataCursor += 4;
          }
 
-      // set up pointers for each iterated relocation and initialise header
+      // set up pointers for each iterated relocation and initialize header
       TR::IteratedExternalRelocation *s;
       for (s = self()->getAOTRelocationTargets().getFirst();
            s != NULL;
            s = s->getNext())
          {
          s->setRelocationData(relocationDataCursor);
-         s->initialiseRelocation(_cg);
+         s->initializeRelocation(_cg);
          relocationDataCursor += s->getSizeOfRelocationData();
          }
       }
@@ -114,7 +114,7 @@ void J9::Z::AheadOfTimeCompile::processRelocations()
 
 uintptr_t findCorrectInlinedSiteIndex(void *constantPool, TR::Compilation *comp, uintptr_t currentInlinedSiteIndex);
 
-uint8_t *J9::Z::AheadOfTimeCompile::initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
+uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
    TR_SharedCache *sharedCache = fej9->sharedCache();
@@ -128,7 +128,7 @@ uint8_t *J9::Z::AheadOfTimeCompile::initialiseAOTRelocationHeader(TR::IteratedEx
 
    // size of relocation goes first in all types
    *(uint16_t *)cursor = relocation->getSizeOfRelocationData();
-   AOTcgDiag5(comp(), "initialiseAOTRelocationHeader cursor=%x size=%x wide=%x pair=%x kind=%x\n",
+   AOTcgDiag5(comp(), "initializeAOTRelocationHeader cursor=%x size=%x wide=%x pair=%x kind=%x\n",
       cursor, *(uint16_t *)cursor, relocation->needsWideOffsets(), relocation->isOrderedPair(), relocation->getTargetKind());
 
    cursor += 2;

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.hpp
@@ -48,7 +48,7 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
      AheadOfTimeCompile(TR::CodeGenerator *cg);
 
     virtual void     processRelocations();
-    virtual uint8_t *initialiseAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
+    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
     TR::list<TR::S390Relocation*>& getRelocationList() {return _relocationList;}
 

--- a/runtime/compiler/z/codegen/J9S390SystemLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390SystemLinkage.cpp
@@ -99,7 +99,7 @@ TR::J9S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node * callNode,
    /*
     * for AOT we create a relocation where uint8_t  *_targetAddress is set to callNode->getSymbolReference(),
     * _targetAddress is used in different relocation types, where sometimes it's an actual address and sometimes (eg. TR_HelperAddress) it's a symref
-    *  for cases when _targetAddress is actually a symref we cast it back to symref in TR::AheadOfTimeCompile::initialiseAOTRelocationHeader
+    *  for cases when _targetAddress is actually a symref we cast it back to symref in TR::AheadOfTimeCompile::initializeAOTRelocationHeader
     *
     * In this case
     * generateRegLitRefInstruction creates a ConstantDataSnippet with reloType: TR_HelperAddress, which creates a 32Bit/64Bit ExternalRelocation
@@ -310,7 +310,7 @@ TR::J9S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
    /*
     * for AOT we create a relocation where uint8_t  *_targetAddress is set to callNode->getSymbolReference(),
     * _targetAddress is used in different relocation types, where sometimes it's an actual address and sometimes (eg. TR_HelperAddress) it's a symref
-    *  for cases when _targetAddress is actually a symref we cast it back to symref in TR::AheadOfTimeCompile::initialiseAOTRelocationHeader
+    *  for cases when _targetAddress is actually a symref we cast it back to symref in TR::AheadOfTimeCompile::initializeAOTRelocationHeader
     *
     * In this case
     * generateRegLitRefInstruction creates a ConstantDataSnippet with reloType: TR_HelperAddress, which creates a 32Bit/64Bit ExternalRelocation

--- a/runtime/ddrext/ddrutils.c
+++ b/runtime/ddrext/ddrutils.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -191,8 +191,8 @@ dbgFindPatternInRange(U_8* pattern, UDATA patternLength, UDATA patternAlignment,
 		U_8*  lastByteToSearchWithinTheRegion = NULL;
 		UDATA bytesToSearchWithinTheRegion = 0;
 		UDATA bytesSearchedWithinTheRegion = 0;
-		dbgRegionIteratorState regionIteratorState; /* initialised by subsequent memset */
-		dbgRegion region; /* initialised by subsequent memset */
+		dbgRegionIteratorState regionIteratorState; /* initialized by subsequent memset */
+		dbgRegion region; /* initialized by subsequent memset */
 		IDATA result = 0;
 
 		memset (&regionIteratorState, 0, sizeof(dbgRegionIteratorState));

--- a/runtime/gc_base/WorkPacketsIterator.cpp
+++ b/runtime/gc_base/WorkPacketsIterator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ MM_PacketListIterator::MM_PacketListIterator(MM_EnvironmentBase *env, MM_WorkPac
 	_typeId = __FUNCTION__;
 	I_32 numLists=0;
 	
-	/* Initialise storage for the packet lists array*/
+	/* Initialize storage for the packet lists array*/
 	for (I_32 i = 0; i < _numPacketLists +1; i++) {    
 		_packetLists[i] = NULL;
 	}

--- a/runtime/gc_include/VerboseGCInterface.h
+++ b/runtime/gc_include/VerboseGCInterface.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ extern "C" {
 /**
  * Initializes the verbose function table.
  */
-void initialiseVerboseFunctionTable(J9JavaVM *javaVM);
+void initializeVerboseFunctionTable(J9JavaVM *javaVM);
 	
 /**
  * Definition of Verbose function table.

--- a/runtime/gc_modron_startup/GCVerboseInterface.cpp
+++ b/runtime/gc_modron_startup/GCVerboseInterface.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,7 +100,7 @@ dummygcDumpMemorySizes(J9JavaVM *javaVM)
  * @param table Pointer to the Verbose function table.
  */
 void
-initialiseVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table)
+initializeVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table)
 {
 	table->gcDebugVerboseStartupLogging = dummygcDebugVerboseStartupLogging;
 	table->gcDebugVerboseShutdownLogging = dummygcDebugVerboseShutdownLogging;

--- a/runtime/gc_modron_startup/mmhelpers.cpp
+++ b/runtime/gc_modron_startup/mmhelpers.cpp
@@ -48,7 +48,7 @@
 
 extern "C" {
 extern J9MemoryManagerFunctions MemoryManagerFunctions;
-extern void initialiseVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table);
+extern void initializeVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table);
 
 /**
  * sets the mode where TLH pages are zeroed

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -138,7 +138,7 @@ UDATA getUserExtendedPrivateAreaMemoryType();
 
 extern "C" {
 extern J9MemoryManagerFunctions MemoryManagerFunctions;
-extern void initialiseVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table);
+extern void initializeVerboseFunctionTableWithDummies(J9MemoryManagerVerboseInterface *table);
 
 static void hookValidatorVMThreadCrash(J9HookInterface * * hookInterface, UDATA eventNum, void * eventData, void * userData);
 static bool gcInitializeVMHooks(MM_GCExtensionsBase *extensions);
@@ -2822,7 +2822,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 		goto error;
 	}
 
-	initialiseVerboseFunctionTableWithDummies(&extensions->verboseFunctionTable);
+	initializeVerboseFunctionTableWithDummies(&extensions->verboseFunctionTable);
 
 	if (JNI_OK != gcParseCommandLineAndInitializeWithValues(vm, memoryParameterTable)) {
 		loadInfo->fatalErrorStr = (char *)j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_GC_FAILED_TO_INITIALIZE_PARSING_COMMAND_LINE, "Failed to initialize, parsing command line.");

--- a/runtime/gc_trace/TgcAllocationContext.cpp
+++ b/runtime/gc_trace/TgcAllocationContext.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@ tgcHookReportAllocationContextStatistics(J9HookInterface** hook, UDATA eventNum,
 
 
 /**
- * Initialise AC tgc tracing.
+ * Initialize AC tgc tracing.
  * Attaches hooks to the appropriate functions handling events used by AC tgc tracing.
  */
 bool

--- a/runtime/gc_trace/TgcConcurrent.cpp
+++ b/runtime/gc_trace/TgcConcurrent.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,8 +81,8 @@ tgcHookConcurrentBackgroundThreadFinished(J9HookInterface** hook, UDATA eventNum
 }
 
 /**
- * Initialise concurrent tgc tracing.
- * Initialises the TgcConcurrentExtensions object associated with concurrent tgc tracing. Attaches hooks
+ * Initialize concurrent tgc tracing.
+ * Initializes the TgcConcurrentExtensions object associated with concurrent tgc tracing. Attaches hooks
  * to the appropriate functions handling events used by concurrent tgc tracing.
  */
 bool

--- a/runtime/gc_trace/TgcConcurrentcardcleaning.cpp
+++ b/runtime/gc_trace/TgcConcurrentcardcleaning.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,8 +86,8 @@ tgcHookCardCleaningComplete(J9HookInterface** hook, UDATA eventNum, void* eventD
 }
 
 /**
- * Initialise cardcleaning tgc tracing.
- * Initialises the TgcConcurrentExtensions object associated with concurrent tgc tracing.
+ * Initialize cardcleaning tgc tracing.
+ * Initializes the TgcConcurrentExtensions object associated with concurrent tgc tracing.
  * Attaches hooks to the appropriate functions handling events used by card cleaning tgc tracing.
  */
 bool

--- a/runtime/gc_trace/TgcExcessivegc.cpp
+++ b/runtime/gc_trace/TgcExcessivegc.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,8 +90,8 @@ tgcHookExcessiveGCRaised(J9HookInterface** hook, UDATA eventNum, void* eventData
 }
 
 /**
- * Initialise excessive tgc tracing.
- * Initialises the TgcExcessiveGCExtensions object associated with excessive GC  tgc tracing. Attaches hooks
+ * Initialize excessive tgc tracing.
+ * Initializes the TgcExcessiveGCExtensions object associated with excessive GC  tgc tracing. Attaches hooks
  * to the appropriate functions handling events used by excessive GC tgc tracing. 
  */
 bool

--- a/runtime/gc_trace/TgcNuma.cpp
+++ b/runtime/gc_trace/TgcNuma.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -119,7 +119,7 @@ tgcHookReportNumaStatistics(J9HookInterface** hook, UDATA eventNum, void* eventD
 
 
 /**
- * Initialise NUMA tgc tracing.
+ * Initialize NUMA tgc tracing.
  * Attaches hooks to the appropriate functions handling events used by NUMA tgc tracing.
  */
 bool

--- a/runtime/gc_trace_standard/TgcCompaction.cpp
+++ b/runtime/gc_trace_standard/TgcCompaction.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -143,8 +143,8 @@ tgcHookCompactEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void*
 
 
 /**
- * Initialise compaction tgc tracing.
- * Initialises the TgcCompactionExtensions object associated with concurrent tgc tracing. Attaches hooks
+ * Initialize compaction tgc tracing.
+ * Initializes the TgcCompactionExtensions object associated with concurrent tgc tracing. Attaches hooks
  * to the appropriate functions handling events used by concurrent tgc tracing.
  */
 bool

--- a/runtime/gc_trace_vlhgc/TgcIntelligentCompact.cpp
+++ b/runtime/gc_trace_vlhgc/TgcIntelligentCompact.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -184,7 +184,7 @@ tgcHookReportIntelligentCompactStatistics(J9HookInterface** hook, UDATA eventNum
 
 
 /**
- * Initialise NUMA tgc tracing.
+ * Initialize NUMA tgc tracing.
  * Attaches hooks to the appropriate functions handling events used by NUMA tgc tracing.
  */
 bool

--- a/runtime/gc_trace_vlhgc/TgcWriteOnceCompaction.cpp
+++ b/runtime/gc_trace_vlhgc/TgcWriteOnceCompaction.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,8 +144,8 @@ tgcHookCompactEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void*
 
 
 /**
- * Initialise compaction tgc tracing.
- * Initialises the TgcCompactionExtensions object associated with concurrent tgc tracing. Attaches hooks
+ * Initialize compaction tgc tracing.
+ * Initializes the TgcCompactionExtensions object associated with concurrent tgc tracing. Attaches hooks
  * to the appropriate functions handling events used by concurrent tgc tracing.
  */
 bool

--- a/runtime/gc_verbose_java/VerboseJava.cpp
+++ b/runtime/gc_verbose_java/VerboseJava.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ J9MemoryManagerVerboseInterface functionTable = {
  * Initializes the verbose function table.
  */
 void
-initialiseVerboseFunctionTable(J9JavaVM *javaVM)
+initializeVerboseFunctionTable(J9JavaVM *javaVM)
 {
 	J9MemoryManagerVerboseInterface *mmFuncTable;
 	J9MemoryManagerVerboseInterface *verboseTable = &functionTable;

--- a/runtime/include/rastrace_external.h
+++ b/runtime/include/rastrace_external.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,7 +90,7 @@ typedef struct OMRTraceLanguageInterface {
 /*
  * =============================================================================
  *  Functions called by users of the trace library at initialisation/shutdown time.
- *  (Runtime functions are called vi UtInterface->UtServerInterface once initialised)
+ *  (Runtime functions are called vi UtInterface->UtServerInterface once initialized)
  * =============================================================================
  */
 
@@ -296,7 +296,7 @@ omr_error_t setTraceHeaderInfo(const char * serviceInfo, const char * startupInf
  * }
  * where ReportCommandLineErrorFunc is the same function (or the same underlying functionality)
  * as passed to the trace engine in field OMRTraceLanguageInterface.ReportCommandLineError when trace
- * was initialised. This allows trace implementors to integrate their own debugging messages
+ * was initialized. This allows trace implementors to integrate their own debugging messages
  * with those from the trace engine without having to create a separate debugging mechanism.
  *
  * @return The integer debug level the trace engine is using.

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -3270,7 +3270,7 @@ jvmtiRegisterTracePointSubscriber(jvmtiEnv* env, char *description, jvmtiTraceSu
 
 		PORT_ACCESS_FROM_JAVAVM(vm);
 
-		/* Create and initialise wrapper structure. This is used in the function wrappers for the user callbacks */
+		/* Create and initialize wrapper structure. This is used in the function wrappers for the user callbacks */
 		UserDataWrapper *wrapper = j9mem_allocate_memory(sizeof(UserDataWrapper), J9MEM_CATEGORY_JVMTI);
 		if (wrapper == NULL) {
 			rc = JVMTI_ERROR_OUT_OF_MEMORY;

--- a/runtime/nls/j9ri/j9ri.nls
+++ b/runtime/nls/j9ri/j9ri.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=initialise JVMRI unable to allocate jvmri dump monitor
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=initialize JVMRI unable to allocate jvmri dump monitor
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable 

--- a/runtime/nls/j9ri/j9ri_ca.nls
+++ b/runtime/nls/j9ri/j9ri_ca.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=La inicialitzaci\u00f3 de JVMRI no pot assignar un supervisor d'abocament de mem\u00f2ria de jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=La inicialitzaci\u00f3 de JVMRI no pot assignar un supervisor d'abocament de mem\u00f2ria de jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_cs.nls
+++ b/runtime/nls/j9ri/j9ri_cs.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=Inicializace JVMRI nem\u016f\u017ee p\u0159id\u011blit monitor v\u00fdpisu jvmri.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=Inicializace JVMRI nem\u016f\u017ee p\u0159id\u011blit monitor v\u00fdpisu jvmri.
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_de.nls
+++ b/runtime/nls/j9ri/j9ri_de.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=Bei der JVMRI-Initialisierung kann der JVMRI-Speicherauszugsmonitor nicht zugeordnet werden.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=Bei der JVMRI-Initialisierung kann der JVMRI-Speicherauszugsmonitor nicht zugeordnet werden.
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_es.nls
+++ b/runtime/nls/j9ri/j9ri_es.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=inicializar JVMRI, no puede asignar supervisor de volcados jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=inicializar JVMRI, no puede asignar supervisor de volcados jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_fr.nls
+++ b/runtime/nls/j9ri/j9ri_fr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=JVMRI en cous d'initialisation ne peut pas allouer de moniteur dump jvri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=JVMRI en cous d'initialisation ne peut pas allouer de moniteur dump jvri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_hu.nls
+++ b/runtime/nls/j9ri/j9ri_hu.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=a JVMRI inicializ\u00e1l\u00e1sa nem tud jvmri ki\u00edrat\u00e1sfigyel\u0151t lefoglalni
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=a JVMRI inicializ\u00e1l\u00e1sa nem tud jvmri ki\u00edrat\u00e1sfigyel\u0151t lefoglalni
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_it.nls
+++ b/runtime/nls/j9ri/j9ri_it.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=JVMRI di inizializzazione: impossibile allocare il controllo di dump jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=JVMRI di inizializzazione: impossibile allocare il controllo di dump jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_ja.nls
+++ b/runtime/nls/j9ri/j9ri_ja.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=\u521d\u671f\u5316 JVMRI \u306f jvmri \u30c0\u30f3\u30d7\u30fb\u30e2\u30cb\u30bf\u30fc\u3092\u5272\u308a\u632f\u308b\u3053\u3068\u304c\u3067\u304d\u307e\u305b\u3093
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=\u521d\u671f\u5316 JVMRI \u306f jvmri \u30c0\u30f3\u30d7\u30fb\u30e2\u30cb\u30bf\u30fc\u3092\u5272\u308a\u632f\u308b\u3053\u3068\u304c\u3067\u304d\u307e\u305b\u3093
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_ko.nls
+++ b/runtime/nls/j9ri/j9ri_ko.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=JVMRI \ucd08\uae30\ud654\uc5d0\uc11c jvmri \ub364\ud504 \ubaa8\ub2c8\ud130\ub97c \ud560\ub2f9\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=JVMRI \ucd08\uae30\ud654\uc5d0\uc11c jvmri \ub364\ud504 \ubaa8\ub2c8\ud130\ub97c \ud560\ub2f9\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_pl.nls
+++ b/runtime/nls/j9ri/j9ri_pl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=JVMRI inicjowania nie mo\u017ce przydzieli\u0107 monitora zrzutu jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=JVMRI inicjowania nie mo\u017ce przydzieli\u0107 monitora zrzutu jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_pt_BR.nls
+++ b/runtime/nls/j9ri/j9ri_pt_BR.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=O JVMRI de inicializa\u00e7\u00e3o n\u00e3o pode alocar monitor de dump jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=O JVMRI de inicializa\u00e7\u00e3o n\u00e3o pode alocar monitor de dump jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_ru.nls
+++ b/runtime/nls/j9ri/j9ri_ru.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=\u043f\u0440\u0438 \u0438\u043d\u0438\u0446\u0438\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438 JVMRI \u043d\u0435 \u0443\u0434\u0430\u0435\u0442\u0441\u044f \u0432\u044b\u0434\u0435\u043b\u0438\u0442\u044c \u043c\u043e\u043d\u0438\u0442\u043e\u0440 \u0434\u0430\u043c\u043f\u0430 jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=\u043f\u0440\u0438 \u0438\u043d\u0438\u0446\u0438\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438 JVMRI \u043d\u0435 \u0443\u0434\u0430\u0435\u0442\u0441\u044f \u0432\u044b\u0434\u0435\u043b\u0438\u0442\u044c \u043c\u043e\u043d\u0438\u0442\u043e\u0440 \u0434\u0430\u043c\u043f\u0430 jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_sk.nls
+++ b/runtime/nls/j9ri/j9ri_sk.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=inicializ\u00e1cia JVMRI nedok\u00e1\u017ee alokova\u0165 monitor v\u00fdpisov jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=inicializ\u00e1cia JVMRI nedok\u00e1\u017ee alokova\u0165 monitor v\u00fdpisov jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_sl.nls
+++ b/runtime/nls/j9ri/j9ri_sl.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=inicializacijski JVMRI ne more dodeliti nadzornika izpisa pomnilnika jvmri
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=inicializacijski JVMRI ne more dodeliti nadzornika izpisa pomnilnika jvmri
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_tr.nls
+++ b/runtime/nls/j9ri/j9ri_tr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=JVMRI kullan\u0131ma haz\u0131rlama i\u015flemi jvmri d\u00f6k\u00fcm izleyicisi ay\u0131ram\u0131yor
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=JVMRI kullan\u0131ma haz\u0131rlama i\u015flemi jvmri d\u00f6k\u00fcm izleyicisi ay\u0131ram\u0131yor
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_zh.nls
+++ b/runtime/nls/j9ri/j9ri_zh.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=\u521d\u59cb\u5316 JVMRI \u65e0\u6cd5\u5206\u914d jvmri \u8f6c\u50a8\u76d1\u89c6\u5668
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=\u521d\u59cb\u5316 JVMRI \u65e0\u6cd5\u5206\u914d jvmri \u8f6c\u50a8\u76d1\u89c6\u5668
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ri/j9ri_zh_CN.nls
+++ b/runtime/nls/j9ri/j9ri_zh_CN.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=\u521d\u59cb\u5316 JVMRI \u65e0\u6cd5\u5206\u914d jvmri \u8f6c\u50a8\u76d1\u89c6\u5668
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=\u521d\u59cb\u5316 JVMRI \u65e0\u6cd5\u5206\u914d jvmri \u8f6c\u50a8\u76d1\u89c6\u5668
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable 

--- a/runtime/nls/j9ri/j9ri_zh_TW.nls
+++ b/runtime/nls/j9ri/j9ri_zh_TW.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -221,11 +221,11 @@ J9NLS_RI_RUNDUMPROUTINE_NOT_SUPPORTED.user_response=Remove the JVMRI RunDumpRout
 # END NON-TRANSLATABLE
 
 # JVMRI is not translatable
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR=\u8d77\u59cb\u8a2d\u5b9a JVMRI \u7121\u6cd5\u914d\u7f6e jvmri \u50be\u51fa\u76e3\u8996\u5668
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR=\u8d77\u59cb\u8a2d\u5b9a JVMRI \u7121\u6cd5\u914d\u7f6e jvmri \u50be\u51fa\u76e3\u8996\u5668
 # START NON-TRANSLATABLE
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialise the JVMRI interface because the JVM was unable to allocate a monitor.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
-J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.explanation=The JVM failed to initialize the JVMRI interface because the JVM was unable to allocate a monitor.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.system_action=The JVM terminates.
+J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR.user_response=Investigate process memory usage and retry.
 # END NON-TRANSLATABLE
 
 # jvmri->TraceRegister, jvmri->TraceDeregister, TraceListener and JVMRAS_VERSION_1_5 are not translatable

--- a/runtime/nls/j9ti/jvmti_fr.nls
+++ b/runtime/nls/j9ti/jvmti_fr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -322,7 +322,7 @@ J9NLS_JVMTI_COM_IBM_ASYNC_EVENT.user_response=None
 
 # END NON-TRANSLATABLE
 
-J9NLS_JVMTI_COM_IBM_JVM_RESET_VM_DUMP_DESCRIPTION=R\u00e9initialise les options de vidage de la machine virtuelle.
+J9NLS_JVMTI_COM_IBM_JVM_RESET_VM_DUMP_DESCRIPTION=R\u00e9initialize les options de vidage de la machine virtuelle.
 # START NON-TRANSLATABLE
 J9NLS_JVMTI_COM_IBM_JVM_RESET_VM_DUMP_DESCRIPTION.explanation=Internationalized description of a JVMTI extension
 J9NLS_JVMTI_COM_IBM_JVM_RESET_VM_DUMP_DESCRIPTION.system_action=None

--- a/runtime/nls/j9vm/j9vm_fr.nls
+++ b/runtime/nls/j9vm/j9vm_fr.nls
@@ -234,7 +234,7 @@ J9NLS_VM_OUT_OF_MEM_FOR_DLL_POOL.user_response=Check the system memory configura
 # END NON-TRANSLATABLE
 
 # Note: %.*s is a class name
-J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS=Erreur irr\u00e9m\u00e9diable : Impossible de trouver et d'initialiser la classe requise %.*s
+J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS=Erreur irr\u00e9m\u00e9diable : Impossible de trouver et d'initializer la classe requise %.*s
 # START NON-TRANSLATABLE
 J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS.sample_input_1=9
 J9NLS_VM_UNABLE_TO_FIND_AND_INITIALIZE_REQUIRED_CLASS.sample_input_2=userClass

--- a/runtime/nls/shrc/j9shr_fr.nls
+++ b/runtime/nls/shrc/j9shr_fr.nls
@@ -2462,7 +2462,7 @@ J9NLS_SHRC_M_FAILED_CREATE_HINTTABLE.system_action=The JVM fails to complete the
 J9NLS_SHRC_M_FAILED_CREATE_HINTTABLE.user_response=System is running low on memory resource for the JVM to work properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_CM_FAILED_INIT_SEGMENTS=impossible d'initialiser les segments de m\u00e9moire de classe du cachelet.
+J9NLS_SHRC_CM_FAILED_INIT_SEGMENTS=impossible d'initializer les segments de m\u00e9moire de classe du cachelet.
 # START NON-TRANSLATABLE
 J9NLS_SHRC_CM_FAILED_INIT_SEGMENTS.explanation=An error has occurred in shared class initialization.
 J9NLS_SHRC_CM_FAILED_INIT_SEGMENTS.system_action=The JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM continues without using Shared Classes.

--- a/runtime/nls/vrfy/j9bcv_fr.nls
+++ b/runtime/nls/vrfy/j9bcv_fr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -399,7 +399,7 @@ J9NLS_BCV_ERR_VERIFY_OUT_OF_MEMORY.user_response=Ensure the system has sufficien
 
 # END NON-TRANSLATABLE
 
-J9NLS_BCV_ERR_WRONG_INIT_METHOD=invokespecial d'un initialiseur incorrect
+J9NLS_BCV_ERR_WRONG_INIT_METHOD=invokespecial d'un initializeur incorrect
 # START NON-TRANSLATABLE
 J9NLS_BCV_ERR_WRONG_INIT_METHOD.explanation=An 'invokespecial' bytecode targets an <init> method of the wrong class for the uninitialized object being constructed.
 J9NLS_BCV_ERR_WRONG_INIT_METHOD.system_action=The JVM will throw a verification or classloading related exception such as java.lang.VerifyError.

--- a/runtime/oti/rasdump_api.h
+++ b/runtime/oti/rasdump_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -212,7 +212,7 @@ printDumpSpec(struct J9JavaVM *vm, IDATA kind, IDATA verboseLevel);
  * @param state [inout] State bit flags. Used to maintain state between multiple calls of runDumpAgent. 
  *                 When you've performed all runDumpAgent calls you must call unwindAfterDump to make 
  *                 sure all locks are cleaned up. The first time runDumpAgent is called, state should 
- *                 be initialised to 0.
+ *                 be initialized to 0.
  * @param detail [in] Detail string for dump cause
  * @param timeNow [in] Time value as returned from j9time_current_time_millis. Used to timestamp the dumps.
  *

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2170,7 +2170,7 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 
 /**
 * @brief Iterate over fields of the specified class in JVMTI order.
-* @param state[in/out]  the walk state that was initialised via fieldOffsetsStartDo()
+* @param state[in/out]  the walk state that was initialized via fieldOffsetsStartDo()
 * @return J9ROMFieldOffsetWalkResult *
 */
 J9ROMFieldOffsetWalkResult *
@@ -2189,7 +2189,7 @@ fullTraversalFieldOffsetsStartDo(J9JavaVM *vm, J9Class *clazz, J9ROMFullTraversa
 
 /**
 * @brief Fully traverse the fields of the specified class and its superclasses.
-* @param state[in/out]  the walk state that was initialised via fullTraversalFieldOffsetsStartDo()
+* @param state[in/out]  the walk state that was initialized via fullTraversalFieldOffsetsStartDo()
 * @return J9ROMFieldShape *
 */
 J9ROMFieldShape *

--- a/runtime/port/common/j9shsem.c
+++ b/runtime/port/common/j9shsem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ j9shsem_params_init(struct J9PortLibrary *portLibrary, struct J9PortShSemParamet
  * Open an existing semaphore set, or create a new one if it does not exist
  * 
  * @param[in] portLibrary The port library.
- * @param[out] handle A semaphore handle is allocated and initialised for use with further calls, NULL on failure.
+ * @param[out] handle A semaphore handle is allocated and initialized for use with further calls, NULL on failure.
  * @param[in] params struct containing semaphore name, permissions, etc.
  *
  * @return

--- a/runtime/port/common/j9shsem_deprecated.c
+++ b/runtime/port/common/j9shsem_deprecated.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ j9shsem_deprecated_openDeprecated (struct J9PortLibrary *portLibrary, const char
  * @param[in] portLibrary The port library.
  * @param[in] cacheDirName The name of the cache directory
  * @param[in] groupPerm Group permissions to open the cache directory
- * @param[out] handle A semaphore handle is allocated and initialised for use with further calls, NULL on failure.
+ * @param[out] handle A semaphore handle is allocated and initialized for use with further calls, NULL on failure.
  * @param[in] semname Unique identifier of the semaphore.
  * @param[in] setSize Size of the semaphore set.
  * @param[in] permission Permission to the semaphore set.

--- a/runtime/port/win32/j9shmem.c
+++ b/runtime/port/win32/j9shmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,7 +105,7 @@ j9shmem_open(struct J9PortLibrary *portLibrary, const char* cacheDirName, uintpt
 		secattr.lpSecurityDescriptor=&secdes;
 		secattr.bInheritHandle = FALSE; 
 
-		/* Initialise the creationMutex */
+		/* Initialize the creationMutex */
 		Trc_PRT_shmem_j9shmem_open_globalMutexCreate();
 		PPG_shmem_creationMutex = CreateMutex(&secattr, FALSE, J9PORT_SHMEM_CREATIONMUTEX);
 		lastError = GetLastError();

--- a/runtime/port/win32/j9shsem.c
+++ b/runtime/port/win32/j9shsem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ j9shsem_open(struct J9PortLibrary *portLibrary, struct j9shsem_handle **handle, 
 		secattr.lpSecurityDescriptor=&secdes;
 		secattr.bInheritHandle = FALSE; 
 
-		/* Initialise the creationMutex */
+		/* Initialize the creationMutex */
 		Trc_PRT_shsem_j9shsem_open_globalMutexCreate();
 		PPG_shsem_creationMutex = CreateMutex(&secattr, FALSE, J9PORT_SHSEM_CREATIONMUTEX);
 		lastError = GetLastError();

--- a/runtime/port/win32/j9shsem_deprecated.c
+++ b/runtime/port/win32/j9shsem_deprecated.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ j9shsem_deprecated_open (struct J9PortLibrary *portLibrary, const char* cacheDir
 		secattr.lpSecurityDescriptor=&secdes;
 		secattr.bInheritHandle = FALSE; 
 
-		/* Initialise the creationMutex */
+		/* Initialize the creationMutex */
 		Trc_PRT_shsem_j9shsem_open_globalMutexCreate();
 		PPG_shsem_creationMutex = CreateMutex(&secattr, FALSE, J9PORT_SHSEM_CREATIONMUTEX);
 		lastError = GetLastError();

--- a/runtime/port/win32/j9sock.c
+++ b/runtime/port/win32/j9sock.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2702,7 +2702,7 @@ createAndRunOneOffDumpAgent(struct J9JavaVM *vm,J9RASdumpContext * context,IDATA
  * state [inout] - State bit flags. Used to maintain state between multiple calls of runDumpAgent. 
  *                 When you've performed all runDumpAgent calls you must call unwindAfterDump passing
  *                 the state variable to make sure all locks are cleaned up. The first time runDumpAgent 
- *                 is called, state should be initialised to 0.
+ *                 is called, state should be initialized to 0.
  * detail    -     Detail string for dump cause
  * timeNow [in] -  Time value as returned from j9time_current_time_millis. Used to timestamp the dumps.
  *

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1233,7 +1233,7 @@ JavaCoreDumpWriter::writeEnvironmentSection(void)
 			}
 		}
 	} else {
-		/* the iterator didn't initialise so no user limits to print */
+		/* the iterator didn't initialize so no user limits to print */
 		_OutputStream.writeCharacters("2CIULIMITERR   Not supported on this platform\n");
 	}
 

--- a/runtime/rastrace/method_trigger.c
+++ b/runtime/rastrace/method_trigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -228,7 +228,7 @@ addMethodBlockEntry(J9VMThread *thr, J9Method *method, RasTriggerMethodRule * ru
 		dbg_err_printf(1, PORTLIB, "<UT> Out of memory processing trigger property.");
 	} else {
 		/*
-		 * Initialise the RasTriggeredMethodBlock
+		 * Initialize the RasTriggeredMethodBlock
 		 */
 		memset(tmb, '\0', sizeof(RasTriggeredMethodBlock));
 		tmb->next = NULL;
@@ -390,7 +390,7 @@ setMethod(J9JavaVM *vm, const char *value, BOOLEAN atRuntime)
 				}
 
 				/*
-				 * Initialise some fields in the new RasMethodTable.
+				 * Initialize some fields in the new RasMethodTable.
 				 */
 				if (i < count) {
 					mt->next = mt + 1;
@@ -637,10 +637,10 @@ addTriggeredMethodSpec(J9VMThread *thr, const char *ptrMethodSpec, const struct 
 		 * Now populate the RasTriggerMethodRule
 		 */
 
-		/* initialise header */
+		/* initialize header */
 		memset(methodRule, '\0', sizeof(RasTriggerMethodRule));
 
-		/* initialise body */
+		/* initialize body */
 		methodRule->next = NULL; /* next method rule           */
 		methodRule->tmbChain = NULL; /* method block entry chain   */
 		methodRule->methodTable = mt; /* method spec etc            */

--- a/runtime/rastrace/rastrace_internal.h
+++ b/runtime/rastrace/rastrace_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -315,9 +315,9 @@ typedef struct UtComponentList{
 	UtDeferredConfigInfo  *deferredConfigInfoHead;
 } UtComponentList;
 
-omr_error_t initialiseComponentData(UtComponentData **componentDataPtr, UtModuleInfo *moduleInfo, const char *componentName);
+omr_error_t initializeComponentData(UtComponentData **componentDataPtr, UtModuleInfo *moduleInfo, const char *componentName);
 void freeComponentData(UtComponentData *componentDataPtr);
-omr_error_t initialiseComponentList(UtComponentList **componentListPtr);
+omr_error_t initializeComponentList(UtComponentList **componentListPtr);
 omr_error_t freeComponentList(UtComponentList *componentList);
 omr_error_t addComponentToList(UtComponentData *componentData, UtComponentList *componentList);
 omr_error_t removeModuleFromList(UtModuleInfo* module, UtComponentList *componentList);

--- a/runtime/rastrace/traceformat.h
+++ b/runtime/rastrace/traceformat.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2014 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,9 +59,9 @@ typedef struct  UtTracePointIterator UtTracePointIterator;
  * This iterator can then be used to obtain trace point iterators over each
  * buffer in the file via calls to omr_trc_getTracePointIteratorForNextBuffer
  *
- * @param[in] portLib An initialised OMRPortLibrary structure.
+ * @param[in] portLib An initialized OMRPortLibrary structure.
  * @param[in] fileName The name of the trace file to open.
- * @param[in,out] iteratorPtr A pointer to a location where the initialised UtTraceFileIterator pointer can be stored.
+ * @param[in,out] iteratorPtr A pointer to a location where the initialized UtTraceFileIterator pointer can be stored.
  * @param[in] getFormatString A callback the formatter can use to obtain a format string for a trace point id in a named module.
  *
  * @return OMR_ERROR_NONE on success

--- a/runtime/rastrace/trccomponent.c
+++ b/runtime/rastrace/trccomponent.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,13 +45,13 @@ static char *UT_MISSING_TRACE_FORMAT = "  Tracepoint format not in dat file";
 #define MAX_QUALIFIED_NAME_LENGTH 16
 
 omr_error_t
-initialiseComponentData(UtComponentData **componentDataPtr, UtModuleInfo *moduleInfo, const char *componentName)
+initializeComponentData(UtComponentData **componentDataPtr, UtModuleInfo *moduleInfo, const char *componentName)
 {
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	UtComponentData *componentData = (UtComponentData *) j9mem_allocate_memory(sizeof(UtComponentData), OMRMEM_CATEGORY_TRACE );
 
-	UT_DBGOUT(2, ("<UT> initialiseComponentData: %s\n", componentName));
+	UT_DBGOUT(2, ("<UT> initializeComponentData: %s\n", componentName));
 	if ( componentData == NULL){
 		UT_DBGOUT(1, ("<UT> Unable to allocate componentData for %s\n", componentName));
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
@@ -101,7 +101,7 @@ initialiseComponentData(UtComponentData **componentDataPtr, UtModuleInfo *module
 	componentData->prev = NULL;
 	
 	*componentDataPtr = componentData;
-	UT_DBGOUT(2, ("<UT> initialiseComponentData complete: %s\n", componentName));
+	UT_DBGOUT(2, ("<UT> initializeComponentData complete: %s\n", componentName));
 
 	return OMR_ERROR_NONE;
 }
@@ -151,12 +151,12 @@ freeComponentData(UtComponentData *componentDataPtr){
 }
 
 omr_error_t
-initialiseComponentList(UtComponentList **componentListPtr)
+initializeComponentList(UtComponentList **componentListPtr)
 {
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	UtComponentList *componentList = (UtComponentList *)j9mem_allocate_memory( sizeof(UtComponentList), OMRMEM_CATEGORY_TRACE);
-	UT_DBGOUT(2, ("<UT> initialiseComponentList: %p\n", componentListPtr));
+	UT_DBGOUT(2, ("<UT> initializeComponentList: %p\n", componentListPtr));
 	if ( componentList == NULL){
 		UT_DBGOUT(1, ("<UT> Unable to allocate component list\n" ));
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
@@ -167,7 +167,7 @@ initialiseComponentList(UtComponentList **componentListPtr)
 	componentList->deferredConfigInfoHead = NULL;
 
 	*componentListPtr = componentList;
-	UT_DBGOUT(2, ("<UT> initialiseComponentList: %p completed\n", componentListPtr));
+	UT_DBGOUT(2, ("<UT> initializeComponentList: %p completed\n", componentListPtr));
 	return OMR_ERROR_NONE;
 }
 

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -569,7 +569,7 @@ initializeUtInterface(void)
 		javaUtServerIntfS.StartupComplete = trcStartupComplete;
 
 		/*
-		 * Initialise the direct module interface, these
+		 * Initialize the direct module interface, these
 		 * are versions of the trace functions that expect
 		 * a J9VMThread as their env parameter rather than
 		 * an OMRVMThread.
@@ -619,7 +619,7 @@ processTraceOptionString(J9JavaVM *vm, char * opts[], IDATA * optIndex, const ch
 }
 
 /*
- * Initialise the trace options from the defaults for the J9VM and any
+ * Initialize the trace options from the defaults for the J9VM and any
  * options that were passed in on the command line.
  *
  * Returns them as newly allocated string key/value pairs in the even/odd elements of opts.

--- a/runtime/rastrace/trclog.c
+++ b/runtime/rastrace/trclog.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@ extern omrthread_tls_key_t j9rasTLSKey;
 
 /*******************************************************************************
  * name        - initEvent
- * description - Initialises a monitor. Takes a monitor name that will be copied.
+ * description - Initializes a monitor. Takes a monitor name that will be copied.
  * parameters  - UtEventSem
  * returns     - int32_t
  ******************************************************************************/
@@ -828,7 +828,7 @@ writeBuffer(UtSubscription *subscription)
 		 * Check for file wrap
 		 */
 		if (*wrap != 0 && *fileSize >= *wrap) {
-			/* Trace options may have changed, re-initialise the trace file header data if necessary */
+			/* Trace options may have changed, re-initialize the trace file header data if necessary */
 			initTraceHeader();
 			
 			if ((bufferType == UT_NORMAL_BUFFER) && (UT_GLOBAL(traceGenerations) > 1)) {
@@ -931,7 +931,7 @@ getTrcBuf(UtThreadData **thr, UtTraceBuffer * oldBuf, int bufferType)
 				}
 
 				/* Set up nextBuf */
-				/* it's okay to set the global buffers here and initialise later because the entire
+				/* it's okay to set the global buffers here and initialize later because the entire
 				 * function call's under the trace lock so nothing can be written to it until we release.
 				 */
 				if (bufferType == UT_NORMAL_BUFFER) {
@@ -964,7 +964,7 @@ getTrcBuf(UtThreadData **thr, UtTraceBuffer * oldBuf, int bufferType)
 
 				oldBuf->lostCount += 1;
 
-				/* it's okay to set the global buffers here and initialise later because the entire
+				/* it's okay to set the global buffers here and initialize later because the entire
 				 * function calls under the trace lock so nothing can be written to it until we release.
 				 */
 				if (bufferType == UT_NORMAL_BUFFER) {

--- a/runtime/rastrace/trcmain.c
+++ b/runtime/rastrace/trcmain.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -223,7 +223,7 @@ moduleLoaded(UtThreadData **thr, UtModuleInfo *modInfo)
 	if (modInfo->intf == NULL) {
 		modInfo->intf = internalUtIntfS.module;
 
-		rc = initialiseComponentData(&compData, modInfo, modInfo->name);
+		rc = initializeComponentData(&compData, modInfo, modInfo->name);
 		if (OMR_ERROR_NONE == rc) {
 			rc = addComponentToList(compData, UT_GLOBAL(componentList));
 		}
@@ -1141,13 +1141,13 @@ initializeTrace(UtThreadData **thr, void **gbl,
 		}
 	}
 
-	rc = initialiseComponentList(&UT_GLOBAL(componentList));
+	rc = initializeComponentList(&UT_GLOBAL(componentList));
 	if (OMR_ERROR_NONE != rc) {
 		UT_DBGOUT(1, ("<UT> Error initializing component list\n"));
 		goto fail;
 	}
 
-	rc = initialiseComponentList(&UT_GLOBAL(unloadedComponentList));
+	rc = initializeComponentList(&UT_GLOBAL(unloadedComponentList));
 	if (OMR_ERROR_NONE != rc) {
 		UT_DBGOUT(1, ("<UT> Error initializing unloaded component list\n"));
 		goto fail;
@@ -1881,7 +1881,7 @@ trcGetTraceMetadata(void **data, int32_t *length)
 {
 	UtTraceFileHdr *traceHeader;
 
-	/* Ensure we have initialised the trace header */
+	/* Ensure we have initialized the trace header */
 	if (initTraceHeader() != OMR_ERROR_NONE) {
 		return OMR_ERROR_INTERNAL;
 	}
@@ -1977,7 +1977,7 @@ trcRegisterTracePointSubscriber(UtThreadData **thr, char *description, utsSubscr
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 	}
 	
-	/* initialise the new subscription data structure */
+	/* initialize the new subscription data structure */
 	newSubscription->subscriber = subscriber;
 	newSubscription->userData = wrapper;
 	newSubscription->alarm = alarm;
@@ -2141,7 +2141,7 @@ fillInUTInterfaces(UtInterface **utIntf, UtServerInterface *utServerIntf, UtModu
 		memcpy(utServerIntf, &utServerIntfS, sizeof(UtServerInterface));
 
 		/*
-		 * Initialise the direct module interface, these are
+		 * Initialize the direct module interface, these are
 		 * wrappers to calls within trace that obtain a UtThreadData
 		 * before calling the real function.
 		 */

--- a/runtime/rastrace/trcmisc.c
+++ b/runtime/rastrace/trcmisc.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -319,7 +319,7 @@ addTraceConfig(UtThreadData **thr, const char *cmd)
 			tmp->next = cfg;
 		}
 
-		/* We should update the trace header here (if it has already been initialised) to
+		/* We should update the trace header here (if it has already been initialized) to
 		 * reflect the change in trace settings.
 		 * Unfortunately it may be in use by a snap dump or we may have returned a pointer to
 		 * it via trcGetTraceMetadata so freeing it or nulling it is unsafe.

--- a/runtime/rastrace/trctrigger.c
+++ b/runtime/rastrace/trctrigger.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2017 IBM Corp. and others
+ * Copyright (c) 2002, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -591,7 +591,7 @@ processTriggerTpnidClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 				}
 
 				/*
-				 * initialise the new tpid range
+				 * initialize the new tpid range
 				 */
 				if (OMR_ERROR_NONE == rc) {
 					/* header */
@@ -735,7 +735,7 @@ processTriggerGroupClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 			UT_DBGOUT(1, ("<UT> Out of memory processing trigger property."));
 		}
 
-		/* initialise the new tpid group */
+		/* initialize the new tpid group */
 		if (OMR_ERROR_NONE == rc) {
 			/* header */
 			memcpy(newTriggerGroupP->header.eyecatcher, "RSGR", 4);

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1831,7 +1831,7 @@ SH_CompositeCacheImpl::next(J9VMThread* currentThread)
 }
 
 /**
- * Initialise ShcItem Block data.
+ * Initialize ShcItem Block data.
  *
  * Simply initializes an "item" to the values set. Hides the _commonCCInfo->vmID in the dataType.
  *

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -603,7 +603,7 @@ private:
 		_romClassProtectEnd = pointer;
 	}
 
-	class SH_SharedCacheHeaderInit : public SH_OSCache::SH_OSCacheInitialiser
+	class SH_SharedCacheHeaderInit : public SH_OSCache::SH_OSCacheInitializer
 	{
 	protected:
 		void *operator new(size_t size, void *memoryPtr) { return memoryPtr; };

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -168,7 +168,7 @@ typedef struct LastErrorInfo {
 class SH_OSCache
 {
 public:
-	class SH_OSCacheInitialiser
+	class SH_OSCacheInitializer
 	{
 		public:
 		virtual void init(char* data, U_32 len, I_32 minAOT, I_32 maxAOT, I_32 minJIT, I_32 maxJIT, U_32 readWriteLen, U_32 softMaxBytes) = 0;
@@ -206,7 +206,7 @@ public:
 	bool isRunningReadOnly();
 
 	virtual bool startup(J9JavaVM* vm, const char* cacheDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, IDATA numLocks,
-			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitialiser* i, UDATA reason) = 0;
+			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* i, UDATA reason) = 0;
 
 	virtual IDATA destroy(bool suppressVerbose, bool isReset = false) = 0;
 

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -49,7 +49,7 @@
 /**
  * Multi-argument constructor
  * 
- * Constructs and initialises a SH_OSCachemmap object and calls startup to open/create 
+ * Constructs and initializes a SH_OSCachemmap object and calls startup to open/create 
  * a shared classes cache.
  * This c'tor is currently used during unit testing only. Therefore we pass J9SH_DIRPERM_ABSENT as cacheDirPerm to startup().
  *
@@ -67,20 +67,20 @@
  * \args J9OSCACHE_OPEN_MODE_GROUPACCESS - creates a cache with group access. Only applies when a cache is created
  * \args J9OSCACHE_OPEN_MODE_CHECK_NETWORK_CACHE - checks whether we are attempting to connect to a networked cache
  * @param [in]  versionData Version data of the cache to connect to
- * @param [in]  initialiser Pointer to an initialiser to be used to initialise the data
+ * @param [in]  initializer Pointer to an initializer to be used to initialize the data
  * 				area of a new cache
  */ 
 SH_OSCachemmap::SH_OSCachemmap(J9PortLibrary* portLibrary, J9JavaVM* vm, const char* cacheDirName, const char* cacheName, J9SharedClassPreinitConfig* piconfig,
-		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser)
+		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer)
 {
 	Trc_SHR_OSC_Mmap_Constructor_Entry(cacheName, piconfig->sharedClassCacheSize, numLocks, createFlag, verboseFlags);
 	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN);
-	startup(vm, cacheDirName, J9SH_DIRPERM_ABSENT, cacheName, piconfig, numLocks, createFlag, verboseFlags, runtimeFlags, openMode, 0, versionData, initialiser, SHR_STARTUP_REASON_NORMAL);
+	startup(vm, cacheDirName, J9SH_DIRPERM_ABSENT, cacheName, piconfig, numLocks, createFlag, verboseFlags, runtimeFlags, openMode, 0, versionData, initializer, SHR_STARTUP_REASON_NORMAL);
 	Trc_SHR_OSC_Mmap_Constructor_Exit();
 }
 
 /**
- * Method to initialise object variables.  This is outside the constructor for
+ * Method to initialize object variables.  This is outside the constructor for
  * consistency with SH_OSCachesysv
  * Note:  This method is public as it is called by the factory method newInstance in SH_OSCache
  * 
@@ -107,7 +107,7 @@ SH_OSCachemmap::initialize(J9PortLibrary* portLibrary, char* memForConstructor, 
 }
 
 /**
- * Method to free resources and re-initialise variables when
+ * Method to free resources and re-initialize variables when
  * cache is no longer required
  */
 void
@@ -147,7 +147,7 @@ SH_OSCachemmap::finalise()
  * \args J9OSCACHE_OPEN_MODE_GROUPACCESS - creates a cache with group access. Only applies when a cache is created
  * \args J9OSCACHE_OPEN_MODE_CHECK_NETWORK_CACHE - checks whether we are attempting to connect to a networked cache
  * @param [in]  versionData Version data of the cache to connect to
- * @param [in]  initialiser Pointer to an initialiser to be used to initialise the data
+ * @param [in]  initializer Pointer to an initializer to be used to initialize the data
  * 				area of a new cache
  * @param [in]  reason Reason for starting up the cache. Used only when startup is called during destroy
  * 
@@ -155,7 +155,7 @@ SH_OSCachemmap::finalise()
  */
 bool
 SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser, UDATA reason)
+		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer, UDATA reason)
 {
 	I_32 mmapCapabilities;
 	IDATA retryCntr;
@@ -378,13 +378,13 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 		}
 		Trc_SHR_OSC_Mmap_startup_goodCreateCacheHeader();
 
-		if (initialiser) {
-			if (!initialiseDataHeader(initialiser)) {
-				Trc_SHR_OSC_Mmap_startup_badInitialiseDataHeader();
+		if (initializer) {
+			if (!initializeDataHeader(initializer)) {
+				Trc_SHR_OSC_Mmap_startup_badInitializeDataHeader();
 				errorHandler(J9NLS_SHRC_OSCACHE_MMAP_STARTUP_ERROR_INITIALISING_DATA_HEADER, NULL);
 	 			goto _errorPostAttach;
 			}
-	 		Trc_SHR_OSC_Mmap_startup_goodInitialiseDataHeader();
+	 		Trc_SHR_OSC_Mmap_startup_goodInitializeDataHeader();
 		}
 		
 		if (_verboseFlags & J9SHR_VERBOSEFLAG_ENABLE_VERBOSE) {
@@ -1266,23 +1266,23 @@ SH_OSCachemmap::setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo)
 }
 
 /**
- * Method to run the initialiser supplied to the multi argument constructor
+ * Method to run the initializer supplied to the multi argument constructor
  * or the startup method against the data area of a new cache
  * 
- * @param [in] initialiser  Struct containing fields to initialize
+ * @param [in] initializer  Struct containing fields to initialize
  * 
  * @return true on success, false on failure
  * THREADING: Pre-req caller holds the cache header write lock
  */
 I_32
-SH_OSCachemmap::initialiseDataHeader(SH_OSCacheInitialiser *initialiser)
+SH_OSCachemmap::initializeDataHeader(SH_OSCacheInitializer *initializer)
 {
 	U_32 readWriteBytes = (U_32)((_config->sharedClassReadWriteBytes > 0) ? _config->sharedClassReadWriteBytes : 0);
 	U_32 softMaxBytes = (U_32)_config->sharedClassSoftMaxBytes;
 
-	Trc_SHR_OSC_Mmap_initialiseDataHeader_Entry();
+	Trc_SHR_OSC_Mmap_initializeDataHeader_Entry();
 	
-	Trc_SHR_OSC_Mmap_initialiseDataHeader_callinginit3(_dataStart,
+	Trc_SHR_OSC_Mmap_initializeDataHeader_callinginit3(_dataStart,
 															_dataLength, 
 															_config->sharedClassMinAOTSize, 
 															_config->sharedClassMaxAOTSize,
@@ -1295,10 +1295,10 @@ SH_OSCachemmap::initialiseDataHeader(SH_OSCacheInitialiser *initialiser)
 		softMaxBytes = (U_32)-1;
 	} else if (softMaxBytes > _actualFileLength) {
 		softMaxBytes = (U_32)_actualFileLength;
-		Trc_SHR_OSC_Mmap_initialiseDataHeader_softMaxBytesTooBig(softMaxBytes);
+		Trc_SHR_OSC_Mmap_initializeDataHeader_softMaxBytesTooBig(softMaxBytes);
 	}
 
-	initialiser->init((char*)_dataStart, 
+	initializer->init((char*)_dataStart, 
 								_dataLength, 
 								(I_32)_config->sharedClassMinAOTSize, 
 								(I_32)_config->sharedClassMaxAOTSize,
@@ -1306,9 +1306,9 @@ SH_OSCachemmap::initialiseDataHeader(SH_OSCacheInitialiser *initialiser)
 								(I_32)_config->sharedClassMaxJITSize,
 								readWriteBytes,
 								softMaxBytes);
-	Trc_SHR_OSC_Mmap_initialiseDataHeader_initialised();
+	Trc_SHR_OSC_Mmap_initializeDataHeader_initialized();
 	
-	Trc_SHR_OSC_Mmap_initialiseDataHeader_Exit();
+	Trc_SHR_OSC_Mmap_initializeDataHeader_Exit();
 	return true;
 }
 

--- a/runtime/shared_common/OSCachemmap.hpp
+++ b/runtime/shared_common/OSCachemmap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ public:
 	static IDATA getCacheStats(J9JavaVM* vm, const char* cacheDirName, const char* filePath, SH_OSCache_Info* returnVal, UDATA reason);
 	  
 	SH_OSCachemmap(J9PortLibrary* portlib, J9JavaVM* vm, const char* cacheDirName, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser);
+			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer);
 	/*This constructor should only be used by this class or its parent*/
 	SH_OSCachemmap() {};
 
@@ -56,7 +56,7 @@ public:
 	void *operator new(size_t sizeArg, void *memoryPtrArg) { return memoryPtrArg; };
 
 	virtual bool startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser, UDATA reason);
+			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer, UDATA reason);
 
 	virtual IDATA destroy(bool suppressVerbose, bool isReset = false);
 
@@ -113,7 +113,7 @@ private:
 	I_32 updateLastDetachedTime();
 	I_32 createCacheHeader(OSCachemmap_header_version_current *cacheHeader, J9PortShcVersion* versionData);
 	bool setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo);
-	I_32 initialiseDataHeader(SH_OSCacheInitialiser *initialiser);
+	I_32 initializeDataHeader(SH_OSCacheInitializer *initializer);
 	void detach();
 	
 	bool deleteCacheFile(LastErrorInfo *lastErrorInfo);

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -77,11 +77,11 @@
  * \args J9OSCACHE_OPEN_MODE_TRY_READONLY_ON_FAIL - if the cache could not be opened read/write - try readonly
  * \args J9OSCACHE_OPEN_MODE_GROUPACCESS - creates a cache with group access
  * @param [in]  versionData Version data of the cache to connect to
- * @param [in]  i Pointer to an initialiser to be used to initialise the data
+ * @param [in]  i Pointer to an initializer to be used to initialize the data
  * 				area of a new cache
  */
 SH_OSCachesysv::SH_OSCachesysv(J9PortLibrary* portLibrary, J9JavaVM* vm, const char* cachedirname, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitialiser* i)
+		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitializer* i)
 {
 	Trc_SHR_OSC_Constructor_Entry(cacheName, piconfig->sharedClassCacheSize, createFlag);
 	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN);
@@ -90,7 +90,7 @@ SH_OSCachesysv::SH_OSCachesysv(J9PortLibrary* portLibrary, J9JavaVM* vm, const c
 }
 
 /**
- * Method to initialise object variables
+ * Method to initialize object variables
  * 
  * @param [in]  portLib  The Port library
  * @param [in]  memForConstructor  Pointer to the memory to build the OSCachemmap into
@@ -135,7 +135,7 @@ SH_OSCachesysv::initialize(J9PortLibrary* portLib, char* memForConstructor, UDAT
  * \args J9OSCACHE_OPEN_MODE_TRY_READONLY_ON_FAIL - if the cache could not be opened read/write - try readonly
  * \args J9OSCACHE_OPEN_MODE_GROUPACCESS - creates a cache with group access
  * @param [in]  versionData Version data of the cache to connect to
- * @param [in]  i Pointer to an initialiser to be used to initialise the data
+ * @param [in]  i Pointer to an initializer to be used to initialize the data
  * 				area of a new cache
  * @param [in]  reason Reason for starting up the cache. Not used for non-persistent cache startup
  * 
@@ -143,7 +143,7 @@ SH_OSCachesysv::initialize(J9PortLibrary* portLib, char* memForConstructor, UDAT
  */
 bool
 SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks, UDATA create,
-		UDATA verboseFlags_, U_64 runtimeFlags_, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitialiser* i, UDATA reason)
+		UDATA verboseFlags_, U_64 runtimeFlags_, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitializer* i, UDATA reason)
 {
 	IDATA retryCount;
 	IDATA shsemrc = 0;
@@ -165,7 +165,7 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	
 	versionData->cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
 	_cacheSize = (piconfig!= NULL) ? (U_32)piconfig->sharedClassCacheSize : (U_32)defaultCacheSize;
-	_initialiser = i;
+	_initializer = i;
 	_totalNumSems = numLocks + 1;		/* +1 because of header mutex */
 	_userSemCntr = 0;
 	retryCount=J9SH_OSCACHE_RETRYMAX;
@@ -919,8 +919,8 @@ SH_OSCachesysv::initializeHeader(const char* cacheDirName, J9PortShcVersion* ver
 	/* jump over to the data area*/
 	region = SHM_DATASTARTFROMHEADER(myHeader);
 
-	if(_initialiser != NULL) { 
-		_initialiser->init((char*)region, dataLength, (I_32)_config->sharedClassMinAOTSize, (I_32)_config->sharedClassMaxAOTSize, (I_32)_config->sharedClassMinJITSize, (I_32)_config->sharedClassMaxJITSize, readWriteBytes, softMaxSize);
+	if(_initializer != NULL) { 
+		_initializer->init((char*)region, dataLength, (I_32)_config->sharedClassMinAOTSize, (I_32)_config->sharedClassMaxAOTSize, (I_32)_config->sharedClassMinJITSize, (I_32)_config->sharedClassMaxJITSize, readWriteBytes, softMaxSize);
 	}
 
 	if (J9_ARE_NO_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_RESTORE)) {
@@ -2677,13 +2677,13 @@ SH_OSCachesysv::getAttachedMemory()
  * @param[in] vm The current J9JavaVM
  * @param[in] cacheName The name of the cache
  * @param[in] numLocks The number of locks to be initialized
- * @param[in] i Pointer to an initialiser to be used to initialise the data area of the new cache
+ * @param[in] i Pointer to an initializer to be used to initialize the data area of the new cache
  * @param[in, out] cacheExist True if the cache to be restored already exits, false otherwise
  *
  * @return 0 on success and -1 on failure
  */
 IDATA
-SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA numLocks, SH_OSCache::SH_OSCacheInitialiser* i, bool* cacheExist)
+SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA numLocks, SH_OSCache::SH_OSCacheInitializer* i, bool* cacheExist)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	IDATA rc = 0;

--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -105,10 +105,10 @@ class SH_OSCachesysv : public SH_OSCache
 {
 public:
 	SH_OSCachesysv(J9PortLibrary* portlib, J9JavaVM* vm, const char* cachedirname, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, IDATA numLocks, UDATA createFlag,
-			UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitialiser* initialiser);
+			UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitializer* initializer);
 
 	virtual bool startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, IDATA numLocks, UDATA createFlag,
-			UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitialiser* i, UDATA reason);
+			UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCache::SH_OSCacheInitializer* i, UDATA reason);
 
 	/**
 	 * Override new operator
@@ -168,7 +168,7 @@ public:
 
 	SH_CacheAccess isCacheAccessible(void) const;
 
-	IDATA restoreFromSnapshot(J9JavaVM* vm, const char* snapshotName, UDATA numLocks, SH_OSCache::SH_OSCacheInitialiser* i, bool* cacheExist);
+	IDATA restoreFromSnapshot(J9JavaVM* vm, const char* snapshotName, UDATA numLocks, SH_OSCache::SH_OSCacheInitializer* i, bool* cacheExist);
 
 /* protected: */
 	/*This constructor should only be used by this class and parent*/
@@ -197,7 +197,7 @@ private:
 
 	const J9SharedClassPreinitConfig* config;
 
-	SH_OSCache::SH_OSCacheInitialiser* _initialiser;
+	SH_OSCache::SH_OSCacheInitializer* _initializer;
 	UDATA _groupPerm;
 
 	I_32 _semid;

--- a/runtime/shared_common/OSCachevmem.cpp
+++ b/runtime/shared_common/OSCachevmem.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@
 #include "UnitTest.hpp"
 
 SH_OSCachevmem::SH_OSCachevmem(J9PortLibrary* portLibrary, const char* cachedirname, const char* cacheName, J9SharedClassPreinitConfig* piconfig,
-		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser)
+		IDATA numLocks, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer)
 {
 	initialize(portLibrary, NULL, OSCACHE_CURRENT_CACHE_GEN);
-	startup(cachedirname, J9SH_DIRPERM_ABSENT, cacheName, piconfig, numLocks, createFlag, verboseFlags, runtimeFlags, openMode, 0, versionData, initialiser, SHR_STARTUP_REASON_NORMAL);
+	startup(cachedirname, J9SH_DIRPERM_ABSENT, cacheName, piconfig, numLocks, createFlag, verboseFlags, runtimeFlags, openMode, 0, versionData, initializer, SHR_STARTUP_REASON_NORMAL);
 }
 
 void
@@ -65,7 +65,7 @@ SH_OSCachevmem::initialize(J9PortLibrary* portLibrary, char* memForConstructor, 
 
 bool
 SH_OSCachevmem::startup(const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser, UDATA reason)
+		UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer, UDATA reason)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	U_32 readWriteBytes = (U_32)((piconfig->sharedClassReadWriteBytes > 0) ? piconfig->sharedClassReadWriteBytes : 0);
@@ -254,14 +254,14 @@ SH_OSCachevmem::startup(const char* ctrlDirName, UDATA cacheDirPerm, const char*
 												piconfig->sharedClassMinJITSize,
 												piconfig->sharedClassMaxJITSize,
 												readWriteBytes);
-		initialiser->init((char*)_dataStart, 
+		initializer->init((char*)_dataStart, 
 									_dataLength, 
 									(I_32)piconfig->sharedClassMinAOTSize, 
 									(I_32)piconfig->sharedClassMaxAOTSize,
 									(I_32)piconfig->sharedClassMinJITSize,
 									(I_32)piconfig->sharedClassMaxJITSize,
 									readWriteBytes);
-		Trc_SHR_OSC_Vmem_startup_initialised();
+		Trc_SHR_OSC_Vmem_startup_initialized();
 	}
 
 	_startupCompleted = true;

--- a/runtime/shared_common/OSCachevmem.hpp
+++ b/runtime/shared_common/OSCachevmem.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ class SH_OSCachevmem : public SH_OSCacheFile
 {
 public:
 	SH_OSCachevmem(J9PortLibrary* portlib, const char* cachedirname, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser);
+			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer);
 	/*This constructor should only be used by this class or its parent*/
 	SH_OSCachevmem() {};
 
@@ -61,7 +61,7 @@ public:
 	void *operator new(size_t sizeArg, void *memoryPtrArg) { return memoryPtrArg; };
 
 	virtual bool startup(const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
-			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitialiser* initialiser, UDATA reason);
+			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, UDATA storageKeyTesting, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer, UDATA reason);
 
 	virtual IDATA destroy(bool suppressVerbose, bool isReset);
 

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -521,8 +521,8 @@ TraceEvent=Trc_SHR_OSC_GlobalLock_getMutex NoEnv Overhead=1 Level=6 Group=OSCach
 TraceEvent=Trc_SHR_OSC_GlobalLock_gotMutex NoEnv Overhead=1 Level=6 Group=OSCache Template="OSCache Global Lock: ACQUIRED for cache rootName=%s"
 TraceEvent=Trc_SHR_OSC_GlobalLock_released NoEnv Overhead=1 Level=4 Group=OSCache Template="OSCache releasing Global Lock semaphore"
 
-TraceEvent=Trc_SHR_OSC_createNewCache_Event4 Obsolete NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache createNewCache calling initialiser, intialiser=%p len=%d"
-TraceEvent=Trc_SHR_OSC_createNewCache_Event5 Obsolete NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache createNewCache return from initialiser"
+TraceEvent=Trc_SHR_OSC_createNewCache_Event4 Obsolete NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache createNewCache calling initializer, intialiser=%p len=%d"
+TraceEvent=Trc_SHR_OSC_createNewCache_Event5 Obsolete NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache createNewCache return from initializer"
 TraceDebug=Trc_SHR_OSC_createNewCache_Debug1 Obsolete NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache createNewCache: GENJVMAT: %d, GENLOCK: %d, GENSTATE: %d"
 TraceDebug=Trc_SHR_OSC_createNewCache_Debug2 Obsolete NoEnv Overhead=1 Level=1 Group=OSCache Template="OSCache createNewCache: currentgeneration in semaphore = %d"
 TraceExit=Trc_SHR_OSC_createNewCache_Exit_recreated Obsolete NoEnv Overhead=1 Level=6 Group=OSCache Template="OSCache createNewCache return opened (semaphore recreated)"
@@ -991,8 +991,8 @@ TraceEvent=Trc_SHR_OSC_Mmap_startup_goodCreateCacheHeader NoEnv Overhead=1 Level
 TraceEvent=Trc_SHR_OSC_Mmap_startup_goodSetCacheLength NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Successfully set cache length to %zu"
 TraceEvent=Trc_SHR_OSC_Mmap_startup_badAttach NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Failed to attach to cache"
 TraceExit=Trc_SHR_OSC_Mmap_startup_badSetCacheLength NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Failed to set cache length to %zu"
-TraceEvent=Trc_SHR_OSC_Mmap_startup_goodInitialiseDataHeader NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Successfully initialised cache data header"
-TraceExit=Trc_SHR_OSC_Mmap_startup_badInitialiseDataHeader NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Failed to initialise cache data header"
+TraceEvent=Trc_SHR_OSC_Mmap_startup_goodInitializeDataHeader NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Successfully initialized cache data header"
+TraceExit=Trc_SHR_OSC_Mmap_startup_badInitializeDataHeader NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Failed to initialize cache data header"
 TraceEvent=Trc_SHR_OSC_Mmap_startup_badCreateCacheHeader NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Failed to create cache header"
 TraceEvent=Trc_SHR_OSC_Mmap_startup_badReleaseHeaderWriteLock NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Failed to release header write lock"
 TraceEvent=Trc_SHR_OSC_Mmap_startup_goodReleaseHeaderWriteLock NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: Successfully released header write lock"
@@ -1140,10 +1140,10 @@ TraceExit=Trc_SHR_OSC_Mmap_updateLastDetachedTime_badreleaselock NoEnv Overhead=
 TraceEvent=Trc_SHR_OSC_Mmap_updateLastDetachedTime_goodreleaselock NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::updateLastDetachedTime: releaseHeaderWriteLock successful"
 TraceExit=Trc_SHR_OSC_Mmap_updateLastDetachedTime_Exit NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::updateLastDetachedTime: Successful exit"
 
-TraceEntry=Trc_SHR_OSC_Mmap_initialiseDataHeader_Entry NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: Entered"
-TraceEvent=Trc_SHR_OSC_Mmap_initialiseDataHeader_callinginit NoEnv Obsolete Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassReadWriteBytes=%zd"
-TraceEvent=Trc_SHR_OSC_Mmap_initialiseDataHeader_initialised NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: Returned from init method"
-TraceExit=Trc_SHR_OSC_Mmap_initialiseDataHeader_Exit NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: Exiting"
+TraceEntry=Trc_SHR_OSC_Mmap_initializeDataHeader_Entry NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: Entered"
+TraceEvent=Trc_SHR_OSC_Mmap_initializeDataHeader_callinginit NoEnv Obsolete Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassReadWriteBytes=%zd"
+TraceEvent=Trc_SHR_OSC_Mmap_initializeDataHeader_initialized NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: Returned from init method"
+TraceExit=Trc_SHR_OSC_Mmap_initializeDataHeader_Exit NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: Exiting"
 
 TraceEntry=Trc_SHR_OSC_Mmap_internalDetach_Entry NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::internalDetach: Entering"
 TraceExit=Trc_SHR_OSC_Mmap_internalDetach_notattached NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::internalDetach: File not attached, returning"
@@ -1826,7 +1826,7 @@ TraceExit=Trc_SHR_OSC_Vmem_startup_closefilefailed NoEnv Overhead=1 Level=1 Temp
 TraceExit=Trc_SHR_OSC_Vmem_startup_cacheNotInitialized NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Attempting to open read-only but cache is not initialized"
 TraceExit=Trc_SHR_OSC_Vmem_startup_allocation_failed NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Memory allocation of %d bytes failed"
 TraceEvent=Trc_SHR_OSC_Vmem_startup_callinginit NoEnv  Obsolete Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassReadWriteBytes=%zd"
-TraceEvent=Trc_SHR_OSC_Vmem_startup_initialised NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Returned from init method"
+TraceEvent=Trc_SHR_OSC_Vmem_startup_initialized NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Returned from init method"
 TraceExit=Trc_SHR_OSC_Vmem_startup_Exit NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Successful exit"
 
 TraceEntry=Trc_SHR_OSC_Vmem_attach_Entry Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::attach: Entered"
@@ -2116,7 +2116,7 @@ TraceEvent=Trc_SHR_ClassDebugData_getDebugAreaEndAddress_Event NoEnv Overhead=1 
 
 TraceEntry=Trc_SHR_ClassDebugData_HeaderInitForDebug_Entry NoEnv Overhead=1 Level=4 Template="ClassDebugDataProvider::HeaderInitForDebug : enter (ca=%p, size=%u)"
 TraceException=Trc_SHR_ClassDebugData_HeaderInitForDebug_NullCacheHdr_Event NoEnv Overhead=1 Level=4 Template="ClassDebugDataProvider::HeaderInitForDebug : null cache header"
-TraceException=Trc_SHR_ClassDebugData_HeaderInitForDebug_AlreadyInit_Event NoEnv Overhead=1 Level=4 Template="ClassDebugDataProvider::HeaderInitForDebug : cache already has an initialised debug area (flags=%x)"
+TraceException=Trc_SHR_ClassDebugData_HeaderInitForDebug_AlreadyInit_Event NoEnv Overhead=1 Level=4 Template="ClassDebugDataProvider::HeaderInitForDebug : cache already has an initialized debug area (flags=%x)"
 TraceExit=Trc_SHR_ClassDebugData_HeaderInitForDebug_Exit NoEnv Overhead=1 Level=4 Template="ClassDebugDataProvider::HeaderInitForDebug : exit (retval=%u)"
 
 TraceEvent=Trc_SHR_ClassDebugData_getRecommendedPercentage_Event NoEnv Overhead=1 Level=4 Template="ClassDebugDataProvider::getRecommendedPercentage : retval=%u"
@@ -2201,7 +2201,7 @@ TraceEntry=Trc_SHR_OSC_Mmap_errorHandler_Entry_V2 NoEnv Overhead=1 Level=1 Templ
 TraceEntry=Trc_SHR_CC_commitUpdate_Entry2 Overhead=1 Level=2 Template="CC commitUpdate: Committing for _scan=%p, _storedMetaUsedBytes=%d, _storedSegmentUsedBytes=%d, _storedReadWriteUsedBytes=%d, _storedAOTUsedBytes=%d, _storedJITUsedBytes=%d"
 TraceEvent=Trc_SHR_CC_rollbackUpdate_Event2 Overhead=1 Level=1 Template="CC rollbackUpdate: Rolling back update for _scan=%p, _storedMetaUsedBytes=%d, _storedSegmentUsedBytes=%d, _storedReadWriteUsedBytes=%d, _storedAOTUsedBytes=%d, _storedJITUsedBytes=%d"
 TraceExit=Trc_SHR_CC_allocate_Exit2 Overhead=1 Level=3 Template="CC allocate: Exiting with result=%p, _scan=%p, _storedMetaUsedBytes=%d, _storedSegmentUsedBytes=%d, _storedReadWriteUsedBytes=%d, _storedAOTUsedBytes=%d, _storedJITUsedBytes=%d" 
-TraceEvent=Trc_SHR_OSC_Mmap_initialiseDataHeader_callinginit2 NoEnv Obsolete Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassReadWriteBytes=%zd"
+TraceEvent=Trc_SHR_OSC_Mmap_initializeDataHeader_callinginit2 NoEnv Obsolete Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassReadWriteBytes=%zd"
 TraceEvent=Trc_SHR_OSC_Vmem_startup_callinginit2 NoEnv Overhead=1 Level=1 Template="SH_OSCachevmem::startup: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassReadWriteBytes=%zd"
 
 TraceEntry=Trc_SHR_CC_setCorruptCacheWithContext_Entry NoEnv Overhead=1 Level=1 Template="CC setCorruptCache: Entering, corruptionCode = %zd, corruptValue = 0x%zx, unitTest = %zd"
@@ -2401,8 +2401,8 @@ TraceExit=Trc_SHR_OSC_Virt_startup_insufficientSpaceForSpecifiedCacheSize Obsole
 TraceEvent=Trc_SHR_OSC_Virt_startup_goodSetCacheLength Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Successfully set cache length to %zu"
 TraceExit=Trc_SHR_OSC_Virt_startup_badCreateCacheHeader Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Failed creating cache header"
 TraceEvent=Trc_SHR_OSC_Virt_startup_goodCreateCacheHeader Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Successfully created cache header"
-TraceExit=Trc_SHR_OSC_Virt_startup_badInitialiseDataHeader Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Failed initializing data header"
-TraceEvent=Trc_SHR_OSC_Virt_startup_goodInitialiseDataHeader Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Successfully initializing data header"
+TraceExit=Trc_SHR_OSC_Virt_startup_badInitializeDataHeader Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Failed initializing data header"
+TraceEvent=Trc_SHR_OSC_Virt_startup_goodInitializeDataHeader Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Successfully initializing data header"
 TraceExit=Trc_SHR_OSC_Virt_startup_badReleaseHeaderWriteLock Obsolete NoEnv Overhead=1 Level=1 Template="SH_OSCachevirt::startup: Failed releasing header lock"
 TraceEvent=Trc_SHR_OSC_Virt_startup_goodReleaseHeaderWriteLock Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Successfully released header lock"
 TraceExit=Trc_SHR_OSC_Virt_startup_Exit Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::startup: Returning success"
@@ -2485,10 +2485,10 @@ TraceEntry=Trc_SHR_OSC_Virt_createCacheHeader_Entry Obsolete NoEnv Overhead=1 Le
 TraceEvent=Trc_SHR_OSC_Virt_createCacheHeader_header Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::createCacheHeader: Created header eyecatcher=%s, size=%u, dataStart=%d, dataLength=%d, createTime=%llu, lastAttachedTime=%llu"
 TraceExit=Trc_SHR_OSC_Virt_createCacheHeader_Exit Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::createCacheHeader: Returning"
 
-TraceEntry=Trc_SHR_OSC_Virt_initialiseDataHeader_Entry Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initialiseDataHeader: Function entered"
-TraceEvent=Trc_SHR_OSC_Virt_initialiseDataHeader_callinginit2 Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initialiseDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassReadWriteBytes=%zd"
-TraceEvent=Trc_SHR_OSC_Virt_initialiseDataHeader_initialised Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initialiseDataHeader: Successfully initialized data header"
-TraceExit=Trc_SHR_OSC_Virt_initialiseDataHeader_Exit Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initialiseDataHeader: Returning"
+TraceEntry=Trc_SHR_OSC_Virt_initializeDataHeader_Entry Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initializeDataHeader: Function entered"
+TraceEvent=Trc_SHR_OSC_Virt_initializeDataHeader_callinginit2 Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initializeDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassReadWriteBytes=%zd"
+TraceEvent=Trc_SHR_OSC_Virt_initializeDataHeader_initialized Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initializeDataHeader: Successfully initialized data header"
+TraceExit=Trc_SHR_OSC_Virt_initializeDataHeader_Exit Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::initializeDataHeader: Returning"
 
 TraceEntry=Trc_SHR_OSC_Virt_internalDetach_Entry Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::internalDetach: Function entered"
 TraceExit=Trc_SHR_OSC_Virt_internalDetach_notattached Obsolete NoEnv Overhead=1 Level=5 Template="SH_OSCachevirt::internalDetach: Not attached"
@@ -2869,8 +2869,8 @@ TraceExit=Trc_SHR_CC_updateRuntimeFullFlags_Exit Overhead=1 Level=4 Template="CC
 TraceEntry=Trc_SHR_CC_unsetCacheHeaderFullFlags_Entry Overhead=1 Level=1 Template="CC updateRuntimeFullFlags: entered with flags %zu"
 TraceExit=Trc_SHR_CC_unsetCacheHeaderFullFlags_Exit Overhead=1 Level=1 Template="CC updateRuntimeFullFlags: exit"
 
-TraceEvent=Trc_SHR_OSC_Mmap_initialiseDataHeader_callinginit3 NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassSoftMaxBytes=%zd, sharedClassReadWriteBytes=%zd"
-TraceException=Trc_SHR_OSC_Mmap_initialiseDataHeader_softMaxBytesTooBig NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initialiseDataHeader: The softmx bytes passed in is too big, it is reset to the cache file size %u"
+TraceEvent=Trc_SHR_OSC_Mmap_initializeDataHeader_callinginit3 NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: Calling init with _mapDataAddr=%p, _mapDataLength=%zu, sharedClassMinAOTSize=%zd, sharedClassMaxAOTSize=%zd, sharedClassMinJITSize=%zd, sharedClassMaxJITSize=%zd, sharedClassSoftMaxBytes=%zd, sharedClassReadWriteBytes=%zd"
+TraceException=Trc_SHR_OSC_Mmap_initializeDataHeader_softMaxBytesTooBig NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::initializeDataHeader: The softmx bytes passed in is too big, it is reset to the cache file size %u"
 TraceException=Trc_SHR_OSC_Sysv_initializeHeader_softMaxBytesTooBig NoEnv Overhead=1 Level=1 Template="SH_OSCachesysv::initializeHeader: The softmx bytes passed in is too big, it is reset to the cache file size %u"
 
 TraceEvent=Trc_SHR_API_j9shr_createSharedClass_softFull_Event Overhead=1 Level=2 Template="API j9shr_classStoreTransaction_createSharedClass : cache is soft full"

--- a/runtime/tests/shared/OSCacheTest.hpp
+++ b/runtime/tests/shared/OSCacheTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 #define CACHE_NAME "OSCacheUnitTest"
 #define CACHE_NAME1 "OSCacheUnitTest1"
 
-class Init : public SH_OSCache::SH_OSCacheInitialiser
+class Init : public SH_OSCache::SH_OSCacheInitializer
 {
 public:
 	void *operator new(size_t t, void* i) { return i; }

--- a/runtime/tests/shared/jvmti/SharedClassesNativeAgent.c
+++ b/runtime/tests/shared/jvmti/SharedClassesNativeAgent.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@
 jboolean jvmti11 = JNI_FALSE;
 JavaVM * globalVM;
 J9PortLibrary * PORTLIB;
-UDATA portlibInitialised = 0; /* 0=No   1=Yes,from VM   2=Yes,created from scratch */
+UDATA portlibInitialized = 0; /* 0=No   1=Yes,from VM   2=Yes,created from scratch */
 jvmtiEnv * globalJvmtiEnv;
 char *testcaseArguments;
 
@@ -59,12 +59,12 @@ Agent_OnUnload(JavaVM * vm)
 static void 
 ensurePortLibrarySetup(JavaVM *vm) 
 {
-    if (portlibInitialised!=0) {
+    if (portlibInitialized!=0) {
     	return;
     }
 	if (vm!=NULL && ((J9JavaVM *) vm)->reserved1_identifier == (void*)J9VM_IDENTIFIER) {
 		PORTLIB = ((J9JavaVM *) vm)->portLibrary;
-		portlibInitialised = 1;
+		portlibInitialized = 1;
 	} else {
 		J9PortLibraryVersion portLibraryVersion;
 		I_32 rc;
@@ -80,7 +80,7 @@ ensurePortLibrarySetup(JavaVM *vm)
 			j9tty_printf(PORTLIB, "Agent: Failed to start port library (%d)\n", rc);
 			return;
 		}
-		portlibInitialised = 2;
+		portlibInitialized = 2;
 	}
 }
 	
@@ -132,7 +132,7 @@ done:
 
 	if (rc == JNI_OK) {
 		globalJvmtiEnv = jvmti_env;
-	} else if (portlibInitialised==2) {
+	} else if (portlibInitialized==2) {
 		j9port_shutdown_library();
 	}
 

--- a/runtime/util/filecache.c
+++ b/runtime/util/filecache.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -296,13 +296,13 @@ j9cached_file_open(struct J9PortLibrary *portLibrary, const char *path, I_32 fla
 		I_8 index;
 		handle = (J9CachedFileHandle *) j9mem_allocate_memory(sizeof(J9CachedFileHandle), OMRMEM_CATEGORY_VM);
 		if(handle) {
-			/* got the handle, now initialise the cache(s) */
+			/* got the handle, now initialize the cache(s) */
 			memset(handle, 0x00, sizeof(J9CachedFileHandle));
 			handle->portLibrary = portLibrary;
 			handle->fd = rawResult;
 			LATEST_LRU() = -1;
 			for (index = 0; index < CACHE_BUFFER_NUM; index++) {
-				/* initialise the individual cache(s) */
+				/* initialize the individual cache(s) */
 				handle->cacheTable[index].cache = (char *) j9mem_allocate_memory(CACHE_BUFFER_SIZE, OMRMEM_CATEGORY_VM);
 				if (handle->cacheTable[index].cache != NULL) {
 					/* created one of the cache(s) */

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -3320,7 +3320,7 @@ verifyNewClasses(J9VMThread * currentThread, jint class_count, J9JVMTIClassPair 
 	}
 
 	/* CMVC 192547 : bytecode verification is usually done at runtime verification phase during ram class initialisation,
-	 * but since we're retransforming a class and the ram class is already initialised, manually run bytecode verification on
+	 * but since we're retransforming a class and the ram class is already initialized, manually run bytecode verification on
 	 * all the newly created ROM classes.
 	 */
 	for (i = 0; i < class_count; ++i) {

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -747,7 +747,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved) {
 			}
 
 			/* Note - verboseStruct not needed for modron verbose gc */
-			initialiseVerboseFunctionTable(vm);
+			initializeVerboseFunctionTable(vm);
 
 			verbosegclogIndex = FIND_AND_CONSUME_ARG( OPTIONAL_LIST_MATCH, OPT_XVERBOSEGCLOG, NULL );
 			if (verbosegclogIndex >= 0) {
@@ -793,7 +793,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved) {
 			break;
 
 		case POST_INIT_STAGE:
-			initialiseVerboseFunctionTable(vm);
+			initializeVerboseFunctionTable(vm);
 			break;
 
 		case LIBRARIES_ONUNLOAD :

--- a/runtime/vm/jvmrisup.c
+++ b/runtime/vm/jvmrisup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -869,7 +869,7 @@ initJVMRI( J9JavaVM * vm )
 {
 	if (omrthread_monitor_init_with_name(&jvmridumpmonitor, 0, "jvmriDumpThread")) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
-		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_RI_INITIALISE_CANT_ALLOCATE_MONITOR);
+		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_RI_INITIALIZE_CANT_ALLOCATE_MONITOR);
 		return JNI_ERR;
 	}
 	

--- a/sourcetools/tracegen/TraceGen.java
+++ b/sourcetools/tracegen/TraceGen.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1058,10 +1058,10 @@ public class TraceGen {
 			this.fileName = fileName;
 			this.printWriter = new PrintWriter(newWriter(new File(fileName)));
 
-			initialiseDATFile();
+			initializeDATFile();
 		}
 
-		private void initialiseDATFile() {
+		private void initializeDATFile() {
 			println(RAS_MAJOR_VERSION + "." + RAS_MINOR_VERSION);
 		}
 

--- a/sourcetools/tracegen/TracePoint.java
+++ b/sourcetools/tracegen/TracePoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 IBM Corp. and others
+ * Copyright (c) 2004, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -611,7 +611,7 @@ public class TracePoint{
 		// Flag as unreachable so prevent bogus warnings during static code analysis.
 		output.write("\t\t\t\tTrace_Unreachable(); \\");
 		output.newLine();
-		// Write early assert case for when trace is not initialised.
+		// Write early assert case for when trace is not initialized.
 		// Important - this case does not cause the assert to trigger vm exit.
 		// If an assert is hit before trace starts we just print it to stderr.
 		output.write("\t\t\t} else { \\");


### PR DESCRIPTION
This will make searching easier as one does not have to check for
alternate spellings.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>