### PR TITLE
Fix OpenJ9 jvm.dll version for Windows

### DIFF
--- a/runtime/makelib/mkconstants.mk.ftl
+++ b/runtime/makelib/mkconstants.mk.ftl
@@ -24,8 +24,16 @@
 </#list>
 
 # Define the Java Version we are compiling
-VERSION_MAJOR?=9
+ifndef VERSION_MAJOR
+$(error VERSION_MAJOR is not set from extensions code)
+endif
 export VERSION_MAJOR
+
+# Define full Java Version
+ifndef OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
+$(error OPENJDK_VERSION_NUMBER_FOUR_POSITIONS is not set from extensions code)
+endif
+export OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
 
 # Define a default target of the root directory for all targets.
 ifndef UMA_TARGET_PATH

--- a/sourcetools/com.ibm.uma/com/ibm/j9/uma/platform/PlatformWindows.java
+++ b/sourcetools/com.ibm.uma/com/ibm/j9/uma/platform/PlatformWindows.java
@@ -38,6 +38,8 @@ import com.ibm.uma.util.FileAssistant;
 public class PlatformWindows extends PlatformImplementation {
 	
 	static final String DEFAULT_RC_PRODUCT_NAME="IBM SDK, Java(tm) 2 Technology Edition";
+	/* version number with dots seperating four parts */
+	static final String OPENJDK_VERSION_NUMBER_FOUR_POSITIONS = System.getenv("OPENJDK_VERSION_NUMBER_FOUR_POSITIONS");
 	
 	public PlatformWindows( IConfiguration buildSpec ) {
 		super(buildSpec);
@@ -186,9 +188,6 @@ public class PlatformWindows extends PlatformImplementation {
 			productName = DEFAULT_RC_PRODUCT_NAME;
 		}
 		
-		int buildIdLow = Integer.parseInt(getBuildId()) & 0xffff;
-		int buildIdHigh = Integer.parseInt(getBuildId()) >> 16;
-		
 		buffer.append(
 				"\n" +
 		"#include <windows.h>\n");
@@ -198,8 +197,8 @@ public class PlatformWindows extends PlatformImplementation {
 				"#include \"j9version.h\"\n" +
 				"\n" +
 				"VS_VERSION_INFO VERSIONINFO\n" +
-				" FILEVERSION " + getMajorVersion() + "," + getMinorVersion()+ ","+ buildIdHigh +"," + buildIdLow + "\n" +
-				" PRODUCTVERSION " + getMajorVersion() + "," + getMinorVersion()+ ","+ buildIdHigh +"," + buildIdLow + "\n" +
+				" FILEVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
+				" PRODUCTVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
 				" FILEFLAGSMASK 0x3fL\n" +
 				" FILEFLAGS 0x0L\n" +
 				" FILEOS VOS_NT_WINDOWS32\n" +
@@ -212,12 +211,12 @@ public class PlatformWindows extends PlatformImplementation {
 				"		BEGIN\n" +
 				"			VALUE \"CompanyName\", \"International Business Machines Corporation\\0\"\n" +
 				"			VALUE \"FileDescription\", \"WebSphere Studio Device Developer\\0\"\n" +
-				"			VALUE \"FileVersion\", \"R" + getMajorVersion() + "." + getMinorVersion()+ " (\" EsBuildVersionString \")\\0\"\n" +
+				"			VALUE \"FileVersion\", \"" + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS + "\\0\"\n" +
 				"			VALUE \"InternalName\", \"" + getTargetNameWithRelease(artifact) + "\\0\"\n" +
 				"			VALUE \"LegalCopyright\", \" Copyright (c) 1991, " + calendar.get(Calendar.YEAR) + " IBM Corp. and others\\0\"\n" +
 				"			VALUE \"OriginalFilename\", \"" + getTargetNameWithRelease(artifact) + ".dll\\0\"\n" +
 				"			VALUE \"ProductName\", \"" + productName + "\\0\"\n" +
-				"			VALUE \"ProductVersion\", \"R" + getMajorVersion() + "." + getMinorVersion()+ "\\0\"\n" +
+				"			VALUE \"ProductVersion\", \"" + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS + "\\0\"\n" +
 				"		END\n" +
 				"	END\n" +
 				"	BLOCK \"VarFileInfo\"\n" +
@@ -517,8 +516,6 @@ public class PlatformWindows extends PlatformImplementation {
 		if (productName == null ) {
 			productName = DEFAULT_RC_PRODUCT_NAME;
 		}
-		int buildIdLow = Integer.parseInt(getBuildId()) & 0xffff;
-		int buildIdHigh = Integer.parseInt(getBuildId()) >> 16;
 		
 		buffer.append(
 				"\n" +
@@ -529,8 +526,8 @@ public class PlatformWindows extends PlatformImplementation {
 				"#include \"j9version.h\"\n" +
 				"\n" +
 				"VS_VERSION_INFO VERSIONINFO\n" +
-				" FILEVERSION " + getMajorVersion() + "," + getMinorVersion()+ ","+ buildIdHigh +"," + buildIdLow + "\n" +
-				" PRODUCTVERSION " + getMajorVersion() + "," + getMinorVersion()+ ","+ buildIdHigh +"," + buildIdLow + "\n" +
+				" FILEVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
+				" PRODUCTVERSION " + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS.replace(".", ",") + "\n" +
 				" FILEFLAGSMASK 0x3fL\n" +
 				" FILEFLAGS 0x0L\n" +
 				" FILEOS VOS_NT_WINDOWS32\n" +
@@ -543,12 +540,12 @@ public class PlatformWindows extends PlatformImplementation {
 				"		BEGIN\n" +
 				"			VALUE \"CompanyName\", \"International Business Machines Corporation\\0\"\n" +
 				"			VALUE \"FileDescription\", \"J9 Virtual Machine Runtime\\0\"\n" +
-				"			VALUE \"FileVersion\", \"R" + getMajorVersion() + "." + getMinorVersion()+ " (\" EsBuildVersionString \")\\0\"\n" +
+				"			VALUE \"FileVersion\", \"" + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS + "\\0\"\n" +
 				"			VALUE \"InternalName\", \"" + getTargetNameWithRelease(artifact) + "\\0\"\n" +
 				"			VALUE \"LegalCopyright\", \" Copyright (c) 1991, " + calendar.get(Calendar.YEAR) + " IBM Corp. and others\\0\"\n" +
 				"			VALUE \"OriginalFilename\", \"" + getTargetNameWithRelease(artifact) + ".dll\\0\"\n" +
 				"			VALUE \"ProductName\", \"" + productName + "\\0\"\n" +
-				"			VALUE \"ProductVersion\", \"R" + getMajorVersion() + "." + getMinorVersion()+ "\\0\"\n" +
+				"			VALUE \"ProductVersion\", \"" + OPENJDK_VERSION_NUMBER_FOUR_POSITIONS + "\\0\"\n" +
 				"		END\n" +
 				"	END\n" +
 				"	BLOCK \"VarFileInfo\"\n" +


### PR DESCRIPTION
Eclipse equinox launcher does not recognise OpenJ9 Java 10 as modular VM. Equinox checks the product version of jvm.dll which for OpenJ9 is always set to 2.9.x.x.

Resolves: #2051

These extensions prs need to be merged prior to this pr:
Java8: ibmruntimes/openj9-openjdk-jdk8#99
Java9: ibmruntimes/openj9-openjdk-jdk9#165
Java10: ibmruntimes/openj9-openjdk-jdk10#43
Java11: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/8

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>