### PR TITLE
Allow fabricated loadaddr for classes in AOT

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.hpp
@@ -61,6 +61,8 @@ public:
 
    TR::CodeGenerator *cg() {return _cg;}
 
+   static bool classAddressUsesReloRecordInfo() { return true; }
+
 private:
    static uint32_t _relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds];
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -634,6 +634,7 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                }
             break;
 
+         case TR_ArbitraryClassAddress:
          case TR_ClassPointer:
             cursor++;           // unused field
             if (is64BitTarget)
@@ -943,5 +944,23 @@ J9::AheadOfTimeCompile::dumpRelocationData()
          }
 
       traceMsg(self()->comp(), "\n");
+      }
+   }
+
+void J9::AheadOfTimeCompile::interceptAOTRelocation(TR::ExternalRelocation *relocation)
+   {
+   OMR::AheadOfTimeCompile::interceptAOTRelocation(relocation);
+
+   if (relocation->getTargetKind() == TR_ClassAddress)
+      {
+      TR::SymbolReference *symRef = NULL;
+      void *p = relocation->getTargetAddress();
+      if (TR::AheadOfTimeCompile::classAddressUsesReloRecordInfo())
+         symRef = (TR::SymbolReference*)((TR_RelocationRecordInformation*)p)->data1;
+      else
+         symRef = (TR::SymbolReference*)p;
+
+      if (symRef->getCPIndex() == -1)
+         relocation->setTargetKind(TR_ArbitraryClassAddress);
       }
    }

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,6 +52,14 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public OMR::AheadOfTimeCompileConnecto
    uint8_t* emitClassChainOffset(uint8_t* cursor, TR_OpaqueClassBlock* classToRemember);
    
    void dumpRelocationData();
+
+   static void interceptAOTRelocation(TR::ExternalRelocation *relocation);
+
+   /**
+    * Return true if an ExternalRelocation of kind TR_ClassAddress is expected
+    * to contain a pointer to TR_RelocationRecordInformation.
+    */
+   static bool classAddressUsesReloRecordInfo() { return false; }
    };
 
 }

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.hpp
@@ -55,6 +55,8 @@ class OMR_EXTENSIBLE AheadOfTimeCompile : public J9::AheadOfTimeCompile
    virtual void     processRelocations();
    virtual uint8_t *initializeAOTRelocationHeader(TR::IteratedExternalRelocation *relocation);
 
+   static bool classAddressUsesReloRecordInfo() { return true; }
+
    private:
    TR::CodeGenerator *_cg;
    static uint32_t _relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds];

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -255,6 +255,9 @@ TR_PPC64RelocationTarget::storeAddressSequence(uint8_t *address, uint8_t *reloLo
          patchAddr4 = (uint16_t *)&patchAddr[3];
          break;
          }
+
+      default:
+         TR_ASSERT_FATAL(false, "unrecognized sequence number %d\n", seqNumber);
       }
 
    *patchAddr1 |= value1;
@@ -287,7 +290,6 @@ TR_PPCRelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecord,
       {
       case TR_AbsoluteMethodAddressOrderedPair:
       case TR_ConstantPoolOrderedPair:
-      case TR_ClassAddress:
       case TR_ClassObject:
       case TR_MethodObject:
          return true;
@@ -305,6 +307,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_ConstantPoolOrderedPair:
       case TR_ClassAddress:
       case TR_ClassObject:
+      case TR_ArbitraryClassAddress:
       case TR_MethodObject:
       case TR_ArrayCopyHelper:
       case TR_ArrayCopyToc:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1024,6 +1024,25 @@ class TR_RelocationRecordClassPointer : public TR_RelocationRecordPointer
       virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
+// Relocation record data to identify the class is as for TR_ClassPointer, but
+// patching in the value is done as though for TR_ClassAddress.
+class TR_RelocationRecordArbitraryClassAddress : public TR_RelocationRecordClassPointer
+   {
+   public:
+      TR_RelocationRecordArbitraryClassAddress() {}
+      TR_RelocationRecordArbitraryClassAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordClassPointer(reloRuntime, record) {}
+      virtual char *name();
+
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+
+   protected:
+      virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+   private:
+      void assertBootstrapLoader(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *clazz);
+   };
+
 class TR_RelocationRecordMethodPointer : public TR_RelocationRecordPointer
    {
    public:

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -186,6 +186,32 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          }
          break;
 
+      case TR_ArbitraryClassAddress:
+         {
+         // ExternalRelocation data is as expected for TR_ClassAddress
+         auto symRef = (TR::SymbolReference *)relocation->getTargetAddress();
+         auto sym = symRef->getSymbol()->castToStaticSymbol();
+         auto j9class = (TR_OpaqueClassBlock *)sym->getStaticAddress();
+         uintptr_t inlinedSiteIndex = findCorrectInlinedSiteIndex(
+            symRef->getOwningMethod(comp)->constantPool(),
+            comp,
+            (uintptr_t)relocation->getTargetAddress2());
+
+         // Data identifying the class is as though for TR_ClassPointer
+         // (TR_RelocationRecordPointerBinaryTemplate)
+         *(uintptrj_t *)cursor = inlinedSiteIndex;
+         cursor += SIZEPOINTER;
+
+         void *loaderForClazz = fej9->getClassLoader(j9class);
+         void *classChainIdentifyingLoaderForClazz = sharedCache->persistentClassLoaderTable()->lookupClassChainAssociatedWithClassLoader(loaderForClazz);
+         uintptrj_t classChainOffsetInSharedCache = (uintptrj_t) sharedCache->offsetInSharedCacheFromPointer(classChainIdentifyingLoaderForClazz);
+         *(uintptrj_t *)cursor = classChainOffsetInSharedCache;
+         cursor += SIZEPOINTER;
+
+         cursor = self()->emitClassChainOffset(cursor, j9class);
+         }
+         break;
+
       case TR_InlinedStaticMethodWithNopGuard:
       case TR_InlinedSpecialMethodWithNopGuard:
       case TR_InlinedVirtualMethodWithNopGuard:
@@ -635,6 +661,9 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    32,                                              // TR_VirtualRamMethodConst               = 53
    40,                                              // TR_InlinedInterfaceMethod              = 54
    40,                                              // TR_InlinedVirtualMethod                = 55
+   0,                                               // TR_NativeMethodAbsolute                = 56,
+   0,                                               // TR_NativeMethodRelative                = 57,
+   32,                                              // TR_ArbitraryClassAddress               = 58,
 
 #else
 
@@ -694,6 +723,9 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    16,                                              // TR_VirtualRamMethodConst               = 53
    20,                                              // TR_InlinedInterfaceMethod              = 54
    20,                                              // TR_InlinedVirtualMethod                = 55
+   0,                                               // TR_NativeMethodAbsolute                = 56,
+   0,                                               // TR_NativeMethodRelative                = 57,
+   16,                                              // TR_ArbitraryClassAddress               = 58,
 #endif
    };
 


### PR DESCRIPTION
More specifically for classes loaded by the bootstrap class loader,
which are unambiguously identifiable at relocation time.

This allows the JIT compiler to make up references to types about which
it has special knowledge. In particular, it's now possible to create a
loadaddr for java/lang/Class "out of thin air," without a corresponding
constant pool entry available.

At a high level, the appropriate relocations are carried out as follows:

  1. Allow TR_ClassAddress ExternalRelocations to be created without a
  constant pool index.

  2. Before grouping into IteratedExternalRelocations, identify these
  and set their kind to the new TR_ArbitraryClassAddress.

  3. Write the relocation record for TR_ArbitraryClassAddress with the
  same data as would be required for TR_ClassPointer.

  4. Relocate TR_ArbitraryClassAddress by finding the class as though
  for TR_ClassPointer, and then patching the code as though for
  TR_ClassAddress (to deal with materialization sequences).

Note that because the compilation has the class pointer, it must have
been through validateArbitraryClass(). In case the class can't be found
at relocation time, the validation record will cause relocation to fail,
so the value used for missing classes is irrelevant.

Power code generation is updated to generate a materialization sequence
and relocation when it encounters a fabricated class symbol reference in
an AOT (ahead of time) compilation. Previously it used an unresolved
snippet, which requires a constant pool index.