### PR TITLE
Remove deprecated VMThread reclamation logic from Z code generator

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -161,22 +161,6 @@ J9::Z::CodeGenerator::CodeGenerator() :
    if (!comp->getOption(TR_DisableBDLLVersioning))
       cg->setSupportsBigDecimalLongLookasideVersioning();
 
-   // Allocate a virtual register for the VM thread & link the virtual & real registers together
-   // TODO: take this part out when doing IL level VM thread work.  It is codegen level VM Thread work
-   if (comp->getOption(TR_Enable390FreeVMThreadReg))
-      {
-      TR::Register *vmThreadRegister = cg->setVMThreadRegister(cg->allocateRegister());
-      if (cg->needsVMThreadDependency())
-         {
-         TR::RealRegister::RegNum vmThreadIndex = cg->getS390PrivateLinkage()->getMethodMetaDataRegister();
-         TR::RealRegister *vmThreadReal = cg->getS390Linkage()->getS390RealRegister(vmThreadIndex);
-         vmThreadRegister->setAssignedRegister(vmThreadReal);
-         vmThreadRegister->setAssociation(vmThreadIndex);
-         vmThreadReal->setAssignedRegister(vmThreadRegister);
-         vmThreadReal->setState(TR::RealRegister::Assigned);
-         }
-      }
-
    // RI support
    if (TR::Options::getCmdLineOptions()->getOption(TR_HWProfilerDisableRIOverPrivateLinkage)
        && comp->getPersistentInfo()->isRuntimeInstrumentationEnabled()
@@ -3834,19 +3818,19 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
    if (!self()->comp()->compileRelocatableCode() && !self()->comp()->getOption(TR_DisableDFP) && TR::Compiler->target.cpu.getS390SupportsDFP())
       {
       if (method == TR::java_math_BigDecimal_DFPIntConstructor ||
-          method == TR::java_math_BigDecimal_DFPLongConstructor || 
+          method == TR::java_math_BigDecimal_DFPLongConstructor ||
           method == TR::java_math_BigDecimal_DFPLongExpConstructor ||
           method == TR::java_math_BigDecimal_DFPAdd ||
           method == TR::java_math_BigDecimal_DFPSubtract ||
           method == TR::java_math_BigDecimal_DFPMultiply ||
-          method == TR::java_math_BigDecimal_DFPDivide || 
+          method == TR::java_math_BigDecimal_DFPDivide ||
           method == TR::java_math_BigDecimal_DFPScaledAdd ||
           method == TR::java_math_BigDecimal_DFPScaledSubtract ||
           method == TR::java_math_BigDecimal_DFPScaledMultiply ||
           method == TR::java_math_BigDecimal_DFPScaledDivide ||
-          method == TR::java_math_BigDecimal_DFPRound || 
+          method == TR::java_math_BigDecimal_DFPRound ||
           method == TR::java_math_BigDecimal_DFPSetScale ||
-          method == TR::java_math_BigDecimal_DFPCompareTo || 
+          method == TR::java_math_BigDecimal_DFPCompareTo ||
           method == TR::java_math_BigDecimal_DFPSignificance ||
           method == TR::java_math_BigDecimal_DFPExponent ||
           method == TR::java_math_BigDecimal_DFPBCDDigits ||

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -241,19 +241,16 @@ TR::S390PrivateLinkage::initS390RealRegisterLinkage()
       }
 
    // meta data register
-   if (!comp()->getOption(TR_Enable390FreeVMThreadReg))
-      {
-      mdReal->setState(TR::RealRegister::Locked);
-      mdReal->setAssignedRegister(mdReal);
-      mdReal->setHasBeenAssignedInMethod(true);
+   mdReal->setState(TR::RealRegister::Locked);
+   mdReal->setAssignedRegister(mdReal);
+   mdReal->setHasBeenAssignedInMethod(true);
 
-      if (cg()->supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
-         {
-         TR::RealRegister * tempHigh = toRealRegister(mdReal)->getHighWordRegister();
-         tempHigh->setState(TR::RealRegister::Locked);
-         tempHigh->setAssignedRegister(tempHigh);
-         tempHigh->setHasBeenAssignedInMethod(true);
-         }
+   if (cg()->supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
+      {
+      TR::RealRegister * tempHigh = toRealRegister(mdReal)->getHighWordRegister();
+      tempHigh->setState(TR::RealRegister::Locked);
+      tempHigh->setAssignedRegister(tempHigh);
+      tempHigh->setHasBeenAssignedInMethod(true);
       }
 
    // additional (forced) restricted regs.
@@ -3213,15 +3210,7 @@ TR::Register * TR::J9S390JNILinkage::buildDirectDispatch(TR::Node * callNode)
    TR::RealRegister * javaLitPoolRealRegister = getLitPoolRealRegister();
 
    TR::Register * javaLitPoolVirtualRegister = javaLitPoolRealRegister;
-   TR::Register * methodMetaDataVirtualRegister;
-   if (comp()->getOption(TR_Enable390FreeVMThreadReg))
-     {
-     methodMetaDataVirtualRegister = codeGen->getVMThreadRegister();
-     }
-   else
-     {
-     methodMetaDataVirtualRegister = methodMetaDataRealRegister;
-     }
+   TR::Register * methodMetaDataVirtualRegister = methodMetaDataRealRegister;
 
    TR::Register * methodAddressReg = NULL;
    TR::Register * javaLitOffsetReg = NULL;
@@ -3807,7 +3796,6 @@ TR::S390PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_Dispatch
    {
    TR::CodeGenerator * codeGen = cg();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   TR::Register * methodMetaDataVirtualRegister = NULL;
    // call base class
    OMR::Z::Linkage::setupBuildArgForLinkage(callNode, dispatchType, deps, isFastJNI, isPassReceiver, killMask, GlobalRegDeps, hasGlRegDeps, systemLinkage);
 
@@ -3820,11 +3808,7 @@ TR::S390PrivateLinkage::setupBuildArgForLinkage(TR::Node * callNode, TR_Dispatch
 
    TR::S390PrivateLinkage * privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
    TR::RealRegister * javaStackPointerRealRegister = privateLinkage->getStackPointerRealRegister();
-
-   if (cg()->comp()->getOption(TR_Enable390FreeVMThreadReg))
-     methodMetaDataVirtualRegister = codeGen->getVMThreadRegister();
-   else
-     methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
+   TR::Register * methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
 
    // store java stack pointer
    generateRXInstruction(codeGen, TR::InstOpCode::getStoreOpCode(), callNode, javaStackPointerRealRegister,
@@ -3888,12 +3872,7 @@ TR::S390PrivateLinkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_Dispa
 
 
    /*****************/
-   TR::Register * methodMetaDataVirtualRegister = NULL;
-
-   if (comp()->getOption(TR_Enable390FreeVMThreadReg))
-     methodMetaDataVirtualRegister = codeGen->getVMThreadRegister();
-   else
-     methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
+   TR::Register * methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
 
 
    // This logic was originally in OMR::Z::Linkage::buildNativeDispatch and the condition is cg()->supportsJITFreeSystemStackPointer().

--- a/runtime/compiler/z/codegen/J9S390SystemLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390SystemLinkage.cpp
@@ -215,11 +215,7 @@ TR::J9S390zLinuxSystemLinkage::performCallNativeFunctionForLinkage(TR::Node * ca
    TR::RealRegister * javaStackPointerRealRegister = privateLinkage->getStackPointerRealRegister();
 
    // get methodMetaDataVirtualRegister
-   TR::Register * methodMetaDataVirtualRegister = NULL;
-   if (codeGen->comp()->getOption(TR_Enable390FreeVMThreadReg))
-     methodMetaDataVirtualRegister = codeGen->getVMThreadRegister();
-   else
-     methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
+   TR::Register * methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
 
    // restore java stack pointer
    generateRXInstruction(codeGen, TR::InstOpCode::getLoadOpCode(), callNode, javaStackPointerRealRegister,
@@ -278,7 +274,6 @@ TR::J9S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
    TR::Compilation *comp = codeGen->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(codeGen->fe());
    // privateLinkage refers to linkage of caller
-   TR::Register * methodMetaDataVirtualRegister;
    TR::Linkage * privateLinkage;
 
    privateLinkage = (TR::S390PrivateLinkage *) cg()->getLinkage(TR_Private);
@@ -371,14 +366,8 @@ TR::J9S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR:
                systemEntryPointRegister, generateS390MemoryReference(methodAddressReg, 16, codeGen));
       }
    // call the JNI function
-   if (comp->getOption(TR_Enable390FreeVMThreadReg))
-       {
-       methodMetaDataVirtualRegister = cg()->getVMThreadRegister();
-       }
-   else
-       {
-       methodMetaDataVirtualRegister = ((TR::S390PrivateLinkage *) privateLinkage)->getMethodMetaDataRealRegister();
-       }
+   TR::Register * methodMetaDataVirtualRegister = ((TR::S390PrivateLinkage *) privateLinkage)->getMethodMetaDataRealRegister();
+
    if (cg()->supportsJITFreeSystemStackPointer())
       {
       auto* systemSPOffsetMR = generateS390MemoryReference(methodMetaDataVirtualRegister, static_cast<int32_t>(fej9->thisThreadGetSystemSPOffset()), codeGen);
@@ -465,11 +454,7 @@ TR::J9S390zOSSystemLinkage::performCallNativeFunctionForLinkage(TR::Node * callN
    TR::RealRegister * javaStackPointerRealRegister = privateLinkage->getStackPointerRealRegister();
 
    // get methodMetaDataVirtualRegister
-   TR::Register * methodMetaDataVirtualRegister = NULL;
-   if (codeGen->comp()->getOption(TR_Enable390FreeVMThreadReg))
-     methodMetaDataVirtualRegister = codeGen->getVMThreadRegister();
-   else
-     methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
+   TR::Register * methodMetaDataVirtualRegister = privateLinkage->getMethodMetaDataRealRegister();
 
    // restore java stack pointer
    generateRXInstruction(codeGen, TR::InstOpCode::getLoadOpCode(), callNode, javaStackPointerRealRegister,

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -171,9 +171,6 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
 
    //Grab the snippet's start point
    getSnippetLabel()->setCodeLocation(cursor);
-
-   //load vm thread into gpr13
-   cursor = generateLoadVMThreadInstruction(cg(), cursor);
 
    //  setup the address of the picbuilder function
 
@@ -416,7 +413,6 @@ J9::Z::UnresolvedDataSnippet::getLength(int32_t  estimatedSnippetStart)
    {
    // *this   swipeable for debugger
    uint32_t length = (TR::Compiler->target.is64Bit() ? (14 + 5 * sizeof(uintptrj_t)) : (12 + 5 * sizeof(uintptrj_t)));
-   length += getLoadVMThreadInstructionLength(cg());
    // For instance snippets, we have the out-of-line sequence
    if (isInstanceData())
       length += (TR::Compiler->target.is64Bit()) ? 36 : 28;
@@ -436,8 +432,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
 
    uint8_t * bufferPos = snippet->getSnippetLabel()->getCodeLocation();
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Unresolved Data Snippet");
-
-   bufferPos = printLoadVMThreadInstruction(pOutFile, bufferPos);
 
    bufferPos = printRuntimeInstrumentationOnOffInstruction(pOutFile, bufferPos, false); // RIOFF
 


### PR DESCRIPTION
* remove and fold code guarded with TR_Enable390FreeVMThreadReg option
* remove and fold code guarded with addVMThreadDependencies, addVMThreadPreCondition,
  addVMThreadPostCondition, needsVMThreadDependency, setVMThreadRequired
* remove calls to snippet functions generateLoadVMThreadInstruction and
  getLoadVMThreadInstructionLength

OpenJ9 cleanup for Issue eclipse/omr#2256

Signed-off-by: Daryl Maier <maier@ca.ibm.com>