### PR TITLE
Add support for Jenkins personal pipeline builds

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -28,29 +28,46 @@
     // if not set, sniff the remote repositories references
 
     stage ('Sniff Repos') {
-        dir('openjdk') {
+        def description = ''
+
+        if (OPENJDK_SHA instanceof Map && OPENJDK_REPO instanceof Map && OPENJDK_BRANCH instanceof Map) {
+            // fetch SHAs for all OpenJDK repositories
+            def OPENJDK_SHAS_BY_RELEASES = [:]
+
+            OPENJDK_SHA.each { release, sha ->
+                if (!sha) {
+                    sha = get_repository_sha(OPENJDK_REPO[release], OPENJDK_BRANCH[release])
+                }
+                OPENJDK_SHAS_BY_RELEASES[release] = sha
+                description += "<br/>OpenJDK${release}: ${get_short_sha(sha)}"
+                echo "OPENJDK${release}_SHA:${sha}"
+            }
+            SHAS['OPENJDK'] = OPENJDK_SHAS_BY_RELEASES
+        } else {
+            // fetch SHA for an OpenJDK repository
             SHAS['OPENJDK'] = OPENJDK_SHA
-            if (SHAS['OPENJDK'] == '') {
+            if (!SHAS['OPENJDK']) {
                 SHAS['OPENJDK'] = get_repository_sha(OPENJDK_REPO, OPENJDK_BRANCH)
             }
+            description += "<br/>OpenJDK: ${get_short_sha(SHAS['OPENJDK'])}"
+            echo "OPENJDK_SHA:${SHAS['OPENJDK']}"
         }
-        dir('openj9') {
-            SHAS['OPENJ9'] = OPENJ9_SHA
-            if ((SHAS['OPENJ9'] == '') && ((OPENJ9_REPO != '') && (OPENJ9_BRANCH != ''))) {
-                SHAS['OPENJ9'] = get_repository_sha(OPENJ9_REPO, OPENJ9_BRANCH)
-            }
+
+        // fetch extensions SHAs
+        SHAS['OPENJ9'] = OPENJ9_SHA
+        if (!SHAS['OPENJ9'] && (OPENJ9_REPO && OPENJ9_BRANCH)) {
+            SHAS['OPENJ9'] = get_repository_sha(OPENJ9_REPO, OPENJ9_BRANCH)
         }
-        dir('omr') {
-            SHAS['OMR'] = OMR_SHA
-            if ((SHAS['OMR'] == '') && ((OMR_REPO != '') && (OMR_BRANCH != ''))){
-                SHAS['OMR'] = get_repository_sha(OMR_REPO, OMR_BRANCH)
-            }
+
+        SHAS['OMR'] = OMR_SHA
+        if (!SHAS['OMR'] && (OMR_REPO && OMR_BRANCH)){
+            SHAS['OMR'] = get_repository_sha(OMR_REPO, OMR_BRANCH)
         }
+
         // Write the SHAs to the Build Description
-        echo "OPENJDK_SHA:${SHAS['OPENJDK']}"
         echo "OPENJ9_SHA:${SHAS['OPENJ9']}"
         echo "OMR_SHA:${SHAS['OMR']}"
-        currentBuild.description = "OpenJ9: ${SHAS['OPENJ9']}<br/>OMR: ${SHAS['OMR']}<br/>OpenJDK: ${SHAS['OPENJDK']}"
+        currentBuild.description = "OpenJ9: ${get_short_sha(SHAS['OPENJ9'])}<br/>OMR: ${get_short_sha(SHAS['OMR'])}${description}"
         return SHAS
     }
 }
@@ -76,6 +93,15 @@ def get_sha(REPO, BRANCH) {
             script: "git ls-remote $REPO refs/heads/$BRANCH | cut -c1-40",
             returnStdout: true
         ).trim()
+}
+
+def get_short_sha(SHA) {
+    if (SHA) {
+        // return the first 7 characters of a given SHA.
+        return SHA.take(7)
+    }
+
+    return SHA
 }
 
 def git_push_auth(REPO, OPTION, CRED_ID) {

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -53,16 +53,14 @@ def parse_variables_file(){
 def get_variables_file() {
     if (params.VARIABLE_FILE && params.VENDOR_REPO && params.VENDOR_BRANCH) {
         stage('Get Variables File') {
-            timestamps {
-                if (params.VENDOR_CREDENTIALS_ID) {
-                    sshagent(credentials:["${params.VENDOR_CREDENTIALS_ID}"]) {
-                        checkout_file()
-                    }
-                } else {
+            if (params.VENDOR_CREDENTIALS_ID) {
+                sshagent(credentials:["${params.VENDOR_CREDENTIALS_ID}"]) {
                     checkout_file()
                 }
-             }
-        }
+            } else {
+                checkout_file()
+            }
+         }
     }
 
     return params.VARIABLE_FILE
@@ -85,69 +83,157 @@ def checkout_file() {
 * When no values are available as build parameters set them to the values
 * available with the variable file otherwise set them to empty strings.
 */
-def set_repos_variables() {
+def set_repos_variables(RELEASES=null) {
     // check if passed as Jenkins build parameters
     // if not set as params, check the variables file
 
-    OPENJDK_REPO = params.OPENJDK_REPO
-    if ((OPENJDK_REPO == null) || (OPENJDK_REPO == '')) {
-        OPENJDK_REPO = get_value(VARIABLES.openjdk_repo, SDK_VERSION)
+    if (!RELEASES) {
+        // set variables (as strings) for a single OpenJDK release
+
+        // fetch OpenJDK repo and branch from variables file as a map
+        def OPENJDK_INFO = get_openjdk_info(SDK_VERSION)
+
+        OPENJDK_REPO = OPENJDK_INFO['REPO']
+        OPENJDK_BRANCH = OPENJDK_INFO['BRANCH']
+        OPENJDK_SHA = OPENJDK_INFO['SHA']
+
+        echo "Using OPENJDK_REPO = ${OPENJDK_REPO} OPENJDK_BRANCH = ${OPENJDK_BRANCH} OPENJDK_SHA = ${OPENJDK_SHA}"
+
+        // set OpenJ9 and OMR repos, branches and SHAs
+        set_extensions_variables()
+
+     } else {
+        // set OpenJDK variables (as maps) for given releases
+        RELEASES.each { RELEASE ->
+            // fetch OpenJDK repo and branch from variables file as a map
+            def OPENJDK_INFO = get_openjdk_info(RELEASE, RELEASES)
+
+            OPENJDK_REPO[RELEASE] = OPENJDK_INFO['REPO']
+            OPENJDK_BRANCH[RELEASE] = OPENJDK_INFO['BRANCH']
+            OPENJDK_SHA[RELEASE] = OPENJDK_INFO['SHA']
+        }
+
+        echo "Using OPENJDK_REPO = ${OPENJDK_REPO.toString()} OPENJDK_BRANCH = ${OPENJDK_BRANCH.toString()} OPENJDK_SHA = ${OPENJDK_SHA.toString()}"
+
+        // default URL and branch for the OpenJ9 and OMR repositories (no entries in defaults.yml)
+        EXTENSIONS = ['OpenJ9': ['repo': 'https://github.com/eclipse/openj9.git',     'branch': 'master'],
+                      'OMR'   : ['repo': 'https://github.com/eclipse/openj9-omr.git', 'branch': 'openj9']]
+
+        // set OpenJ9 and OMR repos, branches and SHAs
+        set_extensions_variables(EXTENSIONS)
+    }
+}
+
+/*
+* Initializes OpenJDK repository URL, branch, SHA for given release and returns
+* them as a map.
+* Build parameters take precedence over custom variables (see variables file).
+* Throws an error if repository URL or branch are not provided. 
+*/
+def get_openjdk_info(SDK_VERSION, RELEASES=null) {
+    // initialize OPENJDK_INFO map with values from variables file
+    def OPENJDK_INFO = ['REPO'  : convert_url(get_value(VARIABLES.openjdk_repo, SDK_VERSION)), 
+                        'BRANCH': get_value(VARIABLES.openjdk_branch, SDK_VERSION),
+                        'SHA'   : '']
+
+    def PARAM_NAME = "OPENJDK"
+    if (RELEASES) {
+        PARAM_NAME += SDK_VERSION
     }
 
-    if ( OPENJDK_REPO == "" ) {
-        error("Must specify the OpenJDK repository")
+    // check if any OPENJDK* build parameters are provided
+    // and override OPENJDK_INFO map with those values
+    OPENJDK_INFO.keySet().each { KEY ->
+        def VALUE = params."${PARAM_NAME}_${KEY}"
+
+        if (VALUE) {
+            // build parameter provided, now override map value
+            if (KEY == 'REPO') { 
+                OPENJDK_INFO[KEY] = convert_url(VALUE)
+            } else {
+                OPENJDK_INFO[KEY] = VALUE
+            }
+        }
+
+        if ((KEY != 'SHA') && (!OPENJDK_INFO[KEY])) {
+            error("Missing ${PARAM_NAME}_${KEY}!")
+        }
     }
 
-    OPENJDK_BRANCH = params.OPENJDK_BRANCH
-    if ((OPENJDK_BRANCH == null) || (OPENJDK_BRANCH == '')) {
-        OPENJDK_BRANCH = get_value(VARIABLES.openjdk_branch, SDK_VERSION)
-    }
+    return OPENJDK_INFO
+}
 
-    if ( OPENJDK_BRANCH == "" ) {
-        error("Must specify the OpenJDK branch")
-    }
-
-    OPENJDK_SHA = (params.OPENJDK_SHA != null) ? params.OPENJDK_SHA : ''
-
-    if ((params.OPENJ9_REPO != null) && (params.OPENJ9_REPO != '')) {
-        //set it to the value passed as build parameter
-         OPENJ9_REPO = params.OPENJ9_REPO
-    } else if (VARIABLES.openj9_repo != null) {
+/*
+* Initializes the OpenJ9 and OMR repositories variables with values from
+* the variables file if they are not set as build parameters. 
+* If no values available in the variable file then initialize these variables
+* with default values, otherwise set them to empty strings (to avoid 
+* downstream builds errors - Jenkins build parameters should not be null).
+*/
+def set_extensions_variables(defaults=null) {
+    OPENJ9_REPO = params.OPENJ9_REPO
+    if (!OPENJ9_REPO) {
         // set it to the value set into the variable file
-         OPENJ9_REPO = VARIABLES.openj9_repo
-    } else {
+        OPENJ9_REPO = VARIABLES.openj9_repo
+    }
+
+    if (!OPENJ9_REPO) {
         OPENJ9_REPO = ''
+        if (defaults) {
+            OPENJ9_REPO = defaults.get('OpenJ9').get('repo')
+        }
     }
+    OPENJ9_REPO = convert_url(OPENJ9_REPO)
 
-    if ((params.OPENJ9_BRANCH != null) && (params.OPENJ9_BRANCH != null)) {
-        OPENJ9_BRANCH = params.OPENJ9_BRANCH
-    } else if (VARIABLES.openj9_branch != null) {
+    OPENJ9_BRANCH = params.OPENJ9_BRANCH
+    if (!OPENJ9_BRANCH) {
          OPENJ9_BRANCH = VARIABLES.openj9_branch
-    } else {
+    }
+
+    if (!OPENJ9_BRANCH) {
         OPENJ9_BRANCH = ''
+        if (defaults) {
+            OPENJ9_BRANCH = defaults.get('OpenJ9').get('branch')
+        }
     }
 
-    OPENJ9_SHA = (params.OPENJ9_SHA != null) ? params.OPENJ9_SHA : ''
+    OPENJ9_SHA = params.OPENJ9_SHA
+    if (!OPENJ9_SHA) {
+        OPENJ9_SHA = ''
+    }
 
-    if ((params.OMR_REPO != null) && (params.OMR_REPO != '')) {
-         OMR_REPO = params.OMR_REPO
-    } else if (VARIABLES.omr_repo != null) {
-         OMR_REPO = VARIABLES.omr_repo
-    } else {
+    OMR_REPO = params.OMR_REPO
+    if (!OMR_REPO) {
+        // set it to the value set into the variable file
+        OMR_REPO = VARIABLES.omr_repo
+    }
+
+    if (!OMR_REPO) {
         OMR_REPO = ''
+        if (defaults) {
+            OMR_REPO = defaults.get('OMR').get('repo')
+        }
+    }
+    OMR_REPO = convert_url(OMR_REPO)
+
+    OMR_BRANCH = params.OMR_BRANCH
+    if (!OMR_BRANCH) {
+        // set it to the value set into the variable file
+        OMR_BRANCH = VARIABLES.omr_branch
     }
 
-    if ((params.OMR_BRANCH != null) && (params.OMR_BRANCH != '')) {
-        OMR_BRANCH = params.OMR_BRANCH
-    } else if (VARIABLES.omr_branch != null) {
-         OMR_BRANCH = VARIABLES.omr_branch
-    } else {
+    if (!OMR_BRANCH) {
         OMR_BRANCH = ''
+        if (defaults) {
+            OMR_BRANCH = defaults.get('OMR').get('branch')
+        }
     }
 
-    OMR_SHA = (params.OMR_SHA != null) ? params.OMR_SHA : ''
+    OMR_SHA = params.OMR_SHA
+    if (!OMR_SHA) {
+        OMR_SHA = ''
+    }
 
-    echo "Using OPENJDK_REPO = ${OPENJDK_REPO} OPENJDK_BRANCH = ${OPENJDK_BRANCH} OPENJDK_SHA = ${OPENJDK_SHA}"
     echo "Using OPENJ9_REPO = ${OPENJ9_REPO} OPENJ9_BRANCH = ${OPENJ9_BRANCH} OPENJ9_SHA = ${OPENJ9_SHA}"
     echo "Using OMR_REPO = ${OMR_REPO} OMR_BRANCH = ${OMR_BRANCH} OMR_SHA = ${OMR_SHA}"
 }
@@ -182,7 +268,7 @@ def get_git_user_credentials_id() {
 * Returns Jenkins credentials ID from the variable file for given key.
 */
 def get_user_credentials_id(KEY) {
-    if ((VARIABLES.credentials != null) && (VARIABLES.credentials."${KEY}" != null)) {
+    if (VARIABLES.credentials && VARIABLES.credentials."${KEY}") {
         return VARIABLES.credentials."${KEY}"
     }
 
@@ -277,7 +363,10 @@ def set_test_targets() {
 }
 
 def set_slack_channel() {
-    SLACK_CHANNEL = VARIABLES.slack_channel
+    SLACK_CHANNEL = params.SLACK_CHANNEL
+    if (!SLACK_CHANNEL && (!params.PERSONAL_BUILD || params.PERSONAL_BUILD != 'true')) {
+        SLACK_CHANNEL = VARIABLES.slack_channel
+    }
 }
 
 /*
@@ -304,7 +393,7 @@ def set_job_variables(job_type) {
     parse_variables_file()
 
     // fetch credentials required to connect to GitHub using ssh protocol
-    USER_CREDENTIALS_ID = get_git_user_credentials_id()
+    set_user_credentials()
 
     switch (job_type) {
         case "build":
@@ -332,6 +421,10 @@ def set_job_variables(job_type) {
             set_test_targets()
             set_slack_channel()
             set_job_names()
+            break
+        case "wrapper":
+            //set variable for pipeline all/personal
+            set_repos_variables(BUILD_RELEASES)
             break
         default:
             error("Unknown Jenkins job type!")
@@ -364,6 +457,35 @@ def printStackTrace(e) {
     def writer = new StringWriter()
     e.printStackTrace(new PrintWriter(writer))
     echo e.toString()
+}
+
+/*
+* Sets USER_CREDENTIALS_ID to the value provided in the variables file or an
+* empty string.
+*/
+def set_user_credentials() {
+    USER_CREDENTIALS_ID = get_git_user_credentials_id()
+    if (!USER_CREDENTIALS_ID) {
+         USER_CREDENTIALS_ID = ''
+    }
+}
+
+/*
+* Converts from SSH to HTTPS protocol the public Git repository URL and from
+* HTTPS to SSH the private repositories.
+*/
+def convert_url(value) {
+    if ((value && value.contains('git@')) && !USER_CREDENTIALS_ID) {
+        // external repos, no credentials, use HTTPS protocol
+        return value.replace(':', '/').replace('git@', 'https://')
+    }
+
+    if ((value && value.startsWith('https://')) && USER_CREDENTIALS_ID) {
+        // private repos, have credentials, use SSH protocol
+        return value.replace('https://', 'git@').replaceFirst('/', ':')
+    }
+
+    return value
 }
 
 return this

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -20,88 +20,279 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def SPECS = ['aix_ppc-64_cmprssptrs'      : ['8', '9', '10'],
-             'linux_390-64_cmprssptrs'    : ['8', '9', '10'],
-             'linux_ppc-64_cmprssptrs_le' : ['8', '9', '10'],
-             'linux_x86-64'               : ['8', '9', '10'],
-             'linux_x86-64_cmprssptrs'    : ['8', '9', '10'],
-             'win_x86'                    : ['8'],
-             'win_x86-64_cmprssptrs'      : ['8', '9', '10']]
+/*
+* It builds and tests the Eclipse OpenJ9 extensions for OpenJDK for one or more
+* versions and platforms by launching Pipeline-Build-Test-JDK${SDK_VERSION}-${SPEC}
+* builds. Multiple pipelines are executed in parallel.
+* When TESTS_TARGETS=none, it only builds the Eclipse OpenJ9 extensions for OpenJDK.
+* VARIABLE_FILE allows to run it in a custom configuration on a different server.
+*
+* Parameters:
+*   PLATFORMS: String - Comma separated platforms to build.
+*              Expected values: all or any of the following: 
+*              aix_ppc-64_cmprssptrs,
+*              linux_x86-64,
+*              linux_x86-64_cmprssptrs,
+*              linux_ppc-64_cmprssptrs_le,
+*              linux_390-64_cmprssptrs,
+*              win_x86-64_cmprssptrs,
+*              win_x86 (Java 8 support only)
+*   Java8: Boolean
+*   Java9: Boolean 
+*   Java10: Boolean (at least one of the Java8, Java9, Java10 is required)
+*   OPENJ9_REPO: String - the OpenJ9 git repository URL: e.g. https://github.com/eclipse/openj9.git (default)
+*   OPENJ9_BRANCH: String - the OpenJ9 branch to clone from: e.g. master (default)
+*   OPENJ9_SHA: String - the last commit SHA of the OpenJ9 repository
+*   OMR_REPO: String - the OMR git repository URL: e.g. https://github.com/eclipse/openj9-omr.git (default)
+*   OMR_BRANCH: String - the OMR branch to clone from: e.g. openj9 (default)
+*   OMR_SHA: the last commit SHA of the OMR repository
+*   OPENJDK8_REPO: String - the OpenJDK8 repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk8.git (default)
+*   OPENJDK8_BRANCH: String - the OpenJDK8 branch to clone from: e.g. openj9 (default)
+*   OPENJDK8_SHA: String - the OpenJDK8 last commit SHA
+*   OPENJDK9_REPO: String - the OpenJDK9 repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk9.git (default)
+*   OPENJDK9_BRANCH: String - the OpenJDK9 branch to clone from: e.g. openj9 (default)
+*   OPENJDK9_SHA: String - the OpenJDK9 last commit SHA 
+*   OPENJDK10_REPO: String - the OpenJDK10 repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk10.git (default)
+*   OPENJDK10_BRANCH: String - the OpenJDK10 branch to clone from: e.g. openj9 (default)
+*   OPENJDK10_SHA: String - the OpenJDK10 last commit SHA
+*   TESTS_TARGETS: String - The test targets to run. Expected values: _sanity, _extended, none
+*   VARIABLE_FILE: String - the custom variables file. Uses defaults.yml when no value is provided.
+*   VENDOR_REPO: String - the repository URL of a Git repository that stores a custom variables file
+*   VENDOR_BRANCH: String - the vendor branch to clone from
+*   VENDOR_CREDENTIALS_ID: String - the Jenkis credentials to connect to the vendor Git repository if VENDOR_REPO is a private repository
+*   LABEL: String - the node label(s) to run this job on; could be any node that has Git installed on it
+*   BUILD_NODE_LABELS: String - the labels of a node to compile and build the Eclipse OpenJ9 extensions for OpenJDK
+*   TEST_NODE_LABELS: String - the labels of a node to run tests on
+*
+*   Node labels could be a single label or node name or a boolean expression(e.g. hw.arch.x86 && sw.os.windows)
+*   Expected value for multiple platforms builds: platform.1=labels.1,platform.2=labels.2,...,etc
+*   e.g. aix_ppc-64_cmprssptrs=csp70027,linux_x86-64=(ci.project.openj9 && hw.arch.x86 && sw.os.ubuntu.14)
+*   Expected value for single platforms builds: label (no platform name required), e.g. csp70027
+*
+*   PERSONAL_BUILD: Choice: true, false - Indicates if is a personal build or not
+*/
 
+RELEASES = ['8', '9', '10', '11', 'next']
 
-def OPENJDK_REPOS = ['8': 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git',
-                     '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git',
-                     '10': 'https://github.com/ibmruntimes/openj9-openjdk-jdk10.git']
-def OPENJDK_BRANCHES = ['8': 'openj9',
-                        '9': 'openj9',
-                        '10': 'openj9']
+SPECS = ['aix_ppc-64_cmprssptrs'      : RELEASES,
+         'linux_390-64_cmprssptrs'    : RELEASES,
+         'linux_ppc-64_cmprssptrs_le' : RELEASES,
+         'linux_x86-64'               : RELEASES,
+         'linux_x86-64_cmprssptrs'    : RELEASES,
+         'win_x86'                    : ['8'],
+         'win_x86-64_cmprssptrs'      : RELEASES]
 
-def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'
-def OPENJ9_BRANCH = 'master'
-
-def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
-def OMR_BRANCH = 'openj9'
-
-def builds = [:]
-
-timeout(time: 10, unit: 'HOURS') {
-    node('worker') {
-
-        checkout scm
-        buildFile = load 'buildenv/jenkins/common/pipeline-functions'
-
-        // fetch SHAs
-        OPENJ9_SHA = buildFile.get_sha(OPENJ9_REPO, OPENJ9_BRANCH)
-        OMR_SHA = buildFile.get_sha(OMR_REPO, OMR_BRANCH)
-
-        // update build description
-        currentBuild.description = "OpenJ9: ${OPENJ9_SHA}<br/>OMR: ${OMR_SHA}"
-
-        echo "OPENJ9_SHA:${OPENJ9_SHA}"
-        echo "OMR_SHA:${OMR_SHA}"
-
-        def OPENJDK_SHAS = [:]
-        OPENJDK_REPOS.each { RELEASE, REPO ->
-            OPENJDK_SHAS["${RELEASE}"] = buildFile.get_sha(REPO, OPENJDK_BRANCHES["${RELEASE}"])
-
-            currentBuild.description += "<br/>OpenJDK${RELEASE}: ${OPENJDK_SHAS[RELEASE]}"
-            echo "OPENJDK${RELEASE}_SHA:${OPENJDK_SHAS[RELEASE]}"
-        }
-
-        SPECS.each { SPEC, SDK_VERSIONS ->
-            SDK_VERSIONS.each { SDK_VERSION ->
-                def OPENJDK_REPO = OPENJDK_REPOS["${SDK_VERSION}"]
-                def OPENJDK_BRANCH = OPENJDK_BRANCHES["${SDK_VERSION}"]
-                def OPENJDK_SHA = OPENJDK_SHAS["${SDK_VERSION}"]
-
-                builds["build_JDK${SDK_VERSION} ${SPEC}"] = { build(OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, SDK_VERSION, SPEC) }
-             }
-        }
-
-        cleanWs()
-    }
-
-    parallel builds
+LABEL = params.LABEL
+if (!LABEL) {
+    LABEL = 'worker'
 }
 
-/*
-* Returns the Jenkins pipeline job that builds and tests OpenJ9 extensions for
-* OpenJDK for give version and spec.
-*/
-def build(OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, SDK_VERSION, SPEC) {
-    stage ("Build JDK${SDK_VERSION} ${SPEC}") {
-        def JOB_NAME = "Pipeline-Build-Test-JDK${SDK_VERSION}-${SPEC}"
+OPENJDK_REPO = [:]
+OPENJDK_BRANCH = [:]
+OPENJDK_SHA = [:]
+
+BUILD_RELEASES = []
+builds = [:]
+
+timeout(time: 10, unit: 'HOURS') {
+    timestamps {
+        node(LABEL) {
+            try {
+                checkout scm
+                def variableFile = load 'buildenv/jenkins/common/variables-functions'
+                def buildFile = load 'buildenv/jenkins/common/pipeline-functions'
+
+                def BUILD_SPECS = get_specs(SPECS)
+                // find releases to build based on given specs
+                BUILD_RELEASES.addAll(get_build_releases(BUILD_SPECS))
+
+                // parse variables file and initialize variables
+                variableFile.set_job_variables('wrapper')
+                def SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+
+                if (params.PERSONAL_BUILD) {
+                    // update build name
+                    wrap([$class: 'BuildUser']) {
+                        currentBuild.displayName = "#${BUILD_NUMBER} - ${BUILD_USER_EMAIL}"
+                    }
+
+                    // update build description
+                    currentBuild.description += "<br/>${params.PLATFORMS}"
+                }
+
+                def BUILD_NODES = get_node_labels(params.BUILD_NODE_LABELS, BUILD_SPECS.keySet())
+                def TEST_NODES = get_node_labels(params.TEST_NODE_LABELS, BUILD_SPECS.keySet())
+
+                BUILD_SPECS.each { SPEC, SDK_VERSIONS ->
+                    SDK_VERSIONS.each { SDK_VERSION ->
+                        // set OpenJDK repos and branch for the downstream build
+                        def REPO = OPENJDK_REPO[SDK_VERSION]
+                        def BRANCH = OPENJDK_BRANCH[SDK_VERSION]
+
+                        // set nodes for the downstream builds
+                        def BUILD_NODE = ''
+                        if (BUILD_NODES[SPEC]) {
+                            BUILD_NODE = BUILD_NODES[SPEC]
+                        }
+                        def TEST_NODE = ''
+                        if (TEST_NODES[SPEC]) {
+                            TEST_NODE = TEST_NODES[SPEC]
+                        }
+
+                        builds["build_test_JDK${SDK_VERSION}_${SPEC}"] = { build(REPO, BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE) }
+                    }
+                }
+            } finally {
+                try{
+                    cleanWs()
+                } catch(e) {
+                    if (variableFile) {
+                        printStackTrace(e)
+                    } else {
+                        echo e.toString()
+                    }
+                }
+            }
+        }
+
+        // launch all pipeline builds
+        parallel builds
+    }
+}
+
+def build(OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE) {
+    def JOB_NAME = "Pipeline-Build-Test-JDK${SDK_VERSION}-${SPEC}"
+
+    stage ("${JOB_NAME}") {
         JOB = build job: JOB_NAME,
                 parameters: [
                     string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
                     string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH),
-                    string(name: 'OPENJDK_SHA', value: OPENJDK_SHA),
+                    string(name: 'OPENJDK_SHA', value: SHAS['OPENJDK'].get(SDK_VERSION)),
                     string(name: 'OPENJ9_REPO', value: OPENJ9_REPO),
                     string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH),
-                    string(name: 'OPENJ9_SHA', value: OPENJ9_SHA),
+                    string(name: 'OPENJ9_SHA', value: SHAS['OPENJ9']),
                     string(name: 'OMR_REPO', value: OMR_REPO),
                     string(name: 'OMR_BRANCH', value: OMR_BRANCH),
-                    string(name: 'OMR_SHA', value: OMR_SHA)]
+                    string(name: 'OMR_SHA', value: SHAS['OMR']),
+                    string(name: 'TESTS_TARGETS', value: params.TESTS_TARGETS),
+                    string(name: 'VARIABLE_FILE', value: params.VARIABLE_FILE),
+                    string(name: 'VENDOR_REPO', value: params.VENDOR_REPO),
+                    string(name: 'VENDOR_BRANCH', value: params.VENDOR_BRANCH),
+                    string(name: 'VENDOR_CREDENTIALS_ID', value: params.VENDOR_CREDENTIALS_ID),
+                    string(name: 'BUILD_NODE', value: BUILD_NODE),
+                    string(name: 'TEST_NODE', value: TEST_NODE),
+                    string(name: 'PERSONAL_BUILD', value: params.PERSONAL_BUILD),
+                    string(name: 'SLACK_CHANNEL', value: params.SLACK_HANDLE)]
         return JOB
     }
+}
+
+/*
+* Parses the build parameters to identify the specs and the releases to build
+* and test. Returns a map of releases by specs.
+*/
+def get_specs(SUPPORTED_SPECS) {
+    def RELEASES = []
+    def PLATFORMS = []
+    def SPECS = [:]
+
+    // get releases 
+    params.each { key, value  ->
+        if ((key.indexOf('Java') != -1) && (value == true)) {
+            RELEASES.add(key.substring(4))
+        }
+    }
+
+    // get specs
+    if (!params.PLATFORMS || (params.PLATFORMS.trim() == 'all')) {
+        // build and test all supported specs
+        PLATFORMS.addAll(SUPPORTED_SPECS.keySet())
+    } else {
+        PLATFORMS.addAll(params.PLATFORMS.split(","))
+    }
+
+    def RELEASES_STR = RELEASES.join(',')
+
+    PLATFORMS.each { SPEC ->
+        SPEC = SPEC.trim()
+        if (!SUPPORTED_SPECS.keySet().contains(SPEC)) {
+            echo "Warning: Unknown or unsupported platform: ${SPEC}"
+            continue
+        }
+
+        if (RELEASES) {
+            // personal build
+            SPEC_RELEASES = SUPPORTED_SPECS[SPEC].intersect(RELEASES)
+         } else {
+            SPEC_RELEASES = SUPPORTED_SPECS[SPEC]
+         }
+
+        if (SPEC_RELEASES) {
+            // populate the releases by specs map
+            SPECS[SPEC] = SPEC_RELEASES
+        } else {
+            echo "Warning: Selected Java versions (${RELEASES_STR}) for ${SPEC} is not supported(nothing to do)!"
+        }
+    }
+
+    if (!SPECS) {
+        error("Invalid PLATFORMS (${params.PLATFORMS}) and/or Java versions selections(${RELEASES_STR})!")
+    }
+
+    return SPECS
+}
+
+/*
+* Returns a list of releases to build.
+*/
+def get_build_releases(BUILD_SPECS) {
+    def BUILD_RELEASES = []
+
+    BUILD_SPECS.values().each { SDK_VERSIONS ->
+        BUILD_RELEASES.addAll(SDK_VERSIONS)
+    }
+
+    return BUILD_RELEASES.unique()
+}
+
+/*
+* Returns a map containing node labels per platform.
+*
+* Labels can be single machine labels - e.g. ub14hcxrt2 or boolean expressions
+* of machine's labels - e.g. sw.os.linux && hw.arch.x66 && !sw.ubuntu14.
+* Multiple platform node labels can be specified as comma separated labels per
+* platform:
+* e.g. linux_x86-64=sw.os.linux && hw.arhc.x66 && !sw.ubuntu14,aix_ppc-64_cmprssptrs=csp700003.
+* For a single platform build, the platform is optional:
+* e.g. sw.os.linux && hw.arch.x66 && !sw.ubuntu14
+*/
+def get_node_labels(NODE_LABELS, SPECS) {
+    def LABELS = [:]
+
+    if (!NODE_LABELS) {
+        return LABELS
+    }
+
+    if ((SPECS.size() == 1) && (NODE_LABELS.indexOf("=") == -1) ){
+        // single platform labels, e.g. NODE_LABELS = label1 && label2
+        LABELS.put(SPECS[0], NODE_LABELS.trim())
+    } else {
+        // multiple platform expected labels:
+        // e.g. linux_xx86-64=label1 && label2, linux_ppc-64_cmprssptrs_le=label3, win_x86=label4
+        NODE_LABELS.trim().split(",").each { ITEM ->
+            def ENTRY = ITEM.trim().split("=")
+            if (ENTRY.size() != 2) {
+                error("Invalid format for node labels: ${ITEM}! Expected value: spec1=labels1,spec2=labels2,...,specNe=labelsN e.g. aix_ppc-64_cmprssptrs=csp70027,linux_x86-64=(ci.project.openj9 && hw.arch.x86 && sw.os.ubuntu.14)")
+            }
+
+            if (!SPECS.contains(ENTRY[0].trim())) {
+                error("Wrong node labels platform: ${ENTRY[0]} in ${ITEM}! It does not match any of your selected platforms: ${params.PLATFORMS}")
+            }
+
+            LABELS.put(ENTRY[0].trim(), ENTRY[1].trim())
+        }
+    }
+
+    return LABELS
 }


### PR DESCRIPTION
Update Pipeline-Build-Test-All to support personal build pipeline. A
personal build pipeline builds and/or tests the Eclipse OpenJ9
extensions for OpenJDK for one or more platforms and versions in
parallel using Pipeline-Build-Test-JDK<version>-<spec> pipelines. When no platforms and Java version provided it builds and tests all of the
OpenJ9 releases on all supported platforms.
Remove hard-coded repositories and branches variable and add support
for vendor configuration.
Reformat set_repos_variables() method to set variables for a single or multiple OpenJDK repositories. Ensure SSH protocol is used for private repositories and HTTPS protocol for public repositories.
Reformat get_shas() method to fetch the SHA for a single or multiple OpenJDK repositories.
Disable slack notification for personal builds.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>