### PR TITLE
Improve DDR interoperability

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureTypeManager.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureTypeManager.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.ibm.j9ddr.StructureReader.StructureDescriptor;
 
@@ -115,6 +116,14 @@ public class StructureTypeManager
 		
 		localSimpleTypeCodeMap.put("char", TYPE_U8);
 		
+		localSimpleTypeCodeMap.put("bool", TYPE_BOOL);
+		localSimpleTypeCodeMap.put("double", TYPE_DOUBLE);
+		localSimpleTypeCodeMap.put("float", TYPE_FLOAT);
+		localSimpleTypeCodeMap.put("fj9object_t", TYPE_FJ9OBJECT);
+		localSimpleTypeCodeMap.put("iconv_t", TYPE_IDATA);
+		localSimpleTypeCodeMap.put("j9objectclass_t", TYPE_J9OBJECTCLASS);
+		localSimpleTypeCodeMap.put("j9objectmonitor_t", TYPE_J9OBJECTMONITOR);
+
 		simpleTypeCodeMap = Collections.unmodifiableMap(localSimpleTypeCodeMap);
 		
 		Map<Integer, String> localSimpleTypeAccessorMap = new HashMap<Integer, String>();
@@ -146,101 +155,56 @@ public class StructureTypeManager
 			}
 		}
 	}
-	
-	public int getType(String type)
+
+	private static final Pattern CVQualifierPattern = Pattern.compile("\\s*\\b(const|volatile)\\s+");
+
+	public int getType(String rawType)
 	{
-		// trim off the const modifier, if present
-		if(type.startsWith("const ")) {
-			return getType(type.substring("const ".length()).trim());
-		}
-		
-		// trim off the volatile modifier
-		if(type.startsWith("volatile ")) {
-			return getType(type.substring("volatile ".length()).trim());
-		}
-		
+		// strip out any const/volatile qualifiers
+		String type = CVQualifierPattern.matcher(rawType).replaceAll("");
+
 		// look for the simple types
-		if(simpleTypeCodeMap.containsKey(type)) {
+		if (simpleTypeCodeMap.containsKey(type)) {
 			return simpleTypeCodeMap.get(type);
 		}
-		
-		// bool?
-		if (type.equals("bool")) {
-			return TYPE_BOOL;
-		}
-		
-		// double??
-		if (type.equals("double")) {
-			return TYPE_DOUBLE;
-		}
-		
-		// float??
-		if (type.equals("float")) {
-			return TYPE_FLOAT;
-		}
-		
-		if (type.equals("fj9object_t")) {
-			return TYPE_FJ9OBJECT;
-		}
-
-		if (type.equals("j9objectclass_t")) {
-			return TYPE_J9OBJECTCLASS;
-		}
-		
-		if (type.equals("j9objectmonitor_t")) {
-			return TYPE_J9OBJECTMONITOR;
-		}
-		
-		if (type.equals("iconv_t")) {
-			return TYPE_IDATA;
-		}	
 
 		CTypeParser parser = new CTypeParser(type);
 
 		// array?
-		if(parser.getSuffix().endsWith("]")) {
+		if (parser.getSuffix().endsWith("]")) {
 			return TYPE_ARRAY;
 		}
-		
-		//bit field?
-		if(parser.getSuffix().contains(":")) {
+
+		// bit field?
+		if (parser.getSuffix().contains(":")) {
 			return TYPE_BITFIELD;
 		}
-		
+
 		// pointer?
-		if(type.endsWith("*")) {
+		if (type.endsWith("*")) {
 			int pointerType = getType(type.substring(0, type.length() - 1).trim());
-			if(TYPE_UNKNOWN == pointerType) {
+			switch (pointerType) {
+			case TYPE_UNKNOWN:
 				return TYPE_UNKNOWN;
-			}
-			switch(pointerType)
-			{
 			case TYPE_STRUCTURE:
 				return TYPE_STRUCTURE_POINTER;
-				
 			case TYPE_FJ9OBJECT:
 				return TYPE_FJ9OBJECT_POINTER;
-				
 			case TYPE_J9OBJECTCLASS:
 				return TYPE_J9OBJECTCLASS_POINTER;
-
 			case TYPE_J9OBJECTMONITOR:
 				return TYPE_J9OBJECTMONITOR_POINTER;
-			
 			case TYPE_J9SRP:
 				return TYPE_J9SRP_POINTER;
-				
 			case TYPE_J9WSRP:
 				return TYPE_J9WSRP_POINTER;
-				
 			case TYPE_ENUM:
 				return TYPE_ENUM_POINTER;
-				
 			default:
 				return TYPE_POINTER;
 			}
 		}
-		
+
 		/* SRP?
 		 * Match types like J9SRP or J9SRP(UDATA) but not J9SRP* or J9SRPHashTable.
 		 */
@@ -254,25 +218,17 @@ public class StructureTypeManager
 		if (type.equals("J9WSRP") || type.startsWith("J9WSRP(")) {
 			return TYPE_J9WSRP;
 		}
-		
-		// struct?
-		if(type.startsWith("struct ") || type.startsWith("class ")) {
-			return TYPE_STRUCTURE;
-		}
-		
-		if (structureNames.contains(type.trim())) {
-			return TYPE_STRUCTURE;
-		}
-		
 
-		if (type.startsWith("enum")) {
+		// struct?
+		if (type.startsWith("struct ") || type.startsWith("class ") || structureNames.contains(type.trim())) {
+			return TYPE_STRUCTURE;
+		}
+
+		if (type.startsWith("enum ") || enumNames.contains(type.trim())) {
 			return TYPE_ENUM;
 		}
-		
-		if (enumNames.contains(type.trim())) {
-			return TYPE_ENUM;
-		}
-				
+
 		return TYPE_UNKNOWN;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -99,8 +99,6 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	private int hiddenInstanceFieldWalkIndex = -1;
 	private ArrayList<HiddenInstanceField> hiddenInstanceFieldList = new ArrayList<HiddenInstanceField>();
 
-	@SuppressWarnings("unused")
-
 	private static final UDATA NO_LOCKWORD_NEEDED = new UDATA(-1);
 	private static final UDATA LOCKWORD_NEEDED = new UDATA(-2);
 
@@ -117,7 +115,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	
 	private void init() throws CorruptDataException {
 		calculateInstanceSize(romClass, superClazz); //initInstanceSize(romClass, superClazz);
-		romFieldsShapeIterator = new J9ROMFieldShapeIterator(romClass.romFields(), romClass.romFieldCount());		
+		romFieldsShapeIterator = new J9ROMFieldShapeIterator(romClass.romFields(), romClass.romFieldCount());
 	}
 	
 	private void nextField() throws CorruptDataException {
@@ -163,7 +161,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 
 		while (romFieldsShapeIterator.hasNext()) {
 			J9ROMFieldShapePointer localField = (J9ROMFieldShapePointer) romFieldsShapeIterator.next();
-			U32 modifiers = localField.modifiers();
+			UDATA modifiers = localField.modifiers();
 
 			/* count the index for jvmti */
 			index = index.add(1);
@@ -365,7 +363,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 			}
 
 			for (HiddenInstanceField hiddenField: hiddenInstanceFieldList) {
-				U32 modifiers = hiddenField.shape().modifiers();
+				UDATA modifiers = hiddenField.shape().modifiers();
 
 				if (modifiers.allBitsIn(J9FieldFlagObject)) {
 					if (useBackfillForObject) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ROMFieldShapeIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ROMFieldShapeIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,16 +29,16 @@ import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.pointer.CorruptPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMFieldShapePointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ROMFieldShapeHelper;
-import com.ibm.j9ddr.vm29.types.U32;
+import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class J9ROMFieldShapeIterator implements Iterator , Iterable <J9ROMFieldShapePointer> {
+public class J9ROMFieldShapeIterator implements Iterator, Iterable<J9ROMFieldShapePointer> {
 
 	J9ROMFieldShapePointer firstField;
 	J9ROMFieldShapePointer lastField;
 	long fieldsLeft;
 	long cursor = 0;
 	
-	public J9ROMFieldShapeIterator(J9ROMFieldShapePointer romFields, U32 romFieldCount) {
+	public J9ROMFieldShapeIterator(J9ROMFieldShapePointer romFields, UDATA romFieldCount) {
 		this.firstField = romFields;
 		this.fieldsLeft = romFieldCount.longValue();
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -280,7 +280,7 @@ public class ObjectFieldInfo {
 
 		Iterable <J9ROMFieldShapePointer>  fields = new J9ROMFieldShapeIterator(romClass.romFields(), romClass.romFieldCount());
 		for  (J9ROMFieldShapePointer f: fields) {
-			U32 modifiers = f.modifiers();
+			UDATA modifiers = f.modifiers();
 			if (!modifiers.anyBitsIn(J9AccStatic) ) {
 
 				if (modifiers.anyBitsIn(J9FieldFlagObject)) {
@@ -305,7 +305,7 @@ public class ObjectFieldInfo {
 		hiddenFieldCount = 0;
 		for (HiddenInstanceField hiddenField : hiddenFieldList) {
 			if (hiddenField.className() == null || className.equals(hiddenField.className())) {
-				U32 modifiers = hiddenField.shape().modifiers();
+				UDATA modifiers = hiddenField.shape().modifiers();
 				if (modifiers.anyBitsIn(J9FieldFlagObject)) {
 					totalObjectCount += 1;
 				} else if (modifiers.anyBitsIn(J9FieldSizeDouble)) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
@@ -135,12 +135,12 @@ public class OptInfo {
 		return ROMHelp.getMethodDebugInfoFromROMMethod(ROMHelp.getOriginalROMMethod(method));
 	}
 	
-	private static SelfRelativePointer getSRPPtr(U32Pointer ptr, U32 flags, long option) {
+	private static SelfRelativePointer getSRPPtr(U32Pointer ptr, UDATA flags, long option) {
 		if ((!(flags.anyBitsIn(option))) || (ptr.isNull())) {
 			return SelfRelativePointer.NULL;
 		}
 
-		return SelfRelativePointer.cast(ptr.add(countBits(COUNT_MASK(flags, option)) - 1));
+		return SelfRelativePointer.cast(ptr.add(countBits(COUNT_MASK(new U32(flags), option)) - 1));
 	}
 
 	public static int countBits(U32 word) {
@@ -177,7 +177,7 @@ public class OptInfo {
 	}
 
 	public static U32 COUNT_MASK(U32 value, long mask) {
-		return (value.bitAnd(((mask) << 1) - 1));
+		return value.bitAnd((mask << 1) - 1);
 	}
 
 	public static String getSourceFileNameForROMClass(J9ROMClassPointer romClass) throws CorruptDataException {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/LocalMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/LocalMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,9 +144,9 @@ public class LocalMap
 	{
 		public final int seekLocals;
 		
-		public final U32 programCounter;
+		public final int programCounter;
 		
-		public BranchState(U32 programCounter, int seekLocals)
+		public BranchState(int programCounter, int seekLocals)
 		{
 			this.seekLocals = seekLocals;
 			this.programCounter = programCounter;
@@ -276,7 +276,7 @@ public class LocalMap
 						
 							/* Collect up any locals that were unknown in the covered exception range. */
 							unknownLocals = 0;
-							for (U32 j = handler.startPC(); j.lt(handler.endPC()); j = j.add(1)) {
+							for (UDATA j = handler.startPC(); j.lt(handler.endPC()); j = j.add(1)) {
 								unknownLocals |= unknownsByPC[j.intValue()];
 							}
 						
@@ -475,7 +475,7 @@ public class LocalMap
 
 					case 1:			/* ifs */
 						offset = new I32(new I16(PARAM_16(bcIndex, 1)));
-						branchStack.push(new BranchState(new U32(pc).add(offset),seekLocals));
+						branchStack.push(new BranchState(pc + offset.intValue(), seekLocals));
 						/* fall through */
 						
 					case 6:		/* invokes */
@@ -499,7 +499,7 @@ public class LocalMap
 							return 0;
 						}
 						BranchState newBranch = branchStack.pop();
-						pc = newBranch.programCounter.intValue();
+						pc = newBranch.programCounter;
 						seekLocals = newBranch.seekLocals;
 						
 						/* Don't look for already known locals */
@@ -531,7 +531,7 @@ public class LocalMap
 							bcIndex = bcIndex.add(temp1);
 							offset = new I32(PARAM_32(bcIndex,0));
 							bcIndex = bcIndex.add(4);
-							branchStack.add(new BranchState(new U32(pc).add(offset),seekLocals));
+							branchStack.add(new BranchState(pc + offset.intValue(), seekLocals));
 						}
 
 						/* finally continue at the default switch case */
@@ -544,7 +544,7 @@ public class LocalMap
 						return 0;
 					}
 					BranchState newBranch = branchStack.pop();
-					pc = newBranch.programCounter.intValue();
+					pc = newBranch.programCounter;
 					seekLocals = newBranch.seekLocals;
 					
 					/* Don't look for already known locals */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/StackMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/StackMap.java
@@ -256,7 +256,7 @@ public class StackMap
 			//Scratch storage is held on-heap in stack data structures and managed inside mapStack.
 			
 			//Build map array - one slot for every PC in method
-			length = (UDATA) J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod);
+			length = J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod);
 			
 			stackStructSize = romMethod.maxStack();
 			

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -656,7 +656,7 @@ public class StackWalker
 				}
 				WALK_O_SLOT(walkState, PointerPointer.cast(methodTypeFrame.methodType()));
 				walkState.argCount = methodTypeFrame.argStackSlots().add(1);
-				walkState.slotType = walkState.slotType = (int)J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL;
+				walkState.slotType = (int)J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL;
 				walkState.slotIndex = 0;
 				walkDescribedPushes(walkState, walkState.arg0EA, walkState.argCount.intValue(), descriptionSlots, walkState.argCount.intValue());
 			}
@@ -939,9 +939,9 @@ public class StackWalker
 				if (walkState.arg0EA.eq(walkState.j2iFrame)) {
 					walkState.bp = walkState.arg0EA;
 					walkState.unwindSP = walkState.bp.subOffset(J9SFJ2IFrame.SIZEOF)
-						.addOffset(UDATA.SIZEOF);
+							.addOffset(UDATA.SIZEOF);
 					walkState.frameFlags = J9SFJ2IFramePointer.cast(walkState.unwindSP)
-						.specialFrameFlags();
+							.specialFrameFlags();
 					//TODO do I need MARK_SLOT_AS_OBJECT here?
 					printFrameType(walkState, "invokeExact J2I");
 				} else {
@@ -1142,7 +1142,7 @@ public class StackWalker
 	
 			walkState.frameFlags = callInFrame.specialFrameFlags();
 			printFrameType(walkState, "JNI call-in");
-	
+
 			if ((walkState.flags & J9_STACKWALK_ITERATE_O_SLOTS) != 0) {
 				try {
 					/*
@@ -1258,7 +1258,7 @@ public class StackWalker
 			walkState.bp = UDATAPointer.cast(jitResolveFrame
 					.taggedRegularReturnSPEA());
 			walkState.frameFlags = jitResolveFrame.specialFrameFlags();
-	
+
 			try {
 				printFrameType(walkState, "JIT resolve");
 		
@@ -1288,9 +1288,9 @@ public class StackWalker
 	
 			walkState.bp = UDATAPointer.cast(specialFrame.savedA0EA());
 			walkState.frameFlags = specialFrame.specialFrameFlags();
-	
+
 			printFrameType(walkState, "Generic special");
-	
+
 			if (((walkState.flags & J9_STACKWALK_ITERATE_O_SLOTS) != 0)
 					&& walkState.literals.notNull()) {
 				try {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/LineNumberIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/LineNumberIterator.java
@@ -145,7 +145,7 @@ public abstract class LineNumberIterator implements Iterator<LineNumber> {
 					lineNumber = lineNumber.add(signExtend(new I16(encoded.bitAnd(0x3FFF)), 14));
 					
 					lineNumberTablePtr = lineNumberTablePtr.add(2);
-				} else if (firstByte.bitAnd(0xE0).eq(0xF0)) {
+				} else if (firstByte.bitAnd(0xF0).eq(0xE0)) {
 					// 5 bytes encoded : 1110000Y xxxxxxxx xxxxxxxx YYYYYYYY YYYYYYYY
 					lineNumberTablePtr = lineNumberTablePtr.add(1);
 					location = location.add(U16Pointer.cast(lineNumberTablePtr).at(0));

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/I32Pointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/I32Pointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@ import com.ibm.j9ddr.vm29.types.I32;
 import com.ibm.j9ddr.vm29.types.Scalar;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class I32Pointer extends Pointer {
+public class I32Pointer extends IDATAPointer {
 
 	public static final int SIZEOF = I32.SIZEOF;
 	public static final I32Pointer NULL = new I32Pointer(0);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/I64Pointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/I64Pointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@ import com.ibm.j9ddr.vm29.types.I64;
 import com.ibm.j9ddr.vm29.types.Scalar;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class I64Pointer extends Pointer {
+public class I64Pointer extends IDATAPointer {
 
 	public static final int SIZEOF = I64.SIZEOF;
 	public static final I64Pointer NULL = new I64Pointer(0);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/U32Pointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/U32Pointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@ import com.ibm.j9ddr.vm29.types.Scalar;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class U32Pointer extends Pointer {
+public class U32Pointer extends UDATAPointer {
 
 	public static final int SIZEOF = U32.SIZEOF;
 	public static final U32Pointer NULL = new U32Pointer(0);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/U64Pointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/U64Pointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@ import com.ibm.j9ddr.vm29.types.Scalar;
 import com.ibm.j9ddr.vm29.types.U64;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
-public class U64Pointer extends Pointer {
+public class U64Pointer extends UDATAPointer {
 
 	public static final int SIZEOF = U64.SIZEOF;
 	public static final U64Pointer NULL = new U64Pointer(0);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ByteDataWrapperHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ByteDataWrapperHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,12 +37,12 @@ public class ByteDataWrapperHelper {
 	
 //	#define BDWEXTBLOCK(bdw) J9SHR_READMEM((bdw)->externalBlockOffset)
 	public static I32 BDWEXTBLOCK(ByteDataWrapperPointer ptr) throws CorruptDataException {
-		return ptr.externalBlockOffset();
+		return new I32(ptr.externalBlockOffset());
 	}	
 
 //	#define BDWLEN(bdw) J9SHR_READMEM((bdw)->dataLength)	
 	public static U32 BDWLEN(ByteDataWrapperPointer ptr) throws CorruptDataException {
-		return ptr.dataLength();
+		return new U32(ptr.dataLength());
 	}
 	
 //	#define BDWTYPE(bdw)  J9SHR_READMEM((bdw)->dataType)

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ClasspathWrapperHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ClasspathWrapperHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,6 @@ public class ClasspathWrapperHelper {
 	
 //	#define CPWLEN(cpw) (sizeof(ClasspathWrapper) + J9SHR_READMEM((cpw)->ClasspathItemSize))
 	public static U32 CPWLEN(ClasspathWrapperPointer ptr) throws CorruptDataException {
-		return ptr.classpathItemSize().add((int)ClasspathWrapper.SIZEOF);
+		return new U32(ptr.classpathItemSize()).add((int)ClasspathWrapper.SIZEOF);
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
@@ -273,7 +273,7 @@ public class J9ClassHelper
 
 		if (!J9ROMClassHelper.isArray(clazz.romClass())) {
 			// Fragment 1. RAM methods + extended method block
-			U32 ramMethodsSize = clazz.romClass().romMethodCount().mult((int)J9Method.SIZEOF);
+			UDATA ramMethodsSize = clazz.romClass().romMethodCount().mult((int)J9Method.SIZEOF);
 			size = size.add(ramMethodsSize);
 			if (vm.runtimeFlags().allBitsIn(J9Consts.J9_RUNTIME_EXTENDED_METHOD_BLOCK)) {
 				UDATA extendedMethodBlockSize = Scalar.roundToSizeofUDATA(new UDATA(clazz.romClass().romMethodCount()));
@@ -292,7 +292,7 @@ public class J9ClassHelper
 			}
 
 			// Fragment 5. Static slots
-			U32 staticSlotCount = clazz.romClass().objectStaticCount().add(clazz.romClass().singleScalarStaticCount());
+			UDATA staticSlotCount = clazz.romClass().objectStaticCount().add(clazz.romClass().singleScalarStaticCount());
 			if (J9BuildFlags.env_data64) {
 				staticSlotCount = staticSlotCount.add(clazz.romClass().doubleScalarStaticCount());
 			} else {
@@ -301,7 +301,7 @@ public class J9ClassHelper
 			size = size.add(Scalar.convertSlotsToBytes(new UDATA(staticSlotCount)));
 			
 			// Fragment 6. Constant pool
-			U32 constantPoolSlotCount = clazz.romClass().ramConstantPoolCount().mult(2);
+			UDATA constantPoolSlotCount = clazz.romClass().ramConstantPoolCount().mult(2);
 			size = size.add(Scalar.convertSlotsToBytes(new UDATA(constantPoolSlotCount)));
 		}
 		
@@ -384,7 +384,7 @@ public class J9ClassHelper
 		if (J9ClassHelper.isArrayClass(j9class)) {
 			J9ArrayClassPointer arrayClass = J9ArrayClassPointer.cast(j9class);
 			
-			U32 modifiers = arrayClass.leafComponentType().romClass().modifiers();
+			UDATA modifiers = arrayClass.leafComponentType().romClass().modifiers();
 
 			//OR in the bogus Sun bits
 			modifiers = modifiers.bitOr(J9JavaAccessFlags.J9AccAbstract);
@@ -392,7 +392,7 @@ public class J9ClassHelper
 			
 			return modifiers.intValue();
 		} else {
-			U32 modifiers = j9class.romClass().modifiers();
+			UDATA modifiers = j9class.romClass().modifiers();
 			
 			if (j9class.romClass().outerClassName().notNull()) {
 				modifiers = j9class.romClass().memberAccessFlags();
@@ -411,7 +411,7 @@ public class J9ClassHelper
 	}
 	
 	public static U32 extendedClassFlags(J9ClassPointer j9class) throws CorruptDataException {
-		return j9class.classFlags();
+		return new U32(j9class.classFlags());
 	}
 
 	public static UDATA classFlags(J9ClassPointer j9class) throws CorruptDataException {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9IndexableObjectHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9IndexableObjectHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ public class J9IndexableObjectHelper extends J9ObjectHelper
 
 	public static U32 size(J9IndexableObjectPointer objPointer) throws CorruptDataException 
 	{
-		U32 size = J9IndexableObjectContiguousPointer.cast(objPointer).size();
+		UDATA size = J9IndexableObjectContiguousPointer.cast(objPointer).size();
 		if(J9BuildFlags.gc_hybridArraylets) {
 			if(size.eq(0)) {
 				size = J9IndexableObjectDiscontiguousPointer.cast(objPointer).size();	 
@@ -75,7 +75,7 @@ public class J9IndexableObjectHelper extends J9ObjectHelper
 			throw new CorruptDataException("java array size with sign bit set");
 		}
 
-		return size;
+		return new U32(size);
 	}
 	
 	public static U32 size(J9ObjectPointer objPointer) throws CorruptDataException 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9MethodDebugInfoHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9MethodDebugInfoHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,10 +32,10 @@ import com.ibm.j9ddr.vm29.types.U32;
 public class J9MethodDebugInfoHelper {
 
 	public static U32 getLineNumberCount(J9MethodDebugInfoPointer ptr) throws CorruptDataException {
+		U32 lineNumberCount = new U32(ptr.lineNumberCount());
 		if (AlgorithmVersion.getVersionOf("VM_LINE_NUMBER_TABLE_VERSION").getAlgorithmVersion() < 1) {
-			return ptr.lineNumberCount();
+			return lineNumberCount;
 		} else {
-			U32 lineNumberCount = ptr.lineNumberCount();
 			if (lineNumberCount.bitAnd(1).eq(0)) {
 				return lineNumberCount.rightShift(1).bitAnd(0x7FFF);
 			} else {
@@ -62,7 +62,7 @@ public class J9MethodDebugInfoHelper {
 	}
 	
 	public static U32 getLineNumberCompressedSize(J9MethodDebugInfoPointer ptr) throws CorruptDataException {
-		U32 lineNumberCount = ptr.lineNumberCount();
+		U32 lineNumberCount = new U32(ptr.lineNumberCount());
 		if (lineNumberCount.bitAnd(1).eq(0)) {
 			return lineNumberCount.rightShift(16).bitAnd(0xFFFF);
 		} else {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9RASHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9RASHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,22 +26,22 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9RASPointer;
 
 public class J9RASHelper {
-	
+
 	private static J9JavaVMPointer cachedVM = null;
-	
+
 	public static J9JavaVMPointer getVM(J9RASPointer rasptr) throws CorruptDataException {
-		if (null != cachedVM) {
-			return cachedVM;
+		if (null == cachedVM) {
+			cachedVM = J9JavaVMPointer.cast(rasptr.vm());
 		}
-		cachedVM = J9JavaVMPointer.cast(rasptr.vm());
 		return cachedVM;
 	}
-	
+
 	public static void setCachedVM(J9JavaVMPointer vm) {
 		cachedVM = vm;
 	}
-	
+
 	public static J9JavaVMPointer getCachedVM() {
 		return cachedVM;
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ROMFieldShapeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ROMFieldShapeHelper.java
@@ -57,7 +57,7 @@ public class J9ROMFieldShapeHelper {
 	public static UDATA romFieldSizeOf(J9ROMFieldShapePointer fieldShapePointer) throws CorruptDataException 
 	{
 		long size = J9ROMFieldShape.SIZEOF;
-		U32 modifiers = fieldShapePointer.modifiers();
+		UDATA modifiers = fieldShapePointer.modifiers();
 		
 		if ((modifiers.anyBitsIn(J9FieldFlagConstant))) {	
 			size += ((modifiers.allBitsIn(J9FieldSizeDouble)) ? U64.SIZEOF : U32.SIZEOF);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ShcItemHdrHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ShcItemHdrHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@ import com.ibm.j9ddr.vm29.types.U32;
 public class ShcItemHdrHelper {
 	/* ->itemLen should never be set or read without these macros as the lower bit is used to indicate staleness */
 	public static U32 CCITEMLEN(ShcItemHdrPointer ptr) throws CorruptDataException {
-		return ptr.itemLen().bitAnd(0xFFFFFFFE);
+		return new U32(ptr.itemLen()).bitAnd(0xFFFFFFFE);
 	}
 	
 	// #define CCITEM(ih) (((U_8*)(ih)) - (CCITEMLEN(ih) - sizeof(ShcItemHdr)))

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ClassWalker.java
@@ -22,6 +22,7 @@
 package com.ibm.j9ddr.vm29.tools.ddrinteractive;
 
 import java.util.HashMap;
+import java.util.regex.Pattern;
 
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.StructureReader.FieldDescriptor;
@@ -36,7 +37,7 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.IClassWalkCallbacks.SlotType;
 public abstract class ClassWalker {
 	/**
 	 * Walks every slots in an object and send the values to the classWalker
-	 * 
+	 *
 	 * @param classWalker
 	 *            a class that will receive the slot and sections of the object
 	 * @throws CorruptDataException
@@ -65,154 +66,146 @@ public abstract class ClassWalker {
 	}
 
 	/**
-	 * It walks through each field in this structure that is represented by methodClass and 
+	 * It walks through each field in this structure that is represented by methodClass and
 	 * registers each field as a slot into ClassWalkerCallBack
-	 * 
+	 *
 	 * It uses the StructureDescriptor of J9DDR to get the FieldDescriptor of a structure.
 	 * The name, type and address are found in the FieldDescriptor. The name, type and address
 	 * are guaranteed to match the current core file, since they are taken from it.
-	 * 
+	 *
 	 * @param methodClass pointer class that is generated for the VM structure
 	 * @param renameFields	list of names to rename the original field names in the structure
-	 * @throws CorruptDataException 
+	 * @throws CorruptDataException
 	 */
 	protected void addObjectsAsSlot(StructurePointer methodClass, HashMap<String, String> renameFields) throws CorruptDataException {
 		/* Get the structure name by removing "Pointer" suffix from the DDR generated class name*/
 		String structureName = methodClass.getClass().getSimpleName().substring(0, methodClass.getClass().getSimpleName().indexOf("Pointer"));
 		/* Get structure descriptor by using structure name */
 		StructureDescriptor sd = StructureCommandUtil.getStructureDescriptor(structureName, getContext());
-		/* Structure descriptor can not be null in normal circumstances, 
-		 * because StructurePointer "methodClass" is generated for an existing structure in the VM, 
-		 * so it should exist. If not, throw an exception. 
+		/* Structure descriptor can not be null in normal circumstances,
+		 * because StructurePointer "methodClass" is generated for an existing structure in the VM,
+		 * so it should exist. If not, throw an exception.
 		 */
 		if (sd == null) {
 			throw new CorruptDataException("Structure \"" + structureName + "\" can not be found.");
 		}
-		
+
 		for ( FieldDescriptor fd : sd.getFields() ) {
 			/* Get the name of the field from field descriptor */
 			String outName = fd.getName();
 			/* Get SlotType by using field type name */
 			SlotType type = getTypeByFieldTypeName(fd.getType());
-		
+
 			/* Get the address of the field by adding the offset to the methodClass'address */
-			AbstractPointer address = U8Pointer.cast(methodClass).addOffset(fd.getOffset()); 
-			
+			AbstractPointer address = U8Pointer.cast(methodClass).addOffset(fd.getOffset());
+
 			/* Rename fields if any defined. */
 			if (null != renameFields) {
 				if (renameFields.containsKey(outName)) {
 					outName = renameFields.get(outName);
 				}
 			}
-			
+
 			/*add the field into classWalkerCallback by its name, type, address and debug extension method name */
 			classWalkerCallback.addSlot(clazz, type, address, outName, getDebugExtForMethodName(outName));
 		}
 	}
-	
-	
+
 	protected void addObjectsasSlot(StructurePointer methodClass) throws CorruptDataException {
 		addObjectsAsSlot(methodClass, null);
 	}
-	
+
 	/**
 	 * Gets the SlotType value by using field's type name.
-	 * Field's type name is identical to how it looks in VM structures unless its type is overwritten by DDR properties file. 
+	 * Field's type name is identical to how it looks in VM structures unless its type is overwritten by DDR properties file.
 	 * Example :
 	 * 		struct  Test{
 	 * 			J9SRP field1;
-	 * 			J9SRP field2;	
+	 * 			J9SRP field2;
 	 * 		}
-	 * 		
+	 *
 	 * 		//overwrite field1's type in ddr .properties files
 	 * 		ddrblob.typeoverride.Test.field1=J9SRP(struct J9UTF8)
-	 * 
+	 *
 	 * fieldTypeName values for:
 	 * 		field1, it is "J9SRP(struct J9UTF8)"
 	 * 		field2, it is "J9SRP"
-	 * 	
-	 *  
+	 *
+	 *
 	 * @param fieldTypeName
 	 * @return SlotType
-	 * @throws CorruptDataException if the passed fieldTypeName is not recognized by any if statements below. 
+	 * @throws CorruptDataException if the passed fieldTypeName is not recognized by any if statements below.
 	 */
-	private SlotType getTypeByFieldTypeName(String fieldTypeName) throws CorruptDataException {
-		/*  
-		 * In the case where type is overwritten by DDR properties files
-		 * J9WSRP(struct J9ROMClass) field1 
-		 * J9WSRP(U32) field2
-		 */
-		if (fieldTypeName.startsWith("J9WSRP(")) {
-			return SlotType.J9_WSRP;
-		}
-		
+	private static SlotType getTypeByFieldTypeName(String fieldTypeName) throws CorruptDataException {
 		/*
-		 * If the field type is a struct J9UTF8 then print the name as well, also make sure
-		 * that this condition is checked before the following 'fieldTypeName.startsWith("J9SRP(")' condition
+		 * Remove any 'struct' or 'class' tags in the type name.
 		 */
-		if (fieldTypeName.startsWith("J9SRP(struct J9UTF8")) {
-			return SlotType.J9_SRP_TO_STRING;
-		}
-		
-		/* 
-		 * In the case where type is overwritten by DDR properties files
-		 * J9SRP(struct J9ROMClass) field1, 
-		 * J9SRP(U32) field2 
-		 */ 
-		if (fieldTypeName.startsWith("J9SRP(")) {
-			return SlotType.J9_SRP;
-		}
-				
-		/* J9WSRP field1 */
-		if (fieldTypeName.equals("J9WSRP")) {
+		String typeName = TypeTagPattern.matcher(fieldTypeName).replaceAll("");
+
+		/*
+		 * J9WSRP (possibly overridden by DDR properties files)
+		 * J9WSRP field1
+		 * J9WSRP(J9ROMClass) field2
+		 * J9WSRP(U32) field3
+		 */
+		if (typeName.equals("J9WSRP") || typeName.startsWith("J9WSRP(")) {
 			return SlotType.J9_WSRP;
 		}
-		/* J9SRP field1) */
-		if (fieldTypeName.equals("J9SRP")) {
-			return SlotType.J9_SRP;
+
+		/*
+		 * J9SRP (possibly overridden by DDR properties files)
+		 * J9SRP field1
+		 * J9SRP(J9ROMClass) field2
+		 * J9SRP(U32) field3
+		 */
+		if (typeName.equals("J9SRP") || typeName.startsWith("J9SRP(")) {
+			return typeName.startsWith("J9SRP(J9UTF8") ? SlotType.J9_SRP_TO_STRING : SlotType.J9_SRP;
 		}
-		
-		if (fieldTypeName.equals("struct J9UTF8*")) {
+
+		if (typeName.equals("J9UTF8*")) {
 			return SlotType.J9_ROM_UTF8;
 		}
-		if (fieldTypeName.equals("U8")) {
+		if (typeName.equals("U8")) {
 			return SlotType.J9_U8;
 		}
-		if (fieldTypeName.equals("I8")) {
+		if (typeName.equals("I8")) {
 			return SlotType.J9_I8;
 		}
-		if (fieldTypeName.equals("U16")) {
+		if (typeName.equals("U16")) {
 			return SlotType.J9_U16;
 		}
-		if (fieldTypeName.equals("I16")) {
+		if (typeName.equals("I16")) {
 			return SlotType.J9_I16;
 		}
-		if (fieldTypeName.equals("U32")) {
+		if (typeName.equals("U32")) {
 			return SlotType.J9_U32;
 		}
-		if (fieldTypeName.equals("I32")) {
+		if (typeName.equals("I32")) {
 			return SlotType.J9_I32;
 		}
-		if (fieldTypeName.equals("U64")) {
+		if (typeName.equals("U64")) {
 			return SlotType.J9_U64;
 		}
-		if (fieldTypeName.equals("I64")) {
+		if (typeName.equals("I64")) {
 			return SlotType.J9_I64;
 		}
-		if (fieldTypeName.equals("UDATA")) {
+		if (typeName.equals("UDATA")) {
 			return SlotType.J9_UDATA;
 		}
-		if (fieldTypeName.equals("IDATA")) {
+		if (typeName.equals("IDATA")) {
 			return SlotType.J9_IDATA;
 		}
-		if (fieldTypeName.equals("struct J9ROMNameAndSignature")) {
+		if (typeName.equals("J9ROMNameAndSignature")) {
 			return SlotType.J9_NAS;
 		}
-		/* if field type name ends with asteriks, assume that is is a pointer type */
-		if (fieldTypeName.endsWith("*")) {
+		/* if type name ends with an asterisk, it is a pointer type */
+		if (typeName.endsWith("*")) {
 			return SlotType.J9_UDATA;
 		}
 		/* throw exception if a new field type name is added to VM which is not recognized by any if block above */
-		throw new CorruptDataException("Field type name is not recognized.");
+		throw new CorruptDataException("Field type name '" + fieldTypeName + "' is not recognized.");
 	}
+
+	private static final Pattern TypeTagPattern = Pattern.compile("\\s*\\b(class|struct)\\s+");
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ public class LinearDumper implements IClassWalkCallbacks {
 	 * @author jeanpb
 	 *
 	 */
-	public class J9ClassRegion implements Comparable<J9ClassRegion> {
+	public static class J9ClassRegion implements Comparable<J9ClassRegion> {
 		public J9ClassRegion(AbstractPointer slotPtr, SlotType type, String name,
 				String additionalInfo, long length, long offset, boolean computePadding) {
 			this.slotPtr = slotPtr;
@@ -149,8 +149,9 @@ public class LinearDumper implements IClassWalkCallbacks {
 		public boolean getComputePadding() {
 			return computePadding;
 		}
-	};
-	public class J9ClassRegionNode implements Comparable<J9ClassRegionNode>{
+	}
+
+	public static class J9ClassRegionNode implements Comparable<J9ClassRegionNode>{
 		private J9ClassRegion nodeValue;
 		private LinkedList<J9ClassRegionNode> children;
 		public J9ClassRegionNode(J9ClassRegion nodeValue) {
@@ -175,7 +176,7 @@ public class LinearDumper implements IClassWalkCallbacks {
 				return 0;
 			}
 		}
-	};
+	}
 
 	private List<J9ClassRegion> classRegions = new LinkedList<J9ClassRegion>();
 	private long firstJ9_ROM_UTF8 = Long.MAX_VALUE;
@@ -543,7 +544,7 @@ public class LinearDumper implements IClassWalkCallbacks {
 			break;
 		default:
 			String detail = "";
-			slotAddress = region.getSlotPtr().at(0).longValue();
+			slotAddress = UDATAPointer.cast(region.getSlotPtr()).at(0).longValue();
 			long slotAddressOriginal = slotAddress;
 			if ((null != region.additionalInfo) && (region.additionalInfo.length() != 0)) {
 				if ("classAndFlags".equals(region.name) && (UDATA.MASK != slotAddress) ) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RamClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RamClassWalker.java
@@ -366,7 +366,7 @@ public class RamClassWalker extends ClassWalker {
 				J9RAMStaticFieldRefPointer staticRef = J9RAMStaticFieldRefPointer.cast(cpEntry);
 				
 				/* if the field ref is resolved static, it has 'flagsAndClass', for other cases (unresolved and resolved instance) it has 'flags'. */
-				if ((staticRef.flagsAndClass().longValue() > 0) && (staticRef.valueOffset().longValue() != -1)) {
+				if ((staticRef.flagsAndClass().longValue() > 0) && !staticRef.valueOffset().eq(UDATA.MAX)) {
 					classWalkerCallback.addSlot(clazz, SlotType.J9_IDATA, staticRef.flagsAndClassEA(), "flagsAndClass");
 				} else {
 					classWalkerCallback.addSlot(clazz, SlotType.J9_UDATA, ref.flagsEA(), "flags");
@@ -425,7 +425,7 @@ public class RamClassWalker extends ClassWalker {
 			J9ROMFieldShapePointer field = fields.getField();
 			
 			String info = fields.getName();
-			U32 modifiers = field.modifiers();
+			UDATA modifiers = field.modifiers();
 			UDATAPointer fieldAddress = ramClass.ramStatics().addOffset(fields.getOffsetOrAddress());
 			
 			String additionalInfo = modifiers.anyBitsIn(J9FieldFlagObject) ? "!j9object" : "";
@@ -437,7 +437,7 @@ public class RamClassWalker extends ClassWalker {
 			}
 		}
 		
-		U32 staticSlotCount = ramClass.romClass().objectStaticCount().add(ramClass.romClass().singleScalarStaticCount());
+		UDATA staticSlotCount = ramClass.romClass().objectStaticCount().add(ramClass.romClass().singleScalarStaticCount());
 		if (J9BuildFlags.env_data64) {
 			staticSlotCount = staticSlotCount.add(ramClass.romClass().doubleScalarStaticCount());
 		} else {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RomClassWalker.java
@@ -98,6 +98,7 @@ import com.ibm.j9ddr.vm29.types.I32;
 import com.ibm.j9ddr.vm29.types.U16;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.U64;
+import com.ibm.j9ddr.vm29.types.UDATA;
 
 /**
  * Walk every slot and sections of a ROMClass
@@ -320,7 +321,7 @@ public class RomClassWalker extends ClassWalker {
 		int fieldLength = 0;
 		
 		U32Pointer initialValue;
-		U32 modifiers;
+		UDATA modifiers;
 		
 		J9ROMNameAndSignaturePointer fieldNAS = field.nameAndSignature();
 		classWalkerCallback.addSlot(clazz, SlotType.J9_ROM_UTF8, fieldNAS.nameEA(), "name");
@@ -712,7 +713,7 @@ public class RomClassWalker extends ClassWalker {
 	}
 	void allSlotsInIntermediateClassDataDo () throws CorruptDataException
 	{
-		U32 count = romClass.intermediateClassDataLength();
+		UDATA count = romClass.intermediateClassDataLength();
 		if (count.gt(0)) {
 			U8Pointer cursor = romClass.intermediateClassData();
 			String j9xHelp = "!j9x "+cursor.getHexAddress()+","+count.getHexValue();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ByteCodeDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ByteCodeDumper.java
@@ -501,7 +501,7 @@ public class ByteCodeDumper {
 
 				/* dump declaringClassName and signature */
 				J9ROMMethodRefPointer romMethodRef = J9ROMMethodRefPointer.cast(info);
-				U32 classRefCPIndex = romMethodRef.classRefCPIndex();
+				UDATA classRefCPIndex = romMethodRef.classRefCPIndex();
 				J9ROMConstantPoolItemPointer cpItem = constantPool.add(classRefCPIndex);
 				J9ROMClassRefPointer romClassRef = J9ROMClassRefPointer.cast(cpItem);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -44,7 +44,6 @@ import static com.ibm.j9ddr.vm29.structure.J9ROMMethodHandleRef.MH_REF_PUTSTATIC
 
 import java.io.PrintStream;
 
-
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.j9.ConstantPoolHelpers;
 import com.ibm.j9ddr.vm29.j9.J9ROMFieldShapeIterator;
@@ -93,7 +92,7 @@ import com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags;
 import com.ibm.j9ddr.vm29.types.U16;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.U8;
-
+import com.ibm.j9ddr.vm29.types.UDATA;
 
 public class J9BCUtil {
 	private static final String nl = System.getProperty("line.separator");
@@ -608,7 +607,7 @@ public class J9BCUtil {
 			}
 		}
 
-		U32 romFieldCount = romClass.romFieldCount();
+		UDATA romFieldCount = romClass.romFieldCount();
 		out.append(String.format("Fields (%d):" + nl, romFieldCount.longValue()));
 
 		J9ROMFieldShapeIterator iterator = new J9ROMFieldShapeIterator(romClass.romFields(), romFieldCount);
@@ -759,7 +758,7 @@ public class J9BCUtil {
 	private static void dumpSourceDebugExtension(PrintStream out, J9ROMClassPointer romClass, long flags) throws CorruptDataException {
 		if (J9BuildFlags.opt_debugInfoServer) {
 			U8Pointer current;
-			U32 temp;
+			UDATA temp;
 
 			if ((flags & J9BCTranslationData.BCT_StripDebugAttributes) == 0) {
 				J9SourceDebugExtensionPointer sde = OptInfo.getSourceDebugExtensionForROMClass(romClass);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/NativeMemInfoCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/NativeMemInfoCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,9 +33,8 @@ import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
 import com.ibm.j9ddr.vm29.j9.walkers.MemoryCategoryIterator;
 import com.ibm.j9ddr.vm29.pointer.generated.OMRMemCategoryPointer;
 import com.ibm.j9ddr.vm29.pointer.helper.OMRMemCategoryHelper;
-import com.ibm.j9ddr.vm29.types.U32;
+import com.ibm.j9ddr.vm29.types.UDATA;
 import com.ibm.j9ddr.vm29.view.dtfj.DTFJContext;
-
 
 public class NativeMemInfoCommand extends Command 
 {
@@ -77,7 +76,7 @@ public class NativeMemInfoCommand extends Command
 
 		final int numberOfChildren = next.numberOfChildren().intValue();
 		for (int i = 0; i < numberOfChildren; i++) {
-			U32 childCode = next.children().at(i);
+			UDATA childCode = next.children().at(i);
 			OMRMemCategoryPointer child = OMRMemCategoryHelper.getMemoryCategory(childCode);
 			printSections(child, level + 1);
 		}
@@ -105,7 +104,7 @@ public class NativeMemInfoCommand extends Command
 		
 		final int numberOfChildren = mcp.numberOfChildren().intValue();
 		for (int i = 0; i < numberOfChildren; i++) {
-			U32 childCode = mcp.children().at(i);
+			UDATA childCode = mcp.children().at(i);
 			OMRMemCategoryPointer child = OMRMemCategoryHelper.getMemoryCategory(childCode);
 			csa.add(computeSize(child));
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
@@ -61,7 +61,7 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9ROMFieldShapePointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
 import com.ibm.j9ddr.vm29.types.U32;
-
+import com.ibm.j9ddr.vm29.types.UDATA;
 
 public class ObjectSizeInfo extends Command 
 {
@@ -71,10 +71,9 @@ public class ObjectSizeInfo extends Command
 	private static final String SPACE_USED = "Space used";
 
 	private String className = null;
-	private PrintStream out;
 	TreeMap<String, ClassFieldInfo> fieldStats;
 	private boolean includeArrays;
-	
+
 	public ObjectSizeInfo()
 	{
 		addCommand("objectsizeinfo", "[-a] [class name]", "Print information about object fields and size of the objects, including unused space");
@@ -115,7 +114,6 @@ public class ObjectSizeInfo extends Command
 	
 	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
 	{
-		this.out = out;
 		fieldStats = new TreeMap<String, ClassFieldInfo> ();
 		Table summary = new Table("Object field size summary");
 		summary.row(ClassFieldInfo.getTitleRow());
@@ -202,7 +200,7 @@ public class ObjectSizeInfo extends Command
 		protected boolean isArray;
 		
 		public String[] getResults() throws CorruptDataException {
-				ArrayList<String> results = new ArrayList(16);
+				ArrayList<String> results = new ArrayList<String>(16);
 				results.add(objectClassString);
 				String totSizeString = "N/A";
 				String minSizeString = "N/A";
@@ -278,7 +276,7 @@ public class ObjectSizeInfo extends Command
 					J9ObjectFieldOffset fo = fieldIter.next();
 					if (!fo.isStatic()) {
 						J9ROMFieldShapePointer f = fo.getField();
-						U32 mods = f.modifiers();
+						UDATA mods = f.modifiers();
 						if (mods.anyBitsIn(J9FieldTypeByte)) {
 							byteCount += 1;
 						} else if (mods.anyBitsIn(J9FieldTypeShort)) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ShrCCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ShrCCommand.java
@@ -305,7 +305,7 @@ public class ShrCCommand extends Command
 
 				} else if (args[0].equals("rtflags")) {
 					if (sharedClassConfig.notNull()) {
-						U64 runtimeFlags = sharedClassConfig.runtimeFlags();
+						UDATA runtimeFlags = sharedClassConfig.runtimeFlags();
 						CommandUtils.dbgPrint(out,"Printing the shared classes runtime flags %s\n", runtimeFlags.getHexValue());
 						printShCFlags(out, runtimeFlags, "RUNTIMEFLAG");
 					}
@@ -421,7 +421,7 @@ public class ShrCCommand extends Command
 			}
 			if (cacheName != null) cacheNameString = cacheName; 
 			VoidPointer headerStart = osCache._headerStart();
-			U32 cacheSize = osCache._cacheSize();
+			UDATA cacheSize = osCache._cacheSize();
 			CommandUtils.dbgPrint(out, "Cache start 0x%x size %d\n", headerStart.getAddress(), cacheSize.longValue());
 			File outFile = new File(cacheDir, cacheNameString);
 			CommandUtils.dbgPrint(out, "Writing cache to %s\n", outFile.getAbsolutePath());
@@ -1338,15 +1338,15 @@ public class ShrCCommand extends Command
 		}
 		
 		public U32 getTotalBytes() throws CorruptDataException {
-			return this.header.totalBytes();
+			return new U32(this.header.totalBytes());
 		}
 		
 		public U32 getSoftMaxBytes() throws CorruptDataException {
-			return this.header.softMaxBytes();
+			return new U32(this.header.softMaxBytes());
 		}
 		
 		public U32 getReadWriteBytes() throws CorruptDataException {
-			return this.header.readWriteBytes();
+			return new U32(this.header.readWriteBytes());
 		}
 		
 		public UDATA getReadWritePtr() throws CorruptDataException {
@@ -1426,11 +1426,11 @@ public class ShrCCommand extends Command
 		}
 		
 		public I32 getMinAOT() throws CorruptDataException {
-			return this.header.minAOT();
+			return new I32(this.header.minAOT());
 		}
 		
 		public I32 getMinJIT() throws CorruptDataException {
-			return this.header.minJIT();
+			return new I32(this.header.minJIT());
 		}
 		
 		public UDATA getAotBytes() throws CorruptDataException {
@@ -1934,7 +1934,7 @@ public class ShrCCommand extends Command
 					if (type.eq(TYPE_CACHELET)) {
 						CacheletWrapperPointer cw = CacheletWrapperPointer.cast(ShcItemHelper.ITEMDATA(walk));
 						J9SharedCacheHeaderPointer header = J9SharedCacheHeaderPointer.cast(CacheletWrapperHelper.CLETDATA(cw));
-						U32 totalBytes = header.totalBytes();
+						UDATA totalBytes = header.totalBytes();
 						UDATA updatePtr = UDATA.cast(header).add(header.updateSRP());
 						UDATA metadataEnd = UDATA.cast(header).add(totalBytes);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/VmCheckCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/VmCheckCommand.java
@@ -478,8 +478,8 @@ public class VmCheckCommand extends Command
 			}
 		}
 
-		U32 ramConstantPoolCount = romClass.ramConstantPoolCount();
-		U32 romConstantPoolCount = romClass.romConstantPoolCount();
+		UDATA ramConstantPoolCount = romClass.ramConstantPoolCount();
+		UDATA romConstantPoolCount = romClass.romConstantPoolCount();
 		if (ramConstantPoolCount.gt(romConstantPoolCount)) {
 			reportError(out, "ramConstantPoolCount=%d > romConstantPoolCount=%d for romClass=0x%s", ramConstantPoolCount.longValue(), romConstantPoolCount.longValue(), Long.toHexString(romClass.getAddress()));
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I32.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I32.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,8 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.types;
 
-
-public class I32 extends IScalar {
+public class I32 extends IDATA {
 	
 	// Constants
 	public static final int SIZEOF = 4;
@@ -54,8 +53,8 @@ public class I32 extends IScalar {
 		return add (new I32(parameter));
 	}
 	
-	public U32 add(U32 parameter) {
-		return new U32(this).add(parameter);
+	public I32 add(U32 parameter) {
+		return new I32(this).add(parameter);
 	}
 
 	public boolean eq(U32 parameter) {
@@ -112,8 +111,8 @@ public class I32 extends IScalar {
 		return sub (new I32(parameter));
 	}
 	
-	public U32 sub(U32 parameter) {
-		return new U32(this).sub(parameter);
+	public I32 sub(U32 parameter) {
+		return new I32(this).sub(parameter);
 	}
 	
 	public U64 sub(U64 parameter) {
@@ -143,7 +142,11 @@ public class I32 extends IScalar {
 	public IDATA sub(IDATA parameter) {
 		return new IDATA(this).sub(parameter);
 	}
-	
+
+	public int intValue() {
+		return (int) data;
+	}
+
 	public long longValue() {
 		return (int) data;
 	}
@@ -166,8 +169,8 @@ public class I32 extends IScalar {
 		return bitOr (new I32(parameter));
 	}
 	
-	public U32 bitOr(U32 parameter) {
-		return new U32(this).bitOr(parameter);
+	public I32 bitOr(U32 parameter) {
+		return new I32(this).bitOr(parameter);
 	}
 	
 	public U64 bitOr(U64 parameter) {
@@ -254,8 +257,8 @@ public class I32 extends IScalar {
 		return bitAnd (new I32(parameter));
 	}
 	
-	public U32 bitAnd(U32 parameter) {
-		return new U32(this).bitAnd(parameter);
+	public I32 bitAnd(U32 parameter) {
+		return new I32(this).bitAnd(parameter);
 	}
 	
 	public U64 bitAnd(U64 parameter) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I64.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ package com.ibm.j9ddr.vm29.types;
 
 import com.ibm.j9ddr.InvalidDataTypeException;
 
-public class I64 extends IScalar {
+public class I64 extends IDATA {
 	
 	// Constants
 	public static final int SIZEOF = 8;
@@ -46,7 +46,11 @@ public class I64 extends IScalar {
 	public I64 add(int number) {
 		return new I64(data + number);
 	}
-	
+
+	public I64 add(long number) {
+		return new I64(data + number);
+	}
+
 	public I64 add(U8 parameter) {
 		return add(new I64(parameter));
 	}
@@ -91,7 +95,11 @@ public class I64 extends IScalar {
 	public I64 sub(int number) {
 		return new I64(data - number);
 	}
-	
+
+	public I64 sub(long number) {
+		return new I64(data - number);
+	}
+
 	public I64 sub(U8 parameter) {
 		return sub(new I64(parameter));
 	}
@@ -127,19 +135,19 @@ public class I64 extends IScalar {
 	public I64 sub(IDATA parameter) {
 		return sub(new I64(parameter));
 	}
-	
-	
+
 	public int intValue() {
-		// TODO: Should we try to return negative numbers up to MAXINT most negative?
-		if (super.intValue() < 0) {
-			throw new InvalidDataTypeException("I_64 contains number larger than MAX_INT");
-		} else {
-			return super.intValue();
+		int value = (int) data;
+
+		if (data != value) {
+			throw new InvalidDataTypeException("I64: conversion to int would lose data");
 		}
+
+		return value;
 	}
-	
+
 	// bitOr
-	
+
 	public I64 bitOr(int number) {
 		return new I64(data | number);
 	}
@@ -270,7 +278,11 @@ public class I64 extends IScalar {
 	public I64 mult(int parameter) {
 		return new I64(data * parameter);
 	}
-	
+
+	public I64 mult(long parameter) {
+		return new I64(data * parameter);
+	}
+
 	public boolean lt(I64 parameter)
 	{
 		return this.data < parameter.data;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/IDATA.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/IDATA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,18 +114,19 @@ public class IDATA extends IScalar {
 	public I64 sub(I64 parameter) {
 		return new I64(this).sub(parameter);
 	}
-	
+
 	public int intValue() {
-		// TODO: Should we try to return negative numbers up to MAXINT most negative?
-		if (SIZEOF == U64.SIZEOF && super.intValue() < 0) {
-			throw new InvalidDataTypeException("IDATA is 32 bits wide and contains a number larger than MAX_INT");
-		} else {
-			return super.intValue();
+		int value = (int) data;
+
+		if (SIZEOF == I64.SIZEOF && data != value) {
+			throw new InvalidDataTypeException("IDATA is 64 bits wide: conversion to int would lose data");
 		}
+
+		return value;
 	}
-	
+
 	public long longValue() {
-		if (SIZEOF == U32.SIZEOF) {
+		if (SIZEOF == I32.SIZEOF) {
 			return (int) data;
 		} else {
 			return data;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U32.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U32.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ package com.ibm.j9ddr.vm29.types;
 
 import com.ibm.j9ddr.InvalidDataTypeException;
 
-public class U32 extends UScalar {
+public class U32 extends UDATA {
 	// Constants
 	public static final int SIZEOF = 4;
 	public static final long MASK = 0xFFFFFFFFL;
@@ -50,7 +50,11 @@ public class U32 extends UScalar {
 	public U32 add(UScalar parameter) {
 		return add(new U32(parameter));
 	}
-	
+
+	public U32 add(I32 parameter) {
+		return new U32(data + parameter.data);
+	}
+
 	public U32 add(U32 parameter) {
 		return new U32(data + parameter.data);
 	}
@@ -121,16 +125,18 @@ public class U32 extends UScalar {
 		return new I64(this).sub(parameter);
 	}
 	
-	public IDATA sub(IDATA parameter) {
-		return new IDATA(this).sub(parameter);
+	public UDATA sub(IDATA parameter) {
+		return new UDATA(this).sub(parameter);
 	}
 	
 	public int intValue() {
-		if (super.intValue() < 0) {
-			throw new InvalidDataTypeException("U_32 contains value larger than Integer.MAX_VALUE");
-		} else {
-			return super.intValue();
+		long value = data;
+
+		if (value < 0 || value > Integer.MAX_VALUE) {
+			throw new InvalidDataTypeException("U32 contains value larger than Integer.MAX_VALUE");
 		}
+
+		return (int) value;
 	}
 	
 	// bitOr
@@ -167,8 +173,8 @@ public class U32 extends UScalar {
 		return new I64(this).bitOr(parameter);
 	}
 	
-	public IDATA bitOr(IDATA parameter) {
-		return new IDATA(this).bitOr(parameter);
+	public UDATA bitOr(IDATA parameter) {
+		return new UDATA(this).bitOr(parameter);
 	}
 	
 	// bitXor
@@ -239,8 +245,8 @@ public class U32 extends UScalar {
 		return new I64(this).bitAnd(parameter);
 	}
 	
-	public IDATA bitAnd(IDATA parameter) {
-		return new IDATA(this).bitAnd(parameter);
+	public UDATA bitAnd(IDATA parameter) {
+		return new UDATA(this).bitAnd(parameter);
 	}
 	
 	// leftShift

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U64.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ package com.ibm.j9ddr.vm29.types;
 
 import com.ibm.j9ddr.InvalidDataTypeException;
 
-public class U64 extends UScalar {
+public class U64 extends UDATA {
 
 	// Constants
 	public static final int SIZEOF = 8;
@@ -44,7 +44,11 @@ public class U64 extends UScalar {
 	public U64 add(int number) {
 		return new U64(data + number);
 	}
-	
+
+	public U64 add(long number) {
+		return new U64(data + number);
+	}
+
 	public U64 add(UScalar parameter) {
 		return add(new U64(parameter));
 	}
@@ -62,7 +66,11 @@ public class U64 extends UScalar {
 	public U64 sub(int number) {
 		return new U64(data - number);
 	}
-	
+
+	public U64 sub(long number) {
+		return new U64(data - number);
+	}
+
 	public U64 sub(UScalar parameter) {
 		return sub(new U64(parameter));
 	}
@@ -87,21 +95,24 @@ public class U64 extends UScalar {
 		return sub(new U64(parameter));
 	}
 
-	
 	public int intValue() {
-		if (super.intValue() < 0) {
-			throw new InvalidDataTypeException("U_64 contains value larger than Integer.MAX_VALUE");
-		} else {
-			return super.intValue();
+		long value = data;
+
+		if (value < 0 || value > Integer.MAX_VALUE) {
+			throw new InvalidDataTypeException("U64 contains value larger than Integer.MAX_VALUE");
 		}
+
+		return (int) value;
 	}
 	
 	public long longValue() {
-		if (super.longValue() < 0) {
-			throw new InvalidDataTypeException("U_64 contains value larger than Long.MAX_VALUE");
-		} else {
-			return super.longValue();
+		long value = data;
+
+		if (value < 0) {
+			throw new InvalidDataTypeException("U64 contains value larger than Long.MAX_VALUE");
 		}
+
+		return value;
 	}
 	
 	// bitOr
@@ -229,22 +240,20 @@ public class U64 extends UScalar {
 	public U64 mult(int parameter) {
 		return new U64(data * parameter);
 	}
-	
+
+	public U64 mult(long parameter) {
+		return new U64(data * parameter);
+	}
+
 	@Override
 	public boolean eq(Scalar parameter) {
-		if (parameter instanceof U64) {
-			return data == parameter.data;
-		} else if (parameter.isSigned()) {
+		if (parameter.isSigned()) {
 			return this.eq(new U64(parameter));
 		} else {
-			if (data < 0) {
-				return false;
-			} else {
-				return longValue() == parameter.longValue();
-			}
+			return data == parameter.data;
 		}
 	}
-	
+
 	@Override
 	public int sizeof()
 	{

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/UDATA.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/UDATA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,13 +94,15 @@ public class UDATA extends UScalar {
 	public UDATA sub(IDATA parameter) {
 		return this.sub(new UDATA(parameter));
 	}
-	
+
 	public int intValue() {
-		if (super.intValue() < 0) {
+		long value = data;
+
+		if (value < 0 || value > Integer.MAX_VALUE) {
 			throw new InvalidDataTypeException("UDATA contains value larger than Integer.MAX_VALUE");
-		} else {
-			return super.intValue();
 		}
+
+		return (int) value;
 	}
 	
 	// bitOr

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntimeMemoryCategory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntimeMemoryCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ import com.ibm.j9ddr.util.IteratorHelpers.IteratorFilter;
 import com.ibm.j9ddr.view.dtfj.J9DDRDTFJUtils;
 import com.ibm.j9ddr.vm29.pointer.generated.OMRMemCategoryPointer;
 import com.ibm.j9ddr.vm29.pointer.helper.OMRMemCategoryHelper;
-import com.ibm.j9ddr.vm29.types.U32;
+import com.ibm.j9ddr.vm29.types.UDATA;
 import com.ibm.j9ddr.vm29.view.dtfj.DTFJContext;
 
 import static com.ibm.j9ddr.vm29.pointer.helper.OMRMemCategoryHelper.IOMRMemCategoryVisitor;
@@ -77,7 +77,7 @@ public class DTFJJavaRuntimeMemoryCategory implements JavaRuntimeMemoryCategory
 			}
 			
 			try {
-				U32 childCode = category.children().at(index++);
+				UDATA childCode = category.children().at(index++);
 				OMRMemCategoryPointer childCategory = OMRMemCategoryHelper.getMemoryCategory(childCode);
 				
 				if (childCategory.categoryCode().eq(childCode)) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJMemoryTagRuntimeMemorySection.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJMemoryTagRuntimeMemorySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ import com.ibm.dtfj.java.JavaRuntimeMemoryCategory;
 import com.ibm.dtfj.java.JavaRuntimeMemorySection;
 import com.ibm.j9ddr.view.dtfj.J9DDRDTFJUtils;
 import com.ibm.j9ddr.vm29.pointer.generated.J9MemTagPointer;
-import com.ibm.j9ddr.vm29.types.U32;
+import com.ibm.j9ddr.vm29.types.UDATA;
 import com.ibm.j9ddr.vm29.view.dtfj.DTFJContext;
 
 import static com.ibm.j9ddr.vm29.structure.J9PortLibrary.J9MEMTAG_EYECATCHER_ALLOC_HEADER;
@@ -55,7 +55,7 @@ public class DTFJMemoryTagRuntimeMemorySection extends DTFJJavaRuntimeMemorySect
 	public int getAllocationType()
 	{
 		try {
-			U32 eyeCatcher = memoryTag.eyeCatcher();
+			UDATA eyeCatcher = memoryTag.eyeCatcher();
 			
 			if (eyeCatcher.eq(J9MEMTAG_EYECATCHER_ALLOC_HEADER)) {
 				return JavaRuntimeMemorySection.ALLOCATION_TYPE_MALLOC_LIVE; 


### PR DESCRIPTION
Core files created on 32-bit platforms should be readable on 64-bit platforms and vice-versa. Because the debug information of some compilers (e.g. Visual Studio) doesn't distinguish between UDATA and U64 (in 64-bit builds) or between UDATA and U32 (in 32-bit builds), we have to be prepared to encounter a U64 object or a U32 object where the C/C++ source used UDATA.

* The interface of the generated pointer classes must be generalized so that accessors for all U32 and U64 fields are declared to return UDATA so that hand-written code is not prematurely bound to either
  specific type.
* Generated pointer types also cannot be bound to the JVM: they must be derived from each core file (like the structure classes are).
* This requires adjustments to the class hierarchy of IDATA and UDATA. U32 and U64 must both extend UDATA so that the expectation for an UDATA object can be satifsfied by either an U32 object (from a 32-bit core file) or an U64 object (from a 64-bit core file).
* Likewise for the pointer types: both U32Pointer and U64Pointer must extend UDATAPointer.

The same situations exist with respect to IDATA, I32 and I64 and their pointer classes.

Some adjustments will be required to the hand-written code. Places where U32 or U64 (or the related pointer types) were expected from a pointer accessor method, instead UDATA (or UDATAPointer) will be returned.