### PR TITLE
Add test cases for the DDR commands_Command 3.1 and 3.2

### DIFF
--- a/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
@@ -128,4 +128,95 @@
 
  </test>
  
+ <test id="Run !dumpmoduleexports">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!dumpmoduleexports $moduleAddr$</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">!j9package 0x</output>
+  <saveoutput regex="no" type="required" saveName="packageAddr" splitIndex="1" splitBy="!j9package ">jdk/internal/vm </saveoutput>
+  <output regex="no" type="required">sun/net</output>
+  <output regex="no" type="required">java/util/stream</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+
+ </test>
+ 
+ <test id="Verify !dumpmoduleexports">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!j9package $packageAddr$</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">Fields for J9Package:</output>
+  <output regex="no" type="required">packageName</output>
+  <output regex="no" type="required">jdk/internal/vm</output>
+  <output regex="no" type="required">module</output>
+  <output regex="no" type="required">exportsHashTable</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">&lt;FAULT&gt;</output>
+
+ </test>
+ 
+ <test id="Run !dumpmodulereads">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!dumpmodulereads $moduleAddr$</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">!j9module 0x</output>
+  <saveoutput regex="no" type="required" saveName="readModuleAddr" splitIndex="1" splitBy="!j9module ">openj9.cuda</saveoutput>
+  <output regex="no" type="required">jdk.net</output>
+  <output regex="no" type="required">java.se</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+
+ </test>
+ 
+ <test id="Verify !dumpmodulereads">
+  <exec command="sh" capture="LOGNAME" platforms="zos.*" >
+    <arg>-c</arg>
+    <arg>echo $$LOGNAME</arg>
+  </exec>
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP.X001' $DUMPFILE$" platforms="zos_390-64.*" />
+  <exec command="cp //'$LOGNAME$.J9CORE.DMP' $DUMPFILE$" platforms="zos_390-31.*" />
+  <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
+  <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
+        <command command="$JDMPVIEW_EXE$">
+                <arg>-core $DUMPFILE$</arg>
+                <input>!j9module $readModuleAddr$</input>
+                <input>quit</input>
+        </command>
+  <output regex="no" type="success">Fields for J9Module:</output>
+  <output regex="no" type="required">moduleName</output>
+  <output regex="no" type="required">version</output>
+  <output regex="no" type="required">readAccessHashTable</output>
+  <output regex="no" type="failure">DDRInteractiveCommandException</output>
+  <output regex="no" type="failure">&lt;FAULT&gt;</output>
+
+ </test>
+ 
  </suite>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -42,7 +42,8 @@
 	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>^os.zos,^os.win,^os.aix</platformRequirements>
+		<!-- Tests excluded on zos and aix because neither platform supports DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<platformRequirements>^os.zos,^os.aix</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Added test cases for `!dumpmoduleexports` and `!dumpmodulereads`.

Example output: 
```
Testing: Run !dumpmoduleexports
Test start time: 2018/06/14 13:13:11 Eastern Standard Time
Running command: C:/bluebird/builds/bld_389348/wa6490/bin/jdmpview.exe -core j9core.dmp
Time spent starting: 4 milliseconds
Time spent executing: 3388 milliseconds
Test result: PASSED

Testing: Verify !dumpmoduleexports
Test start time: 2018/06/14 13:13:15 Eastern Standard Time
Running command: C:/bluebird/builds/bld_389348/wa6490/bin/jdmpview.exe -core j9core.dmp
Time spent starting: 3 milliseconds
Time spent executing: 3145 milliseconds
Test result: PASSED

Testing: Run !dumpmodulereads
Test start time: 2018/06/14 13:13:18 Eastern Standard Time
Running command: C:/bluebird/builds/bld_389348/wa6490/bin/jdmpview.exe -core j9core.dmp
Time spent starting: 3 milliseconds
Time spent executing: 3255 milliseconds
Test result: PASSED

Testing: Verify !dumpmodulereads
Test start time: 2018/06/14 13:13:21 Eastern Standard Time
Running command: C:/bluebird/builds/bld_389348/wa6490/bin/jdmpview.exe -core j9core.dmp
Time spent starting: 5 milliseconds
Time spent executing: 3167 milliseconds
Test result: PASSED

```


\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
**NOTE:** This pull request depends on [PR#1987](https://github.com/eclipse/openj9/pull/1987) and [PR#2021](https://github.com/eclipse/openj9/pull/2021)