### PR TITLE
Fix Escape Analysis's is(NonThis)ArgToCall APIs

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -209,6 +209,7 @@ int32_t TR_EscapeAnalysis::perform()
       _maxInlinedBytecodeSize = 4000 - nodeCount;
       }
 
+   TR_ASSERT_FATAL(_maxSniffDepth < 16, "The argToCall and nonThisArgToCall flags are 16 bits - a depth limit greater than 16 will not fit in these flags");
    if (getLastRun())
       _maxPassNumber = 0; // Notwithstanding our heursitics, if this is the last run, our max "pass number" is zero (which is the first pass)
 

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,8 +157,8 @@ class Candidate : public TR_Link<Candidate>
    bool isProfileOnly()              {return _flags.testAny(ProfileOnly);}
 
    bool usesStackTrace()             {return _flags.testAny(UsesStackTrace);}
-   bool isArgToCall(int32_t depth)   {return (_flags.getValue(CallArgFlagsMask) & (1<<depth)) != 0;}
-   bool isNonThisArgToCall(int32_t depth) {return (_flags.getValue(CallNonThisArgFlagsMask) & (1<<(depth+8))) != 0;}
+   bool isArgToCall(int32_t depth)   {return _argToCallFlags.testAny(1<<depth);}
+   bool isNonThisArgToCall(int32_t depth) {return _nonThisArgToCallFlags.testAny(1<<(depth));}
    bool forceLocalAllocation()       { return _flags.testAny(ForceLocalAllocation);}
 
    void setForceLocalAllocation(bool v = true)       {_flags.set(ForceLocalAllocation, v);}
@@ -173,8 +173,8 @@ class Candidate : public TR_Link<Candidate>
    void setProfileOnly(bool v = true)                {_flags.set(ProfileOnly, v); }
 
    void setUsesStackTrace(bool v = true)             {_flags.set(UsesStackTrace, v);}
-   void setArgToCall(int32_t depth, bool v = true)   {_flags.set(1<<depth, v); if (v == true) _argToCall = true;}
-   void setNonThisArgToCall(int32_t depth, bool v = true)   {_flags.set(1<<(depth+8), v);}
+   void setArgToCall(int32_t depth, bool v = true)   {_argToCallFlags.set(1<<depth, v); if (v == true) _argToCall = true;}
+   void setNonThisArgToCall(int32_t depth, bool v = true)   {_nonThisArgToCallFlags.set(1<<depth, v);}
 
 
    TR::Node *getStringCopyNode() {return _stringCopyNode; }
@@ -284,6 +284,8 @@ class Candidate : public TR_Link<Candidate>
      TR_ScratchList<TR::TreeTop> _virtualCallSitesToBeFixed;
      TR_ScratchList<TR_ColdBlockEscapeInfo>   _coldBlockEscapeInfo;
      flags32_t                  _flags;
+     flags16_t                  _nonThisArgToCallFlags;
+     flags16_t                  _argToCallFlags;
 
      enum // flag bits
          {
@@ -318,15 +320,6 @@ class Candidate : public TR_Link<Candidate>
          ForceLocalAllocation         = 0x00100000,
 
          CallsStringCopy              = 0x00200000,
-
-         // Bit mask for which call depths this candidate is not a 'this' arg to.
-         //
-         CallNonThisArgFlagsMask             = 0x0000FF00,
-
-         // Bit mask for which call depths this candidate is an arg to.
-         //
-         CallArgFlagsMask             = 0x000000FF,
-         LastFlagBit                  = 0
          };
    };
 


### PR DESCRIPTION
EA reserved 8 bits to indicate whether a specific object candidate is
an argument or this argument to a method call at certain depth. 9 bits
are needed when the depths is equal to 8 which is the maximum sniffing
depth. Change the number of bits reserved to 16bits to avoid overflow
when sniffing at maximum depth.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>