### PR TITLE
Create KnownObjectIndex for static final fields and static strings

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -33,6 +33,7 @@
 #include "env/PersistentInfo.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"                    // for TR_HeapMemory, etc
+#include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/j9method.h"
 #include "env/jittypes.h"
@@ -49,6 +50,7 @@
 #include "infra/List.hpp"                      // for List, ListIterator, etc
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/PersistentCHTable.hpp"
+#include "optimizer/J9TransformUtil.hpp"
 
 J9::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation *c) :
    OMR::SymbolReferenceTableConnector(sizeHint, c),
@@ -1016,7 +1018,16 @@ J9::SymbolReferenceTable::findOrCreateStringSymbol(TR::ResolvedMethodSymbol * ow
       }
    else
       {
-      symRef = findOrCreateCPSymbol(owningMethodSymbol, cpIndex, TR::Address, true, stringConst);
+      TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
+      if (!comp()->compileRelocatableCode())
+         {
+         TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
+         if (knot)
+            {
+            knownObjectIndex = knot->getIndexAt((uintptrj_t*)stringConst);
+            }
+         }
+      symRef = findOrCreateCPSymbol(owningMethodSymbol, cpIndex, TR::Address, true, stringConst, knownObjectIndex);
       }
    TR::StaticSymbol * sym = (TR::StaticSymbol *)symRef->getSymbol();
    sym->setConstString();
@@ -1308,7 +1319,33 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
    if (sharesSymbol)
       symRef->setReallySharesSymbol();
 
-   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex);
+   TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
+   if (resolved
+       && isFinal
+       && type == TR::Address
+       && !comp()->compileRelocatableCode())
+      {
+      TR::VMAccessCriticalSection getObjectReferenceLocation(comp());
+      if (*((uintptrj_t*)dataAddress) != NULL)
+         {
+         TR_OpaqueClassBlock *declaringClass = TR::Compiler->cls.objectClass(comp(), *((uintptrj_t*)dataAddress));
+         if (declaringClass)
+            {
+            int32_t clazzNameLength = 0;
+            char *clazzName = comp()->fej9()->getClassNameChars(declaringClass, clazzNameLength);
+            if (J9::TransformUtil::foldFinalFieldsIn(declaringClass, clazzName, clazzNameLength, true, comp()))
+               {
+               TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
+               if (knot)
+                  {
+                  knownObjectIndex = knot->getIndexAt((uintptrj_t*)dataAddress);
+                  }
+               }
+            }
+         }
+      }
+   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex, knownObjectIndex);
+
    checkUserField(symRef);
 
    if (sharesSymbol)

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -5924,6 +5924,8 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
    {
    _staticFieldReferenceEncountered = true;
    TR::SymbolReference * symRef = symRefTab()->findOrCreateStaticSymbol(_methodSymbol, cpIndex, false);
+   if (comp()->getOption(TR_TraceILGen))
+      traceMsg(comp(), "load static symref %d created with knownObjectIndex %d", symRef->getReferenceNumber(), symRef->getKnownObjectIndex());
    TR::StaticSymbol *      symbol = symRef->getSymbol()->castToStaticSymbol();
    TR_ASSERT(symbol, "Didn't geta static symbol.");
 

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -405,7 +405,7 @@ static void *dereferenceStructPointerChain(void *baseStruct, TR::Node *baseNode,
    return NULL;
    }
 
-static bool foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp)
+bool J9::TransformUtil::foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp)
    {
    TR::SimpleRegex *classRegex = comp->getOptions()->getClassesWithFoldableFinalFields();
    if (classRegex)
@@ -443,6 +443,17 @@ static bool foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32
          return false;
       return true;
       }
+
+   static char *enableAggressiveFolding = feGetEnv("TR_EnableAggressiveStaticFinalFieldFolding");
+   if (enableAggressiveFolding
+      && isStatic
+      && comp->fej9()->isClassInitialized(clazz))
+      {
+      if (classNameLength == 16 && !strncmp(className, "java/lang/System", 16))
+         return false;
+      return true;
+      }
+
    return false;
    }
 

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -47,6 +47,7 @@ class OMR_EXTENSIBLE TransformUtil : public OMR::TransformUtilConnector
    {
 public:
    static TR::TreeTop *generateRetranslateCallerWithPrepTrees(TR::Node *node, TR_PersistentMethodInfo::InfoBits reason, TR::Compilation *comp);
+   static bool foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *className, int32_t classNameLength, bool isStatic, TR::Compilation *comp);
 
    static TR::Node *generateArrayElementShiftAmountTrees(
          TR::Compilation *comp,


### PR DESCRIPTION
This change is needed for static final field folding. The part for
adding KnownObjectIndex for static final field is by default turned off.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>