### PR TITLE
Add xLinux spec to OMR build

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
@@ -21,7 +21,7 @@
  *******************************************************************************/
 
 def SDK_VERSIONS = ['8', '10']
-def SPECS = ['linux_ppc-64_cmprssptrs_le', 'linux_390-64_cmprssptrs', 'aix_ppc-64_cmprssptrs']
+def SPECS = ['linux_ppc-64_cmprssptrs_le', 'linux_390-64_cmprssptrs', 'aix_ppc-64_cmprssptrs', 'linux_x86-64_cmprssptrs']
 
 def OPENJDK_REPOS = [:]
 OPENJDK_REPOS['8'] = [repo: 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git', branch: 'openj9']


### PR DESCRIPTION
- Add linux_x86-64_cmprssptrs spec
- Run JDK8,10 just like the other specs

Fixes #1785

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>