### PR TITLE
Fix ForceEarlyReturn stack corruption

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1332,6 +1332,7 @@ obj:;
 			cleanUpForFramePop(REGISTER_ARGS, bp);
 			/* Return from this frame */
 			if (bp == _currentThread->j2iFrame) {
+				pushForceEarlyReturnValue(REGISTER_ARGS);
 				rc = j2iReturn(REGISTER_ARGS);
 			} else {
 				J9SFStackFrame *frame = ((J9SFStackFrame*)(bp + 1)) - 1;
@@ -1339,8 +1340,8 @@ obj:;
 				_literals = frame->savedCP;
 				_pc = frame->savedPC + 3;
 				_arg0EA = frame->savedA0;
+				pushForceEarlyReturnValue(REGISTER_ARGS);
 			}
-			pushForceEarlyReturnValue(REGISTER_ARGS);
 		}
 		return rc;
 	}


### PR DESCRIPTION
When popping a J2I frame, the return value must be pushed before
collapsing the frame (after which execution will continue in compiled
code).

Fixes #2013

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>