### PR TITLE
Add access checks for MethodHandle.invoke parameter and return types

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1085,33 +1085,39 @@ public abstract class MethodHandle {
 			String name,
 			String typeDescriptor,
 			ClassLoader loader) throws Throwable {
-		MethodHandles.Lookup lookup = new MethodHandles.Lookup(currentClass, false);
-		MethodType type = null;
-		
-		switch(cpRefKind){
-		case 1: /* getField */
-			return lookup.findGetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
-		case 2: /* getStatic */
-			return lookup.findStaticGetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
-		case 3: /* putField */
-			return lookup.findSetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
-		case 4: /* putStatic */
-			return lookup.findStaticSetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
-		case 5: /* invokeVirtual */
-			type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
-			return lookup.findVirtual(referenceClazz, name, type);
-		case 6: /* invokeStatic */
-			type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
-			return lookup.findStatic(referenceClazz, name, type);
-		case 7: /* invokeSpecial */ 
-			type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
-			return lookup.findSpecial(referenceClazz, name, type, currentClass);
-		case 8: /* newInvokeSpecial */
-			type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
-			return lookup.findConstructor(referenceClazz, type);
-		case 9: /* invokeInterface */
-			type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
-			return lookup.findVirtual(referenceClazz, name, type);
+		try {
+			MethodHandles.Lookup lookup = new MethodHandles.Lookup(currentClass, false);
+			MethodType type = null;
+			
+			switch(cpRefKind){
+			case 1: /* getField */
+				return lookup.findGetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
+			case 2: /* getStatic */
+				return lookup.findStaticGetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
+			case 3: /* putField */
+				return lookup.findSetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
+			case 4: /* putStatic */
+				return lookup.findStaticSetter(referenceClazz, name, resolveFieldHandleHelper(typeDescriptor, loader));
+			case 5: /* invokeVirtual */
+				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				return lookup.findVirtual(referenceClazz, name, type);
+			case 6: /* invokeStatic */
+				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				return lookup.findStatic(referenceClazz, name, type);
+			case 7: /* invokeSpecial */ 
+				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				return lookup.findSpecial(referenceClazz, name, type, currentClass);
+			case 8: /* newInvokeSpecial */
+				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				return lookup.findConstructor(referenceClazz, type);
+			case 9: /* invokeInterface */
+				type = MethodType.vmResolveFromMethodDescriptorString(typeDescriptor, loader, null);
+				return lookup.findVirtual(referenceClazz, name, type);
+			}
+		} catch (IllegalAccessException iae) {
+			// Java spec expects an IllegalAccessError instead of IllegalAccessException thrown when an application attempts 
+			// (not reflectively) to access or modify a field, or to invoke a method that it doesn't have access to.
+			throw new IllegalAccessError(iae.getMessage()).initCause(iae);
 		}
 		/* Can never happen */
 		throw new UnsupportedOperationException();

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -779,13 +779,9 @@ public class MethodHandles {
 		}
 
 		/*
-		 * Check for methods MethodHandle.invokeExact, MethodHandle.invoke,
-		 * or MethodHandles.varHandleInvoker.  
-		 * Access checks to these methods are not required as these methods are public and therefore
-		 * accessible to everyone.
-		 * However the access checks to the parameter and return classes are required.
+		 * Check access to the parameter and return classes within incoming MethodType
 		 */
-		MethodHandle handleForMHInvokeMethods(Class<?> clazz, String methodName, MethodType type) throws IllegalAccessException {
+		private void accessCheckArgRetTypes(MethodType type) throws IllegalAccessException {
 			if (INTERNAL_PRIVILEGED != accessMode) {
 				for (Class<?> para : type.arguments) {
 					if (!para.isPrimitive()) {
@@ -797,10 +793,22 @@ public class MethodHandles {
 					checkClassAccess(rType);
 				}
 			}
+		}
+		
+		/*
+		 * Check for methods MethodHandle.invokeExact, MethodHandle.invoke,
+		 * or MethodHandles.varHandleInvoker.  
+		 * Access checks to these methods are not required as these methods are public and therefore
+		 * accessible to everyone.
+		 * However the access checks to the parameter and return classes are required.
+		 */
+		MethodHandle handleForMHInvokeMethods(Class<?> clazz, String methodName, MethodType type) throws IllegalAccessException {
 			if (MethodHandle.class.isAssignableFrom(clazz)) {
 				if (INVOKE_EXACT.equals(methodName)) {
+					accessCheckArgRetTypes(type);
 					return type.getInvokeExactHandle();
 				} else if (INVOKE.equals(methodName))  {
+					accessCheckArgRetTypes(type);
 					return new InvokeGenericHandle(type);
 				}
 			}
@@ -811,6 +819,7 @@ public class MethodHandles {
 			if (VarHandle.class.isAssignableFrom(clazz)) {
 				for (AccessMode m : AccessMode.values()) {
 					if (m.methodName().equals(methodName)) {
+						accessCheckArgRetTypes(type);
 						return new VarHandleInvokeGenericHandle(m, type);
 					}
 				}

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -781,10 +781,22 @@ public class MethodHandles {
 		/*
 		 * Check for methods MethodHandle.invokeExact, MethodHandle.invoke,
 		 * or MethodHandles.varHandleInvoker.  
-		 * Access checks are not required as these methods are public and therefore
+		 * Access checks to these methods are not required as these methods are public and therefore
 		 * accessible to everyone.
+		 * However the access checks to the parameter and return classes are required.
 		 */
-		static MethodHandle handleForMHInvokeMethods(Class<?> clazz, String methodName, MethodType type) {
+		MethodHandle handleForMHInvokeMethods(Class<?> clazz, String methodName, MethodType type) throws IllegalAccessException {
+			if (INTERNAL_PRIVILEGED != accessMode) {
+				for (Class<?> para : type.arguments) {
+					if (!para.isPrimitive()) {
+						checkClassAccess(para);
+					}
+				}
+				Class<?> rType = type.returnType();
+				if (!rType.isPrimitive()) {
+					checkClassAccess(rType);
+				}
+			}
 			if (MethodHandle.class.isAssignableFrom(clazz)) {
 				if (INVOKE_EXACT.equals(methodName)) {
 					return type.getInvokeExactHandle();


### PR DESCRIPTION
Add access checks for `MethodHandle.invoke(Exact)` parameter and return types

Though methods `j.l.i.MethodHandle.invoke(Exact)` are public and there is no need for access check, the parameter and return classes require access check by access class.
Throw `IllegalAccessError` instead of `IllegalAccessException` when an application attempts (not refectively) to access or modify a field, or to invoke a method that it doesn't have access to. This is to satisfy Java spec requirements.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>