### PR TITLE
Refactor recompilation API in OSRGuardInsertion

### DIFF
--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -325,7 +325,7 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
          // this will return false
          bool induceOSR = comp()->getMethodSymbol()->induceOSRAfter(cursor, nodeBCI, guard, false, 0, &cfgEnd);
          if (induceOSR)
-            generateTriggeringRecompilationTrees(guard);
+            generateTriggeringRecompilationTrees(guard, TR_PersistentMethodInfo::RecompDueToInlinedMethodRedefinition);
 
          if (trace())
             {
@@ -428,7 +428,7 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
 
                bool induceOSR = targetMethod->induceOSRAfter(inductionPoint, nodeBCI, guard, false, comp()->getOSRInductionOffset(cursor->getNode()), &cfgEnd);
                if (induceOSR)
-                  generateTriggeringRecompilationTrees(guard);
+                  generateTriggeringRecompilationTrees(guard, TR_PersistentMethodInfo::RecompDueToInlinedMethodRedefinition);
 
                if (trace() && induceOSR)
                   traceMsg(comp(), "  OSR induction added successfully\n");
@@ -479,12 +479,12 @@ int32_t TR_OSRGuardInsertion::insertOSRGuards(TR_BitVector &fearGeneratingNodes)
 }
 
 
-void TR_OSRGuardInsertion::generateTriggeringRecompilationTrees(TR::TreeTop *osrGuard)
+void TR_OSRGuardInsertion::generateTriggeringRecompilationTrees(TR::TreeTop *osrGuard, TR_PersistentMethodInfo::InfoBits reason)
    {
    if (comp()->isRecompilationEnabled() && !comp()->getOption(TR_DisableRecompDueToInlinedMethodRedefinition))
       {
       TR::TreeTop *osrInduceBlockStart = osrGuard->getNode()->getBranchDestination();
-      TR::TreeTop *callTree = TR::TransformUtil::generateRetranslateCallerWithPrepTrees(osrInduceBlockStart->getNode(), TR_PersistentMethodInfo::RecompDueToInlinedMethodRedefinition, comp());
+      TR::TreeTop *callTree = TR::TransformUtil::generateRetranslateCallerWithPrepTrees(osrInduceBlockStart->getNode(), reason, comp());
       osrInduceBlockStart->insertTreeTopsAfterMe(callTree);
       }
    }

--- a/runtime/compiler/optimizer/OSRGuardInsertion.hpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.hpp
@@ -25,6 +25,7 @@
 #include <stdint.h>                           // for int32_t
 #include "optimizer/Optimization.hpp"         // for Optimization
 #include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "control/RecompilationInfo.hpp"
 
 namespace TR { class Block; }
 
@@ -48,6 +49,6 @@ class TR_OSRGuardInsertion : public TR::Optimization
    void removeHCRGuards(TR_BitVector &fearGeneratingNodes);
    int32_t insertOSRGuards(TR_BitVector &fearGeneratingNodes);
    void performRemat(TR::TreeTop *osrPoint, TR::TreeTop *osrGuard, TR::TreeTop *rematDest);
-   void generateTriggeringRecompilationTrees(TR::TreeTop *osrGuard);
+   void generateTriggeringRecompilationTrees(TR::TreeTop *osrGuard, TR_PersistentMethodInfo::InfoBits reason);
    };
 #endif


### PR DESCRIPTION
Change the recompilation reason in generateTriggeringRecompilationTrees
to a parameter as there could be various reasons for recompilations.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>