### PR TITLE
Some VMThread reclamation cleanup on x86

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,8 +103,6 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(
 
    TR::J9LinkageUtils::switchToMachineCStack(callNode, cg());
 
-   cg()->setVMThreadRequired(true);
-
    // Allocate adequate register dependencies.
    //
    // pre = number of argument registers
@@ -177,8 +175,6 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(
 
    TR::LabelSymbol *postDepLabel = generateLabelSymbol(cg());
    generateLabelInstruction(LABEL, callNode, postDepLabel, postDeps, cg());
-
-   cg()->setVMThreadRequired(false);
 
    return returnReg;
    }

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1499,8 +1499,6 @@ TR::Register *TR::AMD64JNILinkage::buildDirectJNIDispatch(TR::Node *callNode)
 
    populateJNIDispatchInfo();
 
-   cg()->setVMThreadRequired(true);
-
    static char * disablePureFn = feGetEnv("TR_DISABLE_PURE_FUNC_RECOGNITION");
    if (!isGPUHelper)
       {
@@ -1694,8 +1692,6 @@ TR::Register *TR::AMD64JNILinkage::buildDirectJNIDispatch(TR::Node *callNode)
    TR::LabelSymbol *restartLabel = generateLabelSymbol(cg());
    restartLabel->setEndInternalControlFlow();
    generateLabelInstruction(LABEL, callNode, restartLabel, _JNIDispatchInfo.mergeLabelPostDeps, cg());
-
-   cg()->setVMThreadRequired(false);
 
    return _JNIDispatchInfo.JNIReturnRegister;
    }

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1477,8 +1477,6 @@ TR::X86PrivateLinkage::buildDirectDispatch(
       generateInstruction(FPREGSPILL, callNode, fpSpillDependency, cg());
       }
 
-   cg()->setVMThreadRequired(true);
-
    // Remember where internal control flow region should start,
    // and create labels
    //
@@ -1537,8 +1535,6 @@ TR::X86PrivateLinkage::buildDirectDispatch(
 
    if (cg()->enableRegisterAssociations() && !callNode->getSymbol()->castToMethodSymbol()->preservesAllRegisters())
       associatePreservedRegisters(site.getPostConditionsUnderConstruction(), returnRegister);
-
-   cg()->setVMThreadRequired(false);
 
    return returnRegister;
    }
@@ -2023,8 +2019,6 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
       generateInstruction(FPREGSPILL, callNode, fpSpillDependency, cg());
       }
 
-   cg()->setVMThreadRequired(true);
-
    // If receiver could be NULL, must evaluate it before the call
    // so any exception occurs before the call.
    // Might as well do it outside the internal control flow.
@@ -2276,7 +2270,6 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    if (cg()->enableRegisterAssociations())
       associatePreservedRegisters(site.getPostConditionsUnderConstruction(), returnRegister);
 
-   cg()->setVMThreadRequired(false);
    cg()->setImplicitExceptionPoint(site.getImplicitExceptionPoint());
 
    return returnRegister;

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,8 +85,6 @@ TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPReg
       }
 #endif
 
-   cg()->setVMThreadRequired(true);
-
    TR::RealRegister    *stackPointerReg = machine()->getX86RealRegister(TR::RealRegister::esp);
    TR::SymbolReference *methodSymRef    = callNode->getSymbolReference();
    TR::MethodSymbol    *methodSymbol    = callNode->getSymbol()->castToMethodSymbol();
@@ -96,8 +94,6 @@ TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPReg
       diagnostic("Building call site for %s\n", methodSymbol->getMethod()->signature(trMemory()));
 
    TR::X86VFPDedicateInstruction  *vfpDedicateInstruction = generateVFPDedicateInstruction(machine()->getX86RealRegister(TR::RealRegister::ebx), callNode, cg());
-
-   cg()->setVMThreadRequired(true);
 
    TR::J9LinkageUtils::switchToMachineCStack(callNode, cg());
 
@@ -151,7 +147,6 @@ TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPReg
    TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
 
    generateVFPReleaseInstruction(vfpDedicateInstruction, callNode, cg());
-   cg()->setVMThreadRequired(false);
 
    // Label denoting end of dispatch code sequence; dependencies are on
    // this label rather than on the call
@@ -192,8 +187,6 @@ TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPReg
 
    if (cg()->enableRegisterAssociations())
       associatePreservedRegisters(deps, returnReg);
-
-   cg()->setVMThreadRequired(false);
 
    return returnReg;
    }

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -110,7 +110,6 @@ TR::Register *TR::IA32JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
    TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, 20, cg());
 
-   cg()->setVMThreadRequired(true);
    TR::SymbolReference      *callSymRef = callNode->getSymbolReference();
    TR::MethodSymbol         *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
    TR::ResolvedMethodSymbol *resolvedMethodSymbol = callSymbol->castToResolvedMethodSymbol();
@@ -734,8 +733,6 @@ TR::Register *TR::IA32JNILinkage::buildJNIDispatch(TR::Node *callNode)
    bool useRegisterAssociations = cg()->enableRegisterAssociations() ? true : false;
    if (useRegisterAssociations)
       associatePreservedRegisters(deps, returnRegister);
-
-   cg()->setVMThreadRequired(false);
 
    return returnRegister;
    }

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -331,7 +331,6 @@ TR::Register *TR::IA32PrivateLinkage::buildJNIDispatch(TR::Node *callNode)
 
    TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, 20, cg());
 
-   cg()->setVMThreadRequired(true);
    TR::SymbolReference      *callSymRef = callNode->getSymbolReference();
    TR::MethodSymbol         *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
    TR::ResolvedMethodSymbol *resolvedMethodSymbol = callSymbol->castToResolvedMethodSymbol();
@@ -939,8 +938,6 @@ TR::Register *TR::IA32PrivateLinkage::buildJNIDispatch(TR::Node *callNode)
    bool useRegisterAssociations = cg()->enableRegisterAssociations() ? true : false;
    if (useRegisterAssociations)
       associatePreservedRegisters(deps, returnRegister);
-
-   cg()->setVMThreadRequired(false);
 
    return returnRegister;
    }


### PR DESCRIPTION
* Remove setVMThreadRequired calls on x86
* Remove deprecated VMThread reclamation control logic

OpenJ9 cleanup for Issue eclipse/omr#2256
