### PR TITLE
Add test cases related to invoking some Class methods after an initialization error

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/resources/reflect/A.java
+++ b/test/functional/Java8andUp/src/org/openj9/resources/reflect/A.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.resources.reflect;
+
+public class A {
+
+	static {
+		String x = null;
+		x.getClass();
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/resources/reflect/B.java
+++ b/test/functional/Java8andUp/src/org/openj9/resources/reflect/B.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.resources.reflect;
+
+public class B {
+
+	public int x;
+	public void m() {}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetConstructorTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetConstructorTests.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Constructor;
+
+public class GetConstructorTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetConstructorAfterNewInstance() throws NoSuchMethodException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Constructor constructor = B.class.getConstructor(null);
+			String expectedConstructorSignature = "public org.openj9.resources.reflect.B()";
+			String actualConstructorSignature = constructor.toString();
+			Assert.assertEquals(expectedConstructorSignature, actualConstructorSignature, "wrong signatures for constructors");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetConstructorsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetConstructorsTests.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Constructor;
+
+public class GetConstructorsTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetConstructorsAfterNewInstance() {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Constructor[] constructors = B.class.getConstructors();
+			int expectedConstructorsListSize = 1;
+			int actualConstructorsListSize = constructors.length;
+			Assert.assertEquals(expectedConstructorsListSize, actualConstructorsListSize, "wrong constructors list size");
+			String expectedConstructorSignature = "public org.openj9.resources.reflect.B()";
+			String actualConstructorSignature = constructors[0].toString();
+			Assert.assertEquals(expectedConstructorSignature, actualConstructorSignature, "wrong signatures for constructors");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredConstructorTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredConstructorTests.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Constructor;
+
+public class GetDeclaredConstructorTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetDeclaredConstructorAfterNewInstance() throws NoSuchMethodException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Constructor declaredConstructor = B.class.getDeclaredConstructor(null);
+			String expectedConstructorSignature = "public org.openj9.resources.reflect.B()";
+			String actualConstructorSignature = declaredConstructor.toString();
+			Assert.assertEquals(expectedConstructorSignature, actualConstructorSignature, "wrong signatures for declared constructor");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredConstructorsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredConstructorsTests.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Constructor;
+
+public class GetDeclaredConstructorsTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetDeclaredConstructorsAfterNewInstance() {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Constructor[] declaredConstructors = B.class.getDeclaredConstructors();
+			int expectedConstructorsListSize = 1;
+			int actualConstructorsListSize = declaredConstructors.length;
+			Assert.assertEquals(expectedConstructorsListSize, actualConstructorsListSize, "wrong declared constructors list size");
+			String expectedConstructorSignature = "public org.openj9.resources.reflect.B()";
+			String actualConstructorSignature = declaredConstructors[0].toString();
+			Assert.assertEquals(expectedConstructorSignature, actualConstructorSignature, "wrong signatures for declared constructor");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredFieldTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredFieldTests.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import java.lang.reflect.Field;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class GetDeclaredFieldTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetDeclaredFieldAfterNewInstance() throws NoSuchFieldException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Field declaredField = B.class.getDeclaredField("x");
+			String expectedFieldSignature = "public int org.openj9.resources.reflect.B.x";
+			String actualFieldSignature = declaredField.toString();
+			Assert.assertEquals(expectedFieldSignature, actualFieldSignature, "wrong signatures for field");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredFieldsTests.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import java.lang.reflect.Field;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class GetDeclaredFieldsTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetDeclaredFieldsAfterNewInstance() {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Field[] declaredFields = B.class.getDeclaredFields();
+			int expectedFieldsListSize = 1;
+			int actualFieldsListSize = declaredFields.length;
+			Assert.assertEquals(expectedFieldsListSize, actualFieldsListSize, "wrong declared fields list size");
+			String expectedFieldSignature = "public int org.openj9.resources.reflect.B.x";
+			String actualFieldSignature = declaredFields[0].toString();
+			Assert.assertEquals(expectedFieldSignature, actualFieldSignature, "wrong signatures for declared field");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredMethodTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredMethodTests.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Method;
+
+public class GetDeclaredMethodTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetDeclaredMethodAfterNewInstance() throws NoSuchMethodException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Method declaredMethod = B.class.getDeclaredMethod("m");
+			String expectedMethodSignature = "public void org.openj9.resources.reflect.B.m()";
+			String actualMethodSignature = declaredMethod.toString();
+			Assert.assertEquals(expectedMethodSignature, actualMethodSignature, "wrong signatures for declared method");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredMethodsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetDeclaredMethodsTests.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Method;
+
+public class GetDeclaredMethodsTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetDeclaredMethodsAfterNewInstance() {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Method[] declaredMethods = B.class.getDeclaredMethods();
+			int expectedMethodsListSize = 1;
+			int declaredMethodsListSize = declaredMethods.length;
+			Assert.assertEquals(expectedMethodsListSize, declaredMethodsListSize, "wrong methods list size");
+			String expectedMethodSignature = "public void org.openj9.resources.reflect.B.m()";
+			String actualMethodSignature = declaredMethods[0].toString();
+			Assert.assertEquals(expectedMethodSignature, actualMethodSignature, "wrong signatures for method");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetFieldTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetFieldTests.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import java.lang.reflect.Field;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class GetFieldTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetFieldAfterNewInstance() throws NoSuchFieldException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Field field = B.class.getField("x");
+			String expectedFieldSignature = "public int org.openj9.resources.reflect.B.x";
+			String actualFieldSignature = field.toString();
+			Assert.assertEquals(expectedFieldSignature, actualFieldSignature, "wrong signatures for field");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetFieldsTests.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import java.lang.reflect.Field;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class GetFieldsTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetFieldsAfterNewInstance() {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Field[] fields = B.class.getFields();
+			int expectedFieldsListSize = 1;
+			int fieldsListSize = fields.length;
+			Assert.assertEquals(expectedFieldsListSize, fieldsListSize, "wrong fields list size");
+			String expectedFieldSignature = "public int org.openj9.resources.reflect.B.x";
+			String actualFieldSignature = fields[0].toString();
+			Assert.assertEquals(expectedFieldSignature, actualFieldSignature, "wrong signatures for field");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetMethodTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetMethodTests.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 Felipe Pontes
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.reflect;
+
+import org.openj9.resources.reflect.B;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import java.lang.reflect.Method;
+
+public class GetMethodTests {
+
+	@Test(groups = { "level.sanity" })
+	public void testGetMethodAfterNewInstance() throws NoSuchMethodException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Method method = B.class.getMethod("m");
+			String expectedMethodSignature = "public void org.openj9.resources.reflect.B.m()";
+			String actualMethodSignature = method.toString();
+			Assert.assertEquals(expectedMethodSignature, actualMethodSignature, "wrong signatures for method");
+		}
+	}
+
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/reflect/GetMethodsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/reflect/GetMethodsTests.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import org.openj9.resources.reflect.B;
 
 public class GetMethodsTests {
 	/* contrived method names which have the same String.hashCode(). */
@@ -326,6 +327,22 @@ public class GetMethodsTests {
 		System.arraycopy(jlobjectMethods, 0, result, methodList.length, jlobjectMethods.length);
 		Arrays.sort(result);
 		return result;
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testGetMethodsAfterNewInstance() throws NoSuchMethodException {
+		try {
+			B.class.newInstance();
+		} catch (ExceptionInInitializerError e) {
+		} catch (Exception e) {
+		} finally {
+			Method method = B.class.getMethod("m");
+			Method[] methods = B.class.getMethods();
+			int expectedMethodsListSize = 10;
+			int declaredMethodsListSize = methods.length;
+			Assert.assertEquals(expectedMethodsListSize, declaredMethodsListSize, "wrong methods list size");
+			Assert.assertTrue(Arrays.asList(methods).contains(method));
+		}
 	}
 
 }

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -30,6 +30,17 @@
 	<test name="generalTest">
 		<classes>
 			<class name="org.openj9.test.gpu.SortTest" />
+			<class name="org.openj9.test.reflect.GetConstructorTests" />
+			<class name="org.openj9.test.reflect.GetConstructorsTests" />
+			<class name="org.openj9.test.reflect.GetDeclaredConstructorTests" />
+			<class name="org.openj9.test.reflect.GetDeclaredConstructorsTests" />
+			<class name="org.openj9.test.reflect.GetDeclaredFieldTests" />
+			<class name="org.openj9.test.reflect.GetDeclaredFieldsTests" />
+			<class name="org.openj9.test.reflect.GetDeclaredMethodTests" />
+			<class name="org.openj9.test.reflect.GetDeclaredMethodsTests" />
+			<class name="org.openj9.test.reflect.GetFieldTests" />
+			<class name="org.openj9.test.reflect.GetFieldsTests" />
+			<class name="org.openj9.test.reflect.GetMethodTests" />
 		</classes>
 	</test>
 	<test name="regression">


### PR DESCRIPTION
Test cases to invoke the following methods after an initialization
error:

 * Class.getDeclaredFields
 * Class.getConstructor
 * Class.getConstructors
 * Class.getDeclaredConstructor
 * Class.getDeclaredConstructors
 * Class.getDeclaredField
 * Class.getDeclaredMethod
 * Class.getDeclaredMethods
 * Class.getField
 * Class.getFields
 * Class.getMethod
 * Class.getMethods

Related to #1627, #1837, #1838, #1839, #1840, #1841, #1842, #1843
, #1844, #1845, #1846, and #1847
Signed-off-by: Felipe Pontes <felipepontes@copin.ufcg.edu.br>