### PR TITLE
Fix error message to use the correct stack map frame

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -2414,7 +2414,7 @@ j9bcv_verifyBytecodes (J9PortLibrary * portLib, J9Class * clazz, J9ROMClass * ro
 		UDATA createStackMaps;
 		
 		verifyData->ignoreStackMaps = (verifyData->verificationFlags & J9_VERIFY_IGNORE_STACK_MAPS) != 0;
-		
+		verifyData->createdStackMap = FALSE;
 		verifyData->romMethod = romMethod;
 
 		Trc_BCV_j9bcv_verifyBytecodes_VerifyMethod(verifyData->vmStruct,
@@ -2480,6 +2480,8 @@ _fallBack:
 		
 			if (createStackMaps && verifyData->stackMapsCount) {
 				UDATA mapIndex = 0;
+				/* Non-empty internal stackMap created */
+				verifyData->createdStackMap = TRUE;
 	
 				liveStack = BCV_FIRST_STACK ();
 				/* Initialize stackMaps */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1948,6 +1948,7 @@ typedef struct J9BytecodeVerificationData {
 	UDATA redefinedClassesCount;
 	struct J9PortLibrary * portLib;
 	struct J9JavaVM* javaVM;
+	BOOLEAN createdStackMap;
 } J9BytecodeVerificationData;
 
 /* @ddr_namespace: map_to_type=J9NativeLibrary */

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -956,7 +956,12 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 
 	/* Stackmap Frame: */
 	if (printStackFrame) {
-		printMessage(&msgBuf, "\n%*sStackmap Frame:", INDENT(2));
+		/* Specify if the stack frame is from classfile or internal */
+		if (verifyData->createdStackMap) {
+			printMessage(&msgBuf, "\n%*sStackmap Frame (FallBack):", INDENT(2));
+		} else {
+			printMessage(&msgBuf, "\n%*sStackmap Frame:", INDENT(2));
+		}
 		printTheStackMapFrame(&msgBuf, &stackMapFrameTarget, &methodInfo);
 	}
 
@@ -969,8 +974,10 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 		printExceptionTable(&msgBuf, &methodInfo);
 	}
 
-	/* Stack Map Table: */
-	if (methodInfo.stackMapCount > 0) {
+	/* Stack Map Table:
+	 * Only prints the stackmap table if it is non-empty and not internally generated
+	 */
+	if ((methodInfo.stackMapCount > 0) && (!verifyData->createdStackMap)) {
 		printMessage(&msgBuf, "\n%*sStackmap Table:", INDENT(2));
 		printSimpleStackMapTable(&msgBuf, &methodInfo);
 	}

--- a/runtime/verbose/errormessagehelper.c
+++ b/runtime/verbose/errormessagehelper.c
@@ -411,14 +411,15 @@ exit:
 U_8*
 decodeStackmapFrameData(StackMapFrame* stackMapFrame, U_8* nextStackmapFrame, I_32 stackmapFrameIndex, MethodContextInfo* methodInfo, J9BytecodeVerificationData* verifyData)
 {
-	/* Decode the specified 'Stackmap Frame' data from compressed the stackmap table in the class file */
-	if (NULL != methodInfo->stackMapData) {
-		nextStackmapFrame = decodeStackFrameDataFromStackMapTable(stackMapFrame, nextStackmapFrame, methodInfo);
-	} else {
+	if (verifyData->createdStackMap) {
 		/* Decode the specified 'Stackmap frame' data from verifyData->stackMaps (the decompessed stackmap table)
-		 * as the stackmap table doesn't exist in the class file.
+		 * as the stackmap table doesn't exist in the class file or currently in fallback verification
+		 * so the frame is pointing to internal created stackMap
 		 */
 		nextStackmapFrame = decodeConstuctedStackMapFrameData(stackMapFrame, nextStackmapFrame, stackmapFrameIndex, methodInfo, verifyData);
+	} else {
+		/* Decode the specified 'Stackmap Frame' data from the compressed stackmap table in the class file */
+		nextStackmapFrame = decodeStackFrameDataFromStackMapTable(stackMapFrame, nextStackmapFrame, methodInfo);
 	}
 
 	return nextStackmapFrame;


### PR DESCRIPTION
- added new flag in J9BytecodeVerificationData to track stackMapFrame
- avoid printing internal generated StackMap Table to output

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>