### PR TITLE
JVM Signal Handling Support [Part 2]

### DIFF
--- a/runtime/harmony/include/hyport.h
+++ b/runtime/harmony/include/hyport.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -509,7 +509,7 @@ typedef struct HyPortLibrary
   I_32 (*sig_can_protect) (struct HyPortLibrary * portLibrary,
                                   U_32 flags);
   /** see @ref hysig.c::hysig_set_async_signal_handler "hysig_set_async_signal_handler"*/
-  U_32 (*sig_set_async_signal_handler) (struct HyPortLibrary *
+  I_32 (*sig_set_async_signal_handler) (struct HyPortLibrary *
                                               portLibrary,
                                               hysig_handler_fn handler,
                                               void *handler_arg,

--- a/runtime/harmony/stubs/hyport_shim.c
+++ b/runtime/harmony/stubs/hyport_shim.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -990,7 +990,7 @@ hystub_sig_can_protect(struct HyPortLibrary *portLibrary, U_32 flags)
 	return j9sig_can_protect(flags);
 }
 
-U_32
+I_32
 hystub_sig_set_async_signal_handler(struct HyPortLibrary *portLibrary, hysig_handler_fn handler, void *handler_arg, U_32 flags)
 {
 	PORT_ACCESS_FROM_PORT((J9PortLibrary *)portLibrary->self_handle);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4817,6 +4817,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *flushProcessWriteBuffers)(struct J9JavaVM *vm);
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 	IDATA ( *registerPredefinedHandler)(struct J9JavaVM *vm, U_32 signal, void **oldOSHandler);
+	IDATA ( *registerOSHandler)(struct J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -784,6 +784,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sig_set_single_async_signal_handler(param1,param2,param3,param4) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_single_async_signal_handler((OMRPortLibrary*)privatePortLibrary,(omrsig_handler_fn)param1,param2,param3,param4)
 #define j9sig_map_os_signal_to_portlib_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_os_signal_to_portlib_signal((OMRPortLibrary*)privatePortLibrary,param1)
 #define j9sig_map_portlib_signal_to_os_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_portlib_signal_to_os_signal((OMRPortLibrary*)privatePortLibrary,param1)
+#define j9sig_register_os_handler(param1,param2,param3) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_register_os_handler((OMRPortLibrary*)privatePortLibrary,param1,(void *)param2,param3)
 #define j9sig_info(param1,param2,param3,param4,param5) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4,param5)
 #define j9sig_info_count(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info_count(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9sig_set_options(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_options(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1584,9 +1584,9 @@ setBootLoaderModulePatchPaths(J9JavaVM * javaVM, J9Module * j9module, const char
  * @brief Register jvminit.c::predefinedHandlerWrapper using j9sig_set_*async_signal_handler
  * for the specified signal
  *
- * @param vm pointer to a J9JavaVM
- * @param signal integer value of the signal
- * @param oldOSHandler points to the old signal handler function
+ * @param[in] vm pointer to a J9JavaVM
+ * @param[in] signal integer value of the signal
+ * @param[out] oldOSHandler points to the old signal handler function
  *
  * @return 0 on success and non-zero on failure
  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1593,6 +1593,19 @@ setBootLoaderModulePatchPaths(J9JavaVM * javaVM, J9Module * j9module, const char
 IDATA
 registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler);
 
+/**
+ * @brief Register a signal handler function with the OS for the specified signal.
+ *
+ * @param[in] vm pointer to a J9JavaVM
+ * @param[in] signal integer value of the signal
+ * @param[in] newOSHandler address to the new signal handler function which will be registered
+ * @param[out] oldOSHandler points to the old signal handler function
+ *
+ * @return 0 on success and non-zero on failure
+ */
+IDATA
+registerOSHandler(J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
+
 /* ---------------- romutil.c ---------------- */
 
 /**

--- a/runtime/tests/port/j9processTest.c
+++ b/runtime/tests/port/j9processTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,7 +290,7 @@ setTestProcessGroupSignalHandler(struct J9PortLibrary *portLibrary)
  		rc = 0;
  	}
 #else /* defined(WIN32) */
- 	U_32 setAsyncRC = J9PORT_SIG_ERROR;
+ 	I_32 setAsyncRC = J9PORT_SIG_ERROR;
 	setAsyncRC = j9sig_set_async_signal_handler(processGroupSignalHandler, NULL, J9PORT_SIG_FLAG_SIGQUIT);
 	if (J9PORT_SIG_ERROR == setAsyncRC) {
 		rc = -1;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -362,4 +362,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	flushProcessWriteBuffers,
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 	registerPredefinedHandler,
+	registerOSHandler,
 };

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -770,3 +770,5 @@ TraceException=Trc_VM_failedtoAllocateGuardPage noEnv Overhead=1 Level=1 Templat
 
 TraceException=Trc_VM_registerPredefinedHandler_invalidPortlibSignalFlag NoEnv Overhead=1 Level=1 Template="registerPredefinedHandler - invalid portlib signal flag: %zu"
 TraceEvent=Trc_VM_signalDispatch_signalValue Overhead=1 Level=3 Template="signalDispatch - signal value: %d"
+
+TraceException=Trc_VM_registerOSHandler_invalidPortlibSignalFlag NoEnv Overhead=1 Level=1 Template="registerOSHandler - invalid portlib signal flag: %zu"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6231,13 +6231,14 @@ shutDownHookWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo
  * Invoke jdk.internal.misc.Signal.dispatch(int number) in Java 9 and
  * onwards. Invoke sun.misc.Signal.dispatch(int number) in Java 8.
  *
- * @param vmThread pointer to a J9VMThread
- * @param signal integer value of the signal
+ * @param[in] vmThread pointer to a J9VMThread
+ * @param[in] signal integer value of the signal
  *
  * @return void
  */
 static void
-signalDispatch(J9VMThread *vmThread, I_32 signal) {
+signalDispatch(J9VMThread *vmThread, I_32 signal)
+{
 	J9JavaVM *vm = vmThread->javaVM;
 	J9NameAndSignature nas = {0};
 	I_32 args[] = {signal};
@@ -6265,16 +6266,17 @@ signalDispatch(J9VMThread *vmThread, I_32 signal) {
  * in omrsignal.c once registered using j9sig_set_*async_signal_handler
  * for a specific signal.
  *
- * @param portLibrary the port library
- * @param gpType port library signal flag
- * @param gpInfo GPF information (will be NULL in this case)
- * @param userData user data (will be a pointer to J9JavaVM in this case)
+ * @param[in] portLibrary the port library
+ * @param[in] gpType port library signal flag
+ * @param[in] gpInfo GPF information (will be NULL in this case)
+ * @param[in] userData user data (will be a pointer to J9JavaVM in this case)
  *
  * @return 0 on success and non-zero on failure
  *
  */
 static UDATA
-predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *userData) {
+predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *userData)
+{
 	J9JavaVM *vm = (J9JavaVM *)userData;
 	J9JavaVMAttachArgs attachArgs = {0};
 	J9VMThread *vmThread = NULL;
@@ -6323,7 +6325,8 @@ predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *g
 }
 
 IDATA
-registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler) {
+registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler)
+{
 	IDATA rc = 0;
 	U_32 portlibSignalFlag = 0;
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6339,6 +6339,24 @@ registerPredefinedHandler(J9JavaVM *vm, U_32 signal, void **oldOSHandler) {
 	return rc;
 }
 
+IDATA
+registerOSHandler(J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler)
+{
+	IDATA rc = 0;
+	U_32 portlibSignalFlag = 0;
+
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	portlibSignalFlag = j9sig_map_os_signal_to_portlib_signal(signal);
+	if (0 != portlibSignalFlag) {
+		rc = j9sig_register_os_handler(portlibSignalFlag, newOSHandler, oldOSHandler);
+	} else {
+		Trc_VM_registerOSHandler_invalidPortlibSignalFlag(portlibSignalFlag);
+	}
+
+	return rc;
+}
+
 static jint
 initializeDDR(J9JavaVM * vm)
 {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -610,7 +610,7 @@ freeJavaVM(J9JavaVM * vm)
 #endif
 
 	/* Remove the predefinedHandlerWrapper. */
-	j9sig_set_async_signal_handler(predefinedHandlerWrapper, vm, 0);
+	j9sig_set_single_async_signal_handler(predefinedHandlerWrapper, vm, 0, NULL);
 
 	/* Unload before trace engine exits */
 	UT_MODULE_UNLOADED(J9_UTINTERFACE_FROM_VM(vm));


### PR DESCRIPTION
5 commits added to extend/improve JVM signal handling support.

1) **Add new function registerOSHandler**

    registerOSHandler allows the JVM to register a signal handler function
    with the OS via omrsig_register_os_handler. OMR signal source code to
    restore the original OS handler during shutdown won't work properly if
    we directly register a handler with the OS using OMRSIG_SIGACTION or
    OMRSIG_SIGNAL. By using omrsig_register_os_handler, we make sure that
    the original OS handler is properly cached and restored by OMR.

    registerOSHandler is added to J9InternalFunctions since it will be
    invoked from "jvm.c::JVM_RegisterSignal".

2) **Fix comments and formatting**

3) **Use registerOSHandler in JVM_RegisterSignal**

    Use registerOSHandler in JVM_RegisterSignal instead of directly
    registering a handler using OMRSIG_SIGACTION or OMRSIG_SIGNAL. This will
    fix a potential OMR bug related to caching and restoring original OS
    handlers during shutdown.

4) **Fix usage of omrsig_set_async_signal_handler**

    omrsig_set_async_signal_handler's signature has been changed to return
    an int32_t since it sets return value to OMRPORT_SIG_ERROR (-1) in some
    cases.

    OpenJ9 source code has been amended to accept an int32_t return value
    from omrsig_set_async_signal_handler.

5) **Fix code to remove predefinedHandlerWrapper**

    Since j9sig_set_single_async_signal_handler was used to register
    predefinedHandlerWrapper, j9sig_set_single_async_signal_handler must be
    used to remove/free predefinedHandlerWrapper.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>