### PR TITLE
Fix stringConcatOptTest ignoring JVM_OPTIONS variable

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -55,7 +55,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(MKTREE) $(REPORTDIR); \
-	$(JAVA_COMMAND) -Xjit:count=1,disableAsyncCompilation,verbose,vlog="$(REPORTDIR)$(D)jitv.log" \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xjit:count=1,disableAsyncCompilation,verbose,vlog="$(REPORTDIR)$(D)jitv.log" \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames stringConcatOptTest -groups $(TEST_GROUP) \


### PR DESCRIPTION
To the best of my knowledge this is a safe thing to do. Every other test listed in this file passes JVM_OPTIONS along to the test except for this one. JVM_OPTIONS appears to normally be empty unless the environment variable EXTRA_OPTIONS is set.

Signed-off-by: Noah Weninger <noah.weninger@ibm.com>