### PR TITLE
Update windows repo cache location

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -197,7 +197,7 @@ win_x86-64_cmprssptrs:
     9: 'windows-x86_64-normal-server-release'
     10: 'windows-x86_64-normal-server-release'
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
-  openjdk_reference_repo: 'C:\openjdk\openjdk_cache'
+  openjdk_reference_repo: '/home/jenkins/openjdk_cache'
   extra_configure_options:
     8: '--with-freetype-include=/cygdrive/c/openjdk/freetype-2.5.3/include --with-freetype-lib=/cygdrive/c/openjdk/freetype-2.5.3/lib64 --disable-ccache'
     9: '--with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-toolchain-version=2013 --disable-ccache'


### PR DESCRIPTION
- Use /home/jenkins to be consistent with other specs
- Makes specs more simple
- Updated ref_repo on machines to new location

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>