### PR TITLE
Ensure cpTypeDescription and cpIndex are from the same class

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1146,7 +1146,11 @@ resolveSpecialMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 		 */
 		if (currentClass != NULL) {
 			if ((resolvedClass->romClass != NULL) && (currentClass->romClass != NULL)) {
-				UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(currentClass->romClass), cpIndex);
+				/* Ensure the cpType is taken from the original class.  The cpIndex
+				 * and J9Class must match, even if a redefinition occurs, or the
+				 * check may incorrectly fail.
+				 */
+				UDATA cpType = J9_CP_TYPE(J9ROMCLASS_CPSHAPEDESCRIPTION(J9_CLASS_FROM_CP(ramCP)->romClass), cpIndex);
 				if (J9_JAVA_INTERFACE == (resolvedClass->romClass->modifiers & J9_JAVA_INTERFACE)) {
 					if ((J9CPTYPE_INTERFACE_INSTANCE_METHOD != cpType)
 					&& (J9CPTYPE_INTERFACE_STATIC_METHOD != cpType)


### PR DESCRIPTION
Mixing the cpIndex and cpTypeDescription from two different versions
of the same class can result in incorrect data being used as the
constantpool is not kept consistent between two different versions
of the same class.

This commit only updates invokespecial as resolves of
invokestatic and invokevirtual were already correct.

Fixes: #2128

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>