### PR TITLE
Remove unused debug code from ClassUnloadAssumption.cpp

### DIFF
--- a/runtime/compiler/trj9/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/trj9/runtime/ClassUnloadAssumption.cpp
@@ -1155,36 +1155,6 @@ J9::PersistentInfo::ensureUnloadedAddressSetsAreInitialized()
       _unloadedClassAddresses  = new (PERSISTENT_NEW) TR_AddressSet(_persistentMemory, maxUnloadedAddressRanges);
       _unloadedMethodAddresses = new (PERSISTENT_NEW) TR_AddressSet(_persistentMemory, maxUnloadedAddressRanges);
 
-      static const char *testUnloadedAddressRanges = feGetEnv("TR_testUnloadedAddressRanges");
-      if (testUnloadedAddressRanges)
-         {
-         ::FILE *input = fopen(testUnloadedAddressRanges, "r");
-
-         uint32_t classAddress, methodsStart, methodsSize;
-         int numFields;
-         while (EOF != (numFields = fscanf(input, "%x %x %d;\n", &classAddress, &methodsStart, &methodsSize)))
-            {
-            switch (numFields)
-               {
-               case 3:
-                  addUnloadedClass((TR_OpaqueClassBlock*)(uintptr_t)classAddress, methodsStart, methodsSize);
-                  break;
-               case 1:
-                  fprintf(stderr, "UAR TEST: 0x%08X %c%c\n", classAddress,
-                     isUnloadedClass((void*)classAddress, true)? 'C':'-',
-                     isInUnloadedMethod(classAddress)?           'M':'-');
-                  fscanf(input, "%*s;\n"); // Eat until the next semicolon
-                  break;
-               default:
-                  fprintf(stderr, "UAR TEST: Error scanning line; fscanf returned %d\n", numFields);
-                  fscanf(input, "%*s;\n"); // Eat until the next semicolon
-                  break;
-               }
-            }
-
-         fclose(input);
-         }
-
       return _unloadedClassAddresses && _unloadedMethodAddresses;
       }
    }


### PR DESCRIPTION
Attention was drawn to this code by a warning that a return code
from fscanf wasn't being checked; was mildly shocked to learn about
an fscanf() call in ClassUnloadAssumption.cpp . After consulting
with some other knowledgeable folks, it seems this worrisome code
is unlikely to have been used since its inception, so let's just
remove it.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>