### PR TITLE
Call OMR::CodeGenPhaseConnector in the extensible class on Z

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -170,14 +170,13 @@ J9::CodeGenPhase::getName(TR::CodeGenPhase::PhaseValue phase)
       case SplitWarmAndColdBlocksPhase:
          return "SplitWarmAndColdBlocks";
       case IdentifyUnneededByteConvsPhase:
-	 return "IdentifyUnneededByteConvsPhase";
+	      return "IdentifyUnneededByteConvsPhase";
       case FoldSignCleaningIntoStorePhase:
          return "FoldSignCleaningIntoStore";
       case LateSequentialConstantStoreSimplificationPhase:
          return "LateSequentialConstantStoreSimplification";
       default:
-         // call parent class for common phases
-         return OMR::CodeGenPhase::getName(phase);
+         return OMR::CodeGenPhaseConnector::getName(phase);
       }
    }
 

--- a/runtime/compiler/z/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,8 +90,7 @@ J9::Z::CodeGenPhase::getName(TR::CodeGenPhase::PhaseValue phase)
       case UncommonBCDCHKAddressNodePhase:
          return "UncommonBCDCHKAddressNodePhase";
       default:
-	 // call parent class for common phases
-	 return J9::CodeGenPhase::getName(phase);
+	      return J9::CodeGenPhase::getName(phase);
       }
    }
 


### PR DESCRIPTION
The CodeGenPhase extensible class extensions should call OMR::CodeGenPhaseConnector to make sure it calls the platform specific extension point, otherwise we will end up calling the non-platform specific extension and we may miss some switch cases.

This fixes an issue when building a debug build on Linux on Z which complains that:

```
TR::CodeGenPhase 19 doesn't have a corresponding name.
```

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>