### PR TITLE
Add tests for issue #1950

### DIFF
--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -90,6 +90,8 @@ static jvmtiTest jvmtiTestList[] =
 	{ "rc016", rc016, "com.ibm.jvmti.tests.redefineClasses.rc016", "RedefineClasses" },
 	{ "rc017", rc017, "com.ibm.jvmti.tests.redefineClasses.rc017", "RedefineClasses" },
 	{ "rc018", rc018, "com.ibm.jvmti.tests.redefineClasses.rc018", "RedefineClasses" },
+	{ "rc019a", rc019a, "com.ibm.jvmti.tests.redefineClasses.rc019a", "RedefineClasses" },
+	{ "rc019b", rc019b, "com.ibm.jvmti.tests.redefineClasses.rc019b", "RedefineClasses" },
 	{ "gtgc001", gtgc001, "com.ibm.jvmti.tests.getThreadGroupChildren.gtgc001", "GetThreadGroupChildren" },
 	{ "gtgc002", gtgc002, "com.ibm.jvmti.tests.getThreadGroupChildren.gtgc002", "3 bytes name buffer overflow" },
 	{ "gts001", gts001, "com.ibm.jvmti.tests.getThreadState.gts001", "GetThreadState" },

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -180,6 +180,8 @@ jint JNICALL rc015(agentEnv * env, char * args);
 jint JNICALL rc016(agentEnv * env, char * args);
 jint JNICALL rc017(agentEnv * env, char * args);
 jint JNICALL rc018(agentEnv * env, char * args);
+jint JNICALL rc019a(agentEnv * env, char * args);
+jint JNICALL rc019b(agentEnv * env, char * args);
 jint JNICALL re001(agentEnv * env, char * args);
 jint JNICALL re002(agentEnv * env, char * args);
 jint JNICALL fr001(agentEnv * env, char * args);

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -108,6 +108,10 @@
 		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc016_redefineClass"/>
 		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc017_redefineMultipleClass"/>
 		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc018_redefineClass"/>
+		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc019a_redefineClass"/>
+		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc019a_getValue"/>
+		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc019b_redefineClass"/>
+		<export name="Java_com_ibm_jvmti_tests_redefineClasses_rc019b_getValue"/>
 		<export name="Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilities"/>
 		<export name="Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyLiveCapabilities"/>
 		<export name="Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc002_verifyCapabilityRetention"/>

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.c
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <string.h>
+
+#include "jvmti_test.h"
+
+static agentEnv * env;
+
+
+jint JNICALL
+rc019a(agentEnv * agent_env, char * args)
+{
+	jvmtiError err;
+	jvmtiCapabilities capabilities;
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+
+	env = agent_env; 
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_redefine_classes = 1;	
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to AddCapabilities");
+		return JNI_ERR;
+	}						
+
+	return JNI_OK;
+}
+
+jboolean JNICALL
+Java_com_ibm_jvmti_tests_redefineClasses_rc019a_redefineClass(JNIEnv * jni_env, jclass klass, jclass originalClass, jint classBytesSize, jbyteArray classBytes)
+{
+	JVMTI_ACCESS_FROM_AGENT(env);
+	jbyte * class_bytes;
+	char * classFileName = env->testArgs;
+	jvmtiClassDefinition classdef;
+	jvmtiError err; 
+	
+	err = (*jvmti_env)->Allocate(jvmti_env, classBytesSize, (unsigned char **) &class_bytes);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Unable to allocate temp buffer for the class file");
+		return JNI_FALSE;
+	}
+	
+	(*jni_env)->GetByteArrayRegion(jni_env, classBytes, 0, classBytesSize, class_bytes); 
+
+	classdef.class_bytes = (unsigned char *) class_bytes;
+	classdef.class_byte_count = classBytesSize;
+	classdef.klass = originalClass;
+	
+
+	err = (*jvmti_env)->RedefineClasses(jvmti_env, 1, &classdef);
+	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *) class_bytes);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "RedefineClasses failed");
+		return JNI_FALSE;
+	}
+		
+	return JNI_TRUE;
+}
+
+jobject JNICALL
+Java_com_ibm_jvmti_tests_redefineClasses_rc019a_getValue(JNIEnv * jni_env, jclass klass, jobject o)
+{
+	jobject result = NULL;
+	jclass clazz = (*jni_env)->FindClass(jni_env, "com/ibm/jvmti/tests/redefineClasses/rc019_Super");
+	if (NULL != clazz) {
+		jmethodID mid = (*jni_env)->GetMethodID(jni_env, clazz, "getValue", "()Ljava/lang/String;");
+		if (NULL != mid) {
+			result = (*jni_env)->CallObjectMethod(jni_env, o, mid);
+		}
+	}
+	return result;
+}

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.c
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <string.h>
+
+#include "jvmti_test.h"
+
+static agentEnv * env;
+
+
+jint JNICALL
+rc019b(agentEnv * agent_env, char * args)
+{
+	jvmtiError err;
+	jvmtiCapabilities capabilities;
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+
+	env = agent_env; 
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_redefine_classes = 1;	
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to AddCapabilities");
+		return JNI_ERR;
+	}						
+
+	return JNI_OK;
+}
+
+jboolean JNICALL
+Java_com_ibm_jvmti_tests_redefineClasses_rc019b_redefineClass(JNIEnv * jni_env, jclass klass, jclass originalClass, jint classBytesSize, jbyteArray classBytes)
+{
+	JVMTI_ACCESS_FROM_AGENT(env);
+	jbyte * class_bytes;
+	char * classFileName = env->testArgs;
+	jvmtiClassDefinition classdef;
+	jvmtiError err; 
+	
+	err = (*jvmti_env)->Allocate(jvmti_env, classBytesSize, (unsigned char **) &class_bytes);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Unable to allocate temp buffer for the class file");
+		return JNI_FALSE;
+	}
+	
+	(*jni_env)->GetByteArrayRegion(jni_env, classBytes, 0, classBytesSize, class_bytes); 
+
+	classdef.class_bytes = (unsigned char *) class_bytes;
+	classdef.class_byte_count = classBytesSize;
+	classdef.klass = originalClass;
+	
+
+	err = (*jvmti_env)->RedefineClasses(jvmti_env, 1, &classdef);
+	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *) class_bytes);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "RedefineClasses failed");
+		return JNI_FALSE;
+	}
+		
+	return JNI_TRUE;
+}
+
+jobject JNICALL
+Java_com_ibm_jvmti_tests_redefineClasses_rc019b_getValue(JNIEnv * jni_env, jclass klass, jobject o)
+{
+	jobject result = NULL;
+	jclass clazz = (*jni_env)->FindClass(jni_env, "com/ibm/jvmti/tests/redefineClasses/rc019_Super");
+	if (NULL != clazz) {
+		jmethodID mid = (*jni_env)->GetMethodID(jni_env, clazz, "getValue", "()Ljava/lang/String;");
+		if (NULL != mid) {
+			result = (*jni_env)->CallObjectMethod(jni_env, o, mid);
+		}
+	}
+	return result;
+}

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests_hcr.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests_hcr.xml
@@ -123,6 +123,16 @@
 		<return type="success" value="0"/>
 	</test>
 
+	<test id="rc019a">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:rc019a -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="rc019b">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:rc019b -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
  	<test id="rtc001">
 		<command>$EXE$ $JVM_OPTS$ $EXTRA_Add_OPEN_OPTION$ $AGENTLIB$=test:rtc001 -Dsun.reflect.noInflation=true  -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019_Sub.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019_Sub.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.redefineClasses;
+
+public class rc019_Sub extends rc019_Super {
+	public String getValue() {
+		return "Sub";
+	}
+}

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019_Super.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019_Super.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.redefineClasses;
+
+public class rc019_Super {
+	public String getValue() {
+		return "Super";
+	}
+}

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019a.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.redefineClasses;
+
+import com.ibm.jvmti.tests.util.Util;
+import java.lang.reflect.*;
+
+public class rc019a {
+	public static native boolean redefineClass(Class name, int classBytesSize,
+			byte[] classBytes);
+	public static native String getValue(Object o);
+
+	public boolean testReflectBeforeAndAfterRedefine() {
+		try {
+			rc019_Super o = new rc019_Sub();
+			System.out.println("Before redefine:");
+			String direct = o.getValue();
+			String jni = getValue(o);
+			System.out.println("	Direct getValue() = " + direct);
+			System.out.println("	JNI    getValue() = " + jni);
+			if (direct != jni) {
+				System.out.println("FAIL: values do not match");
+				return false;
+			}
+			Util.redefineClass(getClass(), rc019_Super.class, rc019_Super.class);
+			System.out.println("After redefine:");
+			String aftetDirect = o.getValue();
+			String afterJNI = getValue(o);
+			System.out.println("	Direct getValue() = " + aftetDirect);
+			System.out.println("	JNI    getValue() = " + afterJNI);
+			if (aftetDirect != afterJNI) {
+				System.out.println("FAIL: values do not match");
+				return false;
+			}
+			if (direct != afterJNI) {
+				System.out.println("FAIL: before and after values do not match");
+				return false;			
+			}
+			return true;
+		} catch(Throwable t) {
+			System.out.println("Exception during test:");
+			t.printStackTrace();
+			return false;
+		}
+	}
+
+	public String helpReflectBeforeAndAfterRedefine() {
+		return "Tests that reflect invoke works when used before and after class redefinition";
+	}
+}

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/redefineClasses/rc019b.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.redefineClasses;
+
+import com.ibm.jvmti.tests.util.Util;
+import java.lang.reflect.*;
+
+public class rc019b {
+	public static native boolean redefineClass(Class name, int classBytesSize,
+			byte[] classBytes);
+	public static native String getValue(Object o);
+
+	public boolean testReflectAfterRedefine() {
+		try {
+			rc019_Super o = new rc019_Sub();
+			System.out.println("Before redefine:");
+			String direct = o.getValue();
+			System.out.println("	Direct getValue() = " + direct);
+			Util.redefineClass(getClass(), rc019_Super.class, rc019_Super.class);
+			System.out.println("After redefine:");
+			String aftetDirect = o.getValue();
+			String afterJNI = getValue(o);
+			System.out.println("	Direct getValue() = " + aftetDirect);
+			System.out.println("	JNI    getValue() = " + afterJNI);
+			if (aftetDirect != afterJNI) {
+				System.out.println("FAIL: values do not match");
+				return false;
+			}
+			if (direct != afterJNI) {
+				System.out.println("FAIL: before and after values do not match");
+				return false;			
+			}
+			return true;
+		} catch(Throwable t) {
+			System.out.println("Exception during test:");
+			t.printStackTrace();
+			return false;
+		}
+	}
+
+	public String helpReflectAfterRedefine() {
+		return "Tests that reflect invoke works when used after class redefinition";
+	}
+}


### PR DESCRIPTION
Test that virtual JNI invocation works after class redefinition in both
the case where the invocation is performed both before and after
redefinition and in the case where the invocation is performed only
after redefinition.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>