### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/gc_glue_java/JNICriticalRegion.hpp
+++ b/runtime/gc_glue_java/JNICriticalRegion.hpp
@@ -56,17 +56,19 @@ public:
 	 * Once a thread has successfully entered a critical region, it has privileges similar
 	 * to holding VM access. No object can move while any thread is in a critical region.
 	 *
-	 * @param vmThread  the J9VMThread requesting to enter a critical region
+	 * @param vmThread     the J9VMThread requesting to enter a critical region
+	 * @param hasVMAccess  true if caller has acquired VM access, false if not
 	 */
 	static MMINLINE void
-	enterCriticalRegion(J9VMThread* vmThread)
+	enterCriticalRegion(J9VMThread* vmThread, bool hasVMAccess)
 	{
 		if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_DEBUG_VM_ACCESS)) {
 			Assert_MM_true(J9_VM_FUNCTION(vmThread, currentVMThread)(vmThread->javaVM) == vmThread);
 		}
 
-		/* Expected case: no access, swap in JNI access bits */
-		if (0 == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, 0, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS)) {
+		/* Expected case: swap in JNI access bits */
+		UDATA const expectedFlags = hasVMAccess ? J9_PUBLIC_FLAGS_VM_ACCESS : 0;
+		if (expectedFlags == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, expectedFlags, expectedFlags | J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS)) {
 	 		/* Set the count to 1 */
 	 		vmThread->jniCriticalDirectCount = 1;
 	 	} else if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION)) {
@@ -76,7 +78,7 @@ public:
 			omrthread_t const osThread = vmThread->osThread;
 			omrthread_monitor_t const publicFlagsMutex = vmThread->publicFlagsMutex;
 			omrthread_monitor_enter_using_threadId(publicFlagsMutex, osThread);
-			if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_VM_ACCESS)) {
+			if (hasVMAccess) {
 				/* Entering a critical region with VM access; set the JNI_CRITICAL_REGION flag */
 				VM_VMAccess::setPublicFlags(vmThread, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS);
 				vmThread->jniCriticalDirectCount = 1;
@@ -94,8 +96,6 @@ public:
 				}
 			} else {
 				/* Entering a critical region; acquire VM access and set the JNI_CRITICAL_REGION flag */
-				/* VLHGC holds VM access over all critical region decision-making calls so should never get here */
-				Assert_MM_true(J9_GC_POLICY_BALANCED != ((OMR_VM *)vmThread->javaVM->omrVM)->gcPolicy);
 				if (0 == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, 0, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS)) {
 					/* Set the count to 1 */
 					vmThread->jniCriticalDirectCount = 1;
@@ -123,10 +123,11 @@ public:
 	 * Once a thread has successfully exitted a critical region, objects in the java
 	 * heap are allowed to move again.
 	 *
-	 * @param vmThread  the J9VMThread requesting to exit a critical region
+	 * @param vmThread     the J9VMThread requesting to exit a critical region
+	 * @param hasVMAccess  true if caller has acquired VM access, false if not
 	 */
 	static MMINLINE void
-	exitCriticalRegion(J9VMThread* vmThread)
+	exitCriticalRegion(J9VMThread* vmThread, bool hasVMAccess)
 	{
 		if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_DEBUG_VM_ACCESS)) {
 			Assert_MM_true(J9_VM_FUNCTION(vmThread, currentVMThread)(vmThread->javaVM) == vmThread);
@@ -135,8 +136,9 @@ public:
 		Assert_MM_mustHaveJNICriticalRegion(vmThread);
 		if (--vmThread->jniCriticalDirectCount == 0) {
 			/* Expected case: JNI access, swap in 0 */
-			UDATA const jniAccess = J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS;
-			if (jniAccess != VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, jniAccess, 0)) {
+			UDATA const finalFlags = hasVMAccess ? J9_PUBLIC_FLAGS_VM_ACCESS : 0;
+			UDATA const jniAccess = J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS | finalFlags;
+			if (jniAccess != VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, jniAccess, finalFlags)) {
 				/* Exiting the last critical region; clear the JNI_CRITICAL_REGION and JNI_CRITICAL_ACCESS flags.
 				 * Cache a copy of the flags first to determine if we must respond to an exclusive access request.
 				 */

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -279,7 +279,7 @@ MM_StandardAccessBarrier::jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jar
 		VM_VMAccess::inlineExitVMToJNI(vmThread);
 	} else {
 		// acquire access and return a direct pointer
-		MM_JNICriticalRegion::enterCriticalRegion(vmThread);
+		MM_JNICriticalRegion::enterCriticalRegion(vmThread, false);
 		J9IndexableObject *arrayObject = (J9IndexableObject*)J9_JNI_UNWRAP_REFERENCE(array);
 		data = (void *)_extensions->indexableObjectModel.getDataPointerForContiguous(arrayObject);
 		if(NULL != isCopy) {
@@ -334,7 +334,7 @@ MM_StandardAccessBarrier::jniReleasePrimitiveArrayCritical(J9VMThread* vmThread,
 			Trc_MM_JNIReleasePrimitiveArrayCritical_invalid(vmThread, arrayObject, elems, data);
 		}
 
-		MM_JNICriticalRegion::exitCriticalRegion(vmThread);
+		MM_JNICriticalRegion::exitCriticalRegion(vmThread, false);
 	}
 }
 
@@ -399,7 +399,7 @@ MM_StandardAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str
 		vmThread->jniCriticalCopyCount += 1;
 	} else {
 		// acquire access and return a direct pointer
-		MM_JNICriticalRegion::enterCriticalRegion(vmThread);
+		MM_JNICriticalRegion::enterCriticalRegion(vmThread, hasVMAccess);
 		J9Object *stringObject = (J9Object*)J9_JNI_UNWRAP_REFERENCE(str);
 		J9IndexableObject *valueObject = (J9IndexableObject*)J9VMJAVALANGSTRING_VALUE(vmThread, stringObject);
 
@@ -449,7 +449,7 @@ MM_StandardAccessBarrier::jniReleaseStringCritical(J9VMThread* vmThread, jstring
 		 * because of complexity of required code
 		 */
 		// direct pointer, just drop access
-		MM_JNICriticalRegion::exitCriticalRegion(vmThread);
+		MM_JNICriticalRegion::exitCriticalRegion(vmThread, hasVMAccess);
 	}
 
 	if (hasVMAccess) {

--- a/runtime/gc_realtime/RealtimeAccessBarrier.cpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.cpp
@@ -401,7 +401,7 @@ MM_RealtimeAccessBarrier::jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jar
 		VM_VMAccess::inlineExitVMToJNI(vmThread);
 	} else {
 		// acquire access and return a direct pointer
-		MM_JNICriticalRegion::enterCriticalRegion(vmThread);
+		MM_JNICriticalRegion::enterCriticalRegion(vmThread, false);
 		data = (void *)_extensions->indexableObjectModel.getDataPointerForContiguous(arrayObject);
 		if(NULL != isCopy) {
 			*isCopy = JNI_FALSE;
@@ -459,7 +459,7 @@ MM_RealtimeAccessBarrier::jniReleasePrimitiveArrayCritical(J9VMThread* vmThread,
 			Trc_MM_JNIReleasePrimitiveArrayCritical_invalid(vmThread, arrayObject, elems, data);
 		}
 
-		MM_JNICriticalRegion::exitCriticalRegion(vmThread);
+		MM_JNICriticalRegion::exitCriticalRegion(vmThread, false);
 	}
 }
 
@@ -530,7 +530,7 @@ MM_RealtimeAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str
 		vmThread->jniCriticalCopyCount += 1;
 	} else {
 		// acquire access and return a direct pointer
-		MM_JNICriticalRegion::enterCriticalRegion(vmThread);
+		MM_JNICriticalRegion::enterCriticalRegion(vmThread, hasVMAccess);
 		J9Object *stringObject = (J9Object*)J9_JNI_UNWRAP_REFERENCE(str);
 		J9IndexableObject *valueObject = (J9IndexableObject*)J9VMJAVALANGSTRING_VALUE(vmThread, stringObject);
 
@@ -581,7 +581,7 @@ MM_RealtimeAccessBarrier::jniReleaseStringCritical(J9VMThread* vmThread, jstring
 		}
 	} else {
 		// direct pointer, just drop access
-		MM_JNICriticalRegion::exitCriticalRegion(vmThread);
+		MM_JNICriticalRegion::exitCriticalRegion(vmThread, hasVMAccess);
 	}
 
 	if (hasVMAccess) {

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -288,7 +288,7 @@ MM_VLHGCAccessBarrier::jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray
 		vmThread->jniCriticalCopyCount += 1;
 	} else {
 		// acquire access and return a direct pointer
-		MM_JNICriticalRegion::enterCriticalRegion(vmThread);
+		MM_JNICriticalRegion::enterCriticalRegion(vmThread, true);
 		Assert_MM_true(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS);
 		arrayObject = (J9IndexableObject*)J9_JNI_UNWRAP_REFERENCE(array);
 		data = (void *)_extensions->indexableObjectModel.getDataPointerForContiguous(arrayObject);
@@ -358,7 +358,7 @@ MM_VLHGCAccessBarrier::jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, ja
 		Assert_MM_true((*criticalCount) > 0);
 		MM_AtomicOperations::subtract(criticalCount, 1);
 #endif /* defined(J9VM_GC_MODRON_COMPACTION) || defined(J9VM_GC_MODRON_SCAVENGER)*/
-		MM_JNICriticalRegion::exitCriticalRegion(vmThread);
+		MM_JNICriticalRegion::exitCriticalRegion(vmThread, true);
 	}
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 }
@@ -424,7 +424,7 @@ MM_VLHGCAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str, j
 		vmThread->jniCriticalCopyCount += 1;
 	} else {
 		// acquire access and return a direct pointer
-		MM_JNICriticalRegion::enterCriticalRegion(vmThread);
+		MM_JNICriticalRegion::enterCriticalRegion(vmThread, true);
 		Assert_MM_true(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS);
 		data = (jchar*)_extensions->indexableObjectModel.getDataPointerForContiguous(valueObject);
 
@@ -484,7 +484,7 @@ MM_VLHGCAccessBarrier::jniReleaseStringCritical(J9VMThread* vmThread, jstring st
 		Assert_MM_true((*criticalCount) > 0);
 		MM_AtomicOperations::subtract(criticalCount, 1);
 #endif /* defined(J9VM_GC_MODRON_COMPACTION) || defined(J9VM_GC_MODRON_SCAVENGER)*/
-		MM_JNICriticalRegion::exitCriticalRegion(vmThread);
+		MM_JNICriticalRegion::exitCriticalRegion(vmThread, true);
 	}
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 }

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3179,26 +3179,6 @@ releaseSafePointVMAccess(J9VMThread * vmThread);
 void
 releaseExclusiveVMAccessFromExternalThread(J9JavaVM * vm);
 
-/**
- * Enter a JNI critical region (i.e. GetPrimitiveArrayCritical or GetStringCritical).
- * Once a thread has successfully entered a critical region, it has privileges similar
- * to holding VM access. No object can move while any thread is in a critical region.
- *
- * @param vmThread  the J9VMThread requesting to enter a critical region
- */
-void  
-enterCriticalRegion(J9VMThread* vmThread);
-
-/**
- * Enter a JNI critical region (i.e. GetPrimitiveArrayCritical or GetStringCritical).
- * Once a thread has successfully entered a critical region, it has privileges similar
- * to holding VM access. No object can move while any thread is in a critical region.
- *
- * @param vmThread  the J9VMThread requesting to exit a critical region
- */
-void  
-exitCriticalRegion(J9VMThread* vmThread);
-
 
 #if (defined(J9VM_GC_REALTIME))
 /**


### PR DESCRIPTION
- ensure vm state at every init stage
- optimize JNI critical enter and exit

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>