### PR TITLE
Update Linux makefile to allow compilation with GCC 7.3

### DIFF
--- a/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
@@ -93,7 +93,4 @@ RUN cd /root \
 ENV JAVA_HOME="/root/bootjdk10"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
-# The below CFLAG prevents "error: inline function ${FUNCTION_NAME} declared but never defined [-Werror]"
-ENV CFLAGS="-fgnu89-inline"
-
 WORKDIR /root

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -1,5 +1,5 @@
 <#-- 
-	Copyright (c) 1998, 2017 IBM Corp. and others
+	Copyright (c) 1998, 2018 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -152,6 +152,16 @@ ifdef USE_PPC_GCC
   PPC_GCC_CXXFLAGS+=-O3 -fno-strict-aliasing
 endif
 </#if>
+
+<#-- GCC versions greater than 5 default to GNU11 but OpenJ9 uses
+GNU89 inline semantics. -fgnu89-inline option is appended to CFLAGS
+to allow compilation with GCC versions greater than 5 and GNU89 inline
+semantics. Reference - https://gcc.gnu.org/gcc-5/porting_to.html.
+-->
+GCCVERSIONGTEQ5 := $(shell expr `gcc -dumpversion | cut -f1 -d.` \>= 5)
+ifeq "$(GCCVERSIONGTEQ5)" "1"
+    CFLAGS+=-fgnu89-inline
+endif
 
 <#if !uma.spec.processor.ppc>
 CXXFLAGS+=-fno-exceptions -fno-rtti -fno-threadsafe-statics


### PR DESCRIPTION
GCC versions greater than 5 default to GNU11 but OpenJ9 uses
GNU89 inline semantics. -fgnu89-inline option is appended to CFLAGS
to allow compilation with GCC versions greater than 5 and GNU89 inline
semantics. Reference - https://gcc.gnu.org/gcc-5/porting_to.html.

JDK11 Linux x86 DockerFile no longer needs to initialize CFLAGS with
-fgnu89-inline since the Linux makefile now accounts for -fgnu89-inline
option if the GCC version is greater than 5.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>