### PR TITLE
Read Barrier for CompareAndSwapObject

### DIFF
--- a/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -9756,6 +9756,7 @@ static TR::Register *VMinlineCompareAndSwap(
       // Compare-And-Swap on object reference, while primarily is a store operation, it is also an implicit read (it 
       // reads the existing value to be compared with a provided compare value, before the store itself), hence needs
       // a read barrier
+      generateS390IEInstruction(cg, TR::InstOpCode::NIAI, 1, 0, node);
       generateRXYInstruction(cg, guardedLoadMnemonic, node, tempReadBarrier, generateS390MemoryReference(*casMemRef, 0, cg));
 
       cg->stopUsingRegister(tempReadBarrier);

--- a/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/trj9/z/codegen/J9TreeEvaluator.cpp
@@ -9747,6 +9747,20 @@ static TR::Register *VMinlineCompareAndSwap(
          }
       }
 
+   if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() && isObj)
+      {
+      TR::Register* tempReadBarrier = cg->allocateRegister();
+
+      auto guardedLoadMnemonic = usingCompressedPointers ? TR::InstOpCode::LLGFSG : TR::InstOpCode::LGG;
+
+      // Compare-And-Swap on object reference, while primarily is a store operation, it is also an implicit read (it 
+      // reads the existing value to be compared with a provided compare value, before the store itself), hence needs
+      // a read barrier
+      generateRXYInstruction(cg, guardedLoadMnemonic, node, tempReadBarrier, generateS390MemoryReference(*casMemRef, 0, cg));
+
+      cg->stopUsingRegister(tempReadBarrier);
+      }
+
    // Compare and swap
    //
    generateRSInstruction(cg, casOp, node, oldVReg, newVReg, casMemRef);


### PR DESCRIPTION
Compare-And-Swap on object reference, while primarily is a store
operation, it is also an implicit read (it reads the existing value to
be compared with a provided compare value, before the store itself),
hence needs a read barrier.

This change is an extension of #1573 with JIT support.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>