### PR TITLE
j.l.Class.getMethods() should select more specific method

### DIFF
--- a/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
@@ -377,6 +377,72 @@ public class Test_Class {
 		java.security.AccessController.doPrivileged(action);
 	}
 
+	static class ParentClass {
+		public static void methodPublicStatic() {}
+		public void methodPublicInstance() {}
+		static void methodPkgPrivateStatic() {}
+		void methodPkgPrivateInstance() {}
+		private static void methodPrivateStatic() {}
+		private void methodPrivateInstance() {}
+	}
+
+	static class ChildClass extends ParentClass {
+		public static void methodPublicStatic() {}
+		public void methodPublicInstance() {}
+		static void methodPkgPrivateStatic() {}
+		void methodPkgPrivateInstance() {}
+		private static void methodPrivateStatic() {}
+		private void methodPrivateInstance() {}
+	}
+
+	static interface SuperInterface {
+		void methodPublicInterface(); 
+		public static void methodPublicStatic() {};
+	}
+
+	static interface SubInterface extends SuperInterface {
+		void methodPublicInterface(); 
+		public static void methodPublicStatic() {};
+		default void defaultMethodPublicInterface() {}
+	}
+
+	static class ClassImplInterface implements SubInterface {
+		public void methodPublicInterface() {}
+		public static void methodPublicStatic() {};
+		public void defaultMethodPublicInterface() {}
+	}
+	
+	@Test
+	public void test_getMethods_subtest3() {
+		final Method[] methods = ChildClass.class.getMethods();
+		for (Method method : methods) {
+			final Class<?> declaringClass = method.getDeclaringClass();
+			if (declaringClass.equals(ParentClass.class)) {
+				Assert.fail("Should not return Method " + method.getName() + " declared in class " + declaringClass.getName());
+			}
+		}
+	}
+	@Test
+	public void test_getMethods_subtest4() {
+		final Method[] methods = SubInterface.class.getMethods();
+		for (Method method : methods) {
+			final Class<?> declaringClass = method.getDeclaringClass();
+			if (declaringClass.equals(SuperInterface.class)) {
+				Assert.fail("Should not return Method " + method.getName() + " declared in class " + declaringClass.getName());
+			}
+		}
+	}
+	@Test
+	public void test_getMethods_subtest5() {
+		final Method[] methods = ClassImplInterface.class.getMethods();
+		for (Method method : methods) {
+			final Class<?> declaringClass = method.getDeclaringClass();
+			if (declaringClass.equals(SuperInterface.class) || declaringClass.equals(SubInterface.class)) {
+				Assert.fail("Should not return Method " + method.getName() + " declared in class " + declaringClass.getName());
+			}
+		}
+	}
+
 	static String[] concatenateObjectMethods(String methodList[]) {
 		final String[] jlobjectMethods = new String[] {
 				objectClass + ".equals(java.lang.Object)boolean",
@@ -560,7 +626,7 @@ public class Test_Class {
 		if (classes.length != 15) {
 			for (int i = 0; i < classes.length; i++)
 				logger.debug("classes[" + i + "]: " + classes[i]);
-			Assert.fail("Incorrect class array returned");
+			Assert.fail("Incorrect class array returned: expected 15 but returned " + classes.length);
 		}
 	}
 
@@ -782,13 +848,13 @@ public class Test_Class {
 	 */
 	@Test
 	public void test_getDeclaredClasses() {
-		int len = 60;
+		int len = 65;
 		// Test for method java.lang.Class [] java.lang.Class.getDeclaredClasses()
 		Class[] declaredClasses = Test_Class.class.getDeclaredClasses();
 		if (declaredClasses.length != len) {
 			for (int i = 0; i < declaredClasses.length; i++)
 				logger.debug("declared[" + i + "]: " + declaredClasses[i]);
-			Assert.fail("Incorrect class array returned");
+			Assert.fail("Incorrect class array returned: expected 65 but returned " + declaredClasses.length);
 		}
 	}
 

--- a/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
@@ -353,6 +353,72 @@ public void test_getMethods_subtest2() {
 	java.security.AccessController.doPrivileged(action);
 }
 
+static class ParentClass {
+	public static void methodPublicStatic() {}
+	public void methodPublicInstance() {}
+	static void methodPkgPrivateStatic() {}
+	void methodPkgPrivateInstance() {}
+	private static void methodPrivateStatic() {}
+	private void methodPrivateInstance() {}
+}
+
+static class ChildClass extends ParentClass {
+	public static void methodPublicStatic() {}
+	public void methodPublicInstance() {}
+	static void methodPkgPrivateStatic() {}
+	void methodPkgPrivateInstance() {}
+	private static void methodPrivateStatic() {}
+	private void methodPrivateInstance() {}
+}
+
+static interface SuperInterface {
+	void methodPublicInterface(); 
+	public static void methodPublicStatic() {};
+}
+
+static interface SubInterface extends SuperInterface {
+	void methodPublicInterface(); 
+	public static void methodPublicStatic() {};
+	default void defaultMethodPublicInterface() {}
+}
+
+static class ClassImplInterface implements SubInterface {
+	public void methodPublicInterface() {}
+	public static void methodPublicStatic() {};
+	public void defaultMethodPublicInterface() {}
+}
+
+@Test
+public void test_getMethods_subtest3() {
+	final Method[] methods = ChildClass.class.getMethods();
+	for (Method method : methods) {
+		final Class<?> declaringClass = method.getDeclaringClass();
+		if (declaringClass.equals(ParentClass.class)) {
+			Assert.fail("Should not return Method " + method.getName() + " declared in class " + declaringClass.getName());
+		}
+	}
+}
+@Test
+public void test_getMethods_subtest4() {
+	final Method[] methods = SubInterface.class.getMethods();
+	for (Method method : methods) {
+		final Class<?> declaringClass = method.getDeclaringClass();
+		if (declaringClass.equals(SuperInterface.class)) {
+			Assert.fail("Should not return Method " + method.getName() + " declared in class " + declaringClass.getName());
+		}
+	}
+}
+@Test
+public void test_getMethods_subtest5() {
+	final Method[] methods = ClassImplInterface.class.getMethods();
+	for (Method method : methods) {
+		final Class<?> declaringClass = method.getDeclaringClass();
+		if (declaringClass.equals(SuperInterface.class) || declaringClass.equals(SubInterface.class)) {
+			Assert.fail("Should not return Method " + method.getName() + " declared in class " + declaringClass.getName());
+		}
+	}
+}
+
 static String[] concatenateObjectMethods(String methodList[]) {
 	final String[] jlobjectMethods = new String[] {
 			objectClass+".equals(java.lang.Object)boolean",
@@ -536,7 +602,7 @@ public void test_getClasses() {
 	if (classes.length != 15) {
 		for (int i=0; i<classes.length; i++)
 			logger.debug("classes[" + i + "]: " + classes[i]);
-		Assert.fail("Incorrect class array returned");
+		Assert.fail("Incorrect class array returned: expected 15 but returned " + classes.length);
 	}
 }
 
@@ -749,13 +815,13 @@ public void test_getConstructors() {
  */
 @Test
 public void test_getDeclaredClasses() {
-	int len = 60;
+	int len = 65;
 	// Test for method java.lang.Class [] java.lang.Class.getDeclaredClasses()
 	Class[] declaredClasses = Test_Class.class.getDeclaredClasses();
 	if (declaredClasses.length != len) {
 		for (int i=0; i<declaredClasses.length; i++)
 			logger.debug("declared[" + i + "]: " + declaredClasses[i]);
-		Assert.fail("Incorrect class array returned");
+		Assert.fail("Incorrect class array returned: expected 65 but returned " + declaredClasses.length);
 	}
 }
 


### PR DESCRIPTION
`j.l.Class.getMethods()` should select more specific method

As per Java spec:
For methods with same signature (name, parameter types) and return type, only the most specific method should be selected. 
Method `N` is more specific than `M` if:
`N` is declared by a `class` and `M` is declared by an `interface`; or
`N` and `M` are both declared by either `classes` or `interfaces` and `N's` declaring type is the same as or a subtype of `M's` declaring type.
Select most specific method from a set of methods with same signature using algorithm above.
Added tests to verify this behaviour.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>