### PR TITLE
Fix cmdLineTester_callsitedbgddrext

### DIFF
--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -36,10 +36,10 @@
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
 	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -nonZeroExitWhenError; \
+	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on aix github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.aix</platformRequirements>
+		<!-- temporarily disable this test on aix, win, zos github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.aix,^os.win,^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Added missing plats option.
- Exclude test on win and z/OS util ddr is supported.

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>