### PR TITLE
Runtime recalculate GMP kickoff headroom

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -760,12 +760,6 @@ gcInitializeCalculatedValues(J9JavaVM *javaVM, IDATA* memoryParameters)
 		extensions->tarokRememberedSetCardListMaxSize = 8 * extensions->tarokRememberedSetCardListSize;
 	}
 
-	if (0 == extensions->tarokKickoffHeadroomRegionCount) {
-		/* If kickoff headroom is not set, the default is (arbitrarily chosen to be) 1% of heap */
-		UDATA regionCount = extensions->memoryMax / extensions->regionSize;
-		extensions->tarokKickoffHeadroomRegionCount = regionCount / 100;
-	}
-
 #endif /* defined (J9VM_GC_VLHGC) */
 
 	/* Number of GC threads must be initialized at this point */

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -310,11 +310,25 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
-		if (try_scan(&scan_start, "tarokKickoffHeadroomRegionCount=")) {
-			if(!scan_udata_memory_size_helper(vm, &scan_start, &(extensions->tarokKickoffHeadroomRegionCount), "tarokKickoffHeadroomRegionCount=")) {
+		if (try_scan(&scan_start, "tarokKickoffHeadroomRegionRate=")) {
+			if(!scan_u32_helper(vm, &scan_start, &(extensions->tarokKickoffHeadroomRegionRate), "tarokKickoffHeadroomRegionRate=")) {
 				returnValue = JNI_EINVAL;
 				break;
 			}
+			if (50 < extensions->tarokKickoffHeadroomRegionRate) {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_INTEGER_OUT_OF_RANGE, "tarokKickoffHeadroomRegionRate=", (UDATA)0, (UDATA)50);
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			continue;
+		}
+
+		if (try_scan(&scan_start, "tarokKickoffHeadroomInBytes=")) {
+			if(!scan_udata_memory_size_helper(vm, &scan_start, &(extensions->tarokKickoffHeadroomInBytes), "tarokKickoffHeadroomInBytes=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->tarokForceKickoffHeadroomInBytes = true;
 			continue;
 		}
 

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -650,6 +650,9 @@ MM_IncrementalGenerationalGC::initializeTaxationThreshold(MM_EnvironmentVLHGC *e
 
 	/* we need to calculate the taxation threshold after the initial heap inflation, which happens before collectorStartup */
 	_taxationThreshold = _schedulingDelegate.getInitialTaxationThreshold(env);
+	/* initialize GMP Kickoff Headroom Region Count */
+	_schedulingDelegate.initializeKickoffHeadroom(env);
+
 
 	UDATA minimumKickOff = extensions->regionSize * 2;
 	if (_taxationThreshold < minimumKickOff) {

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -237,9 +237,26 @@ private:
 	 */
 	double calculateAverageCopyForwardRate(MM_EnvironmentVLHGC *env);
 
+	/**
+	 * Estimate total free memory
+	 * @param env[in] the master GC thread
+	 * @oaram freeRegionMemory[in]
+	 * @param defragmentedMemory[in]
+	 * @oaram reservedFreeMemory[in]
+	 * @return total free memory(bytes)
+	 */
+	UDATA estimateTotalFreeMemory(MM_EnvironmentVLHGC *env, UDATA freeRegionMemory, UDATA defragmentedMemory, UDATA reservedFreeMemory);
+
+	/**
+	 * Calculate GMP Kickoff Headroom In Bytes
+	 * the
+	 */
+	UDATA calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, UDATA totalFreeMemory);
+
 protected:
 	
 public:
+	UDATA initializeKickoffHeadroom(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Calculate the allocation threshold for the first taxation period. This should be called


### PR DESCRIPTION

	- GMP kickoff Headroom was set 1% of heap by default or 
	set by user via -XXgc:tarokKickoffHeadroomRegionCount=.
	- fixed size headroom count could be too big or too small for 
	some special cases, then trigger the GMP too early or too late.
	- new tarokKickoffHeadroomRegionRate(default 2% can be set via
	-XXgc:tarokKickoffHeadroomRegionRate=nn, 0% <= nn<=50%) base on
	current free memory(not include eden and survivor) for calculating
	the headroom in bytes.
	- update -XXgc:tarokKickoffHeadroomRegionCount= option to 
	-XXgc:tarokKickoffHeadroomInBytes to allow the headroom be a 
	fraction of region size.
	- tarokKickoffHeadroomInBytes is initialized during 
	initializeTaxationThreshold.
	- tarokKickoffHeadroomInBytes is recalculating during
	calculatePGCCompactionRate.

depends eclipse/omr#2646

Signed-off-by: Lin Hu <linhu@ca.ibm.com>