### PR TITLE
Add frontend method getVFT entry to read the virtual function table

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8590,6 +8590,11 @@ TR_J9VM::getPrimitiveArrayAllocationClass(J9Class *clazz)
    return (TR_OpaqueClassBlock *) clazz;
    }
 
+intptrj_t
+TR_J9VMBase::getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset)
+   {
+   return *(intptrj_t*) (((uint8_t *)clazz) + offset);
+   }
 
 
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1005,6 +1005,8 @@ public:
    virtual void *getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *classPointer);
    virtual bool isMethodBreakpointed(TR_OpaqueMethodBlock *method);
 
+   virtual intptrj_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset);
+
    protected:
 #if defined(TR_TARGET_S390)
    int32_t getS390MachineName(TR_S390MachineType machine, char* processorName, int32_t stringLength);


### PR DESCRIPTION
Currently, VP directly reads this from the class pointer (in OMR). We would like to avoid having the optimizer directly read fields from classes. This change is required for JITaaS support.

Signed-off-by: Noah Weninger <noah.weninger@ibm.com>