### PR TITLE
Make jvmtiGetAvailableProcessors identical to JVM_ActiveProcessorCount

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5499,7 +5499,6 @@ JVM_RegisterUnsafeMethods(JNIEnv* env, jclass unsafeClz)
 jint JNICALL
 JVM_ActiveProcessorCount(void)
 {
-	PORT_ACCESS_FROM_JAVAVM(BFUjavaVM);
 	jint num;
 
 	Trc_SC_ActiveProcessorCount_Entry();
@@ -5509,10 +5508,7 @@ JVM_ActiveProcessorCount(void)
 	 * RTC 112959: [was 209402] Liberty JAX-RS Default Executor poor performance.  Match reference implementation behaviour
 	 * to return the bound CPUs rather than physical CPUs.
 	 */
-	num = (jint)j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
-	if (num < 1) {
-		num = 1;
-	}
+	num = (jint) ((J9JavaVM *) BFUjavaVM)->internalVMFunctions->getNumTargetProcessorsCommon((J9JavaVM *) BFUjavaVM);
 
 	Trc_SC_ActiveProcessorCount_Exit(num);
 

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -201,15 +201,12 @@ jvmtiGetAvailableProcessors(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
-	PORT_ACCESS_FROM_JAVAVM(vm);
-	UDATA cpuCount;
 
 	Trc_JVMTI_jvmtiGetAvailableProcessors_Entry(env);
 
 	ENSURE_NON_NULL(processor_count_ptr);
 
-	cpuCount = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE);
-	*processor_count_ptr = ((cpuCount == 0) ? 1 : (jint) cpuCount);
+	*processor_count_ptr = (jint) vm->internalVMFunctions->getNumTargetProcessorsCommon(vm);
 	rc = JVMTI_ERROR_NONE;
 
 done:

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4819,6 +4819,7 @@ typedef struct J9InternalVMFunctions {
 	IDATA ( *registerOSHandler)(struct J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
 	void ( *throwNativeOOMError)(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
 	void ( *throwNewJavaIoIOException)(JNIEnv *env, const char *message);
+	UDATA ( *getNumTargetProcessorsCommon)(struct J9JavaVM *vm);
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3457,6 +3457,17 @@ setSystemPropertyValue(J9JavaVM * vm, J9VMSystemProperty * property, char * newV
 UDATA
 addSystemProperty(J9JavaVM * vm, const char* propName,  const char* propValue, UDATA flags);
 
+/**
+ * This function returns the number of available processors, taking into account resource limits
+ * (including cgroup limits if -XX:+UseContainerSupport is set).
+ * 
+ * @param [in] vm the J9JavaVM
+ * 
+ * @return the number of available processors.
+ */
+UDATA
+getNumTargetProcessorsCommon(J9JavaVM * vm);
+
 /* ---------------- vmruntimestate.c ---------------- */
 
 /**

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -365,4 +365,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	registerOSHandler,
 	throwNativeOOMError,
 	throwNewJavaIoIOException,
+	getNumTargetProcessorsCommon
 };

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1417,3 +1417,24 @@ getMUtf8String(J9JavaVM * vm, const char *userString, UDATA stringLength) {
 	}
 	return result;
 }
+
+/**
+ * This function returns the number of available processors, taking into account resource limits
+ * (including cgroup limits if -XX:+UseContainerSupport is set).
+ * 
+ * @param [in] vm the J9JavaVM
+ * 
+ * @return the number of available processors.
+ */
+UDATA
+getNumTargetProcessorsCommon(J9JavaVM * vm) {
+	UDATA cpuCount;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	cpuCount = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
+	if (cpuCount == 0) {
+		return 1;
+	} else {
+		return cpuCount;
+	}
+}


### PR DESCRIPTION
This change causes `jvmtiGetAvailableProcessors` to behave identically
to `JVM_ActiveProcessorCount`, moving the common code to a separate
internal VM function.

This change addresses the consistency issue between the functions,
also causing `jvmtiGetAvailableProcessors` take into account cgroup limits
when appropriate as discussed in #1166.

Issue: #1166
Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>