### PR TITLE
CMake: fix bug in m4 generated files

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -105,6 +105,26 @@ add_custom_target(j9vm_hookgen
 		${CMAKE_CURRENT_SOURCE_DIR}/include/mmhook.h
 )
 
+# Note we do this here rather than in the redirector directory to work arround
+# issues in cmake. If we did it there each target which consumed generated.c has
+# its own rule to create it. Which causes a race condition when building in parallel
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"
+	DEPENDS  oti/helpers.m4 redirector/generated.c.m4
+	COMMAND m4 -I "${CMAKE_CURRENT_SOURCE_DIR}/oti" -I "${CMAKE_CURRENT_SOURCE_DIR}/redirector" "${CMAKE_CURRENT_SOURCE_DIR}/redirector/generated.c.m4" > generated.c
+	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/redirector"
+)
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/j9vm/generated.h"
+	DEPENDS oti/helpers.m4  redirector/forwarders.m4 j9vm/generated.h.m4
+	COMMAND m4 -I "${CMAKE_CURRENT_SOURCE_DIR}/oti" -I "${CMAKE_CURRENT_SOURCE_DIR}/redirector" "${CMAKE_CURRENT_SOURCE_DIR}/j9vm/generated.h.m4" > generated.h
+	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/j9vm"
+)
+
+add_custom_target(j9vm_m4gen
+	DEPENDS
+		"${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"
+		"${CMAKE_CURRENT_BINARY_DIR}/j9vm/generated.h"
+)
+
 
 ###
 ### Helper interface libraries
@@ -122,7 +142,10 @@ target_include_directories(j9vm_interface
 		nls
 		${CMAKE_CURRENT_BINARY_DIR}
 )
-add_dependencies(j9vm_interface j9vm_hookgen)
+add_dependencies(j9vm_interface
+	j9vm_hookgen
+	j9vm_m4gen
+)
 
 # j9vm_gc_includes is used to track the include directories that are consumed by the various gc components
 add_library(j9vm_gc_includes INTERFACE)

--- a/runtime/j9vm/CMakeLists.txt
+++ b/runtime/j9vm/CMakeLists.txt
@@ -23,17 +23,6 @@
 # We dont want to suffix vm version to shared libs
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
-# Run M4 to create generated.g
-# TODO this should be output in the binary dir, not the source dir
-add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/generated.h
-	DEPENDS  ${CMAKE_CURRENT_SOURCE_DIR}/../oti/helpers.m4  ${CMAKE_CURRENT_SOURCE_DIR}/../redirector/forwarders.m4 generated.h.m4
-	COMMAND m4 -I ${CMAKE_CURRENT_SOURCE_DIR}/../oti -I ${CMAKE_CURRENT_SOURCE_DIR}/../redirector ${CMAKE_CURRENT_SOURCE_DIR}/generated.h.m4 > generated.h
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-# We wrap it up in a custom target so we can depend on the generation across directories
-add_custom_target(jvm_generated DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generated.h)
-
 add_tracegen(j9scar.tdf)
 
 # Note we add all the actual sources to this interface library.
@@ -50,7 +39,7 @@ target_sources(jvm_common INTERFACE
 	#TODO this is gross
 	${CMAKE_CURRENT_SOURCE_DIR}/../hyvm/harmony_vm.c
 )
-add_dependencies(jvm_common jvm_generated)
+
 target_link_libraries(jvm_common
 	INTERFACE
 		j9vm_interface

--- a/runtime/j9vm_b150/CMakeLists.txt
+++ b/runtime/j9vm_b150/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(jvm_b150
 add_dependencies(jvm_b150
 	omrgc_hookgen
 	trc_j9scar
-	jvm_generated
 )
 
 target_compile_definitions(jvm_b150

--- a/runtime/j9vm_b156/CMakeLists.txt
+++ b/runtime/j9vm_b156/CMakeLists.txt
@@ -39,7 +39,6 @@ target_link_libraries(jvm_b156
 add_dependencies(jvm_b156
 	omrgc_hookgen
 	trc_j9scar
-	jvm_generated
 )
 
 target_compile_definitions(jvm_b156

--- a/runtime/redirector/CMakeLists.txt
+++ b/runtime/redirector/CMakeLists.txt
@@ -23,44 +23,14 @@
 # Dont append version suffix
 set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
 
+set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/generated.c" PROPERTIES GENERATED TRUE)
 
-add_custom_command(OUTPUT generated.c
-	DEPENDS  ${CMAKE_CURRENT_SOURCE_DIR}/../oti/helpers.m4 generated.c.m4
-	COMMAND m4 -I ${CMAKE_CURRENT_SOURCE_DIR}/../oti -I ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/generated.c.m4 > generated.c
-)
 
-add_library(jvm_b150_redirect SHARED
-	generated.c
-	redirector.c
-)
-target_link_libraries(jvm_b150_redirect
-	PRIVATE
-		j9vm_interface
-		dl
-)
-target_include_directories(jvm_b150_redirect
-	PRIVATE
-		${j9vm_SOURCE_DIR}/j9vm
-)
-set_target_properties(jvm_b150_redirect PROPERTIES LIBRARY_OUTPUT_NAME jvm_b150)
-
-add_library(jvm_b156_redirect SHARED
-	generated.c
-	redirector.c
-)
-target_link_libraries(jvm_b156_redirect
-	PRIVATE
-		j9vm_interface
-		dl
-)
-target_include_directories(jvm_b156_redirect
-	PRIVATE
-		${j9vm_SOURCE_DIR}/j9vm
-)
-set_target_properties(jvm_b156_redirect PROPERTIES LIBRARY_OUTPUT_NAME jvm_b156)
-
+################################################################################
+# Redirector
+################################################################################
 add_library(jvm_redirect SHARED
-	generated.c
+	"${CMAKE_CURRENT_BINARY_DIR}/generated.c"
 	redirector.c
 )
 target_link_libraries(jvm_redirect
@@ -70,12 +40,52 @@ target_link_libraries(jvm_redirect
 )
 target_include_directories(jvm_redirect
 	PRIVATE
-		${j9vm_SOURCE_DIR}/j9vm
+		"${j9vm_SOURCE_DIR}/j9vm"
+		"${j9vm_BINARY_DIR}/j9vm"
 )
 set_target_properties(jvm_redirect PROPERTIES LIBRARY_OUTPUT_NAME jvm)
+
+################################################################################
+# Redirector b150
+################################################################################
+add_library(jvm_b150_redirect SHARED
+	"${CMAKE_CURRENT_BINARY_DIR}/generated.c"
+	redirector.c
+)
+target_link_libraries(jvm_b150_redirect
+	PRIVATE
+		j9vm_interface
+		dl
+)
+target_include_directories(jvm_b150_redirect
+	PRIVATE
+		"${j9vm_SOURCE_DIR}/j9vm"
+		"${j9vm_BINARY_DIR}/j9vm"
+)
+set_target_properties(jvm_b150_redirect PROPERTIES LIBRARY_OUTPUT_NAME jvm_b150)
+
+################################################################################
+# Redirector b156
+################################################################################
+add_library(jvm_b156_redirect SHARED
+	"${CMAKE_CURRENT_BINARY_DIR}/generated.c"
+	redirector.c
+)
+target_link_libraries(jvm_b156_redirect
+	PRIVATE
+		j9vm_interface
+		dl
+)
+target_include_directories(jvm_b156_redirect
+	PRIVATE
+		"${j9vm_SOURCE_DIR}/j9vm"
+		"${j9vm_BINARY_DIR}/j9vm"
+)
+set_target_properties(jvm_b156_redirect PROPERTIES LIBRARY_OUTPUT_NAME jvm_b156)
+
+
 
 install(
 	TARGETS jvm_b150_redirect jvm_b156_redirect jvm_redirect
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}/redirector
 )
-

--- a/runtime/tests/j9vm/CMakeLists.txt
+++ b/runtime/tests/j9vm/CMakeLists.txt
@@ -31,6 +31,11 @@ target_link_libraries(j9vmtest
 		jvm
 )
 
+target_include_directories(j9vmtest
+	PRIVATE
+		"${j9vm_BINARY_DIR}/j9vm"
+)
+
 install(
 	TARGETS j9vmtest
 	LIBRARY DESTINATION ${j9vm_SOURCE_DIR}

--- a/runtime/tests/jni/CMakeLists.txt
+++ b/runtime/tests/jni/CMakeLists.txt
@@ -41,6 +41,10 @@ target_link_libraries(j9ben
 		j9thr
 		jvm
 )
+target_include_directories(j9ben
+	PRIVATE
+		"${j9vm_BINARY_DIR}/j9vm"
+)
 
 install(
 	TARGETS j9ben


### PR DESCRIPTION
When running in parallel, it is possible that make will try using
a m4 generated file before it is finished generating

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>