### PR TITLE
Add generic Jenkins files pipelines

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -289,6 +289,13 @@ def set_job_names() {
 * Initializes all of the required variables for a Jenkins job by given job type.
 */
 def set_job_variables(job_type) {
+    // check mandatory parameters if any
+    try {
+        validate_arguments(ARGS)
+    } catch(MissingPropertyException e){
+        // ignore when ARGS is not set
+    }
+
     // initialize VARIABLES
     parse_variables_file()
 
@@ -325,6 +332,34 @@ def set_job_variables(job_type) {
         default:
             error("Unknown Jenkins job type!")
     }
+}
+
+/*
+* Checks if mandatory arguments are set.
+*/
+def validate_arguments(ARGS) {
+    for (arg in ARGS) {
+        if (!params.get(arg)) {
+            error("Must specify ${arg}")
+        }
+
+        if (arg == 'PLATFORM') {
+            // set SPEC - a groovy variable - here
+            // SPEC cannot be a build parameter because build parameters are
+            // exported as environment variables and it will overwrite the
+            // make SPEC variable set in the configure phase in build.build() method
+            SPEC = params.get(arg)
+        }
+    }
+}
+
+/*
+* Prints the error stack trace.
+*/
+def printStackTrace(e) {
+    def writer = new StringWriter()
+    e.printStackTrace(new PrintWriter(writer))
+    echo e.toString()
 }
 
 return this

--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+ARGS = ['SDK_VERSION', 'PLATFORM']
+
+timeout(time: 10, unit: 'HOURS') {
+    timestamps {
+        node('master') {
+            try{
+                retry(5){
+                    checkout scm
+                }
+
+                variableFile = load 'buildenv/jenkins/common/variables-functions'
+
+                // identify the pipeline type: build, test or pull request and
+                // initialize required variables
+                if (run_tests()) {
+                    if (!params.ghprbPullId) {
+                        // test pipeline
+                        variableFile.set_job_variables('test')
+                    } else {
+                        // pull request pipeline
+                        variableFile.set_job_variables('pullRequest')
+                    }
+                } else {
+                    // build or pull request compile only pipeline 
+                    variableFile.set_job_variables('build')
+                }
+
+                if (!params.UPSTREAM_JOB_NAME && !params.UPSTREAM_JOB_NAME) {
+                    // the test pipeline requires resources(e.g. a jdk) from an
+                    // upstream build pipeline identified by the UPSTREAM_JOB_NAME,
+                    // UPSTREAM_JOB_NAME parameters
+                    // if they are not set then it is not a test pipeline, could be
+                    // a build or a pull request pipeline, thus load resource here
+                    // to avoid another source checkout on the slave
+                    buildFile = load 'buildenv/jenkins/common/build'
+                }
+            } finally {
+                try{
+                    cleanWs()
+                } catch(e) {
+                    variableFile.printStackTrace(e)
+                }
+            }
+        }
+    }
+
+    node("${NODE}") {
+        if (!run_tests()) {
+            // build or pull request compile only pipeline: compile, archive,
+            // clean up
+            buildFile.build_all()
+        } else {
+            checkout scm
+            testFile = load 'buildenv/jenkins/common/test'
+
+            if (params.UPSTREAM_JOB_NAME && params.UPSTREAM_JOB_NUMBER) {
+                // test pipeline: fetch resources from upstream job, run tests,
+                // archive results, clean up
+                testFile.test_all_with_fetch()
+            } else {
+                // pull request pipeline: compile, run tests, archive results,
+                // clean up
+                buildFile.build_pr()
+                testFile.test_all()
+            }
+        }
+    }
+}
+
+/*
+* Returns true if TEST_TARGET Jenkins build parameter is set to any value
+* except 'none', otherwise returns false.
+*/
+def run_tests() {
+    return (params.TEST_TARGET && (params.TEST_TARGET != 'none'))
+}

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+ARGS = ['SDK_VERSION', 'PLATFORM']
+
+timestamps {
+    node('master') {
+        try{
+            retry(5) {
+                checkout scm
+            }
+            variableFile = load 'buildenv/jenkins/common/variables-functions'
+            variableFile.set_job_variables('pipeline')
+
+            buildFile = load 'buildenv/jenkins/common/pipeline-functions'
+            SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+        } finally {
+            try{
+                cleanWs()
+            } catch(e) {
+                variableFile.printStackTrace(e)
+            }
+        }
+    }
+}
+
+
+jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS)


### PR DESCRIPTION
- add Jenkins file for build and test any platform
- add pipeline wrapper for any platform
These Jenkins files allow the OpenJ9 extensions build and test for any
supported version and platform. New platforms can be added easily
without creating new Jenkins files only parameterized Jenkins jobs.
Pipeline-Build-Test-Any-Platform could also replace the all of the
Pipeline-Build-Test-JDK\<version\>-\<platform\> wrappers.
Build-Test-Any-Platform could replace all of the
Build-JDK\<version\>-\<platform\>, Test-Sanity-JDK\<version\>-\<platform\>, Test-Extended-JDK\<version\>-\<platform\> and PullRequest-*-JDK\<version\>-\<platform\> scripts.

Fixes #1897

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>