### PR TITLE
Catch failures in cleanWs stage of the job

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -259,7 +259,13 @@ def build_all() {
                 archive()
             }
         } finally {
-            cleanWs()
+            try {
+		cleanWs()
+	    } catch(e) {
+		echo e.toString()
+		echo e.printStackTrace()
+		sh "ps -ef"
+	    }
         }
     }
 }

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -128,9 +128,8 @@ def test_all() {
             *  holding open the file(s).
             */
             echo e.toString()
-            if (SPEC.startsWith("win_")) {
-                sh "ps -W"
-            }
+            echo e.printStackTrace()
+            sh "ps -ef"
         }
     }
 }


### PR DESCRIPTION
* [skip ci]
* occasionally there are failure to cleanup the workspace due to ??
* adding the try/catch causes the job to pass if only failing in cleanWs
    as well as displaying 'ps' output at the time of failing to cleanWs
* remove windows specific handling in the catch for the test/cleanWs case
    as 'ps -ef' works for windows via jnlp or ssh jenkins connection

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>