### PR TITLE
Change Git to SCM step for Copyright and Line Endings checks

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheck
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheck
@@ -29,10 +29,17 @@ timeout(time: 6, unit: 'HOURS') {
     stage('Copyright Check') {
         node ('worker') {
             timestamps {
-                git url: SRC_REPO
-                sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
-                sh "git checkout --detach ${sha1}"
-                sh 'git fetch origin'
+                checkout changelog: false, poll: false,
+                        scm: [$class: 'GitSCM',
+                            branches: [[name: sha1]],
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions: [[$class: 'CloneOption',
+                                            depth: 0,
+                                            noTags: false,
+                                            reference: '/home/jenkins/openjdk_cache',
+                                            shallow: false]],
+                            userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+                                                    url: SRC_REPO]]]
                 FILES = sh (
                     script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
                     returnStdout: true

--- a/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck
+++ b/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck
@@ -29,10 +29,17 @@ timeout(time: 6, unit: 'HOURS') {
     stage('Line Endings Check') {
         node ('worker') {
             timestamps {
-                git url: SRC_REPO
-                sh "git fetch --tags --progress origin +refs/pull/*:refs/remotes/origin/pr/*"
-                sh "git checkout --detach ${sha1}"
-                sh 'git fetch origin'
+                checkout changelog: false, poll: false,
+                        scm: [$class: 'GitSCM',
+                            branches: [[name: sha1]],
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions: [[$class: 'CloneOption',
+                                            depth: 0,
+                                            noTags: false,
+                                            reference: '/home/jenkins/openjdk_cache',
+                                            shallow: false]],
+                            userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+                                                    url: SRC_REPO]]]
                 FILES = sh (
                     script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
                     returnStdout: true


### PR DESCRIPTION
- Replaces 4 commands with 1
- Eliminates extra fetch for no reason
- 'git url: SRC_REPO' defaults to master branch which
  fails when the SRC_REPO has no master branch

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>