### PR TITLE
Remove validateArbitraryClass calls in J9ValuePropagation.cpp

### DIFF
--- a/runtime/compiler/trj9/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/trj9/optimizer/J9ValuePropagation.cpp
@@ -522,7 +522,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                {
                TR_OpaqueClassBlock *arrayComponentClass = comp()->fej9()->getComponentClassFromArrayClass(thisClass);
                // J9Class pointer introduced by the opt has to be remembered under AOT
-               if (!((TR_ResolvedJ9Method*)comp()->getCurrentMethod())->validateArbitraryClass(comp(), (J9Class *) arrayComponentClass))
+               if (!arrayComponentClass)
                   {
                   if (trace())
                      traceMsg(comp(), "Array component class cannot be remembered, quit transforming Class.getComponentType on node %p\n", node);
@@ -603,14 +603,6 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                }
             else
                {
-               // J9Class pointer introduced by the opt has to be remembered under AOT
-               if (!((TR_ResolvedJ9Method*)comp()->getCurrentMethod())->validateArbitraryClass(comp(), (J9Class *) superClass))
-                 {
-                 if (trace())
-                    traceMsg(comp(), "Super class cannot be remembered, quit transforming getSuperclass on node %p\n", node);
-                 break;
-                 }
-
                if (!performTransformation(comp(), "%sTransforming %s on node %p into an aloadi\n", OPT_DETAILS, signature, node))
                   break;
 


### PR DESCRIPTION
There are two calls to validateArbitraryClass() in J9ValuePropagation
that are unnecessary.

The first passes the result from getComponentClassFromArrayClass()
which itself calls validateArbitraryClass() before returning a result.
The J9ValuePropagation code only needs to check to see if the returned
class is NULL.

The second uses the result from getSuperClass() which also calls
validateArbitraryClass() before returning a result. In this case,
the NULL return value is already handled by the code around this
call, so the entire clause to "bail" if validateArbitraryClass()
fails can simply be removed.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>