### PR TITLE
Fix Dump ConfigurationUnavailableException issue and dsn name for z/OS

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1132,6 +1132,7 @@
 	cd $(REPORTDIR); \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-Xdump:dynamic \
+	-Dremote.server.option=$(Q)$(JVM_OPTIONS) -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false$(Q) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jlm_tests.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames testOpenJ9DiagnosticsMXBean \
@@ -1147,6 +1148,8 @@
 		<subsets>
 			<subset>SE80</subset>
 			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 


### PR DESCRIPTION
1) As the dump settings are changed one after the other, at times we get a Dump configuration cannot be changed as another dump change is in progress, introducing a delay fixes the issue. 
2) Fixed systemDumpToFile in Dump API  to replace file with dsn for z/OS
Signed-off-by: Chandrakala <chandra-ms@in.ibm.com>