### PR TITLE
Fix String.contentEquals(StringBuffer buffer)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -2979,7 +2979,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			byte[] sbValue = buffer.getValue();
 
 			if (coder == buffer.getCoder()) {
-				for (int i = 0; i < s1Length; ++i) {
+				for (int i = 0; i < s1Value.length; ++i) {
 					if (s1Value[i] != sbValue[i]) {
 						return false;
 					}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_String.java
@@ -580,6 +580,15 @@ public class Test_String {
 	}
 
 	/**
+	 * @tests java.lang.String#contentEquals(java.lang.StringBuffer)
+	 */
+	@Test
+	public void test_contentEquals() {
+		AssertJUnit.assertTrue("contentEquals: failed to return true with matching strings", hw1.contentEquals(new StringBuffer(hw2)));
+		AssertJUnit.assertFalse("contentEquals: failed to return false with non matching strings", hw1.contentEquals(new StringBuffer(hello1)));
+	}
+
+	/**
 	 * @tests java.lang.String#getBytes()
 	 */
 	@Test


### PR DESCRIPTION
Fix the String.contentEquals() function to check all bytes
of a string when a UTF16 String and StringBuffer are passed.

Signed-off-by: Daniel Hong <daniel.hong@live.com>