### PR TITLE
Increase timeout on OMR build form 6 to 8 hours

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
@@ -40,7 +40,7 @@ def ALL_SHAS = [:]
 
 def SLACK_CHANNEL
 
-timeout(time: 6, unit: 'HOURS') {
+timeout(time: 8, unit: 'HOURS') {
     node('worker') {
         timestamps {
             checkout scm


### PR DESCRIPTION
- We had a build during the day that was almost complete
  but timed out after 6 hours. It timed out becasue it
  spent alot of time waiting for a machine. Increasing
  to 8 hours will likely be sufficient for the time being.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>