### PR TITLE
Add warning message for slow exclusive vm request in verbose gc

### DIFF
--- a/runtime/gc_glue_java/JNICriticalRegion.cpp
+++ b/runtime/gc_glue_java/JNICriticalRegion.cpp
@@ -115,7 +115,7 @@ MM_JNICriticalRegion::releaseAccess(J9VMThread* vmThread, UDATA* accessMask)
 			}
 		}
 		if(shouldRespond) {
-			VM_VMAccess::respondToExclusiveRequest(vmThread, vm, PORTLIB, timeNow);
+			VM_VMAccess::respondToExclusiveRequest(vmThread, vm, PORTLIB, timeNow, J9_EXCLUSIVE_SLOW_REASON_JNICRITICAL);
 		}
 		omrthread_monitor_exit(vm->exclusiveAccessMutex);
 	}

--- a/runtime/gc_glue_java/JNICriticalRegion.hpp
+++ b/runtime/gc_glue_java/JNICriticalRegion.hpp
@@ -158,7 +158,7 @@ public:
 					PORT_ACCESS_FROM_JAVAVM(vm);
 					U_64 const timeNow = VM_VMAccess::updateExclusiveVMAccessStats(vmThread, vm, PORTLIB);
 					if (--vm->jniCriticalResponseCount == 0) {
-						VM_VMAccess::respondToExclusiveRequest(vmThread, vm, PORTLIB, timeNow);
+						VM_VMAccess::respondToExclusiveRequest(vmThread, vm, PORTLIB, timeNow, J9_EXCLUSIVE_SLOW_REASON_JNICRITICAL);
 					}
 					omrthread_monitor_exit_using_threadId(exclusiveAccessMutex, osThread);
 				}

--- a/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.hpp
+++ b/runtime/gc_verbose_handler_standard_java/VerboseHandlerOutputStandardJava.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,8 @@ class MM_VerboseHandlerOutputStandardJava : public MM_VerboseHandlerOutputStanda
 {
 private:
 protected:
-	J9HookInterface** _mmHooks;  /**< Pointers to the Hook interface */
+	J9HookInterface** _mmHooks;  /**< Pointers to the mm Hook interface */
+	J9HookInterface **_vmHooks;  /**< Pointers to the vm Hook interface */
 public:
 
 private:
@@ -78,6 +79,7 @@ protected:
 	MM_VerboseHandlerOutputStandardJava(MM_GCExtensions *extensions) :
 		MM_VerboseHandlerOutputStandard(extensions)
 		, _mmHooks(NULL)
+		, _vmHooks(NULL)
 	{};
 
 public:
@@ -107,6 +109,13 @@ public:
 	 */
 	void handleClassUnloadEnd(J9HookInterface** hook, UDATA eventNum, void* eventData);
 #endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
+
+	/**
+	 * @param hook Hook interface used by the JVM.
+	 * @param eventNum The hook event number.
+	 * @param eventData hook specific event data.
+	 */
+	void handleSlowExclusive(J9HookInterface **hook, UDATA eventNum, void *eventData);
 };
 
 #endif /* VERBOSEHANDLEROUTPUTSTANDARDJAVA_HPP_ */

--- a/runtime/oti/VMAccess.hpp
+++ b/runtime/oti/VMAccess.hpp
@@ -32,6 +32,8 @@
 
 #define J9_EXCLUSIVE_SLOW_TOLERANCE_REALTIME 5
 #define J9_EXCLUSIVE_SLOW_TOLERANCE_STANDARD 50
+#define J9_EXCLUSIVE_SLOW_REASON_JNICRITICAL 1
+#define J9_EXCLUSIVE_SLOW_REASON_EXCLUSIVE   2
 
 class VM_VMAccess
 {
@@ -314,7 +316,7 @@ public:
 	 * @parm[in] timeNow the value returned from updateExclusiveVMAccessStats
 	 */
 	static VMINLINE void
-	respondToExclusiveRequest(J9VMThread* currentThread, J9JavaVM *vm, J9PortLibrary *portLibrary, U_64 timeNow)
+	respondToExclusiveRequest(J9VMThread *currentThread, J9JavaVM *vm, J9PortLibrary *portLibrary, U_64 timeNow, UDATA reason)
 	{
 		PORT_ACCESS_FROM_PORT(portLibrary);
 		U_64 const timeTaken = j9time_hires_delta(vm->omrVM->exclusiveVMAccessStats.startTime, timeNow, J9PORT_TIME_DELTA_IN_MILLISECONDS);
@@ -323,7 +325,7 @@ public:
 			slowTolerance = J9_EXCLUSIVE_SLOW_TOLERANCE_REALTIME;
 		}
 		if (timeTaken > slowTolerance) {
-			TRIGGER_J9HOOK_VM_SLOW_EXCLUSIVE(vm->hookInterface, currentThread, (UDATA) timeTaken);
+			TRIGGER_J9HOOK_VM_SLOW_EXCLUSIVE(vm->hookInterface, currentThread, (UDATA) timeTaken, reason);
 		}
 		omrthread_monitor_notify_all(vm->exclusiveAccessMutex);
 	}

--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -256,6 +256,7 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<struct>J9VMSlowExclusiveEvent</struct>
 		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
 		<data type="UDATA" name="timeTaken" description="time in ms it took this thread to respond" />
+		<data type="UDATA" name="reason" description="the cause of slow" />
 	</event>
 
 	<event>

--- a/runtime/vm/VMAccess.cpp
+++ b/runtime/vm/VMAccess.cpp
@@ -370,7 +370,7 @@ void   internalAcquireVMAccessNoMutexWithMask(J9VMThread * vmThread, UDATA haltM
 					slowTolerance = J9_EXCLUSIVE_SLOW_TOLERANCE_REALTIME;
 				}
 				if (timeTaken > slowTolerance) {
-					TRIGGER_J9HOOK_VM_SLOW_EXCLUSIVE(vm->hookInterface, vmThread, (UDATA) timeTaken);
+					TRIGGER_J9HOOK_VM_SLOW_EXCLUSIVE(vm->hookInterface, vmThread, (UDATA) timeTaken, J9_EXCLUSIVE_SLOW_REASON_JNICRITICAL);
 				}
 				omrthread_monitor_notify_all(vm->exclusiveAccessMutex);
 			}
@@ -437,7 +437,7 @@ static void  internalReleaseVMAccessNoMutexNoCheck(J9VMThread * vmThread)
 
 			--vm->exclusiveAccessResponseCount;
 			if (vm->exclusiveAccessResponseCount == 0) {
-				VM_VMAccess::respondToExclusiveRequest(vmThread, vm, PORTLIB, timeNow);
+				VM_VMAccess::respondToExclusiveRequest(vmThread, vm, PORTLIB, timeNow, J9_EXCLUSIVE_SLOW_REASON_EXCLUSIVE);
 			}
 		}
 		if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_REQUEST_SAFE_POINT)) {


### PR DESCRIPTION
	
	- warning message shows the reason(JNICritical or Exclusive Access) 
	and time taken of slow exclusive request for performance diagnosis.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>