### PR TITLE
Prepare Balanced for implicit Master

### DIFF
--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -391,6 +391,10 @@ MM_IncrementalGenerationalGC::masterThreadGarbageCollect(MM_EnvironmentBase *env
 	 * allow concurrent operations.
 	 */
 	_forceConcurrentTermination = false;
+
+	/* Release any resources that might be bound to this master thread,
+	 * since it may be implicit and change for other phases of the cycle */
+	_interRegionRememberedSet->releaseCardBufferControlBlockListForThread(env, env);
 }
 
 void
@@ -1590,11 +1594,7 @@ MM_IncrementalGenerationalGC::incrementRegionAges(MM_EnvironmentVLHGC *env, UDAT
 	/* Overflowing stable regions releases buffers to thread local pool. Move them now to the locked global pool.
 	 * (if this is run in context of non-GC thread there will be not further opportinities to do it).
 	 */
-	env->_rsclBufferControlBlockCount -= _interRegionRememberedSet->releaseCardBufferControlBlockList(env, env->_rsclBufferControlBlockHead, env->_rsclBufferControlBlockTail);
-	Assert_MM_true(0 == env->_rsclBufferControlBlockCount);
-	env->_rsclBufferControlBlockHead = NULL;
-	env->_rsclBufferControlBlockTail = NULL;
-
+	_interRegionRememberedSet->releaseCardBufferControlBlockListForThread(env, env);
 }
 
 void 
@@ -1713,8 +1713,6 @@ MM_IncrementalGenerationalGC::declareAllRegionsAsMarked(MM_EnvironmentVLHGC *env
 bool
 MM_IncrementalGenerationalGC::isMarked(void *objectPtr)
 {
-	/* NOTE:  we shouldn't be using this entry-point for checking if an object is marked if we are currently within a cycle (the caller should use the mark map that they are working on) */
-	Assert_MM_false(_masterGCThread.isGarbageCollectInProgress());
 	/* the mark map used for PGC should be the most accurate */
 	return _markMapManager->getPartialGCMap()->isBitSet(static_cast<J9Object*>(objectPtr));
 }
@@ -2045,6 +2043,10 @@ MM_IncrementalGenerationalGC::masterThreadConcurrentCollect(MM_EnvironmentBase *
 	_persistentGlobalMarkPhaseState._vlhgcCycleStats.merge(&static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats);
 
 	env->_cycleState = NULL;
+
+	/* Release any resources that might be bound to this master thread,
+	 * since it may be implicit and more importantly change for other phases of the cycle */
+	_interRegionRememberedSet->releaseCardBufferControlBlockListForThread(env, env);
 	
 	/* return the number of bytes scanned since the caller needs to pass it into postConcurrentUpdateStatsAndReport for stats reporting */
 	return bytesConcurrentlyScanned;

--- a/runtime/gc_vlhgc/InterRegionRememberedSet.hpp
+++ b/runtime/gc_vlhgc/InterRegionRememberedSet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -235,6 +235,11 @@ public:
 	 * @return the number of buffers in the list being released 
 	 */
 	UDATA releaseCardBufferControlBlockList(MM_EnvironmentVLHGC* env, MM_CardBufferControlBlock *controlBlockHead, MM_CardBufferControlBlock *controlBlockTail = NULL);
+	
+	/**
+	 * release the complete list (from head to tail) of BufferControlBlocks for a given thread, and set the head and tail pointers to null.
+	 */
+	void releaseCardBufferControlBlockListForThread(MM_EnvironmentVLHGC* env, MM_EnvironmentVLHGC* threadEnv);
 
 	/**
 	 * release a BufferControlBlock list to the thread local pool.


### PR DESCRIPTION
Changes that remove assumption that Master GC thread is always an
explicit/same GC thread. Basically, release any local resources at the
end of a phase (either STW or concurrent), since master GC thread (in
future) may move from one thread to another from a phase to a phase,
within the same  GC cycle.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>