### PR TITLE
Change -version output to include -Bit after [32|64]

### DIFF
--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -134,15 +134,15 @@ jint computeFullVersionString(J9JavaVM* vm)
 
 #ifdef J9VM_ENV_DATA64
 	#ifdef J9VM_GC_COMPRESSED_POINTERS
-		#define MEM_INFO "-64 Compressed References "
+		#define MEM_INFO "-64-Bit Compressed References "
 	#else
-		#define MEM_INFO "-64 "
+		#define MEM_INFO "-64-Bit "
 	#endif
 #else
 	#if defined(J9ZOS390) || defined(S390)
-		#define MEM_INFO "-31 "
+		#define MEM_INFO "-31-Bit "
 	#else
-		#define MEM_INFO "-32 "
+		#define MEM_INFO "-32-Bit "
 	#endif
 #endif
 


### PR DESCRIPTION
Change `-version` output to include `-Bit` after `[32|64]`

To satisfy `OpenJDK` make script which does grep `64-Bit` to determine the `bootjdk` type.
Note: this affects the system properties `java.vm.info` and `java.fullversion` in `Java 8` and upwards.
Now a `Java 8 -version` output looks like:
```
java version "1.8.0_171"
Java(TM) SE Runtime Environment (build 8.0.6.0 - pxa6480sr6-20180423_01(SR6))
IBM J9 VM (build 2.9, JRE 1.8.0 Linux amd64-64-Bit Compressed References 20180426_385464 (JIT enabled, AOT enabled)
OpenJ9   - 4b971df
OMR      - 35eb960
IBM      - 4f87eeb)
JCL - 20180412_01 based on Oracle jdk8u171-b11
```

closes: #1774 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>