### PR TITLE
Remove hideUnsafe test from Java 9 and above builds

### DIFF
--- a/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
@@ -118,32 +118,6 @@ public static class SubClassTest extends ClassTest{
 	}
 
 /**
- * @tests java.lang.Class - protecting access to sun.misc.Unsafe
- */
-@Test
-public void test_hideUnsafe() {
-	try {
-		jdk.internal.misc.Unsafe.class.getDeclaredMethod("getUnsafe");
-		AssertJUnit.assertTrue("Found getUnsafe via getDeclaredMethod", false);
-	} catch (NoSuchMethodException e) {
-	}
-
-	try {
-		jdk.internal.misc.Unsafe.class.getMethod("getUnsafe");
-		AssertJUnit.assertTrue("Found getUnsafe via getMethod", false);
-	} catch (NoSuchMethodException e) {
-	}
-
-	for (Method method : jdk.internal.misc.Unsafe.class.getDeclaredMethods()) {
-		AssertJUnit.assertFalse("Found getUnsafe via getDeclaredMethods", method.getName().equals("getUnsafe"));
-	}
-
-	for (Method method : jdk.internal.misc.Unsafe.class.getMethods()) {
-		AssertJUnit.assertFalse("Found getUnsafe via getMethods", method.getName().equals("getUnsafe"));
-	}
-}
-
-/**
  * @tests java.lang.Class#forName(java.lang.String)
  */
 @Test


### PR DESCRIPTION
With the Java modularity changes in Java 9, Unsafe is exposed if
`jdk.internal.misc` is exported from `java/base`, which this test suite
does. Thus, the test will always fail in Java 9 and above, and should be
removed.

[skip ci]
Test only change that Travis won't encounter.

Closes #1583 

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>