### PR TITLE
Bring up Java 11 - j.l.Access.getBytesNoRepl()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -48,6 +48,9 @@ import sun.reflect.annotation.AnnotationType;
 import java.lang.Module;
 import java.util.Iterator;
 import java.util.List;
+/*[IF Java11]*/
+import java.nio.charset.Charset;
+/*[ENDIF]*/
 /*[ELSE]
 import java.lang.reflect.Module;
 /*[ENDIF]*/
@@ -361,6 +364,12 @@ final class Access implements JavaLangAccess {
 /*[IF Java11]*/
 	public void blockedOn(Interruptible interruptible) {
 		Thread.blockedOn(interruptible);
+	}
+	public byte[] getBytesNoRepl(String str, Charset charset) {
+		return StringCoding.getBytesNoRepl(str, charset);
+	}
+	public String newStringNoRepl(byte[] bytes, Charset charset) {
+		return StringCoding.newStringNoRepl(bytes, charset);
 	}
 /*[ENDIF]*/
 	


### PR DESCRIPTION
Bring up `Java 11` - `j.l.Access.getBytesNoRepl()`

Fix `Java 11` raw build error:
```
error: Access is not abstract and does not override abstract method
getBytesNoRepl(String,Charset) in JavaLangAccess
```

Verified manually that `pConfig` still compiles.

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>