### PR TITLE
Update labels in line with recent changes

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -24,13 +24,17 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 Documentation
 =============
 
-This directory contains documentation about various components in OpenJ9
-
-* **`compiler`**: Documentation about the compiler technology, codenamed
-  Testarossa. 
+This directory contains the following types of documentation:
 
 * **`processes`**: Documentation about the processes used in OpenJ9.
 
-Much documentation about OpenJ9 is best considered in tandem with the
+* **`release-notes`**: Release notes for different releases of OpenJ9.
+
+* **`compiler`**: Documentation about the compiler technology, codenamed
+  Testarossa.
+
+* **`diagnostics`**: Documentation about the diagnostic component of OpenJ9.
+
+Documentation about OpenJ9 technology or components is best considered in tandem with the
 [documentation from Eclipse OMR](https://github.com/eclipse/omr/tree/master/doc),
 as OpenJ9 is built upon the foundational technologies provided by OMR.

--- a/doc/processes/labels.md
+++ b/doc/processes/labels.md
@@ -31,7 +31,7 @@ Priority
 Describe the priority of the particular issue.
 
 * `pri:high`
-* `pri:medium` 
+* `pri:medium`
 * `pri:low`
 
 
@@ -40,7 +40,7 @@ JDK
 Indicate if this issue is specific for a given JDK level, such as JDK8.
 
 * `jdk8`
-* `jdk9` 
+* `jdk9`
 * `jdk10`
 * `jdk11`
 
@@ -57,13 +57,13 @@ contributors for a particular area to the relevant items.
 * `comp:doc`
 * `comp:gc`
 * `comp:build`
-* `comp:port` 
+* `comp:port`
 
 
 Dependencies
 ---
 OpenJ9 builds with several other projects: 'Eclipse OMR' & an 'OpenJDK
-extensions for OpenJ9' repo for each JDK level.  These labels help to 
+extensions for OpenJ9' repo for each JDK level.  These labels help to
 identify dependent changes to ensure they are merged together or in the
 correct order:
 
@@ -86,17 +86,17 @@ Labels for issues that affect performance or footprint.
 * `perf`
 * `footprint`
 
-Documentation
+External documentation
 ---
-Labels to indicate a PR or issues should be tagged in the release notes
-or the What's New documentation.
+Label to indicate that a PR or issue requires external documentation (new feature / change in
+  behavior / limitation).
 
-* `doc:releasenote`
-* `doc:whatsnew`
+* `doc:externals`
+
+**Note:** When you use this label, you must open an [issue](https://github.com/eclipse/openj9-docs/issues/new?template=new-documentation-change.md) in the OpenJ9 documentation repo.
 
 End User issues
 ---
 To indicate an issue has been raised by an end user or affects the User-experience rather than being a developer-centric issue.
 
 * `userRaised`
-


### PR DESCRIPTION
doc:whatsnew and doc:releasenotes have been
replaced with doc:externals.

Also added a link to an issue template in the
OpenJ9 docs repo for external changes.

Tidy up doc README.md to cover other types
of doc now in this directory. E.g.
Release notes.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>