### PR TITLE
Remove .gitattributes file as it breaks travis builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,23 +18,6 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
-# This .gitattributes file will cause all text files EXCEPT for
-# those specifically listed below to be encoded as EBCDIC.
-# Selected binary files will not be translated at all.
-
-# The default for text files
-* git-encoding=iso8859-1 working-tree-encoding=ibm-1047
-
-# Specific types of files remain as ASCII
-*.xml git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-*.dtd git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-*.xsd git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-buildspecs/* git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-
-# git's files (which MUST be ASCII)
-.gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-.gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-
 # Binary files
 *.jpg git-encoding=BINARY working-tree-encoding=BINARY
 *.png git-encoding=BINARY working-tree-encoding=BINARY


### PR DESCRIPTION
Travis builds have been updated to newer versions of git which recognize
the `worktree-encoding` attribute.  This means the current files are
invalid as they force the encoding of all files as ebcdic.

Other builds, and developers, will be broken when they update to
newer versions of git.

This solution won't work long term.  Removing the file now so we
can unblock builds while thinking about the right long term solution.

This backs out part of #1685

See also https://github.com/eclipse/omr/pull/2695

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>