### PR TITLE
Fixed issue with deleting the temp file with OpenJ9DiagnosticsMXBean test

### DIFF
--- a/test/functional/JLM_Tests/src/org/openj9/test/management/JvmCpuMonitorMXBeanTest.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/management/JvmCpuMonitorMXBeanTest.java
@@ -55,7 +55,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.CountDownLatch;
-import java.util.Random;
 
 import org.openj9.test.management.util.*;
 import com.ibm.lang.management.*;
@@ -87,7 +86,7 @@ public class JvmCpuMonitorMXBeanTest {
 	 * @param args
 	 */
 	@Test
-	public void runJvmCpuMonitorMXBeanTest() {
+	public void runJvmCpuMonitorMXBeanTest() throws IOException {
 		int retryCounter = 0;
 		boolean localTest = true;
 		boolean isConnected = false;
@@ -407,7 +406,7 @@ public class JvmCpuMonitorMXBeanTest {
 	/**
 	 * Internal function: Starts a remote server to connect to.
 	 */
-	private static void startRemoteMonitor() {
+	private static void startRemoteMonitor() throws IOException {
 		logger.info("Starting Remote Server to Monitor!");
 
 		ArrayList<String> argBuffer = new ArrayList<String>();
@@ -417,8 +416,8 @@ public class JvmCpuMonitorMXBeanTest {
 		 * for its existence on the file-system. When this goes missing, it implies the child
 		 * process is up and running.
 		 */
-		Random randomGenerator = new Random();
-		String tmpName = System.getProperty("java.io.tmpdir") + fs + randomGenerator.nextInt(10000) + ".lock";
+		File file = File.createTempFile("tmp", ".lock");
+		String tmpName = file.getAbsolutePath();
 
 		String javaExec = System.getProperty("java.home") + fs + "bin" + fs + "java";
 		argBuffer.add(javaExec);

--- a/test/functional/JLM_Tests/src/org/openj9/test/management/ProcessLocking.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/management/ProcessLocking.java
@@ -23,9 +23,6 @@ package org.openj9.test.management;
 
 import java.io.*;
 import java.io.BufferedReader;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 
 import org.testng.log4testng.Logger;
 
@@ -35,9 +32,6 @@ public class ProcessLocking {
 
 	private String tmpdir;
 	private File file;
-	private RandomAccessFile randomAccessFile;
-	private FileChannel fileChannel;
-	private FileLock fileLock;
 	private InputStream in;
 	private InputStreamReader inStream;
 	private BufferedReader br;
@@ -45,8 +39,6 @@ public class ProcessLocking {
 	public ProcessLocking(String filename) {
 		try {
 			file = new File(filename);
-			randomAccessFile = new RandomAccessFile(file, "rw");
-			fileChannel = randomAccessFile.getChannel();
 		} catch (Exception e) {
 			logger.error("Unexpected exception occured " + e.getMessage(), e);
 		}


### PR DESCRIPTION
Fixed issue with deleting the temp file by removing unused fileChannel to the temp file

Signed-off-by: Chandrakala <chandra-ms@in.ibm.com>