### PR TITLE
Unfinalized processing may discover more Phantom References

### DIFF
--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1159,7 +1159,8 @@ void
 MM_RealtimeMarkingScheme::scanPhantomReferenceObjects(MM_EnvironmentRealtime *env)
 {
 	GC_Environment *gcEnv = env->getGCEnvironment();
-	Assert_MM_true(gcEnv->_referenceObjectBuffer->isEmpty());
+	/* unfinalized processing may discover more phantom reference objects */
+	gcEnv->_referenceObjectBuffer->flush(env);
 	const UDATA maxIndex = MM_HeapRegionDescriptorRealtime::getReferenceObjectListCount(env);
 	UDATA listIndex;
 	for (listIndex = 0; listIndex < maxIndex; ++listIndex) {


### PR DESCRIPTION
An assertion at the beginning of scan in
MM_RealtimeMarkingScheme::scanPhantomReferenceObjects()
is not accurate. The processing of Unfinalized objects in Clearable
Marking phase might introduce new Phantom Reference objects so buffer
might be not empty. This is fixed already for all collectors but not for
Metronome

Fixes #2159

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>