### PR TITLE
Cmake simplifications

### DIFF
--- a/runtime/GNUmakefile
+++ b/runtime/GNUmakefile
@@ -29,9 +29,7 @@
 clean: clean_phase_omr
 
 phase_omr:
-ifneq ($(ENABLE_CMAKE),true)
 	$(MAKE) $(MFLAGS) -C omr
-endif
 
 clean_phase_omr:
 	$(MAKE) $(MFLAGS) -C omr clean


### PR DESCRIPTION
Use OPENJ9_ENABLE_CMAKE directly, instead of ENABLE_CMAKE: buildtools.mk includes spec.gmk and thus has direct access to OPENJ9_ENABLE_CMAKE. Cmake is now consistently selected if $(OPENJ9_ENABLE_CMAKE)=true and not based on whether `ENABLE_CMAKE` is defined.

GNUmakefile should not be used with cmake and so doesn't need conditional code based on ENABLE_CMAKE.

Add missing dependencies for ddr.