### PR TITLE
Remove libffi workaround

### DIFF
--- a/runtime/include/j9lib.h.in
+++ b/runtime/include/j9lib.h.in
@@ -53,7 +53,6 @@ extern"C"{
 #define J9_VERIFIER_TEST_NATIVES_DLL_NAME "bcvwhite"
 #define J9_IFA_DLL_NAME "j9ifa29"
 #define J9_CHECK_JNI_DLL_NAME "j9jnichk29"
-#define J9_LIBFFI_DLL_NAME "ffi29"
 #define J9_CHECK_VM_DLL_NAME "j9vmchk29"
 #define J9_HARMONY_PORT_LIBRARY_SHIM_DLL_NAME "hyprtshim29"
 #define J9_CHECK_GC_DLL_NAME "j9gcchk29"

--- a/runtime/libffi/module.xml
+++ b/runtime/libffi/module.xml
@@ -146,17 +146,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<makefilestub data="FFI_COPY_template = $(UMA_PATH_TO_ROOT)include/$(notdir $(strip $1)) : $1 ; cp -f $$&lt; $$@" />
 			<makefilestub data="$(foreach H,$(FFI_HEADERS),$(eval $(call FFI_COPY_template,$H)))" />
 			<makefilestub data="UMA_OBJECTS_PREREQS += $(addprefix $(UMA_PATH_TO_ROOT)include/,$(notdir $(FFI_HEADERS)))" />
-			<!-- TODO: Temporary workaround for OpenJ9 JDK9 builds referring directly to the ffi shared library -->
-			<!-- TODO: Remove once the makefiles no longer refer to the ffi shared library -->
-			<makefilestub data="workaround:" />
-			<makefilestub data="&#x9;cp -f $(UMA_PATH_TO_ROOT)libj9thr29.so $(UMA_PATH_TO_ROOT)libffi29.so">
-				<exclude-if condition="spec.win_x86.*" />
-			</makefilestub>
-			<makefilestub data="&#x9;cp -f $(UMA_PATH_TO_ROOT)j9thr29.dll $(UMA_PATH_TO_ROOT)ffi29.dll">
-				<include-if condition="spec.win_x86.*" />
-			</makefilestub>
-			<makefilestub data="TARGETS+=workaround" />
-			<!-- TODO: End of temporary workaround -->
 		</makefilestubs>
 		<vpaths>
 			<!-- vpaths for PPC -->


### PR DESCRIPTION
Now that the build scripts no longer refer to the shared library,
stoping faking it up.

Follow up from #1900

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>