### PR TITLE
Update Dockerfile for Ubuntu16 JDK8 s390x

### DIFF
--- a/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/s390x/ubuntu16/Dockerfile
@@ -27,10 +27,6 @@ FROM ubuntu:16.04
 # This section installs the required OS tools.
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
-    software-properties-common \
-    python-software-properties \
-  && apt-get update \
-  && apt-get install -qq -y --no-install-recommends \
     autoconf \
     ca-certificates \
     ccache \


### PR DESCRIPTION
`software-properties-common` and `python-software-properties` are only
needed to install `add-apt-repository`. `add-apt-repository` is not used to
add a repository. so, `software-properties-common` and
`python-software-properties` dependencies have been removed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>