### PR TITLE
WIP: Add support for building with ccache

### DIFF
--- a/runtime/compiler/module.xml
+++ b/runtime/compiler/module.xml
@@ -58,7 +58,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 		<commands>
 			<command line="$(MAKE) -C compiler clean" type="clean"/>
-			<command line="$(MAKE) -C compiler" type="all"/>
+			<command line="$(MAKE) -C compiler $(if $(filter-out undefined,$(origin UMA_CCACHE)), 'CC=$(CC)' 'CXX=$(CXX)')" type="all"/>
 		</commands>
 	</artifact>
 </module>

--- a/runtime/makelib/mkconstants.mk.ftl
+++ b/runtime/makelib/mkconstants.mk.ftl
@@ -163,6 +163,15 @@ ifdef UMA_CLANG
   endif
 endif
 
+ifndef CCACHE
+  CCACHE:=ccache
+endif
+
+ifdef UMA_CCACHE
+  CC:=$(CCACHE) $(CC)
+  CXX:=$(CCACHE) $(CXX)
+endif
+
 # Define the JIT HOST type.
 <#if uma.spec.processor.x86 || uma.spec.processor.amd64>
 TR_HOST=TR_HOST_X86


### PR DESCRIPTION
Allow using ccache in a way which is compatabile with openj9 builds
(where you can't add symlinked versions of the compiler to the path)

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>