### PR TITLE
Fail if we cannot determine NODE

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -197,6 +197,9 @@ def set_node(job_type) {
     // fetch labels (space separated string) for given platform/spec
     labels = get_value(VARIABLES."${SPEC}".node_labels."${job_type}", SDK_VERSION)
     NODE = labels.replaceAll(" ", "&&")
+    if (!NODE) {
+        error("Cannot find label value matching JOB_TYPE:'${job_type}' SPEC:'${SPEC}' and SDK_VERSION:'${SDK_VERSION}'")
+    }
 }
 
 /*


### PR DESCRIPTION
- Throw error if we cannot find a 'label' entry in
  vairables file that matches the job_type, SPEC,
  and SDK_VERSION passed.

[skip ci]

Fixes #1746

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>