### PR TITLE
WIP: Move accumulatorNodeUsage to OpenJ9 Z CodeGenerator

### DIFF
--- a/runtime/compiler/trj9/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/trj9/z/codegen/J9CodeGenerator.cpp
@@ -215,6 +215,9 @@ J9::Z::CodeGenerator::CodeGenerator() :
       {
       self()->setHasFixedFrameC_CallingConvention();
       }
+
+   _accumulatorNodeUsage = 0;
+
    }
 
 

--- a/runtime/compiler/trj9/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/trj9/z/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,6 +125,11 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    TR_OpaquePseudoRegister * evaluateOPRNode(TR::Node* node);
    TR_PseudoRegister * evaluateBCDNode(TR::Node * node);
 
+   int32_t _accumulatorNodeUsage;
+
+   void setAccumulatorNodeUsage(int32_t n) { _accumulatorNodeUsage = n; }
+   int32_t getAccumulatorNodeUsage()       { return _accumulatorNodeUsage; }
+   void incAccumulatorNodeUsage()          { _accumulatorNodeUsage++; }
 
    // --------------------------------------------------------------------------
    // Storage references


### PR DESCRIPTION
This patch is part of https://github.com/eclipse/omr/issues/1892.

It is an upstream change where the _accumulatorNodeUsage field is
relocated to OpenJ9 J9::Z::CodeGenerator from OMR::CodeGenerator.

Signed-off-by: John Xu <xujohn@ca.ibm.com>