### PR TITLE
Add copyValue method to ObjectAccessBarrier

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -178,6 +178,9 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_getLockwordAddress,
 	j9gc_objaccess_cloneObject,
 	j9gc_objaccess_cloneIndexableObject,
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	j9gc_objaccess_copyValue,
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	j9gc_objaccess_asConstantPoolObject,
 #if defined(J9VM_GC_REALTIME)
 	j9gc_objaccess_referenceGet,

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -228,6 +228,9 @@ public:
 	virtual j9objectmonitor_t *getLockwordAddress(J9VMThread *vmThread, J9Object *object);
 	virtual void cloneObject(J9VMThread *vmThread, J9Object *srcObject, J9Object *destObject);
 	virtual void cloneIndexableObject(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	virtual void copyValue(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	virtual J9Object* asConstantPoolObject(J9VMThread *vmThread, J9Object* toConvert, UDATA allocationFlags);
 	virtual void storeObjectToInternalVMSlot(J9VMThread *vmThread, J9Object** destSlot, J9Object *value);
 	virtual J9Object *readObjectFromInternalVMSlot(J9VMThread *vmThread, J9Object **srcSlot);

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -618,6 +618,18 @@ j9gc_objaccess_cloneIndexableObject(J9VMThread *vmThread, J9IndexableObject *src
 	return barrier->cloneIndexableObject(vmThread, srcObject, destObject);
 }
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+void
+j9gc_objaccess_copyValue(
+		J9VMThread *vmThread, J9Class *valueClass,
+		J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset
+) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->copyValue(vmThread, valueClass, srcObject, srcOffset, destObject, destOffset);
+}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
+
 /**
  * Helper function to clone an object to tenure if required so that it can be saved in the constantpool.
  */

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -96,6 +96,9 @@ extern J9_CFUNC UDATA j9gc_software_read_barrier_enabled(J9JavaVM *javaVM);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreAddress(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_cloneObject(J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+extern J9_CFUNC void j9gc_objaccess_copyValue(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 extern J9_CFUNC j9object_t j9gc_objaccess_asConstantPoolObject(J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags);
 extern J9_CFUNC jvmtiIterationControl j9mm_iterate_heaps(J9JavaVM *vm, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl(*func)(J9JavaVM *vm, struct J9MM_IterateHeapDescriptor *heapDesc, void *userData), void *userData);
 extern J9_CFUNC int gcStartupHeapManagement(J9JavaVM * vm);

--- a/runtime/gc_glue_java/MixedObjectModel.hpp
+++ b/runtime/gc_glue_java/MixedObjectModel.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,6 +85,19 @@ public:
 		return getSizeInBytesWithoutHeader(objectPtr) + sizeof(J9Object);
 	}
 	
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/**
+	 * Returns the size of a class' fields in bytes.
+	 * @param clazz Pointer to the class whose fields size is required
+	 * @return Size of class' fields in bytes
+	 */
+	MMINLINE UDATA
+	getFieldsSizeInBytes(J9Class *clazz)
+	{
+		return clazz->backfillOffset - sizeof(J9Object) - sizeof(j9objectmonitor_t);
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 	/**
 	 * Returns the header size of a given  object.
 	 * @param arrayPtr Ptr to an array for which header size will be returned

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -396,6 +396,18 @@ public:
 #endif /* defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
 	}
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/* TODO: implement copyValue without barriers */
+	VMINLINE void
+	copyValue(J9VMThread *vmThread, J9Class *valueClass, j9object_t srcObject, UDATA srcOffset, j9object_t destObject, UDATA destOffset)
+	{
+/* #if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyValue(vmThread, valueClass, srcObject, srcOffset, destObject, destOffset);
+/* #else defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
+/* #endif defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 	/**
 	 * Read an object field: perform any pre-use barriers, calculate an effective address
 	 * and perform the work.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4362,6 +4362,9 @@ typedef struct J9MemoryManagerFunctions {
 	j9objectmonitor_t*  ( *j9gc_objaccess_getLockwordAddress)(struct J9VMThread *vmThread, j9object_t object) ;
 	void  ( *j9gc_objaccess_cloneObject)(struct J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject) ;
 	void  ( *j9gc_objaccess_cloneIndexableObject)(struct J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject) ;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	void ( *j9gc_objaccess_copyValue)(struct J9VMThread *vmThread, struct J9Class *valueClass, j9object_t srcObject, UDATA srcOffset, j9object_t destObject, UDATA destOffset) ;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	j9object_t  ( *j9gc_objaccess_asConstantPoolObject)(struct J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags) ;
 #if defined(J9VM_GC_REALTIME)
 	j9object_t  ( *j9gc_objaccess_referenceGet)(struct J9VMThread *vmThread, j9object_t refObject) ;


### PR DESCRIPTION
Add new method to MM_ObjectAccessBarrier to copy fields of a value class
instance into another value class instance.

This method differs from the cloneObject method in that the target
instances can be flattened within other objects, arrays,  or values, and is
intended to be used with bytecodes such as putfield, getfield, etc.

Since values may be flattened, it may not have an object header. For
this reason, the method must be given the value's J9Class explicitly.
Flattening also means values may not be 8-byte aligned. In
nocompressedrefs, this means copyValue cannot simply iterate through
fields 8-bytes at a time with the description bits the way cloneObject
does, as mixedObjectReadObject and mixedObjectStoreObject would be
performing unaligned reads and writes.

Signed-off-by: Eric Zhang <eric99.zhang@gmail.com>