### PR TITLE
Check for boolean array when running bastore bytecode

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5543,6 +5543,9 @@ done:
 				I_8 value = (I_8)*(I_32*)_sp;
 				_pc += 1;
 				_sp += 3;
+				if (J9OBJECT_CLAZZ(_currentThread, arrayref) == _vm->booleanArrayClass) {
+					value &= 1;
+				}
 				_objectAccessBarrier.inlineIndexableObjectStoreI8(_currentThread, arrayref, index, value);
 			}
 		}


### PR DESCRIPTION
Check for boolean array when running bastore bytecode

The JVM spec states: "If the arrayref refers to an array whose
components are of type boolean, then the int value is narrowed by taking
the bitwise AND of value and 1; the result is stored as the component of
the array indexed by index"

Issue: #2049

Signed-off-by: tajila <atobia@ca.ibm.com>