### PR TITLE
Print Memory Stats

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2713,6 +2713,13 @@ void TR::CompilationInfo::stopCompilationThreads()
          fprintf(stderr, "Allocated memory for profile info = %d KB\n", getJProfilerThread()->getProfileInfoFootprint()/1024);
       }
 
+   static char * printPersistentMem = feGetEnv("TR_PrintPersistentMem");
+   if (printPersistentMem)
+      {
+      if (trPersistentMemory)
+         trPersistentMemory->printMemStats();
+      }
+
    TR_DataCacheManager::getManager()->printStatistics();
 
    bool aotStatsEnabled = TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableAOTStats);

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -6554,6 +6554,9 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
          // number of processors might change
          if (crtTime > lastProcNumCheck + 300000) // every 5 mins
             {
+            if (trPersistentMemory && TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseJitMemory))
+               trPersistentMemory->printMemStatsToVlog();
+
             // time to reevaluate the number of processors
             compInfo->computeAndCacheCpuEntitlement();
             uint32_t tempProc = compInfo->getNumTargetCPUs(); // TODO is this needed?


### PR DESCRIPTION
Added the printing of JIT memory stats at shutdown if the `TR_PrintPersistentMem` env var is set, and every 5 minutes in the vlog if `verbose={jitMemory}` is set.

Depends on https://github.com/eclipse/omr/pull/2542