### PR TITLE
Use VersionCheck.major() to check 9 and up, and remove TestMisc.isJava9 

### DIFF
--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -37,6 +37,7 @@
 	<property name="src_90" location="./src_90" />
 	<property name="build" location="./bin" />
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/>
 
 	<target name="init">
 		<fail message="BUILD_ROOT must be defined." unless="BUILD_ROOT" />
@@ -58,10 +59,12 @@
 					<src path="${src}" />
 					<src path="${src_80}" />
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" />
 					<classpath>
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/commons-exec.jar" />
+						<pathelement location="${JAVA_BIN}/../../lib/tools.jar" />
 					</classpath>
 				</javac>
 			</then>
@@ -75,11 +78,13 @@
 						<property name="addExports" value="--add-exports java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-exports java.management/javax.management=ALL-UNNAMED --add-exports java.base/java.security=ALL-UNNAMED" />
 					</else>
 				</if>
+				<property name="TestUtilitiesExports" value="--add-exports java.base/com.ibm.tools.attach.target=ALL-UNNAMED" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${src_90}" />
 					<src path="${transformerListener}" />
-					<compilerarg line='${addExports}' />
+					<src path="${TestUtilities}" />
+					<compilerarg line='${addExports} ${TestUtilitiesExports}' />
 					<classpath>
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar" />

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementUtils.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementUtils.java
@@ -22,6 +22,7 @@
 
 package org.openj9.test.java.lang.management;
 
+import org.openj9.test.util.VersionCheck;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
@@ -234,7 +235,7 @@ public class TestManagementUtils {
 		// Null file name
 		StackTraceElement st = new StackTraceElement("foo.bar.DeclaringClass", "methodName", null, 42);
 		CompositeData cd = TestUtil.toCompositeData(st);
-		int numValues = TestMisc.isJava9 ? 8 : 5;
+		int numValues = (VersionCheck.major() >= 9) ? 8 : 5;
 
 		// Examine the returned CompositeData
 		AssertJUnit.assertEquals(numValues, cd.values().size());

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMisc.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMisc.java
@@ -39,7 +39,6 @@ import com.ibm.java.lang.management.internal.ManagementUtils;
 public class TestMisc {
 
 	private static Logger logger = Logger.getLogger(TestMisc.class);
-	public static final boolean isJava9 = "9".equalsIgnoreCase(System.getProperty("java.specification.version"));
 
 	@BeforeClass
 	protected void setUp() throws Exception {

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMonitorInfo.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestMonitorInfo.java
@@ -22,6 +22,7 @@
 
 package org.openj9.test.java.lang.management;
 
+import org.openj9.test.util.VersionCheck;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
 import org.testng.annotations.BeforeClass;
@@ -363,7 +364,7 @@ public class TestMonitorInfo {
 		CompositeType cType = createStackTraceElementCompositeTypeObject();
 		String[] names;
 		Object[] values;
-		if (TestMisc.isJava9) {
+		if (VersionCheck.major() >= 9) {
 			String[] namesTmp = TestMisc.getJava9STEMethodNames();
 			Object[] valuesTmp = {
 					new String("foo.bar.Blobby"),
@@ -401,7 +402,7 @@ public class TestMonitorInfo {
 		String[] typeNames;
 		String[] typeDescs;
 		OpenType[] typeTypes;
-		if (TestMisc.isJava9) {
+		if (VersionCheck.major() >= 9) {
 			String[] typeNamesTmp = TestMisc.getJava9STEMethodNames();
 			String[] typeDescsTmp = TestMisc.getJava9STEMethodNames();
 			OpenType[] typeTypesTmp = {


### PR DESCRIPTION
[ci skip]

Fixes #2073

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>