### PR TITLE
Atomic-free JNI work

### DIFF
--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -1042,7 +1042,7 @@ clearNonZAAPEligibleBit(JNIEnv *env, jclass nativeClass, const JNINativeMethod *
 	jint count = nativeMethodCount;
 	J9Class *j9clazz = NULL;
 
-	vmFuncs->internalAcquireVMAccess(vmThread);
+	vmFuncs->internalEnterVMFromJNI(vmThread);
 	j9clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, J9_JNI_UNWRAP_REFERENCE(nativeClass));
 
 	while (0 < count) {


### PR DESCRIPTION
Fix ZOS-specific JNI function which missed the change from acquire VM
access to enter VM.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>