### PR TITLE
Modify shutdown sequence to fix CS issue

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -54,7 +54,6 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	gcShutdownHeapManagement,
 	initializeMutatorModelJava,
 	cleanupMutatorModelJava,
-	internalFreeMemorySpace,
 #if defined(J9VM_GC_FINALIZATION)
 	j9gc_finalizer_startup,
 	j9gc_finalizer_shutdown,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -209,7 +209,6 @@ extern J9_CFUNC struct J9HookInterface** j9gc_get_omr_hook_interface(OMR_VM *omr
 extern J9_CFUNC void j9gc_objaccess_staticStoreU32(J9VMThread *vmThread, J9Class *clazz, U_32 *destSlot, U_32 value, UDATA isVolatile);
 extern J9_CFUNC IDATA initializeMutatorModelJava(J9VMThread* vmThread);
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreU64Split(J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile);
-extern J9_CFUNC void internalFreeMemorySpace(J9JavaVM * javaVM, void * memorySpace);
 extern J9_CFUNC IDATA j9gc_objaccess_staticReadI32(J9VMThread *vmThread, J9Class *clazz, I_32 *srcSlot, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreObject(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, j9object_t value, UDATA isVolatile);
 extern J9_CFUNC UDATA j9gc_objaccess_staticReadU32(J9VMThread *vmThread, J9Class *clazz, U_32 *srcSlot, UDATA isVolatile);

--- a/runtime/gc_modron_startup/gcmspace.cpp
+++ b/runtime/gc_modron_startup/gcmspace.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -131,29 +131,6 @@ cleanup:
 
 	/* TODO: Cleanup for the memorySpace class (if necessary) */
 	return NULL;
-}
-
-/**
- * Frees all memory spaces.
- * @param memorySpace pointer to the list (pool) of memory spaces
- */
-void
-internalFreeMemorySpace(J9JavaVM * javaVM, void * memorySpace)
-{
-	MM_EnvironmentBase env(javaVM->omrVM);
-
-	MM_MemorySpace *modronMemorySpace = (MM_MemorySpace *)memorySpace;
-	if  (modronMemorySpace) {
-		if (!(javaVM->runtimeFlags & J9_RUNTIME_SHUTDOWN)) {
-			TRIGGER_J9HOOK_MM_PRIVATE_HEAP_DELETE(
-				MM_GCExtensions::getExtensions(javaVM)->privateHookInterface,
-				env.getOmrVMThread(),
-				modronMemorySpace);
-		}
-
-		modronMemorySpace->kill(&env);
-
-	}
 }
 
 } /* extern "C" */

--- a/runtime/gc_modron_startup/gcmspace.h
+++ b/runtime/gc_modron_startup/gcmspace.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,6 @@ extern "C" {
 
 MM_MemorySpace *internalAllocateMemorySpaceWithMaximum(J9JavaVM * javaVM, UDATA minimumSpaceSize, UDATA minimumNewSpaceSize, UDATA initialNewSpaceSize, UDATA maximumNewSpaceSize, UDATA minimumTenureSpaceSize, UDATA initialTenureSpaceSize, UDATA maximumTenureSpaceSize, UDATA memoryMax, UDATA baseAddress, UDATA tenureFlags);
 MM_MemorySpace *internalAllocateMemorySpaceWithMaximumWithEnv(MM_EnvironmentBase *env, J9JavaVM *javaVM, UDATA minimumSpaceSize, UDATA minimumNewSpaceSize, UDATA initialNewSpaceSize, UDATA maximumNewSpaceSize, UDATA minimumTenureSpaceSize, UDATA initialTenureSpaceSize, UDATA maximumTenureSpaceSize, UDATA memoryMax, UDATA baseAddress, UDATA tenureFlags);
-void internalFreeMemorySpace(J9JavaVM * javaVM, void * memorySpace);
 
 #ifdef __cplusplus
 } /* extern "C" { */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4285,7 +4285,6 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *gcShutdownHeapManagement)(struct J9JavaVM * vm) ;
 	IDATA  ( *initializeMutatorModelJava)(struct J9VMThread* vmThread) ;
 	void  ( *cleanupMutatorModelJava)(struct J9VMThread* vmThread) ;
-	void  ( *internalFreeMemorySpace)(struct J9JavaVM * javaVM, void * memorySpace) ;
 #if defined(J9VM_GC_FINALIZATION)
 	int  ( *j9gc_finalizer_startup)(struct J9JavaVM * vm) ;
 	void  ( *j9gc_finalizer_shutdown)(struct J9JavaVM * vm) ;


### PR DESCRIPTION
Fixing two issues with Concurrent Scavenger:
1. Modified shutdown sequence to do Scavenger tear down later in the
sequence; after all of the mutator threads are done. 
2. Added a new case in flushGCCaches to clear a GC Slave thread copy
cache when starting up with many GC threads and GC slave thread is
brought up during active scavenger cycle but doesn't do any actual work
and so is actually acting like a mutator thread until the next cycle.

Signed-off-by: Evgenia Badyanova <evgeniab@ca.ibm.com>