### PR TITLE
Update test_getModifiers_classTypes for Java 9 and up

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
@@ -23,7 +23,6 @@
 # Exclude tests temporarily
 
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
-org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														1582 generic-all
 org.openj9.test.java.lang.management.TestRuntimeMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.java.lang.management.TestThreadMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -23,7 +23,6 @@
 # Exclude tests temporarily
 
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN												                    AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
-org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														JTC-JAT-133182 generic-all
 org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all

--- a/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
@@ -1107,7 +1107,7 @@ public void test_getModifiers_classTypes() {
 		0x0009, // public static
 		0x0011, // public final
 		0x0019, // public final static
-		0x0008, // static
+		0x0000, //
 		0x0410, // static
 		0x0400, // abstract
 		0x1001, // public synthetic


### PR DESCRIPTION
In Java 9 and 10, getModifiers() for staticInnerAnonymousClazz returns 0
instead of 8,  for both Hotspot and OpenJ9.
Also unexcluded the test for Java 9 and 10.

[ci skip]

Closes #1582 

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Reviewer: @llxia 