### PR TITLE
Fix JVM_RegisterSignal

### DIFF
--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -785,6 +785,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sig_map_os_signal_to_portlib_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_os_signal_to_portlib_signal((OMRPortLibrary*)privatePortLibrary,param1)
 #define j9sig_map_portlib_signal_to_os_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_portlib_signal_to_os_signal((OMRPortLibrary*)privatePortLibrary,param1)
 #define j9sig_register_os_handler(param1,param2,param3) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_register_os_handler((OMRPortLibrary*)privatePortLibrary,param1,(void *)param2,param3)
+#define j9sig_is_master_signal_handler(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_is_master_signal_handler((OMRPortLibrary*)privatePortLibrary,(void *)param1)
 #define j9sig_info(param1,param2,param3,param4,param5) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4,param5)
 #define j9sig_info_count(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info_count(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9sig_set_options(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_options(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)


### PR DESCRIPTION
1. Add j9sig* macro for the newly added omrsig_is_master_signal_handler

	omrsig_is_master_signal_handler is a newly added OMR function. So,
	j9sig_is_master_signal_handler macro is added to invoke
	omrsig_is_master_signal_handler from J9.

2. Fix JVM_RegisterSignal

	JVM_RegisterSignal should return J9_USE_OLD_JAVA_SIGNAL_HANDLER if old
	OS handler is a master signal handler. If old OS handler is a master
	signal handler, then a Java signal handler was previously registered
	with the signal. sun.misc.Signal.handle(...) or
	jdk.internal.misc.Signal.handle(...) will return the old Java signal
	handler if JVM_RegisterSignal returns J9_USE_OLD_JAVA_SIGNAL_HANDLER.
	Otherwise, an instance of NativeHandler is returned with the
	oldHandler's address stored in NativeHandler.handler. 

	Java 8 - NativeHandler is sun.misc.NativeSignalHandler
	Java 9 - NativeHandler is jdk.internal.misc.Signal.NativeHandler

Fixes #1984

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>