### PR TITLE
Add new DDR commands for modularity__Command 3.1 and 3.2

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ModuleHashTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ModuleHashTable.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.j9;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.j9.StringTable.StringEqualFunction;
+import com.ibm.j9ddr.vm29.j9.StringTable.StringHashFunction;
+import com.ibm.j9ddr.vm29.pointer.generated.J9HashTablePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.types.UDATA;
+
+/**
+ * ModuleHashTable is used for accessing hash tables in J9Modules (e.g. readAccessHashTable)  
+ */
+
+public class ModuleHashTable extends HashTable_V1<J9ModulePointer>
+{
+	protected ModuleHashTable(J9HashTablePointer hashTablePointer, boolean isInline, Class<J9ModulePointer> structType,
+			HashEqualFunction<J9ModulePointer> equalFn,
+			HashFunction<J9ModulePointer> hashFn) throws CorruptDataException 
+	{
+		super(hashTablePointer, isInline, structType, equalFn, hashFn);
+	}
+
+	/**
+	 * Opens J9HashTable from J9HashTablePointer
+	 * 
+	 * @param structure
+	 * 					the J9HashTablePointer
+	 * 
+	 * @throws CorruptDataException
+	 * 					when fails to read from structure
+	 */
+	
+	public static HashTable<J9ModulePointer> fromJ9HashTable(J9HashTablePointer structure) throws CorruptDataException 
+	{
+		return new ModuleHashTable(structure, false, J9ModulePointer.class, new ModuleHashEqualFn(), new ModuleHashFn());
+	}
+	
+	private static class ModuleHashFn implements HashFunction<J9ModulePointer> 
+	{
+		ModuleHashFn()
+		{
+			super();
+		}
+
+		private StringHashFunction<J9ModulePointer> stringHashFn = new StringTable.StringHashFunction<J9ModulePointer>();
+
+		public UDATA hash(J9ModulePointer entry) throws CorruptDataException {
+			return stringHashFn.hash(entry);
+		}
+	}
+	
+	private static class ModuleHashEqualFn implements HashEqualFunction<J9ModulePointer> 
+	{
+		ModuleHashEqualFn()
+		{
+			super();
+		}
+
+		private StringEqualFunction<J9ModulePointer> stringHashEqualFn = new StringEqualFunction<J9ModulePointer>();
+
+		public boolean equal(J9ModulePointer entry1, J9ModulePointer entry2) throws CorruptDataException {
+			return stringHashEqualFn.equal(entry1, entry2);
+		}
+
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
@@ -44,6 +44,8 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRegionsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRomClassLinearCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllSegmentsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpContendedLoadTable;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleReadsCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleExportsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpRamClassLinearCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpRomClassCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpRomClassLinearCommand;
@@ -179,6 +181,8 @@ public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnab
 		toPassBack.add(new CPDescriptionCommand());
 		toPassBack.add(new FindAllModulesCommand());
 		toPassBack.add(new FindModuleByNameCommand());
+		toPassBack.add(new DumpModuleExportsCommand());
+		toPassBack.add(new DumpModuleReadsCommand());
 
 		loadPlugins(toPassBack, loader);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/StructureCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/StructureCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,7 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9Clas
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9ClassStructureFormatter;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9MethodFieldFormatter;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9MethodStructureFormatter;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9ModuleStructureFormatter;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9ObjectFieldFormatter;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9ObjectStructureFormatter;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions.J9ROMMethodStructureFormatter;
@@ -89,6 +90,7 @@ public class StructureCommand extends BaseStructureCommand
 		registerStructureFormatter(new J9ClassStructureFormatter());
 		registerStructureFormatter(new J9MethodStructureFormatter());
 		registerStructureFormatter(new J9ROMMethodStructureFormatter());
+		registerStructureFormatter(new J9ModuleStructureFormatter());
 	}
 
 	private void loadDefaultFormatters() 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleExportsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleExportsCommand.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.ObjectModel;
+import com.ibm.j9ddr.vm29.j9.Pool;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PackagePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PoolPointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.JavaVersionHelper;
+
+/**
+ * Dumpmoduleexports command displays all display all j9packages exported by the target module
+ * 
+ * Example:
+ * !dumpmoduleexports 0x00000130550C7E88
+ * Example output: 
+ * !j9package 0x00000130550DB1A8
+ * !j9package 0x00000130550DB1F8
+ * !j9package 0x00000130550DB248
+ * .....(A list of every package the module exports)
+ */
+public class DumpModuleExportsCommand extends Command
+{
+
+	public DumpModuleExportsCommand()
+	{
+		addCommand("dumpmoduleexports", "<targetModuleAddress>", "display all j9packages exported by the target module");
+	}
+	
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+	{
+		if (args.length != 1) {
+			CommandUtils.dbgPrint(out, "Usage: !dumpmoduleexports <targetModuleAddress>\n");
+			return;
+		}			
+		try {
+			J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+			if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+				String targetModuleAddress = args[0];
+				J9PoolPointer pool = vm.modularityPool();
+				Pool<J9ModulePointer> packagePool = Pool.fromJ9Pool(pool, J9ModulePointer.class);
+				SlotIterator<J9ModulePointer> poolIterator = packagePool.iterator();
+				J9ModulePointer ptr = null;
+				J9PackagePointer packagePtr = null;
+				while (poolIterator.hasNext()) {
+					ptr = poolIterator.next();
+					/*
+					 * Since both packages and modules could be in the pool, the
+					 * iterator checks on the region and make sure that it is
+					 * pointing to a package. (For modules, the first field must
+					 * be in heap since it is an object while for j9package it
+					 * is a J9UTF8.)
+					 */
+					if (!ObjectModel.isPointerInHeap(vm, ptr.moduleName())) {
+						packagePtr = J9PackagePointer.cast(ptr);
+						/*
+						 * Iterate through the packages and if the package's
+						 * exported module name matches the target module,
+						 * output its address.
+						 */
+						if (packagePtr.module().getHexAddress().equals(targetModuleAddress)) {
+							String packageName = J9UTF8Helper.stringValue(packagePtr.packageName());
+							String hexAddress = packagePtr.getHexAddress();
+							out.printf("%-45s !j9package %s%n", packageName, hexAddress);
+						}
+					}
+				}
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException(e);
+		}
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleReadsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleReadsCommand.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.HashTable;
+import com.ibm.j9ddr.vm29.j9.ModuleHashTable;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9HashTablePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.JavaVersionHelper;
+
+/**
+ * DumpModuleReads command displays all modules that the target module reads
+ * 
+ * Example:
+ * !dumpmodulereads 0x00000130550C7E88
+ * Example output: 
+ * !j9module 0x000001305F46DB38
+ * !j9module 0x00000130550DBB58
+ * !j9module 0x000001305F469EA8
+ * .....(A list of every module read by the target module)
+ */
+public class DumpModuleReadsCommand extends Command{
+
+	public DumpModuleReadsCommand()
+	{
+		addCommand("dumpmodulereads", "<targetModuleAddress>", "display all modules read by the target module");
+	}
+
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException {
+		if (args.length != 1) {
+			CommandUtils.dbgPrint(out, "Usage: !dumpmodulereads <targetModuleAddress>\n");
+			return;
+		}
+		try {
+			J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+			if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+				String targetModuleAddress = args[0];
+				J9ModulePointer modulePtr = J9ModulePointer.cast(Long.decode(targetModuleAddress));
+				J9HashTablePointer readTable = modulePtr.readAccessHashTable();
+				HashTable<J9ModulePointer> moduleHashTable = ModuleHashTable.fromJ9HashTable(readTable);
+				SlotIterator<J9ModulePointer> slotIterator = moduleHashTable.iterator();
+				while (slotIterator.hasNext()) {
+					J9ModulePointer readModulePtr = slotIterator.next();
+					String moduleName = J9ObjectHelper.stringValue(readModulePtr.moduleName());
+					String hexAddress = readModulePtr.getHexAddress();
+					out.printf("%-30s !j9module %s%n", moduleName, hexAddress);
+				}
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException(e);
+		}
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/J9ModuleStructureFormatter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/structureformat/extensions/J9ModuleStructureFormatter.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.structureformat.extensions;
+
+import java.io.PrintStream;
+import java.util.List;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.BaseStructureFormatter;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.FormatWalkResult;
+import com.ibm.j9ddr.tools.ddrinteractive.IFieldFormatter;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+
+/**
+ * Structure Formatter that adds a suffix to the command "!j9module $moduleAddress$" output
+ * 
+ * Example output (suffix part):
+ * Module name: java.instrument
+ * To display all j9packages exported by the module, use !dumpmoduleexports 0x000001305F46DB38
+ * To display all modules that the target module reads, use !dumpmodulereads 0x000001305F46DB38
+ */
+public class J9ModuleStructureFormatter extends BaseStructureFormatter 
+{
+
+	@Override
+	public FormatWalkResult postFormat(String type, long address,
+			PrintStream out, Context context,
+			List<IFieldFormatter> fieldFormatters, String[] extraArgs) 
+	{
+		if (type.equalsIgnoreCase("j9module") && address != 0) {
+			J9ModulePointer modulePtr = J9ModulePointer.cast(address);
+
+			try {
+				out.println("Module name: " + J9ObjectHelper.stringValue(modulePtr.moduleName()));
+			} catch (CorruptDataException e) {
+				// Do nothing
+				return FormatWalkResult.KEEP_WALKING;
+			}
+			out.println("To display all j9packages exported by the module, use !dumpmoduleexports "
+					+ modulePtr.getHexAddress());
+			out.println("To display all modules that the target module reads, use !dumpmodulereads "
+					+ modulePtr.getHexAddress());
+		}
+
+		return FormatWalkResult.KEEP_WALKING;
+	}
+
+	
+}


### PR DESCRIPTION
Added two commands:

1.  `!dumpmoduleexports [targertModuleAddress]` display all j9packages
exported by the target module 
2.  `!dumpmodulereads [targetModuleAddress]` display all modules that the
target reads
Related issue: [#1859](https://github.com/eclipse/openj9/issues/1859)
Created ModuleHashTable.java to access J9HashTables in modules

Examples: 
!dumpmoduleexports: 
```
com/ibm/oti/reflect                           !j9package 0x00000130550DB1A8
java/util/concurrent/locks                    !j9package 0x00000130550DB1F8
com/sun/net/ssl/internal/www/protocol/https   !j9package 0x00000130550DB248
sun/net/www/protocol/http/ntlm                !j9package 0x00000130550DB298
sun/net/util                                  !j9package 0x00000130550DB2E8
jdk/internal/perf                             !j9package 0x00000130550DB338
java/nio/charset/spi                          !j9package 0x00000130550DB388
java/util/zip                                 !j9package 0x00000130550DB3D8
sun/util/logging                              !j9package 0x00000130550DB428
java/security/spec                            !j9package 0x00000130550DB478
jdk/internal/misc                             !j9package 0x00000130550DB4C8
sun/net/dns                                   !j9package 0x00000130550DB518
java/io                                       !j9package 0x00000130550DB568
java/security                                 !j9package 0x00000130550DB5B8
jdk/internal/org/objectweb/asm                !j9package 0x00000130550DB608
java/util/jar                                 !j9package 0x00000130550DB658
sun/security/x509                             !j9package 0x00000130550DB6A8
java/util/regex                               !j9package 0x00000130550DB6F8
sun/net/spi                                   !j9package 0x00000130550DB748
sun/security/ssl                              !j9package 0x00000130550DA098
com/sun/crypto/provider                       !j9package 0x00000130550DA0E8
sun/reflect/generics/reflectiveObjects        !j9package 0x00000130550DA138
com/ibm/jit                                   !j9package 0x00000130550DA188
jdk/internal/jimage/decompressor              !j9package 0x00000130550DA1D8
com/sun/net/ssl/internal/ssl                  !j9package 0x00000130550DA228
java/nio/channels                             !j9package 0x00000130550DA278
java/util/concurrent                          !j9package 0x00000130550DA2C8
sun/util/resources/cldr                       !j9package 0x00000130550DA318
sun/util/cldr                                 !j9package 0x00000130550DA368
javax/security/auth/x500                      !j9package 0x00000130550DA3B8
sun/security/action                           !j9package 0x00000130550DA408
java/nio                                      !j9package 0x00000130550DA458
sun/text/spi                                  !j9package 0x00000130550DA4A8
java/lang                                     !j9package 0x00000130550DA4F8
jdk/internal/org/objectweb/asm/tree/analysis  !j9package 0x00000130550DA548
javax/security/cert                           !j9package 0x00000130550DA598
sun/net/ext                                   !j9package 0x00000130550DA5E8
sun/net/www/protocol/jrt                      !j9package 0x00000130550DA638
java/security/acl                             !j9package 0x00000130550DA688
sun/text/resources/cldr                       !j9package 0x00000130550DA6D8
sun/net/www/protocol/mailto                   !j9package 0x00000130550DA728
sun/security/rsa                              !j9package 0x00000130550DA778
java/util                                     !j9package 0x00000130550DA7C8
java/text/spi                                 !j9package 0x00000130550DA818
sun/util/locale                               !j9package 0x00000130550DA868
sun/security/tools                            !j9package 0x00000130550DA8B8
java/nio/file/attribute                       !j9package 0x00000130550DA908
jdk/internal/org/xml/sax                      !j9package 0x00000130550DA958
javax/security/auth/spi                       !j9package 0x00000130550DA9A8
jdk/internal/ref                              !j9package 0x00000130550DA9F8
sun/invoke/util                               !j9package 0x00000130550DAA48
sun/security/pkcs                             !j9package 0x00000130550DAA98
java/nio/file/spi                             !j9package 0x00000130550DAAE8
com/ibm/oti/vm                                !j9package 0x00000130550DAB38
java/nio/channels/spi                         !j9package 0x00000130550DAB88
jdk/internal/org/xml/sax/helpers              !j9package 0x00000130550DABD8
jdk/internal/loader                           !j9package 0x00000130550DAC28
sun/nio/fs                                    !j9package 0x00000130550DAC78
jdk/internal/org/objectweb/asm/tree           !j9package 0x00000130550DACC8
sun/util/calendar                             !j9package 0x00000130550DAD18
javax/security/auth/login                     !j9package 0x00000130550DAD68
java/nio/charset                              !j9package 0x00000130550DADB8
com/ibm/oti/util                              !j9package 0x00000130550DAE08
javax/crypto/interfaces                       !j9package 0x00000130550DAE58
sun/reflect/generics/factory                  !j9package 0x00000130550DAEA8
sun/util/spi                                  !j9package 0x00000130550DAEF8
java/net/spi                                  !j9package 0x00000130550DAF48
sun/security/timestamp                        !j9package 0x00000130550DAF98
sun/text/normalizer                           !j9package 0x00000130550DAFE8
sun/net/www/protocol/jmod                     !j9package 0x00000130550DF5E8
sun/net/www/protocol/http                     !j9package 0x00000130550DF638
com/sun/net/ssl                               !j9package 0x00000130550DF688
sun/reflect/generics/tree                     !j9package 0x00000130550DF6D8
jdk/internal/vm/annotation                    !j9package 0x00000130550DF728
java/security/cert                            !j9package 0x00000130550DF778
javax/crypto                                  !j9package 0x00000130550DF7C8
sun/reflect/generics/repository               !j9package 0x00000130550DF818
sun/net/smtp                                  !j9package 0x00000130550DF868
com/sun/java/util/jar/pack                    !j9package 0x00000130550DF8B8
sun/reflect/generics/scope                    !j9package 0x00000130550DF908
com/ibm/sharedclasses/spi                     !j9package 0x00000130550DF958
jdk/internal/org/objectweb/asm/commons        !j9package 0x00000130550DF9A8
sun/net                                       !j9package 0x00000130550DF9F8
sun/launcher/resources                        !j9package 0x00000130550DFA48
com/ibm/tools/attach/target                   !j9package 0x00000130550DFA98
com/ibm/gpu/spi                               !j9package 0x00000130550DFAE8
sun/util/locale/provider                      !j9package 0x00000130550DFB38
sun/util/resources                            !j9package 0x00000130550DFB88
java/time/zone                                !j9package 0x00000130550DFBD8
sun/reflect/generics/visitor                  !j9package 0x00000130550DFC28
jdk/internal/jmod                             !j9package 0x00000130550DFC78
sun/security/pkcs12                           !j9package 0x00000130550DFCC8
com/sun/security/cert/internal/x509           !j9package 0x00000130550DFD18
sun/security/pkcs10                           !j9package 0x00000130550DFD68
sun/net/ftp/impl                              !j9package 0x00000130550DFDB8
sun/security/provider/certpath                !j9package 0x00000130550DFE08
sun/security/provider/certpath/ssl            !j9package 0x00000130550DFE58
sun/security/util                             !j9package 0x00000130550DFEA8
java/security/interfaces                      !j9package 0x00000130550DFEF8
java/lang/ref                                 !j9package 0x00000130550DFF48
sun/reflect/misc                              !j9package 0x00000130550DFF98
java/text                                     !j9package 0x00000130550DFFE8
sun/nio                                       !j9package 0x00000130550E0038
sun/io                                        !j9package 0x00000130550E0088
sun/net/www/protocol/file                     !j9package 0x00000130550E00D8
jdk/internal/jrtfs                            !j9package 0x00000130550E0128
sun/security/internal/spec                    !j9package 0x00000130550E0178
sun/net/www                                   !j9package 0x00000130550E01C8
sun/reflect/annotation                        !j9package 0x00000130550E0218
java/time/chrono                              !j9package 0x00000130550E0268
jdk/internal/org/objectweb/asm/util           !j9package 0x00000130550E02B8
sun/security/tools/keytool                    !j9package 0x00000130550E0308
sun/net/www/protocol/https                    !j9package 0x00000130550E0358
sun/security/validator                        !j9package 0x00000130550E03A8
java/net                                      !j9package 0x00000130550E03F8
sun/net/www/protocol/jar                      !j9package 0x00000130550E0448
jdk/internal/util                             !j9package 0x00000130550E0498
jdk/internal/util/jar                         !j9package 0x00000130550E04E8
com/ibm/oti/lang                              !j9package 0x00000130550E0538
java/time                                     !j9package 0x00000130550C7F28
sun/security/internal/interfaces              !j9package 0x00000130550C7F78
sun/text                                      !j9package 0x00000130550C7FC8
java/time/temporal                            !j9package 0x00000130550C8018
javax/security/auth/callback                  !j9package 0x00000130550C8068
java/lang/reflect                             !j9package 0x00000130550C80B8
sun/text/bidi                                 !j9package 0x00000130550C8108
java/util/function                            !j9package 0x00000130550C8158
sun/text/resources                            !j9package 0x00000130550C81A8
java/lang/invoke                              !j9package 0x00000130550C81F8
javax/net/ssl                                 !j9package 0x00000130550C8248
java/lang/module                              !j9package 0x00000130550C8298
jdk/internal/math                             !j9package 0x00000130550C82E8
java/nio/file                                 !j9package 0x00000130550C8338
jdk/internal/reflect                          !j9package 0x00000130550C8388
sun/reflect/generics/parser                   !j9package 0x00000130550C83D8
sun/util                                      !j9package 0x00000130550C8428
jdk/internal/util/xml/impl                    !j9package 0x00000130550C8478
sun/net/www/content/text                      !j9package 0x00000130550C84C8
sun/net/sdp                                   !j9package 0x00000130550C8518
sun/net/www/protocol/ftp                      !j9package 0x00000130550C8568
java/util/spi                                 !j9package 0x00000130550C85B8
sun/security/provider                         !j9package 0x00000130550C8608
javax/security/auth                           !j9package 0x00000130550C8658
com/sun/security/ntlm                         !j9package 0x00000130550C86A8
sun/net/idn                                   !j9package 0x00000130550C86F8
sun/invoke/empty                              !j9package 0x00000130550C8748
jdk/internal                                  !j9package 0x00000130550C8798
jdk/internal/org/objectweb/asm/signature      !j9package 0x00000130550C87E8
jdk/internal/util/xml                         !j9package 0x00000130550C8838
jdk/internal/logger                           !j9package 0x00000130550C8888
sun/net/ftp                                   !j9package 0x00000130550C88D8
javax/crypto/spec                             !j9package 0x00000130550C8928
jdk/internal/jimage                           !j9package 0x00000130550C8978
java/time/format                              !j9package 0x00000130550C89C8
sun/launcher                                  !j9package 0x00000130550C8A18
javax/net                                     !j9package 0x00000130550C8A68
java/lang/annotation                          !j9package 0x00000130550C8AB8
sun/invoke                                    !j9package 0x00000130550C8B08
jdk/internal/module                           !j9package 0x00000130550C8B58
sun/nio/cs                                    !j9package 0x00000130550C8BA8
sun/security/jca                              !j9package 0x00000130550C8BF8
java/util/concurrent/atomic                   !j9package 0x00000130550C8C48
sun/nio/ch                                    !j9package 0x00000130550C8C98
java/util/stream                              !j9package 0x00000130550C8CE8
java/math                                     !j9package 0x00000130550C8D38
jdk/internal/vm                               !j9package 0x00000130550C8D88
sun/net/www/http                              !j9package 0x00000130550C8DD8
```
!dumpmodulereads: 
```
> !dumpmodulereads 0x00000130550C7E88
java.instrument                !j9module 0x000001305F46DB38
jdk.xml.dom                    !j9module 0x00000130550DBB58
jdk.accessibility              !j9module 0x000001305F469EA8
java.logging                   !j9module 0x000001305F477388
jdk.jshell                     !j9module 0x000001305F471D98
jdk.jdwp.agent                 !j9module 0x000001305F477248
openj9.dtfj                    !j9module 0x000001305F469FE8
java.scripting                 !j9module 0x000001305F46DD98
jdk.dynalink                   !j9module 0x000001305F4685E8
jdk.jdeps                      !j9module 0x000001305F469518
openj9.zosconditionhandling    !j9module 0x000001305F4710C8
jdk.management.agent           !j9module 0x000001305F469298
jdk.internal.opt               !j9module 0x000001305F46ABA8
openj9.jvm                     !j9module 0x000001305F471528
java.compiler                  !j9module 0x00000130550DBCE8
java.sql                       !j9module 0x00000130550DB798
openj9.gpu                     !j9module 0x00000130550DB978
java.xml.crypto                !j9module 0x000001305F46CDC8
jdk.naming.rmi                 !j9module 0x000001305F477D68
java.naming                    !j9module 0x000001305F477EF8
openj9.cuda                    !j9module 0x000001305F477298
jdk.jdi                        !j9module 0x00000130550DBF18
java.xml                       !j9module 0x000001305F46BCB8
openj9.sharedclasses           !j9module 0x00000130550DBA68
jdk.attach                     !j9module 0x000001305F478798
java.desktop                   !j9module 0x000001305F46E1F8
jdk.jartool                    !j9module 0x000001305F46B6E8
jdk.crypto.ec                  !j9module 0x000001305F477E58
jdk.localedata                 !j9module 0x000001305F471168
jdk.unsupported                !j9module 0x000001305F4684A8
jdk.naming.dns                 !j9module 0x000001305F46CCD8
jdk.jsobject                   !j9module 0x000001305F46DA48
jdk.compiler                   !j9module 0x000001305F46ACE8
java.security.sasl             !j9module 0x000001305F46DED8
jdk.scripting.nashorn          !j9module 0x000001305F4767A8
openj9.dataaccess              !j9module 0x000001305F477CC8
java.prefs                     !j9module 0x000001305F478928
java.management                !j9module 0x000001305F468B18
jdk.charsets                   !j9module 0x000001305F471398
jdk.net                        !j9module 0x000001305F471CF8
jdk.security.auth              !j9module 0x000001305F478BF8
jdk.editpad                    !j9module 0x000001305F478D88
jdk.crypto.cryptoki            !j9module 0x000001305F478E78
jdk.jlink                      !j9module 0x000001305F4699A8
java.rmi                       !j9module 0x000001305F478F68
java.smartcardio               !j9module 0x000001305F471438
jdk.internal.le                !j9module 0x000001305F46B8C8
jdk.internal.ed                !j9module 0x000001305F4691A8
jdk.crypto.mscapi              !j9module 0x000001305F469478
java.security.jgss             !j9module 0x000001305F471708
jdk.management                 !j9module 0x000001305F478448
jdk.httpserver                 !j9module 0x000001305F479468
jdk.internal.jvmstat           !j9module 0x000001305F4795A8
jdk.zipfs                      !j9module 0x00000130550DB8D8
jdk.javadoc                    !j9module 0x000001305F474498
jdk.jstatd                     !j9module 0x000001305F4715C8
jdk.sctp                       !j9module 0x000001305F46D868
jdk.security.jgss              !j9module 0x000001305F46D958
java.management.rmi            !j9module 0x000001305F46E0B8
jdk.jconsole                   !j9module 0x000001305F469D18
java.sql.rowset                !j9module 0x000001305F4789C8
java.se                        !j9module 0x000001305F46DE88
java.datatransfer              !j9module 0x000001305F476668
```

Signed-off-by: Charles_Zheng <Juntian.Zheng@ibm.com>