### PR TITLE
Improve entropy of reply key

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.security.SecureRandom;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
@@ -210,6 +211,16 @@ public class IPC {
 			}
 			return randomGen.nextInt();
 		}
+	}
+	
+	/**
+	 * Create a truly random string of hexadecimal characters with 64 bits of entropy.
+	 * This may be slow.
+	 * @return hexadecimal string
+	 */
+	public static String getRandomString() {
+		SecureRandom randomGenerator = new SecureRandom();
+		return Long.toHexString(randomGenerator.nextLong());
 	}
 
 	/**

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -385,7 +385,7 @@ final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 
 				targetServer = new ServerSocket(0); /* select a free port */
 				portNumber = Integer.valueOf(targetServer.getLocalPort());
-				String key = Integer.toHexString((IPC.getRandomNumber()));
+				String key = IPC.getRandomString();
 				replyFile = new Reply(portNumber, key, TargetDirectory.getTargetDirectoryPath(descriptor.id()), descriptor.getUid());
 				try {
 					replyFile.writeReply();


### PR DESCRIPTION
com.ibm.tools.attach.target.Reply uses a randomly generated key to verify that
the process responding to an attach attempt is the intended target.  The
existing approach used a random value based on time, which makes it
predictable. The key also had only 32 bits of entropy.

Use SecureRandom to generate a longer and more random value when security is
important.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>