### PR TITLE
Add stub methods to bringup jdk-11+19

### DIFF
--- a/runtime/j9vm/CMakeLists.txt
+++ b/runtime/j9vm/CMakeLists.txt
@@ -33,7 +33,7 @@ target_sources(jvm_common INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/j7vmi.c
 	${CMAKE_CURRENT_SOURCE_DIR}/j8vmi.c
 	${CMAKE_CURRENT_SOURCE_DIR}/j9memcategories.c
-	${CMAKE_CURRENT_SOURCE_DIR}/java9vmi.c
+	${CMAKE_CURRENT_SOURCE_DIR}/java11vmi.c
 	${CMAKE_CURRENT_SOURCE_DIR}/jvm.c
 	${CMAKE_CURRENT_SOURCE_DIR}/vmi.c
 	#TODO this is gross

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1797,4 +1797,22 @@ JVM_BeforeHalt()
 {
 	/* To be implemented via https://github.com/eclipse/openj9/issues/1459 */
 }
+JNIEXPORT jclass JNICALL
+JVM_GetNestHost(JNIEnv *env, jclass clz)
+{
+	assert(!"JVM_GetNestHost unimplemented");
+	return NULL;
+}
+JNIEXPORT jobjectArray JNICALL
+JVM_GetNestMembers(JNIEnv *env, jclass clz)
+{
+	assert(!"JVM_GetNestMembers unimplemented");
+	return NULL;
+}
+JNIEXPORT jboolean JNICALL
+JVM_AreNestMates(JNIEnv *env, jclass clzOne, jclass clzTwo)
+{
+	assert(!"JVM_AreNestMates unimplemented");
+	return JNI_FALSE;
+}
 #endif /* J9VM_JCL_SE11 */

--- a/runtime/j9vm/module.xml
+++ b/runtime/j9vm/module.xml
@@ -85,7 +85,7 @@
 			</vpath>
 		</vpaths>
 		<objects>
-			<object name="java9vmi"/>
+			<object name="java11vmi"/>
 			<object name="j8vmi"/>
 			<object name="j7vmi"/>
 			<object name="j7verify"/>

--- a/runtime/j9vm_b150/module.xml
+++ b/runtime/j9vm_b150/module.xml
@@ -71,13 +71,13 @@
 			<vpath pattern="j7vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="j8vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="j9memcategories.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
-			<vpath pattern="java9vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="java11vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="jvm.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="ut_j9scar.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 		</vpaths>
 		<objects>
-			<object name="java9vmi"/>
+			<object name="java11vmi"/>
 			<object name="j8vmi"/>
 			<object name="j7vmi"/>
 			<object name="j7verify"/>

--- a/runtime/j9vm_b156/module.xml
+++ b/runtime/j9vm_b156/module.xml
@@ -71,13 +71,13 @@
 			<vpath pattern="j7vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="j8vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="j9memcategories.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
-			<vpath pattern="java9vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="java11vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="jvm.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="ut_j9scar.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 		</vpaths>
 		<objects>
-			<object name="java9vmi"/>
+			<object name="java11vmi"/>
 			<object name="j8vmi"/>
 			<object name="j7vmi"/>
 			<object name="j7verify"/>

--- a/runtime/j9vm_jdk11/module.xml
+++ b/runtime/j9vm_jdk11/module.xml
@@ -31,6 +31,9 @@
 		<export name="JNI_GetDefaultJavaVMInitArgs"/>
 		<export name="_JVM_GetCallerClass@4" />
 		<export name="JVM_BeforeHalt" />
+		<export name="JVM_GetNestHost" />
+		<export name="JVM_GetNestMembers" />
+		<export name="JVM_AreNestMates" />
 	</exports>
 
 	<artifact type="shared" name="jvm" scope="jdk11" loadgroup="top" buildlocal="true" appendrelease="false">
@@ -73,13 +76,13 @@
 			<vpath pattern="j7vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="j8vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="j9memcategories.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
-			<vpath pattern="java9vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
+			<vpath pattern="java11vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="jvm.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="ut_j9scar.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 			<vpath pattern="vmi.c" path="../j9vm" augmentObjects="true" augmentIncludes="true" type="relativepath"/>
 		</vpaths>
 		<objects>
-			<object name="java9vmi"/>
+			<object name="java11vmi"/>
 			<object name="j8vmi"/>
 			<object name="j7vmi"/>
 			<object name="j7verify"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -313,3 +313,9 @@ _X(JVM_WaitForReferencePendingList,JNICALL,false,void ,JNIEnv *env)
 _X(JVM_GetNanoTimeAdjustment,JNICALL,true,jlong ,JNIEnv *env, jclass clazz, jlong offsetSeconds)
 _IF([defined(J9VM_JCL_SE11)],
 	[_X(JVM_BeforeHalt,JNICALL,false,void,void)])
+_IF([defined(J9VM_JCL_SE11)],
+	[_X(JVM_GetNestHost,JNICALL,false,jclass,JNIEnv *env,jclass clz)])
+_IF([defined(J9VM_JCL_SE11)],
+	[_X(JVM_GetNestMembers,JNICALL,false,jobjectArray,JNIEnv *env,jclass clz)])
+_IF([defined(J9VM_JCL_SE11)],
+	[_X(JVM_AreNestMates,JNICALL,false,jboolean,JNIEnv *env,jclass clzOne, jclass clzTwo)])

--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -33,6 +33,9 @@
 	<exports group="jdk11">
 		<export name="_JVM_GetCallerClass@4" />
 		<export name="JVM_BeforeHalt" />
+		<export name="JVM_GetNestHost" />
+		<export name="JVM_GetNestMembers" />
+		<export name="JVM_AreNestMates" />
 	</exports>
 	<exports group="prejdk11">
 		<export name="_JVM_GetCallerClass@8" />


### PR DESCRIPTION
Add stub methods to bringup `jdk-11+19`

```
JVM_GetNestHost
JVM_GetNestMembers
JVM_AreNestMates
```

issue: #2269 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>