### PR TITLE
WIP: backOffFromSafePoint in CS

### DIFF
--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -1148,7 +1148,7 @@ MM_RealtimeMarkingScheme::scanSoftReferenceObjects(MM_EnvironmentRealtime *env)
 		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_gcExtensions->referenceObjectLists[listIndex];
 			referenceObjectList->startSoftReferenceProcessing();
-			processReferenceList(env, NULL, referenceObjectList->getPriorSoftList(), &gcEnv->_markJavaStats._weakReferenceStats);
+			processReferenceList(env, NULL, referenceObjectList->getPriorSoftList(), &gcEnv->_markJavaStats._softReferenceStats);
 			_scheduler->condYieldFromGC(env);
 		}
 	}
@@ -1166,7 +1166,7 @@ MM_RealtimeMarkingScheme::scanPhantomReferenceObjects(MM_EnvironmentRealtime *en
 		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_gcExtensions->referenceObjectLists[listIndex];
 			referenceObjectList->startPhantomReferenceProcessing();
-			processReferenceList(env, NULL, referenceObjectList->getPriorPhantomList(), &gcEnv->_markJavaStats._weakReferenceStats);
+			processReferenceList(env, NULL, referenceObjectList->getPriorPhantomList(), &gcEnv->_markJavaStats._phantomReferenceStats);
 			_scheduler->condYieldFromGC(env);
 		}
 	}


### PR DESCRIPTION
Fix a problem where a thread wants to acquire safePointVMaccess, while a
Concurrent Scavenger (CS) cycle is about to start (exclusive access has
already been requested). An example is a thread wanting to acquire
safePointVMaccess is to do class replacement heap walk.

In the transition from the first STW increment to the concurrent phase
of a CS cycle, the master thread would appear that it still holds VM
access (and prevents any other party acquiring safePoint or exclusive VM
access), but in reality the the other party would be oblivious of this
fact. 

The fix is for Master GC thread to call backOffFromSafePoint at the end
of first STW increment, which will transition itself from a Safe Point
state (which has been created when Safe Point access request has been
raised, since Master thread was inactive/safe at that point) to an
unsafe state (and holding VM assess). That transition, will make the
thread that requested safePoint VM access become aware of one more
thread holding VM access and wait for it for respond.

The end effect is, the safePoint VM access will be obatined only when
master GC thread releases VM access, hence there are no active GC
threads mutating the heap and potentially preventing from safely walking
it.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>