### PR TITLE
Pass a field's declaring class to foldFinalFieldIn

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1328,7 +1328,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
       TR::VMAccessCriticalSection getObjectReferenceLocation(comp());
       if (*((uintptrj_t*)dataAddress) != NULL)
          {
-         TR_OpaqueClassBlock *declaringClass = TR::Compiler->cls.objectClass(comp(), *((uintptrj_t*)dataAddress));
+         TR_OpaqueClassBlock *declaringClass = owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
          if (declaringClass)
             {
             int32_t clazzNameLength = 0;


### PR DESCRIPTION
Static final field folding is undesirably turned on because the field's
class is passed to foldFinalFieldIn instead of its declaring class.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>