### PR TITLE
Optimize JVMTI watched fields

### DIFF
--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -134,7 +134,8 @@ static void jvmtiHookVMStarted (J9HookInterface** hook, UDATA eventNum, void* ev
 static void jvmtiHookModuleSystemStarted (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookClassFileLoadHook (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookResourceExhausted(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
-static jfieldID findWatchedField (J9JVMTIEnv * j9env, UDATA watchFlag, UDATA tag, J9Class * fieldClass);
+static UDATA findFieldIndexFromOffset(J9VMThread *currentThread, J9Class *clazz, UDATA offset, UDATA isStatic, J9Class **declaringClass);
+static jfieldID findWatchedField (J9VMThread *currentThread, J9JVMTIEnv * j9env, UDATA isWrite, UDATA isStatic, UDATA tag, J9Class * fieldClass);
 static void jvmtiHookGetEnv (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookVmDumpStart (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookVmDumpEnd (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
@@ -911,13 +912,15 @@ jvmtiHookFieldAccess(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 		J9Method * method;
 		IDATA location;
 		J9VMThread * currentThread;
-		J9Class * objectClass;
+		J9Class * clazz;
+		UDATA isStatic;
 
 		if (eventNum == J9HOOK_VM_GET_FIELD) {
 			J9VMGetFieldEvent * data = eventData;
 
+			isStatic = FALSE;
 			objectSlot = data->objectAddress;
-			objectClass = J9OBJECT_CLAZZ(data->currentThread, *objectSlot);
+			clazz = J9OBJECT_CLAZZ(data->currentThread, *objectSlot);
 			tag = data->offset;
 			method = data->method;
 			location = data->location;
@@ -925,8 +928,9 @@ jvmtiHookFieldAccess(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 		} else {
 			J9VMGetStaticFieldEvent * data = eventData;
 
+			isStatic = TRUE;
 			objectSlot = NULL;
-			objectClass = NULL;
+			clazz = data->declaringClass;
 			tag = (UDATA) data->fieldAddress;
 			method = data->method;
 			location = data->location;
@@ -935,7 +939,7 @@ jvmtiHookFieldAccess(J9HookInterface** hook, UDATA eventNum, void* eventData, vo
 
 		/* Current thread has VM access, and the field watch list is only modified under exclusive */
 
-		fieldID = findWatchedField(j9env, J9JVMTI_WATCH_FIELD_ACCESS, tag, objectClass);
+		fieldID = findWatchedField(currentThread, j9env, FALSE, isStatic, tag, clazz);
 
 		/* If the current field is not being watched, do nothing */
 
@@ -993,13 +997,15 @@ jvmtiHookFieldModification(J9HookInterface** hook, UDATA eventNum, void* eventDa
 		IDATA location;
 		J9VMThread * currentThread;
 		void * valueAddress;
-		J9Class * objectClass;
+		J9Class * clazz;
+		UDATA isStatic;
 
 		if (eventNum == J9HOOK_VM_PUT_FIELD) {
 			J9VMPutFieldEvent * data = eventData;
 
+			isStatic = FALSE;
 			objectSlot = data->objectAddress;
-			objectClass = J9OBJECT_CLAZZ(data->currentThread, *objectSlot);
+			clazz = J9OBJECT_CLAZZ(data->currentThread, *objectSlot);
 			tag = data->offset;
 			valueAddress = data->valueAddress;
 			currentThread = data->currentThread;
@@ -1008,8 +1014,9 @@ jvmtiHookFieldModification(J9HookInterface** hook, UDATA eventNum, void* eventDa
 		} else {
 			J9VMPutStaticFieldEvent * data = eventData;
 
+			isStatic = TRUE;
 			objectSlot = NULL;
-			objectClass = NULL;
+			clazz = data->declaringClass;
 			tag = (UDATA) data->fieldAddress;
 			valueAddress = data->valueAddress;
 			currentThread = data->currentThread;
@@ -1019,7 +1026,7 @@ jvmtiHookFieldModification(J9HookInterface** hook, UDATA eventNum, void* eventDa
 
 		/* Current thread has VM access, and the field watch list is only modified under exclusive */
 
-		fieldID = findWatchedField(j9env, J9JVMTI_WATCH_FIELD_MODIFICATION, tag, objectClass);
+		fieldID = findWatchedField(currentThread, j9env, TRUE, isStatic, tag, clazz);
 
 		/* If the current field is not being watched, do nothing */
 
@@ -1086,39 +1093,78 @@ jvmtiHookRequiredDebugAttributes(J9HookInterface** hook, UDATA eventNum, void* e
 	TRACE_JVMTI_EVENT_RETURN(jvmtiHookRequiredDebugAttributes);
 }
 
-
-static jfieldID
-findWatchedField(J9JVMTIEnv * j9env, UDATA watchFlag, UDATA tag, J9Class * fieldClass)
+static UDATA
+findFieldIndexFromOffset(J9VMThread *currentThread, J9Class *clazz, UDATA offset, UDATA isStatic, J9Class **declaringClass)
 {
-	jfieldID result = NULL;
-	J9JVMTIWatchedField * watchedField;
-	pool_state poolState;
-
-	/* Scan currently watched fields for one matching the tag and static/instance flag */
-
-	watchedField = pool_startDo(j9env->watchedFieldPool, &poolState);
-	while (watchedField != NULL) {
-		J9JNIFieldID * fieldID = (J9JNIFieldID *) watchedField->fieldID;
-
-		if ((watchedField->flags & watchFlag) != 0) {
-			if (fieldClass == NULL) {
-				if (((fieldID->field->modifiers & J9AccStatic) != 0) && ((((UDATA) fieldID->declaringClass->ramStatics) + fieldID->offset) == tag)) {
-					result = (jfieldID) fieldID;
-					break;
-				}
-			} else {
-				if (((fieldID->field->modifiers & J9AccStatic) == 0) && (fieldID->offset == tag) && isSameOrSuperClassOf(fieldID->declaringClass,fieldClass)) {
-					result = (jfieldID) fieldID;
-					break;
+	UDATA index = 0;
+	J9JavaVM * const vm = currentThread->javaVM;
+	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
+	U_32 const walkFlags = J9VM_FIELD_OFFSET_WALK_INCLUDE_STATIC | J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE;
+	U_32 staticBit = 0;
+	if (isStatic) {
+		staticBit = J9AccStatic;
+		offset -= (UDATA)clazz->ramStatics;
+	}
+	for(;;) {
+		J9ROMClass * const romClass = clazz->romClass;
+		J9Class * const superclazz = GET_SUPERCLASS(clazz);
+		J9ROMFieldOffsetWalkState state;
+		J9ROMFieldOffsetWalkResult *result = vmFuncs->fieldOffsetsStartDo(vm, romClass, superclazz, &state, walkFlags);
+		while (NULL != result->field) {
+			if (staticBit == (result->field->modifiers & J9AccStatic)) {
+				if (offset == result->offset) {
+					if (NULL != declaringClass) {
+						*declaringClass = clazz;
+					}
+					goto done;
 				}
 			}
+			index += 1;
+			result = vmFuncs->fieldOffsetsNextDo(&state);
 		}
-		watchedField = pool_nextDo(&poolState);
+		/* Static fields must be found in the input class */
+		Assert_JVMTI_false(isStatic);
+		/* Instance fields may come from any superclass */
+		clazz = superclazz;
+		Assert_JVMTI_notNull(clazz);
+		/* Start the index counting again for each superclass */
+		index = 0;
 	}
-
-	return result;
+done:
+	return index;
 }
 
+static jfieldID
+findWatchedField(J9VMThread *currentThread, J9JVMTIEnv * j9env, UDATA isWrite, UDATA isStatic, UDATA tag, J9Class * fieldClass)
+{
+	jfieldID result = NULL;
+	J9Class *declaringClass = NULL;
+	J9JVMTIWatchedClass *watchedClass = NULL;
+	UDATA index = findFieldIndexFromOffset(currentThread, fieldClass, tag, isStatic, &declaringClass);
+	watchedClass = hashTableFind(j9env->watchedClasses, &declaringClass);
+	if (NULL != watchedClass) {
+		UDATA *watchBits = (UDATA*)&watchedClass->watchBits;
+		UDATA found = FALSE;
+		if (J9JVMTI_CLASS_REQUIRES_ALLOCATED_J9JVMTI_WATCHED_FIELD_ACCESS_BITS(declaringClass)) {
+			watchBits = watchedClass->watchBits;
+		}
+		if (isWrite) {
+			found = watchBits[J9JVMTI_WATCHED_FIELD_ARRAY_INDEX(index)] & J9JVMTI_WATCHED_FIELD_MODIFICATION_BIT(index);
+		} else {
+			found = watchBits[J9JVMTI_WATCHED_FIELD_ARRAY_INDEX(index)] & J9JVMTI_WATCHED_FIELD_ACCESS_BIT(index);			
+		}
+		if (found) {
+			/* In order for a watch to have been placed, the fieldID for the field in question
+			 * must already have been created (it's a parameter to the JVMTI calls).
+			 */
+			void **jniIDs = declaringClass->jniIDs;
+			Assert_JVMTI_notNull(jniIDs);
+			result = (jfieldID)(jniIDs[index + declaringClass->romClass->romMethodCount]);
+			Assert_JVMTI_notNull(result);
+		}
+	}
+	return result;
+}
 
 static void
 jvmtiHookVMShutdownLast(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
@@ -2325,56 +2371,71 @@ jvmtiHookCheckForDataBreakpoint(J9HookInterface** hook, UDATA eventNum, void* ev
 
 	j9env = pool_startDo(jvmtiData->environments, &envPoolState);
 	while (j9env != NULL) {
-		J9JVMTIWatchedField * watchedField;
-		pool_state watchPoolState;
-
 		/* CMVC 196966: only inspect live (not disposed) environments */
 		if (0 == (j9env->flags & J9JVMTIENV_FLAG_DISPOSED)) {
-			omrthread_monitor_enter(j9env->mutex);
-			watchedField = pool_startDo(j9env->watchedFieldPool, &watchPoolState);
-			while (watchedField != NULL) {
-				J9JNIFieldID * fieldID = (J9JNIFieldID *) watchedField->fieldID;
-				J9ROMFieldShape * romField = fieldID->field;
+			J9HashTableState walkState;
+			J9JVMTIWatchedClass *watchedClass = hashTableStartDo(j9env->watchedClasses, &walkState);
+			while (NULL != watchedClass) {
+				J9Class *clazz = watchedClass->clazz;
+				J9ROMClass *romClass = clazz->romClass;
+				UDATA fieldCount = romClass->romFieldCount;
+				UDATA *watchBits = (UDATA*)&watchedClass->watchBits;
+				UDATA index = 0;
+				UDATA descriptionsRemaining = 0;
+				UDATA descriptionBits = 0;
+				if (fieldCount > J9JVMTI_WATCHED_FIELDS_PER_UDATA) {
+					watchBits = watchedClass->watchBits;				
+				}
+				while (index < fieldCount) {
+					if (0 == descriptionsRemaining) {
+						descriptionsRemaining = J9JVMTI_WATCHED_FIELDS_PER_UDATA;
+						descriptionBits = *watchBits++;
+					}
+					if (descriptionBits & (data->isStore ? 2 : 1)) {
+						/* In order for a watch to have been placed, the fieldID for the field in question
+						 * must already have been created (it's a parameter to the JVMTI calls).
+						 */
+						void **jniIDs = clazz->jniIDs;
+						J9JNIFieldID *fieldID = NULL;
+						J9ROMFieldShape * romField = NULL;
+						Assert_JVMTI_notNull(jniIDs);
+						fieldID = (J9JNIFieldID*)(jniIDs[index + clazz->romClass->romMethodCount]);
+						Assert_JVMTI_notNull(fieldID);
+						romField = fieldID->field;
+						if ((romField->modifiers & J9AccStatic) == (data->isStatic ? J9AccStatic : 0)) {
+							if (data->resolvedField == NULL) {
+								J9UTF8 * romFieldClassName = J9ROMCLASS_CLASSNAME(fieldID->declaringClass->romClass);
 
-				if ((romField->modifiers & J9AccStatic) == (data->isStatic ? J9AccStatic : 0)) {
-					if (watchedField->flags & (data->isStore ? J9JVMTI_WATCH_FIELD_MODIFICATION : J9JVMTI_WATCH_FIELD_ACCESS)) {
-						if (data->resolvedField == NULL) {
-							J9UTF8 * romFieldClassName = J9ROMCLASS_CLASSNAME(fieldID->declaringClass->romClass);
+								if (J9UTF8_EQUALS(resolveClassName, romFieldClassName)) {
+									J9UTF8 * romFieldName = J9ROMFIELDSHAPE_NAME(romField);
 
-							if (J9UTF8_EQUALS(resolveClassName, romFieldClassName)) {
-								J9UTF8 * romFieldName = J9ROMFIELDSHAPE_NAME(romField);
+									if (J9UTF8_EQUALS(resolveName, romFieldName)) {
+										J9UTF8 * romFieldSig = J9ROMFIELDSHAPE_SIGNATURE(romField);
 
-								if (J9UTF8_EQUALS(resolveName, romFieldName)) {
-									J9UTF8 * romFieldSig = J9ROMFIELDSHAPE_SIGNATURE(romField);
-
-									if (J9UTF8_EQUALS(resolveSig, romFieldSig)) {
-										data->result = J9_JIT_RESOLVE_FAIL_COMPILE;
-										break;
+										if (J9UTF8_EQUALS(resolveSig, romFieldSig)) {
+											data->result = J9_JIT_RESOLVE_FAIL_COMPILE;
+											goto done;
+										}
 									}
 								}
-							}
-						} else {
-							if (data->resolvedField == romField) {
-								data->result = J9_JIT_RESOLVE_FAIL_COMPILE;
-								break;
+							} else {
+								if (data->resolvedField == romField) {
+									data->result = J9_JIT_RESOLVE_FAIL_COMPILE;
+									goto done;
+								}
 							}
 						}
 					}
+					index += 1;
 				}
-
-				watchedField = pool_nextDo(&watchPoolState);
-			}
-			omrthread_monitor_exit(j9env->mutex);
-
-			if (data->result == J9_JIT_RESOLVE_FAIL_COMPILE) {
-				break;
+				watchedClass = hashTableNextDo(&walkState);
 			}
 		}
 		j9env = pool_nextDo(&envPoolState);
 	}
-
 	omrthread_monitor_exit(jvmtiData->mutex);
 
+done:
 	TRACE_JVMTI_EVENT_RETURN(jvmtiHookCheckForDataBreakpoint);
 }
 
@@ -3088,29 +3149,18 @@ removeUnloadedAgentBreakpoints(J9JVMTIEnv * j9env, J9VMThread * currentThread, J
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 
-#if (defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)) 
 static void
 removeUnloadedFieldWatches(J9JVMTIEnv * j9env, J9Class * unloadedClass)
 {
-	J9JVMTIWatchedField * watchedField;
-	pool_state poolState;
-
-	/* Remove all watches for fields within the unloaded class */
-
-	watchedField = pool_startDo(j9env->watchedFieldPool, &poolState);
-	while (watchedField != NULL) {
-		J9JNIFieldID * fieldID = (J9JNIFieldID *) watchedField->fieldID;
-
-		if (fieldID->declaringClass == unloadedClass) {
-			pool_removeElement(j9env->watchedFieldPool, watchedField);
+	J9HashTableState walkState;
+	J9JVMTIWatchedClass *watchedClass = hashTableStartDo(j9env->watchedClasses, &walkState);
+	while (NULL != watchedClass) {
+		if (unloadedClass == watchedClass->clazz) {
+			hashTableDoRemove(&walkState);
 		}
-
-		watchedField = pool_nextDo(&poolState);
+		watchedClass = hashTableNextDo(&walkState);
 	}
 }
-
-
-#endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)

--- a/runtime/jvmti/jvmtiWatchedField.c
+++ b/runtime/jvmti/jvmtiWatchedField.c
@@ -23,8 +23,8 @@
 #include "jvmtiHelpers.h"
 #include "jvmti_internal.h"
 
-static jvmtiError setFieldWatch (jvmtiEnv* env, jclass klass, jfieldID field, UDATA flag);
-static jvmtiError clearFieldWatch (jvmtiEnv* env, jclass klass, jfieldID field, UDATA flag);
+static jvmtiError setFieldWatch (jvmtiEnv* env, jclass klass, jfieldID field, UDATA isModification);
+static jvmtiError clearFieldWatch (jvmtiEnv* env, jclass klass, jfieldID field, UDATA isModification);
 
 
 jvmtiError JNICALL
@@ -39,7 +39,7 @@ jvmtiSetFieldAccessWatch(jvmtiEnv* env,
 	ENSURE_PHASE_LIVE(env);
 	ENSURE_CAPABILITY(env, can_generate_field_access_events);
 
-	rc = setFieldWatch(env, klass, field, J9JVMTI_WATCH_FIELD_ACCESS);
+	rc = setFieldWatch(env, klass, field, FALSE);
 
 done:
 	TRACE_JVMTI_RETURN(jvmtiSetFieldAccessWatch);
@@ -58,7 +58,7 @@ jvmtiClearFieldAccessWatch(jvmtiEnv* env,
 	ENSURE_PHASE_LIVE(env);
 	ENSURE_CAPABILITY(env, can_generate_field_access_events);
 
-	rc = clearFieldWatch(env, klass, field, J9JVMTI_WATCH_FIELD_ACCESS);
+	rc = clearFieldWatch(env, klass, field, FALSE);
 
 done:
 	TRACE_JVMTI_RETURN(jvmtiClearFieldAccessWatch);
@@ -77,7 +77,7 @@ jvmtiSetFieldModificationWatch(jvmtiEnv* env,
 	ENSURE_PHASE_LIVE(env);
 	ENSURE_CAPABILITY(env, can_generate_field_modification_events);
 
-	rc = setFieldWatch(env, klass, field, J9JVMTI_WATCH_FIELD_MODIFICATION);
+	rc = setFieldWatch(env, klass, field, TRUE);
 
 done:
 	TRACE_JVMTI_RETURN(jvmtiSetFieldModificationWatch);
@@ -96,7 +96,7 @@ jvmtiClearFieldModificationWatch(jvmtiEnv* env,
 	ENSURE_PHASE_LIVE(env);
 	ENSURE_CAPABILITY(env, can_generate_field_modification_events);
 
-	rc = clearFieldWatch(env, klass, field, J9JVMTI_WATCH_FIELD_MODIFICATION);
+	rc = clearFieldWatch(env, klass, field, TRUE);
 
 done:
 	TRACE_JVMTI_RETURN(jvmtiClearFieldModificationWatch);
@@ -107,7 +107,7 @@ static jvmtiError
 setFieldWatch(jvmtiEnv* env,
 	jclass klass,
 	jfieldID field,
-	UDATA flag)
+	UDATA isModification)
 {
 	J9JVMTIEnv * j9env = (J9JVMTIEnv *) env;
 	J9JavaVM * vm = j9env->vm;
@@ -116,8 +116,13 @@ setFieldWatch(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		pool_state poolState;
-		J9JVMTIWatchedField * watchedField;
+		J9Class *clazz = NULL;
+		J9JNIFieldID *fieldID = NULL;
+		UDATA localFieldIndex = 0;
+		UDATA fieldCount = 0;
+		UDATA *watchBits = NULL;
+		UDATA watchBit = 0;
+		J9JVMTIWatchedClass *watchedClass = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -126,44 +131,59 @@ setFieldWatch(jvmtiEnv* env,
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
 
-		/* Scan currently watched fields to see if this agent is already watching */
-
-		watchedField = pool_startDo(j9env->watchedFieldPool, &poolState);
-		while (watchedField != NULL) {
-			if (watchedField->fieldID == field) {
-				break;
-			}
-			watchedField = pool_nextDo(&poolState);
-		}
-
-		/* If a watch already exists, tag it with the new request (access or modify), or error if it is already tagged */
-
-		if (watchedField != NULL) {
-			if (watchedField->flags & flag) {
-				rc = JVMTI_ERROR_DUPLICATE;
-			} else {
-				watchedField->flags |= flag;
-			}
-		} else {
-			watchedField = pool_newElement(j9env->watchedFieldPool);
-			if (watchedField == NULL) {
+		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
+		fieldID = (J9JNIFieldID*)field;
+		localFieldIndex = fieldID->index - fieldID->declaringClass->romClass->romMethodCount;
+		fieldCount = clazz->romClass->romFieldCount;
+		watchedClass = hashTableFind(j9env->watchedClasses, &clazz);
+		if (NULL == watchedClass) {
+			J9JVMTIWatchedClass exemplar = { clazz, NULL };
+			watchedClass = hashTableAdd(j9env->watchedClasses, &exemplar);
+			if (NULL == watchedClass) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 			} else {
-				watchedField->flags = flag;
-				watchedField->fieldID = field;
-#ifdef J9VM_JIT_FULL_SPEED_DEBUG
-				if (J9_FSD_ENABLED(vm)) {
-					vm->jitConfig->jitDataBreakpointAdded(currentThread);
+				UDATA fieldCount = clazz->romClass->romFieldCount;
+				if (fieldCount <= J9JVMTI_WATCHED_FIELDS_PER_UDATA) {
+					watchedClass->watchBits = (UDATA*)0;
+				} else {
+					UDATA allocSize = sizeof(UDATA) * J9JVMTI_WATCHED_FIELD_ARRAY_INDEX(fieldCount + (J9JVMTI_WATCHED_FIELDS_PER_UDATA - 1));
+					PORT_ACCESS_FROM_VMC(currentThread);
+					watchBits = j9mem_allocate_memory(allocSize, J9MEM_CATEGORY_JVMTI);
+					if (NULL == watchBits) {
+						hashTableRemove(j9env->watchedClasses, watchedClass);
+						rc = JVMTI_ERROR_OUT_OF_MEMORY;
+					} else {
+						memset(watchBits, 0, allocSize);
+						watchedClass->watchBits = watchBits;
+					}
 				}
-#endif
 			}
 		}
 
 		if (rc == JVMTI_ERROR_NONE) {
-			if (flag == J9JVMTI_WATCH_FIELD_MODIFICATION) {
-				hookEvent(j9env, JVMTI_EVENT_FIELD_MODIFICATION);
+			if (fieldCount <= J9JVMTI_WATCHED_FIELDS_PER_UDATA) {
+				watchBits = (UDATA*)&watchedClass->watchBits;
 			} else {
-				hookEvent(j9env, JVMTI_EVENT_FIELD_ACCESS);
+				watchBits = watchedClass->watchBits;	
+			}
+			watchBits += J9JVMTI_WATCHED_FIELD_ARRAY_INDEX(localFieldIndex);
+			if (isModification) {
+				watchBit = J9JVMTI_WATCHED_FIELD_MODIFICATION_BIT(localFieldIndex);	
+			} else {
+				watchBit = J9JVMTI_WATCHED_FIELD_ACCESS_BIT(localFieldIndex);	
+			}
+			if (*watchBits & watchBit) {
+				rc = JVMTI_ERROR_DUPLICATE;
+			} else {
+				*watchBits |= watchBit;
+				if (J9_FSD_ENABLED(vm)) {
+					vm->jitConfig->jitDataBreakpointAdded(currentThread);
+				}
+				if (isModification) {
+					hookEvent(j9env, JVMTI_EVENT_FIELD_MODIFICATION);
+				} else {
+					hookEvent(j9env, JVMTI_EVENT_FIELD_ACCESS);
+				}
 			}
 		}
 
@@ -181,7 +201,7 @@ static jvmtiError
 clearFieldWatch(jvmtiEnv* env,
 	jclass klass,
 	jfieldID field,
-	UDATA flag)
+	UDATA isModification)
 {
 	J9JVMTIEnv * j9env = (J9JVMTIEnv *) env;
 	J9JavaVM * vm = j9env->vm;
@@ -190,8 +210,12 @@ clearFieldWatch(jvmtiEnv* env,
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
-		pool_state poolState;
-		J9JVMTIWatchedField * watchedField;
+		J9Class *clazz = NULL;
+		J9JNIFieldID *fieldID = NULL;
+		UDATA localFieldIndex = 0;
+		UDATA *watchBits = NULL;
+		UDATA watchBit = 0;
+		J9JVMTIWatchedClass *watchedClass = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -200,34 +224,35 @@ clearFieldWatch(jvmtiEnv* env,
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
 
-		/* Scan currently watched fields to see if this agent is watching the field */
-
-		watchedField = pool_startDo(j9env->watchedFieldPool, &poolState);
-		while (watchedField != NULL) {
-			if (watchedField->fieldID == field) {
-				break;
-			}
-			watchedField = pool_nextDo(&poolState);
-		}
-
-		/* If the field is not being watched at all, or not watched with the requested flag (access or modify), error */
-
-		if ((watchedField == NULL) || !(watchedField->flags & flag)) {
+		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
+		fieldID = (J9JNIFieldID*)field;
+		localFieldIndex = fieldID->index - fieldID->declaringClass->romClass->romMethodCount;
+		watchedClass = hashTableFind(j9env->watchedClasses, &clazz);
+		if (NULL == watchedClass) {
 			rc = JVMTI_ERROR_NOT_FOUND;
 		} else {
-			if (flag == J9JVMTI_WATCH_FIELD_MODIFICATION) {
-				unhookEvent(j9env, JVMTI_EVENT_FIELD_MODIFICATION);
+			UDATA fieldCount = clazz->romClass->romFieldCount;
+			if (fieldCount <= J9JVMTI_WATCHED_FIELDS_PER_UDATA) {
+				watchBits = (UDATA*)&watchedClass->watchBits;
 			} else {
-				unhookEvent(j9env, JVMTI_EVENT_FIELD_ACCESS);
+				watchBits = watchedClass->watchBits;	
 			}
-			watchedField->flags &= ~flag;
-			if (watchedField->flags == 0) {
-				pool_removeElement(j9env->watchedFieldPool, watchedField);
-#ifdef J9VM_JIT_FULL_SPEED_DEBUG
+			watchBits += J9JVMTI_WATCHED_FIELD_ARRAY_INDEX(localFieldIndex);
+			if (isModification) {
+				watchBit = J9JVMTI_WATCHED_FIELD_MODIFICATION_BIT(localFieldIndex);	
+			} else {
+				watchBit = J9JVMTI_WATCHED_FIELD_ACCESS_BIT(localFieldIndex);	
+			}
+			if (0 == (*watchBits & watchBit)) {
+				rc = JVMTI_ERROR_NOT_FOUND;
+			} else {
+				*watchBits &= ~watchBit;
 				if (J9_FSD_ENABLED(vm)) {
 					vm->jitConfig->jitDataBreakpointRemoved(currentThread);
 				}
-#endif
+				/* Consider checking for any remaining watches on the class
+				 * and removing the hash table entry if there are none.
+				 */
 			}
 		}
 

--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -613,6 +613,7 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
 		<data type="struct J9Method*" name = "method" description="current method" />
 		<data type="IDATA" name = "location" description="current pc offset" />
+		<data type="struct J9Class*" name = "declaringClass" description="declaring class of the static field" />
 		<data type="void*" name="fieldAddress" description="an indirect pointer to the static field being read" />
 	</event>
 
@@ -627,6 +628,7 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
 		<data type="struct J9Method*" name = "method" description="current method" />
 		<data type="IDATA" name = "location" description="current pc offset" />
+		<data type="struct J9Class*" name = "declaringClass" description="declaring class of the static field" />
 		<data type="void*" name="fieldAddress" description="an indirect pointer to the static field being written" />
 		<data type="void*" name="valueAddress" description="a pointer to the value which is about to be stored" />
 	</event>

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,13 +91,17 @@ typedef struct J9JVMTIObjectTag {
 	jlong tag;
 } J9JVMTIObjectTag;
 
-#define J9JVMTI_WATCH_FIELD_ACCESS 1
-#define J9JVMTI_WATCH_FIELD_MODIFICATION 2
+#define J9JVMTI_J9JVMTI_WATCHED_FIELD_ACCESS_BITS_PER_FIELD 2
+#define J9JVMTI_WATCHED_FIELDS_PER_UDATA (sizeof(UDATA) * 8 / J9JVMTI_J9JVMTI_WATCHED_FIELD_ACCESS_BITS_PER_FIELD)
+#define J9JVMTI_CLASS_REQUIRES_ALLOCATED_J9JVMTI_WATCHED_FIELD_ACCESS_BITS(clazz) ((clazz)->romClass->romFieldCount > J9JVMTI_WATCHED_FIELDS_PER_UDATA)
+#define J9JVMTI_WATCHED_FIELD_ARRAY_INDEX(index) ((index) / J9JVMTI_WATCHED_FIELDS_PER_UDATA)
+#define J9JVMTI_WATCHED_FIELD_ACCESS_BIT(index) (1 << (((index) * J9JVMTI_J9JVMTI_WATCHED_FIELD_ACCESS_BITS_PER_FIELD) % J9JVMTI_WATCHED_FIELDS_PER_UDATA))
+#define J9JVMTI_WATCHED_FIELD_MODIFICATION_BIT(index) (J9JVMTI_WATCHED_FIELD_ACCESS_BIT(index) << 1)
 
-typedef struct J9JVMTIWatchedField {
-	UDATA flags;
-	jfieldID fieldID;
-} J9JVMTIWatchedField;
+typedef struct J9JVMTIWatchedClass {
+	J9Class *clazz;
+	UDATA *watchBits;
+} J9JVMTIWatchedClass;
 
 typedef struct J9JVMTIBreakpointedMethod {
 	UDATA referenceCount;
@@ -152,7 +156,7 @@ typedef struct J9JVMTIEnv {
 	J9Pool* threadDataPool;
 	J9HashTable* objectTagTable;
 	J9JVMTIEventEnableMap globalEventEnable;
-	J9Pool* watchedFieldPool;
+	J9HashTable *watchedClasses;
 	J9Pool* breakpoints;
 	omrthread_tls_key_t tlsKey;
 	J9JVMTIHookInterfaceWithID vmHook;
@@ -557,5 +561,3 @@ typedef struct jvmtiGcp_translation {
 #define PORT_ACCESS_FROM_JVMTI(env) PORT_ACCESS_FROM_JAVAVM(((J9JVMTIEnv *) (env))->vm)
 
 #endif     /* jvmtiInternal_h */
-
-

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6093,7 +6093,8 @@ retry:
 #if defined(DO_HOOKS)
 		if (J9_EVENT_IS_HOOKED(_vm->hookInterface, J9HOOK_VM_GET_STATIC_FIELD)) {
 			updateVMStruct(REGISTER_ARGS);
-			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(_vm->hookInterface, _currentThread, _literals, _pc - _literals->bytecodes, valueAddress);
+			J9Class *fieldClass = (J9Class*)(classAndFlags & ~(UDATA)J9StaticFieldRefFlagBits);
+			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(_vm->hookInterface, _currentThread, _literals, _pc - _literals->bytecodes, fieldClass, valueAddress);
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			if (immediateAsyncPending()) {
 				rc = GOTO_ASYNC_CHECK;
@@ -6181,7 +6182,8 @@ retry:
 #if defined(DO_HOOKS)
 		if (J9_EVENT_IS_HOOKED(_vm->hookInterface, J9HOOK_VM_PUT_STATIC_FIELD)) {
 			updateVMStruct(REGISTER_ARGS);
-			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(_vm->hookInterface, _currentThread, _literals, _pc - _literals->bytecodes, valueAddress, _sp);
+			J9Class *fieldClass = (J9Class*)(classAndFlags & ~(UDATA)J9StaticFieldRefFlagBits);
+			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(_vm->hookInterface, _currentThread, _literals, _pc - _literals->bytecodes, fieldClass, valueAddress, _sp);
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			if (immediateAsyncPending()) {
 				rc = GOTO_ASYNC_CHECK;

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -1031,7 +1031,7 @@ getStaticIntField(JNIEnv *env, jclass clazz, jfieldID fieldID)
 	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_GET_STATIC_FIELD)) {
 		J9Method *method = findNativeMethodFrame(currentThread)->method;
 		if (NULL != method) {
-			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, valueAddress);
+			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, declaringClass, valueAddress);
 		}
 	}
 	bool isVolatile = J9_ARE_ANY_BITS_SET(modifiers, J9AccVolatile);
@@ -1059,7 +1059,7 @@ setStaticIntField(JNIEnv *env, jclass clazz, jfieldID fieldID, jint value)
 	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_PUT_STATIC_FIELD)) {
 		J9Method *method = findNativeMethodFrame(currentThread)->method;
 		if (NULL != method) {
-			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, valueAddress, (void*)&value);
+			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, declaringClass, valueAddress, (void*)&value);
 		}
 	}
 	bool isVolatile = J9_ARE_ANY_BITS_SET(modifiers, J9AccVolatile);
@@ -1090,7 +1090,7 @@ getStaticLongField(JNIEnv *env, jclass clazz, jfieldID fieldID)
 	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_GET_STATIC_FIELD)) {
 		J9Method *method = findNativeMethodFrame(currentThread)->method;
 		if (NULL != method) {
-			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, valueAddress);
+			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, declaringClass, valueAddress);
 		}
 	}
 	bool isVolatile = J9_ARE_ANY_BITS_SET(modifiers, J9AccVolatile);
@@ -1118,7 +1118,7 @@ setStaticDoubleFieldIndirect(JNIEnv *env, jobject clazz, jfieldID fieldID, void 
 	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_PUT_STATIC_FIELD)) {
 		J9Method *method = findNativeMethodFrame(currentThread)->method;
 		if (NULL != method) {
-			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, valueAddress, value);
+			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, declaringClass, valueAddress, value);
 		}
 	}
 	bool isVolatile = J9_ARE_ANY_BITS_SET(modifiers, J9AccVolatile);
@@ -1149,7 +1149,7 @@ getStaticObjectField(JNIEnv *env, jclass clazz, jfieldID fieldID)
 	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_GET_STATIC_FIELD)) {
 		J9Method *method = findNativeMethodFrame(currentThread)->method;
 		if (NULL != method) {
-			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, valueAddress);
+			ALWAYS_TRIGGER_J9HOOK_VM_GET_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, declaringClass, valueAddress);
 		}
 	}
 	bool isVolatile = J9_ARE_ANY_BITS_SET(modifiers, J9AccVolatile);
@@ -1179,7 +1179,7 @@ setStaticObjectField(JNIEnv *env, jclass clazz, jfieldID fieldID, jobject value)
 		J9Method *method = findNativeMethodFrame(currentThread)->method;
 		if (NULL != method) {
 			j9object_t valueObject = (NULL == value) ? NULL : J9_JNI_UNWRAP_REFERENCE(value);
-			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, valueAddress, (void*)&valueObject);
+			ALWAYS_TRIGGER_J9HOOK_VM_PUT_STATIC_FIELD(vm->hookInterface, currentThread, method, 0, declaringClass, valueAddress, (void*)&valueObject);
 		}
 	}
 	bool isVolatile = J9_ARE_ANY_BITS_SET(modifiers, J9AccVolatile);


### PR DESCRIPTION
Replace the watched field pool with a class-based hash table which uses
a bit array to describe watched fields.  This should greatly improve
performance when a large number of watches are in place.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>