### PR TITLE
WIP: Use getters for CodeCache fields

### DIFF
--- a/runtime/compiler/trj9/ras/DebugExt.cpp
+++ b/runtime/compiler/trj9/ras/DebugExt.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2775,12 +2775,12 @@ TR_DebugExt::dxPrintCodeCacheInfo(TR::CodeCache *cacheInfo)
    _dbgPrintf("  ->trampolineBase = (U_8*)0x%p\n", localCacheInfo->_trampolineBase);
    _dbgPrintf("  ->resolvedMethodHT = (OMR::CodeCacheHashTable*)0x%p\n", localCacheInfo->_resolvedMethodHT);
    _dbgPrintf("  ->unresolvedMethodHT = (OMR::CodeCacheHashTable*)0x%p\n", localCacheInfo->_unresolvedMethodHT);
-   _dbgPrintf("  ->hashEntrySlab = (OMR::CodeCacheHashEntrySlab*)0x%p\n", localCacheInfo->_hashEntrySlab);
-   _dbgPrintf("  ->hashEntryFreeList = (OMR::CodeCacheHashEntry*)0x%p\n", localCacheInfo->_hashEntryFreeList);
+   _dbgPrintf("  ->hashEntrySlab = (OMR::CodeCacheHashEntrySlab*)0x%p\n", localCacheInfo->hashEntrySlab());
+   _dbgPrintf("  ->hashEntryFreeList = (OMR::CodeCacheHashEntry*)0x%p\n", localCacheInfo->hashEntryFreeList());
    _dbgPrintf("  ->tempTrampolinesMax = (U_32)%u\n", localCacheInfo->_tempTrampolinesMax);
    _dbgPrintf("  ->flags = (U_32)0x%x\n", localCacheInfo->_flags);
-   _dbgPrintf("  ->trampolineSyncList = (OMR::CodeCacheTempTrampolineSyncBlock*)0x%p\n", localCacheInfo->_trampolineSyncList);
-   _dbgPrintf("  ->freeBlockList = (OMR::CodeCacheFreeCacheBlock*)0x%p\n", localCacheInfo->_freeBlockList);
+   _dbgPrintf("  ->trampolineSyncList = (OMR::CodeCacheTempTrampolineSyncBlock*)0x%p\n", localCacheInfo->trampolineSyncList());
+   _dbgPrintf("  ->freeBlockList = (OMR::CodeCacheFreeCacheBlock*)0x%p\n", localCacheInfo->freeBlockList());
    _dbgPrintf("  ->mutex = (TR::Monitor*)0x%p\n", localCacheInfo->_mutex);
 #if defined(TR_TARGET_X86)
    _dbgPrintf("  ->prefetchCodeSnippetAddress = (uintptrj_t)0x%p\n", localCacheInfo->_CCPreLoadedCode[TR_AllocPrefetch]);
@@ -2822,8 +2822,8 @@ TR_DebugExt::dxPrintFreeCodeCacheBlockList(TR::CodeCache *cacheInfo)
       return;
       }
    TR::CodeCache *localCacheInfo = (TR::CodeCache*) dxMallocAndRead(sizeof(TR::CodeCache), cacheInfo);
-   _dbgPrintf("  List of free block starting at:(OMR::CodeCacheFreeCacheBlock*)0x%p\n", localCacheInfo->_freeBlockList);
-   OMR::CodeCacheFreeCacheBlock *freeBlock = localCacheInfo->_freeBlockList;
+   _dbgPrintf("  List of free block starting at:(OMR::CodeCacheFreeCacheBlock*)0x%p\n", localCacheInfo->freeBlockList());
+   OMR::CodeCacheFreeCacheBlock *freeBlock = localCacheInfo->freeBlockList();
    while (freeBlock)
       {
       freeBlock = dxPrintFreeCodeCacheBlock(freeBlock);

--- a/runtime/compiler/trj9/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/trj9/runtime/J9CodeCache.cpp
@@ -638,7 +638,7 @@ J9::CodeCache::onFSDDecompile()
       return;
 
    _flags &= ~OMR::CODECACHE_FULL_SYNC_REQUIRED;
-   for (syncBlock = _trampolineSyncList; syncBlock; syncBlock = syncBlock->_next)
+   for (syncBlock = self()->trampolineSyncList(); syncBlock; syncBlock = syncBlock->_next)
       syncBlock->_entryCount = 0;
 
    _tempTrampolineNext = _tempTrampolineBase;
@@ -654,16 +654,16 @@ int32_t
 J9::CodeCache::reserveUnresolvedTrampoline(void *cp, int32_t cpIndex)
    {
    int32_t retValue = OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS; // assume success
-   
+
    // If the platform does not need trampolines, return success
    TR::CodeCacheConfig &config = _manager->codeCacheConfig();
    if (!config.needsMethodTrampolines())
       return OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS;
-   
+
    // scope for cache critical section
       {
       CacheCriticalSection reserveTrampoline(self());
-      
+
       // check if we already have a reservation for this name/classLoader key
       OMR::CodeCacheHashEntry *entry = _unresolvedMethodHT->findUnresolvedMethod(cp, cpIndex);
       if (!entry)
@@ -674,7 +674,7 @@ J9::CodeCache::reserveUnresolvedTrampoline(void *cp, int32_t cpIndex)
             {
             if (!self()->addUnresolvedMethod(cp, cpIndex))
                retValue = OMR::CodeCacheErrorCode::ERRORCODE_FATALERROR; // couldn't allocate memory from VM
-            } 
+            }
          else // no space in this code cache; must allocate a new one
             {
             _almostFull = TR_yes;
@@ -686,7 +686,7 @@ J9::CodeCache::reserveUnresolvedTrampoline(void *cp, int32_t cpIndex)
             }
          }
       }
-   
+
    return retValue;
    }
 


### PR DESCRIPTION
Replace direct access to some CodeCache fields with getter functions.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>