### PR TITLE
Add test for modular findResource

### DIFF
--- a/test/functional/Java9andUp/playlist.xml
+++ b/test/functional/Java9andUp/playlist.xml
@@ -335,4 +335,24 @@
 			<subset>SE110</subset>
 		</subsets>
 	</test>
+	<test>
+		<testCaseName>TestClassLoaderFindResource</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestClassLoaderFindResource \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
 </playlist>

--- a/test/functional/Java9andUp/src/org/openj9/test/modularity/TestClassLoader.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/modularity/TestClassLoader.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.modularity;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class TestClassLoader extends URLClassLoader {
+	public TestClassLoader(String name, URL[] urls, ClassLoader parent) {
+		super(name, urls, parent);
+	}
+	public TestClassLoader(URL[] urls) {
+		super(urls);
+	}
+	@Override
+	public URL findResource(String moduleName, String name) throws IOException {
+		return super.findResource(moduleName, name);
+	}		
+}

--- a/test/functional/Java9andUp/src/org/openj9/test/modularity/TestClassLoaderFindResource.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/modularity/TestClassLoaderFindResource.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.modularity;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+
+import org.openj9.test.util.FileUtilities;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+@Test(groups = { "level.extended" })
+public class TestClassLoaderFindResource {
+	private static final byte[] HELLO_WORLD_BYTES = "hello, world\n".getBytes();
+	private static final String TESTFILE_TXT = "testfile.txt";
+	private static final File TEMP_DIR = new File(System.getProperty("java.io.tmpdir"));
+	private File workDir;
+	private File testFile;
+
+	@Test
+	public void testFindresourceNullModule() throws IOException {
+		try (TestClassLoader ldr = new TestClassLoader(createURLList())) {
+			URL res = ldr.findResource(null, TESTFILE_TXT);
+			checkResource(res);
+		}
+	}
+
+	@Test
+	public void testFindresourceNonModular() throws IOException {
+		try (TestClassLoader ldr = new TestClassLoader(createURLList())) {
+			URL res = ldr.findResource(TESTFILE_TXT);
+			checkResource(res);
+		}
+	}
+
+	void checkResource(URL res) throws FileNotFoundException, IOException {
+		assertNotNull(res, "Resource not found");
+		FileInputStream resStream = new FileInputStream(res.getFile());
+		byte[] resultBytes = resStream.readAllBytes();
+		resStream.close();
+		assertTrue(Arrays.equals(HELLO_WORLD_BYTES, resultBytes));
+	}
+	
+	@BeforeMethod
+	public void setup(Method testMethod) throws FileNotFoundException, IOException {
+		String methodName = testMethod.getName();
+		workDir = new File(TEMP_DIR, methodName);
+		workDir.deleteOnExit();
+		workDir.mkdir();
+		testFile = new File(workDir, TESTFILE_TXT);
+		testFile.createNewFile();
+		testFile.deleteOnExit();
+		try (FileOutputStream s = new FileOutputStream(testFile)) {
+			s.write(HELLO_WORLD_BYTES);
+		}
+	}
+
+	private URL[] createURLList() throws MalformedURLException {
+		URL urlList[] = new URL[1];
+		urlList[0] = workDir.toURI().toURL();
+		return urlList;
+	}
+
+	@AfterMethod
+	public void teardown() throws IOException {
+		FileUtilities.deleteRecursive(workDir);
+	}
+}

--- a/test/functional/Java9andUp/testng.xml
+++ b/test/functional/Java9andUp/testng.xml
@@ -112,4 +112,9 @@
 			<class name="org.openj9.test.access.staticAccessChecks.DenyAccess" />
 		</classes>
     </test>
+	<test name="TestClassLoaderFindResource">
+		<classes>
+			<class name="org.openj9.test.modularity.TestClassLoaderFindResource" />
+		</classes>
+    </test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
Test case for https://github.com/eclipse/openj9/pull/1947.
This tests findResource from the null module and non-modular
classloaders.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>