### PR TITLE
Update guidelines to add user doc process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following
 Secondary Licenses when the conditions for such availability set
 forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-General Public License, version 2 with the GNU Classpath 
+General Public License, version 2 with the GNU Classpath
 Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
@@ -27,10 +27,11 @@ Thank you for your interest in Eclipse OpenJ9!
 We welcome and encourage all kinds of contributions to the project, not only
 code. This includes bug reports, user experience feedback, assistance in
 reproducing issues and more. Contributions to the website
-(https://github.com/eclipse/openj9-website), to the system verification tests
-(https://github.com/eclipse/openj9-systemtest), or Eclipse OMR
-(https://github.com/eclipse/omr) which is an integral part of OpenJ9 are all
-also welcome. 
+(https://github.com/eclipse/openj9-website), to the user documentation
+(https://github.com/eclipse/openj9-docs), to the system verification tests
+(https://github.com/eclipse/openj9-systemtest), or to Eclipse OMR
+(https://github.com/eclipse/omr), which is an integral part of OpenJ9 are all
+also welcome.
 
 
 ## Submitting a contribution to OpenJ9
@@ -48,9 +49,15 @@ Following these guidelines will help us merge your pull requests smoothly:
 3. We encourage you to open a pull request early, and mark it as "Work In
    Progress", by prefixing the PR title with "WIP". This allows feedback to
    start early, and helps create a better end product. Committers will wait
-   until after you've removed the WIP prefix to merge your changes. 
+   until after you've removed the WIP prefix to merge your changes.
 
-4. Please carefully read and adhere to the legal considerations and
+4. If your contribution introduces an external change that requires an update
+   to the [user documentation](https://www.eclipse.org/openj9/docs/), add the
+   label `doc:externals` and open an  [issue](https://github.com/eclipse/openj9-docs/issues/new?template=new-documentation-change.md)
+   at the user documentation repository. Examples of an external change include
+   a new command line option, a change in behavior, or a restriction.
+
+5. Please carefully read and adhere to the legal considerations and
    copyright/license requirements outlined below.
 
 ## Commit Guidelines
@@ -69,7 +76,7 @@ copying resources into the body of the commit over providing external links.
 Structure large commit messages with headers, references etc. Remember, however,
 that the commit message is always going to be rendered in plain text.
 
-Please add `[skip ci]` to the commit message when the change doesn't require a 
+Please add `[skip ci]` to the commit message when the change doesn't require a
 compilation, such as documentation only changes, to avoid unnecessarily wasting
 the project's build resources.
 
@@ -80,7 +87,7 @@ https://help.github.com/articles/closing-issues-using-keywords/
 For example:
 
 ```
-Correct race in frobnicator 
+Correct race in frobnicator
 
 This patch eliminates the race condition in issue #1234.
 
@@ -168,7 +175,7 @@ Here is the checklist for contributions to be _acceptable_:
 Your signing of the ECA will be verified by a webservice called 'ip-validation'
 that checks the email address that signed-off on your commits has signed the
 ECA. **Note**: This service is case-sensitive, so ensure the email that signed
-the ECA and that signed-off on your commits is the same, down to the case. 
+the ECA and that signed-off on your commits is the same, down to the case.
 
 ### Copyright Notice and Licensing Requirements
 
@@ -189,23 +196,23 @@ The template for the copyright notice and dual-license is as follows:
 ```
 /*******************************************************************************
  * Copyright (c) %s, %s IBM Corp. and others
- * 
+ *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
  * or the Apache License, Version 2.0 which accompanies this distribution and
  * is available at https://www.apache.org/licenses/LICENSE-2.0.
- * 
+ *
  * This Source Code may also be made available under the following
  * Secondary Licenses when the conditions for such availability set
  * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
- * General Public License, version 2 with the GNU Classpath 
+ * General Public License, version 2 with the GNU Classpath
  * Exception [1] and GNU General Public License, version 2 with the
  * OpenJDK Assembly Exception [2].
- * 
+ *
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] http://openjdk.java.net/legal/assembly-exception.html
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 ```


### PR DESCRIPTION
Insert a new instruction (4) to provide
steps for contributions that change the
externals in some way. Adds link to
issue template in the user doc repo.

Process now lines up with
doc/processes/labels.md file.

Also add the user doc repo to the
list of places where we accept
contributions.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>