### PR TITLE
 cleanWs after load jenkinsfiles

### DIFF
--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-aix_ppc-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_390-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_ppc-64_cmprssptrs_le
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-linux_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK10-win_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-aix_ppc-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_390-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_ppc-64_cmprssptrs_le
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-linux_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK8-win_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-aix_ppc-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_390-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_ppc-64_cmprssptrs_le
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-linux_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Extended-JDK9-win_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-aix_ppc-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_390-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_ppc-64_cmprssptrs_le
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-linux_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK10-win_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK11-linux_ppc-64_cmprssptrs_le_valhalla_nestmates
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK11-linux_ppc-64_cmprssptrs_le_valhalla_nestmates
@@ -37,6 +37,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-aix_ppc-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_390-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_ppc-64_cmprssptrs_le
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-linux_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK8-win_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-aix_ppc-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-aix_ppc-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_390-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_390-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_ppc-64_cmprssptrs_le
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-linux_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-win_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-Sanity-JDK9-win_x86-64_cmprssptrs
@@ -38,6 +38,7 @@ timeout(time: 10, unit: 'HOURS') {
         checkout scm
         buildfile = load 'buildenv/jenkins/common/build'
         testfile = load 'buildenv/jenkins/common/test'
+        cleanWs()
 
         // Build
         buildfile.build_pr()

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -170,7 +170,7 @@ win_x86-64_cmprssptrs:
     9: 'windows-x86_64-normal-server-release'
     10: 'windows-x86_64-normal-server-release'
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
-  openjdk_reference_repo: '/cygdrive/c/openjdk/openjdk_cache'
+  openjdk_reference_repo: 'C:\openjdk\openjdk_cache'
   extra_configure_options:
     8: '--with-freetype-include=/cygdrive/c/openjdk/freetype-2.5.3/include --with-freetype-lib=/cygdrive/c/openjdk/freetype-2.5.3/lib64 --disable-ccache'
     9: '--with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-toolchain-version=2013 --disable-ccache'


### PR DESCRIPTION
- If the OpenJ9 repo is in the Workspace then
  the git clone will not try to use the reference
  repo. Instead it will simply try and fetch
  the OpenJDK extensions repo from Github. If we
  remove the OpenJ9 repo from the workspace then
  the OpenJDK clone will use the reference repo.
- Only affects PR builds that run testing
  because we only load the OpenJ9 repo in those
  builds.

[skip ci]

Issue #1873

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

Depends #1905 