### PR TITLE
Support for resetting code cache allocation pointers

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,7 +94,29 @@ public:
                                                           int32_t cpIndex);
 
    OMR::CodeCacheHashEntry *  findUnresolvedMethod(void *constPool, int32_t constPoolIndex);
+ 
 
+  /**
+   * @brief Restore warmCodeAlloc/coldCodeAlloc and trampoline pointers to their initial positions
+   */
+   void resetCodeCache();
+
+   private:
+   /**
+    * @brief Restore trampoline pointers to their initial positions
+    */
+   void resetTrampolines();
+   /**
+   * @brief Remember the initial position of warmCodeAlloc/coldCodeAlloc pointers
+   */
+   void setInitialAllocationPointers();
+   /**
+   * @brief Restore warmCodeAlloc/coldCodeAlloc pointers to their initial positions
+   */
+   void resetAllocationPointers();
+
+   uint8_t * _warmCodeAllocBase; // used to reset the allocation pointers to initial values
+   uint8_t * _coldCodeAllocBase;
    };
 
 


### PR DESCRIPTION
This support could be used for TOSS_CODE scenarios when we compile a method,
but then throw away the compilation result.

CodeCache will add two new fields which will remember the initial position of
_warmCodeAlloc and _coldCodeAlloc.
resetAllocationPointers() will reset _warmCodeAlloc and _coldCodeAlloc to
their initial values.
resetTrampolines() will reset the trampoline status.
resetCodeCache() will reset both allocation pointers and trampolines.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>