### PR TITLE
Limit variable lifetimes to smallest enclosing scope

### DIFF
--- a/runtime/jcl/common/proxy.c
+++ b/runtime/jcl/common/proxy.c
@@ -36,10 +36,7 @@ static jclass proxyDefineClass(
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9StackWalkState walkState;
-	J9Class * clazz;
-	j9object_t heapClass = NULL;
-	j9object_t protectionDomainDirectReference = NULL;
-	j9object_t classLoaderObject;
+	J9Class * clazz = NULL;
 
 	/* Walk the stack to find the caller class loader and protection domain */
 	vmFuncs->internalEnterVMFromJNI(currentThread);
@@ -57,12 +54,12 @@ static jclass proxyDefineClass(
 
 	clazz = J9_CLASS_FROM_CP(walkState.constantPool);
 	if (classLoader == NULL) {
-		classLoaderObject = J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, clazz->classLoader);
+		j9object_t classLoaderObject = J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, clazz->classLoader);
 		classLoader = vmFuncs->j9jni_createLocalRef(env, classLoaderObject);
 	}
 	if (pd == NULL) {
-		heapClass = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
-		protectionDomainDirectReference = J9VMJAVALANGCLASS_PROTECTIONDOMAIN(currentThread, heapClass);
+		j9object_t heapClass = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
+		j9object_t protectionDomainDirectReference = J9VMJAVALANGCLASS_PROTECTIONDOMAIN(currentThread, heapClass);
 		pd = vmFuncs->j9jni_createLocalRef(env, protectionDomainDirectReference);
 	}
 


### PR DESCRIPTION
Minor cleanup to move variable definitions to smallest enclosing scopes.