### PR TITLE
Remove duplicate function calculateArrayElementAddress in DAA

### DIFF
--- a/runtime/compiler/trj9/optimizer/DataAccessAccelerator.hpp
+++ b/runtime/compiler/trj9/optimizer/DataAccessAccelerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -211,8 +211,6 @@ class TR_DataAccessAccelerator : public TR::Optimization
    TR::Node* insertDecimalSetIntrinsic(TR::TreeTop* callTreeTop, TR::Node* callNode, int32_t sourceNumBytes, int32_t targetNumBytes);
 
    bool inlineCheckPackedDecimal(TR::TreeTop* callTreeTop, TR::Node* callNode);
-
-   TR::Node* calculateArrayElementAddress(TR::Node* callNode, TR::Node* byteArray, TR::Node* offset, int32_t headerSize, int32_t width);
 
    private:
 


### PR DESCRIPTION
Remove the duplicate function calculateArrayElementAddress function 
and replace usages with calls to constructAddressNode.

Signed-off-by: Daniel Hong <daniel.hong@live.com>