### PR TITLE
Make java/lang/Class available in AOT

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -258,7 +258,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    TR_OpaqueClassBlock *getSystemClassPointer() { return _SystemClassPointer; }
    TR_OpaqueClassBlock *getReferenceClassPointer() { return _ReferenceClassPointer; }
    TR_OpaqueClassBlock *getJITHelpersClassPointer() { return _JITHelpersClassPointer; }
-   TR_OpaqueClassBlock *getClassClassPointer();
+   TR_OpaqueClassBlock *getClassClassPointer(bool isVettedForAOT = false);
 
    // Monitors
    TR_Array<List<TR::RegisterMappedSymbol> * > & getMonitorAutos() { return _monitorAutos; }
@@ -342,6 +342,9 @@ private:
    TR_OpaqueClassBlock               *_SystemClassPointer;
    TR_OpaqueClassBlock               *_ReferenceClassPointer;
    TR_OpaqueClassBlock               *_JITHelpersClassPointer;
+
+   TR_OpaqueClassBlock               *_aotClassClassPointer;
+   bool                               _aotClassClassPointerInitialized;
 
    TR_Array<List<TR::RegisterMappedSymbol> *> _monitorAutos;
    TR::list<TR::SymbolReference*>             _monitorAutoSymRefsInCompiledMethod;

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1224,7 +1224,7 @@ TR_J9InlinerPolicy::createUnsafePutWithOffset(TR::ResolvedMethodSymbol *calleeSy
         traceMsg(comp(),"Setting node %p as an unsafe static wrtbar\n",indirectAccessTreeTop->getNode());
      indirectAccessTreeTop->getNode()->setIsUnsafeStaticWrtBar(true);
      }
-   TR_OpaqueClassBlock *javaLangClass = comp()->fe()->getClassFromSignature("Ljava/lang/Class;",17, comp()->getCurrentMethod(),true);
+   TR_OpaqueClassBlock *javaLangClass = comp()->getClassClassPointer(/* isVettedForAOT = */ true);
    // If we are not able to get javaLangClass it is still inefficient to put direct Access far
    // So in that case we will generate lowTagCmpTest to branch to indirect access if true
    bool needNotLowTagged = javaLangClass != NULL  || conversionNeeded ;


### PR DESCRIPTION
Currently getClassClassPointer() refuses to return the J9Class pointer
for java/lang/Class when compiling AOT (ahead of time) even though Class
is practically guaranteed to be identical at AOT load time.

This commit allows callers to opt in to finding Class, in which case
they must ensure that their use of the J9Class pointer is acceptable for
AOT compilation.