### PR TITLE
Add unnamed modules to read set of transformed classes

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -742,6 +742,16 @@ callDynamicLoader(J9JavaVM * vm, J9LoadROMClassData *loadData, U_8 * intermediat
 			FALSE, /* isIntermediateROMClass */
 			localBuffer);
 
+	/* The module of a class transformed by a JVMTI agent needs access to unnamed modules */
+	if (classFileBytesReplacedByRIA || classFileBytesReplacedByRCA) {
+		J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
+		J9Module *module = vm->internalVMFunctions->findModuleForPackage(currentThread, loadData->classLoader,
+				loadData->className, (U_32) packageNameLength(loadData->romClass));
+		if (NULL != module) {
+			module->isLoose = TRUE;
+		}
+	}
+
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_RECREATE_CLASSFILE_ONLOAD)) {
 		if (BCT_ERR_NO_ERROR == result) {
 			U_8 * classFileBytes = NULL;


### PR DESCRIPTION
Classes modified by JVMTI via ClassFileLoadHook need their modules
to read the unnamed modules of the bootstrap and application classloaders.

Fixes #2054

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>