### PR TITLE
Add implementation of String.repeat(count)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -3847,7 +3847,49 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 		return string;
 	}
-	/*[ENDIF] Java11*/
+
+	/**
+	 * Returns a string whose value is the concatenation of this string repeated
+	 * count times. 
+	 * 
+	 * @param count
+	 *            a positive integer indicating the number of times to be repeated
+	 * @return a string whose value is the concatenation of this string repeated count times
+	 * @throws IllegalArgumentException
+	 *             if the count is negative
+	 * @since 11
+	 */
+	public String repeat(int count) {
+		if (count < 0) {
+			throw new IllegalArgumentException();
+		} else if (count == 0 || isEmpty()) {
+			return "";
+		} else if (count == 1) {
+			return this;
+		}
+
+		int length = lengthInternal();
+		int repeatlen = length * count;
+
+		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			byte[] buffer = new byte[repeatlen];
+
+			for (int i = 0; i < count; i++) {
+				compressedArrayCopy(value, 0, buffer, i * length, length);				
+			}
+
+			return new String(buffer, LATIN1);
+		} else {
+			byte[] buffer = new byte[repeatlen * 2];
+
+			for (int i = 0; i < count; i++) {
+				decompressedArrayCopy(value, 0, buffer, i * length, length);				
+			}
+				
+			return new String(buffer, UTF16);
+		}
+	}
+	/*[ENDIF] Java11 */
 
 /*[ELSE] Sidecar19-SE*/
 	// DO NOT CHANGE OR MOVE THIS LINE

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -24,32 +24,9 @@
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>StringvalueOfCodePoint_JDK11_CompactStrings_Enabled</testCaseName>
+		<testCaseName>String_CompactStrings</testCaseName>
 		<variations>
 			<variation>-XX:+CompactStrings</variation>
-		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
-			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Test_String \
-			-groups $(TEST_GROUP) \
-			-excludegroups $(DEFAULT_EXCLUDE); \
-			$(TEST_STATUS)
-		</command>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>SE110</subset>
-		</subsets>
-	</test>
-
-	<test>
-		<testCaseName>StringvalueOfCodePoint_JDK11_CompactStrings_Disabled</testCaseName>
-		<variations>
-			<variation>-XX:-CompactStrings</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \

--- a/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -63,4 +63,41 @@ public class Test_String {
 			// Expected exception
 		}
 	}
+
+	/*
+	 * Test Java 11 method String.repeat(count)
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testRepeat() {
+		String empty = "";
+		String latin1 = "abc123";
+		String nonLatin1 = "abc\u0153";
+		String str;
+
+		// Verify that correct strings are produced under normal conditions
+		Assert.assertTrue(latin1.repeat(3).equals("abc123abc123abc123"), "Repeat failed to produce correct string (LATIN1)");
+		Assert.assertTrue(nonLatin1.repeat(3).equals("abc\u0153abc\u0153abc\u0153"), "Repeat failed to produce correct string (non-LATIN1)");
+
+		Assert.assertTrue(empty.repeat(0) == empty, "Failed to return identical empty string - empty base (0)");
+		Assert.assertTrue(empty.repeat(2) == empty, "Failed to return identical empty string - empty base (2)");
+		Assert.assertTrue(latin1.repeat(0) == empty, "Failed to return identical empty string - nonempty base (0)");
+
+		// Verify that IllegalArgumentException is thrown for count < 0
+		try {
+			str = empty.repeat(-1);
+			Assert.fail("Failed to detect invalid count -1");
+		} catch (IllegalArgumentException e) {
+			// Expected exception
+		}
+
+		try {
+			str = latin1.repeat(-3);
+			Assert.fail("Failed to detect invalid count -3");
+		} catch (IllegalArgumentException e) {
+			// Expected exception
+		}
+
+		// Verify that a reference to the instance that called the function is returned for count == 1
+		Assert.assertTrue(latin1.repeat(1) == latin1, "Should be identical on count 1");
+	}
 }


### PR DESCRIPTION
Add implementation of java.lang.String.repeat(count).
This is only for Java 11.

Closes #1660
    
Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>