### PR TITLE
Add Valhalla Nestmates PR Build

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -245,7 +245,7 @@ def set_test_variables() {
     set_release()
     set_jdk_folder()
     
-    if ( SPEC ==~ /.*valhalla_nestmates/) {
+    if ( SPEC ==~ /.*valhalla_nestmates.*/) {
         JAVA_VERSION = "Valhalla"
     } else {
         JAVA_VERSION = "SE" + "${SDK_VERSION}" + "0"

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -246,7 +246,7 @@ def set_test_variables() {
     set_release()
     set_jdk_folder()
     
-    if ( SPEC ==~ /.*valhalla_nestmates.*/) {
+    if ( SPEC ==~ /.*valhalla.*/) {
         JAVA_VERSION = "Valhalla"
     } else {
         JAVA_VERSION = "SE" + "${SDK_VERSION}" + "0"

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -240,6 +240,7 @@ def set_build_variables() {
 
 /*
 * Sets variables for a test job on a given platform.
+* Note that JAVA_BIN is set separately within buildenv/jenkins/common/test
 */
 def set_test_variables() {
     set_release()

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -244,7 +244,12 @@ def set_build_variables() {
 def set_test_variables() {
     set_release()
     set_jdk_folder()
-    JAVA_VERSION = "SE" + "${SDK_VERSION}" + "0"
+    
+    if ( SPEC ==~ /.*valhalla_nestmates/) {
+        JAVA_VERSION = "Valhalla"
+    } else {
+        JAVA_VERSION = "SE" + "${SDK_VERSION}" + "0"
+    }
     TEST_DEPENDENCIES_JOB_NAME = VARIABLES.test_dependencies_job_name
 }
 

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK11-linux_ppc-64_cmprssptrs_le_valhalla_nestmates
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK11-linux_ppc-64_cmprssptrs_le_valhalla_nestmates
@@ -19,13 +19,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
+// The SDK version and repository must be updated once the openj9-openjdk-jdk11
+// is available 
 SDK_VERSION = '10'
 SPEC = 'linux_ppc-64_cmprssptrs_le_valhalla_nestmates'
 TEST_TARGET = '_sanity'
 
 node('master') {
-    echo "creating node1"
     checkout scm
     variableFile = load 'buildenv/jenkins/common/variables-functions'
     variableFile.set_job_variables('pullRequest')
@@ -33,7 +33,6 @@ node('master') {
 }
 
 node("${NODE}") {
-    echo "creating node23"
     checkout scm
     buildfile = load 'buildenv/jenkins/common/build'
     testfile = load 'buildenv/jenkins/common/test'

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_ppc-64_cmprssptrs_le_valhalla_nestmates
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_ppc-64_cmprssptrs_le_valhalla_nestmates
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_ppc-64_cmprssptrs_le_valhalla_nestmates'
+TEST_TARGET = '_sanity'
+
+node('master') {
+    echo "creating node1"
+    checkout scm
+    variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('pullRequest')
+    cleanWs()
+}
+
+node("${NODE}") {
+    echo "creating node23"
+    checkout scm
+    buildfile = load 'buildenv/jenkins/common/build'
+    testfile = load 'buildenv/jenkins/common/test'
+
+    // Build
+    buildfile.build_pr()
+
+    // Test
+    archive_test = [:]
+    archive_test['Archive'] = { buildfile.archive() }
+    archive_test['Test'] = { testfile.test_all() }
+    parallel archive_test
+    
+    buildfile.git_clean()
+}

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -65,6 +65,20 @@ linux_ppc-64_cmprssptrs_le:
       9: 'ppcle'
       10: 'ppcle'
 #========================================#
+# Linux PPCLE 64bits Compressed Pointers Valhalla Nestmates
+#========================================#
+linux_ppc-64_cmprssptrs_le_valhalla_nestmates:
+  boot_jdk:
+    10: '/usr/lib/jvm/adoptojdk-java-ppc64le-90'
+  release:
+    10: 'linux-ppc64le-normal-server-release'
+  freemarker: '/home/jenkins/freemarker.jar'
+  node_labels:
+    build:
+      10: 'ppcle'
+    test:
+      10: 'ppcle'
+#========================================#
 # Linux S390 64bits Compressed Pointers
 # Note: boot_jdk 8 must use an Adopt JDK8 build rather than an 
 # IBM 7 for the bootJDK or compiling corba will fail to find Object.

--- a/buildspecs/linux_ppc-64_cmprssptrs_le_valhalla_nestmates.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le_valhalla_nestmates.spec
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+ 
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ 
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+ 
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<spec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/j9/builder/spec" xsi:schemaLocation="http://www.ibm.com/j9/builder/spec spec-v1.xsd" id="linux_ppc-64_cmprssptrs_le_valhalla_nestmates">
+	<name>Linux PPC LE 64bit Compressed Pointers Valhalla Nestmates</name>
+	<asmBuilderName>LinuxPPC64LE</asmBuilderName>
+	<cpuArchitecture>ppc</cpuArchitecture>
+	<os>linux</os>
+	<defaultJCL>Sidecar</defaultJCL>
+	<defaultSizes>desktop (256M + big OS stack)</defaultSizes>
+	<priority>150</priority>
+	<owners>
+		<owner>Talia.McCormick@ibm.com</owner>
+	</owners>
+	<properties>
+		<property name="SE6_extension" value="tar.gz"/>
+		<property name="SE6_package" value="xp64le"/>
+		<property name="aotTarget" value="ppc-linux"/>
+		<property name="complianceTestingJavaLibraryPath" value="linux_ppcle-64"/>
+		<property name="directoryDelimiter" value="/"/>
+		<property name="graph_arch.cpu" value="{$spec.arch.cpuISA$}"/>
+		<property name="graph_commands.chroot" value=""/>
+		<property name="graph_commands.unix.remote_host" value=""/>
+		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
+		<property name="graph_label.classlib" value="150"/>
+		<property name="graph_label.java5" value="j9vmxp64lecmprssptrs24"/>
+		<property name="graph_label.java6" value="pxp64lecmprssptrs60"/>
+		<property name="graph_label.java60_26" value="pxp64lecmprssptrs60_26"/>
+		<property name="graph_label.java6_rebuilt_extension" value="zip"/>
+		<property name="graph_label.java7" value="pxp64lecmprssptrs70"/>
+		<property name="graph_label.java70_27" value="pxp64lecmprssptrs70_27"/>
+		<property name="graph_label.java8" value="pxp64lecmprssptrs80"/>
+		<property name="graph_label.java9" value="pxp64lecmprssptrs90"/>
+		<property name="graph_label.osid" value="lnx"/>
+		<property name="graph_label.profile" value="_cmprssptrs_le"/>
+		<property name="graph_make_parallel_arg" value="-j `numberOfCPUs`"/>
+		<property name="graph_req.arch0" value="arch:ppcle"/>
+		<property name="graph_req.arch1" value=""/>
+		<property name="graph_req.aux0" value="{$common.req.build.cuda$}"/>
+		<property name="graph_req.aux1" value=""/>
+		<property name="graph_req.build" value="{$common.req.build.java9$}"/>
+		<property name="graph_req.build2" value="{$common.req.build.java8$}"/>
+		<property name="graph_req.machine" value="{$machine_mapping.ppc64le$}"/>
+		<property name="graph_req.machine.test" value="{$spec.property.graph_req.machine$}"/>
+		<property name="graph_req.os" value="{$machine_mapping.linux$}"/>
+		<property name="graph_req.os.build" value="{$spec.property.graph_req.os$}"/>
+		<property name="graph_req.os.perf" value="{$spec.property.graph_req.os$}"/>
+		<property name="graph_se_classlib.java5" value="jcl_se.zip"/>
+		<property name="graph_se_classlib.java6" value="jcl_se.zip"/>
+		<property name="graph_variant.testing_suffix" value=""/>
+		<property name="graph_variant.trailingID" value=""/>
+		<property name="isReallyUnix" value="true"/>
+		<property name="j2seRuntimeDir" value="jre/lib/ppc64le"/>
+		<property name="j2seTags" value="pxp64lecmprssptrs60,j9vmxp64lecmprssptrs24"/>
+		<property name="j9dt.compileTarget" value="makefile"/>
+		<property name="j9dt.make" value="gmake"/>
+		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
+		<property name="javatestPlatform" value="linux_ppc-64_le_cr"/>
+		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
+		<property name="jclMemoryMax" value="-Xmx64m"/>
+		<property name="jclOSStackSizeMax" value=""/>
+		<property name="jgrinderTestingSupported" value="true"/>
+		<property name="jitTestingOptLevel" value="optlevel=warm"/>
+		<property name="localRootPath" value="$(J9_UNIX_ROOT)"/>
+		<property name="longLimitCmd" value=""/>
+		<property name="main_shortname" value="xl64"/>
+		<property name="os.lineDelimiter" value="unix"/>
+		<property name="platform_arch" value="ppc64le"/>
+		<property name="svn_stream" value=""/>
+		<property name="uma_make_cmd_ar" value="ar"/>
+		<property name="uma_make_cmd_as" value="xlC_r"/>
+		<property name="uma_make_cmd_cc" value="xlC_r"/>
+		<property name="uma_make_cmd_cpp" value="cpp"/>
+		<property name="uma_make_cmd_cxx" value="$(CC)"/>
+		<property name="uma_make_cmd_cxx_dll_ld" value="xlc_r"/>
+		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
+		<property name="uma_make_cmd_dll_ld" value="xlc_r"/>
+		<property name="uma_make_cmd_exe_ld" value="xlc_r"/>
+		<property name="uma_make_cmd_ppc_gcc_cxx" value="gcc"/>
+		<property name="uma_make_cmd_ranlib" value="ranlib"/>
+		<property name="uma_processor" value="ppc,ppc64"/>
+		<property name="uma_type" value="unix,linux"/>
+	</properties>
+	<features>
+		<feature id="cmprssptrs"/>
+		<feature id="combogc"/>
+		<feature id="core"/>
+		<feature id="dbgext"/>
+		<feature id="gpu"/>
+		<feature id="se"/>
+		<feature id="se60_26"/>
+		<feature id="se7"/>
+		<feature id="se70_27"/>
+	</features>
+	<source>
+		<project id="com.ibm.jvmti.tests"/>
+		<project id="compiler"/>
+	</source>
+	<flags>
+		<flag id="arch_power" value="true"/>
+		<flag id="build_SE6_package" value="true"/>
+		<flag id="build_autobuild" value="true"/>
+		<flag id="build_dropToHursley" value="true"/>
+		<flag id="build_dropToToronto" value="true"/>
+		<flag id="build_j2se" value="true"/>
+		<flag id="build_java6proxy" value="true"/>
+		<flag id="build_java8" value="true"/>
+		<flag id="build_java9" value="true"/>
+		<flag id="build_product" value="true"/>
+		<flag id="build_stage_toronto_lab" value="true"/>
+		<flag id="env_hasFPU" value="true"/>
+		<flag id="env_littleEndian" value="true"/>
+		<flag id="env_sharedLibsCalleeGlobalTableSetup" value="true"/>
+		<flag id="env_sharedLibsUseGlobalTable" value="true"/>
+		<flag id="gc_batchClearTLH" value="true"/>
+		<flag id="gc_debugAsserts" value="true"/>
+		<flag id="gc_inlinedAllocFields" value="true"/>
+		<flag id="gc_minimumObjectSize" value="true"/>
+		<flag id="gc_subpoolsAlias" value="true"/>
+		<flag id="graph_cmdLineTester" value="true"/>
+		<flag id="graph_compile" value="true"/>
+		<flag id="graph_enableModularityTesting" value="true"/>
+		<flag id="graph_enableTesting" value="true"/>
+		<flag id="graph_enableTesting_Java8" value="true"/>
+		<flag id="graph_j2seSanity" value="true"/>
+		<flag id="graph_jgrinder" value="true"/>
+		<flag id="graph_mirrorToPoughkeepsie" value="true"/>
+		<flag id="graph_plumhall" value="true"/>
+		<flag id="graph_useJTCTestingPlaylist" value="true"/>
+		<flag id="graph_verification" value="true"/>
+		<flag id="interp_aotCompileSupport" value="true"/>
+		<flag id="interp_aotRuntimeSupport" value="true"/>
+		<flag id="interp_debugSupport" value="true"/>
+		<flag id="interp_enableJitOnDesktop" value="true"/>
+		<flag id="interp_flagsInClassSlot" value="true"/>
+		<flag id="interp_gpHandler" value="true"/>
+		<flag id="interp_growableStacks" value="true"/>
+		<flag id="interp_hotCodeReplacement" value="true"/>
+		<flag id="interp_nativeSupport" value="true"/>
+		<flag id="interp_profilingBytecodes" value="true"/>
+		<flag id="interp_sigQuitThread" value="true"/>
+		<flag id="interp_useUnsafeHelper" value="true"/>
+		<flag id="ive_jxeFileRelocator" value="true"/>
+		<flag id="ive_jxeInPlaceRelocator" value="true"/>
+		<flag id="ive_jxeNatives" value="true"/>
+		<flag id="ive_jxeOERelocator" value="true"/>
+		<flag id="ive_jxeStreamingRelocator" value="true"/>
+		<flag id="ive_romImageHelpers" value="true"/>
+		<flag id="jit_classUnloadRwmonitor" value="true"/>
+		<flag id="jit_dynamicLoopTransfer" value="true"/>
+		<flag id="jit_fullSpeedDebug" value="true"/>
+		<flag id="jit_gcOnResolveSupport" value="true"/>
+		<flag id="jit_needsTrampolines" value="true"/>
+		<flag id="jit_newDualHelpers" value="true"/>
+		<flag id="jit_newInstancePrototype" value="true"/>
+		<flag id="jit_requiresTrapHandler" value="true"/>
+		<flag id="jit_runtimeInstrumentation" value="true"/>
+		<flag id="jit_supportsDirectJNI" value="true"/>
+		<flag id="module_algorithm_test" value="true"/>
+		<flag id="module_bcutil" value="true"/>
+		<flag id="module_bcverify" value="true"/>
+		<flag id="module_callconv" value="true"/>
+		<flag id="module_cassume" value="true"/>
+		<flag id="module_cfdumper" value="true"/>
+		<flag id="module_codegen_common" value="true"/>
+		<flag id="module_codegen_comsched" value="true"/>
+		<flag id="module_codegen_ilgen" value="true"/>
+		<flag id="module_codegen_opt" value="true"/>
+		<flag id="module_codegen_ppc" value="true"/>
+		<flag id="module_codegen_sched" value="true"/>
+		<flag id="module_codert_common" value="true"/>
+		<flag id="module_codert_ppc" value="true"/>
+		<flag id="module_codert_vm" value="true"/>
+		<flag id="module_cpo_common" value="true"/>
+		<flag id="module_cpo_controller" value="true"/>
+		<flag id="module_dbginfoserv" value="true"/>
+		<flag id="module_ddr" value="true"/>
+		<flag id="module_ddr_gdb_plugin" value="true"/>
+		<flag id="module_ddrext" value="true"/>
+		<flag id="module_exe" value="true"/>
+		<flag id="module_exe.j9" value="true"/>
+		<flag id="module_gc_modron_eprof" value="true"/>
+		<flag id="module_gdb" value="true"/>
+		<flag id="module_gdb_plugin" value="true"/>
+		<flag id="module_gptest" value="true"/>
+		<flag id="module_j9vm" value="true"/>
+		<flag id="module_j9vmtest" value="true"/>
+		<flag id="module_jcl.profile_scar" value="true"/>
+		<flag id="module_jcl.scar" value="true"/>
+		<flag id="module_jextractnatives" value="true"/>
+		<flag id="module_jit_common" value="true"/>
+		<flag id="module_jit_ppc" value="true"/>
+		<flag id="module_jit_vm" value="true"/>
+		<flag id="module_jitdebug_common" value="true"/>
+		<flag id="module_jitrt_common" value="true"/>
+		<flag id="module_jitrt_ppc" value="true"/>
+		<flag id="module_jniargtests" value="true"/>
+		<flag id="module_jnichk" value="true"/>
+		<flag id="module_jniinv" value="true"/>
+		<flag id="module_jnitest" value="true"/>
+		<flag id="module_jvmti" value="true"/>
+		<flag id="module_jvmtitst" value="true"/>
+		<flag id="module_lifecycle_tests" value="true"/>
+		<flag id="module_mvmtest" value="true"/>
+		<flag id="module_porttest" value="true"/>
+		<flag id="module_rasdump" value="true"/>
+		<flag id="module_rastrace" value="true"/>
+		<flag id="module_shared" value="true"/>
+		<flag id="module_shared_common" value="true"/>
+		<flag id="module_shared_test" value="true"/>
+		<flag id="module_shared_util" value="true"/>
+		<flag id="module_ute" value="true"/>
+		<flag id="module_utetst" value="true"/>
+		<flag id="module_verbose" value="true"/>
+		<flag id="module_vmall" value="true"/>
+		<flag id="module_zip" value="true"/>
+		<flag id="module_zlib" value="true"/>
+		<flag id="opt_annotations" value="true"/>
+		<flag id="opt_bigInteger" value="true"/>
+		<flag id="opt_debugInfoServer" value="true"/>
+		<flag id="opt_debugJsr45Support" value="true"/>
+		<flag id="opt_deprecatedMethods" value="true"/>
+		<flag id="opt_dynamicLoadSupport" value="true"/>
+		<flag id="opt_icbuilderSupport" value="true"/>
+		<flag id="opt_infoServer" value="true"/>
+		<flag id="opt_invariantInterning" value="true"/>
+		<flag id="opt_jvmti" value="true"/>
+		<flag id="opt_jxeLoadSupport" value="true"/>
+		<flag id="opt_memoryCheckSupport" value="true"/>
+		<flag id="opt_methodHandle" value="true"/>
+		<flag id="opt_multiVm" value="true"/>
+		<flag id="opt_panama" value="false"/>
+		<flag id="opt_reflect" value="true"/>
+		<flag id="opt_remoteConsoleSupport" value="true"/>
+		<flag id="opt_sharedClasses" value="true"/>
+		<flag id="opt_sidecar" value="true"/>
+		<flag id="opt_srpAvlTreeSupport" value="true"/>
+		<flag id="opt_stringCompression" value="true"/>
+		<flag id="opt_useFfi" value="true"/>
+		<flag id="opt_useFfiOnly" value="true"/>
+		<flag id="opt_valhallaValueTypes" value="false"/>
+		<flag id="opt_valhallaNestmates" value="true"/>
+		<flag id="opt_zipSupport" value="true"/>
+		<flag id="opt_zlibCompression" value="true"/>
+		<flag id="opt_zlibSupport" value="true"/>
+		<flag id="port_omrsigSupport" value="true"/>
+		<flag id="port_runtimeInstrumentation" value="true"/>
+		<flag id="port_signalSupport" value="true"/>
+		<flag id="prof_eventReporting" value="true"/>
+		<flag id="ras_dumpAgents" value="true"/>
+		<flag id="ras_eyecatchers" value="true"/>
+		<flag id="size_optimizeSendTargets" value="true"/>
+		<flag id="test_cunit" value="true"/>
+		<flag id="test_jvmti" value="true"/>
+		<flag id="thr_asyncNameUpdate" value="true"/>
+		<flag id="thr_lockNursery" value="true"/>
+		<flag id="thr_lockReservation" value="true"/>
+		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_gnuDebugSymbols" value="true"/>
+		<flag id="uma_supportsIpv6" value="true"/>
+	</flags>
+</spec>


### PR DESCRIPTION
This commit adds an automated Valhalla Nestmates PR build which compiles the VM with the J9VM_OPT_VALHALLA_NESTMATES build flag enabled and runs the Valhalla tests against it.

Test playlists will be updated in a subsequent commit to include the other sanity tests. Test config will be updated in a subsequent commit to update the Valhalla nestmates test options.

Signed-off-by: Talia McCormick <Talia.McCormick@ibm.com>