### PR TITLE
Fix memory leak in shrinit.cpp

### DIFF
--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -3941,7 +3941,14 @@ j9shr_shutdown(J9JavaVM *vm)
 		}
 		j9mem_free_memory(vm->sharedCacheAPI);
 	}
-
+	if (vm->sharedInvariantInternTable != NULL) {
+		if (vm->sharedInvariantInternTable->sharedInvariantSRPHashtable != NULL) {
+			srpHashTableFree(vm->sharedInvariantInternTable->sharedInvariantSRPHashtable);
+			vm->sharedInvariantInternTable->sharedInvariantSRPHashtable = NULL;
+		}
+		j9mem_free_memory(vm->sharedInvariantInternTable);
+		vm->sharedInvariantInternTable = NULL;
+	}
 	if (vm->sharedClassConfig) {
 		J9SharedClassConfig* config = vm->sharedClassConfig;
 		struct J9Pool* cpCachePool = config->jclClasspathCache;

--- a/runtime/util/srphashtable.c
+++ b/runtime/util/srphashtable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@
 
 #define SRPHASHTABLE_CREATED_BY_SRPHASHTABLENEW 1
 #define SRPHASHTABLE_CREATED_BY_SRPHASHTABLENEWINREGION 2
-#define SRPHASHTABLE_CREATED_BY_SRPHASHTABLERECREATE 3
+#define SRPHASHTABLE_CREATED_BY_SRPHASHTABLERECREATE 4
 
 #define ROUND_TO_SIZEOF_UDATA(number) (((number) + (sizeof(UDATA) - 1)) & (~(sizeof(UDATA) - 1)))
 


### PR DESCRIPTION
1. We never free vm->sharedInvariantInternTable and
vm->sharedInvariantInternTable->sharedInvariantSRPHashtable.
2. srpHashTableFree() checks the SRPHASHTABLE_CREATED_BY_XXX bits, the
current value SRPHASHTABLE_CREATED_BY_SRPHASHTABLERECREATE(==3) will
incorrectly set both SRPHASHTABLE_CREATED_BY_SRPHASHTABLERECREATE and
SRPHASHTABLE_CREATED_BY_SRPHASHTABLENEWINREGION. Change
SRPHASHTABLE_CREATED_BY_SRPHASHTABLERECREATE to 4.

Signed-off-by: hangshao <hangshao@ca.ibm.com>