### PR TITLE
Fix to remove static data used in Decimal Format Peephole

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -389,6 +389,16 @@ private:
 
    // OSR
    TR::NodeChecklist                *_processedOSRNodes;
+
+   // DecimalFormatPeephole
+   struct methodRenamePair{
+      char* srcMethodSignature;
+      char* dstMethodSignature;
+   };
+
+   static const int32_t              _numDecFormatRenames = 9;
+   static struct methodRenamePair    _decFormatRenames[_numDecFormatRenames];
+   TR::SymbolReference               *_decFormatRenamesDstSymRef[_numDecFormatRenames];
    };
 
 #endif


### PR DESCRIPTION
Decimal Format Peephole was using static data that might be
used by more then one compiler thread at the same time resulting
in a compile time crash.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>