### PR TITLE
Avoid NULL dereference in DTFJ

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9VMThreadPointerUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9VMThreadPointerUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -277,10 +277,12 @@ public class J9VMThreadPointerUtil {
 			thrinfo.lockObject = null;
 			vmstate = getInflatedMonitorState(j9self, j9state, thrinfo);
 		}
-		
-		if(thrinfo.rawLock != null) {
-			if(thrinfo.rawLock.flags().allBitsIn(J9THREAD_MONITOR_OBJECT)) {
-				thrinfo.lockObject = J9ObjectPointer.cast(thrinfo.rawLock.userData());
+
+		if((thrinfo.lockObject == null) || thrinfo.lockObject.isNull()) {
+			if(!((thrinfo.rawLock == null) || thrinfo.rawLock.isNull())) {
+				if(thrinfo.rawLock.flags().allBitsIn(J9THREAD_MONITOR_OBJECT)) {
+					thrinfo.lockObject = J9ObjectPointer.cast(thrinfo.rawLock.userData());
+				}
 			}
 		}
 		


### PR DESCRIPTION
J9VMThreadPointerUtil.getJ9State() was copied from thrinfo.c but is
missing some checks.  This can lead to a NULL pointer dereference,
causing a CorruptDataException to be thrown.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>