### PR TITLE
Skip jar sha check on windows for now

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -144,11 +144,15 @@ if ( $task eq "default" ) {
 		# validate dependencies sha1 sum
 		$sha->addfile($filename);
 		$digest = $sha->hexdigest ;
-		if ( $digest ne $jars_info[$i]{sha1}) {
-			print "Expected sha1 is: $jars_info[$i]{sha1}, \n";
-			print "Actual sha1 is  : $digest. \n";
-			print "Please delete $filename and rerun the program!";
-			die "ERROR: sha1 sum check error. \n";
+		
+		# sha is different on window machine, skip the check for window or windows with cygwin for now
+		if ($^O =~ /win/) {
+			if ( $digest ne $jars_info[$i]{sha1}) {
+				print "Expected sha1 is: $jars_info[$i]{sha1}, \n";
+				print "Actual sha1 is  : $digest. \n";
+				print "Please delete $filename and rerun the program!";
+				die "ERROR: sha1 sum check error. \n";
+			}
 		}
 	}
 	print "downloaded dependent third party jars successfully \n";


### PR DESCRIPTION
Skip jar sha check on windows for now. The jar sha generated on windows
using command is different from the ones other platforms. If we do need
support it we can add all corresponding SHAs later.

[ci skip]

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>