### PR TITLE
Update readme for dependent branches

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -68,9 +68,11 @@ You can also request a Pull Request build from the extensions repos or openj9-om
 ##### Dependent Changes
 
 - If you have dependent change(s) in either eclipse/omr, eclipse/openj9-omr, or ibmruntimes/openj9-openjdk-jdk\*, you can build & test with all needed changes
-- Request a build by including the PR ref in your trigger comment
+- Request a build by including the PR ref or branch name in your trigger comment
 - Ex. Dependent change in OMR Pull Request `#123`
     - `Jenkins test sanity depends eclipse/omr#123`
+- Ex. Dependent change in eclipse/omr master branch (useful if a dependent OMR PR is already merged)
+    - `Jenkins test sanity depends eclipse/omr#master`
 - Ex. Dependent change in OpenJ9-OMR Pull Request `#456`
     - `Jenkins test sanity depends eclipse/openj9-omr#456`
 - Ex. Dependent change in OpenJDK Pull Request `#789`


### PR DESCRIPTION
PullRequests support building with dependent changes
in branches now too. This is particularly useful
when you have an OMR change that was merged and
your change is dependent. Because the PR is merged,
you cannot build with the dependent PR because the
merge ref is removed when the PR is merged. The default
branch to build omr is openj9. If you build against
master, you will pickup the merged dependent PR.

Issue #827
Related #1698
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>