### PR TITLE
Shorten path used by tar for test output

### DIFF
--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -97,7 +97,7 @@ def publish() {
             step([$class: 'Publisher', reportFilenamePattern: '**/testng-results.xml'])
             step([$class: "TapPublisher", testResults: "**/*.tap"])
             if (currentBuild.result == 'UNSTABLE') {
-                sh "tar -zcf test_output${TEST_TARGET}.tar.gz $WORKSPACE/openj9/test/TestConfig/test_output_*"
+                sh "tar -zcf test_output${TEST_TARGET}.tar.gz openj9/test/TestConfig/test_output_*"
 			    archiveArtifacts artifacts: "**/test_output${TEST_TARGET}.tar.gz", fingerprint: true, allowEmptyArchive: true
             }
         }


### PR DESCRIPTION
* [skip ci]
* $WORKSPACE on windows differs based on the jenkins connection type
    reducing to relative path will work for either case

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>