### PR TITLE
Remove test_hideUnsafe from exclude file for Java 9 and 10

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
@@ -24,7 +24,6 @@
 
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
 org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														1582 generic-all
-org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	1583 generic-all
 org.openj9.test.java.lang.management.TestRuntimeMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.java.lang.management.TestThreadMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -24,7 +24,6 @@
 
 org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN												                    AN-https://github.ibm.com/runtimes/test/issues/46 generic-all
 org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														JTC-JAT-133182 generic-all
-org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	BPW-https://github.ibm.com/runtimes/test/issues/109 generic-all
 org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.attachAPI.TestAttachAPI:test_agntld01																	238 generic-all


### PR DESCRIPTION
In [PR#1833](https://github.com/eclipse/openj9/pull/1833), test_hideUnsafe was removed from Test_Class.java in Java 9 and above since it was unnecessary. This commit removes it from the exclude files for Java 9 and 10.

[ci skip]

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Reviewer @llxia 