### PR TITLE
Remove duplicate functional testing

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -176,14 +176,14 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                     if (SPEC.contains("win") || SDK_VERSION == "9" || SDK_VERSION == "10") {
                         TARGET_NAMES = ["Sanity"]
                     } else {
-                        TARGET_NAMES = ["Sanity", "sanity.functional", "sanity.system"]
+                        TARGET_NAMES = ["sanity.functional", "sanity.system"]
                     }
                     break
                 case "_extended":
                     if (SPEC.contains("win") || SDK_VERSION == "9" || SDK_VERSION == "10") {
                         TARGET_NAMES = ["Extended"]
                     } else {
-                        TARGET_NAMES = ["Extended", "extended.functional"]
+                        TARGET_NAMES = ["extended.functional"]
                     }
                     break
                 // temporary for OMR acceptance. This should be removed once we completely switch to AdoptOpenJDK test Jenkins file


### PR DESCRIPTION
- Remove old style sanity & extended (functional)
  from nightly builds.
- Machine resources are limited and new style (Adopt Pipelines)
  functional testing is stable, so this removes the
  old style (OpenJ9 pipelines)

Related #2117
Issue #1450
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

cc @llxia 