### PR TITLE
Fix attach API logging

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -286,6 +286,12 @@ public class IPC {
 		}
 	}
 
+	private static void printMessageWithHeader(String msg, PrintStream log) {
+		tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
+		printLogMessageHeader(log);
+		log.println(msg);
+	}
+
 	/**
 	 * Print the information about a throwable, including the exact class,
 	 * message, and stack trace.
@@ -294,14 +300,12 @@ public class IPC {
 	 * @note nothing is printed if logging is disabled
 	 */
 	public synchronized static void logMessage(String msg, Throwable thrown) {
-		try (PrintStream log = getLogStream()) {
-			if (!Objects.isNull(log)) {
-				tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
-				printLogMessageHeader(log);
-				log.println(msg);
-				thrown.printStackTrace(log);
-				log.flush();
-			}
+		@SuppressWarnings("resource") /* this will be closed when the VM exits */
+		PrintStream log = getLogStream();
+		if (!Objects.isNull(log)) {
+			printMessageWithHeader(msg, log);
+			thrown.printStackTrace(log);
+			log.flush();
 		}
 	}
 
@@ -312,13 +316,11 @@ public class IPC {
 	 * @note no message is printed if logging is disabled
 	 */
 	private synchronized static void printLogMessage(final String msg) {
-		try (PrintStream log = getLogStream()) {
-			if (!Objects.isNull(log)) {
-				tracepoint(TRACEPOINT_STATUS_LOGGING, msg);
-				printLogMessageHeader(log);
-				log.println(msg);
-				log.flush();
-			}
+		@SuppressWarnings("resource") /* this will be closed when the VM exits */
+		PrintStream log = getLogStream();
+		if (!Objects.isNull(log)) {
+			printMessageWithHeader(msg, log);
+			log.flush();
 		}
 	}
 


### PR DESCRIPTION
Commit 87e9c4531ad2923ad5d9d545b8342e7d9d745c76 added (amongst other things)
try-with-resources blocks
which closed the log file after the first message.  This reverts
that change.  Also refactor out some common code.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>