### PR TITLE
Remove string to boolean expression conversion for node's labels

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -192,11 +192,14 @@ def get_user_credentials_id(KEY) {
 /*
 * Sets the NODE variable to the labels identifying nodes by platform suitable
 * to run a Jenkins job.
+* Fetches the labels from the variables file when the NODE is not set as build
+* parameter.
+* The node's labels could be a single label - e.g. label1 - or a boolean 
+* expression - e.g. label1 && label2 || label3. 
 */
 def set_node(job_type) {
-    // fetch labels (space separated string) for given platform/spec
-    labels = get_value(VARIABLES."${SPEC}".node_labels."${job_type}", SDK_VERSION)
-    NODE = labels.replaceAll(" ", "&&")
+    // fetch labels for given platform/spec
+    NODE = (!params.NODE) ? get_value(VARIABLES."${SPEC}".node_labels."${job_type}", SDK_VERSION) : params.NODE
     if (!NODE) {
         error("Cannot find label value matching JOB_TYPE:'${job_type}' SPEC:'${SPEC}' and SDK_VERSION:'${SDK_VERSION}'")
     }


### PR DESCRIPTION
This allows the use of any boolean expression (can contain other logical
operators not only AND). The variables file requires the labels to be
provided as boolean expressions instead of strings (space separated
labels) for multiple labels.
It also checks first if the NODE is passed as argument. 

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>