### PR TITLE
Cleanup deprecated code related to buildVFTCall

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1500,11 +1500,7 @@ void TR::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, 
 
    if (methodSymRef->getSymbol()->castToMethodSymbol()->isComputed())
       {
-      TR::Node *addressChild = site.getCallNode()->getFirstChild();
-      //if (addressChild->getRegister() || addressChild->getReferenceCount() >= 2) // TODO:JSR292: Try to avoid the explicit load
-         buildVFTCall(site, CALLReg, doneLabel, site.evaluateVFT(), NULL);
-      //else
-         //buildVFTCall(site, CALLMem, doneLabel, NULL, generateX86MemoryReference(site.getCallNode(), cg()));
+      buildVFTCall(site, CALLReg, site.evaluateVFT(), NULL);
       }
    else if (evaluateVftEarly)
       {
@@ -1515,7 +1511,7 @@ void TR::AMD64PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &site, 
       {
       // Call through VFT
       //
-      buildVFTCall(site, CALLMem, doneLabel, NULL, generateX86MemoryReference(site.evaluateVFT(), methodSymRef->getOffset(), cg()));
+      buildVFTCall(site, CALLMem, NULL, generateX86MemoryReference(site.evaluateVFT(), methodSymRef->getOffset(), cg()));
       }
    else
       {

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -2485,10 +2485,8 @@ bool TR::X86PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::LabelSy
       }
    }
 
-TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::LabelSymbol *doneLabel, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref, TR::Instruction *goodPlaceForAMiniTrampoline)
+TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref)
    {
-   // TODO: Remove doneLabel argument.  It's not used, and it's puzzling to the caller.
-
    TR::Node *callNode = site.getCallNode();
    if (cg()->enableSinglePrecisionMethods() &&
        comp()->getJittedMethodSymbol()->usesSinglePrecisionMode())
@@ -2534,24 +2532,12 @@ TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X
          TR::LabelSymbol *jmpLabel   = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
          callInstr = generateLabelInstruction(CALLImm4, callNode, jmpLabel, cg());
 
-         // Jump (either outlined or as a mini-trampoline)
+         // Jump outlined
          //
-         TR_OutlinedInstructions *outlined;
-         TR::Instruction *cursor = goodPlaceForAMiniTrampoline;
-         if (goodPlaceForAMiniTrampoline)
-            {
-            outlined = NULL;
-            }
-         else
-            {
-            outlined = new (cg()->trHeapMemory()) TR_OutlinedInstructions(jmpLabel, cg());
-            cg()->getOutlinedInstructionsList().push_front(outlined);
-            outlined->swapInstructionListsWithCompilation();
-            }
-         cursor = generateLabelInstruction(cursor, LABEL,  jmpLabel, cg()); cursor->setNode(callNode);
-         cursor = generateRegInstruction  (cursor, JMPReg, targetAddressReg, cg());
-         if (outlined)
-            outlined->swapInstructionListsWithCompilation();
+         {
+         TR_OutlinedInstructionsGenerator og(jmpLabel, callNode, cg());
+         generateRegInstruction(JMPReg, callNode, targetAddressReg, cg());
+         }
 
          // The targetAddressReg doesn't appear to be used in mainline code, so
          // register assignment may do weird things like spill it.  We'd prefer it
@@ -2949,7 +2935,7 @@ void TR::X86PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86CallSi
    TR::Instruction *lastITableDispatchStart = generateLabelInstruction(  LABEL, callNode, lastITableDispatchLabel, cg());
    generateRegImmInstruction( MOV4RegImm4, callNode, vtableIndexReg, fej9->getITableEntryJitVTableOffset(), cg());
    generateRegMemInstruction( SUBRegMem(), callNode, vtableIndexReg, generateX86MemoryReference(scratchReg, fej9->convertITableIndexToOffset(itableIndex), cg()), cg());
-   buildVFTCall(site,         JMPMem, doneLabel, NULL, generateX86MemoryReference(vftReg, vtableIndexReg, 0, cg()));
+   buildVFTCall(site,         JMPMem, NULL, generateX86MemoryReference(vftReg, vtableIndexReg, 0, cg()));
 
    // Without PIC slots, lastITableDispatchStart takes the place of various "first instruction" pointers
    //

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -268,7 +268,7 @@ class X86PrivateLinkage : public TR::Linkage
    virtual TR::Instruction *buildPICSlot(TR::X86PICSlot picSlot, TR::LabelSymbol *mismatchLabel, TR::LabelSymbol *doneLabel, TR::X86CallSite &site)=0;
    virtual void buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel);
    virtual void buildIPIC(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk)=0;
-   virtual TR::Instruction *buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::LabelSymbol *doneLabel, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref, TR::Instruction *goodPlaceForAMiniTrampoline=NULL);
+   virtual TR::Instruction *buildVFTCall(TR::X86CallSite &site, TR_X86OpCode dispatchOp, TR::Register *targetAddressReg, TR::MemoryReference *targetAddressMemref);
    virtual void buildInterfaceDispatchUsingLastITable (TR::X86CallSite &site, int32_t numIPicSlots, TR::X86PICSlot &lastPicSlot, TR::Instruction *&slotPatchInstruction, TR::LabelSymbol *doneLabel, TR::LabelSymbol *lookupDispatchSnippetLabel, TR_OpaqueClassBlock *declaringClass, uintptrj_t itableIndex);
 
    // Creates a thunk for interpreted virtual calls, used to initialize

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -1528,7 +1528,7 @@ void TR::IA32PrivateLinkage::buildVirtualOrComputedCall(
       TR::Register *targetAddress = site.evaluateVFT();
       if (targetAddress->getRegisterPair())
          targetAddress = targetAddress->getRegisterPair()->getLowOrder();
-      buildVFTCall(site, CALLReg, doneLabel, targetAddress, NULL);
+      buildVFTCall(site, CALLReg, targetAddress, NULL);
       }
    else if (resolvedSite && site.resolvedVirtualShouldUseVFTCall())
       {
@@ -1539,7 +1539,7 @@ void TR::IA32PrivateLinkage::buildVirtualOrComputedCall(
       if (!resolvedSite)
          offset = 0;
 
-      buildVFTCall(site, CALLMem, doneLabel, NULL, generateX86MemoryReference(site.evaluateVFT(), offset, cg()));
+      buildVFTCall(site, CALLMem, NULL, generateX86MemoryReference(site.evaluateVFT(), offset, cg()));
       }
    else
       {


### PR DESCRIPTION
Code cleanup related to TR::X86PrivateLinkage::buildVFTCall,
removing two deprecated parameters.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>