### PR TITLE
Reduce number of resolved methods created in StringPeepholes

### DIFF
--- a/runtime/compiler/trj9/env/VMJ9.h
+++ b/runtime/compiler/trj9/env/VMJ9.h
@@ -323,6 +323,19 @@ public:
    virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, char *, char *, TR_OpaqueClassBlock * = NULL);
 
    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
+   /**
+   * @brief Create a TR_ResolvedMethod given a class, method name and signature
+   *
+   * The function will scan all methods from the given class until a match for
+   * the method name and signature is found
+   *
+   * @param trMemory     Pointer to TR_Memory object used for memory allocation
+   * @param classPointer The j9class that is searched for method name/signature
+   * @param methodName   Null terminated string denoting the method name we are looking for
+   * @param signature    Null terminated string denoting the signature of the method we want
+   * @return             A pointer to a TR_ResolvedMethod for the indicated j9method, or null if not found
+   */
+   virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature);
    virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true);
    virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
 
@@ -1133,6 +1146,7 @@ public:
    virtual bool               methodsCanBeInlinedEvenIfEventHooksEnabled();
    virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method);
    virtual void               getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
+   virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature);
    virtual void               scanClassForReservation(TR_OpaqueClassBlock *,  TR::Compilation *comp);
    virtual uint32_t           getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName,
                                                      uint32_t fieldLen, char * sig, uint32_t sigLen, UDATA options);

--- a/runtime/compiler/trj9/optimizer/StringPeepholes.hpp
+++ b/runtime/compiler/trj9/optimizer/StringPeepholes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,7 @@ class TR_StringPeepholes : public TR::Optimization
    TR::TreeTop *detectBDPattern(TR::Block *block, TR::TreeTop *tt, TR::Node *node);
    TR::TreeTop *detectFormatPattern(TR::TreeTop *tt, TR::TreeTop *exit, TR::Node *node);
    TR::TreeTop *detectSubMulSetScalePattern(TR::TreeTop *tt, TR::TreeTop *exit, TR::Node *node);
-   TR::SymbolReference *findSymRefForValueOf(const char *sig, int len);
+   TR::SymbolReference *findSymRefForValueOf(const char *sig);
 
    bool checkMethodSignature(TR::SymbolReference *symRef, const char *sig);
    TR::TreeTop *searchForStringAppend(const char *sig, TR::TreeTop *tt, TR::TreeTop *exitTree,


### PR DESCRIPTION
Profiles show that creating a TR_ResolvedMethod is quite expensive in terms
of CPU cycles. Many resolved methods are created during StringPeepholes
optimization in findSymRefForValueOf() where the JIT scans the String class
for a specific method identified by name and signature. The exiting code
creates a resolved method for every method in the String class, puts those
resolved methods in a linked list and then starts to do name/signature
comparisons. This is inefficient both in tems of CPU and memory.

This commit changes the algorithm so that the JIT does the name/signature
comparison as it visits each method in the String class. As a result, only
one TR_ResolvedMethod is created and the linked list is eliminated.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>