### PR TITLE
Deprecate InstOpCodeTables and rename OpCodeBinaryEncoding

### DIFF
--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -28,7 +28,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/ControlFlowEvaluator.cpp \
     omr/compiler/z/codegen/FPTreeEvaluator.cpp \
     omr/compiler/z/codegen/InstOpCode.cpp \
-    omr/compiler/z/codegen/InstOpCodeTables.cpp \
     omr/compiler/z/codegen/OMRCodeGenPhase.cpp \
     omr/compiler/z/codegen/OMRCodeGenerator.cpp \
     omr/compiler/z/codegen/OMRInstruction.cpp \

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -20412,7 +20412,7 @@ TR::Register* J9::Z::TreeEvaluator::pdstoreEvaluatorHelper(TR::Node *node, TR::C
 
             if (cg->traceBCDCodeGen())
                traceMsg(comp,"\tAccumulating a leading sign type: have to restore the sign code for the copy: signSize %d, signCopyOp %s\n",
-                        signSize,  TR::InstOpCode::binaryEncodings[signCopyOp].name);
+                        signSize,  TR::InstOpCode::metadata[signCopyOp].name);
 
 
             generateSS1Instruction(cg, signCopyOp, node,

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -20412,7 +20412,7 @@ TR::Register* J9::Z::TreeEvaluator::pdstoreEvaluatorHelper(TR::Node *node, TR::C
 
             if (cg->traceBCDCodeGen())
                traceMsg(comp,"\tAccumulating a leading sign type: have to restore the sign code for the copy: signSize %d, signCopyOp %s\n",
-                        signSize,  TR::InstOpCode::opCodeToNameMap[signCopyOp]);
+                        signSize,  TR::InstOpCode::binaryEncodings[signCopyOp].name);
 
 
             generateSS1Instruction(cg, signCopyOp, node,


### PR DESCRIPTION
As part of an OMR change in https://github.com/eclipse/omr/pull/2561 we've done some refactoring to
the InstOpCode tables. We need up update OpenJ9 accordingly.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>