### PR TITLE
Set proper java.specification.version

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -374,37 +374,25 @@ private static void ensureProperties() {
 	
 	systemProperties = new Properties();
 
-	if (osEncoding != null)
+	if (osEncoding != null) {
 		systemProperties.put("os.encoding", osEncoding); //$NON-NLS-1$
+	}
 	/*[PR The launcher apparently needs sun.jnu.encoding property or it does not work]*/
 	systemProperties.put("ibm.system.encoding", platformEncoding); //$NON-NLS-1$
 	systemProperties.put("sun.jnu.encoding", platformEncoding); //$NON-NLS-1$
-	
 	systemProperties.put("file.encoding", fileEncoding); //$NON-NLS-1$
-
 	systemProperties.put("file.encoding.pkg", "sun.io"); //$NON-NLS-1$ //$NON-NLS-2$
-
-	/*[IF Sidecar19-SE]*/
-	systemProperties.put("java.specification.version", "9"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[ELSE]*/ 
-	systemProperties.put("java.specification.version", "1.8"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[ENDIF] Sidecar19-SE */
-	
-
 	systemProperties.put("java.specification.vendor", "Oracle Corporation"); //$NON-NLS-1$ //$NON-NLS-2$
 	systemProperties.put("java.specification.name", "Java Platform API Specification"); //$NON-NLS-1$ //$NON-NLS-2$
-
 	systemProperties.put("com.ibm.oti.configuration", "scar"); //$NON-NLS-1$
-	/*[IF] Clear
-	systemProperties.put("com.ibm.oti.configuration", "clear"); //$NON-NLS-1$
-	systemProperties.put("com.ibm.oti.configuration.dir", "jclClear"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[ENDIF]*/
 
 	String[] list = getPropertyList();
-	for (int i=0; i<list.length; i+=2) {
+	for (int i = 0; i < list.length; i += 2) {
 		String key = list[i];
 		/*[PR 100209] getPropertyList should use fewer local refs */
-		if (key == null) break;
+		if (key == null) {
+			break;
+		}
 		systemProperties.put(key, list[i+1]);
 	}
 	

--- a/runtime/include/vmi.h
+++ b/runtime/include/vmi.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -269,27 +269,28 @@ GetInitArgs(VMInterface* vmi);
  *
  * <TABLE>
  * <TR><TD><B>Property Name</B></TD>			<TD><B>Example Value or Description</B></TD></TR>
- * <TR><TD>java.vendor</TD>			<TD>"IBM Corporation"</TD></TR>
- * <TR><TD>java.vendor.url</TD>			<TD>"http://www.ibm.com/"</TD></TR>
- * <TR><TD>java.vm.specification.version</TD>	<TD>"1.0"</TD></TR>
+ * <TR><TD>java.vendor</TD>			<TD>"Eclipse OpenJ9"</TD></TR>
+ * <TR><TD>java.vendor.url</TD>			<TD>"http://www.eclipse.org/openj9"</TD></TR>
+ * <TR><TD>java.specification.version</TD>	<TD>"1.8"</TD></TR>
+ * <TR><TD>java.vm.specification.version</TD>	<TD>"1.8"</TD></TR>
  * <TR><TD>java.vm.specification.vendor</TD>	<TD>"Oracle Corporation"</TD></TR>
  * <TR><TD>java.vm.specification.name</TD>	<TD>"Java Virtual Machine Specification"</TD></TR>
- * <TR><TD>java.vm.version</TD>			<TD>"2.3"</TD></TR>
- * <TR><TD>java.vm.vendor</TD>			<TD>"IBM Corporation"</TD></TR>
- * <TR><TD>java.vm.name	</TD>		<TD>"J9"</TD></TR>
- * <TR><TD>java.vm.info</TD>			<TD>"IBM J9 2.3 Windows XP x86-32  (JIT enabled)
-<BR>J9VM - 20041211_0834_lHdSMR
-<BR>JIT  - dev_level20041210_1800"</TD></TR>
- * <TR><TD>java.compiler</TD>			<TD>"j9jit23"</TD></TR>
- * <TR><TD>java.class.version</TD>		<TD>"49.0"</TD></TR>
+ * <TR><TD>java.vm.version</TD>			<TD>"master-1ca0ab98"</TD></TR>
+ * <TR><TD>java.vm.vendor</TD>			<TD>"Eclipse OpenJ9"</TD></TR>
+ * <TR><TD>java.vm.name	</TD>		<TD>"Eclipse OpenJ9 VM"</TD></TR>
+ * <TR><TD>java.vm.info</TD>			<TD>"JRE 1.8.0 Linux amd64-64-Bit Compressed References 20180601_201 (JIT enabled, AOT enabled)
+<BR>OpenJ9   - 1ca0ab98
+<BR>OMR      - 05d2b8a2
+<BR>JCL      - c2aa0348 based on jdk8u172-b11"</TD></TR>
+ * <TR><TD>java.compiler</TD>			<TD>"j9jit29"</TD></TR>
+ * <TR><TD>java.class.version</TD>		<TD>"52.0"</TD></TR>
  * <TR><TD>java.home</TD>			<TD>the absolute path of the parent directory of the directory containing the vm
 <BR>i.e. for a vm /clear/bin/vm.exe, java.home is /clear</TD></TR>
  * <TR><TD>java.class.path</TD>			<TD>the application class path</TD></TR>
  * <TR><TD>java.library.path</TD>			<TD>the application library path</TD></TR>
  * <TR><TD>&nbsp;</TD><TD>&nbsp;</TD></TR>
- * <TR><TD>com.ibm.oti.system.class.path	<TD>the bootstrap class path</TD></TR>
  * <TR><TD>com.ibm.oti.vm.bootstrap.library.path	<TD>the bootstrap library path</TD></TR>
- * <TR><TD>com.ibm.oti.vm.library.version	<TD>"23"</TD></TR>
+ * <TR><TD>com.ibm.oti.vm.library.version	<TD>"29"</TD></TR>
  * </TABLE>
  *
  * @return a @ref vmiError "VMI error code"

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -659,7 +659,7 @@ static char * addEndorsedBundles(J9PortLibrary *portLib, char *endorsedDir, char
 
 
 /**
-  * Initialize the com.ibm.oti.system.class.path system property by scanning the vm args and extracting 
+  * Initialize the BOOT_PATH_SYS_PROP (sun.boot.class.path) system property by scanning the vm args and extracting
   * the value of any -Xbootclasspath: argument.  If no bootpath is explicitly specified then use a default
   * value appropriate for this class library.
   * 
@@ -827,8 +827,7 @@ _end:
   *
   * @return 0 On success, non-zero otherwise.
   *
-  * @note Requires that the 'java.home' and 'com.ibm.oti.system.class.path' system properties 
-  *            have been set in the VMI.
+  * @note Requires that the 'java.home' system property has been set in the VMI.
   */
 static IDATA computeFinalBootstrapClassPath(J9JavaVM * vm)
 {

--- a/runtime/vm/vmifunc.c
+++ b/runtime/vm/vmifunc.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -223,27 +223,28 @@ vmi_getPortLibrary(VMInterface* vmi)
  *
  * <TABLE>
  * <TR><TD><B>Property Name</B></TD>			<TD><B>Example Value or Description</B></TD></TR>
- * <TR><TD>java.vendor</TD>			<TD>"IBM Corporation"</TD></TR>
- * <TR><TD>java.vendor.url</TD>			<TD>"http://www.ibm.com/"</TD></TR>
- * <TR><TD>java.vm.specification.version</TD>	<TD>"1.0"</TD></TR>
+ * <TR><TD>java.vendor</TD>			<TD>"Eclipse OpenJ9"</TD></TR>
+ * <TR><TD>java.vendor.url</TD>			<TD>"http://www.eclipse.org/openj9"</TD></TR>
+ * <TR><TD>java.specification.version</TD>	<TD>"1.8"</TD></TR>
+ * <TR><TD>java.vm.specification.version</TD>	<TD>"1.8"</TD></TR>
  * <TR><TD>java.vm.specification.vendor</TD>	<TD>"Oracle Corporation"</TD></TR>
  * <TR><TD>java.vm.specification.name</TD>	<TD>"Java Virtual Machine Specification"</TD></TR>
- * <TR><TD>java.vm.version</TD>			<TD>"2.3"</TD></TR>
- * <TR><TD>java.vm.vendor</TD>			<TD>"IBM Corporation"</TD></TR>
- * <TR><TD>java.vm.name	</TD>		<TD>"J9"</TD></TR>
- * <TR><TD>java.vm.info</TD>			<TD>"IBM J9 2.3 Windows XP x86-32  (JIT enabled)
-<BR>J9VM - 20041211_0834_lHdSMR
-<BR>JIT  - dev_level20041210_1800"</TD></TR>
- * <TR><TD>java.compiler</TD>			<TD>"j9jit23"</TD></TR>
- * <TR><TD>java.class.version</TD>		<TD>"49.0"</TD></TR>
+ * <TR><TD>java.vm.version</TD>			<TD>"master-1ca0ab98"</TD></TR>
+ * <TR><TD>java.vm.vendor</TD>			<TD>"Eclipse OpenJ9"</TD></TR>
+ * <TR><TD>java.vm.name	</TD>		<TD>"Eclipse OpenJ9 VM"</TD></TR>
+ * <TR><TD>java.vm.info</TD>			<TD>"JRE 1.8.0 Linux amd64-64-Bit Compressed References 20180601_201 (JIT enabled, AOT enabled)
+<BR>OpenJ9   - 1ca0ab98
+<BR>OMR      - 05d2b8a2
+<BR>JCL      - c2aa0348 based on jdk8u172-b11"</TD></TR>
+ * <TR><TD>java.compiler</TD>			<TD>"j9jit29"</TD></TR>
+ * <TR><TD>java.class.version</TD>		<TD>"52.0"</TD></TR>
  * <TR><TD>java.home</TD>			<TD>the absolute path of the parent directory of the directory containing the vm
 <BR>i.e. for a vm /clear/bin/vm.exe, java.home is /clear</TD></TR>
  * <TR><TD>java.class.path</TD>			<TD>the application class path</TD></TR>
  * <TR><TD>java.library.path</TD>			<TD>the application library path</TD></TR>
  * <TR><TD>&nbsp;</TD><TD>&nbsp;</TD></TR>
- * <TR><TD>com.ibm.oti.system.class.path	<TD>the bootstrap class path</TD></TR>
  * <TR><TD>com.ibm.oti.vm.bootstrap.library.path	<TD>the bootstrap library path</TD></TR>
- * <TR><TD>com.ibm.oti.vm.library.version	<TD>"23"</TD></TR>
+ * <TR><TD>com.ibm.oti.vm.library.version	<TD>"29"</TD></TR>
  * </TABLE>
  *
  * @return a @ref vmiError "VMI error code"

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -742,6 +742,11 @@ initializeSystemProperties(J9JavaVM * vm)
 		goto fail;
 	}
 
+	rc = addSystemProperty(vm, "java.specification.version", specificationVersion, 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
+	
 	rc = addSystemProperty(vm, "java.vm.specification.version", specificationVersion, 0);
 	if (J9SYSPROP_ERROR_NONE != rc) {
 		goto fail;


### PR DESCRIPTION
Set proper `java.specification.version`

Removed the setting of `java.specification.version` by Java code;
Set `java.specification.version` to same value as `java.vm.specification.version` in C code.
Minor refactoring around code affected by this PR.

Now `Java 10 ./java -XshowSettings:properties -version 2>&1 | grep specification` output following:
```
    java.specification.name = Java Platform API Specification
    java.specification.vendor = Oracle Corporation
    java.specification.version = 10
    java.vm.specification.name = Java Virtual Machine Specification
    java.vm.specification.vendor = Oracle Corporation
    java.vm.specification.version = 10
``` 

closes: #2036 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>