### PR TITLE
Check for boolean when running putfield/static bytecode

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -148,7 +148,7 @@
 #define J9StaticFieldRefBaseType 0x1
 #define J9StaticFieldRefDouble 0x2
 #define J9StaticFieldRefFlagBits 0x1F
-#define J9StaticFieldRefIsolated 0x8
+#define J9StaticFieldRefBoolean 0x8
 #define J9StaticFieldRefPutResolved 0x10
 #define J9StaticFieldRefVolatile 0x4
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6301,7 +6301,11 @@ retry:
 					_objectAccessBarrier.inlineStaticStoreU64(_currentThread, fieldClass, (U_64*)valueAddress, *(U_64*)_sp, isVolatile);
 					_sp += 2;
 				} else {
-					_objectAccessBarrier.inlineStaticStoreU32(_currentThread, fieldClass, (U_32*)valueAddress, *(U_32*)_sp, isVolatile);
+					U_32 value = *(U_32*)_sp;
+					if (J9_ARE_ALL_BITS_SET(classAndFlags, J9StaticFieldRefBoolean)) {
+						value &= 1;
+					}
+					_objectAccessBarrier.inlineStaticStoreU32(_currentThread, fieldClass, (U_32*)valueAddress, value, isVolatile);
 					_sp += 1;
 				}
 			} else {
@@ -6482,7 +6486,11 @@ retry:
 					rc = THROW_NPE;
 					goto done;
 				}
-				_objectAccessBarrier.inlineMixedObjectStoreU32(_currentThread, objectref, newValueOffset, *(U_32*)_sp, isVolatile);
+				U_32 value = *(U_32*)_sp;
+				if (J9FieldTypeBoolean == (flags & J9FieldTypeMask)) {
+					value &= 1;
+				}
+				_objectAccessBarrier.inlineMixedObjectStoreU32(_currentThread, objectref, newValueOffset, value, isVolatile);
 				_sp += 2;
 			}
 		}

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -766,6 +766,8 @@ illegalAccess:
 					localClassAndFlagsData |= J9StaticFieldRefBaseType;
 					if ((modifiers & J9FieldSizeDouble) == J9FieldSizeDouble) {
 						localClassAndFlagsData |= J9StaticFieldRefDouble;
+					} else if (J9FieldTypeBoolean == (modifiers & J9FieldTypeMask)) {
+						localClassAndFlagsData |= J9StaticFieldRefBoolean;
 					}
 				}
 				/* Check if volatile and set the localClassAndFlags to have StaticFieldRefVolatile. */


### PR DESCRIPTION
The JVM spec states "If the value is of type int and the field
descriptor type is boolean, then the int value is narrowed by taking the
bitwise AND of value and 1, resulting in value'"

issue: #2049

Signed-off-by: tajila <atobia@ca.ibm.com>