### PR TITLE
Remove deprecation tag from Java 8 javadoc

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1551,8 +1551,10 @@ public final Package[] getDefinedPackages() {
  *
  * @param		name		The name of the package to find
  * @return		The package requested, or null
- * 
+/*[IF Sidecar19-SE]
+ *
  * @deprecated Use getDefinedPackage(String)
+/*[ENDIF]
  */
 /*[IF Sidecar19-SE]*/
 @Deprecated(forRemoval=false, since="9")


### PR DESCRIPTION
getPackage(String) is deprecated beginning with Java 9