### PR TITLE
Fix Windows compilation warning treated as error

### DIFF
--- a/runtime/j9vm/java9vmi.c
+++ b/runtime/j9vm/java9vmi.c
@@ -950,7 +950,7 @@ JVM_DefineModule(JNIEnv * env, jobject module, jstring version, jstring location
 
 #if J9VM_JAVA9_BUILD >= 156
 		if ((classLoader != vm->systemClassLoader) && (classLoader != vm->platformClassLoader)) {
-			U_32 pkgIndex = 0;
+			jsize pkgIndex = 0;
 			for (pkgIndex = 0; pkgIndex < numPackages; pkgIndex++) {
 				const char *packageName = packages[pkgIndex];
 #define JAVADOT "java."


### PR DESCRIPTION
Fix Windows compilation warning treated as error

Making `pkgIndex` a `jsize` to match the type of `numPackages`.

Reviewer: @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>