### PR TITLE
Optimize JVMTI watched fields

### DIFF
--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -2429,6 +2429,8 @@ jvmtiHookCheckForDataBreakpoint(J9HookInterface** hook, UDATA eventNum, void* ev
 						}
 					}
 					index += 1;
+					descriptionsRemaining -= 1;
+					descriptionBits >>= J9JVMTI_WATCHED_FIELD_BITS_PER_FIELD;
 				}
 				watchedClass = hashTableNextDo(&walkState);
 			}


### PR DESCRIPTION
Fix data breakpoint hook to correctly decode the bitfield for watched
fields.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>