### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -494,7 +494,7 @@ setThrowableSlots:
 		J9VMJAVALANGTHROWABLE_SET_STACKTRACE(currentThread, unwrappedThrowable, NULL);
 	}
 done:
-	vmfns->internalReleaseVMAccess(currentThread);
+	vmfns->internalExitVMToJNI(currentThread);
 }
 
 
@@ -561,7 +561,7 @@ JVM_FindLoadedClass(JNIEnv* env, jobject classLoader, jobject className)
 			vmClassLoader,
 			J9_FINDCLASS_FLAG_EXISTING_ONLY);
 done:
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	if (NULL == loadedClass) {
 		return NULL;
@@ -731,7 +731,7 @@ JVM_GetArrayElement(JNIEnv *env, jobject array, jint index)
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return elementJNIRef;
 }
@@ -775,7 +775,7 @@ JVM_GetArrayLength(JNIEnv *env, jobject array)
 		}
 	}
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return arrayLength;
 }
@@ -789,7 +789,7 @@ java_lang_Class_vmRef(JNIEnv* env, jobject clazz)
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	ramClass = J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(clazz) );
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	return ramClass;
 }
@@ -1335,7 +1335,7 @@ JVM_GetPrimitiveArrayElement(JNIEnv *env, jobject array, jint index, jint wCode)
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return value;
 }
@@ -1366,7 +1366,7 @@ JVM_GetStackTraceDepth(JNIEnv* env, jobject throwable)
 
 	vmfns->internalEnterVMFromJNI(currentThread);
 	numberOfFrames = (jint)vmfns->iterateStackTrace(currentThread, (j9object_t*)throwable, NULL, NULL, pruneConstructors);
-	vmfns->internalReleaseVMAccess(currentThread);
+	vmfns->internalExitVMToJNI(currentThread);
 
 	return numberOfFrames;
 }
@@ -1460,7 +1460,7 @@ JVM_GetStackTraceElement(JNIEnv* env, jobject throwable, jint index)
 
 	vmfns->internalEnterVMFromJNI(currentThread);
 	vmfns->iterateStackTrace(currentThread, (j9object_t*)throwable, getStackTraceElementIterator, &userData, pruneConstructors);
-	vmfns->internalReleaseVMAccess(currentThread);
+	vmfns->internalExitVMToJNI(currentThread);
 
 	/* Bail if we couldn't find the frame */
 	if (TRUE != userData.found) {
@@ -1514,7 +1514,7 @@ JVM_IHashCode(JNIEnv *env, jobject obj)
 
 		vmFuncs->internalEnterVMFromJNI(currentThread);
 		result = vm->memoryManagerFunctions->j9gc_objaccess_getObjectHashCode(vm, J9_JNI_UNWRAP_REFERENCE(obj));
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
 	return result;
@@ -1559,7 +1559,7 @@ JVM_InternString(JNIEnv *env, jstring str)
 		stringObject = J9_JNI_UNWRAP_REFERENCE(str);
 		stringObject = javaVM->memoryManagerFunctions->j9gc_internString(currentThread, stringObject);
 		str = vmfns->j9jni_createLocalRef(env, stringObject);
-		vmfns->internalReleaseVMAccess(currentThread);
+		vmfns->internalExitVMToJNI(currentThread);
 	}
 
 	return str;
@@ -1613,7 +1613,7 @@ JVM_IsInterrupted(JNIEnv* env, jobject thread, jboolean unknown)
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, J9_JNI_UNWRAP_REFERENCE(thread) );
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	assert(targetThread == currentThread);
 
@@ -1679,7 +1679,7 @@ JVM_IsThreadAlive(JNIEnv* jniEnv, jobject targetThread)
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	vmThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, J9_JNI_UNWRAP_REFERENCE(targetThread) );
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	/* Assume that a non-null threadRef indicates the thread is alive */
 	return (NULL == vmThread) ? JNI_FALSE : JNI_TRUE;
@@ -1713,7 +1713,7 @@ JVM_NewArray(JNIEnv* jniEnv, jclass componentType, jint dimension)
 	}
 
 	arrayRef = vm->internalVMFunctions->j9jni_createLocalRef(jniEnv, newArray);
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	return arrayRef;
 }
 
@@ -1799,7 +1799,7 @@ JVM_NewMultiArray(JNIEnv *env, jclass eltClass, jintArray dim)
 		}
 	}
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -2008,7 +2008,7 @@ JVM_SetArrayElement(JNIEnv *env, jobject array, jint index, jobject value)
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return;
 }
@@ -2195,7 +2195,7 @@ JVM_SetPrimitiveArrayElement(JNIEnv *env, jobject array, jint index, jvalue valu
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return;
 }
@@ -2230,7 +2230,7 @@ JVM_SetThreadPriority(JNIEnv* env, jobject thread, jint priority)
 	vm = currentThread->javaVM;
 	vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	vmThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, J9_JNI_UNWRAP_REFERENCE(thread) );
-	vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	if ( (NULL != vmThread) && (NULL != vmThread->osThread)) {
 		J9ThreadEnv* threadEnv = getJ9ThreadEnv(env);
@@ -2276,7 +2276,7 @@ JVM_StartThread(JNIEnv* jniEnv, jobject newThread)
 			javaVM,
 			NULL);
 
-	javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	if (result != J9_THREAD_START_NO_ERROR) {
 		assert(!"JVM_StartThread() failed!");
@@ -2463,7 +2463,7 @@ throwNativeOOMError(JNIEnv *env, U_32 moduleName, U_32 messageNumber)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vmFuncs->setNativeOutOfMemoryError(currentThread, moduleName, messageNumber);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -2640,7 +2640,7 @@ done:
 
 	result = vmFuncs->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	if ((U_8*)utf8NameStackBuffer != utf8Name) {
 		j9mem_free_memory(utf8Name);

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5829,7 +5829,7 @@ JVM_DefineClassWithSource(JNIEnv *env, const char * className, jobject classLoad
 
 	if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(classNameString))) {
 		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (UDATA *)*(j9object_t*)classNameString);
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 		return NULL;
 	}
 
@@ -5838,11 +5838,11 @@ JVM_DefineClassWithSource(JNIEnv *env, const char * className, jobject classLoad
 	if (NULL == vmLoader) {
 		vmLoader = vmFuncs->internalAllocateClassLoader(vm, loaderObject);
 		if (NULL == vmLoader) {
-			vmFuncs->internalReleaseVMAccess(currentThread);
+			vmFuncs->internalExitVMToJNI(currentThread);
 			return NULL;
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return jvmDefineClassHelper(env, classLoader, classNameString, (jbyte*)classArray, 0, length, domain, 0);
 }
 

--- a/runtime/jcl/common/annparser.c
+++ b/runtime/jcl/common/annparser.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ Java_com_ibm_oti_reflect_AnnotationParser_getAnnotationsData__Ljava_lang_reflect
 			result = vmThread->javaVM->internalVMFunctions->j9jni_createLocalRef(env, annotationsData);
 		}
 	}
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 	return result;
 }
 
@@ -93,7 +93,7 @@ getExecutableAnnotationDataHelper(JNIEnv *env, jobject jlrMethod, METHOD_OBJECT_
 			result = vmThread->javaVM->internalVMFunctions->j9jni_createLocalRef(env, annotationsData);
 		}
 	}
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 	return result;
 }
 

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,11 +51,11 @@ Java_java_lang_ClassLoader_defineClassImpl(JNIEnv *env, jobject receiver, jstrin
 
 		if (CLASSNAME_INVALID == vmFuncs->verifyQualifiedName(currentThread, J9_JNI_UNWRAP_REFERENCE(className))) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNOCLASSDEFFOUNDERROR, (UDATA *)*(j9object_t*)className);
-			vmFuncs->internalReleaseVMAccess(currentThread);
+			vmFuncs->internalExitVMToJNI(currentThread);
 			return NULL;
 		}
 
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 #endif
 
@@ -92,7 +92,7 @@ Java_com_ibm_oti_vm_BootstrapClassLoader_addJar(JNIEnv *env, jobject receiver, j
 		newCount = (jint)addJarToSystemClassLoaderClassPathEntries(vm, jarPathBuffer);
 		j9mem_free_memory(jarPathBuffer);
 		vmFuncs->releaseExclusiveVMAccess(currentThread);
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 	/* If any error occcurred, throw OutOfMemoryError */
 	if (0 == newCount) {

--- a/runtime/jcl/common/com_ibm_oti_vm_VM.c
+++ b/runtime/jcl/common/com_ibm_oti_vm_VM.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,7 +137,7 @@ Java_com_ibm_oti_vm_VM_getNonBootstrapClassLoader(JNIEnv *env, jclass jlClass)
 		}
 		vmFuncs->freeStackWalkCaches(currentThread, &walkState);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 

--- a/runtime/jcl/common/exhelp.c
+++ b/runtime/jcl/common/exhelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,7 +79,7 @@ throwNativeOOMError(JNIEnv *env, U_32 moduleName, U_32 messageNumber)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vmFuncs->setNativeOutOfMemoryError(currentThread, moduleName, messageNumber);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 

--- a/runtime/jcl/common/gpu.c
+++ b/runtime/jcl/common/gpu.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ Java_com_ibm_gpu_Kernel_launch(JNIEnv *env,
 						blockDimX, blockDimY, blockDimZ,
 						args);
 
-		jvm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+		jvm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 		if (NULL != args) {
 			j9mem_free_memory(args);
@@ -131,7 +131,7 @@ Java_java_util_stream_IntPipeline_promoteGPUCompile(JNIEnv *env, jclass clazz)
 
 		vmFuncs->internalEnterVMFromJNI(vmThread);
 		vm->jitConfig->promoteGPUCompile(vmThread);
-		vmFuncs->internalReleaseVMAccess(vmThread);
+		vmFuncs->internalExitVMToJNI(vmThread);
 	}
 }
 

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -205,7 +205,7 @@ Java_java_lang_invoke_MethodHandle_requestCustomThunkFromJit(JNIEnv* env, jobjec
 		J9_JNI_UNWRAP_REFERENCE(handle), 
 		J9_JNI_UNWRAP_REFERENCE(thunk), 
 		J9_METHOD_HANDLE_COMPILE_CUSTOM);
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 }
 
 jclass JNICALL
@@ -312,7 +312,7 @@ Java_java_lang_invoke_PrimitiveHandle_lookupMethod(JNIEnv *env, jobject handle, 
 	}
 
 _cleanup:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	if (signatureUTF8 != (J9UTF8*)signatureUTF8Buffer) {
 		j9mem_free_memory(signatureUTF8);
@@ -631,7 +631,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromField(JNIEnv *
 	J9VMJAVALANGINVOKEPRIMITIVEHANDLE_SET_RAWMODIFIERS(vmThread, J9_JNI_UNWRAP_REFERENCE(handle), fieldID->field->modifiers);
 	result = JNI_TRUE;
 
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }
 
@@ -693,7 +693,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod(JNIEnv 
 	result = JNI_TRUE;
 
 _cleanup:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	return result;
 }
@@ -719,7 +719,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromConstructor(JN
 
 	result = JNI_TRUE;
 
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }
 
@@ -761,7 +761,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle(
 	}
 
 _done:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }
 
@@ -783,7 +783,7 @@ Java_java_lang_invoke_MethodHandles_00024Lookup_setAccessClassForSecuritCheck(JN
 		toInstall = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(accessClass));
 	}
 	vmThread->methodHandlesLookupAccessClass = toInstall;
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 }
 
 /* Return the field offset of the 'vmRef' field in j.l.Class.
@@ -843,7 +843,7 @@ Java_java_lang_invoke_MutableCallSite_freeGlobalRef(JNIEnv *env, jclass mutableC
 		vmFuncs->internalEnterVMFromJNI(vmThread);
 		globalRef = (jobject)((UDATA)J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(mutableCallSite))->ramStatics + ((UDATA)bypassOffset & ~(UDATA)J9_SUN_FIELD_OFFSET_MASK));
 		vmFuncs->j9jni_deleteGlobalRef(env, globalRef, FALSE);
-		vmFuncs->internalReleaseVMAccess(vmThread);
+		vmFuncs->internalExitVMToJNI(vmThread);
 	}
 	return;
 }
@@ -1051,6 +1051,6 @@ clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *
 		count -= 1;
 		nativeMethod +=1;
 	}
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 }
 #endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */

--- a/runtime/jcl/common/java_dyn_methodtype.c
+++ b/runtime/jcl/common/java_dyn_methodtype.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2016 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,6 @@ Java_java_lang_invoke_MethodType_makeTenured(JNIEnv *env, jclass clazz, jobject 
 	} else {
 		methodTypeRef = vmFuncs->j9jni_createLocalRef(env, methodType);
 	}
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return methodTypeRef;
 }

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -76,7 +76,7 @@ Java_java_lang_Class_getDeclaredAnnotationsData(JNIEnv *env, jobject jlClass)
 			result = vmThread->javaVM->internalVMFunctions->j9jni_createLocalRef(env, annotationsData);
 		}
 	}
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 	return result;
 }
 
@@ -228,7 +228,7 @@ Java_java_lang_Class_getStackClasses(JNIEnv *env, jclass jlHeapClass, jint maxDe
 	result = vmFuncs->j9jni_createLocalRef(env, arrayObject);
 
 _throwException:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	return result;
 }
@@ -265,7 +265,7 @@ Java_java_lang_Class_isClassADeclaredClass(JNIEnv *env, jobject jlClass, jobject
 		srpCursor ++;
 	}
 
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 	return result;
 }
 
@@ -356,7 +356,7 @@ Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass
 		}
 	}
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return classNameRef;
 }
 
@@ -388,7 +388,7 @@ Java_java_lang_Class_getGenericSignature(JNIEnv *env, jobject recv)
 		result = vmFuncs->j9jni_createLocalRef(env, stringObject);
 		releaseOptInfoBuffer(vm, romClass);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -500,7 +500,7 @@ retry:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -557,7 +557,7 @@ retry:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -590,7 +590,7 @@ oom:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -650,7 +650,7 @@ retry:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -718,7 +718,7 @@ retry:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -782,7 +782,7 @@ retry:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -802,7 +802,7 @@ Java_java_lang_Class_getDeclaringClassImpl(JNIEnv *env, jobject recv)
 		resultObject = J9VM_J9CLASS_TO_HEAPCLASS(outerClass);
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -841,7 +841,7 @@ Java_java_lang_Class_getEnclosingObject(JNIEnv *env, jobject recv)
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -865,7 +865,7 @@ Java_java_lang_Class_getEnclosingObjectClass(JNIEnv *env, jobject recv)
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -962,7 +962,7 @@ _done:
 		}
 	}
 	jobject result = vmFuncs->j9jni_createLocalRef(env, resultObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -988,7 +988,7 @@ Java_java_lang_Class_getStaticMethodCountImpl(JNIEnv *env, jobject recv)
 		}
 		clazz = VM_VMHelpers::getSuperclass(clazz);
 	} while (NULL != clazz);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -1037,7 +1037,7 @@ Java_java_lang_Class_getStaticMethodsImpl(JNIEnv *env, jobject recv, jobject arr
 		result = JNI_FALSE;
 	}
 done:
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -1077,7 +1077,7 @@ Java_java_lang_Class_getVirtualMethodCountImpl(JNIEnv *env, jobject recv)
 		}
 skip: ;
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -1170,7 +1170,7 @@ skip: ;
 		}
 	}
 done:
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -1644,7 +1644,7 @@ _clearAllocation:
 _throwException:
 	vmFuncs->freeStackWalkCaches(vmThread, &walkState);
 _walkStateUninitialized:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	/* Trc_JCL_java_security_AccessController_getAccSnapshot_Exit(vmThread, result); */
 	return result;
 }
@@ -1720,7 +1720,7 @@ Java_java_security_AccessController_getCallerPD(JNIEnv* env, jclass jsAccessCont
 
 _throwException:
 	vmFuncs->freeStackWalkCaches(vmThread, &walkState);
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	return result;
 }
@@ -1836,7 +1836,7 @@ Java_java_lang_Class_getNestHostImpl(JNIEnv *env, jobject recv)
 		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 	}
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -1903,7 +1903,7 @@ Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv)
 	result = vmFuncs->j9jni_createLocalRef(env, resultObject);
 
 _done:
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */

--- a/runtime/jcl/common/java_lang_J9VMInternals.cpp
+++ b/runtime/jcl/common/java_lang_J9VMInternals.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ Java_java_lang_J9VMInternals_getStackTrace(JNIEnv * env, jclass recv, jobject th
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	j9object_t traceObject = (j9object_t)getStackTrace(currentThread, (j9object_t*)throwable, (UDATA)pruneConstructors);
 	jobject result = vmFuncs->j9jni_createLocalRef(env, traceObject);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -147,7 +147,7 @@ Java_java_lang_invoke_FieldVarHandle_unreflectField(JNIEnv *env, jobject handle,
 
 	J9VMJAVALANGINVOKEVARHANDLE_SET_MODIFIERS(vmThread, J9_JNI_UNWRAP_REFERENCE(handle), fieldID->field->modifiers);
 
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return fieldOffset;
 }
 

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -69,7 +69,7 @@ defineClassCommon(JNIEnv *env, jobject classLoaderObject,
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	isContiguousClassBytes = J9ISCONTIGUOUSARRAY(vm, *(J9IndexableObject **)classRep);
 	if (!isContiguousClassBytes) {
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 		/* Make a "flat" copy of classRep */
 		if (length < 0) {
 			throwNewIndexOutOfBoundsException(env, NULL);
@@ -209,7 +209,7 @@ done:
 			
 	result = vmFuncs->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	if ((U_8*)utf8NameStackBuffer != utf8Name) {
 		j9mem_free_memory(utf8Name);

--- a/runtime/jcl/common/jclvm.c
+++ b/runtime/jcl/common/jclvm.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ Java_com_ibm_oti_vm_VM_localGC(JNIEnv *env, jclass clazz)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vm->memoryManagerFunctions->j9gc_modron_local_collect(currentThread);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -77,7 +77,7 @@ Java_com_ibm_oti_vm_VM_globalGC(JNIEnv *env, jclass clazz)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vm->memoryManagerFunctions->j9gc_modron_global_collect(currentThread);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -132,8 +132,7 @@ Java_com_ibm_oti_vm_VM_allInstances(JNIEnv * env, jclass unused, jclass clazz, j
 	 	count = (jint)allInstances(env, clazz, target);
 
 		javaVM->internalVMFunctions->releaseExclusiveVMAccess(vmThread);
-		/* releaseVMAccess(vmThread); */
-		javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+		javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	return count;
@@ -182,7 +181,7 @@ Java_com_ibm_oti_vm_VM_setCommonData(JNIEnv * env, jclass unused, jobject string
 				J9VMJAVALANGSTRING_SET_VALUE(vmThread, unwrappedString2, stringBytes1);
 			}
 
-			javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+			javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 		}
 	}
 

--- a/runtime/jcl/common/jithelpers.c
+++ b/runtime/jcl/common/jithelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,7 +38,7 @@ Java_com_ibm_jit_JITHelpers_javaLangClassJ9ClassOffset(JNIEnv *env, jclass ignor
 
 	vmThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	offset = (jint) J9VMJAVALANGCLASS_VMREF_OFFSET(vmThread);
-	vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	return offset;
 }
@@ -252,7 +252,7 @@ Java_com_ibm_jit_JITHelpers_getJ9ClassFromClass64(JNIEnv *env, jobject rcv, jcla
 
 	vmThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(c));
-	vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 	return (jlong)(UDATA)clazz;
 }
 
@@ -268,7 +268,7 @@ Java_com_ibm_jit_JITHelpers_getClassFromJ9Class64(JNIEnv *env, jobject rcv, jlon
 	if (NULL == classRef) {
 		vmfns->setNativeOutOfMemoryError(vmThread, 0, 0);
 	}
-	vmfns->internalReleaseVMAccess(vmThread);
+	vmfns->internalExitVMToJNI(vmThread);
 	return classRef;
 }
 
@@ -358,7 +358,7 @@ Java_com_ibm_jit_JITHelpers_getJ9ClassFromClass32(JNIEnv *env, jobject rcv, jcla
 
 	vmThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(c));
-	vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 	return (jint)(UDATA)clazz;
 }
 
@@ -374,7 +374,7 @@ Java_com_ibm_jit_JITHelpers_getClassFromJ9Class32(JNIEnv *env, jobject rcv, jint
 	if (NULL == classRef) {
 		vmfns->setNativeOutOfMemoryError(vmThread, 0, 0);
 	}
-	vmfns->internalReleaseVMAccess(vmThread);
+	vmfns->internalExitVMToJNI(vmThread);
 	return classRef;
 }
 

--- a/runtime/jcl/common/orbvmhelpers.c
+++ b/runtime/jcl/common/orbvmhelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2014 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,7 @@ Java_com_ibm_oti_vm_ORBVMHelpers_getJ9ClassFromClass64(JNIEnv *env, jclass rcv, 
 		clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, *(j9object_t*)c);
 	}
 
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	return (jlong)(UDATA)clazz;
 }
@@ -119,7 +119,7 @@ Java_com_ibm_oti_vm_ORBVMHelpers_getJ9ClassFromClass32(JNIEnv *env, jclass rcv, 
 
 	vmThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, *(j9object_t*)c);
-	vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 	return (jint)(UDATA)clazz;
 }
 
@@ -180,7 +180,7 @@ Java_com_ibm_rmi_io_IIOPInputStream_00024LUDCLStackWalkOptimizer_LUDCLMarkFrame(
 
 	vmfuncs->internalEnterVMFromJNI(vmThread);
 	vm->walkStackFrames(vmThread, &walkState);
-	vmfuncs->internalReleaseVMAccess(vmThread);
+	vmfuncs->internalExitVMToJNI(vmThread);
 
 	vmThread->ludclBPOffset = (U_32) (vmThread->stackObject->end - walkState.bp);
 	vmThread->ludclInlineDepth = (U_32) walkState.inlineDepth;
@@ -268,7 +268,7 @@ Java_com_ibm_oti_vm_ORBVMHelpers_LatestUserDefinedLoader(JNIEnv *env, jclass rcv
 	vm->walkStackFrames(vmThread, &walkState);
 
 	result = vm->internalVMFunctions->j9jni_createLocalRef(env, walkState.userData1);
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	return result;
 }

--- a/runtime/jcl/common/proxy.c
+++ b/runtime/jcl/common/proxy.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ static jclass proxyDefineClass(
 	walkState.flags = J9_STACKWALK_VISIBLE_ONLY | J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_COUNT_SPECIFIED;
 	vm->walkStackFrames(currentThread, &walkState);
 	if (walkState.framesWalked == 0) {
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 		throwNewInternalError(env, NULL);
 		return NULL;
 	}
@@ -66,7 +66,7 @@ static jclass proxyDefineClass(
 		pd = vmFuncs->j9jni_createLocalRef(env, protectionDomainDirectReference);
 	}
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return defineClassCommon(env, classLoader, className, classBytes, offset, length, pd, 0, NULL);
 }

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,7 +137,7 @@ getClassTypeAnnotationsAsByteArray(JNIEnv *env, jclass jlClass) {
     		}
     	}
     }
-    releaseVMAccess(vmThread);
+    exitVMToJNI(vmThread);
     return result;
 }
 
@@ -170,7 +170,7 @@ getFieldTypeAnnotationsAsByteArray(JNIEnv *env, jobject jlrField) {
     		}
     	}
     }
-    releaseVMAccess(vmThread);
+    exitVMToJNI(vmThread);
     return result;
 }
 
@@ -296,7 +296,7 @@ getMethodParametersAsArray(JNIEnv *env, jobject jlrExecutable)
 
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 	executableID = (J9JNIMethodID *)reflectMethodToID(vmThread, jlrExecutable);
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	Trc_JCL_getMethodParametersAsArray_Event3(env, executableID);
 
@@ -349,7 +349,7 @@ getMethodParametersAsArray(JNIEnv *env, jobject jlrExecutable)
 							if (NULL == nameCharArray) {
 								vmFuncs->internalEnterVMFromJNI(vmThread);
 								vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
-								vmFuncs->internalReleaseVMAccess(vmThread);
+								vmFuncs->internalExitVMToJNI(vmThread);
 								Trc_JCL_getMethodParametersAsArray_Failed_To_Allocate_Memory_For_NameCharArray(env, utf8Length + 1);
 								goto error;
 							}
@@ -1030,7 +1030,7 @@ idToReflectField(J9VMThread* vmThread, jfieldID fieldID)
 			}
 		}
 	}
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 	return result;
 }
 
@@ -1057,7 +1057,7 @@ idToReflectMethod(J9VMThread* vmThread, jmethodID methodID)
 			}
 		}
 	}
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 	return result;
 }
 
@@ -1158,7 +1158,7 @@ preloadReflectWrapperClasses(J9JavaVM *javaVM)
 		(void) javaVM->internalVMFunctions->internalFindKnownClass(javaVM->mainThread, i, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
 	}
 	(void) javaVM->internalVMFunctions->internalFindKnownClass(javaVM->mainThread, J9VMCONSTANTPOOL_JAVALANGREFLECTINVOCATIONTARGETEXCEPTION, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
-	releaseVMAccess(javaVM->mainThread);
+	exitVMToJNI(javaVM->mainThread);
 }
 
 void
@@ -1201,7 +1201,7 @@ Java_java_lang_reflect_Array_multiNewArrayImpl(JNIEnv *env, jclass unusedClass, 
 
 		if (J9ROMCLASS_IS_ARRAY(componentTypeClass->romClass) && ((((J9ArrayClass *)componentTypeClass)->arity + dimensions) > J9_ARRAY_DIMENSION_LIMIT)) {
 			/* The spec says to throw IllegalArgumentException if the number of dimensions is greater than J9_ARRAY_DIMENSION_LIMIT */
-			releaseVMAccess(vmThread);
+			exitVMToJNI(vmThread);
 			throwNewIllegalArgumentException(env, NULL);
 			goto exit;
 		}
@@ -1231,7 +1231,7 @@ Java_java_lang_reflect_Array_multiNewArrayImpl(JNIEnv *env, jclass unusedClass, 
 			}
 		}
 	}
-	releaseVMAccess(vmThread);
+	exitVMToJNI(vmThread);
 exit:
 	return result;
 }
@@ -1333,7 +1333,7 @@ getDeclaredFieldHelper(JNIEnv *env, jobject declaringClass, jstring fieldName)
 			vmFuncs->setNativeOutOfMemoryError(vmThread, 0, 0);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }
 
@@ -1448,7 +1448,7 @@ heapoutofmemory:
 	goto done;
 
 done:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }
 
@@ -1562,7 +1562,7 @@ heapoutofmemory:
 	goto done;
 
 done:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }
 
@@ -1712,6 +1712,6 @@ heapoutofmemory:
 	goto done;
 
 done:
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 	return result;
 }

--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -1016,13 +1016,13 @@ Java_com_ibm_oti_shared_SharedClassAbstractHelper_initializeShareableClassloader
 	if (NULL == nativeClassloader) {
 		nativeClassloader = vm->internalVMFunctions->internalAllocateClassLoader(vm, J9_JNI_UNWRAP_REFERENCE(classloader));
 		if (NULL == nativeClassloader) {
-			vm->internalVMFunctions->internalReleaseVMAccess((J9VMThread *)env);
+			vm->internalVMFunctions->internalExitVMToJNI((J9VMThread *)env);
 			return 0;
 		}
 	}
 
 	nativeClassloader->flags |= J9CLASSLOADER_SHARED_CLASSES_ENABLED;
-	vm->internalVMFunctions->internalReleaseVMAccess((J9VMThread *)env);
+	vm->internalVMFunctions->internalExitVMToJNI((J9VMThread *)env);
 
 	result = sizeof(J9ROMClassCookieSharedClass);
 
@@ -1064,7 +1064,7 @@ Java_com_ibm_oti_shared_SharedClassTokenHelperImpl_findSharedClassImpl2(JNIEnv* 
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (!getStringPair(env, &nameChars, &nameLen, &tokenChars, &tokenLen, classNameObj, tokenObj)) {
 		goto _errorPostNameToken;
@@ -1149,7 +1149,7 @@ Java_com_ibm_oti_shared_SharedClassTokenHelperImpl_storeSharedClassImpl2(JNIEnv*
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
 	romClass = J9VM_J9CLASS_FROM_JCLASS(vmThread, clazzObj)->romClass;
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (!getStringChars(env, &tokenChars, &tokenLen, tokenObj)) {
 		goto _error;
@@ -1246,7 +1246,7 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_findSharedClassImpl3(JNIEnv* en
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	urlGetPathID = JCL_CACHE_GET(env, MID_java_net_URL_getPath);
 	if (NULL == urlGetPathID) {
@@ -1358,7 +1358,7 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_storeSharedClassImpl3(JNIEnv* e
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
 	romClass = J9VM_J9CLASS_FROM_JCLASS(vmThread, clazzObj)->romClass;
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	urlGetPathID = JCL_CACHE_GET(env, MID_java_net_URL_getPath);
 	if (NULL == urlGetPathID) {
@@ -1482,7 +1482,7 @@ Java_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_storeSharedClassImpl2(
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
 	romClass = J9VM_J9CLASS_FROM_JCLASS(vmThread, clazzObj)->romClass;
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (!getStringChars(env, &partitionChars, &partitionLen, partitionObj)) {
 		goto _error;
@@ -1631,7 +1631,7 @@ Java_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_findSharedClassImpl2(J
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (!getStringPair(env, &nameChars, &nameLen, &partitionChars, &partitionLen, classNameObj, partitionObj)) {
 		Trc_JCL_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_findSharedClassImpl_ExitError2_Event(env, helperID);
@@ -1904,7 +1904,7 @@ Java_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_notifyClasspathChange2
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(classLoaderObj));
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	omrthread_monitor_enter(vm->sharedClassConfig->jclCacheMutex);
 
@@ -2030,7 +2030,7 @@ Java_com_ibm_oti_shared_SharedDataHelperImpl_storeSharedDataImpl(JNIEnv* env, jo
 
 	vm->internalVMFunctions->internalEnterVMFromJNI(vmThread);
 	classloader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(loaderObj));
-	vm->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vm->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 	if (!getStringChars(env, &tokenChars, &tokenLen, tokenObj)) {
 		goto _error;

--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -56,7 +56,7 @@ Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader
 
 		classLoaderObject = J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, vm->systemClassLoader);
 		classLoader = vmFuncs->j9jni_createLocalRef(env, classLoaderObject);
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
 	result = defineClassCommon(env, classLoader, className, classRep, offset, length, protectionDomain, J9_FINDCLASS_FLAG_UNSAFE, NULL);
@@ -64,7 +64,7 @@ Java_sun_misc_Unsafe_defineClass__Ljava_lang_String_2_3BIILjava_lang_ClassLoader
 	if (result != NULL) {
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 		vm->internalVMFunctions->fixUnsafeMethods(currentThread, result);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	return result;
@@ -83,12 +83,12 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	if (NULL == bytecodes) {
 		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGNULLPOINTEREXCEPTION, NULL);
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 		return NULL;
 	}
 	if (NULL == hostClass) {
 		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGILLEGALARGUMENTEXCEPTION, NULL);
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 		return NULL;
 	}
 
@@ -104,7 +104,7 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 		hostClassLoader = vm->systemClassLoader->classLoaderObject;
 	}
 	jobject hostClassLoaderLocalRef = vmFuncs->j9jni_createLocalRef(env, hostClassLoader);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	jsize length = env->GetArrayLength(bytecodes);
 
@@ -119,7 +119,7 @@ Java_sun_misc_Unsafe_defineAnonymousClass(JNIEnv *env, jobject receiver, jclass 
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vmFuncs->fixUnsafeMethods(currentThread, anonClass);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return anonClass;
 }
@@ -179,7 +179,7 @@ Java_sun_misc_Unsafe_allocateMemory(JNIEnv *env, jobject receiver, jlong size)
 	} else {
 		result = (jlong)(UDATA)unsafeAllocateMemory(currentThread, actualSize, TRUE);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -198,7 +198,7 @@ Java_sun_misc_Unsafe_allocateDBBMemory(JNIEnv *env, jobject receiver, jlong size
 	} else {
 		result = (jlong)(UDATA)unsafeAllocateDBBMemory(currentThread, actualSize, TRUE);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -222,7 +222,7 @@ Java_sun_misc_Unsafe_allocateMemoryNoException(JNIEnv *env, jobject receiver, jl
 	} else {
 		result = (jlong)(UDATA)unsafeAllocateMemory(currentThread, actualSize, FALSE);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -262,7 +262,7 @@ Java_sun_misc_Unsafe_reallocateMemory(JNIEnv *env, jobject receiver, jlong addre
 	} else {
 		result = (jlong)(UDATA)unsafeReallocateMemory(currentThread, (void*)(UDATA)address, actualSize);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -281,7 +281,7 @@ Java_sun_misc_Unsafe_reallocateDBBMemory(JNIEnv *env, jobject receiver, jlong ad
 	} else {
 		result = (jlong)(UDATA)unsafeReallocateDBBMemory(currentThread, (void*)(UDATA)address, actualSize);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return result;
 }
 
@@ -307,7 +307,7 @@ Java_sun_misc_Unsafe_ensureClassInitialized(JNIEnv *env, jobject receiver, jclas
 			vmFuncs->initializeClass(currentThread, j9clazz);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -319,7 +319,7 @@ Java_sun_misc_Unsafe_park(JNIEnv *env, jobject receiver, jboolean isAbsolute, jl
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vmFuncs->threadParkImpl(currentThread, (IDATA)isAbsolute, (I_64)time);
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -331,7 +331,7 @@ Java_sun_misc_Unsafe_unpark(JNIEnv *env, jobject receiver, jthread thread)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vmFuncs->threadUnparkImpl(currentThread, J9_JNI_UNWRAP_REFERENCE(thread));
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -347,7 +347,7 @@ Java_sun_misc_Unsafe_throwException(JNIEnv *env, jobject receiver, jthrowable ex
 	} else {
 		currentThread->currentException = J9_JNI_UNWRAP_REFERENCE(exception);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -370,7 +370,7 @@ oom:
 			goto oom;
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -392,7 +392,7 @@ Java_sun_misc_Unsafe_monitorExit(JNIEnv *env, jobject receiver, jobject obj)
 			VM_ObjectMonitor::recordJNIMonitorExit(currentThread, object);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -417,7 +417,7 @@ Java_sun_misc_Unsafe_tryMonitorEnter(JNIEnv *env, jobject receiver, jobject obj)
 			VM_ObjectMonitor::recordJNIMonitorEnter(currentThread, object);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return entered;
 }
 
@@ -527,7 +527,7 @@ illegal:
 			VM_ArrayCopyHelpers::primitiveArrayCopy(currentThread, sourceObject, sourceIndex, destObject, destIndex, elementCount, logElementSize);
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -552,7 +552,7 @@ Java_sun_misc_Unsafe_objectFieldOffset(JNIEnv *env, jobject receiver, jobject fi
 			offset = (jlong)fieldID->offset + J9_OBJECT_HEADER_SIZE;
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return offset;
 }
 
@@ -583,7 +583,7 @@ illegal:
 		offset -= sizeof(J9IndexableObjectContiguous);
 		VM_ArrayCopyHelpers::primitiveArrayFill(currentThread, object, (UDATA)offset, actualSize, (U_8)value);
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 
@@ -608,7 +608,7 @@ Java_sun_misc_Unsafe_staticFieldBase__Ljava_lang_reflect_Field_2(JNIEnv *env, jo
 			base = vmFuncs->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(fieldID->declaringClass));
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return base;
 }
 
@@ -638,7 +638,7 @@ Java_sun_misc_Unsafe_staticFieldOffset(JNIEnv *env, jobject receiver, jobject fi
 			}
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	return offset;
 }
 
@@ -700,7 +700,7 @@ Java_jdk_internal_misc_Unsafe_shouldBeInitialized(JNIEnv *env, jobject receiver,
 			result = JNI_TRUE;
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return result;
 }
@@ -730,7 +730,7 @@ Java_jdk_internal_misc_Unsafe_objectFieldOffset1(JNIEnv *env, jobject receiver, 
 			offset = (jlong)fieldID->offset + J9_OBJECT_HEADER_SIZE;
 		}
 	}
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	
 	return offset;
 }

--- a/runtime/jcl/common/sun_reflect_ConstantPool.c
+++ b/runtime/jcl/common/sun_reflect_ConstantPool.c
@@ -159,7 +159,7 @@ getStringAt(JNIEnv *env, jobject unusedObject, jobject constantPoolOop, jint cpI
 				returnValue = vmFunctions->j9jni_createLocalRef(env, stringObject);
 			}
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -182,7 +182,7 @@ getClassAt(JNIEnv *env, jobject constantPoolOop, jint cpIndex, UDATA resolveFlag
 		if (NULL != clazz) {
 			returnValue = vmFunctions->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -258,7 +258,7 @@ getMethodAt(JNIEnv *env, jobject constantPoolOop, jint cpIndex, UDATA resolveFla
 			}
 		}
 
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 
 		if (NULL != methodID) {
 			if (NULL != jlClass) {
@@ -335,7 +335,7 @@ retry:
 			}
 		}
 
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 
 		if (NULL != fieldID) {
 			if (NULL != jlClass) {
@@ -367,7 +367,7 @@ getSingleSlotConstant(JNIEnv *env, jobject constantPoolOop, jint cpIndex, UDATA 
 		if (OK == result) {
 			returnValue = cpEntry->data;
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -394,7 +394,7 @@ getDoubleSlotConstant(JNIEnv *env, jobject constantPoolOop, jint cpIndex, UDATA 
 			returnValue = (((U_64)(cpEntry->slot1)) << 32) | ((U_64)(cpEntry->slot2));
 #endif
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -420,7 +420,7 @@ Java_sun_reflect_ConstantPool_getSize0(JNIEnv *env, jobject unusedObject, jobjec
 				result = OK;
 			}
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -506,7 +506,7 @@ Java_java_lang_invoke_MethodHandle_getCPClassNameAt(JNIEnv *env, jobject unusedO
 				break;
 			}
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -573,7 +573,7 @@ Java_sun_reflect_ConstantPool_getMemberRefInfoAt0(JNIEnv *env, jobject unusedObj
 				}
 			}
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	if ((NULL != classNameObject) && (NULL != nameObject) && (NULL != signatureObject)) {
@@ -660,7 +660,7 @@ Java_java_lang_invoke_MethodHandle_getCPTypeAt(JNIEnv *env, jclass unusedClass, 
 			cpType = J9_CP_TYPE(cpShapeDescription, cpIndex);
 			result = OK;
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -695,7 +695,7 @@ Java_java_lang_invoke_MethodHandle_getCPMethodTypeAt(JNIEnv *env, jclass unusedC
 				returnValue = vmFunctions->j9jni_createLocalRef(env, methodTypeObject);
 			}
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);
@@ -730,7 +730,7 @@ Java_java_lang_invoke_MethodHandle_getCPMethodHandleAt(JNIEnv *env, jclass unuse
 				returnValue = vmFunctions->j9jni_createLocalRef(env, methodHandleObject);
 			}
 		}
-		vmFunctions->internalReleaseVMAccess(vmThread);
+		vmFunctions->internalExitVMToJNI(vmThread);
 	}
 
 	checkResult(env, result);

--- a/runtime/jvmti/jvmtiBreakpoint.c
+++ b/runtime/jvmti/jvmtiBreakpoint.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ jvmtiSetBreakpoint(jvmtiEnv* env,
 			}
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiSetBreakpoint);
@@ -147,7 +147,7 @@ jvmtiClearBreakpoint(jvmtiEnv* env,
 			}
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiClearBreakpoint);

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -344,7 +344,7 @@ jvmtiAddCapabilities(jvmtiEnv* env,
 				}
 			}
 			vmFuncs->releaseExclusiveVMAccess(currentThread);
-			vmFuncs->internalReleaseVMAccess(currentThread);
+			vmFuncs->internalExitVMToJNI(currentThread);
 		}
 	}
 

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -180,7 +180,7 @@ jvmtiGetLoadedClasses(jvmtiEnv* env,
 		omrthread_monitor_exit(vm->classTableMutex);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetLoadedClasses);
@@ -264,7 +264,7 @@ jvmtiGetClassLoaderClasses(jvmtiEnv* env,
 		omrthread_monitor_exit(vm->classTableMutex);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassLoaderClasses);
@@ -379,7 +379,7 @@ jvmtiGetClassSignature(jvmtiEnv* env,
 		}
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	if (rc != JVMTI_ERROR_NONE) {
@@ -416,7 +416,7 @@ jvmtiGetClassStatus(jvmtiEnv* env,
 		*status_ptr = getClassStatus(clazz);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassStatus);
@@ -457,7 +457,7 @@ jvmtiGetSourceFileName(jvmtiEnv* env,
 			releaseOptInfoBuffer(vm, clazz->romClass);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetSourceFileName);
@@ -516,7 +516,7 @@ jvmtiGetClassModifiers(jvmtiEnv* env,
 		*modifiers_ptr = (jint) (modifiers & 0xFFFF);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassModifiers);
@@ -578,7 +578,7 @@ jvmtiGetClassMethods(jvmtiEnv* env,
 			*methods_ptr = methodIDs;
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassMethods);
@@ -649,7 +649,7 @@ jvmtiGetClassFields(jvmtiEnv* env,
 			*fields_ptr = fieldIDs;
 		}
 done:
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassFields);
@@ -722,7 +722,7 @@ jvmtiGetImplementedInterfaces(jvmtiEnv* env,
 		*interface_count_ptr = interfaceCount;
 		*interfaces_ptr = interfaces;
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetImplementedInterfaces);
@@ -755,7 +755,7 @@ jvmtiIsInterface(jvmtiEnv* env,
 		*is_interface_ptr = (clazz->romClass->modifiers & J9AccInterface) ? JNI_TRUE : JNI_FALSE;
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIsInterface);
@@ -788,7 +788,7 @@ jvmtiIsArrayClass(jvmtiEnv* env,
 		*is_array_class_ptr = (J9ROMCLASS_IS_ARRAY(clazz->romClass)) ? JNI_TRUE : JNI_FALSE;
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIsArrayClass);
@@ -826,7 +826,7 @@ jvmtiGetClassLoader(jvmtiEnv* env,
 			*classloader_ptr = vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *)currentThread, J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, classLoader));
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassLoader);
@@ -873,7 +873,7 @@ jvmtiGetSourceDebugExtension(jvmtiEnv* env,
 			releaseOptInfoBuffer(vm, clazz->romClass);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 #else
 	Trc_JVMTI_jvmtiGetSourceDebugExtension_Entry(env);
@@ -910,7 +910,7 @@ jvmtiRedefineClasses(jvmtiEnv* env,
 
 		rc = redefineClassesCommon(env, class_count, class_definitions, currentThread, J9_FINDCLASS_FLAG_REDEFINING);
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	omrthread_monitor_exit(jvmtiData->redefineMutex);
@@ -1405,7 +1405,7 @@ jvmtiRetransformClasses(jvmtiEnv* env,
 			j9mem_free_memory(class_definitions);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	omrthread_monitor_exit(jvmtiData->redefineMutex);
@@ -1454,7 +1454,7 @@ jvmtiIsModifiableClass(jvmtiEnv* env,
 		}
 		*is_modifiable_class_ptr = modifiable;
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIsModifiableClass);
@@ -1497,7 +1497,7 @@ jvmtiGetClassVersionNumbers(jvmtiEnv* env,
 		}
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetClassVersionNumbers);
@@ -1640,7 +1640,7 @@ jvmtiGetConstantPool(jvmtiEnv* env,
 		*constant_pool_bytes_ptr = constantPoolBuf;
 		
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 		jvmtiGetConstantPool_free(PORTLIB, &translation);
 	}

--- a/runtime/jvmti/jvmtiEventManagement.c
+++ b/runtime/jvmti/jvmtiEventManagement.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,7 +190,7 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 		rc = setEventNotificationMode(j9env, currentThread, mode, event_type, event_thread, J9JVMTI_LOWEST_EVENT, J9JVMTI_HIGHEST_EVENT);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiSetEventNotificationMode);
@@ -254,7 +254,7 @@ jvmtiGenerateEvents(jvmtiEnv* env,
 			}
 
 			vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 			/* Wait for the events to be reported */
 

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -948,7 +948,7 @@ jvmtiSetExtensionEventCallback(jvmtiEnv* env,
 		if (rc == JVMTI_ERROR_NONE) {
 			J9JVMTI_EXTENSION_CALLBACK(j9env, extension_event_index) = (jvmtiExtensionEvent) J9_COMPATIBLE_FUNCTION_POINTER( callback );
 		}
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiSetExtensionEventCallback);
@@ -1398,7 +1398,7 @@ jvmtiJlmSet(jvmtiEnv* env, jint option, ...)
 		}
 	
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 #endif /* OMR_THR_JLM */
@@ -1490,7 +1490,7 @@ jvmtiGetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr, ..
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetOSThreadID);
@@ -1533,7 +1533,7 @@ jvmtiGetStackTraceExtended(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetStackTraceExtended);
@@ -1607,7 +1607,7 @@ fail:
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetAllStackTracesExtended);
@@ -1688,7 +1688,7 @@ fail:
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetThreadListStackTracesExtended);
@@ -2620,7 +2620,7 @@ jvmtiGetMethodAndClassNames(jvmtiEnv *jvmti_env,  void * ramMethods, jint ramMet
 
 		*ramMethodStringsSize = (jint)totalStringsLength;
 
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 done:
@@ -2767,7 +2767,7 @@ jvmtiJlmDumpHelper(jvmtiEnv* env, void ** dump_info, jint dump_format)
 			omrthread_lib_unlock(self);
 		}
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 #endif
 	return rc;
@@ -3247,7 +3247,7 @@ jvmtiGetJ9vmThread(jvmtiEnv *env, jthread thread, void **vmThreadPtr, ...)
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetJ9vmThread);

--- a/runtime/jvmti/jvmtiField.c
+++ b/runtime/jvmti/jvmtiField.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ done:
 			j9mem_free_memory(signature);
 			j9mem_free_memory(generic);
 		}
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetFieldName);
@@ -143,7 +143,7 @@ jvmtiGetFieldDeclaringClass(jvmtiEnv* env,
 		*declaring_class_ptr = (jclass) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VM_J9CLASS_TO_HEAPCLASS(fieldClass));
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetFieldDeclaringClass);
@@ -180,7 +180,7 @@ jvmtiGetFieldModifiers(jvmtiEnv* env,
 		rc = JVMTI_ERROR_NONE;
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetFieldModifiers);
@@ -216,7 +216,7 @@ jvmtiIsFieldSynthetic(jvmtiEnv* env,
 		*is_synthetic_ptr = (romFieldShape->modifiers & J9AccSynthetic) ? JNI_TRUE : JNI_FALSE;
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIsFieldSynthetic);

--- a/runtime/jvmti/jvmtiForceEarlyReturn.c
+++ b/runtime/jvmti/jvmtiForceEarlyReturn.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -238,7 +238,7 @@ resume:
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiPopFrame);

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -126,7 +126,7 @@ jvmtiDisposeEnvironment(jvmtiEnv* env)
 
 		omrthread_monitor_exit(jvmtiData->mutex);
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiDisposeEnvironment);

--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -210,7 +210,7 @@ jvmtiGetTag(jvmtiEnv* env,
 		}
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetTag);
@@ -275,7 +275,7 @@ jvmtiSetTag(jvmtiEnv* env,
 			rc = JVMTI_ERROR_INVALID_OBJECT;
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiSetTag);
@@ -302,7 +302,7 @@ jvmtiForceGarbageCollection(jvmtiEnv* env)
 		vm->memoryManagerFunctions->j9gc_modron_global_collect(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiForceGarbageCollection);
@@ -405,7 +405,7 @@ jvmtiGetObjectsWithTags(jvmtiEnv* env,
 		omrthread_monitor_exit(((J9JVMTIEnv *)env)->mutex);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetObjectsWithTags);
@@ -548,7 +548,7 @@ jvmtiFollowReferences(jvmtiEnv* env, jint heap_filter, jclass klass, jobject ini
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiFollowReferences);
@@ -1344,7 +1344,7 @@ jvmtiError JNICALL jvmtiIterateThroughHeap(jvmtiEnv* env,
 		vmFuncs->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIterateThroughHeap);

--- a/runtime/jvmti/jvmtiHeap10.c
+++ b/runtime/jvmti/jvmtiHeap10.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,7 +104,7 @@ jvmtiIterateOverHeap(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIterateOverHeap);
@@ -154,7 +154,7 @@ jvmtiIterateOverInstancesOfClass(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIterateOverInstancesOfClass);
@@ -205,7 +205,7 @@ jvmtiIterateOverObjectsReachableFromObject(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIterateOverObjectsReachableFromObject);
@@ -249,7 +249,7 @@ jvmtiIterateOverReachableObjects(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiIterateOverReachableObjects);

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -505,7 +505,7 @@ fail:
 
 		omrthread_monitor_exit(jvmtiData->mutex);
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	return rc;

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -318,7 +318,7 @@ jvmtiHookMethodEnter(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 			jmethodID methodID;
 
 			methodID = getCurrentMethodID(currentThread, method);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			if (methodID != NULL) {
 				if (callback != NULL) {
 					callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID);
@@ -665,7 +665,7 @@ jvmtiHookClassLoad(J9HookInterface** hook, UDATA eventNum, void* eventData, void
 				j9object_t * classRef = (j9object_t*) currentThread->arg0EA;
 
 				*classRef = J9VM_J9CLASS_TO_HEAPCLASS(data->clazz);
-				currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, (jclass) classRef);
 				finishedEvent(currentThread, JVMTI_EVENT_CLASS_LOAD, hadVMAccess, javaOffloadOldState);
 			}
@@ -847,7 +847,7 @@ jvmtiHookClassPrepare(J9HookInterface** hook, UDATA eventNum, void* eventData, v
 			j9object_t * classRef = (j9object_t*) currentThread->arg0EA;
 
 			*classRef = J9VM_J9CLASS_TO_HEAPCLASS(data->clazz);
-			currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, (jclass) classRef);
 			finishedEvent(currentThread, JVMTI_EVENT_CLASS_PREPARE, hadVMAccess, javaOffloadOldState);
 		}
@@ -880,7 +880,7 @@ jvmtiHookSingleStep(J9HookInterface** hook, UDATA eventNum, void* eventData, voi
 			jmethodID methodID;
 
 			methodID = getCurrentMethodID(currentThread, data->method);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			if (methodID != NULL) {
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jlocation) data->location);
 			}
@@ -960,7 +960,7 @@ jvmtiHookFieldAccess(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 				clazz = getCurrentClass(((J9JNIFieldID *) fieldID)->declaringClass);
 				*classRef = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 				methodID = getCurrentMethodID(currentThread, method);
-				vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 				if (methodID != NULL) {
 					callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jlocation) location, (jclass) classRef, (jobject) objectRef, fieldID);
 				}
@@ -1060,7 +1060,7 @@ jvmtiHookFieldModification(J9HookInterface** hook, UDATA eventNum, void* eventDa
 				clazz = getCurrentClass(((J9JNIFieldID *) fieldID)->declaringClass);
 				*classRef = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 				methodID = getCurrentMethodID(currentThread, method);
-				vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 				if (methodID != NULL) {
 					callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jlocation) location, (jclass) classRef, (jobject) objectRef, fieldID, signatureType, newValue);
 				}
@@ -1205,7 +1205,7 @@ jvmtiHookBreakpoint(J9HookInterface** hook, UDATA eventNum, void* eventData, voi
 			if (prepareForEvent(j9env, currentThread, currentThread, JVMTI_EVENT_BREAKPOINT, &threadRef, &hadVMAccess, TRUE, 0, &javaOffloadOldState)) {
 				jmethodID methodID = agentBreakpoint->method;
 
-				currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jlocation) location);
 				finishedEvent(currentThread, JVMTI_EVENT_BREAKPOINT, hadVMAccess, javaOffloadOldState);
 			}
@@ -1295,7 +1295,7 @@ jvmtiHookExceptionThrow(J9HookInterface** hook, UDATA eventNum, void* eventData,
 					throwMethodID = NULL;
 				}
 			}
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			if (throwMethodID != NULL) {
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef,
 					throwMethodID, (jlocation) throwLocation, (jobject) exceptionRef,
@@ -1372,7 +1372,7 @@ jvmtiHookMethodExit(J9HookInterface** hook, UDATA eventNum, void* eventData, voi
 				fillInJValue(signatureType, &returnValue, valueAddress,  (j9object_t*) currentThread->arg0EA);
 			}
 			methodID = getCurrentMethodID(currentThread, method);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			if (methodID != NULL) {
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jboolean) poppedByException, returnValue);
 			}
@@ -1647,7 +1647,7 @@ jvmtiHookMonitorContendedEnter(J9HookInterface** hook, UDATA eventNum, void* eve
 				objectRef = (jobject) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t)lock->userData);
 			}
 
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, objectRef);
 			finishedEvent(currentThread, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, hadVMAccess, javaOffloadOldState);
 		}
@@ -1685,7 +1685,7 @@ jvmtiHookMonitorContendedEntered(J9HookInterface** hook, UDATA eventNum, void* e
 				objectRef = (jobject) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t)lock->userData);
 			}
 
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, objectRef);
 			finishedEvent(currentThread, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, hadVMAccess, javaOffloadOldState);
 		}
@@ -1724,7 +1724,7 @@ jvmtiHookMonitorWait(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 				objectRef = (jobject) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t)lock->userData);
 			}
 
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, objectRef, timeout);
 			finishedEvent(currentThread, JVMTI_EVENT_MONITOR_WAIT, hadVMAccess, javaOffloadOldState);
 		}
@@ -1763,7 +1763,7 @@ jvmtiHookMonitorWaited(J9HookInterface** hook, UDATA eventNum, void* eventData, 
 				objectRef = (jobject) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t)lock->userData);
 			}
 
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, objectRef, timed_out);
 			finishedEvent(currentThread, JVMTI_EVENT_MONITOR_WAITED, hadVMAccess, javaOffloadOldState);
 		}
@@ -1798,7 +1798,7 @@ jvmtiHookFramePop(J9HookInterface** hook, UDATA eventNum, void* eventData, void*
 			jmethodID methodID;
 
 			methodID = getCurrentMethodID(currentThread, method);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			if (methodID != NULL) {
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jboolean) data->poppedByException);
 			}
@@ -1852,7 +1852,7 @@ jvmtiHookExceptionCatch(J9HookInterface** hook, UDATA eventNum, void* eventData,
 				*exceptionRef = exception;
 			}
 			catchMethodID = getCurrentMethodID(currentThread, catchMethod);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			if (catchMethodID != NULL) {
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, catchMethodID, (jlocation) catchLocation, (jobject) exceptionRef);
 			}
@@ -1923,7 +1923,7 @@ jvmtiHookResourceExhausted(J9HookInterface** hook, UDATA eventNum, void* eventDa
 				}
 			}
 
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, flags, NULL, messageSelect);
 
 			finishedEvent(currentThread, JVMTI_EVENT_RESOURCE_EXHAUSTED, hadVMAccess, javaOffloadOldState);
@@ -2255,7 +2255,7 @@ jvmtiHookClassFileLoadHook(J9HookInterface** hook, UDATA eventNum, void* eventDa
 				*classRef = J9VM_J9CLASS_TO_HEAPCLASS(oldClass);
 			}
 
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 			callback(
 				(jvmtiEnv *) j9env,
@@ -2661,7 +2661,7 @@ jvmtiHookCompilingStart(J9HookInterface** hook, UDATA eventNum, void* eventData,
 		jmethodID methodID;
 
 		methodID = getCurrentMethodID(currentThread, method);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 		if (methodID != NULL) {
 			if (callback != NULL) {
 				callback((jvmtiEnv *) j9env, methodID);
@@ -2698,7 +2698,7 @@ jvmtiHookCompilingEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, v
 		jmethodID methodID;
 
 		methodID = getCurrentMethodID(currentThread, method);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 		if (methodID != NULL) {
 			if (callback != NULL) {
 				callback((jvmtiEnv *) j9env, methodID);
@@ -2743,7 +2743,7 @@ jvmtiHookObjectAllocate(J9HookInterface** hook, UDATA eventNum, void* eventData,
 				*objectRef = data->object;
 				clazz = J9OBJECT_CLAZZ(currentThread, data->object);
 				*classRef = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
-				vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, (jobject) objectRef, (jclass) classRef, (jlong) data->size);
 				currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 				data->object = J9_JNI_UNWRAP_REDIRECTED_REFERENCE(objectRef);
@@ -2769,7 +2769,7 @@ jvmtiHookObjectAllocate(J9HookInterface** hook, UDATA eventNum, void* eventData,
 				*objectRef = data->object;
 				clazz = J9OBJECT_CLAZZ(currentThread, data->object);
 				*classRef = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
-				vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, (jobject) objectRef, (jclass) classRef, (jlong) data->size);
 				currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 				data->object = J9_JNI_UNWRAP_REDIRECTED_REFERENCE(objectRef);
@@ -2808,7 +2808,7 @@ jvmtiHookJNINativeBind(J9HookInterface** hook, UDATA eventNum, void* eventData, 
 			jmethodID methodID;
 
 			methodID = getCurrentMethodID(currentThread, data->nativeMethod);
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, data->nativeMethodAddress, &(data->nativeMethodAddress));
 			finishedEvent(currentThread, JVMTI_EVENT_NATIVE_METHOD_BIND, hadVMAccess, javaOffloadOldState);
 		}
@@ -3242,7 +3242,7 @@ jvmtiHookVmDumpStart(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 	if (prepareForEvent(j9env, currentThread, currentThread, J9JVMTI_EVENT_COM_IBM_VM_DUMP_START, NULL, &hadVMAccess, TRUE, 0, &javaOffloadOldState)) {
 		J9JavaVM * vm = currentThread->javaVM;
 
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 		if (callback != NULL) {
 			callback((jvmtiEnv *) j9env, data->label, COM_IBM_VM_DUMP_START, data->detail);
 		}
@@ -3272,7 +3272,7 @@ jvmtiHookVmDumpEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void
 	if (prepareForEvent(j9env, currentThread, currentThread, J9JVMTI_EVENT_COM_IBM_VM_DUMP_END, NULL, &hadVMAccess, TRUE, 0, &javaOffloadOldState)) {
 		J9JavaVM * vm = currentThread->javaVM;
 
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 		if (callback != NULL) {
 			callback((jvmtiEnv *) j9env, data->label, COM_IBM_VM_DUMP_END, data->detail);
 		}

--- a/runtime/jvmti/jvmtiLocalVariable.c
+++ b/runtime/jvmti/jvmtiLocalVariable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -421,7 +421,7 @@ jvmtiGetOrSetLocal(jvmtiEnv* env,
 			}
 			releaseVMThread(currentThread, targetThread);
 		}
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	return rc;

--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,7 @@ jvmtiGetMethodDeclaringClass(jvmtiEnv* env,
 		*declaring_class_ptr = (jclass) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VM_J9CLASS_TO_HEAPCLASS(methodClass));
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetMethodDeclaringClass);

--- a/runtime/jvmti/jvmtiModules.c
+++ b/runtime/jvmti/jvmtiModules.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -293,7 +293,7 @@ jvmtiGetAllModules(jvmtiEnv* jvmtiEnv, jint* module_count_ptr, jobject** modules
 		omrthread_monitor_exit(vm->classLoaderBlocksMutex);
 #endif
 done:
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 	return rc;
 }
@@ -372,7 +372,7 @@ jvmtiGetNamedModule(jvmtiEnv* jvmtiEnv, jobject class_loader, const char* packag
 			j9mem_free_memory(packageName);
 		}
 done:
-		vmFuncs->internalReleaseVMAccess(currentThread);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 	return rc;
 }

--- a/runtime/jvmti/jvmtiObject.c
+++ b/runtime/jvmti/jvmtiObject.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,7 +60,7 @@ jvmtiGetObjectSize(jvmtiEnv* env,
 		*size_ptr = getObjectSize(vm, *(j9object_t*)object);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_ONE_JVMTI_RETURN(jvmtiGetObjectSize2, *size_ptr);
@@ -92,7 +92,7 @@ jvmtiGetObjectHashCode(jvmtiEnv* env,
 		obj = *((j9object_t*) object);
 		*hash_code_ptr = (jint)objectHashCode(vm, obj);
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_ONE_JVMTI_RETURN(jvmtiGetObjectHashCode2, *hash_code_ptr);
@@ -183,7 +183,7 @@ jvmtiGetObjectMonitorUsage(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_FOUR_JVMTI_RETURN(jvmtiGetObjectMonitorUsage2, info_ptr->owner, info_ptr->entry_count, info_ptr->notify_waiter_count, info_ptr->waiter_count);

--- a/runtime/jvmti/jvmtiRawMonitor.c
+++ b/runtime/jvmti/jvmtiRawMonitor.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,7 +106,7 @@ jvmtiRawMonitorEnter(jvmtiEnv* env,
 					if (0 == (currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)) {
 block:
 						vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-						vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+						vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 					}
 				}
 			}
@@ -136,7 +136,7 @@ block:
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 			{
 				vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-				vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+				vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			}
 			rc = JVMTI_ERROR_INTERNAL;
 		}
@@ -176,7 +176,7 @@ jvmtiRawMonitorExit(jvmtiEnv* env,
 					/* Acquire VM access if the current thread does not already have it */
 					if (0 == (currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)) {
 						vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-						vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+						vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 					}
 					/* There is still a timing hole here, since the thread may be suspended at this point */
 				}
@@ -242,7 +242,7 @@ jvmtiRawMonitorWait(jvmtiEnv* env,
 					/* Acquire VM access if the current thread does not already have it */
 					if (0 == (currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)) {
 						vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
-						vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+						vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 					}
 
 					/* There is still a timing hole here, since the thread may be suspended at this point */

--- a/runtime/jvmti/jvmtiStackFrame.c
+++ b/runtime/jvmti/jvmtiStackFrame.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,7 @@ jvmtiGetStackTrace(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetStackTrace);
@@ -143,7 +143,7 @@ fail:
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetAllStackTraces);
@@ -235,7 +235,7 @@ fail:
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetThreadListStackTraces);
@@ -279,7 +279,7 @@ jvmtiGetFrameCount(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetFrameCount);
@@ -338,7 +338,7 @@ jvmtiPopFrame(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiPopFrame);
@@ -399,7 +399,7 @@ jvmtiGetFrameLocation(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetFrameLocation);
@@ -460,7 +460,7 @@ jvmtiNotifyFramePop(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiNotifyFramePop);

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -112,7 +112,7 @@ jvmtiGetThreadState(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetThreadState);
@@ -173,7 +173,7 @@ jvmtiGetAllThreads(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetAllThreads);
@@ -204,12 +204,12 @@ jvmtiSuspendThread(jvmtiEnv* env,
 		/* If the current thread was suspended, block now until it is resumed */
 
 		if (currentThreadSuspended) {
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			setHaltFlag(currentThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 			vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiSuspendThread);
@@ -252,12 +252,12 @@ jvmtiSuspendThreadList(jvmtiEnv* env,
 		/* If the current thread appeared in the list (and was marked as suspended), block now until the thread is resumed */
 
 		if (currentThreadEverSuspended) {
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 			setHaltFlag(currentThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 			vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	}
 
@@ -285,7 +285,7 @@ jvmtiResumeThread(jvmtiEnv* env,
 		rc = resumeThread(currentThread, thread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiResumeThread);
@@ -322,7 +322,7 @@ jvmtiResumeThreadList(jvmtiEnv* env,
 		}
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiResumeThreadList);
@@ -364,7 +364,7 @@ jvmtiStopThread(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiStopThread);
@@ -401,7 +401,7 @@ jvmtiInterruptThread(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiInterruptThread);
@@ -493,7 +493,7 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 		}
 done:
 		releaseVMThread(currentThread, targetThread);
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetThreadInfo);
@@ -552,7 +552,7 @@ jvmtiGetOwnedMonitorInfo(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetOwnedMonitorInfo);
@@ -663,7 +663,7 @@ doneRelease:
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetOwnedMonitorStackDepthInfo);
@@ -710,7 +710,7 @@ jvmtiGetCurrentContendedMonitor(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetCurrentContendedMonitor);
@@ -771,7 +771,7 @@ jvmtiRunAgentThread(jvmtiEnv* env,
 			}
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiRunAgentThread);
@@ -804,7 +804,7 @@ jvmtiSetThreadLocalStorage(jvmtiEnv* env,
 		}
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiSetThreadLocalStorage);
@@ -838,7 +838,7 @@ jvmtiGetThreadLocalStorage(jvmtiEnv* env,
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetThreadLocalStorage);
@@ -1023,7 +1023,7 @@ jvmtiGetCurrentThread(jvmtiEnv* env,
 
 		*thread_ptr = (jthread) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t) currentThread->threadObject);
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetCurrentThread);

--- a/runtime/jvmti/jvmtiThreadGroup.c
+++ b/runtime/jvmti/jvmtiThreadGroup.c
@@ -59,7 +59,7 @@ jvmtiGetTopThreadGroups(jvmtiEnv* env,
 				*groups_ptr = groups;
 			}
 done:
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 		}
 	} else {
@@ -112,7 +112,7 @@ jvmtiGetThreadGroupInfo(jvmtiEnv* env,
 				info_ptr->is_daemon = (jboolean)J9VMJAVALANGTHREADGROUP_ISDAEMON(currentThread, threadGroupObject);
 			}
 done:
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 		}
 	}
 
@@ -233,7 +233,7 @@ jvmtiGetThreadGroupChildren(jvmtiEnv* env,
 			currentThread->javaVM->internalVMFunctions->objectMonitorExit(currentThread, childrenThreadsLock);
 
 done:
-			vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+			vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 		}
 	}
 

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,7 +133,7 @@ jvmtiGetThreadCpuTime(jvmtiEnv* env,
 			}
 		}
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	TRACE_JVMTI_RETURN(jvmtiGetThreadCpuTime);

--- a/runtime/jvmti/jvmtiWatchedField.c
+++ b/runtime/jvmti/jvmtiWatchedField.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -170,7 +170,7 @@ setFieldWatch(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	return rc;
@@ -234,7 +234,7 @@ clearFieldWatch(jvmtiEnv* env,
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
 
 done:
-		vm->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	return rc;

--- a/runtime/jvmti/suspendhelper.cpp
+++ b/runtime/jvmti/suspendhelper.cpp
@@ -45,7 +45,7 @@ suspendThread(J9VMThread *currentThread, jthread thread, UDATA allowNull, UDATA 
 				if (currentThread == targetThread) {
 					*currentThreadSuspended = TRUE;
 				} else {
-					currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+					currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 					omrthread_monitor_enter(targetThread->publicFlagsMutex);
 					VM_VMAccess::setHaltFlagForVMAccessRelease(targetThread, J9_PUBLIC_FLAGS_HALT_THREAD_JAVA_SUSPEND);
 					if (VM_VMAccess::mustWaitForVMAccessRelease(targetThread)) {

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -139,7 +139,7 @@ JVM_LatestUserDefinedLoader_Impl(JNIEnv *env)
 	vm->walkStackFrames(vmThread, &walkState);
 
 	result = vmFuncs->j9jni_createLocalRef(env, walkState.userData1);
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	Trc_SunVMI_LatestUserDefinedLoader_Exit(env, result);
 
@@ -296,7 +296,7 @@ JVM_GetCallerClass_Impl(JNIEnv *env, jint depth)
 		result = vmFuncs->j9jni_createLocalRef(env, walkState.userData2);
 	}
 
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	Trc_SunVMI_GetCallerClass_Exit(env, result);
 
@@ -324,7 +324,7 @@ JVM_NewInstanceFromConstructor_Impl(JNIEnv * env, jobject c, jobjectArray args)
 	methodID = vm->reflectFunctions.idFromConstructorObject(vmThread, J9_JNI_UNWRAP_REFERENCE(c));
 	classObj = J9VM_J9CLASS_TO_HEAPCLASS(J9_CURRENT_CLASS(J9_CLASS_FROM_METHOD(methodID->method)));
 	classRef = vmFuncs->j9jni_createLocalRef(env, classObj);
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	obj = (*env)->AllocObject(env, classRef);
 	if (obj) {
@@ -387,7 +387,7 @@ JVM_GetClassAccessFlags_Impl(JNIEnv * env, jclass clazzRef)
 			modifiers = romClass->modifiers & 0xFFFF;
 		}
 	}	
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	Trc_SunVMI_GetClassAccessFlags_Exit(env, modifiers);
 
@@ -493,7 +493,7 @@ JVM_GetClassContext_Impl(JNIEnv *env)
 
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 	vm->walkStackFrames(vmThread, &walkState);
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	classCtx = (*env)->NewObjectArray(env, (jsize)(UDATA) walkState.userData1, VM.jlClass, 0);
 	if (classCtx) {
@@ -503,7 +503,7 @@ JVM_GetClassContext_Impl(JNIEnv *env)
 		vmFuncs->internalEnterVMFromJNI(vmThread);
 		walkState.userData2 = *((j9object_t*) classCtx);
 		vm->walkStackFrames(vmThread, &walkState);
-		vmFuncs->internalReleaseVMAccess(vmThread);
+		vmFuncs->internalExitVMToJNI(vmThread);
 	}
 
 	Trc_SunVMI_GetClassContext_Exit(env, classCtx);
@@ -539,7 +539,7 @@ JVM_GCNoCompact_Impl(void)
 
 	VM.javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	VM.javaVM->memoryManagerFunctions->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_NOT_AGGRESSIVE);
-	VM.javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	VM.javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	Trc_SunVMI_GCNoCompact_Exit(currentThread);
 }
@@ -624,7 +624,7 @@ JVM_GC_Impl(void)
 
 	VM.javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 	VM.javaVM->memoryManagerFunctions->j9gc_modron_global_collect(currentThread);
-	VM.javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+	VM.javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 	Trc_SunVMI_GC_Exit(currentThread);
 }
@@ -713,7 +713,7 @@ JVM_GetSystemPackages_Impl(JNIEnv* env)
 		VM.monitorExit(vm->classTableMutex);
 	}
 
-	funcs->internalReleaseVMAccess(vmThread);
+	funcs->internalExitVMToJNI(vmThread);
 
 	/* push local frame with room for the 3 elements: jlsClass, result, packageStringRef */
 	if (NULL != packageIDList) {
@@ -743,7 +743,7 @@ JVM_GetSystemPackages_Impl(JNIEnv* env)
 						if (packageString) {
 							packageStringRef = funcs->j9jni_createLocalRef(env, packageString);
 						}
-						funcs->internalReleaseVMAccess(vmThread);
+						funcs->internalExitVMToJNI(vmThread);
 
 						if (packageStringRef) {
 							(*env)->SetObjectArrayElement(env, result, (jsize) i, packageStringRef);
@@ -876,7 +876,7 @@ JVM_GetSystemPackage_Impl(JNIEnv* env, jstring pkgName)
 	}
 
 done:
-	funcs->internalReleaseVMAccess(vmThread);
+	funcs->internalExitVMToJNI(vmThread);
 
 	(*env)->ReleaseStringUTFChars(env, pkgName, utfPkgName);
 
@@ -945,7 +945,7 @@ JVM_AllocateNewArray_Impl(JNIEnv *env, jclass caller, jclass current, jint lengt
 		currentClass = (J9ArrayClass *)J9VM_J9CLASS_FROM_JCLASS(currentThread, current);
 		elementType = currentThread->javaVM->internalVMFunctions->j9jni_createLocalRef(
 			env, J9VM_J9CLASS_TO_HEAPCLASS(currentClass->componentType));
-		currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 		result = (*env)->NewObjectArray(env, length, elementType, 0);
 		(*env)->DeleteLocalRef(env, elementType);
@@ -989,7 +989,7 @@ JVM_GetClassLoader_Impl(JNIEnv *env, jobject obj)
 
 	cloader = vmFuncs->j9jni_createLocalRef(env, j9ClassLoader);
 
-	vmFuncs->internalReleaseVMAccess(vmThread);
+	vmFuncs->internalExitVMToJNI(vmThread);
 
 	Trc_SunVMI_GetClassLoader_Exit(env, cloader);
 
@@ -1073,7 +1073,7 @@ internalFindClassFromClassLoader(JNIEnv* env, char* className, jboolean init, jo
 		if (NULL == loader) {
 			loader = vmFuncs->internalAllocateClassLoader(vm, J9_JNI_UNWRAP_REFERENCE(classLoader));
 			if (NULL == loader) {
-				vmFuncs->internalReleaseVMAccess((J9VMThread *)env);
+				vmFuncs->internalExitVMToJNI((J9VMThread *)env);
 				if (throwError == JNI_FALSE) {
 					(*env)->ExceptionClear(env);
 				}
@@ -1110,7 +1110,7 @@ internalFindClassFromClassLoader(JNIEnv* env, char* className, jboolean init, jo
 		classRef = vmFuncs->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(clazz));
 	}
 
-	vmFuncs->internalReleaseVMAccess(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	if (initializeSent == TRUE) {
 

--- a/runtime/tests/jni/montest.c
+++ b/runtime/tests/jni/montest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ Java_j9vm_test_monitor_Helpers_monitorReserve(JNIEnv * env, jclass clazz, jobjec
 	lockEA = J9OBJECT_MONITOR_EA(vmThread, obj);
 
 	if (lockEA == NULL) {
-		vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);		
+		vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);		
 		errorClazz = (*env)->FindClass(env, "java/lang/Error");
 		if (errorClazz != NULL) {
 			(*env)->ThrowNew(env, errorClazz, "Object has no lock word");
@@ -84,7 +84,7 @@ Java_j9vm_test_monitor_Helpers_monitorReserve(JNIEnv * env, jclass clazz, jobjec
 	lock = *lockEA;
 
 	if (lock != 0) {
-		vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);		
+		vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);		
 		errorClazz = (*env)->FindClass(env, "java/lang/Error");
 		if (errorClazz != NULL) {
 			(*env)->ThrowNew(env, errorClazz, "Object's lock word is not 0");
@@ -94,7 +94,7 @@ Java_j9vm_test_monitor_Helpers_monitorReserve(JNIEnv * env, jclass clazz, jobjec
 
 	*lockEA = (j9objectmonitor_t)(UDATA)vmThread | OBJECT_HEADER_LOCK_RESERVED;
 
-	vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
+	vmThread->javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
 
 #endif
 }

--- a/runtime/tests/thread/thrstate/testsetup.c
+++ b/runtime/tests/thread/thrstate/testsetup.c
@@ -450,7 +450,7 @@ test_cleanup(JNIEnv *env, BOOLEAN ignoreExpectedFailures)
 	cleanupMonitor(env, TESTDATA(rawMonitor));
 
 	j9tty_printf(PORTLIB, "releasing VM access\n");
-	vmFuncs->internalReleaseVMAccess(currentThread); /* release access so we can use JNI */
+	vmFuncs->internalExitVMToJNI(currentThread); /* release access so we can use JNI */
 	cleanupObject(env, &TESTDATA(blockingObject), &TESTDATA(blockingObjectRef));
 
 	cleanupObject(env, &TESTDATA(objectNoMonitor), &TESTDATA(objectNoMonitorRef));

--- a/runtime/thrtrace/thrtrace.c
+++ b/runtime/thrtrace/thrtrace.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,7 +45,7 @@ Java_com_ibm_oti_vm_thread_Tracing_reset(JNIEnv *env, jobject recv)
 	omrthread_reset_tracing();
 
 	vmstruct->javaVM->internalVMFunctions->releaseExclusiveVMAccess(vmstruct);
-	vmstruct->javaVM->internalVMFunctions->internalReleaseVMAccess(vmstruct);
+	vmstruct->javaVM->internalVMFunctions->internalExitVMToJNI(vmstruct);
 #endif /* OMR_THR_TRACING */
 	return ;
 }

--- a/runtime/util/eventframe.c
+++ b/runtime/util/eventframe.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,7 +106,7 @@ pushEventFrame(J9VMThread * currentThread, UDATA wantVMAccess, UDATA jniRefSlots
 
 	if (!wantVMAccess) {
 		Assert_VMUtil_true(0 == jniRefSlots);
-		currentThread->javaVM->internalVMFunctions->internalReleaseVMAccess(currentThread);
+		currentThread->javaVM->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
 	/* Return the state of VM access upon entry to this function */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5725,6 +5725,12 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 		*BFUjavaVM = vm;
 	}
 
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+	/* Ensure we are in the VM without VM access */
+	enterVMFromJNI(env);
+	releaseVMAccess(env);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+
 	if (JNI_OK != (stageRC = runInitializationStage(vm, JCL_INITIALIZED))) {
 		goto error;
 	}


### PR DESCRIPTION
- fix JVMTI to properly exit to JNI context
- fix all JNI natives to use exit VM instead of release access

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>