### PR TITLE
Test caching of Class related queries

### DIFF
--- a/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Class.java
@@ -994,6 +994,12 @@ public class Test_Class {
 	public void test_getDeclaringClass() {
 		// Test for method java.lang.Class java.lang.Class.getDeclaringClass()
 		AssertJUnit.assertTrue(ClassTest.class.getDeclaringClass().equals(Test_Class.class));
+		// Test caching of java.lang.Class java.lang.Class.getDeclaringClass() null result
+		AssertJUnit.assertTrue(ClassTest.class.getDeclaringClass().equals(Test_Class.class));
+		// Test for method java.lang.Class java.lang.Class.getDeclaringClass() with null DeclaringClass
+		AssertJUnit.assertTrue(Test_Class.class.getDeclaringClass().equals(null));
+		// Test caching of method java.lang.Class java.lang.Class.getDeclaringClass() null result
+		AssertJUnit.assertTrue(Test_Class.class.getDeclaringClass().equals(null));
 	}
 
 	/**


### PR DESCRIPTION
This change calls Class related queries for the second
time to test if caching results works properly.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>