### PR TITLE
Use the OpenJ9 SHA to distinguish different builds for SCC.

### DIFF
--- a/runtime/oti/j9argscan.h
+++ b/runtime/oti/j9argscan.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,6 +84,23 @@ uintptr_t scan_hex(char **scan_start, uintptr_t* result);
 * @return uintptr_t
 */
 uintptr_t scan_hex_caseflag(char **scan_start, BOOLEAN uppercaseAllowed, uintptr_t* result);
+
+/**
+* @brief
+* @param **scan_start
+* @param *result
+* @return uintptr_t
+*/
+uintptr_t scan_hex_u64(char **scan_start, uint64_t* result);
+
+
+/**
+* @brief
+* @param **scan_start
+* @param *result
+* @return uintptr_t
+*/
+uintptr_t scan_hex_caseflag_u64(char **scan_start, BOOLEAN uppercaseAllowed, uint64_t* result);
 
 /**
 * @brief

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -2210,6 +2210,14 @@ setCurrentCacheVersion(J9JavaVM *vm, UDATA j2seVersion, J9PortShcVersion* result
 U_32
 getJVMFeature(J9JavaVM *vm);
 
+/**
+ * Get the OpenJ9 SHA
+ *
+ * @return uint64_t The OpenJ9 SHA
+ */
+uint64_t
+getOpenJ9Sha();
+
 /* ---------------- cphelp.c ---------------- */
 
 /**

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -862,7 +862,7 @@ SH_OSCache::initOSCacheHeader(OSCache_header_version_current* header, J9PortShcV
 	SRP_SET(header->dataStart, _dataStart);
 	header->dataLength = (U_32)_dataLength;
 	header->generation = (U_32)_activeGeneration;
-	header->buildID = J9UniqueBuildID;
+	header->buildID = getOpenJ9Sha();
 	header->cacheInitComplete = 0;
 
 	Trc_SHR_OSC_initOSCacheHeader_Exit();
@@ -922,9 +922,10 @@ SH_OSCache::checkOSCacheHeader(OSCache_header_version_current* header, J9PortShc
 		 */
 		return J9SH_OSCACHE_HEADER_DIFF_BUILDID;
 	}
-
-	if (_doCheckBuildID && (header->buildID != J9UniqueBuildID)) {
-		Trc_SHR_OSC_checkOSCacheHeader_wrongBuildID_2((U_64)J9UniqueBuildID, header->buildID);
+	
+	U_64 OpenJ9Sha = getOpenJ9Sha();
+	if (_doCheckBuildID && (header->buildID != OpenJ9Sha)) {
+		Trc_SHR_OSC_checkOSCacheHeader_wrongBuildID_3(OpenJ9Sha, header->buildID);
 		if (J9_ARE_ALL_BITS_SET(_runtimeFlags, J9SHR_RUNTIMEFLAG_RESTORE_CHECK)) {
 			OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_CORRUPT_CACHE_HEADER_INCORRECT_BUILDID);
 		}

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2333,7 +2333,7 @@ TraceException=Trc_SHR_API_j9shr_stringTransaction_stop_ExitWriteMutex_Event Ove
 TraceException=Trc_SHR_API_j9shr_stringTransaction_start_SegMutex_Event Overhead=1 Level=1 Template="API j9shr_stringTransaction_start : Error: omrthread_monitor_enter(segmentMutex) failed"
 TraceException=Trc_SHR_API_j9shr_stringTransaction_start_WriteLock_Event Overhead=1 Level=1 Template="API j9shr_stringTransaction_start : Error: enterWriteMutex() failed"
 
-TraceExit=Trc_SHR_OSC_checkOSCacheHeader_wrongBuildID_2 NoEnv Overhead=1 Level=1 Template="OSCache::checkOSCacheHeader: Exit - wrong build ID. VM build ID: %llu . Shared Cache build ID: %llu"
+TraceExit=Trc_SHR_OSC_checkOSCacheHeader_wrongBuildID_2 NoEnv Obsolete Overhead=1 Level=1 Template="OSCache::checkOSCacheHeader: Exit - wrong build ID. VM build ID: %llu . Shared Cache build ID: %llu"
 
 TraceException=Trc_SHR_CM_readCacheletHints_noManager Overhead=1 Level=1 Template="CM readCacheletHints no manager for type %zu"
 
@@ -2906,3 +2906,4 @@ TraceExit=Trc_SHR_CM_allocateROMClass_Exit3 Overhead=1 Level=3 Template="CM allo
 
 TraceEvent=Trc_SHR_INIT_isClassFromPatchedModule_ClassFromPatchedModule_Event Test Overhead=1 Level=3 Template="INIT isClassFromPatchedModule: Class (classname=%.*s) is from a patched module (URL=%.*s)."
 TraceEvent=Trc_SHR_INIT_hookFindSharedClass_classFromUnresolvedModule Overhead=1 Level=3 Template="INIT hookFindSharedClass: Class (classname=%.*s) is from an unresolved module. Returning NULL."
+TraceExit=Trc_SHR_OSC_checkOSCacheHeader_wrongBuildID_3 NoEnv Overhead=1 Level=1 Template="OSCache::checkOSCacheHeader: Exit - wrong build ID. VM OpenJ9 SHA: %llx . Shared Cache OpenJ9 SHA: %llx"

--- a/runtime/util/shchelp_j9.c
+++ b/runtime/util/shchelp_j9.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corp. and others
+ * Copyright (c) 2013, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 #include "util_api.h"
+#include "j9version.h"
+#include "ut_j9vmutil.h"
+
+#define OPENJ9_SHA_MIN_BITS 28
 
 /**
  * Populate a J9PortShcVersion struct with the version data of the running JVM
@@ -60,4 +64,25 @@ getJVMFeature(J9JavaVM *vm)
 #endif /* defined(J9VM_GC_COMPRESSED_POINTERS) */
 #endif /* defined(J9VM_ENV_DATA64) */
 	return ret;
+}
+
+/**
+ * Get the OpenJ9 SHA
+ *
+ * @return uint64_t The OpenJ9 SHA
+ */
+uint64_t
+getOpenJ9Sha()
+{
+	uint64_t sha = 0;
+	char *str = J9VM_VERSION_STRING;
+	
+	if (scan_hex_u64(&str, &sha) < OPENJ9_SHA_MIN_BITS) {
+		Assert_VMUtil_ShouldNeverHappen();
+	}
+	if (0 == sha) {
+		Assert_VMUtil_ShouldNeverHappen();
+	}
+
+	return sha;
 }

--- a/runtime/util_core/j9argscan.c
+++ b/runtime/util_core/j9argscan.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -297,6 +297,64 @@ uintptr_t scan_hex_caseflag(char **scan_start, BOOLEAN uppercaseAllowed, uintptr
 	*result = total;
 
 	return rc;
+}
+
+/**
+ * @Scan the hexadecimal uint64_t number and store the result in *result
+ * @param[in] scan_start The string to be scanned
+ * @param[in] uppercaseFalg Whether upper case letter is allowed
+ * @param[out] result The result
+ * @return the number of bits used to store the hexadecimal number or 0 on failure.
+ */
+uintptr_t
+scan_hex_u64(char **scan_start, uint64_t* result)
+{
+	return	scan_hex_caseflag_u64(scan_start, TRUE, result);
+}
+
+/**
+ * Scan the hexadecimal uint64_t number and store the result in *result 
+ * @param[in] scan_start The string to be scanned
+ * @param[in] uppercaseFalg Whether uppercase letter is allowed
+ * @param[out] result The result
+ * @return the number of bits used to store the hexadecimal number or 0 on failure.
+ */
+uintptr_t
+scan_hex_caseflag_u64(char **scan_start, BOOLEAN uppercaseAllowed, uint64_t* result)
+{
+	uint64_t total = 0;
+	uint64_t delta = 0;
+	char *hex = *scan_start;
+	uintptr_t bits = 0;
+
+	try_scan(&hex, "0x");
+
+	while (('\0' != *hex)
+			&& (bits <= 60)
+	) {
+		/*
+		 * Decode hex digit
+		 */
+		char x = *hex;
+		if (x >= '0' && x <= '9') {
+			delta = (x - '0');
+		} else if (x >= 'a' && x <= 'f') {
+			delta = 10 + (x - 'a');
+		} else if (x >= 'A' && x <= 'F' && uppercaseAllowed) {
+			delta = 10 + (x - 'A');
+		} else {
+			break;
+		}
+
+		total = (total << 4) + delta;
+		bits += 4;
+		hex++;
+	}
+
+	*scan_start = hex;
+	*result = total;
+
+	return bits;
 }
 
 


### PR DESCRIPTION
1. Add a helper to turn the OpenJ9 SHA string (J9VM_VERSION_STRING)
 to a number.
2. Set header->buildID to OpenJ9 SHA.

Fixes #1645

Signed-off-by: hangshao <hangshao@ca.ibm.com>