### PR TITLE
Clean up attach API code

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
@@ -36,7 +36,6 @@ import com.ibm.oti.vm.VM;
  * public because it is used by java.lang.System
  * 
  */
-@SuppressWarnings("synthetic-access")
 public class AttachHandler extends Thread {
 
 	/*[PR Jazz 3007] remove duplicate definition of SYNC_FILE_PERMISSIONS */
@@ -71,7 +70,7 @@ public class AttachHandler extends Thread {
 	private static AttachStateValues attachState = AttachStateValues.ATTACH_UNINITIALIZED;
 	private static boolean waitingForSemaphore = false;
 
-	private static final class AttachStateSync {
+	static final class AttachStateSync {
 		/**
 		 * Empty class for synchronization objects.
 		 */
@@ -81,7 +80,7 @@ public class AttachHandler extends Thread {
 
 	static int notificationCount;
 
-	private static final class syncObject {
+	static final class syncObject {
 		/**
 		 * Empty class for synchronization objects.
 		 */

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
@@ -28,6 +28,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * This class maintains the directory holding the attach API file artifacts.
+ *
+ */
 public abstract class CommonDirectory {
 	private static final String ATTACH_LOCK = "_attachlock"; //$NON-NLS-1$
 	private static final String COM_IBM_TOOLS_ATTACH_DIRECTORY = "com.ibm.tools.attach.directory"; //$NON-NLS-1$
@@ -38,7 +42,7 @@ public abstract class CommonDirectory {
 	static final int SEMAPHORE_OKAY = 0;
 	private static final String TRASH_PREFIX = ".trash_"; //$NON-NLS-1$
 
-	static final class syncObject {}
+	static final class syncObject { /* empty class for synchronization only. */}
 	private static final syncObject accessorMutex = new syncObject();
 	private static FileLock attachLock;
 	private static File commonDirFile; /* file where all IPC files are held */
@@ -293,6 +297,10 @@ public abstract class CommonDirectory {
 		IPC.destroySemaphore();
 	}
 
+	/**
+	 * Count the number of target directories in the common directory
+	 * @return Number of directories
+	 */
 	public static int countTargetDirectories () {
 		File dir= getCommonDirFileObject();
 
@@ -324,7 +332,6 @@ public abstract class CommonDirectory {
 	 * look for leftover files and directories from previous VMs
 	 */
 	/*[PR Jazz 37778 deleteStaleDirectories was always called with checkProcess=true */
-	@SuppressWarnings("synthetic-access")
 	static void deleteStaleDirectories(String myId) {
 		long myUid = IPC.getUid();
 		File[] vmDirs = getCommonDirFileObject().listFiles(new DirectorySampler());
@@ -414,8 +421,7 @@ public abstract class CommonDirectory {
 			TargetDirectory.deleteTargetDirectory(dirMember.getName());
 		}
 		Advertisement advert;
-		try {
-			FileInputStream propStream = new FileInputStream(advertFile);
+		try (FileInputStream propStream = new FileInputStream(advertFile)) {
 			advert = Advertisement.readAdvertisementFile(propStream); /* throws IOException if file cannot be read */
 			propStream.close();
 		} catch (IOException e) {
@@ -466,13 +472,19 @@ public abstract class CommonDirectory {
 		return masterLock;
 	}
 	
+	/**
+	 * Get the UID of a file's owner
+	 * @param path file path
+	 * @return UID of file owner
+	 */
 	public static native long getFileOwner(String path);
 	
-	private static final class DirectorySampler implements FileFilter {
+	static final class DirectorySampler implements FileFilter {
 
 		private int acceptCount = 16;
 		private long skip;
 		private long range = 2;
+		@Override
 		public boolean accept(File candidate) {
 			if (acceptCount > 0) { /* accept the first N files unconditionally */
 				--acceptCount;

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -294,14 +294,14 @@ public class IPC {
 	 * @note nothing is printed if logging is disabled
 	 */
 	public synchronized static void logMessage(String msg, Throwable thrown) {
-		@SuppressWarnings("resource")
-		PrintStream log = getLogStream();
-		if (!Objects.isNull(log)) {
-			tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
-			printLogMessageHeader(log);
-			log.println(msg);
-			thrown.printStackTrace(log);
-			log.flush();
+		try (PrintStream log = getLogStream()) {
+			if (!Objects.isNull(log)) {
+				tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
+				printLogMessageHeader(log);
+				log.println(msg);
+				thrown.printStackTrace(log);
+				log.flush();
+			}
 		}
 	}
 
@@ -312,13 +312,13 @@ public class IPC {
 	 * @note no message is printed if logging is disabled
 	 */
 	private synchronized static void printLogMessage(final String msg) {
-		@SuppressWarnings("resource")
-		PrintStream log = getLogStream();
-		if (!Objects.isNull(log)) {
-			tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
-			printLogMessageHeader(log);
-			log.println(msg);
-			log.flush();
+		try (PrintStream log = getLogStream()) {
+			if (!Objects.isNull(log)) {
+				tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
+				printLogMessageHeader(log);
+				log.println(msg);
+				log.flush();
+			}
 		}
 	}
 

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -2,7 +2,7 @@
 package com.ibm.tools.attach.attacher;
 
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,6 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 	 * @param id
 	 *            identifier for the VM
 	 */
-	@SuppressWarnings("unused")
 	OpenJ9VirtualMachine(AttachProvider provider, String id)
 			throws NullPointerException {
 		super(provider, id);
@@ -100,7 +99,6 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 			/*[MSG "K0554", "Virtual machine ID or display name is null"]*/
 			throw new NullPointerException(getString("K0554")); //$NON-NLS-1$
 		}
-		new IPC();
 		this.targetId = id;
 		this.myProvider = (OpenJ9AttachProvider) provider;
 		this.descriptor = (OpenJ9VirtualMachineDescriptor) myProvider.getDescriptor(id);
@@ -305,7 +303,6 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 		}
 	}
 
-	@SuppressWarnings("boxing")
 	private static boolean parseResponse(String response) throws IOException,
 			AgentInitializationException, AgentLoadException, IllegalArgumentException
 			, AttachOperationFailedException 
@@ -326,7 +323,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 				if (null == status) {
 					throw new AgentInitializationException(trimmedResponse);
 				} else {
-					throw new AgentInitializationException(trimmedResponse, status);
+					throw new AgentInitializationException(trimmedResponse, status.intValue());
 				}
 			} else if (response.contains(EXCEPTION_AGENT_LOAD_EXCEPTION)) {
 				throw new AgentLoadException(trimmedResponse);
@@ -353,15 +350,13 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 	 * @param response
 	 * @return Integer value of status, or null if the string does not end in a number
 	 */
-	@SuppressWarnings("boxing")
 	private static Integer getStatusValue(String response) {
 		Pattern rvPattern = Pattern.compile("(-?\\d+)\\s*$");  //$NON-NLS-1$
 		Matcher rvMatcher = rvPattern.matcher(response);
 		if (rvMatcher.find()) {
 			String status = rvMatcher.group(1);
 			try {
-				int statusValue = Integer.parseInt(status);
-				return statusValue;
+				return Integer.getInteger(status);
 			} catch (NumberFormatException e) {
 				IPC.logMessage("Error parsing response", response); //$NON-NLS-1$
 				return null;


### PR DESCRIPTION
Fix visibility of methods to avoid synthetic methods.  Remove autoboxing. Add
try-with-resources to close files.  Add javadoc for public classes and methods.
Remove spurious object creation.  Remove all warning suppression.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>