### PR TITLE
Add timeout to infrastructure pipeline jobs

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/branchSplit
+++ b/buildenv/jenkins/jobs/infrastructure/branchSplit
@@ -38,23 +38,25 @@ if (OMR_SHA == '') {
 }
 
 def clone_branch_push(REPO, NEW_BRANCH, SPLIT_SHA) {
-    node ('worker') {
-        git "${HTTP}${REPO}"
+    timeout(time: 3, unit: 'HOURS') {
+        node ('worker') {
+            git "${HTTP}${REPO}"
 
-        REPO_NAME = REPO.substring(REPO.lastIndexOf('/') +1, REPO.lastIndexOf('.git'))
-        echo "REPO_NAME = '${REPO_NAME}'"
+            REPO_NAME = REPO.substring(REPO.lastIndexOf('/') +1, REPO.lastIndexOf('.git'))
+            echo "REPO_NAME = '${REPO_NAME}'"
 
-        // branch from sha/tag/branch
-        sh "git checkout -b '${NEW_BRANCH}' '${SPLIT_SHA}'"
+            // branch from sha/tag/branch
+            sh "git checkout -b '${NEW_BRANCH}' '${SPLIT_SHA}'"
 
-        withCredentials([usernamePassword(credentialsId: 'b6987280-6402-458f-bdd6-7affc2e360d4', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-            sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${REPO} '${NEW_BRANCH}'"
+            withCredentials([usernamePassword(credentialsId: 'b6987280-6402-458f-bdd6-7affc2e360d4', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${REPO} '${NEW_BRANCH}'"
+            }
+
+            // Set the build description
+            currentBuild.description += "<br/>${REPO_NAME}: ${SPLIT_SHA}"
+
+            cleanWs()
         }
-
-        // Set the build description
-        currentBuild.description += "<br/>${REPO_NAME}: ${SPLIT_SHA}"
-
-        cleanWs()
     }
 }
 

--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheck
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheck
@@ -25,60 +25,62 @@ String SRC_REPO = 'https://github.com/${ghprbGhRepository}.git'
 def BAD_FILES = []
 String HASHES = '###################################'
 
-stage('Copyright Check') {
-    node ('worker') {
-        timestamps {
-            git url: SRC_REPO
-            sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
-            sh "git checkout --detach ${sha1}"
-            sh 'git fetch origin'
-            FILES = sh (
-                script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
-                returnStdout: true
-            ).trim()
-            echo FILES
-            if (FILES == "") {
-                echo "There are no files to check for copyrights"
-            } else {
-                def FILES_LIST = FILES.split("\\r?\\n")
-                DATE_YEAR = sh (
-                    script: "date +%Y",
+timeout(time: 6, unit: 'HOURS') {
+    stage('Copyright Check') {
+        node ('worker') {
+            timestamps {
+                git url: SRC_REPO
+                sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
+                sh "git checkout --detach ${sha1}"
+                sh 'git fetch origin'
+                FILES = sh (
+                    script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
                     returnStdout: true
                 ).trim()
-                
-                // Set a different Copyright regex depending on the Repo the PR is from
-                if (ghprbGhRepository ==~ "eclipse.*") {
-                    REGEX = "\'Copyright \\(c\\) ([0-9]{4}), ${DATE_YEAR}\'"
-                } else if (ghprbGhRepository ==~ "ibmruntimes.*") {
-                    REGEX = "\'\\(c\\) Copyright IBM Corp. ([0-9]{4}), ${DATE_YEAR} All Rights Reserved\'"
+                echo FILES
+                if (FILES == "") {
+                    echo "There are no files to check for copyrights"
                 } else {
-                    echo "ERROR: Unrecognized repository. Unable to determine correct Copyright regex"
-                    sh 'exit 1'
-                }
-
-                FILES_LIST.each() {
-                    println "Checking file: '${it}'"
-                    RESULT = sh (
-                        script: "grep -qE ${REGEX} '${it}'",
-                        returnStatus: true)
-                    if(RESULT != 0) {
-                        echo "FAILURE - Copyright date in file: '${it}' appears to be incorrect"
-                        FAIL = true
-                        BAD_FILES << "${it}"
+                    def FILES_LIST = FILES.split("\\r?\\n")
+                    DATE_YEAR = sh (
+                        script: "date +%Y",
+                        returnStdout: true
+                    ).trim()
+                    
+                    // Set a different Copyright regex depending on the Repo the PR is from
+                    if (ghprbGhRepository ==~ "eclipse.*") {
+                        REGEX = "\'Copyright \\(c\\) ([0-9]{4}), ${DATE_YEAR}\'"
+                    } else if (ghprbGhRepository ==~ "ibmruntimes.*") {
+                        REGEX = "\'\\(c\\) Copyright IBM Corp. ([0-9]{4}), ${DATE_YEAR} All Rights Reserved\'"
                     } else {
-                        echo "Copyright date in file: appears to be correct"
+                        echo "ERROR: Unrecognized repository. Unable to determine correct Copyright regex"
+                        sh 'exit 1'
                     }
-                }
-                if (FAIL) {
-                    echo "${HASHES}"
-                    echo "The following files were modified and have incorrect copyrights"
-                    BAD_FILES.each() {
-                        echo "${it}"
+
+                    FILES_LIST.each() {
+                        println "Checking file: '${it}'"
+                        RESULT = sh (
+                            script: "grep -qE ${REGEX} '${it}'",
+                            returnStatus: true)
+                        if(RESULT != 0) {
+                            echo "FAILURE - Copyright date in file: '${it}' appears to be incorrect"
+                            FAIL = true
+                            BAD_FILES << "${it}"
+                        } else {
+                            echo "Copyright date in file: appears to be correct"
+                        }
                     }
-                    echo "${HASHES}"
-                    sh 'exit 1'
-                } else {
-                    echo "All modified files appear to have correct copyrights"
+                    if (FAIL) {
+                        echo "${HASHES}"
+                        echo "The following files were modified and have incorrect copyrights"
+                        BAD_FILES.each() {
+                            echo "${it}"
+                        }
+                        echo "${HASHES}"
+                        sh 'exit 1'
+                    } else {
+                        echo "All modified files appear to have correct copyrights"
+                    }
                 }
             }
         }

--- a/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck
+++ b/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck
@@ -25,71 +25,73 @@ String SRC_REPO = 'https://github.com/${ghprbGhRepository}.git'
 def BAD_FILES = []
 String HASHES = '###################################'
 
-stage('Line Endings Check') {
-    node ('worker') {
-        timestamps {
-            git url: SRC_REPO
-            sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
-            sh "git checkout --detach ${sha1}"
-            sh 'git fetch origin'
-            FILES = sh (
-                script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
-                returnStdout: true
-            ).trim()
-            echo FILES
-            if (FILES == "") {
-                echo "There are no files to check for line endings"
-            } else {
-                def FILES_LIST = FILES.split("\\r?\\n")
-                FILES_LIST.each() {
-                    println "Checking file: '${it}'"
-                    TYPE = sh (
-                        script: "file -b '${it}'",
-                        returnStdout: true
-                    ).trim()
-
-                    switch (TYPE) {
-                        case ~/empty/:
-                            echo "Empty file: '${it}'"
-                            break
-                        case ~/.*text.*/:
-                            switch (it.toLowerCase()) {
-                                case ~/.*\.bat|.*\.cmd/:
-                                    switch(TYPE) {
-                                        case ~/.*CRLF line terminators.*/:
-                                            echo "Good windows script: '${it}' type: '${TYPE}'"
-                                            break
-                                        default:
-                                            echo "ERROR - should have CRLF line terminators: '${it}' type: '${TYPE}'"
-                                            FAIL = true
-                                            BAD_FILES << "${it}"
-                                    }
-                                default:
-                                    switch (TYPE) {
-                                        case ~/.*CR.* line terminators.*/:
-                                            echo "ERROR - should have LF line terminators: '${it}' type: '${TYPE}'"
-                                            FAIL = true
-                                            BAD_FILES << "${it}"
-                                            break
-                                        default:
-                                            echo "Good text file: '${it}' type: '${TYPE}'"
-                                            break
-                                    }
-                            }
-                        default:
-                            echo "Non-text file: '${it}' type: '${TYPE}'"
-                    }
-                }
-                if (FAIL) {
-                    echo "${HASHES}"
-                    echo "The following files were modified and have incorrect line endings"
-                    BAD_FILES.each() {
-                        echo "${it}"
-                    }
-                    echo "${HASHES}"
-                    sh 'exit 1'
+timeout(time: 6, unit: 'HOURS') {
+    stage('Line Endings Check') {
+        node ('worker') {
+            timestamps {
+                git url: SRC_REPO
+                sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
+                sh "git checkout --detach ${sha1}"
+                sh 'git fetch origin'
+                FILES = sh (
+                    script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
+                    returnStdout: true
+                ).trim()
+                echo FILES
+                if (FILES == "") {
+                    echo "There are no files to check for line endings"
                 } else {
-                    echo "All modified files appear to have correct line endings"
+                    def FILES_LIST = FILES.split("\\r?\\n")
+                    FILES_LIST.each() {
+                        println "Checking file: '${it}'"
+                        TYPE = sh (
+                            script: "file -b '${it}'",
+                            returnStdout: true
+                        ).trim()
+
+                        switch (TYPE) {
+                            case ~/empty/:
+                                echo "Empty file: '${it}'"
+                                break
+                            case ~/.*text.*/:
+                                switch (it.toLowerCase()) {
+                                    case ~/.*\.bat|.*\.cmd/:
+                                        switch(TYPE) {
+                                            case ~/.*CRLF line terminators.*/:
+                                                echo "Good windows script: '${it}' type: '${TYPE}'"
+                                                break
+                                            default:
+                                                echo "ERROR - should have CRLF line terminators: '${it}' type: '${TYPE}'"
+                                                FAIL = true
+                                                BAD_FILES << "${it}"
+                                        }
+                                    default:
+                                        switch (TYPE) {
+                                            case ~/.*CR.* line terminators.*/:
+                                                echo "ERROR - should have LF line terminators: '${it}' type: '${TYPE}'"
+                                                FAIL = true
+                                                BAD_FILES << "${it}"
+                                                break
+                                            default:
+                                                echo "Good text file: '${it}' type: '${TYPE}'"
+                                                break
+                                        }
+                                }
+                            default:
+                                echo "Non-text file: '${it}' type: '${TYPE}'"
+                        }
+                    }
+                    if (FAIL) {
+                        echo "${HASHES}"
+                        echo "The following files were modified and have incorrect line endings"
+                        BAD_FILES.each() {
+                            echo "${it}"
+                        }
+                        echo "${HASHES}"
+                        sh 'exit 1'
+                    } else {
+                        echo "All modified files appear to have correct line endings"
+                    }
                 }
             }
         }

--- a/buildenv/jenkins/jobs/infrastructure/omrMirror
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror
@@ -29,6 +29,9 @@ pipeline {
         TARGET_REPO  = 'github.com/eclipse/openj9-omr.git'
         ARCHIVE_FILE = "OMR_COMMIT"
     }
+
+    options { timeout(time: 3, unit: 'HOURS') }
+
     stages {
         stage('Mirror') {
             steps {

--- a/buildenv/jenkins/jobs/infrastructure/tagRepos
+++ b/buildenv/jenkins/jobs/infrastructure/tagRepos
@@ -27,36 +27,39 @@ HTTP = 'https://'
 OMR_REPO = 'github.com/eclipse/openj9-omr.git'
 OPENJ9_REPO = 'github.com/eclipse/openj9.git'
 
+
 def clone_branch_push(REPO, TAG_NAME, TAG_ANNOTATION, TAG_POINT, POINT_TYPE) {
-    node ('worker') {
-        git "${HTTP}${REPO}"
+    timeout(time: 3, unit: 'MINUTES') {
+        node ('worker') {
+            git "${HTTP}${REPO}"
 
-        def REPO_NAME = REPO.substring(REPO.lastIndexOf('/') +1, REPO.lastIndexOf('.git'))
-        echo "REPO_NAME: ${REPO_NAME}"
+            def REPO_NAME = REPO.substring(REPO.lastIndexOf('/') +1, REPO.lastIndexOf('.git'))
+            echo "REPO_NAME: ${REPO_NAME}"
 
-        // Prefix branch names with ref remote since we don't create local refs for branches
-        def POINT_TYPE_PREFIX = ''
-        if (POINT_TYPE == 'BRANCH') {
-            POINT_TYPE_PREFIX = 'refs/remotes/origin/'
+            // Prefix branch names with ref remote since we don't create local refs for branches
+            def POINT_TYPE_PREFIX = ''
+            if (POINT_TYPE == 'BRANCH') {
+                POINT_TYPE_PREFIX = 'refs/remotes/origin/'
+            }
+
+            def SHA = sh (
+                script: "git rev-parse --short ${POINT_TYPE_PREFIX}${TAG_POINT}",
+                returnStdout: true
+            )
+            echo "${REPO} SHA: ${SHA}"
+
+            // Set the build description
+            currentBuild.description += "<br/>${REPO_NAME}: ${SHA}"
+
+            // Tag SHA
+            sh "git tag -a '${TAG_NAME}' -m '${TAG_ANNOTATION}' ${POINT_TYPE_PREFIX}${TAG_POINT}"
+            sh "git show ${TAG_NAME}"
+
+            withCredentials([usernamePassword(credentialsId: 'b6987280-6402-458f-bdd6-7affc2e360d4', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${REPO} 'refs/tags/${TAG_NAME}'"
+            }
+            cleanWs()
         }
-
-        def SHA = sh (
-            script: "git rev-parse --short ${POINT_TYPE_PREFIX}${TAG_POINT}",
-            returnStdout: true
-        )
-        echo "${REPO} SHA: ${SHA}"
-
-        // Set the build description
-        currentBuild.description += "<br/>${REPO_NAME}: ${SHA}"
-
-        // Tag SHA
-        sh "git tag -a '${TAG_NAME}' -m '${TAG_ANNOTATION}' ${POINT_TYPE_PREFIX}${TAG_POINT}"
-        sh "git show ${TAG_NAME}"
-
-        withCredentials([usernamePassword(credentialsId: 'b6987280-6402-458f-bdd6-7affc2e360d4', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-            sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${REPO} 'refs/tags/${TAG_NAME}'"
-        }
-        cleanWs()
     }
 }
 


### PR DESCRIPTION
Set timeout to 6 hours for copyright and lineEndings check 
and to 3 hours for the other infrastructure jobs.

Fixes #974 

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>