### PR TITLE
Always re-initialize JNI method IDs after class redefinition

### DIFF
--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -419,13 +419,7 @@ fixJNIMethodID(J9VMThread *currentThread, J9Method *oldMethod, J9Method *newMeth
 			}
 		}
 		newJNIIDs[getMethodIndex(newMethod)] = oldMethodID;
-
-		if (extensionsUsed) {
-			vmFuncs->initializeMethodID(currentThread, oldMethodID, newMethod);
-		} else {
-			/* update only method, vtable index always remains the same */
-			oldMethodID->method = newMethod;
-		}
+		vmFuncs->initializeMethodID(currentThread, oldMethodID, newMethod);
 	}
 done:
 	return rc;


### PR DESCRIPTION
In fast HCR, newly-created JNI method IDs were being created incorrectly
(vTableIndex of 0), resulting in JNI invocations beaing treated as
non-virtual.
 
Fixes: #1950

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>