### PR TITLE
Add new DDR commands for modularity__Command 1 and 2

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
@@ -52,7 +52,9 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpSegmentsInListComman
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpSegregatedStatsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpStringTableCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.ExtendedMethodFlagInfoCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindAllModulesCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindMethodFromPcCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindModuleByNameCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindOverlappingSegmentsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindPatternCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindStackValueCommand;
@@ -175,6 +177,8 @@ public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnab
 		toPassBack.add(new ObjectSizeInfo());
 		toPassBack.add(new DumpContendedLoadTable());
 		toPassBack.add(new CPDescriptionCommand());
+		toPassBack.add(new FindAllModulesCommand());
+		toPassBack.add(new FindModuleByNameCommand());
 
 		loadPlugins(toPassBack, loader);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/JavaVersionHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/JavaVersionHelper.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.types.UDATA;
+
+/**
+ * JavaVersionHelper helps check if the JVM version is new enough
+ */
+public class JavaVersionHelper 
+{
+	public final static int J2SE_SERVICE_RELEASE_MASK = 0xFFFF;
+	public final static int J2SE_19 = 9;
+	public final static int J2SE_JAVA_SPEC_VERSION_SHIFT = 8;
+	
+	/**
+	 * Returns true if the Java version is Java9 and up.
+	 * @param vm J9JavaVMPointer
+	 * @param out The output print stream
+	 * @return if the Java version is Java9 and up or not.
+	 * @throws CorruptDataException
+	 */
+	public static boolean ensureJava9AndUp(J9JavaVMPointer vm, PrintStream out) throws CorruptDataException 
+	{
+		int javaVersion = vm.j2seVersion().bitAnd(J2SE_SERVICE_RELEASE_MASK).intValue() >> J2SE_JAVA_SPEC_VERSION_SHIFT;
+		if (javaVersion < J2SE_19) {
+			out.printf("This command only works with core file created by VM with Java version 9 or higher%n"
+					+ "The current VM Java version is: %s%n", javaVersion);
+			return false;
+		}
+		return true;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FindAllModulesCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FindAllModulesCommand.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.ObjectModel;
+import com.ibm.j9ddr.vm29.j9.Pool;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PoolPointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.JavaVersionHelper;
+
+/**
+ * FindAllModules command displays all the modules loaded by the runtime
+ * 
+ * Example:
+ * 			!findallmodules
+ * Example output: 
+ * 			jdk.javadoc			!j9module 0x000001305F474498
+ * 			jdk.attach			!j9module 0x000001305F478798
+ * 			java.prefs			!j9module 0x000001305F478928
+ *			.....(A list of every module loaded by the runtime)
+ */
+public class FindAllModulesCommand extends Command 
+{
+	public FindAllModulesCommand() 
+	{
+		addCommand("findallmodules", "", "Outputs all the modules loaded by the runtime");
+	}
+
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+	{
+		try {
+			J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+			if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+				J9PoolPointer pool = vm.modularityPool();
+				Pool<J9ModulePointer> modulePool = Pool.fromJ9Pool(pool, J9ModulePointer.class);
+				SlotIterator<J9ModulePointer> poolIterator = modulePool.iterator();
+				J9ModulePointer modulePtr = null;
+				J9ObjectPointer moduleNameObjPtr = null;
+				while (poolIterator.hasNext()) {
+					modulePtr = poolIterator.next();
+					moduleNameObjPtr = modulePtr.moduleName();
+					/*
+					 * Since both packages and modules could be in the pool, the
+					 * iterator checks on the region and make sure that it is
+					 * pointing to a module. (For modules, the first field must
+					 * be in heap since it is an object while for j9package it
+					 * is a J9UTF8.)
+					 */
+					if (ObjectModel.isPointerInHeap(vm, moduleNameObjPtr)) {
+						String moduleName = J9ObjectHelper.stringValue(moduleNameObjPtr);
+						String hexAddress = modulePtr.getHexAddress();
+						out.printf("%-30s !j9module %s%n", moduleName, hexAddress);
+					}
+				}
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException(e);
+		}
+
+	}
+}
+

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FindModuleByNameCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FindModuleByNameCommand.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.util.PatternString;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.ObjectModel;
+import com.ibm.j9ddr.vm29.j9.Pool;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PoolPointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.JavaVersionHelper;
+
+/**
+ * FindModuleByName command find the modules corresponding to its module name
+ * 
+ * Example:
+ * 			!findmodulebyname java.base
+ * Example output: 
+ * 			Searching for modules named 'java.base' in VM=13053677e00
+ *			java.base			!j9module 0x00000130550C7E88
+ *			Found 1 module(s) named java.base
+ */
+public class FindModuleByNameCommand extends Command
+{
+	public FindModuleByNameCommand()
+	{
+		addCommand("findmodulebyname", "<moduleName>", "find the modules corresponding to a name pattern (e.g. 'java.*')");
+	}
+
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException
+	{
+		if (args.length == 0) {
+			printUsage(out);
+			return;
+		}
+		try {
+			J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+			if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+				J9PoolPointer pool = vm.modularityPool();
+				Pool<J9ModulePointer> modulePool = Pool.fromJ9Pool(pool, J9ModulePointer.class);
+				SlotIterator<J9ModulePointer> poolIterator = modulePool.iterator();
+				J9ModulePointer modulePtr = null;
+
+				int hitCount = 0;
+				String searchModuleName = args[0];
+				J9ObjectPointer moduleNameObjPtr = null;
+				PatternString pattern = new PatternString(searchModuleName);
+
+				out.printf("Searching for modules named '%s' in VM=%s%n", searchModuleName,
+						Long.toHexString(vm.getAddress()));
+				while (poolIterator.hasNext()) {
+					modulePtr = poolIterator.next();
+					moduleNameObjPtr = modulePtr.moduleName();
+					if (ObjectModel.isPointerInHeap(vm, moduleNameObjPtr)
+							&& pattern.isMatch(J9ObjectHelper.stringValue(moduleNameObjPtr))) {
+						hitCount++;
+
+						String moduleName = J9ObjectHelper.stringValue(moduleNameObjPtr);
+						String hexAddress = modulePtr.getHexAddress();
+						out.printf("%-30s !j9module %s%n", moduleName, hexAddress);
+					}
+				}
+				out.printf("Found %d module(s) named '%s'%n", hitCount, searchModuleName);
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException(e);
+		}
+	}
+
+	/**
+	 * Prints the usage for the findmodulebyname command.
+	 *
+	 * @param out The PrintStream the usage statement prints to
+	 */
+	private void printUsage(PrintStream out) 
+	{
+		out.println("findmodulebyname <moduleNamePattern> - find the modules corresponding to a name pattern (e.g. 'java.*')");
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
@@ -104,10 +104,17 @@ class CheckEngine
 
 	private GCHeapRegionManager _hrm;
 		
-	public CheckEngine(J9JavaVMPointer vm, CheckReporter reporter)
+	public CheckEngine(J9JavaVMPointer vm, CheckReporter reporter) throws CorruptDataException
 	{
 		_javaVM = vm;
 		_reporter = reporter;
+
+		/*
+		 * Even if hrm is null, all helpers that use it will null check it and
+		 * attempt to allocate it and handle the failure
+		 */
+		MM_HeapRegionManagerPointer hrmPtr = MM_GCExtensionsPointer.cast(_javaVM.gcExtensions()).heapRegionManager();
+		_hrm = GCHeapRegionManager.fromHeapRegionManager(hrmPtr);
 	}
 	
 	public J9JavaVMPointer getJavaVM()
@@ -317,7 +324,7 @@ class CheckEngine
 		
 		if(J9BuildFlags.gc_generational) {
 			if(scavengerEnabled) {
-				GCHeapRegionDescriptor objectRegion = findRegionForPointer(object, regionDesc);
+				GCHeapRegionDescriptor objectRegion = ObjectModel.findRegionForPointer(_javaVM, _hrm, object, regionDesc);
 				if(objectRegion == null) {
 					/* should be impossible, since checkObjectIndirect() already verified that the object exists */
 					return J9MODRON_GCCHK_RC_NOT_FOUND;
@@ -359,50 +366,6 @@ class CheckEngine
 		}
 		
 		return J9MODRON_SLOT_ITERATOR_OK;		
-	}
-
-	private GCHeapRegionDescriptor findRegionForPointer(AbstractPointer pointer, GCHeapRegionDescriptor region)
-	{
-		GCHeapRegionDescriptor regionDesc = null;
-		
-		if(region != null && region.isAddressInRegion(pointer)) {
-			return region;
-		}
-		
-		regionDesc = regionForAddress(pointer);
-		if(null != regionDesc) {
-			return regionDesc;
-		}
-		
-		// TODO kmt : this is tragically slow
-		try {
-			GCHeapRegionIterator iterator = GCHeapRegionIterator.from();
-			while(iterator.hasNext()) {
-				regionDesc = GCHeapRegionDescriptor.fromHeapRegionDescriptor(iterator.next());
-				if(isPointerInRegion(pointer, regionDesc)) {
-					return regionDesc;
-				}
-			}
-		} catch (CorruptDataException e) {}
-		return null;
-	}
-	
-	// TODO kmt : this doesn't belong here
-	private GCHeapRegionDescriptor regionForAddress(AbstractPointer pointer)
-	{
-		try {
-			if(null == _hrm) {
-				MM_HeapRegionManagerPointer hrm = MM_GCExtensionsPointer.cast(_javaVM.gcExtensions()).heapRegionManager();
-				_hrm = GCHeapRegionManager.fromHeapRegionManager(hrm);
-			}
-			return _hrm.regionDescriptorForAddress(pointer);
-		} catch (CorruptDataException cde) {}
-		return null;
-	}
-
-	private boolean isPointerInRegion(AbstractPointer pointer, GCHeapRegionDescriptor region)
-	{
-		return pointer.gte(region.getLowAddress()) && pointer.lt(region.getHighAddress());
 	}
 
 	private int checkObjectIndirect(J9ObjectPointer object)
@@ -448,7 +411,7 @@ class CheckEngine
 			return J9MODRON_GCCHK_RC_OK;
 		}
 		
-		regionDesc[0] = findRegionForPointer(object, regionDesc[0]);
+		regionDesc[0] = ObjectModel.findRegionForPointer(_javaVM, _hrm, object, regionDesc[0]);
 		if(regionDesc[0] == null) {
 			/* Is the object on the stack? */
 			GCVMThreadListIterator threadListIterator = GCVMThreadListIterator.from();
@@ -494,7 +457,7 @@ class CheckEngine
 					// Replace the object and resume
 					object = newObject[0];
 
-					regionDesc[0] = findRegionForPointer(object, regionDesc[0]);
+					regionDesc[0] = ObjectModel.findRegionForPointer(_javaVM, _hrm, object, regionDesc[0]);
 					if(regionDesc[0] == null) {
 						/* Is the object on the stack? */
 						GCVMThreadListIterator threadListIterator = GCVMThreadListIterator.from();
@@ -532,7 +495,7 @@ class CheckEngine
 				// Replace the object and resume
 				object = newObject[0];
 
-				regionDesc[0] = findRegionForPointer(object, regionDesc[0]);
+				regionDesc[0] = ObjectModel.findRegionForPointer(_javaVM, _hrm, object, regionDesc[0]);
 				if(regionDesc[0] == null) {
 					return J9MODRON_GCCHK_RC_NOT_FOUND;
 				}
@@ -721,7 +684,7 @@ class CheckEngine
 			
 			/* Additional checks for the remembered set */
 			if(object.notNull()) {
-				GCHeapRegionDescriptor objectRegion = findRegionForPointer(object, null);
+				GCHeapRegionDescriptor objectRegion = ObjectModel.findRegionForPointer(_javaVM, _hrm, object, null);
 				
 				if (objectRegion == null) {
 					/* shouldn't happen, since checkObjectIndirect() already verified this object */


### PR DESCRIPTION
Added two commands:
1. `!findallmodules                                 Outputs all the modules loaded by the runtime`
2. `findmodulebyname          <moduleName>         find the modules corresponding to its module name`
Related issue: https://github.com/eclipse/openj9/issues/1859

Refactored `ObjectModel.java` and `CheckEngine.java` to make some pointer check helper functions public static.

Made change in PointerGenerator.java as DDR wouldn't compile without the change, for detail look at: https://github.com/eclipse/openj9/issues/1973

Signed-off-by: Charles_Zheng Juntian.Zheng@ibm.com

Examples:
findallmodules:
```
> !findallmodules
jdk.javadoc                    !j9module 0x000001305F474498
jdk.attach                     !j9module 0x000001305F478798
java.prefs                     !j9module 0x000001305F478928
java.sql.rowset                !j9module 0x000001305F4789C8
jdk.security.auth              !j9module 0x000001305F478BF8
jdk.editpad                    !j9module 0x000001305F478D88
jdk.crypto.cryptoki            !j9module 0x000001305F478E78
java.rmi                       !j9module 0x000001305F478F68
jdk.httpserver                 !j9module 0x000001305F479468
jdk.internal.jvmstat           !j9module 0x000001305F4795A8
java.datatransfer              !j9module 0x000001305F476668
jdk.scripting.nashorn          !j9module 0x000001305F4767A8
jdk.jdwp.agent                 !j9module 0x000001305F477248
openj9.cuda                    !j9module 0x000001305F477298
java.logging                   !j9module 0x000001305F477388
openj9.dataaccess              !j9module 0x000001305F477CC8
jdk.naming.rmi                 !j9module 0x000001305F477D68
jdk.crypto.ec                  !j9module 0x000001305F477E58
java.naming                    !j9module 0x000001305F477EF8
jdk.management                 !j9module 0x000001305F478448
jdk.jlink                      !j9module 0x000001305F4699A8
jdk.jconsole                   !j9module 0x000001305F469D18
jdk.accessibility              !j9module 0x000001305F469EA8
openj9.dtfj                    !j9module 0x000001305F469FE8
openj9.zosconditionhandling    !j9module 0x000001305F4710C8
jdk.localedata                 !j9module 0x000001305F471168
jdk.charsets                   !j9module 0x000001305F471398
java.smartcardio               !j9module 0x000001305F471438
openj9.jvm                     !j9module 0x000001305F471528
jdk.jstatd                     !j9module 0x000001305F4715C8
java.security.jgss             !j9module 0x000001305F471708
jdk.net                        !j9module 0x000001305F471CF8
jdk.jshell                     !j9module 0x000001305F471D98
java.management                !j9module 0x000001305F468B18
jdk.internal.ed                !j9module 0x000001305F4691A8
jdk.management.agent           !j9module 0x000001305F469298
jdk.crypto.mscapi              !j9module 0x000001305F469478
jdk.jdeps                      !j9module 0x000001305F469518
java.xml                       !j9module 0x000001305F46BCB8
jdk.internal.opt               !j9module 0x000001305F46ABA8
jdk.compiler                   !j9module 0x000001305F46ACE8
jdk.jartool                    !j9module 0x000001305F46B6E8
jdk.internal.le                !j9module 0x000001305F46B8C8
jdk.unsupported                !j9module 0x000001305F4684A8
jdk.dynalink                   !j9module 0x000001305F4685E8
java.scripting                 !j9module 0x000001305F46DD98
java.se                        !j9module 0x000001305F46DE88
java.security.sasl             !j9module 0x000001305F46DED8
java.management.rmi            !j9module 0x000001305F46E0B8
java.desktop                   !j9module 0x000001305F46E1F8
jdk.naming.dns                 !j9module 0x000001305F46CCD8
java.xml.crypto                !j9module 0x000001305F46CDC8
jdk.sctp                       !j9module 0x000001305F46D868
jdk.security.jgss              !j9module 0x000001305F46D958
jdk.jsobject                   !j9module 0x000001305F46DA48
java.instrument                !j9module 0x000001305F46DB38
java.sql                       !j9module 0x00000130550DB798
jdk.zipfs                      !j9module 0x00000130550DB8D8
openj9.gpu                     !j9module 0x00000130550DB978
openj9.sharedclasses           !j9module 0x00000130550DBA68
jdk.xml.dom                    !j9module 0x00000130550DBB58
java.compiler                  !j9module 0x00000130550DBCE8
jdk.jdi                        !j9module 0x00000130550DBF18
java.base                      !j9module 0x00000130550C7E88
```

findmodulebyname:
```
> !findmodulebyname java.base
Searching for modules named 'java.base' in VM=13053677e00
java.base			!j9module 0x00000130550C7E88
Found 1 module(s) named java.base
```


Also, added test cases for the two commands