### PR TITLE
VirtualFree requires dwSize 0 for MEM_RELEASE

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5260,7 +5260,7 @@ preloadUser32Dll(J9JavaVM *vm)
 		}
 		LoadLibrary(USER32_DLL);
 		if (0 != contiguousRegionStart) {
-			VirtualFree((LPVOID)contiguousRegionStart, contiguousRegionSize, MEM_RELEASE);
+			VirtualFree((LPVOID)contiguousRegionStart, 0, MEM_RELEASE);
 		}
 	}
 

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_exclude.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_exclude.xml
@@ -50,7 +50,7 @@
 <exclude id="-Xthr:secondarySpinForObjectMonitors on command line" platform="aix.*" shouldFix="false"><reason>Only for platforms that three tier spin is enabled</reason></exclude>
 
 <include id="-Xpreloaduser32" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
-<include id="-Xpreloaduser32 -Xprotectcontiguous" platform="none" shouldFix="true"><reason>Intermittent failures on Windows platforms and not available on other platforms</reason></include>
+<include id="-Xpreloaduser32 -Xprotectcontiguous" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
 <include id="-Xpreloaduser32 -Xnoprotectcontiguous" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
 <include id="-Xnopreloaduser32" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>
 <include id="-Xnopreloaduser32 -Xprotectcontiguous" platform="win_x86.*" shouldFix="false"><reason>Only available on Windows platforms</reason></include>


### PR DESCRIPTION
`VirtualFree` requires `dwSize 0` for `MEM_RELEASE`

If the `dwFreeType` parameter is `MEM_RELEASE`, this parameter must be `0` (zero). The function frees the entire region that is reserved in the initial allocation call to `VirtualAlloc`.
Re-enable tests with `-Xpreloaduser32 -Xprotectcontiguous`.

closes: #2065 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>