### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -705,7 +705,9 @@ finishedEvent(J9VMThread * currentThread, UDATA eventNumber, UDATA hadVMAccess, 
 	/* Acquire VM access if the current thread does not already have it */
 
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
-	currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
+	if (currentThread->inNative) {
+		currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
+	}
 #else /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	if (!(currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)) {
 		currentThread->javaVM->internalVMFunctions->internalAcquireVMAccess(currentThread);

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1376,7 +1376,6 @@ jvmtiHookMethodExit(J9HookInterface** hook, UDATA eventNum, void* eventData, voi
 			if (methodID != NULL) {
 				callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, methodID, (jboolean) poppedByException, returnValue);
 			}
-			vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 			finishedEvent(currentThread, JVMTI_EVENT_METHOD_EXIT, hadVMAccess, javaOffloadOldState);
 		}
 	}

--- a/runtime/util/eventframe.c
+++ b/runtime/util/eventframe.c
@@ -38,7 +38,9 @@ popEventFrame(J9VMThread * currentThread, UDATA hadVMAccess)
 	/* Acquire VM access if the current thread does not already have it */
 
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
-	currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
+	if (currentThread->inNative) {
+		currentThread->javaVM->internalVMFunctions->internalEnterVMFromJNI(currentThread);
+	}
 #else /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	if (!(currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)) {
 		currentThread->javaVM->internalVMFunctions->internalAcquireVMAccess(currentThread);
@@ -81,7 +83,9 @@ pushEventFrame(J9VMThread * currentThread, UDATA wantVMAccess, UDATA jniRefSlots
 
 	/* Acquire VM access if the current thread does not already have it.  Remember the access state. */
 
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 	Assert_VMUtil_false(currentThread->inNative);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	if (currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) {
 		hadVMAccess = TRUE;
 	} else {


### PR DESCRIPTION
In JVMTI, do not enter the VM multiple times.  Entering the VM allows
the GC to run, which corrupts any object pointers fetched between
successive enters.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>