### PR TITLE
Disable rtti / exceptions / etc on osx compiles

### DIFF
--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -83,9 +83,7 @@ endif
 CFLAGS += $(UMA_OPTIMIZATION_CFLAGS)
 CXXFLAGS += $(UMA_OPTIMIZATION_CXXFLAGS)
 
-<#if uma.spec.flags.env_gcc.enabled>
-  CXXFLAGS += -fno-exceptions -fno-threadsafe-statics
-</#if>
+CXXFLAGS += -fno-rtti -fno-exceptions -fno-threadsafe-statics
 
 ifdef j9vm_uma_gnuDebugSymbols
   CFLAGS += -g


### PR DESCRIPTION
Add CXXFLAGS += -fno-rtti -fno-exceptions -fno-threadsafe-statics
flags to OSX to work around compile failures as OpenJ9 vm
code doesn't link libc++.

issue #36

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>