### PR TITLE
Fix a debug build failing due to incorrect reference count

### DIFF
--- a/runtime/compiler/trj9/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/trj9/optimizer/MonitorElimination.cpp
@@ -1474,7 +1474,7 @@ void TR::MonitorElimination::transformMonitorsIntoTMRegions()
          TR::Node *monentNode = nullChkNode->getFirstChild();
          TR::Node *passThroughNode = TR::Node::create(nullChkNode, TR::PassThrough, 1, monentNode->getFirstChild());
          TR::TreeTop *nullchkTree = TR::TreeTop::create(comp(), nullChkNode);
-         nullChkNode->setFirst(passThroughNode);
+         nullChkNode->setAndIncChild(0, passThroughNode);
          monitor->getMonitorTree()->insertBefore(nullchkTree);
          debugTrace(tracer(), "\tMoving monent to TT and dec ref count", nullchkTree, nullchkTree->getNode());
          monitor->getMonitorTree()->setNode(monentNode);


### PR DESCRIPTION
In building transaction regions, when we have a monent under nullchk, we rip out nullchk to new tree and replace it's first child with newly created PassThrough node. We should increase reference count of PassThrough node when we set it as first child of NullChk node. Incorrect reference count was causing asserts to be thrown.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>