### PR TITLE
Adding missed OS check for GS support in Port Library for zLinux

### DIFF
--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -507,6 +507,11 @@ typedef struct J9ProcessorDesc {
 
 /* STFLE bit 57 - Message-security-assist-extension-5 facility */
 #define J9PORT_S390_FEATURE_MSA_EXTENSION_5 57
+
+/* zLinux features
+ * Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on z.
+ */
+#define J9PORT_HWCAP_S390_GS 0x4000
 
 /* x86 features
  * INTEL INSTRUCTION SET REFERENCE, A-M

--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -66,10 +66,10 @@
 #include "j9csrsi.h"
 #endif /* defined(J9ZOS390) */
 
-#if defined(LINUXPPC)
+#if (defined(LINUXPPC) || (defined(S390) && defined(LINUX)))
 #include "auxv.h"
 #include <strings.h>
-#endif /* defined(LINUXPPC) */
+#endif /* (defined(LINUXPPC) || (defined(S390) && defined(LINUX))) */
 
 #if defined(AIXPPC)
 #include <fcntl.h>
@@ -772,6 +772,9 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	if (J9_ARE_NO_BITS_SET(*(int*) 200, S390_STFLE_BIT)) {
 		return -1;
 	}
+#else /* LINUX S390*/
+	/* Some s390 features require OS support on Linux, querying auxv for AT_HWCAP bit-mask of processor capabilities. */
+	unsigned long auxvFeatures = query_auxv(AT_HWCAP);
 #endif /* defined(J9ZOS390) */
 
 	/* GS hardwrae support */
@@ -779,6 +782,8 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 #if defined(J9ZOS390)
 		/* GS OS support */
 		if (J9_ARE_ALL_BITS_SET(cvtgsf, 0x1)) /* CVTGSF bit is X'01' bit at byte X'17A' off CVT */
+#else /* LINUX S390*/
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_GS))
 #endif /* defined(J9ZOS390) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_GUARDED_STORAGE);


### PR DESCRIPTION
Use aux vector to check Guarded Storage support for Linux OS on s390
hardware.

Fixes: #1764

Signed-off-by: Evgenia Badyanova <evgeniab@ca.ibm.com>