### PR TITLE
Remove JDK9 from nightly build

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -20,20 +20,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-def SPECS = ['aix_ppc-64_cmprssptrs'      : ['8', '9', '10'],
-             'linux_390-64_cmprssptrs'    : ['8', '9', '10'],
-             'linux_ppc-64_cmprssptrs_le' : ['8', '9', '10'],
-             'linux_x86-64'               : ['8', '9', '10'],
-             'linux_x86-64_cmprssptrs'    : ['8', '9', '10'],
+def SPECS = ['aix_ppc-64_cmprssptrs'      : ['8', '10'],
+             'linux_390-64_cmprssptrs'    : ['8', '10'],
+             'linux_ppc-64_cmprssptrs_le' : ['8', '10'],
+             'linux_x86-64'               : ['8', '10'],
+             'linux_x86-64_cmprssptrs'    : ['8', '10'],
              'win_x86'                    : ['8'],
-             'win_x86-64_cmprssptrs'      : ['8', '9', '10']]
+             'win_x86-64_cmprssptrs'      : ['8', '10']]
 
 
 def OPENJDK_REPOS = ['8': 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git',
-                     '9': 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git',
                      '10': 'https://github.com/ibmruntimes/openj9-openjdk-jdk10.git']
 def OPENJDK_BRANCHES = ['8': 'openj9',
-                        '9': 'openj9',
                         '10': 'openj9']
 
 def OPENJ9_REPO = 'https://github.com/eclipse/openj9.git'


### PR DESCRIPTION
- After 0.9 release, OpenJ9 support for JDK9 is finished
- Remove from nightly build to free up machine resources

Issue #2020
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

Note: Depends on the 0.9 release being finished