### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/gc_glue_java/JNICriticalRegion.hpp
+++ b/runtime/gc_glue_java/JNICriticalRegion.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright (c) 1991, 2018 IBM Corp. and others
  *
@@ -66,55 +65,55 @@ public:
 			Assert_MM_true(J9_VM_FUNCTION(vmThread, currentVMThread)(vmThread->javaVM) == vmThread);
 		}
 
-		/* Expected case: swap in JNI access bits */
-		UDATA const expectedFlags = hasVMAccess ? J9_PUBLIC_FLAGS_VM_ACCESS : 0;
-		if (expectedFlags == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, expectedFlags, expectedFlags | J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS)) {
-	 		/* Set the count to 1 */
-	 		vmThread->jniCriticalDirectCount = 1;
-	 	} else if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION)) {
-	  		/* Nested critical region; increment the count */
-	  		vmThread->jniCriticalDirectCount += 1;
-	 	} else {
-			omrthread_t const osThread = vmThread->osThread;
-			omrthread_monitor_t const publicFlagsMutex = vmThread->publicFlagsMutex;
-			omrthread_monitor_enter_using_threadId(publicFlagsMutex, osThread);
-			if (hasVMAccess) {
-				/* Entering a critical region with VM access; set the JNI_CRITICAL_REGION flag */
-				VM_VMAccess::setPublicFlags(vmThread, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS);
+		/* Handle nested case first to avoid the unnecessary atomic */
+		if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION)) {
+			/* Nested critical region; increment the count */
+			vmThread->jniCriticalDirectCount += 1;
+	  	} else {
+			UDATA const criticalFlags = J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS;
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+			UDATA const expectedFlags = J9_PUBLIC_FLAGS_VM_ACCESS;
+#else /* J9VM_INTERP_ATOMIC_FREE_JNI */
+			UDATA const expectedFlags = hasVMAccess ? J9_PUBLIC_FLAGS_VM_ACCESS : 0;
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+			/* Expected case: swap in JNI access bits */
+			if (expectedFlags == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, expectedFlags, expectedFlags | criticalFlags)) {
+				/* First entry into a critical region */
 				vmThread->jniCriticalDirectCount = 1;
-
-				/* The current thread has VM access and just acquired JNI critical access.
-				 * If an exclusive request is in progress and the current thread has already
-				 * been requested to halt, then adjust the JNI response count accordingly.
-				 */
-				if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_HALT_THREAD_EXCLUSIVE)) {
-					J9JavaVM* const vm = vmThread->javaVM;
-					omrthread_monitor_t const exclusiveAccessMutex = vm->exclusiveAccessMutex;
-					omrthread_monitor_enter_using_threadId(exclusiveAccessMutex, osThread);
-					vm->jniCriticalResponseCount += 1;
-					omrthread_monitor_exit_using_threadId(exclusiveAccessMutex, osThread);
-				}
 			} else {
-				/* Entering a critical region; acquire VM access and set the JNI_CRITICAL_REGION flag */
-				if (0 == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, 0, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS)) {
-					/* Set the count to 1 */
+				omrthread_t const osThread = vmThread->osThread;
+				omrthread_monitor_t const publicFlagsMutex = vmThread->publicFlagsMutex;
+				omrthread_monitor_enter_using_threadId(publicFlagsMutex, osThread);
+				if (hasVMAccess) {
+					/* Entering the first critical region with VM access; set the critical flags */
+					VM_VMAccess::setPublicFlags(vmThread, criticalFlags);
 					vmThread->jniCriticalDirectCount = 1;
+
+					/* The current thread has VM access and just acquired JNI critical access.
+					 * If an exclusive request is in progress and the current thread has already
+					 * been requested to halt, then adjust the JNI response count accordingly.
+					 */
+					if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_HALT_THREAD_EXCLUSIVE)) {
+						J9JavaVM* const vm = vmThread->javaVM;
+						omrthread_monitor_t const exclusiveAccessMutex = vm->exclusiveAccessMutex;
+						omrthread_monitor_enter_using_threadId(exclusiveAccessMutex, osThread);
+						vm->jniCriticalResponseCount += 1;
+						omrthread_monitor_exit_using_threadId(exclusiveAccessMutex, osThread);
+					}
 				} else {
-#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
-					J9_VM_FUNCTION(vmThread, internalEnterVMFromJNI)(vmThread);
-#else /* J9VM_INTERP_ATOMIC_FREE_JNI */
-					J9_VM_FUNCTION(vmThread, internalAcquireVMAccessNoMutex)(vmThread);
-#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
-					VM_VMAccess::setPublicFlags(vmThread, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS);
-					vmThread->jniCriticalDirectCount = 1;
-#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
-					J9_VM_FUNCTION(vmThread, internalExitVMToJNI)(vmThread);
-#else /* J9VM_INTERP_ATOMIC_FREE_JNI */
-					J9_VM_FUNCTION(vmThread, internalReleaseVMAccessNoMutex)(vmThread);
-#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+					/* Entering the first critical region; acquire VM access and set the critical flags */
+					if (0 == VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, 0, criticalFlags)) {
+						/* Set the count to 1 */
+						vmThread->jniCriticalDirectCount = 1;
+					} else {
+						J9_VM_FUNCTION(vmThread, internalEnterVMFromJNI)(vmThread);
+						VM_VMAccess::setPublicFlags(vmThread, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS);
+						vmThread->jniCriticalDirectCount = 1;
+						J9_VM_FUNCTION(vmThread, internalExitVMToJNI)(vmThread);
+					}
 				}
+				omrthread_monitor_exit_using_threadId(publicFlagsMutex, osThread);
 			}
-			omrthread_monitor_exit_using_threadId(publicFlagsMutex, osThread);
 	 	}
 	}
 
@@ -135,17 +134,22 @@ public:
 
 		Assert_MM_mustHaveJNICriticalRegion(vmThread);
 		if (--vmThread->jniCriticalDirectCount == 0) {
-			/* Expected case: JNI access, swap in 0 */
+			/* Exitting last critical region, swap out critical flags */
+			UDATA const criticalFlags = J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS;
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+			UDATA const finalFlags = J9_PUBLIC_FLAGS_VM_ACCESS;
+#else /* J9VM_INTERP_ATOMIC_FREE_JNI */
 			UDATA const finalFlags = hasVMAccess ? J9_PUBLIC_FLAGS_VM_ACCESS : 0;
-			UDATA const jniAccess = J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS | finalFlags;
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
+			UDATA const jniAccess = criticalFlags | finalFlags;
 			if (jniAccess != VM_AtomicSupport::lockCompareExchange(&vmThread->publicFlags, jniAccess, finalFlags)) {
-				/* Exiting the last critical region; clear the JNI_CRITICAL_REGION and JNI_CRITICAL_ACCESS flags.
+				/* Exiting the last critical region; clear the critical flags.
 				 * Cache a copy of the flags first to determine if we must respond to an exclusive access request.
 				 */
 				omrthread_t const osThread = vmThread->osThread;
 				omrthread_monitor_t const publicFlagsMutex = vmThread->publicFlagsMutex;
 				omrthread_monitor_enter_using_threadId(publicFlagsMutex, osThread);
-				UDATA const publicFlags = VM_VMAccess::clearPublicFlagsNoMutex(vmThread, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS);
+				UDATA const publicFlags = VM_VMAccess::clearPublicFlagsNoMutex(vmThread, criticalFlags);
 				if (J9_ARE_ALL_BITS_SET(publicFlags, J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS | J9_PUBLIC_FLAGS_HALT_THREAD_EXCLUSIVE)) {
 					/* If an exclusive request is pending, then respond. */
 					J9JavaVM* const vm = vmThread->javaVM;


### PR DESCRIPTION
- check nested critical first to avoid atomic
- atomic-free expects VM access to be held
- enter/exit VM are aliased to acquire/release VM access in the old VM

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>