### PR TITLE
Add JenkinsFiles for xLinux large heap

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-JDK10-linux_x86-64
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+
+node('master') {
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
+}
+
+node("${NODE}") {
+
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-JDK8-linux_x86-64
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+
+node('master') {
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
+}
+
+node("${NODE}") {
+
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/builds/Build-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-JDK9-linux_x86-64
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+
+node('master') {
+	timestamps {
+	    checkout scm
+	    variableFile = load 'buildenv/jenkins/common/variables-functions'
+	    variableFile.set_job_variables('build')
+	    buildfile = load 'buildenv/jenkins/common/build'
+	    cleanWs()
+	}
+}
+
+node("${NODE}") {
+
+    buildfile.build_all()
+}

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -21,7 +21,12 @@
  *******************************************************************************/
 
 def SDK_VERSIONS = ['8', '9', '10']
-def SPECS = ['linux_ppc-64_cmprssptrs_le', 'linux_390-64_cmprssptrs', 'aix_ppc-64_cmprssptrs', 'linux_x86-64_cmprssptrs', 'win_x86-64_cmprssptrs']
+def SPECS = ['linux_ppc-64_cmprssptrs_le',
+            'linux_390-64_cmprssptrs',
+            'aix_ppc-64_cmprssptrs',
+            'linux_x86-64_cmprssptrs',
+            'linux_x86-64',
+            'win_x86-64_cmprssptrs']
 
 def OPENJDK_REPOS = ['8': 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git',
                      '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git',

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK10-linux_x86-64
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS)

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK8-linux_x86-64
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS)

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-JDK9-linux_x86-64
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+
+node('master') {
+
+    checkout scm
+    def commonFile = load 'buildenv/jenkins/common/variables-functions'
+    commonFile.set_job_variables('pipeline')
+
+    buildfile = load 'buildenv/jenkins/common/pipeline-functions'
+    SHAS = buildfile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+}
+
+jobs = buildfile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS)

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK10-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+        timestamps {
+            checkout scm
+            variableFile = load 'buildenv/jenkins/common/variables-functions'
+            variableFile.set_job_variables('build')
+            buildfile = load 'buildenv/jenkins/common/build'
+            cleanWs()
+        }
+    }
+
+    node("${NODE}") {
+
+        buildfile.build_all()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK8-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+        timestamps {
+            checkout scm
+            variableFile = load 'buildenv/jenkins/common/variables-functions'
+            variableFile.set_job_variables('build')
+            buildfile = load 'buildenv/jenkins/common/build'
+            cleanWs()
+        }
+    }
+
+    node("${NODE}") {
+
+        buildfile.build_all()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Compile-JDK9-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+        timestamps {
+            checkout scm
+            variableFile = load 'buildenv/jenkins/common/variables-functions'
+            variableFile.set_job_variables('build')
+            buildfile = load 'buildenv/jenkins/common/build'
+            cleanWs()
+        }
+    }
+
+    node("${NODE}") {
+
+        buildfile.build_all()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_x86-64
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_extended'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+
+        checkout scm
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('pullRequest')
+        cleanWs()
+    }
+
+    node("${NODE}") {
+
+        checkout scm
+        buildfile = load 'buildenv/jenkins/common/build'
+        testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
+
+        // Build
+        buildfile.build_pr()
+
+        // Test
+        archive_test = [:]
+        archive_test['Archive'] = { buildfile.archive() }
+        archive_test['Test'] = { testfile.test_all() }
+
+        parallel archive_test
+        buildfile.git_clean()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_x86-64
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_extended'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+
+        checkout scm
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('pullRequest')
+        cleanWs()
+    }
+
+    node("${NODE}") {
+
+        checkout scm
+        buildfile = load 'buildenv/jenkins/common/build'
+        testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
+
+        // Build
+        buildfile.build_pr()
+
+        // Test
+        archive_test = [:]
+        archive_test['Archive'] = { buildfile.archive() }
+        archive_test['Test'] = { testfile.test_all() }
+
+        parallel archive_test
+        buildfile.git_clean()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_x86-64
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_extended'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+
+        checkout scm
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('pullRequest')
+        cleanWs()
+    }
+
+    node("${NODE}") {
+
+        checkout scm
+        buildfile = load 'buildenv/jenkins/common/build'
+        testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
+
+        // Build
+        buildfile.build_pr()
+
+        // Test
+        archive_test = [:]
+        archive_test['Archive'] = { buildfile.archive() }
+        archive_test['Test'] = { testfile.test_all() }
+
+        parallel archive_test
+        buildfile.git_clean()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_x86-64
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_sanity'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+
+        checkout scm
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('pullRequest')
+        cleanWs()
+    }
+
+    node("${NODE}") {
+
+        checkout scm
+        buildfile = load 'buildenv/jenkins/common/build'
+        testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
+
+        // Build
+        buildfile.build_pr()
+
+        // Test
+        archive_test = [:]
+        archive_test['Archive'] = { buildfile.archive() }
+        archive_test['Test'] = { testfile.test_all() }
+
+        parallel archive_test
+        buildfile.git_clean()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_x86-64
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_sanity'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+
+        checkout scm
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('pullRequest')
+        cleanWs()
+    }
+
+    node("${NODE}") {
+
+        checkout scm
+        buildfile = load 'buildenv/jenkins/common/build'
+        testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
+
+        // Build
+        buildfile.build_pr()
+
+        // Test
+        archive_test = [:]
+        archive_test['Archive'] = { buildfile.archive() }
+        archive_test['Test'] = { testfile.test_all() }
+
+        parallel archive_test
+        buildfile.git_clean()
+    }
+}

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_x86-64
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_sanity'
+
+timeout(time: 10, unit: 'HOURS') {
+    node('master') {
+
+        checkout scm
+        variableFile = load 'buildenv/jenkins/common/variables-functions'
+        variableFile.set_job_variables('pullRequest')
+        cleanWs()
+    }
+
+    node("${NODE}") {
+
+        checkout scm
+        buildfile = load 'buildenv/jenkins/common/build'
+        testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
+
+        // Build
+        buildfile.build_pr()
+
+        // Test
+        archive_test = [:]
+        archive_test['Archive'] = { buildfile.archive() }
+        archive_test['Test'] = { testfile.test_all() }
+
+        parallel archive_test
+        buildfile.git_clean()
+    }
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK10-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    cleanWs()
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK8-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    cleanWs()
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/tests/Test-Extended-JDK9-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_extended'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    cleanWs()
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_x86-64
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK10-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '10'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    cleanWs()
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-linux_x86-64
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK8-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '8'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    cleanWs()
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-linux_x86-64
+++ b/buildenv/jenkins/jobs/tests/Test-Sanity-JDK9-linux_x86-64
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+SDK_VERSION = '9'
+SPEC = 'linux_x86-64'
+TEST_TARGET = '_sanity'
+
+node('master') {
+
+    checkout scm
+    def variableFile = load 'buildenv/jenkins/common/variables-functions'
+    variableFile.set_job_variables('test')
+    cleanWs()
+}
+
+node("${NODE}") {
+
+    cleanWs()
+    checkout scm
+    def buildfile = load 'buildenv/jenkins/common/test'
+    buildfile.test_all_with_fetch()
+}

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -158,6 +158,33 @@ linux_x86-64_cmprssptrs:
       9: 'hw.arch.x86 && sw.os.ubuntu.16'
       10: 'hw.arch.x86 && sw.os.ubuntu.16'
 #========================================#
+# Linux x86 64bits Large Heap
+#========================================#
+linux_x86-64:
+  boot_jdk:
+    8: '/usr/lib/jvm/java-7-openjdk-amd64'
+    9: '/usr/lib/jvm/adoptojdk-java-80'
+    10: '/usr/lib/jvm/adoptojdk-java-90'
+  release:
+    8: 'linux-x86_64-normal-server-release'
+    9: 'linux-x86_64-normal-server-release'
+    10: 'linux-x86_64-normal-server-release'
+  freemarker: '/home/jenkins/freemarker.jar'
+  openjdk_reference_repo: '/home/jenkins/openjdk_cache'
+  node_labels:
+    build:
+      8: 'hw.arch.x86 && sw.os.ubuntu.16'
+      9: 'hw.arch.x86 && sw.os.ubuntu.16'
+      10: 'hw.arch.x86 && sw.os.ubuntu.16'
+    test:
+      8: 'hw.arch.x86 && sw.os.ubuntu.16'
+      9: 'hw.arch.x86 && sw.os.ubuntu.16'
+      10: 'hw.arch.x86 && sw.os.ubuntu.16'
+  extra_configure_options:
+    8: '--with-noncompressedrefs'
+    9: '--with-noncompressedrefs'
+    10: '--with-noncompressedrefs'
+#========================================#
 # Windows x86 64bits Compressed Pointers
 #========================================#
 win_x86-64_cmprssptrs:


### PR DESCRIPTION
- Add files for:
   - Build
   - Sanity
   - Extended
   - PRs
   - Nightly Pipelines
- Add linux_x86-64 spec to varialbles file

[skip ci]

Issue #1669

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

## Status
- Build
   - 8 [![Build Status](https://ci.eclipse.org/openj9/job/Build-JDK8-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Build-JDK8-linux_x86-64)
   - 9 [![Build Status](https://ci.eclipse.org/openj9/job/Build-JDK9-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Build-JDK9-linux_x86-64)
   - 10 [![Build Status](https://ci.eclipse.org/openj9/job/Build-JDK10-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Build-JDK10-linux_x86-64)
- Sanity
   - 8 [![Build Status](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK8-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK8-linux_x86-64)
   - 9 [![Build Status](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK9-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK9-linux_x86-64)
   - 10 [![Build Status](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Test-Sanity-JDK10-linux_x86-64)
- Extended
   - 8 [![Build Status](https://ci.eclipse.org/openj9/job/Test-Extended-JDK8-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK8-linux_x86-64)
   - 9 [![Build Status](https://ci.eclipse.org/openj9/job/Test-Extended-JDK9-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK9-linux_x86-64)
   - 10 [![Build Status](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-linux_x86-64/badge/icon)](https://ci.eclipse.org/openj9/job/Test-Extended-JDK10-linux_x86-64)