### PR TITLE
 Prevent invalid variable values in MethodType

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1148,8 +1148,14 @@ public final class MethodType implements Serializable {
 					}
 				}
 			);
-			fReturnType.set(this, in.readObject());
-			fArguments.set(this, in.readObject());
+			try {
+				fReturnType.set(this, in.readObject());
+				fArguments.set(this, in.readObject());
+			} catch(Exception e) {
+				fReturnType.set(this, void.class);
+				fArguments.set(this, EMTPY_PARAMS);
+				throw e;
+			}
 		} catch (IllegalAccessException e) {
 		} catch (NoSuchFieldException e) {
 		}


### PR DESCRIPTION
If an exception occurs during deserialization, instance of MethodType
can be left in an invalid state which may cause crashes if they are
used.  Detect these exceptions and reset the MethodType to something
valid.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>