### PR TITLE
Fix JVMTI field event reporting

### DIFF
--- a/runtime/vm/jnifield.cpp
+++ b/runtime/vm/jnifield.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corp. and others
+ * Copyright (c) 2012, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -210,6 +210,7 @@ getPrimitiveField(JNIEnv *env, jobject obj, jfieldID fieldID)
 
 
 	object = J9_JNI_UNWRAP_REFERENCE(obj);
+	FieldEvents::triggerGetEvents(vmThread, j9FieldID, object);
 
 	{
 		valueOffset += J9_OBJECT_HEADER_SIZE;
@@ -220,7 +221,6 @@ getPrimitiveField(JNIEnv *env, jobject obj, jfieldID fieldID)
 		VM_AtomicSupport::readBarrier();
 	}
 
-	FieldEvents::triggerGetEvents(vmThread, j9FieldID, object);
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 	return value;
 }
@@ -293,6 +293,7 @@ putPrimitiveField(JNIEnv *env, jobject obj, jfieldID fieldID, ValueType value)
 	VM_VMAccess::inlineEnterVMFromJNI(vmThread);
 
 	object = J9_JNI_UNWRAP_REFERENCE(obj);
+	FieldEvents::triggerSetEvents(vmThread, j9FieldID, object, &value);
 
 	if (j9FieldID->field->modifiers & J9AccVolatile) {
 		VM_AtomicSupport::writeBarrier();
@@ -307,7 +308,6 @@ putPrimitiveField(JNIEnv *env, jobject obj, jfieldID fieldID, ValueType value)
 		VM_AtomicSupport::readWriteBarrier();
 	}
 
-	FieldEvents::triggerSetEvents(vmThread, j9FieldID, object, &value);
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 }
 
@@ -381,6 +381,7 @@ getObjectField(JNIEnv *env, jobject obj, jfieldID fieldID)
 	VM_VMAccess::inlineEnterVMFromJNI(vmThread);
 
 	object = J9_JNI_UNWRAP_REFERENCE(obj);
+	FieldEvents::triggerGetEvents(vmThread, j9FieldID, object);
 
 	{
 		valueOffset += J9_OBJECT_HEADER_SIZE;
@@ -393,7 +394,6 @@ getObjectField(JNIEnv *env, jobject obj, jfieldID fieldID)
 
 	valueRef = VM_VMHelpers::createLocalRef(env, value);
 
-	FieldEvents::triggerGetEvents(vmThread, j9FieldID, object);
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 	return valueRef;
 }
@@ -416,6 +416,7 @@ setObjectField(JNIEnv *env, jobject obj, jfieldID fieldID, jobject valueRef)
 
 	/* A NULL value is ok */
 	value = (NULL == valueRef)? NULL : (j9object_t)J9_JNI_UNWRAP_REFERENCE(valueRef);
+	FieldEvents::triggerSetEvents(vmThread, j9FieldID, object, &value);
 
 	if (j9FieldID->field->modifiers & J9AccVolatile) {
 		VM_AtomicSupport::writeBarrier();
@@ -430,7 +431,6 @@ setObjectField(JNIEnv *env, jobject obj, jfieldID fieldID, jobject valueRef)
 		VM_AtomicSupport::readWriteBarrier();
 	}
 
-	FieldEvents::triggerSetEvents(vmThread, j9FieldID, object, &value);
 	VM_VMAccess::inlineExitVMToJNI(vmThread);
 }
 


### PR DESCRIPTION
The JVMTI field watch/modify events should be reported before the object
field is read/written.  JNI modifications to instance fields were
reporting the event after the write.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>