### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/compiler/trj9/control/HookedByTheJit.cpp
+++ b/runtime/compiler/trj9/control/HookedByTheJit.cpp
@@ -6530,12 +6530,17 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
          currentThread = vm->mainThread;
 
          do {
-            if (currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)
-               {
-               vm->internalVMFunctions->J9SignalAsyncEvent(vm, currentThread, jitConfig->sampleInterruptHandlerKey);
-               currentThread->stackOverflowMark = (UDATA *) J9_EVENT_SOM_VALUE;
-               numActiveThreads++;
-               }
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+            if (!currentThread->inNative)
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+            {
+               if (currentThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)
+                  {
+                  vm->internalVMFunctions->J9SignalAsyncEvent(vm, currentThread, jitConfig->sampleInterruptHandlerKey);
+                  currentThread->stackOverflowMark = (UDATA *) J9_EVENT_SOM_VALUE;
+                  numActiveThreads++;
+                  }
+            }
          } while ((currentThread = currentThread->linkNext) != vm->mainThread);
 
          compInfo->_stats._sampleMessagesSent += numActiveThreads;


### PR DESCRIPTION
- Fix RAS dump code to prioritize inNative over VM access in the
atomic-free VM.

- The JIT sampler is depending on VM access to determine the state of a
thread.  Wrap this check in a "not in native" check first in the
atomic-free VM.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>