### PR TITLE
OSX: Fix BlockPriorityQueue stored element type

### DIFF
--- a/runtime/compiler/optimizer/JProfilingBlock.hpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,10 +37,11 @@ class BlockParents;
 class TR_JProfilingBlock : public TR::Optimization
    {
    protected:
-   typedef TR::typed_allocator<std::pair<int32_t, TR::Block *>, TR::Region & > BlockContainerAllocator;
-   typedef std::vector<std::pair<int32_t, TR::Block *>, BlockContainerAllocator > BlockQueueContainer;
-   typedef std::greater<std::pair<int32_t, TR::Block *>> BlockQueueCompare;
-   typedef std::priority_queue< size_t, BlockQueueContainer, BlockQueueCompare > BlockPriorityQueue;
+   typedef std::pair<int32_t, TR::Block*> BlockQueueItem;
+   typedef TR::typed_allocator<BlockQueueItem, TR::Region&> BlockContainerAllocator;
+   typedef std::vector<BlockQueueItem, BlockContainerAllocator> BlockQueueContainer;
+   typedef std::greater<BlockQueueItem> BlockQueueCompare;
+   typedef std::priority_queue<BlockQueueItem,BlockQueueContainer,BlockQueueCompare> BlockPriorityQueue;
 
    public:
    static int32_t nestedLoopRecompileThreshold;


### PR DESCRIPTION
In std::priority_queue<T,V,C> where,
  * T = stored element type
  * V = <T,A> = container vector, with A being the allocator
  * C = comparator  

if T is not the same type as V::value_type, it results in
undefined behaviour.

Previously, the priority_queue was being set up as
std::priority_queue<size_t,V,C> with
V = < int32_t , BlockContainerAllocator>.
To Clang, size_t and int32_t aren't equivalent, and that fails
the [static assertion in libc++](https://github.com/llvm-mirror/libcxx/blob/1639392a4af6150c69d77bbda1327b2fbce8c293/include/queue#L437) meant to prevent undefined
behavior that may arise from this.

issue: #36

Also-by: Robert Young <rwy0717@gmail.com>
Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>