### PR TITLE
Increase highly polymorphic callsite threshold

### DIFF
--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -433,7 +433,7 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
    }
 
 bool
-TR_PersistentCHTable::hasTwoOrMoreCompiledImplementors(
+TR_PersistentCHTable::hasThreeOrMoreCompiledImplementors(
    TR_OpaqueClassBlock * thisClass, int32_t cpIndex, TR_ResolvedMethod * callerMethod, TR::Compilation * comp, TR_Hotness hotness, bool locked)
    {
    if (comp->getOption(TR_DisableCHOpts))
@@ -445,8 +445,8 @@ TR_PersistentCHTable::hasTwoOrMoreCompiledImplementors(
    TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, true);
    if (!classInfo) return false;
 
-   TR_ResolvedMethod *implArray[2];
-   return TR_ClassQueries::collectCompiledImplementorsCapped(classInfo,implArray,2,cpIndex,callerMethod,comp,hotness,locked) == 2;
+   TR_ResolvedMethod *implArray[3];
+   return TR_ClassQueries::collectCompiledImplementorsCapped(classInfo,implArray,3,cpIndex,callerMethod,comp,hotness,locked) == 3;
    }
 
 int32_t

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -68,7 +68,7 @@ class TR_PersistentCHTable
    TR_OpaqueClassBlock *findSingleConcreteSubClass(TR_OpaqueClassBlock *, TR::Compilation *);
    TR_ResolvedMethod * findSingleImplementer(TR_OpaqueClassBlock * thisClass, int32_t cpIndexOrVftSlot, TR_ResolvedMethod * callerMethod, TR::Compilation * comp, bool locked, TR_YesNoMaybe useGetResolvedInterfaceMethod);
 
-   bool hasTwoOrMoreCompiledImplementors(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, TR_Hotness hotness = warm, bool locked = false);
+   bool hasThreeOrMoreCompiledImplementors(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, TR_Hotness hotness = warm, bool locked = false);
    int32_t findnInterfaceImplementers(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *implArray[], int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false);
    TR_ResolvedMethod * findSingleJittedImplementer(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, TR::ResolvedMethodSymbol*, bool locked = false);
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2867,7 +2867,7 @@ TR_J9VMBase::maybeHighlyPolymorphic(TR::Compilation *comp, TR_ResolvedMethod *ca
          int len = 1;
          traceMsg(comp, "maybeHighlyPolymorphic classOfMethod: %s yizhang\n", getClassNameChars(classOfMethod, len));
          TR_PersistentCHTable *chTable = comp->getPersistentInfo()->getPersistentCHTable();
-         if (chTable->hasTwoOrMoreCompiledImplementors(classOfMethod, cpIndex, caller, comp, warm))
+         if (chTable->hasThreeOrMoreCompiledImplementors(classOfMethod, cpIndex, caller, comp, warm))
             {
             return true;
             }


### PR DESCRIPTION
This change increases the threshold for considering a callsite as highly
polymorphic from 2 implementors to 3. This change was found to improve
the inlining decisions in an internal appserver benchmark which lead to
an improvement in throughput.

Issue: #2124

Signed-off-by: jimmyk <jimmyk@ca.ibm.com>