### PR TITLE
WIP: Virtualized CodeGenerator Hierarchy

### DIFF
--- a/runtime/compiler/codegen/CodeGenerator.hpp
+++ b/runtime/compiler/codegen/CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/codegen/CodeGenerator.hpp
+++ b/runtime/compiler/codegen/CodeGenerator.hpp
@@ -27,7 +27,7 @@
 
 namespace TR
 {
-class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGeneratorConnector
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public J9::CodeGeneratorConnector
    {
    public:
 

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3468,7 +3468,7 @@ J9::CodeGenerator::rematerializeCompressedRefs(
           }
       }
 
-   if (self()->materializesHeapBase() &&
+   if (materializesHeapBase() &&
        !isLowMemHeap &&
        parent && (!parent->getOpCode().isStore()) &&
        (node->getOpCodeValue() == TR::lconst) &&

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3197,15 +3197,15 @@ J9::CodeGenerator::rematerializeCompressedRefs(
       ((node->getFirstChild()->getOpCodeValue() == TR::ladd &&
        node->getFirstChild()->containsCompressionSequence()) ||
        ((node->getFirstChild()->getOpCodeValue() == TR::lshl) &&
-        (self()->canFoldLargeOffsetInAddressing() || (TR::Compiler->vm.heapBaseAddress() == 0)) &&
-        self()->isAddressScaleIndexSupported((1 << TR::Compiler->om.compressedReferenceShiftOffset())))))
+        (canFoldLargeOffsetInAddressing() || (TR::Compiler->vm.heapBaseAddress() == 0)) &&
+        isAddressScaleIndexSupported((1 << TR::Compiler->om.compressedReferenceShiftOffset())))))
       {
       if (parent &&
           (node->getReferenceCount() > 1) &&
           ((parent->getOpCode().isStoreIndirect() && (childNum == 0)) ||
            parent->getOpCode().isLoadVar() ||
            (self()->getSupportsConstantOffsetInAddressing() && parent->getOpCode().isArrayRef() &&
-            (self()->canFoldLargeOffsetInAddressing() || parent->getSecondChild()->getOpCode().isLoadConst()))) &&
+            (canFoldLargeOffsetInAddressing() || parent->getSecondChild()->getOpCode().isLoadConst()))) &&
           performTransformation(self()->comp(), "%sRematerializing node %p(%s) in decompression sequence\n", OPT_DETAILS, node, node->getOpCode().getName()))
          {
          if ((node->getReferenceCount() > 1) &&
@@ -3252,7 +3252,7 @@ J9::CodeGenerator::rematerializeCompressedRefs(
             // on x86, prevent remat of the l2a again thereby allowing
             // nodes to use the result of the add already done
             //
-            if (!self()->canFoldLargeOffsetInAddressing())
+            if (!canFoldLargeOffsetInAddressing())
                {
                if (!rematerializedNodes->find(node))
                   rematerializedNodes->add(node);
@@ -3264,7 +3264,7 @@ J9::CodeGenerator::rematerializeCompressedRefs(
 
          if (parent &&
              ((parent->getOpCode().isArrayRef() &&
-               !self()->canFoldLargeOffsetInAddressing() &&
+               !canFoldLargeOffsetInAddressing() &&
                !parent->getSecondChild()->getOpCode().isLoadConst()) ||
                !self()->getSupportsConstantOffsetInAddressing()) &&
               performTransformation(self()->comp(), "%sYanking %p(%s) in decompression sequence\n", OPT_DETAILS, node, node->getOpCode().getName()))
@@ -3904,7 +3904,7 @@ J9::CodeGenerator::allocateLinkageRegisters()
 
    TR::Delimiter d(self()->comp(), self()->comp()->getOptions()->getAnyOption(TR_TraceOptDetails|TR_CountOptTransformations), "AllocateLinkageRegisters");
 
-   if (!self()->prepareForGRA())
+   if (!prepareForGRA())
       {
       dumpOptDetails(self()->comp(), "  prepareForGRA failed -- giving up\n");
       return;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1597,7 +1597,7 @@ J9::CodeGenerator::doInstructionSelection()
          fixedUpBlock = false;
          TR::Block *block = node->getBlock();
          self()->setCurrentEvaluationBlock(block);
-         self()->setCurrentBlockIndex(block->getNumber());
+         setCurrentBlockIndex(block->getNumber());
          self()->resetMethodModifiedByRA();
 
          liveMonitorStack = (liveMonitorStacks.find(block->getNumber()) != liveMonitorStacks.end()) ?

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3030,7 +3030,7 @@ J9::CodeGenerator::compressedReferenceRematerialization()
       if (self()->comp()->getOption(TR_TraceCG))
          self()->comp()->dumpMethodTrees("Trees after this remat phase", self()->comp()->getMethodSymbol());
 
-      if (self()->shouldYankCompressedRefs())
+      if (shouldYankCompressedRefs())
          {
          visitCount = self()->comp()->incVisitCount();
          vcount_t secondVisitCount = self()->comp()->incVisitCount();

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4150,8 +4150,8 @@ J9::CodeGenerator::changeParmLoadsToRegLoads(TR::Node *node, TR::Node **regLoads
                   lowLRI  = lri;
                   highLRI = lri+1;
                   }
-               TR_GlobalRegisterNumber lowReg  = self()->getLinkageGlobalRegisterNumber(lowLRI,  node->getDataType());
-               TR_GlobalRegisterNumber highReg = self()->getLinkageGlobalRegisterNumber(highLRI, node->getDataType());
+               TR_GlobalRegisterNumber lowReg  = getLinkageGlobalRegisterNumber(lowLRI,  node->getDataType());
+               TR_GlobalRegisterNumber highReg = getLinkageGlobalRegisterNumber(highLRI, node->getDataType());
 
                if (lowReg != -1 && highReg != -1 && !globalRegsWithRegLoad->isSet(lowReg) && !globalRegsWithRegLoad->isSet(highReg)
                   && performTransformation(self()->comp(), "O^O LINKAGE REGISTER ALLOCATION: transforming %s into %s\n", self()->comp()->getDebug()->getName(node), self()->comp()->getDebug()->getName(regLoadOp)))
@@ -4198,8 +4198,8 @@ J9::CodeGenerator::changeParmLoadsToRegLoads(TR::Node *node, TR::Node **regLoads
             // if not 64 bit and data type is 64 bit, need to place it into two registers
             if ((TR::Compiler->target.is32Bit() && !self()->use64BitRegsOn32Bit()) && dt == TR::Int64)
                {
-               TR_GlobalRegisterNumber lowReg  = self()->getLinkageGlobalRegisterNumber(lri+1, dt);
-               TR_GlobalRegisterNumber highReg = self()->getLinkageGlobalRegisterNumber(lri, dt);
+               TR_GlobalRegisterNumber lowReg  = getLinkageGlobalRegisterNumber(lri+1, dt);
+               TR_GlobalRegisterNumber highReg = getLinkageGlobalRegisterNumber(lri, dt);
 
                if (lowReg != -1 && highReg != -1 && !globalRegsWithRegLoad->isSet(lowReg) && !globalRegsWithRegLoad->isSet(highReg) &&
                    performTransformation(self()->comp(), "O^O LINKAGE REGISTER ALLOCATION: transforming aggregate parm %s into xRegLoad\n", self()->comp()->getDebug()->getName(node)))
@@ -4218,7 +4218,7 @@ J9::CodeGenerator::changeParmLoadsToRegLoads(TR::Node *node, TR::Node **regLoads
                }
             else
                {
-               TR_GlobalRegisterNumber reg = self()->getLinkageGlobalRegisterNumber(lri, dt);
+               TR_GlobalRegisterNumber reg = getLinkageGlobalRegisterNumber(lri, dt);
 
                if (reg != -1 && !globalRegsWithRegLoad->isSet(reg) &&
                    performTransformation(self()->comp(), "O^O LINKAGE REGISTER ALLOCATION: transforming aggregate parm %s into xRegLoad\n", self()->comp()->getDebug()->getName(node)))
@@ -4235,7 +4235,7 @@ J9::CodeGenerator::changeParmLoadsToRegLoads(TR::Node *node, TR::Node **regLoads
             }
          else
             {
-            TR_GlobalRegisterNumber reg = self()->getLinkageGlobalRegisterNumber(parm->getLinkageRegisterIndex(), node->getDataType());
+            TR_GlobalRegisterNumber reg = getLinkageGlobalRegisterNumber(parm->getLinkageRegisterIndex(), node->getDataType());
             if (reg != -1 && !globalRegsWithRegLoad->isSet(reg)
                && performTransformation(self()->comp(), "O^O LINKAGE REGISTER ALLOCATION: transforming %s into %s\n", self()->comp()->getDebug()->getName(node), self()->comp()->getDebug()->getName(regLoadOp)))
                {

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1437,7 +1437,7 @@ J9::CodeGenerator::zeroOutAutoOnEdge(
 void
 J9::CodeGenerator::doInstructionSelection()
    {
-   self()->setNextAvailableBlockIndex(self()->comp()->getFlowGraph()->getNextNodeNumber() + 1);
+   setNextAvailableBlockIndex(comp()->getFlowGraph()->getNextNodeNumber() + 1);
 
    J9::SetMonitorStateOnBlockEntry::LiveMonitorStacks liveMonitorStacks(
       (J9::SetMonitorStateOnBlockEntry::LiveMonitorStacksComparator()),

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1437,7 +1437,7 @@ J9::CodeGenerator::zeroOutAutoOnEdge(
 void
 J9::CodeGenerator::doInstructionSelection()
    {
-   setNextAvailableBlockIndex(comp()->getFlowGraph()->getNextNodeNumber() + 1);
+   setNextAvailableBlockIndex(self()->comp()->getFlowGraph()->getNextNodeNumber() + 1);
 
    J9::SetMonitorStateOnBlockEntry::LiveMonitorStacks liveMonitorStacks(
       (J9::SetMonitorStateOnBlockEntry::LiveMonitorStacksComparator()),

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2248,7 +2248,7 @@ J9::CodeGenerator::doInstructionSelection()
 void
 J9::CodeGenerator::splitWarmAndColdBlocks()
    {
-   if (!self()->allowSplitWarmAndColdBlocks() || self()->comp()->compileRelocatableCode())
+   if (!allowSplitWarmAndColdBlocks() || self()->comp()->compileRelocatableCode())
       {
       return;
       }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2233,7 +2233,7 @@ J9::CodeGenerator::doInstructionSelection()
    if (self()->getDebug())
       self()->getDebug()->roundAddressEnumerationCounters();
 
-   self()->endInstructionSelection();
+   endInstructionSelection();
 
    if (self()->comp()->getOption(TR_TraceCG))
       diagnostic("</selection>\n");

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1456,7 +1456,7 @@ J9::CodeGenerator::doInstructionSelection()
    if (self()->comp()->getOption(TR_TraceCG) || debug("traceGRA"))
       self()->comp()->getDebug()->setupToDumpTreesAndInstructions("Performing Instruction Selection");
 
-   self()->beginInstructionSelection();
+   beginInstructionSelection();
 
    {
    TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -57,7 +57,7 @@ namespace TR { class TreeTop; }
 namespace J9
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGeneratorConnector
    {
 public:
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -160,7 +160,7 @@ public:
 
    bool alwaysGeneratesAKnownCleanSign(TR::Node *node) { return false; } // no virt
    bool alwaysGeneratesAKnownPositiveCleanSign(TR::Node *node) { return false; } // no virt
-   TR_RawBCDSignCode alwaysGeneratedSign(TR::Node *node) { return raw_bcd_sign_unknown; } // no virt
+   virtual TR_RawBCDSignCode alwaysGeneratedSign(TR::Node *node) { return raw_bcd_sign_unknown; } // no virt
 
    void foldSignCleaningIntoStore();
    void swapChildrenIfNeeded(TR::Node *store, char *optDetails);

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -271,7 +271,7 @@ private:
 
    uint16_t changeParmLoadsToRegLoads(TR::Node*node, TR::Node **regLoads, TR_BitVector *globalRegsWithRegLoad, TR_BitVector &killedParms, vcount_t visitCount); // returns number of RegLoad nodes created
 
-   virtual static bool wantToPatchClassPointer(TR::Compilation *comp,
+   static bool wantToPatchClassPointer(TR::Compilation *comp,
                                        const TR_OpaqueClassBlock *allegedClassPointer,
                                        const char *locationDescription,
                                        const void *location)

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -158,8 +158,8 @@ public:
    bool hasSignCleans() { return _flags4.testAny(HasSignCleans);}
    void setHasSignCleans() { _flags4.set(HasSignCleans);}
 
-   bool alwaysGeneratesAKnownCleanSign(TR::Node *node) { return false; } // no virt
-   bool alwaysGeneratesAKnownPositiveCleanSign(TR::Node *node) { return false; } // no virt
+   virtual bool alwaysGeneratesAKnownCleanSign(TR::Node *node) { return false; } // no virt
+   virtual bool alwaysGeneratesAKnownPositiveCleanSign(TR::Node *node) { return false; } // no virt
    virtual TR_RawBCDSignCode alwaysGeneratedSign(TR::Node *node) { return raw_bcd_sign_unknown; } // no virt
 
    void foldSignCleaningIntoStore();
@@ -271,7 +271,7 @@ private:
 
    uint16_t changeParmLoadsToRegLoads(TR::Node*node, TR::Node **regLoads, TR_BitVector *globalRegsWithRegLoad, TR_BitVector &killedParms, vcount_t visitCount); // returns number of RegLoad nodes created
 
-   static bool wantToPatchClassPointer(TR::Compilation *comp,
+   virtual static bool wantToPatchClassPointer(TR::Compilation *comp,
                                        const TR_OpaqueClassBlock *allegedClassPointer,
                                        const char *locationDescription,
                                        const void *location)
@@ -409,7 +409,7 @@ public:
     *    The number of nodes between a monext and the next monent before
     *    transforming a monitored region with transactional lock elision.
     */
-   int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; }
+   virtual int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; }
 
 private:
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -104,7 +104,7 @@ public:
 
    TR::Linkage *createLinkageForCompilation();
 
-   bool enableAESInHardwareTransformations() {return false;}
+   virtual bool enableAESInHardwareTransformations() {return false;}
 
    bool isMethodInAtomicLongGroup(TR::RecognizedMethod rm);
 

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -1619,7 +1619,7 @@ J9::Node::hasKnownCleanSign()
    {
    TR_ASSERT(self()->getType().isBCD(), "hasKnownCleanSign only supported for BCD type nodes\n");
    TR_ASSERT(self()->hasDecimalInfo(), "attempting to access _decimalInfo._hasCleanSign field for node %s %p that does not have it", self()->getOpCode().getName(), self());
-   if (self()->alwaysGeneratesAKnownCleanSign())
+   if (alwaysGeneratesAKnownCleanSign())
       return true;
    else
       return self()->signStateIsKnown() && _unionPropertyB._decimalInfo._hasCleanSign == 1;

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -245,7 +245,7 @@ J9::Power::CodeGenerator::lowerTreeIfNeeded(
 
    if ((node->getOpCode().isLeftShift() ||
         node->getOpCode().isRightShift() || node->getOpCode().isRotate()) &&
-       self()->needsNormalizationBeforeShifts() &&
+       needsNormalizationBeforeShifts() &&
        !node->isNormalizedShift())
       {
       TR::Node *second = node->getSecondChild();

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -180,7 +180,7 @@ J9::Power::CodeGenerator::generateBinaryEncodingPrologue(
       {
       if (comp->getOption(TR_FullSpeedDebug) || comp->getOption(TR_SupportSwitchToInterpreter))
          {
-         self()->generateSwitchToInterpreterPrePrologue(NULL, comp->getStartTree()->getNode());
+         generateSwitchToInterpreterPrePrologue(NULL, comp->getStartTree()->getNode());
          }
       else
          {

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -69,7 +69,7 @@ namespace J9
 namespace Power
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public J9::CodeGenerator
    {
    public:
 

--- a/runtime/compiler/x/amd64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/amd64/codegen/J9CodeGenerator.hpp
@@ -49,7 +49,7 @@ namespace X86
 namespace AMD64
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public J9::X86::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public J9::X86::CodeGenerator
    {
    public:
 

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -33,7 +33,7 @@ namespace J9
 namespace X86
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public J9::CodeGenerator
    {
    public:
 

--- a/runtime/compiler/x/i386/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/i386/codegen/J9CodeGenerator.hpp
@@ -48,7 +48,7 @@ namespace X86
 namespace i386
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public J9::X86::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public J9::X86::CodeGenerator
    {
    public:
 

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -327,7 +327,7 @@ J9::Z::CodeGenerator::lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop
 
    // J9, Z
    //
-   if (self()->codegenSupportsLoadlessBNDCheck() &&
+   if (codegenSupportsLoadlessBNDCheck() &&
       parent->getOpCode().isBndCheck() &&
       (parent->getFirstChild()->getOpCode().isLoadVar() ||
       parent->getSecondChild()->getOpCode().isLoadVar()))

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -51,7 +51,7 @@ namespace J9
 namespace Z
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public J9::CodeGenerator
    {
    public:
 


### PR DESCRIPTION
* Commented out `OMR_EXTENSIBLE` from `CodeGenerator` class declarations
* Removed `self()` from function calls of `CodeGenerator`

Since virtualizing the `CodeGenerator` hierarchy requires changes from both, the OMR and OpenJ9, projects this PR is linked to [a related one in omr](https://github.com/eclipse/omr/pull/2639) achieving the same purpose.

Signed-off-by: Samer AL Masri <almasri@ualberta.ca>