### PR TITLE
WIP: Inline byte-reversing functions on X86

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3103,6 +3103,14 @@ bool TR_J9VMBase::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, 
                dontInlineRecognizedMethod = true;
                break;
                }
+         case TR::java_lang_Long_reverseBytes:
+         case TR::java_lang_Integer_reverseBytes:
+         case TR::java_lang_Short_reverseBytes:
+            if (!TR::Compiler->target.cpu.isARM())
+               {
+               dontInlineRecognizedMethod = true;
+               break;
+               }
          case TR::java_lang_String_hashCodeImplDecompressed:
          case TR::java_lang_String_hashCodeImplCompressed:
             if (!TR::Compiler->om.canGenerateArraylets()){

--- a/runtime/compiler/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.cpp
@@ -114,16 +114,10 @@ J9::MethodSymbol::isPureFunction()
       case TR::java_lang_StrictMath_sqrt:
       case TR::java_lang_StrictMath_tan:
       case TR::java_lang_StrictMath_tanh:
-         /*
-      case TR::java_math_BigDecimal_valueOf:
-      case TR::java_math_BigDecimal_add:
-      case TR::java_math_BigDecimal_subtract:
-      case TR::java_math_BigDecimal_multiply:
-      case TR::java_math_BigInteger_add:
-      case TR::java_math_BigInteger_subtract:
-      case TR::java_math_BigInteger_multiply:
-         */
-      return true;
+      case TR::java_lang_Long_reverseBytes:
+      case TR::java_lang_Integer_reverseBytes:
+      case TR::java_lang_Short_reverseBytes:
+         return true;
       default:
          return false;
       }

--- a/runtime/compiler/optimizer/J9Simplifier.hpp
+++ b/runtime/compiler/optimizer/J9Simplifier.hpp
@@ -54,9 +54,6 @@ class Simplifier : public OMR::Simplifier
 
    private:
 
-   bool isRecognizedPowMethod(TR::Node *node);
-   bool isRecognizedAbsMethod(TR::Node *node);
-
    TR::Node *getUnsafeIorByteChild(TR::Node * child, TR::ILOpCodes b2iOpCode, int32_t mulConst);
    TR::Node *getLastUnsafeIorByteChild(TR::Node * child);
 


### PR DESCRIPTION
X86 CodeGen now properly inlines following three functions:
java.lang.Long.reverseBytes()
java.lang.Integer.reverseBytes()
java.lang.Short.reverseBytes()

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>