### PR TITLE
Fix the condition to decide recompilation level

### DIFF
--- a/runtime/compiler/control/CompilationController.cpp
+++ b/runtime/compiler/control/CompilationController.cpp
@@ -205,7 +205,7 @@ TR_OptimizationPlan *TR::DefaultCompilationStrategy::processEvent(TR_MethodEvent
          methodInfo = bodyInfo->getMethodInfo();
 
          if (methodInfo->getReasonForRecompilation() == TR_PersistentMethodInfo::RecompDueToInlinedMethodRedefinition ||
-             methodInfo->getReasonForRecompilation() == TR_PersistentMethodInfo::RecompDueToJProfiling)
+             (methodInfo->getReasonForRecompilation() == TR_PersistentMethodInfo::RecompDueToJProfiling && !bodyInfo->getIsProfilingBody())) // if the recompilation is triggered from a JProfiling block but not in a profiled compilation keep the current compilation level unchanged
             {
             hotnessLevel = bodyInfo->getHotness();
             plan = TR_OptimizationPlan::alloc(hotnessLevel);


### PR DESCRIPTION
When a recompilation is triggered by JProfiling, the triggering method
body could be both profiled or non-profiled body. If the triggering
compilation is a profiled compilation we need to promote the
recompilation to the next level.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>