### PR TITLE
J9 DDR generator file fixes and legacy mode

### DIFF
--- a/debugtools/DDR_VM/generate-ddr.xml
+++ b/debugtools/DDR_VM/generate-ddr.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2017, 2017 IBM Corp. and others
+  Copyright (c) 2017, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,6 +88,9 @@
 
 				<arg value="-v" />
 				<arg value="@{version}" />
+
+				<arg value="-l" />
+				<arg value="true" />
 			</java>
 		</sequential>
 	</macrodef>
@@ -110,6 +113,9 @@
 
 				<arg value="-s" />
 				<arg value="@{superset}" />
+
+				<arg value="-l" />
+				<arg value="true" />
 			</java>
 		</sequential>
 	</macrodef>

--- a/debugtools/DDR_VM/generate.xml
+++ b/debugtools/DDR_VM/generate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2010, 2017 IBM Corp. and others
+  Copyright (c) 2010, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,7 +126,7 @@
 
 	<target name="generate_stubs">
 		<java classname="com.ibm.j9ddr.tools.StructureStubGenerator">
-			<arg line="-o ${DDR_VM}/src -p ${STUBS_PACKAGE_NAME}  -f ${superset.dir}" />
+			<arg line="-o ${DDR_VM}/src -p ${STUBS_PACKAGE_NAME}  -f ${superset.dir} -l true" />
 			<classpath>
 				<pathelement location="${DDR_TOOLS_LIB}" />
 				<pathelement location="${DDR_CORE_LIB}" />
@@ -139,7 +139,7 @@
 
 	<target name="generate_pointer_classes">
 		<java classname="com.ibm.j9ddr.tools.PointerGenerator">
-			<arg line="-o ${DDR_VM}/src -p ${POINTERS_PACKAGE_NAME} -f ${superset.dir}  -v ${VM_VERSION} -u false -c ${basedir}/generate.properties" />
+			<arg line="-o ${DDR_VM}/src -p ${POINTERS_PACKAGE_NAME} -f ${superset.dir}  -v ${VM_VERSION} -u false -c ${basedir}/generate.properties -l true" />
 			<classpath>
 				<pathelement location="${DDR_TOOLS_LIB}" />
 				<pathelement location="${DDR_CORE_LIB}" />

--- a/debugtools/DDR_VM/launch_configs/Generate Pointer Classes (vm29).launch
+++ b/debugtools/DDR_VM/launch_configs/Generate Pointer Classes (vm29).launch
@@ -8,6 +8,6 @@
 <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.j9ddr.tools.PointerGenerator"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-o &quot;${workspace_loc:DDR_VM}/src&quot; -p com.ibm.j9ddr.vm29.pointer.generated -f &quot;${workspace_loc:DDR_Artifacts}/supersets/29&quot; -v 29 -s &quot;superset.ibuild.dat&quot;"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-o &quot;${workspace_loc:DDR_VM}/src&quot; -p com.ibm.j9ddr.vm29.pointer.generated -f &quot;${workspace_loc:DDR_Artifacts}/supersets/29&quot; -v 29 -s &quot;superset.ibuild.dat&quot; -l true"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="DDR_VM"/>
 </launchConfiguration>

--- a/debugtools/DDR_VM/launch_configs/Generate Structure Stubs (vm29).launch
+++ b/debugtools/DDR_VM/launch_configs/Generate Structure Stubs (vm29).launch
@@ -8,6 +8,6 @@
 <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.ibm.j9ddr.tools.StructureStubGenerator"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-o &quot;${workspace_loc:DDR_VM}/src&quot; -p com.ibm.j9ddr.vm29.structure -f &quot;${workspace_loc:DDR_Artifacts}/supersets/29&quot; -s &quot;superset.ibuild.dat&quot;"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-o &quot;${workspace_loc:DDR_VM}/src&quot; -p com.ibm.j9ddr.vm29.structure -f &quot;${workspace_loc:DDR_Artifacts}/supersets/29&quot; -s &quot;superset.ibuild.dat&quot; -l true"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="DDR_VM"/>
 </launchConfiguration>

--- a/debugtools/DDR_VM/manual_build.xml
+++ b/debugtools/DDR_VM/manual_build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2010, 2017 IBM Corp. and others
+  Copyright (c) 2010, 2018 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,7 +123,7 @@
 
 	<target name="generate_stubs">
 		<java classname="com.ibm.j9ddr.tools.StructureStubGenerator">
-			<arg line="-o ${DDR_VM}/src -p ${STUBS_PACKAGE_NAME}  -f ${superset.dir}" />
+			<arg line="-o ${DDR_VM}/src -p ${STUBS_PACKAGE_NAME}  -f ${superset.dir} -l true" />
 			<classpath>
 				<pathelement location="${DDR_TOOLS_LIB}" />
 				<pathelement location="${DDR_CORE_LIB}" />
@@ -136,7 +136,7 @@
 
 	<target name="generate_pointer_classes">
 		<java classname="com.ibm.j9ddr.tools.PointerGenerator">
-			<arg line="-o ${DDR_VM}/src -p ${POINTERS_PACKAGE_NAME} -f ${superset.dir}  -v ${VM_VERSION} -u false -c ${basedir}/generate.properties" />
+			<arg line="-o ${DDR_VM}/src -p ${POINTERS_PACKAGE_NAME} -f ${superset.dir}  -v ${VM_VERSION} -u false -c ${basedir}/generate.properties -l true" />
 			<classpath>
 				<pathelement location="${DDR_TOOLS_LIB}" />
 				<pathelement location="${DDR_CORE_LIB}" />


### PR DESCRIPTION
Fix index out of bounds in PointerGenerator.java. Code assumed there
would always be a number after '_v', which is erroneous if there is a
field with name ending like that.

Omit anonymous fields on aix since they start with #, an illegal
character, and aren't used in DDR.

Added legacy mode, where it checks for the suffix '_v#' for legacy DDR,
and it doesn't for new DDR since the new DDR does not generate the
offset suffixes for fields.

Change old world configs to use legacy mode in PointerGenerator and
StructureStubGenerator.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Reviewer: @keithc-ca 