### PR TITLE
Add support for vendor tests to Jenkins pipelines

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
- def get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH) {
+def get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, VENDOR_TEST_REPOS_MAP=null, VENDOR_TEST_BRANCHES_MAP=null, VENDOR_TEST_SHAS_MAP=null) {
     // Get a set of SHAs for a standard OpenJ9 build
     def SHAS = [:]
 
@@ -68,6 +68,23 @@
         echo "OPENJ9_SHA:${SHAS['OPENJ9']}"
         echo "OMR_SHA:${SHAS['OMR']}"
         currentBuild.description = "OpenJ9: ${get_short_sha(SHAS['OPENJ9'])}<br/>OMR: ${get_short_sha(SHAS['OMR'])}${description}"
+
+        if (VENDOR_TEST_REPOS_MAP && VENDOR_TEST_BRANCHES_MAP) {
+            // fetch SHAs for vendor test repositories
+            VENDOR_TEST_REPOS_MAP.each { repoName, vendorRepoURL ->
+                if (!VENDOR_TEST_SHAS_MAP[repoName]) {
+                    VENDOR_TEST_SHAS_MAP[repoName] = get_repository_sha(vendorRepoURL, VENDOR_TEST_BRANCHES_MAP[repoName])
+                }
+
+                // update build description
+                currentBuild.description += "<br/>${repoName}: ${get_short_sha(VENDOR_TEST_SHAS_MAP[repoName])}"
+                echo "${repoName}_SHA: ${VENDOR_TEST_SHAS_MAP[repoName]}"
+            }
+
+            // add vendor test repositories SHAs to the list
+            SHAS['VENDOR_TEST'] = VENDOR_TEST_SHAS_MAP
+        }
+
         return SHAS
     }
 }
@@ -138,7 +155,7 @@ def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO
     }
 }
 
-def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, OPENJ9_SHA) {
+def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST) {
     stage ("${JOB_NAME}") {
         return build_with_slack(JOB_NAME,
             [string(name: 'UPSTREAM_JOB_NAME', value: UPSTREAM_JOB_NAME),
@@ -148,7 +165,15 @@ def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, VA
             string(name: 'VENDOR_BRANCH', value: VENDOR_BRANCH),
             string(name: 'VENDOR_CREDENTIALS_ID', value: VENDOR_CREDENTIALS_ID),
             string(name: 'NODE', value: NODE),
-            string(name: 'OPENJ9_SHA', value: OPENJ9_SHA)])
+            string(name: 'OPENJ9_REPO', value: OPENJ9_REPO),
+            string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH),
+            string(name: 'OPENJ9_SHA', value: OPENJ9_SHA),
+            string(name: 'VENDOR_TEST_REPOS', value: VENDOR_TEST_REPOS),
+            string(name: 'VENDOR_TEST_BRANCHES', value: VENDOR_TEST_BRANCHES),
+            string(name: 'VENDOR_TEST_SHAS', value: VENDOR_TEST_SHAS),
+            string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),
+            string(name: 'USER_CREDENTIALS_ID', value: USER_CREDENTIALS_ID),
+            string(name: 'BUILD_LIST', value: BUILD_LIST)])
     }
 }
 
@@ -185,7 +210,7 @@ def build_with_slack(JOB_NAME, PARAMETERS) {
     return JOB
 }
 
-def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS) {
+def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_DIRS_MAP, USER_CREDENTIALS_ID, BUILD_LIST) {
     def jobs = [:]
 
     // compile the source and build the SDK
@@ -195,7 +220,15 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
     if (TESTS_TARGETS.trim() != "none") {
         def testjobs = [:]
-        def TARGET_NAMES = [:]
+        def TARGET_NAMES = []
+
+        if (SHAS['VENDOR_TEST']) {
+            // the downstream job is expecting comma separated SHAs
+            // convert vendor shas map to a string
+            VENDOR_TEST_SHAS = SHAS['VENDOR_TEST'].values().join(',')
+        }
+
+        echo "Using VENDOR_TEST_REPOS = ${VENDOR_TEST_REPOS}, VENDOR_TEST_BRANCHES = ${VENDOR_TEST_BRANCHES}, VENDOR_TEST_SHAS = ${VENDOR_TEST_SHAS}, VENDOR_TEST_DIRS = ${VENDOR_TEST_DIRS}, BUILD_LIST = ${BUILD_LIST}" 
 
         def targets = TESTS_TARGETS.split(",")
         targets.each { target ->
@@ -206,33 +239,33 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                 //  - OpenJ9 test pipelines will be completely removed once we switch to use AdoptOpenJDK test pipelines
                 case "_sanity":
                     if (SPEC.contains("win") || SDK_VERSION == "9") {
-                        TARGET_NAMES = ["Sanity"]
+                        TARGET_NAMES.add("Sanity")
                     } else {
-                        TARGET_NAMES = ["sanity.functional", "sanity.system"]
+                        TARGET_NAMES.addAll(["sanity.functional", "sanity.system"])
                     }
                     break
                 case "_extended":
                     if (SPEC.contains("win") || SDK_VERSION == "9") {
-                        TARGET_NAMES = ["Extended"]
+                        TARGET_NAMES.add("Extended")
                     } else {
-                        TARGET_NAMES = ["extended.functional", "extended.system"]
+                        TARGET_NAMES.addAll(["extended.functional", "extended.system"])
                     }
                     break
                 // temporary for OMR acceptance. This should be removed once we completely switch to AdoptOpenJDK test Jenkins file
                 case "_sanity.tmp":
-                    TARGET_NAMES = ["Sanity"]
+                    TARGET_NAMES.add("Sanity")
                     break
                 default:
-                    TARGET_NAMES = ["${target}"]
+                    TARGET_NAMES.add(target.trim())
             }
+        }
 
-            for ( name in TARGET_NAMES ) {
-                def TEST_JOB_NAME = "Test-${name}-JDK${SDK_VERSION}-${SPEC}"
-                testjobs["${TEST_JOB_NAME}"] = {
-                    // run tests against the SDK build in the upstream job: Build-JDK${SDK_VERSION}-${SPEC}
-                    jobs["${TEST_JOB_NAME}"] = build_with_one_upstream(TEST_JOB_NAME, BUILD_JOB_NAME, jobs["build"].getNumber(), params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, SHAS['OPENJ9'])
-                    echo "JOB: ${TEST_JOB_NAME} PASSED in: ${jobs[TEST_JOB_NAME].getDurationString()}"
-                }
+        for (name in TARGET_NAMES) {
+            def TEST_JOB_NAME = "Test-${name}-JDK${SDK_VERSION}-${SPEC}"
+            testjobs["${TEST_JOB_NAME}"] = {
+                // run tests against the SDK build in the upstream job: Build-JDK${SDK_VERSION}-${SPEC}
+                jobs["${TEST_JOB_NAME}"] = build_with_one_upstream(TEST_JOB_NAME, BUILD_JOB_NAME, jobs["build"].getNumber(), params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST)
+                echo "JOB: ${TEST_JOB_NAME} PASSED in: ${jobs[TEST_JOB_NAME].getDurationString()}"
             }
         }
         parallel testjobs

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -418,6 +418,7 @@ def set_job_variables(job_type) {
         case "pipeline":
             // set variables for a pipeline job
             set_repos_variables()
+            set_vendor_variables()
             set_test_targets()
             set_slack_channel()
             set_job_names()
@@ -486,6 +487,119 @@ def convert_url(value) {
     }
 
     return value
+}
+
+/*
+* Checks for vendor test sources and initializes variables required to clone the
+* vendor test source Git repositories. Uses variable files when build parameters
+* are not provided.
+*/
+def set_vendor_variables() {
+    VENDOR_TEST_REPOS_MAP = [:]
+    VENDOR_TEST_BRANCHES_MAP = [:]
+    VENDOR_TEST_DIRS_MAP = [:]
+    VENDOR_TEST_SHAS_MAP = [:]
+
+    // initialize variables from build parameters
+    // VENDOR_TEST* build parameters are comma separated string parameters
+    // convert each comma separated string parameter to array
+    def branches = []
+    if (params.VENDOR_TEST_BRANCHES) {
+        branches.addAll(params.VENDOR_TEST_BRANCHES.tokenize(','))
+    }
+
+    def shas = []
+    if (params.VENDOR_TEST_SHAS) {
+        shas.addAll(params.VENDOR_TEST_SHAS.tokenize(','))
+    }
+
+    def dirs = []
+    if (params.VENDOR_TEST_DIRS) {
+        dirs.addAll(params.VENDOR_TEST_DIRS.tokenize(','))
+    }
+
+    BUILD_LIST = params.BUILD_LIST
+    if (!BUILD_LIST) {
+        BUILD_LIST = ''
+    }
+
+    if (params.VENDOR_TEST_REPOS) {
+        // populate the VENDOR_TEST_* maps
+
+        params.VENDOR_TEST_REPOS.tokenize(',').eachWithIndex { repoURL, index ->
+            repoURL = repoURL.trim()
+            REPO_NAME = get_repo_name_from_url(repoURL)
+            VENDOR_TEST_REPOS_MAP[REPO_NAME] = repoURL
+
+            if (branches[index]) {
+                VENDOR_TEST_BRANCHES_MAP[REPO_NAME] = branches[index].trim()
+            } else {
+                error("Missing branch for ${repoURL} from VENDOR_TEST_BRANCHES parameter")
+            }
+
+            if (dirs[index]) {
+                VENDOR_TEST_DIRS_MAP[REPO_NAME] = dirs[index].trim()
+            }
+
+            if (shas[index]) {
+                VENDOR_TEST_SHAS_MAP[REPO_NAME] = shas[index].trim()
+            }
+        }
+    } else {
+        // fetch from variables file
+
+        if (VARIABLES.vendor_source && VARIABLES.vendor_source.test) {
+            // parse the vendor source multi-map 
+            // and populate the VENDOR_TEST_* maps
+
+             VARIABLES.vendor_source.test.each { entry ->
+                REPO_NAME = get_repo_name_from_url(entry.get('repo'))
+
+                VENDOR_TEST_REPOS_MAP[REPO_NAME] = entry.get('repo')
+                VENDOR_TEST_BRANCHES_MAP[REPO_NAME] = entry.get('branch')
+                VENDOR_TEST_DIRS_MAP[REPO_NAME] = entry.get('directory')
+
+                if (entry.get('build_list')) {
+                    // a comma separated list of vendor tests projects
+                    if (BUILD_LIST) {
+                        BUILD_LIST += ","
+                    }
+                    BUILD_LIST += entry.get('build_list').join(',')
+               }
+            }
+        }
+    }
+
+    // the downstream job expects VENDOR_TEST* parameters to be comma separated strings
+    // convert VENDOR_TEST* maps to strings
+    if (VENDOR_TEST_REPOS_MAP) {
+        VENDOR_TEST_REPOS = VENDOR_TEST_REPOS_MAP.values().join(',')
+    } else {
+        VENDOR_TEST_REPOS = ''
+    }
+
+    if (VENDOR_TEST_BRANCHES_MAP) {
+        VENDOR_TEST_BRANCHES = VENDOR_TEST_BRANCHES_MAP.values().join(',')
+    } else {
+        VENDOR_TEST_BRANCHES = ''
+    }
+
+    if (!VENDOR_TEST_SHAS_MAP) {
+        VENDOR_TEST_SHAS = ''
+    }
+
+    if (VENDOR_TEST_DIRS_MAP) {
+        VENDOR_TEST_DIRS = VENDOR_TEST_DIRS_MAP.values().join(',')
+    } else {
+        VENDOR_TEST_DIRS = ''
+    }
+}
+
+/*
+*  Extracts the Git repository name from URL and converts it to upper case.
+*/
+def get_repo_name_from_url(URL) {
+    return URL.substring(URL.lastIndexOf('/') + 1, URL.lastIndexOf('.git')).toUpperCase()
 }
 
 return this

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -32,16 +32,18 @@ timestamps {
             variableFile.set_job_variables('pipeline')
 
             buildFile = load 'buildenv/jenkins/common/pipeline-functions'
-            SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
+            SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_SHAS_MAP)
         } finally {
             try{
                 cleanWs()
             } catch(e) {
-                variableFile.printStackTrace(e)
+                if (variableFile) {
+                    variableFile.printStackTrace(e)
+                }
             }
         }
     }
 }
 
 
-jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS)
+jobs = buildFile.workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, TESTS_TARGETS, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_DIRS_MAP, USER_CREDENTIALS_ID, BUILD_LIST)


### PR DESCRIPTION
Update the pipelines wrapper to check for vendor test source related
variables(Git repository URL, branch, SHA, etc.) and pass them to the
downstream job (the test pipeline) as comma separated string parameters.
Check for vendor test variables and initialize them from variables file
when no build parameters are available. 
Update get_shas() method to also fetch vendor test repositories SHAs.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>