### PR TITLE
Fix modularity checks when loading superclasses and interfaces

### DIFF
--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1258,7 +1258,6 @@ extern J9_CFUNC void  dbgDumpStack (J9VMThread *vmThread, IDATA delta);
 #ifndef _J9VMVISIBILITY_
 #define _J9VMVISIBILITY_
 extern J9_CFUNC IDATA  checkVisibility (J9VMThread* currentThread, J9Class* sourceClass, J9Class* destClass, UDATA modifiers, UDATA lookupOptions);
-extern J9_CFUNC IDATA  checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions);
 #endif /* _J9VMVISIBILITY_ */
 
 /* J9VMVolatileLongFunctions*/

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -35,6 +35,7 @@
 #include "ut_j9vm.h"
 #include "j9bcvnls.h"
 #include "j2sever.h"
+#include "vm_internal.h"
 
 #include "VMHelpers.hpp"
 
@@ -1552,7 +1553,7 @@ loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9
 				 */
 				bool superClassIsPublic = J9_ARE_ALL_BITS_SET(superclass->romClass->modifiers, J9_JAVA_PUBLIC);
 				if ((!superClassIsPublic && (packageID != superclass->packageID))
-				|| (superClassIsPublic && !checkModuleAccess(vmThread, vm, romClass, module, superclass->romClass, superclass->module, superclass->packageID, 0))
+					|| (superClassIsPublic && (J9_VISIBILITY_ALLOWED != checkModuleAccess(vmThread, vm, romClass, module, superclass->romClass, superclass->module, superclass->packageID, 0)))
 				) {
 					Trc_VM_CreateRAMClassFromROMClass_superclassNotVisible(vmThread, superclass, superclass->classLoader, classLoader);
 					setCurrentExceptionForBadClass(vmThread, superclassName, J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSERROR);
@@ -1595,7 +1596,7 @@ loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9
 						 */
 						bool interfaceIsPublic = J9_ARE_ALL_BITS_SET(interfaceClass->romClass->modifiers, J9_JAVA_PUBLIC);
 						if ((!interfaceIsPublic && (packageID != interfaceClass->packageID))
-						|| (interfaceIsPublic && !checkModuleAccess(vmThread, vm, romClass, module, interfaceClass->romClass, interfaceClass->module, interfaceClass->packageID, 0))
+							|| (interfaceIsPublic && (J9_VISIBILITY_ALLOWED != checkModuleAccess(vmThread, vm, romClass, module, interfaceClass->romClass, interfaceClass->module, interfaceClass->packageID, 0)))
 						) {
 							Trc_VM_CreateRAMClassFromROMClass_interfaceNotVisible(vmThread, interfaceClass, interfaceClass->classLoader, classLoader);
 							setCurrentExceptionForBadClass(vmThread, J9ROMCLASS_CLASSNAME(interfaceClass->romClass), J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSERROR);

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -35,36 +35,6 @@ static UDATA loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA o
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 
 
-
-/**
- * Check module access from srcModule to destModule.
- *
- * The algorithm for validating module access is:
- * 1) check to see if the source module `reads` the dest module.
- * 2) check to see if the dest module exports the package (that
- * dest class belongs to) to the source module.
- *
- * For reflective calls, the rules are slightly different as all reflect
- * reflect accesses implicitly have read access.  Set the
- *  J9_LOOK_REFLECT_CALL flag in the lookup options for reflective
- * checks.
- *
- * The unnamedModules export all the packages they own and have read access to all modules
- * they require access to.
- *
- * @param[in] currentThread the current J9VMThread
- * @param[in] vm the javaVM
- * @param[in] srcRomClass the accessing class
- * @param[in] srcModule the module of the src class
- * @param[in] destRomClass the accessing class
- * @param[in] destModule the module of the dest class
- * @param[in] destPackageID packageID of the dest class
- * @param[in] lookupOptions J9_LOOK* options
- *
- * @return 	J9_VISIBILITY_ALLOWED if the access is allowed,
- * 			J9_VISIBILITY_MODULE_READ_ACCESS_ERROR if module read access error occurred,
- * 			J9_VISIBILITY_MODULE_PACKAGE_EXPORT_ERROR if module package access error
- */
 IDATA
 checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions)
 {

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -336,6 +336,41 @@ convertCStringToByteArray(J9VMThread *currentThread, const char *byteArray);
 void
 initializeROMClasses(J9JavaVM *vm);
 
+/* ------------------- visible.c ----------------- */
+
+/**
+ * Check module access from srcModule to destModule.
+ *
+ * The algorithm for validating module access is:
+ * 1) check to see if the source module `reads` the dest module.
+ * 2) check to see if the dest module exports the package (that
+ * dest class belongs to) to the source module.
+ *
+ * For reflective calls, the rules are slightly different as all reflect
+ * reflect accesses implicitly have read access.  Set the
+ *  J9_LOOK_REFLECT_CALL flag in the lookup options for reflective
+ * checks.
+ *
+ * The unnamedModules export all the packages they own and have read access to all modules
+ * they require access to.
+ *
+ * @param[in] currentThread the current J9VMThread
+ * @param[in] vm the javaVM
+ * @param[in] srcRomClass the accessing class
+ * @param[in] srcModule the module of the src class
+ * @param[in] destRomClass the accessing class
+ * @param[in] destModule the module of the dest class
+ * @param[in] destPackageID packageID of the dest class
+ * @param[in] lookupOptions J9_LOOK* options
+ *
+ * @return 	J9_VISIBILITY_ALLOWED if the access is allowed,
+ * 			J9_VISIBILITY_MODULE_READ_ACCESS_ERROR if module read access error occurred,
+ * 			J9_VISIBILITY_MODULE_PACKAGE_EXPORT_ERROR if module package access error
+ */
+
+IDATA
+checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions);
+
 /* ------------------- guardedstorage.c ----------------- */
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)


### PR DESCRIPTION
Fix modularity checks when loading superclasses and interfaces

Signed-off-by: tajila <atobia@ca.ibm.com>