### PR TITLE
Update longabout file's date to that of the latest change

### DIFF
--- a/longabout.html
+++ b/longabout.html
@@ -8,7 +8,7 @@
 <body lang="EN-US">
 <h2>About This Content</h2>
 
-<p><em>September 8, 2017</em></p>
+<p><em>January 24, 2018</em></p>
 <h3>License</h3>
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
@@ -36,7 +36,7 @@ for informational purposes only, and you should look to the Redistributor's lice
 terms and conditions of use.</p>
 
 <h4>Eclipse OMR</h4>
-<p>Copyright (c) 2017, 2017 IBM Corp. and others</p>
+<p>Copyright (c) 2017, 2018 IBM Corp. and others</p>
 <p>
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 <p>


### PR DESCRIPTION
Which was the addition of the musl bit, which was merged on the
24th of January 2018.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>