### PR TITLE
Throw IAE when last char in replacement string is '$' or '\'

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1280,3 +1280,5 @@ K0703="Negative length"
 
 #java.lang.String
 K0800="Invalid Unicode code point - {0}"
+K0801="Last character in replacement string can't be \, character to be escaped is required."
+K0802="Last character in replacement string can't be $, group index is required."

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -1869,5 +1869,29 @@ public class Test_String {
 		}
 	}
 
+	/**
+	 * @tests java.lang.String#replaceAll(String, String)
+	 */
+	@Test
+	public void test_replaceAll_last_char_dollarsign() {
+		try {
+			"1a2b3c".replaceAll("[0-9]", "$");
+			Assert.fail("IAE should be thrown if `$` is the last character in replacement string!");
+		} catch (IllegalArgumentException iie) {
+			// expected
+		}
+	}
+	/**
+	 * @tests java.lang.String#replaceAll(String, String)
+	 */
+	@Test
+	public void test_replaceAll_last_char_backslash() {
+		try {
+			"1a2b3c".replaceAll("[0-9]", "\\");
+			Assert.fail("IAE should be thrown if `\\` is the last character in replacement string!");
+		} catch (IllegalArgumentException iie) {
+			// expected
+		}
+	}
 
 }


### PR DESCRIPTION
Throw `IAE` when last char in replacement string is `$` or `\`

The last character of `String substitute` in `j.l.String.replaceAll(regex, substitute)` can't be `$` which is treated as references to captured subsequences, or `\` which is used to escape literal characters.
`$` requires a group index to follow, and `\` requires a character to be escaped.
Added test to verify this behaviour.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>