### PR TITLE
Limit the invokestatic/special CP consistency check to JDK 9

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -456,23 +456,28 @@ tryAgain:
 		cpClass = J9_CLASS_FROM_CP(ramCP);
 		lookupOptions |= J9_LOOK_CLCONSTRAINTS;
 
-		if ((cpClass != NULL) && (cpClass->romClass != NULL)) {
-			UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(cpClass->romClass), cpIndex);
-			if (isResolvedClassAnInterface) {
-				if ((J9CPTYPE_INTERFACE_STATIC_METHOD != cpType)
-				&& (J9CPTYPE_INTERFACE_INSTANCE_METHOD != cpType)
-				&& (J9CPTYPE_INTERFACE_METHOD != cpType)
-				) {
-					setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
-					goto done;
-				}
-			} else {
-				if ((J9CPTYPE_INTERFACE_STATIC_METHOD == cpType)
-				|| (J9CPTYPE_INTERFACE_INSTANCE_METHOD == cpType)
-				|| (J9CPTYPE_INTERFACE_METHOD == cpType)
-				) {
-					setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
-					goto done;
+		if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_19) {
+			/* This check is only required in Java9 and there have been applications that
+			 * fail when this check is enabled on Java8.
+			 */
+			if ((cpClass != NULL) && (cpClass->romClass != NULL)) {
+				UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(cpClass->romClass), cpIndex);
+				if (isResolvedClassAnInterface) {
+					if ((J9CPTYPE_INTERFACE_STATIC_METHOD != cpType)
+					&& (J9CPTYPE_INTERFACE_INSTANCE_METHOD != cpType)
+					&& (J9CPTYPE_INTERFACE_METHOD != cpType)
+					) {
+						setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
+						goto done;
+					}
+				} else {
+					if ((J9CPTYPE_INTERFACE_STATIC_METHOD == cpType)
+					|| (J9CPTYPE_INTERFACE_INSTANCE_METHOD == cpType)
+					|| (J9CPTYPE_INTERFACE_METHOD == cpType)
+					) {
+						setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
+						goto done;
+					}
 				}
 			}
 		}
@@ -1135,24 +1140,29 @@ resolveSpecialMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 		lookupOptions |= J9_LOOK_NO_THROW;
 	}
 
-	if (currentClass != NULL) {
-		if ((resolvedClass->romClass != NULL) && (currentClass->romClass != NULL)) {
-			UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(currentClass->romClass), cpIndex);
-			if (J9_JAVA_INTERFACE == (resolvedClass->romClass->modifiers & J9_JAVA_INTERFACE)) {
-				if ((J9CPTYPE_INTERFACE_INSTANCE_METHOD != cpType)
-				&& (J9CPTYPE_INTERFACE_STATIC_METHOD != cpType)
-				&& (J9CPTYPE_INTERFACE_METHOD != cpType)
-				) {
-					setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
-					goto done;
-				}
-			} else {
-				if ((J9CPTYPE_INTERFACE_INSTANCE_METHOD == cpType)
-				|| (J9CPTYPE_INTERFACE_STATIC_METHOD == cpType)
-				|| (J9CPTYPE_INTERFACE_METHOD == cpType)
-				) {
-					setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
-					goto done;
+	if (J2SE_VERSION(vmStruct->javaVM) >= J2SE_19) {
+		/* This check is only required in Java9 and there have been applications that
+		 * fail when this check is enabled on Java8.
+		 */
+		if (currentClass != NULL) {
+			if ((resolvedClass->romClass != NULL) && (currentClass->romClass != NULL)) {
+				UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(currentClass->romClass), cpIndex);
+				if (J9_JAVA_INTERFACE == (resolvedClass->romClass->modifiers & J9_JAVA_INTERFACE)) {
+					if ((J9CPTYPE_INTERFACE_INSTANCE_METHOD != cpType)
+					&& (J9CPTYPE_INTERFACE_STATIC_METHOD != cpType)
+					&& (J9CPTYPE_INTERFACE_METHOD != cpType)
+					) {
+						setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
+						goto done;
+					}
+				} else {
+					if ((J9CPTYPE_INTERFACE_INSTANCE_METHOD == cpType)
+					|| (J9CPTYPE_INTERFACE_STATIC_METHOD == cpType)
+					|| (J9CPTYPE_INTERFACE_METHOD == cpType)
+					) {
+						setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
+						goto done;
+					}
 				}
 			}
 		}
@@ -1282,8 +1292,6 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 		 */
 		if ((NULL != cpShapeDescription)
 		&& (resolvedClass == J9VMJAVALANGINVOKEMETHODHANDLE(vm))
-		&& (J9CPTYPE_INSTANCE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex))
-		&& (J9CPTYPE_INTERFACE_INSTANCE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex))
 		) {
 			J9UTF8 *nameUTF = J9ROMNAMEANDSIGNATURE_NAME(nameAndSig);
 			J9UTF8 *sigUTF = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);


### PR DESCRIPTION
The checks, added in PR #1167, are required for JDK 9.  We've had
reports of applications failing due to these ICCEs when running on
JDK 8.

This is a stop-gap solution to allow the JDK8 applications to continue
to run successfully while we get to the root cause on JDK8 as the
CP types look correct at first glance.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>