### PR TITLE
Remove unused validateInterfaceImplementation from inliner

### DIFF
--- a/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/trj9/optimizer/InlinerTempForJ9.cpp
@@ -284,14 +284,6 @@ void TR_MultipleCallTargetInliner::generateNodeEstimate::operator ()(TR_CallTarg
    }
 
 bool
-TR_J9InlinerUtil::validateInterfaceImplementation(TR_ResolvedMethod *interfaceMethod)
-   {
-   if (comp()->compileRelocatableCode())
-      return ((TR_J9InlinerPolicy*)inliner()->getPolicy())->isMethodInSharedCache(interfaceMethod);
-   return true;
-   }
-
-bool
 TR_J9InlinerPolicy::isMethodInSharedCache(TR_ResolvedMethod *interfaceMethod)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());

--- a/runtime/compiler/trj9/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/trj9/optimizer/J9Inliner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,7 +138,6 @@ class TR_J9InlinerUtil: public OMR_InlinerUtil
       static void checkForConstClass(TR_CallTarget *target, TR_InlinerTracer *tracer);
       virtual bool needTargetedInlining(TR::ResolvedMethodSymbol *callee);
    protected:
-      virtual bool validateInterfaceImplementation(TR_ResolvedMethod *interfaceMethod);
       virtual void refineColdness (TR::Node* node, bool& isCold);
       virtual void computeMethodBranchProfileInfo (TR::Block * cfgBlock, TR_CallTarget* calltarget, TR::ResolvedMethodSymbol* callerSymbol);
       virtual int32_t getCallCount(TR::Node *callNode);


### PR DESCRIPTION
Vestigial call related to early AOT processing can be removed.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>