### PR TITLE
Change jvmtiGetAvailableProcessors to use J9PORT_CPU_TARGET

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -5508,6 +5508,8 @@ JVM_ActiveProcessorCount(void)
 	 * Runtime.availableProcessors() by specification returns a number greater or equal to 1.
 	 * RTC 112959: [was 209402] Liberty JAX-RS Default Executor poor performance.  Match reference implementation behaviour
 	 * to return the bound CPUs rather than physical CPUs.
+	 *
+	 * This implementation should be kept consistent with jvmtiGetAvailableProcessors
 	 */
 	num = (jint)j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
 	if (num < 1) {

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -208,8 +208,9 @@ jvmtiGetAvailableProcessors(jvmtiEnv* env,
 
 	ENSURE_NON_NULL(processor_count_ptr);
 
-	cpuCount = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE);
-	*processor_count_ptr = ((cpuCount == 0) ? 1 : (jint) cpuCount);
+	/* This implementation should be kept consistent with JVM_ActiveProcessorCount */
+	cpuCount = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
+	*processor_count_ptr = ((cpuCount < 1) ? 1 : (jint) cpuCount);
 	rc = JVMTI_ERROR_NONE;
 
 done:


### PR DESCRIPTION
This change causes `jvmtiGetAvailableProcessors` to behave identically
to `JVM_ActiveProcessorCount`, also taking into account cgroup limits
when appropriate as discussed in #1166.

Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>