### PR TITLE
Correctly handle special cases of interface invocation

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -839,14 +839,21 @@ public class MethodHandles {
 		static MethodHandle adaptInterfaceLookupsOfObjectMethodsIfRequired(MethodHandle handle, Class<?> clazz, String methodName, MethodType type) throws NoSuchMethodException, IllegalAccessException {
 			assert handle instanceof InterfaceHandle;
 			/* Object methods need to be treated specially if the interface hasn't declared them itself */
-			if (Object.class == handle.getDefc()) {
+			Class<?> handleClass = handle.getDefc();
+			if (Object.class == handleClass) {
 				if (!Modifier.isPublic(handle.getModifiers())) {
 					/* Interfaces only inherit *public* methods from Object */
 					throw new NoSuchMethodException(clazz + "." + methodName + type); //$NON-NLS-1$					
 				}
 				handle = new VirtualHandle(new DirectHandle(Object.class, methodName, type, MethodHandle.KIND_SPECIAL, Object.class));
 				handle = handle.cloneWithNewType(handle.type.changeParameterType(0, clazz));
+			/*[IF Java11]*/
+			} else if (!Modifier.isPublic(handle.getModifiers())) {
+				handle = new DirectHandle(handleClass, methodName, type, MethodHandle.KIND_SPECIAL, handleClass, true);
+				handle = handle.cloneWithNewType(handle.type.changeParameterType(0, clazz));				
+			/*[ENDIF] Java11*/
 			}
+
 			return handle;
 		}
 

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1505,6 +1505,8 @@ retry:
 		}
 		goto retry;
 	}
+	// TODO: Future work required to support private/Object in the JIT
+	Assert_CodertVM_true(J9_ARE_NO_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_TAG_BITS));
 	indexAndLiteralsEA[2] = (UDATA)interfaceClass;
 	indexAndLiteralsEA[3] = methodIndexAndArgCount >> 8; /* remove argCount */
 	JIT_RETURN_UDATA(1);

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -667,6 +667,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromMethod(JNIEnv 
 			vmSlotValue = methodID->vTableIndex;
 			break;
 		case J9_METHOD_HANDLE_KIND_INTERFACE:
+			Assert_JCL_true(J9_ARE_ANY_BITS_SET(methodID->vTableIndex, J9_JNI_MID_INTERFACE));
 			vmSlotValue = methodID->vTableIndex & ~J9_JNI_MID_INTERFACE;
 			break;
 		case J9_METHOD_HANDLE_KIND_SPECIAL:

--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,10 @@ jitGetInterfaceITableIndexFromCP(J9VMThread *currentThread, J9ConstantPool *cons
 		}
 		interfaceClass = (J9Class*)localEntry.interfaceClass;
 		methodIndexAndArgCount = localEntry.methodIndexAndArgCount;
+	}
+	// TODO: Future work required to support private/Object in the JIT
+	if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_TAG_BITS)) {
+		interfaceClass = NULL;
 	}
 	*pITableIndex = methodIndexAndArgCount >> 8;
 done:

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -817,6 +817,24 @@ extern "C" {
 #define J9_CLASSLOADER_TYPE_BOOT		1
 #define J9_CLASSLOADER_TYPE_PLATFORM	2
 
+/* Tag bits for J9RAMInterfaceMethodRef->methodIndexAndArgCount:
+ *
+ *	J9_ITABLE_INDEX_METHOD_INDEX - index represents a direct method index
+ *	J9_ITABLE_INDEX_OBJECT		 - use Object rather than the targetted interfaceClass
+ *
+ * Private methods in interface will have only J9_ITABLE_INDEX_METHOD_INDEX set, indicating that
+ * the underlying index is a method index into the interfaceClass of the ref.
+ *
+ * vTable methods in Object will have only J9_ITABLE_INDEX_OBJECT set, indicating that
+ * the underlying index is a vTable index in Object.
+ *
+ * Non-vTable methods in Object will have J9_ITABLE_INDEX_OBJECT and J9_ITABLE_INDEX_METHOD_INDEX set,
+ * indicating that the underlying index is a method index in Object.
+ */
+#define J9_ITABLE_INDEX_METHOD_INDEX	((UDATA)1 << ((8 * sizeof(UDATA)) - 1))
+#define J9_ITABLE_INDEX_OBJECT			((UDATA)1 << ((8 * sizeof(UDATA)) - 2))
+#define J9_ITABLE_INDEX_TAG_BITS		(J9_ITABLE_INDEX_METHOD_INDEX | J9_ITABLE_INDEX_OBJECT)
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -228,11 +228,12 @@ extern _ENTRY globalLeConditionHandlerENTRY;
 static VMINLINE J9Method*
 mapVirtualMethod(J9VMThread *currentThread, J9Method *method, UDATA vTableIndex, J9Class *receiverClass)
 {
+	/* J9_JNI_MID_INTERFACE will be set only for iTable methods.  Private interface methods
+	 * and Object methods will not have the tag.
+	 */
 	if (J9_ARE_ANY_BITS_SET(vTableIndex, J9_JNI_MID_INTERFACE)) {
 		UDATA iTableIndex = vTableIndex & ~(UDATA)J9_JNI_MID_INTERFACE;
 		J9Class *interfaceClass = J9_CLASS_FROM_METHOD(method);
-		// TODO: should this code be handling Object methods?
-		// refactor VMHelpers convertITableIndexToVTableIndex to take NAS?
 		vTableIndex = 0;
 		J9ITable * iTable = receiverClass->lastITable;
 		if (interfaceClass == iTable->interfaceClass) {

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -2106,7 +2106,8 @@ initializeMethodID(J9VMThread * currentThread, J9JNIMethodID * methodID, J9Metho
 {
 	UDATA vTableIndex = 0;
 
-	if ((J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccStatic) == 0) {
+	/* The vTable does not contain private or static methods */
+	if (J9_ARE_NO_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccStatic | J9AccPrivate)) {
 		J9Class * declaringClass = J9_CLASS_FROM_METHOD(method);
 
 		if (declaringClass->romClass->modifiers & J9AccInterface) {
@@ -2114,9 +2115,12 @@ initializeMethodID(J9VMThread * currentThread, J9JNIMethodID * methodID, J9Metho
 			 * always use the declaring class of the interface method.  Pass NULL here to allow
 			 * for methodIDs to be created on obsolete classes for HCR purposes.
 			 */
-			vTableIndex = getITableIndexForMethod(method, NULL) | J9_JNI_MID_INTERFACE;
+			vTableIndex = getITableIndexForMethod(method, NULL);
+			Assert_VM_false(J9_ARE_ANY_BITS_SET(vTableIndex, J9_JNI_MID_INTERFACE));
+			vTableIndex |= J9_JNI_MID_INTERFACE;
 		} else {
 			vTableIndex = getVTableIndexForMethod(method, declaringClass, currentThread);
+			Assert_VM_false(J9_ARE_ANY_BITS_SET(vTableIndex, J9_JNI_MID_INTERFACE));
 		}
 	}
 

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -31,6 +31,7 @@
 #include "ut_j9vm.h"
 #include "rommeth.h"
 #include "stackwalk.h"
+#include "j9modifiers_api.h"
 #include "VMHelpers.hpp"
 
 #define MAX_STACK_SLOTS 255
@@ -1045,16 +1046,42 @@ resolveInterfaceMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA
 			J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
 			UDATA methodIndex = 0;
 			UDATA oldArgCount = ramInterfaceMethodRef->methodIndexAndArgCount & 255;
-			/* Object methods may be invoked via invokeinterface.  In that case, use Object
-			 * for the interfaceClass in the ref.  The methodIndex value doesn't matter as
-			 * Object will never be found in an iTable.
-			 */
+			UDATA tagBits = 0;
+			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 			if (J9_ARE_ANY_BITS_SET(methodClass->romClass->modifiers, J9_JAVA_INTERFACE)) {
-				methodIndex = getITableIndexForMethod(method, interfaceClass) << 8;
+				/* Resolved method is in an interface class */
+				if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccPrivate)) {
+					/* Resolved method is a private interface method which does not appear in the
+					 * vTable or iTable.  Use the index into ramMethods in interfaceClass.
+					 */
+					methodIndex = (method - methodClass->ramMethods);
+					tagBits |= J9_ITABLE_INDEX_METHOD_INDEX;				
+				} else {
+					/* Resolved method is a public interface method which appears in the
+					 * vTable and iTable.  Use the iTable index in interfaceClass.
+					 */
+					methodIndex = getITableIndexForMethod(method, interfaceClass);
+				}
 			} else {
-				interfaceClass = methodClass;
+				/* Resolved method is in Object */
+				Assert_VM_true(methodClass == J9VMJAVALANGOBJECT_OR_NULL(vm));
+				if (J9ROMMETHOD_HAS_VTABLE(romMethod)) {
+					/* Resolved method is in the vTable, so it must be invoked via the
+					 * receiver's vTable.
+					 */
+					methodIndex = getVTableIndexForMethod(method, methodClass, vmStruct);
+				} else {
+					/* Resolved method is not in the vTable, so invoke it directly
+					 * via the index into ramMethods in Object.
+					 */
+					methodIndex = (method - methodClass->ramMethods);
+					tagBits |= J9_ITABLE_INDEX_METHOD_INDEX;
+				}
+				tagBits |= J9_ITABLE_INDEX_OBJECT;
 			}
-			methodIndex |= oldArgCount;
+			methodIndex <<= 8;
+			Assert_VM_true(J9_ARE_NO_BITS_SET(methodIndex, J9_ITABLE_INDEX_TAG_BITS));
+			methodIndex = methodIndex | tagBits | oldArgCount;
 			ramCPEntry->methodIndexAndArgCount = methodIndex;
 			/* interfaceClass is used to indicate resolved. Make sure to write it last */
 			issueWriteBarrier();


### PR DESCRIPTION
- When the resolved method is an Object method, the invokeinterface
bytecode was not ensuring that the receiver class implements the
targetted interface.

- Allow invokeinterface to target private interface methods.

- Allow JNI method IDs to target private interface methods.

- Allow InterfaceMethodHandle adapt private interface methods to a
DirectHandle in Java 11.  Full MethodHandle support for private
interface methods will likely require more work in the future.

- This does not fix the JIT for the private interface method case - that
requires further design work.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>