### PR TITLE
Fix putfield/static il trees to comply with JVM spec

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1255,7 +1255,6 @@ J9::SymbolReferenceTable::dynamicMethodSymrefsByCallSiteIndex(int32_t index)
    return _dynamicMethodSymrefsByCallSiteIndex[index];
    }
 
-
 bool
 J9::SymbolReferenceTable::isFieldClassObject(TR::SymbolReference *symRef)
    {
@@ -1265,6 +1264,28 @@ J9::SymbolReferenceTable::isFieldClassObject(TR::SymbolReference *symRef)
    return false;
    }
 
+static bool isSignatureTypeBool(const char *fieldSignature, int32_t len)
+   {
+   return len == 1 && fieldSignature[0] == 'Z';
+   }
+
+bool
+J9::SymbolReferenceTable::isFieldTypeBool(TR::SymbolReference *symRef)
+   {
+   int32_t len;
+   const char *fieldSignature = symRef->getOwningMethod(comp())->fieldSignatureChars(symRef->getCPIndex(), len);
+   dumpOptDetails(comp(), "got field signature as %s\n", fieldSignature);
+   return isSignatureTypeBool(fieldSignature, len);
+   }
+
+bool
+J9::SymbolReferenceTable::isStaticTypeBool(TR::SymbolReference *symRef)
+   {
+   int32_t len;
+   const char *fieldSignature = symRef->getOwningMethod(comp())->staticSignatureChars(symRef->getCPIndex(), len);
+   dumpOptDetails(comp(), "got static signature as %s\n", fieldSignature);
+   return isSignatureTypeBool(fieldSignature, len);
+   }
 
 static bool parmSlotCameFromExpandingAnArchetypeArgPlaceholder(int32_t slot, TR::ResolvedMethodSymbol *sym, TR_Memory *mem)
    {

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -261,6 +261,8 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
 
    List<TR::SymbolReference> *dynamicMethodSymrefsByCallSiteIndex(int32_t index);
    bool isFieldClassObject(TR::SymbolReference *symRef);
+   bool isFieldTypeBool(TR::SymbolReference *symRef);
+   bool isStaticTypeBool(TR::SymbolReference *symRef);
    void addParameters(TR::ResolvedMethodSymbol * owningMethodSymbol);
 
    // NO LONGER NEEDED?  Disabled since inception (2009)

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -7213,7 +7213,11 @@ TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
       node = TR::Node::createWithSymRef(TR::wrtbari, 3, 3, addressNode, value, parentObject, symRef);
       }
    else
+      {
+      if (type == TR::Int8 && symRefTab()->isFieldTypeBool(symRef))
+         value = TR::Node::create(TR::iand, 2, value, TR::Node::create(TR::iconst, 0, 1));
       node = TR::Node::createWithSymRef(comp()->il.opCodeForIndirectStore(type), 2, 2, addressNode, value, symRef);
+      }
 
    if (symbol->isPrivate() && _classInfo && comp()->getNeedsClassLookahead())
       {
@@ -7337,6 +7341,10 @@ TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
    TR::DataType type = symbol->getDataType();
 
    TR::Node * node;
+
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)fe();
+   if (type == TR::Int8 && symRefTab()->isStaticTypeBool(symRef))
+      value = TR::Node::create(TR::iand, 2, value, TR::Node::create(TR::iconst, 0, 1));
 
    if (type == TR::Address && _generateWriteBarriers)
       {


### PR DESCRIPTION
The JVM spec states "If the value is of type int and the field
descriptor type is boolean, then the int value is narrowed by taking the
bitwise AND of value and 1, resulting in value'"

This is the JIT part of the change. The VM part is #2057

 issue: #2049

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>