### PR TITLE
Add Windows x86 32 bits support to Jenkins pipeline 

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -34,13 +34,14 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - Linux s390x (zLinux)
     - Linux PPCLE (pLinux)
     - AIX PPC (aix)
-    - Windows (win)
+    - Windows 64 bits (win)
+    - Windows 32 bits (win32) - supported on JDK8 only
 - Current supported Java verisons are Java8 and Java9
 - OpenJ9 committers can request builds by commenting in a pull request
     - Format: `Jenkins <build type> <level> <platform(s)> <java version(s)>`
     - Build Types: compile,test
     - Levels: sanity,extended (only if Build Type is test)
-    - Platforms: xlinux,xlinuxlargeheap,zlinux,plinux,aix,win
+    - Platforms: xlinux,zlinux,plinux,aix,win,win32
     - Java Versions: jdk8,jdk9,jdk10
 - Note: You can use keyword `all` for level, platform or version
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -20,13 +20,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def SDK_VERSIONS = ['8', '9', '10']
-def SPECS = ['linux_ppc-64_cmprssptrs_le',
-            'linux_390-64_cmprssptrs',
-            'aix_ppc-64_cmprssptrs',
-            'linux_x86-64_cmprssptrs',
-            'linux_x86-64',
-            'win_x86-64_cmprssptrs']
+def SPECS = ['aix_ppc-64_cmprssptrs'      : ['8', '9', '10'],
+             'linux_390-64_cmprssptrs'    : ['8', '9', '10'],
+             'linux_ppc-64_cmprssptrs_le' : ['8', '9', '10'],
+             'linux_x86-64'               : ['8', '9', '10'],
+             'linux_x86-64_cmprssptrs'    : ['8', '9', '10'],
+             'win_x86'                    : ['8'],
+             'win_x86-64_cmprssptrs'      : ['8', '9', '10']]
+
 
 def OPENJDK_REPOS = ['8': 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git',
                      '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git',
@@ -56,22 +57,23 @@ timeout(time: 10, unit: 'HOURS') {
         // update build description
         currentBuild.description = "OpenJ9: ${OPENJ9_SHA}<br/>OMR: ${OMR_SHA}"
 
-        SDK_VERSIONS.each { SDK_VERSION ->
-            def OPENJDK_REPO = OPENJDK_REPOS["${SDK_VERSION}"]
-            def OPENJDK_BRANCH = OPENJDK_BRANCHES["${SDK_VERSION}"]
-            def OPENJDK_SHA = buildFile.get_sha(OPENJDK_REPO, OPENJDK_BRANCH)
+        echo "OPENJ9_SHA:${OPENJ9_SHA}"
+        echo "OMR_SHA:${OMR_SHA}"
 
-            // append OpenJDK SHA to the build description
-            currentBuild.description += "<br/>OpenJDK${SDK_VERSION}: ${OPENJDK_SHA}"
+        def OPENJDK_SHAS = [:]
+        OPENJDK_REPOS.each { RELEASE, REPO ->
+            OPENJDK_SHAS["${RELEASE}"] = buildFile.get_sha(REPO, OPENJDK_BRANCHES["${RELEASE}"])
 
-            echo "Building OpenJ9 extensions for OpenJDK${SDK_VERSION}"
-            echo "OPENJDK_REPO = ${OPENJDK_REPO}"
-            echo "OPENJDK_BRANCH = ${OPENJDK_BRANCH}"
-            echo "OPENJDK_SHA:${OPENJDK_SHA}"
-            echo "OPENJ9_SHA:${OPENJ9_SHA}"
-            echo "OMR_SHA:${OMR_SHA}"
+            currentBuild.description += "<br/>OpenJDK${RELEASE}: ${OPENJDK_SHAS[RELEASE]}"
+            echo "OPENJDK${RELEASE}_SHA:${OPENJDK_SHAS[RELEASE]}"
+        }
 
-            SPECS.each { SPEC ->
+        SPECS.each { SPEC, SDK_VERSIONS ->
+            SDK_VERSIONS.each { SDK_VERSION ->
+                def OPENJDK_REPO = OPENJDK_REPOS["${SDK_VERSION}"]
+                def OPENJDK_BRANCH = OPENJDK_BRANCHES["${SDK_VERSION}"]
+                def OPENJDK_SHA = OPENJDK_SHAS["${SDK_VERSION}"]
+
                 builds["build_JDK${SDK_VERSION} ${SPEC}"] = { build(OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, SDK_VERSION, SPEC) }
              }
         }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -242,3 +242,20 @@ win_x86-64_cmprssptrs:
       8: 'hw.arch.x86 && sw.os.windows'
       9: 'hw.arch.x86 && sw.os.windows'
       10: 'hw.arch.x86 && sw.os.windows'
+#========================================#
+# Windows x86 32bits 
+#========================================#
+win_x86:
+  boot_jdk:
+    8: '/cygdrive/c/openjdk/jdk7'
+  release:
+    8: 'windows-x86-normal-server-release'
+  extra_configure_options:
+    8: '--with-freetype-include=/cygdrive/c/openjdk/freetype-2.5.3/include --with-freetype-lib=/cygdrive/c/openjdk/freetype-2.5.3/lib32 --with-target-bits=32 --disable-ccache'
+  freemarker: '/cygdrive/c/openjdk/freemarker.jar'
+  openjdk_reference_repo: 'C:\openjdk\openjdk_cache'
+  node_labels:
+    build:
+      8: 'hw.arch.x86 && sw.os.windows'
+    test:
+      8: 'hw.arch.x86 && sw.os.windows'


### PR DESCRIPTION
- add Windows x86 32 bits to variable file
- add Windows x86 32 bits support for JDK8 only - the only JDK level with win 32 bits support - to the pipelines wrapper. Reformat the Pipeline-Build-Test-All script support platforms per release. This allows to add new platforms for one or more releases.
- update README file

[ci skip]

Depends on PR #2093

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>