### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5458,6 +5458,7 @@ typedef struct J9JavaVM {
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
 #if defined(LINUX)
 	J9PortVmemIdentifier exclusiveGuardPage;
+	omrthread_monitor_t flushMutex;
 #elif defined(WIN32) /* LINUX */
 	void *flushFunction;
 #endif /* WIN32 */


### PR DESCRIPTION
flushProcessWriteBuffers on Linux needs to be mutex protected, to avoid
a race condition resulting in attempting to modify write-protected
memory.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>