### PR TITLE
Exclude Windows J9test -Xpreloaduser32 -Xprotectcontiguous

### DIFF
--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_exclude.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_exclude.xml
@@ -50,7 +50,7 @@
 <exclude id="-Xthr:secondarySpinForObjectMonitors on command line" platform="aix.*" shouldFix="false"><reason>Only for platforms that three tier spin is enabled</reason></exclude>
 
 <include id="-Xpreloaduser32" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
-<include id="-Xpreloaduser32 -Xprotectcontiguous" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
+<include id="-Xpreloaduser32 -Xprotectcontiguous" platform="none" shouldFix="true"><reason>Intermittent failures on Windows platforms and not available on other platforms</reason></include>
 <include id="-Xpreloaduser32 -Xnoprotectcontiguous" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
 <include id="-Xnopreloaduser32" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
 <include id="-Xnopreloaduser32 -Xprotectcontiguous" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>


### PR DESCRIPTION
Exclude `Windows J9test -Xpreloaduser32 -Xprotectcontiguous`

Excluding `cmdLineTest_J9test subtest -Xpreloaduser32 -Xprotectcontiguous` for `Win64` platform as well.
This avoids intermittent golden failure and allow build promotion before a fix is identified.

Related to: #2065 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>