### PR TITLE
Increase default shared cache size.

### DIFF
--- a/runtime/oti/j9cfg_builder.h
+++ b/runtime/oti/j9cfg_builder.h
@@ -61,6 +61,13 @@
 #define J9_INVARIANT_INTERN_TABLE_NODE_COUNT 2345
 #define J9_SHARED_CLASS_CACHE_MIN_SIZE (4 * 1024)
 #define J9_SHARED_CLASS_CACHE_MAX_SIZE I_32_MAX
+/* Default shared class cache size for Java 9 (and up) on 64-bit platforms (if OS allows) */
+#define J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM (300 * 1024 * 1024)
+/* Default shared class soft max size for Java 9 (and up) on 64-bit platforms. This value is only set if the OS allows default cache size to be greater than J9_SHARED_CLASS_CACHE_MIN_DEFAULT_CACHE_SIZE_FOR_SOFTMAX */
+#define J9_SHARED_CLASS_CACHE_DEFAULT_SOFTMAX_SIZE_64BIT_PLATFORM (64 * 1024 * 1024)
+/* The minimum default shared class cache size to set a default soft max. Java 9 (and up) on 64-bit platforms only. */
+#define J9_SHARED_CLASS_CACHE_MIN_DEFAULT_CACHE_SIZE_FOR_SOFTMAX (80 * 1024 *1024)
+/* Default shared class cache size for Java 8 on all platforms, Java 9 (and up) on 32-bit platforms */
 #define J9_SHARED_CLASS_CACHE_DEFAULT_SIZE (16 * 1024 * 1024)
 
 #define J9_FIXED_SPACE_SIZE_NUMERATOR 0

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
  */
 
 #include <string.h>
+#include "j2sever.h"
 #include "j9cfg.h"
 #include "j9port.h"
 #include "pool_api.h"
@@ -162,11 +163,18 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	struct J9FileStat statBuf;
 	IDATA errorCode = J9SH_OSCACHE_FAILURE;
 	LastErrorInfo lastErrorInfo;
+
+	UDATA defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
+#if defined(J9VM_ENV_DATA64)
+	if (J2SE_VERSION(vm) >= J2SE_19) {
+		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+	}
+#endif /* J9VM_ENV_DATA64 */
 	
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 
 	Trc_SHR_OSC_Mmap_startup_Entry(cacheName, ctrlDirName,
-		(piconfig!= NULL)? piconfig->sharedClassCacheSize : J9_SHARED_CLASS_CACHE_DEFAULT_SIZE,
+		(piconfig!= NULL)? piconfig->sharedClassCacheSize : defaultCacheSize,
 		numLocks, createFlag, verboseFlags, openMode);
 	
 	versionData->cacheType = J9PORT_SHR_CACHE_TYPE_PERSISTENT;

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -149,17 +149,22 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	IDATA shsemrc = 0;
 	IDATA semLength = 0;
 	LastErrorInfo lastErrorInfo;
-
+	UDATA defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
+#if defined(J9VM_ENV_DATA64)
+	if (J2SE_VERSION(vm) >= J2SE_19) {
+		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+	}
+#endif /* J9VM_ENV_DATA64 */
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	
-	Trc_SHR_OSC_startup_Entry(cacheName, (piconfig!= NULL)? piconfig->sharedClassCacheSize : J9_SHARED_CLASS_CACHE_DEFAULT_SIZE, create);
+	Trc_SHR_OSC_startup_Entry(cacheName, (piconfig!= NULL)? piconfig->sharedClassCacheSize : defaultCacheSize, create);
 
 	if (openMode & J9OSCACHE_OPEN_MODE_GROUPACCESS) {
 		_groupPerm = 1;
 	}
 	
 	versionData->cacheType = J9PORT_SHR_CACHE_TYPE_NONPERSISTENT;
-	_cacheSize = (piconfig!= NULL) ? (U_32)piconfig->sharedClassCacheSize : J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
+	_cacheSize = (piconfig!= NULL) ? (U_32)piconfig->sharedClassCacheSize : (U_32)defaultCacheSize;
 	_initialiser = i;
 	_totalNumSems = numLocks + 1;		/* +1 because of header mutex */
 	_userSemCntr = 0;

--- a/runtime/shared_common/shrinit.h
+++ b/runtime/shared_common/shrinit.h
@@ -57,7 +57,7 @@ BOOLEAN j9shr_isAddressInCache(J9JavaVM *vm, void *address, UDATA length);
 void j9shr_populatePreinitConfigDefaults(J9JavaVM *vm, J9SharedClassPreinitConfig *updatedWithDefaults);
 BOOLEAN j9shr_isPlatformDefaultPersistent(struct J9JavaVM* vm);
 UDATA j9shr_isBCIEnabled(J9JavaVM *vm);
-UDATA ensureCorrectCacheSizes(J9PortLibrary* portlib, U_64 runtimeFlags, UDATA verboseFlags, J9SharedClassPreinitConfig* piconfig);
+UDATA ensureCorrectCacheSizes(J9JavaVM *vm, J9PortLibrary* portlib, U_64 runtimeFlags, UDATA verboseFlags, J9SharedClassPreinitConfig* piconfig);
 UDATA parseArgs(J9JavaVM* vm, char* options, U_64* runtimeFlags, UDATA* verboseFlags, char** cacheName, char** modContext, char** expireTime, char** ctrlDirName, char** cacheDirPerm, char** methodSpecs, UDATA* printStatsOptions, UDATA* storageKeyTesting);
 UDATA convertPermToDecimal(J9JavaVM *vm, const char *permStr);
 SCAbstractAPI * initializeSharedAPI(J9JavaVM *vm);

--- a/runtime/tests/shared/AOTDataMinMaxTest.cpp
+++ b/runtime/tests/shared/AOTDataMinMaxTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,7 +101,7 @@ AOTDataMinMaxTest::openTestCache(I_32 cacheSize, I_32 minaot, I_32 maxaot)
 	cacheDetails->sharedClassCacheSize = cacheSize;
 	cacheDetails->sharedClassMinAOTSize = minaot;
 	cacheDetails->sharedClassMaxAOTSize = maxaot;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, cacheDetails);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, cacheDetails);
 	extraRuntimeFlags = getDefaultRuntimeFlags();
 
 	sharedclassconfig = (J9SharedClassConfig *) j9mem_allocate_memory(sizeof(J9SharedClassConfig) + sizeof(J9SharedClassCacheDescriptor), J9MEM_CATEGORY_CLASSES);

--- a/runtime/tests/shared/AttachedDataMinMaxTest.cpp
+++ b/runtime/tests/shared/AttachedDataMinMaxTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,7 +98,7 @@ AttachedDataMinMaxTest::openTestCache(I_32 cacheSize, I_32 minjit, I_32 maxjit)
 	cacheDetails->sharedClassCacheSize = cacheSize;
 	cacheDetails->sharedClassMinJITSize = minjit;
 	cacheDetails->sharedClassMaxJITSize = maxjit;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, cacheDetails);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, cacheDetails);
 	extraRuntimeFlags = getDefaultRuntimeFlags();
 
 

--- a/runtime/tests/shared/CompositeCacheSizesTests.cpp
+++ b/runtime/tests/shared/CompositeCacheSizesTests.cpp
@@ -161,7 +161,7 @@ test1(J9JavaVM* vm)
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
 
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -212,7 +212,7 @@ test2(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -283,7 +283,7 @@ test3(J9JavaVM* vm)
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
 	/* 1.1 * (maxSharedStringTableSize * 300) might be greater than SHMMAX and pass J9SHR_RUNTIMEFLAG_ENABLE_PERSISTENT_CACHE to avoid cache size to be resized to SHMMAX */
-	ensureCorrectCacheSizes(vm->portLibrary, J9SHR_RUNTIMEFLAG_ENABLE_PERSISTENT_CACHE, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, J9SHR_RUNTIMEFLAG_ENABLE_PERSISTENT_CACHE, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -336,7 +336,7 @@ test4(J9JavaVM* vm)
 	piconfig.sharedClassDebugAreaBytes = -1;
 	piconfig.sharedClassSoftMaxBytes = -1;
 
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, &piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, &piconfig);
 	requiredBytes = SH_CompositeCacheImpl::getRequiredConstrBytesWithCommonInfo(false, false);
 	totalSize = requiredBytes + piconfig.sharedClassCacheSize;
 	if (!(memForCC = (SH_CompositeCacheImpl*)j9mem_allocate_memory(totalSize, J9MEM_CATEGORY_CLASSES))) {
@@ -459,7 +459,7 @@ test5(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -510,7 +510,7 @@ test6(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -568,7 +568,7 @@ test7(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -618,7 +618,7 @@ test8(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -674,7 +674,7 @@ test9(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -723,7 +723,7 @@ test10(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = MAIN_CACHE_SIZE;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -770,7 +770,7 @@ test11(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = -1;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -817,7 +817,7 @@ test12(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = MAIN_CACHE_SIZE+1024;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig);
+	ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig);
 	retval = createTestCompositeCache(vm, &testCC, piconfig, testName);
 
 	if (retval != TEST_PASS) {
@@ -866,7 +866,7 @@ test13(J9JavaVM* vm)
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
 
-	if(0 == ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig))
+	if(0 == ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig))
 	{
 		ERRPRINTF(("Failed to ensure correct sizes for minaot and maxaot.\n"));
 		retval = TEST_ERROR;
@@ -901,7 +901,7 @@ test14(J9JavaVM* vm)
 	piconfig->sharedClassMaxJITSize = MAIN_CACHE_SIZE-200;
 	piconfig->sharedClassDebugAreaBytes = -1;
 	piconfig->sharedClassSoftMaxBytes = -1;
-	if(0 == ensureCorrectCacheSizes(vm->portLibrary, 0, (UDATA)0, piconfig))
+	if(0 == ensureCorrectCacheSizes(vm, vm->portLibrary, 0, (UDATA)0, piconfig))
 	{
 		ERRPRINTF(("Failed to ensure correct sizes for minjit and maxjit.\n"));
 		retval = TEST_ERROR;

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -837,11 +837,17 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 		osc = new(osc) SH_OSCachesysv(PORTLIB, vm, cacheDir, OSCACHETEST_SIZE_NAME, piconfig, 1, J9SH_OSCACHE_CREATE, 1, 0, 0, &versionData, NULL);
 
 		if(osc->getError() < 0) {
-			if ((i == 0) && (J9_SHARED_CLASS_CACHE_DEFAULT_SIZE > 1024) && (J9_SHARED_CLASS_CACHE_DEFAULT_SIZE < shmmax)) {
+			UDATA defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
+#if defined(J9VM_ENV_DATA64)
+			if (J2SE_VERSION(vm) >= J2SE_19) {
+				defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+			}
+#endif /* J9VM_ENV_DATA64 */
+			if ((i == 0) && (defaultSize > 1024) && (defaultSize < shmmax)) {
 				/*CMVC 153490: if we fail alloc ulimit the lets retry tests with the default size*/
-				j9tty_printf(PORTLIB, "testSize: shmmax (%lld Bytes) was to big, retrying with J9_SHARED_CLASS_CACHE_DEFAULT_SIZE(%d Bytes).\n", shmmax, J9_SHARED_CLASS_CACHE_DEFAULT_SIZE);
+				j9tty_printf(PORTLIB, "testSize: shmmax (%lld Bytes) was to big, retrying with default size(%d Bytes).\n", shmmax, defaultSize);
 				i = 0;
-				shmmax = (J9_SHARED_CLASS_CACHE_DEFAULT_SIZE - 1024);
+				shmmax = (defaultSize - 1024);
 				/* Set up sizes to use default value */
 				size[0] = shmmax;
 				expectedLength[0] = SHM_CACHEDATASIZE(((UDATA)size[0]));

--- a/runtime/tests/shared/SCStoreTransactionTests.cpp
+++ b/runtime/tests/shared/SCStoreTransactionTests.cpp
@@ -32,6 +32,8 @@ extern "C"
 
 #define TEST_PASS 0
 #define TEST_ERROR -1
+/* A size greater than the shared cache size (or softmx size if it is set) */
+#define ROMCLASS_LARGE_SIZE (70 * 1024 *1024)
 
 #if defined(J9SHR_CACHELET_SUPPORT)
 IDATA
@@ -1190,7 +1192,7 @@ test16(J9JavaVM* vm)
 	void * romclassmem = NULL;
 	const char * testName = "test16";
 	J9ROMClass * romclass = NULL;
-	U_32 romclassSize = 20971520;
+	U_32 romclassSize = ROMCLASS_LARGE_SIZE;
 	const char * romclassName = "CacheFilledTestClassNonOrphan";
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9RomClassRequirements sizes;
@@ -1283,7 +1285,7 @@ test17(J9JavaVM* vm)
 	void * romclassmem = NULL;
 	const char * testName = "test17";
 	J9ROMClass * romclass = NULL;
-	U_32 romclassSize = 20971520;
+	U_32 romclassSize = ROMCLASS_LARGE_SIZE;
 	const char * romclassName = "CacheFilledTestClassOrphan";
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9RomClassRequirements sizes;
@@ -1377,7 +1379,7 @@ test18(J9JavaVM* vm)
 	const char * testName = "test18";
 	J9ROMClass * romclass = NULL;
 	U_32 romclassSize = 1024;
-	U_32 romclassSizeLarge = 20971520;
+	U_32 romclassSizeLarge = ROMCLASS_LARGE_SIZE;
 	const char * romclassName = "NonOrphanClassCacheFilledTest";
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9RomClassRequirements sizes;
@@ -1498,7 +1500,7 @@ test19(J9JavaVM* vm)
 	const char * testName = "test19";
 	J9ROMClass * romclass = NULL;
 	U_32 romclassSize = 1024;
-	U_32 romclassSizeLarge = 20971520;
+	U_32 romclassSizeLarge = ROMCLASS_LARGE_SIZE;
 	const char * romclassName = "CacheFilledMetadataUpdateClassOrphan";
 	const char * testclassName = "TestROMClass";
 	PORT_ACCESS_FROM_JAVAVM(vm);

--- a/runtime/tests/shared/main.c
+++ b/runtime/tests/shared/main.c
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -407,6 +407,13 @@ setupArguments(struct j9cmdlineOptions* startupOptions,JavaVMInitArgs* vm_args,v
 			if (vmOptionsTableAddOption(vmOptionsTable, "-Xshareclasses:nonpersistent,name=testSCTransactions,enablebci,reset", NULL) != J9CMDLINE_OK) {
 				goto cleanup;
 			}
+		}
+		/* The test needs a debug area size of 2MB (using -Xscdmx2m). The default cache size is 300MB on 64-bit platforms on Java 9 and up, which might not be allowed
+		 * by the OS due to the shmmax setting. The cache size will be adjusted to shmmax and debug area size will also be adjusted proportionally, resulting in the debug area
+		 * size to be much smaller than 2MB. Set cache size to 16MB for this test so that it won't be unstable due to the shmmax setting on the test machines.
+		 */
+		if (vmOptionsTableAddOption(vmOptionsTable, "-Xscmx16m", NULL) != J9CMDLINE_OK) {
+			goto cleanup;
 		}
 		if (vmOptionsTableAddOption(vmOptionsTable, "-Xscdmx2m", NULL) != J9CMDLINE_OK) {
 			goto cleanup;

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -191,12 +191,8 @@ dumpMemorySizes(J9JavaVM *jvm)
 
 		J9SharedClassPreinitConfig updatedWithDefaults = *(jvm->sharedClassPreinitConfig);
 		j9shr_Query_PopulatePreinitConfigDefaults(jvm, &updatedWithDefaults);
-		if (FIND_ARG_IN_VMARGS(EXACT_MEMORY_MATCH, VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS, NULL) >= 0) {
-			dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassCacheSize, "-XX:SharedCacheHardLimit=", J9NLS_VERB_SIZES_XXSHARED_CACHE_HARD_LIMIT_EQUALS);
-			dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassSoftMaxBytes, "-Xscmx", J9NLS_VERB_SIZES_XSCMX_V1);
-		} else {
-			dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassCacheSize, "-Xscmx", J9NLS_VERB_SIZES_XSCMX);
-		}
+		dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassCacheSize, "-XX:SharedCacheHardLimit=", J9NLS_VERB_SIZES_XXSHARED_CACHE_HARD_LIMIT_EQUALS);
+		dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassSoftMaxBytes, "-Xscmx", J9NLS_VERB_SIZES_XSCMX_V1);
 		dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassDebugAreaBytes, "-Xscdmx", J9NLS_VERB_SIZES_XSCDMX);
 		dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassMinAOTSize, "-Xscminaot", J9NLS_VERB_SIZES_XSCMINAOT);
 		dumpQualifiedSize(PORTLIB, updatedWithDefaults.sharedClassMaxAOTSize, "-Xscmaxaot", J9NLS_VERB_SIZES_XSCMAXAOT);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1728,13 +1728,13 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 							parseErrorOption = VMOPT_XSCMX;
 							goto _memParseError;
 						}
-						if (OPTION_OK != (parseError = setMemoryOptionToOptElse(vm, &(piConfig->sharedClassCacheSize), VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS, J9_SHARED_CLASS_CACHE_DEFAULT_SIZE, FALSE))) {
+						if (OPTION_OK != (parseError = setMemoryOptionToOptElse(vm, &(piConfig->sharedClassCacheSize), VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS, 0, FALSE))) {
 							parseErrorOption = VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS;
 							goto _memParseError;
 						}
 					} else {
 						piConfig->sharedClassSoftMaxBytes = -1;
-						if (OPTION_OK != (parseError = setMemoryOptionToOptElse(vm, &(piConfig->sharedClassCacheSize), VMOPT_XSCMX, J9_SHARED_CLASS_CACHE_DEFAULT_SIZE, FALSE))) {
+						if (OPTION_OK != (parseError = setMemoryOptionToOptElse(vm, &(piConfig->sharedClassCacheSize), VMOPT_XSCMX, 0, FALSE))) {
 							parseErrorOption = VMOPT_XSCMX;
 							goto _memParseError;
 						}

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -55,6 +55,8 @@
 	
 	<variable name="NON_WINDOWS_PLATFORMS" value="aix.*,linux.*,zos.*" />
 	<variable name="WINDOWS_PLATFORMS" value="win.*" />
+	<variable name="NON_64BIT_PLATFORMS" value="SE.*bits\.3[12]" />
+	<variable name="64BIT_PLATFORMS" value="SE.*bits\.64" />
 
 	<!-- 
 		Following variable specifies cache directory to be used by tests for 'cacheDirPerm' sub-option.
@@ -483,7 +485,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<test id="Test 27: CMVC 168131 : Ensure cache size is default (16 MB)" timeout="600" runPath=".">
+	<test id="Test 27: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">shared memory ID[\s]*= [\d]*</output>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">cache size[\s]*= 167[\d][\d][\d][\d][\d][\D]</output>
@@ -502,7 +504,7 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<test id="Test 29: CMVC 168131 : Ensure cache size is default (16 MB)" timeout="600" runPath=".">
+	<test id="Test 29: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,printStats -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">cache size[\s]* = 167[\d][\d][\d][\d][\d][\D]</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
@@ -970,6 +972,49 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
+	<test id="Test 54- cleanup: destroy cache" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,destroy</command>
+		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
+		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
+		<output type="success" caseSensitive="yes" regex="no">is destroyed</output>
+		
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="yes" regex="no">JVM requested Java dump</output>
+		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
+	</test>
+	
+	<test id="Test 55 Check default cache size on Java 8" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -verbose:sizes $currentMode$ -Xtrace:print={j9shr.369,j9shr.734} -version</command>
+		<output type="success" caseSensitive="yes" regex="no" showMatch="yes">SH_OSCachemmap::startup: Successfully set cache length to 16777216</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">OSCache startup.*length=16777216 create=1</output>
+		<output type="required" caseSensitive="yes" regex="no" showMatch="yes">XX:SharedCacheHardLimit=16M</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 55 Check default cache size on Java 9 and up" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -verbose:sizes $currentMode$ -Xtrace:print={j9shr.369,j9shr.734} -version</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$NON_64BIT_PLATFORMS$">SH_OSCachemmap::startup: Successfully set cache length to 16777216</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$NON_64BIT_PLATFORMS$">OSCache startup.*length=16777216 create=1</output>
+		<output type="required" caseSensitive="yes" regex="no" showMatch="yes" platforms="NON_64BIT_PLATFORMS">XX:SharedCacheHardLimit=16M</output>
+
+		<output type="success" caseSensitive="yes" regex="no" showMatch="yes" platforms="$64BIT_PLATFORMS$">SH_OSCachemmap::startup: Successfully set cache length to 314572800</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$64BIT_PLATFORMS$">OSCache startup.*length=314572800 create=1</output>
+		<output type="required" caseSensitive="yes" regex="no" showMatch="yes" platforms="$64BIT_PLATFORMS$">XX:SharedCacheHardLimit=300M</output>
+		<output type="required" caseSensitive="yes" regex="no" showMatch="yes" platforms="$64BIT_PLATFORMS$">Xscmx64M</output>
+		
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
 	<test id="At end destroy cache for cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-2.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-2.xml
@@ -244,9 +244,9 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<test id="Test 74: -Xshareclasses code coverage : cache sizes : -Xscmaxaot32m" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ -Xscmaxaot32m $currentMode$ -version</command>
-		<output type="success" caseSensitive="yes" regex="no">-Xscmaxaot value is greater than the shared cache size, so it has been set to unlimited</output>
+	<test id="Test 74: -Xshareclasses code coverage : cache sizes : -Xscmaxaot70m" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -Xscmaxaot70m $currentMode$ -version</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">The maximum allowed AOT space should not be greater than the softmx limit|-Xscmaxaot value is greater than the shared cache size, so it has been set to unlimited</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
@@ -261,15 +261,6 @@
 	<test id="Test 76: -Xshareclasses code coverage : Invalid -Xitsn value" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -Xitsn1000000 $currentMode$ -version</command>
 		<output type="success" caseSensitive="yes" regex="no">-Xitsn option is outside of the range of prime number values supported by the VM</output>
-		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
-	</test>
-	
-	<test id="Test 77: -Xshareclasses code coverage : verbose:sizes runs j9shr_Query_PopulatePreinitConfigDefaults()" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ -verbose:sizes $currentMode$ -version</command>
-		<output type="success" caseSensitive="yes" regex="no">Xscmx16M</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude.xml
@@ -204,4 +204,16 @@
 	<exclude id="Test 182-d: Verify that Intermediate Class Data is present" platform="latest">
 		<reason>This test doesn't work for openj9</reason>
 	</exclude>
+	<exclude id="Test 27: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" platform="SE[^8]\d+">
+		<reason>The default non-persistent cache size is not 16MB on Java 9 and up</reason>
+	</exclude>
+	<exclude id="Test 29: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" platform="SE[^8]\d+">
+		<reason>The default non-persistent cache size is not 16MB on Java 9 and up</reason>
+	</exclude>
+	<exclude id="Test 55 Check default cache size on Java 8" platform="SE[^8]\d+">
+		<reason>This test should not be run on Java 9 and up</reason>
+	</exclude>
+	<exclude id="Test 55 Check default cache size on Java 9 and up" platform="SE80">
+		<reason>This test should not be run on Java 8</reason>
+	</exclude>
 </suite>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -39,7 +39,7 @@
 	-DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DJAVA_HOME='$(JDK_HOME)' -DSCMODE=204 -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION) -plats all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION)_$(BITS) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
@@ -370,7 +370,7 @@
 	<test id="Test 11-a: Test create a cache with -Xscmx12m" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xscmx12m -verbose:sizes -version</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">(java|openjdk) version</output>
-		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">-Xscmx12M\s+shared class cache size</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">XX:SharedCacheHardLimit=12M\s+shared class cache size</output>
 
 		<output type="failure" caseSensitive="no" regex="no">error</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>


### PR DESCRIPTION
1. The default shared cache size is changed to 300MB on 64-bit platforms
on Java 9 and up.
2. If the OS does not allow the default cache size to be 300MB, it will
be set to maximum feasible value.
3. If the OS allows the default cache size to be greater than 80MB, a
default softmax size of 64MB will be set.

Fixes #1164

Signed-off-by: hangshao <hangshao@ca.ibm.com>