### PR TITLE
Add missing OS checks for feautures on Linux on Z

### DIFF
--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -508,10 +508,24 @@ typedef struct J9ProcessorDesc {
 /* STFLE bit 57 - Message-security-assist-extension-5 facility */
 #define J9PORT_S390_FEATURE_MSA_EXTENSION_5 57
 
-/* zLinux features
- * Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on z.
+/*  Linux on Z features
+ *  Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on Z.
  */
-#define J9PORT_HWCAP_S390_GS 0x4000
+#define J9PORT_HWCAP_S390_ESAN3     0x1
+#define J9PORT_HWCAP_S390_ZARCH     0x2
+#define J9PORT_HWCAP_S390_STFLE     0x4
+#define J9PORT_HWCAP_S390_MSA       0x8
+#define J9PORT_HWCAP_S390_LDISP     0x10
+#define J9PORT_HWCAP_S390_EIMM      0x20
+#define J9PORT_HWCAP_S390_DFP       0x40
+#define J9PORT_HWCAP_S390_HPAGE     0x80
+#define J9PORT_HWCAP_S390_ETF3EH    0x100
+#define J9PORT_HWCAP_S390_HIGH_GPRS 0x200
+#define J9PORT_HWCAP_S390_TE        0x400
+#define J9PORT_HWCAP_S390_VXRS      0x800
+#define J9PORT_HWCAP_S390_VXRS_BCD  0x1000
+#define J9PORT_HWCAP_S390_VXRS_EXT  0x2000
+#define J9PORT_HWCAP_S390_GS        0x4000
 
 /* x86 features
  * INTEL INSTRUCTION SET REFERENCE, A-M

--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -772,17 +772,17 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	if (J9_ARE_NO_BITS_SET(*(int*) 200, S390_STFLE_BIT)) {
 		return -1;
 	}
-#else /* LINUX S390*/
+#elif defined(LINUX) /* LINUX S390*/
 	/* Some s390 features require OS support on Linux, querying auxv for AT_HWCAP bit-mask of processor capabilities. */
 	unsigned long auxvFeatures = query_auxv(AT_HWCAP);
 #endif /* defined(J9ZOS390) */
 
-	/* GS hardwrae support */
+	/* GS hardware support */
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_GUARDED_STORAGE)) {
 #if defined(J9ZOS390)
 		/* GS OS support */
 		if (J9_ARE_ALL_BITS_SET(cvtgsf, 0x1)) /* CVTGSF bit is X'01' bit at byte X'17A' off CVT */
-#else /* LINUX S390*/
+#elif defined(LINUX) /* LINUX S390*/
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_GS))
 #endif /* defined(J9ZOS390) */
 		{
@@ -808,37 +808,82 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 #if defined(J9ZOS390)
 		/* TE OS support */
 		if (J9_ARE_ALL_BITS_SET(cvttxj, 0xC))
+#elif defined(LINUX) /* LINUX S390 */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_TE))
 #endif /* defined(J9ZOS390) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_TE);
 		}
 	}
 
+#if (defined(S390) && defined(LINUX))
+	/* OS Support of HPAGE on Linux on Z */
+	if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_HPAGE)){
+		setFeature(desc, J9PORT_S390_FEATURE_HPAGE);
+	}
+#endif /* defined(S390) && defined(LINUX) */
+
 	/* HIGH_GPRS support */
 #if defined(OMR_ENV_DATA64)
-	setFeature(desc, J9PORT_S390_FEATURE_HIGH_GPRS);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+	if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_HIGH_GPRS))
+#endif /* defined(S390) && defined(LINUX) */
+	{
+		setFeature(desc, J9PORT_S390_FEATURE_HIGH_GPRS);
+	}
 #endif /* defined(OMR_ENV_DATA64) */
 
 	/* Miscellaneous facility detection */
 
 	if (testSTFLE(portLibrary, 0)) {
-		setFeature(desc, J9PORT_S390_FEATURE_ESAN3);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_ESAN3))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_ESAN3);
+		}
 	}
 
 	if (testSTFLE(portLibrary, 2)) {
-		setFeature(desc, J9PORT_S390_FEATURE_ZARCH);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_ZARCH))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_ZARCH);
+		}
 	}
 
 	if (testSTFLE(portLibrary, 7)) {
-		setFeature(desc, J9PORT_S390_FEATURE_STFLE);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_STFLE))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_STFLE);
+		}
 	}
 
 	if (testSTFLE(portLibrary, 17)) {
-		setFeature(desc, J9PORT_S390_FEATURE_MSA);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_MSA))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_MSA);
+		}
 	}
 
 	if (testSTFLE(portLibrary, 42) && testSTFLE(portLibrary, 44)) {
-		setFeature(desc, J9PORT_S390_FEATURE_DFP);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_DFP))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_DFP);
+		}
 	}
 
 	if (testSTFLE(portLibrary, 32)) {
@@ -879,15 +924,27 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	/* z990 facility and processor detection */
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_LONG_DISPLACEMENT)) {
-		setFeature(desc, J9PORT_S390_FEATURE_LONG_DISPLACEMENT);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_LDISP))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_LONG_DISPLACEMENT);
 
-		desc->processor = PROCESSOR_S390_GP6;
+			desc->processor = PROCESSOR_S390_GP6;
+		}
 	}
 
 	/* z9 facility and processor detection */
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_EXTENDED_IMMEDIATE)) {
-		setFeature(desc, J9PORT_S390_FEATURE_EXTENDED_IMMEDIATE);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_EIMM))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_EXTENDED_IMMEDIATE);
+		}
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_EXTENDED_TRANSLATION_3)) {
@@ -895,7 +952,13 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_ETF3_ENHANCEMENT)) {
-		setFeature(desc, J9PORT_S390_FEATURE_ETF3_ENHANCEMENT);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_ETF3EH))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_ETF3_ENHANCEMENT);
+		}
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_EXTENDED_IMMEDIATE) &&
@@ -946,12 +1009,15 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 #if defined(J9ZOS390)
 		/* Vector facility requires hardware and OS support */
 		if (getS390zOS_supportsVectorFacility())
+#else
+		/* Vector facility requires hardware and OS support */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS))
 #endif
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_FACILITY);
-		}
 
-		desc->processor = PROCESSOR_S390_GP11;
+			desc->processor = PROCESSOR_S390_GP11;
+		}
 	}
 
 	/* z14 facility and processor detection */
@@ -969,15 +1035,27 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL)) {
-		setFeature(desc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS_BCD))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL);
 
-		desc->processor = PROCESSOR_S390_GP12;
+			desc->processor = PROCESSOR_S390_GP12;
+		}
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1)) {
-		setFeature(desc, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1);
+#if (defined(S390) && defined(LINUX))
+	/* OS Support for Linux on Z */
+		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS_EXT))
+#endif /* defined(S390) && defined(LINUX) */
+		{
+			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1);
 
-		desc->processor = PROCESSOR_S390_GP12;
+			desc->processor = PROCESSOR_S390_GP12;
+		}
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_MSA_EXTENSION_8)) {


### PR DESCRIPTION
Use aux vector to check OS dependent features for
Linux on Z.

Signed-off-by: Daniel Hong <daniel.hong@live.com>