### PR TITLE
Fix incorrect usage of TR::Options

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4416,7 +4416,7 @@ void
 J9::CodeGenerator::createHWPRecords()
    {
    if (self()->comp()->getPersistentInfo()->isRuntimeInstrumentationEnabled() &&
-       TR::Options::getCmdLineOptions()->getOption(TR_EnableHardwareProfileIndirectDispatch))
+       self()->comp()->getOption(TR_EnableHardwareProfileIndirectDispatch))
       {
       self()->comp()->fej9()->createHWProfilerRecords(self()->comp());
       }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7465,7 +7465,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             // Check to see if there is sufficient physical memory available for this compilation
             // Temporarily only do this for JSR292 compilations
             if (TR::CompilationInfo::isJSR292(details.getMethod())
-                || compiler->getOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
+                || compiler->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                {
                bool incompleteInfo = false;
                int64_t physicalLimitB_64bit = compInfo->computeFreePhysicalLimitAndAbortCompilationIfLow(compiler,
@@ -7486,7 +7486,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                         // If we weren't able to get all the memory information
                         // only lower the limit for JSR292 compilations
                         if (TR::CompilationInfo::isJSR292(details.getMethod())
-                            && compiler->getOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
+                            && compiler->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                            {
                            proposedScratchMemoryLimitB = (physicalLimitB >= scratchSegmentProvider.allocationLimit()
                                                           ? physicalLimitB
@@ -7501,7 +7501,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                            }
                         else // Not enough physical memory to use even a regular scratch space limit
                            {
-                           if (compiler->getOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
+                           if (compiler->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                               {
                               proposedScratchMemoryLimitB = (physicalLimitB >= TR::Options::getScratchSpaceLowerBound()
                                                              ? physicalLimitB
@@ -7958,7 +7958,7 @@ TR::CompilationInfoPerThreadBase::compile(
                );
             }
 
-         if (compiler->getOptions()->getOption(TR_AlwaysSafeFatal)) {
+         if (compiler->getOption(TR_AlwaysSafeFatal)) {
             TR_ASSERT_SAFE_FATAL(false, "alwaysSafeFatal set");
              TR_VerboseLog::writeLineLocked(
                TR_Vlog_INFO ,
@@ -7968,7 +7968,7 @@ TR::CompilationInfoPerThreadBase::compile(
                );
          }
 
-         if (compiler->getOptions()->getOption(TR_AlwaysFatalAssert)) {
+         if (compiler->getOption(TR_AlwaysFatalAssert)) {
             TR_ASSERT_FATAL(false, "alwaysFatalAssert set");
          }
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7465,7 +7465,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             // Check to see if there is sufficient physical memory available for this compilation
             // Temporarily only do this for JSR292 compilations
             if (TR::CompilationInfo::isJSR292(details.getMethod())
-                || TR::Options::getCmdLineOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
+                || compiler->getOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                {
                bool incompleteInfo = false;
                int64_t physicalLimitB_64bit = compInfo->computeFreePhysicalLimitAndAbortCompilationIfLow(compiler,
@@ -7486,7 +7486,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                         // If we weren't able to get all the memory information
                         // only lower the limit for JSR292 compilations
                         if (TR::CompilationInfo::isJSR292(details.getMethod())
-                            && TR::Options::getCmdLineOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
+                            && compiler->getOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                            {
                            proposedScratchMemoryLimitB = (physicalLimitB >= scratchSegmentProvider.allocationLimit()
                                                           ? physicalLimitB
@@ -7501,7 +7501,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                            }
                         else // Not enough physical memory to use even a regular scratch space limit
                            {
-                           if (TR::Options::getCmdLineOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
+                           if (compiler->getOptions()->getOption(TR_EnableSelfTuningScratchMemoryUsageBeforeCompile))
                               {
                               proposedScratchMemoryLimitB = (physicalLimitB >= TR::Options::getScratchSpaceLowerBound()
                                                              ? physicalLimitB

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1116,7 +1116,7 @@ TR_ResolvedJ9MethodBase::isInlineable(TR::Compilation *comp)
 
 static intptrj_t getInitialCountForMethod(TR_ResolvedMethod *m, TR::Compilation *comp)
    {
-   TR::Options * options = comp->getOptions()->getCmdLineOptions();
+   TR::Options * options = comp->getOptions();
 
    intptrj_t initialCount = m->hasBackwardBranches() ? options->getInitialBCount() : options->getInitialCount();
 
@@ -1132,7 +1132,7 @@ static intptrj_t getInitialCountForMethod(TR_ResolvedMethod *m, TR::Compilation 
           // Do not change the counts on zos at the moment since the shared cache capacity is higher on this platform
           // and by increasing counts we could end up significantly impacting startup
 #else
-          bool startupTimeMatters = TR::Options::isQuickstartDetected() || TR::Options::getCmdLineOptions()->getOption(TR_UseLowerMethodCounts);
+          bool startupTimeMatters = TR::Options::isQuickstartDetected() || comp->getOption(TR_UseLowerMethodCounts);
 
           if (!startupTimeMatters)
              {
@@ -1222,14 +1222,13 @@ TR_ResolvedJ9MethodBase::isCold(TR::Compilation * comp, bool isIndirectCall, TR:
 
    intptrj_t count = getInvocationCount();
 
-   TR::Options * options = comp->getOptions()->getCmdLineOptions();
    intptrj_t initialCount = getInitialCountForMethod(this, comp);
 
    if (count < 0 || count > initialCount)
       return false;
 
    // if compiling a BigDecimal method, block isn't cold
-   if ((!options->getOption(TR_DisableDFP) && !comp->getOptions()->getAOTCmdLineOptions()->getOption(TR_DisableDFP)) &&
+   if ((!comp->getOption(TR_DisableDFP)) &&
        (
 #ifdef TR_TARGET_S390
        TR::Compiler->target.cpu.getS390SupportsDFP() ||
@@ -2054,8 +2053,7 @@ TR_ResolvedRelocatableJ9Method::createResolvedMethodFromJ9Method(TR::Compilation
    if (dontInline)
       return NULL;
 
-   if (TR::Options::getCmdLineOptions()->getOption(TR_DisableDFP) ||
-       TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableDFP) ||
+   if (comp->getOption(TR_DisableDFP) ||
        (!(TR::Compiler->target.cpu.supportsDecimalFloatingPoint()
 #ifdef TR_TARGET_S390
        || TR::Compiler->target.cpu.getS390SupportsDFP()

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -366,10 +366,10 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
 
    prependEntryCode(blocks(0));
 
-   if (!comp()->getOptions()->getOption(TR_DisableGuardedCountingRecompilations) &&
+   if (!comp()->getOption(TR_DisableGuardedCountingRecompilations) &&
        comp()->getRecompilationInfo() && comp()->getRecompilationInfo()->shouldBeCompiledAgain() &&
        !comp()->getRecompilationInfo()->isRecompilation() && // only do it for first time compilations
-       (!comp()->getPersistentInfo()->_countForRecompile || comp()->getOptions()->getOption(TR_EnableMultipleGCRPeriods)) &&
+       (!comp()->getPersistentInfo()->_countForRecompile || comp()->getOption(TR_EnableMultipleGCRPeriods)) &&
        comp()->isOutermostMethod() &&
        comp()->getOptions()->getInsertGCRTrees() &&
        !comp()->isDLT() && !method()->isJNINative())
@@ -1212,7 +1212,7 @@ TR_J9ByteCodeIlGenerator::createGeneratedFirstBlock()
 bool
 TR_J9ByteCodeIlGenerator::hasFPU()
    {
-   bool result = !comp()->getOptions()->getOption(TR_DisableFPCodeGen) ? TR::Compiler->target.cpu.hasFPU() : false;
+   bool result = !comp()->getOption(TR_DisableFPCodeGen) ? TR::Compiler->target.cpu.hasFPU() : false;
    return result;
    }
 

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -76,7 +76,7 @@ public:
    bool                      inliningCheckIfFinalizeObjectIsBeneficial()
    {
        return (comp()->getOption(TR_FullSpeedDebug) || comp()->getOptLevel() <= cold ||
-         (!comp()->getOptions()->getOption(TR_DisableInlineCheckIfFinalizeObject) && fej9()->isBenefitInliningCheckIfFinalizeObject()) ||
+         (!comp()->getOption(TR_DisableInlineCheckIfFinalizeObject) && fej9()->isBenefitInliningCheckIfFinalizeObject()) ||
            (comp()->getCurrentMethod()->isConstructor() && !comp()->getCurrentMethod()->isFinal()));
    }
    virtual TR::ResolvedMethodSymbol *methodSymbol() const { return _methodSymbol;}

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -1498,7 +1498,7 @@ Candidate *TR_EscapeAnalysis::createCandidateIfValid(TR::Node *node, TR_OpaqueCl
       // Don't convert double-word arrays if platform does not have double-word aligned stacks
       // will handle stack alignment later
       else if (!comp()->cg()->getHasDoubleWordAlignedStack() &&
-                node->getOpCodeValue() == TR::newarray && !comp()->getOptions()->getOption(TR_EnableSIMDLibrary))
+                node->getOpCodeValue() == TR::newarray && !comp()->getOption(TR_EnableSIMDLibrary))
          {
          TR::Node *typeNode = node->getSecondChild();
          if (typeNode->getInt() == 7 || typeNode->getInt() == 11)

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -434,7 +434,7 @@ bool J9::TransformUtil::foldFinalFieldsIn(TR_OpaqueClassBlock *clazz, char *clas
       return true;
 
    static char *enableJCLFolding = feGetEnv("TR_EnableJCLStaticFinalFieldFolding");
-   if ((enableJCLFolding || TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts))
+   if ((enableJCLFolding || comp->getOption(TR_AggressiveOpts))
        && isStatic
        && comp->fej9()->isClassLibraryClass(clazz)
        && comp->fej9()->isClassInitialized(clazz))

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3389,7 +3389,7 @@ TR_SPMDKernelParallelizer::perform()
    TR_HashTab* reductionOperationsHashTab = new (comp()->trStackMemory()) TR_HashTab(comp()->trMemory(), stackAlloc);
 
   //TODO: make independent of GPU
-   if ((!comp()->getOptions()->getOption(TR_DisableAutoSIMD) &&
+   if ((!comp()->getOption(TR_DisableAutoSIMD) &&
         comp()->cg()->getSupportsAutoSIMD()) ||
         comp()->getOptions()->getEnableGPU(TR_EnableGPU))
       collectParallelLoops(root, simdLoops, reductionOperationsHashTab, useDefInfo);
@@ -4188,7 +4188,7 @@ TR_SPMDKernelParallelizer::collectParallelLoops(TR_RegionStructure *region,
    TR_HashId id = 0;
 
    if (isSPMDKernelLoop(region, comp()) ||
-       (!comp()->getOptions()->getOption(TR_DisableAutoSIMD) &&
+       (!comp()->getOption(TR_DisableAutoSIMD) &&
         comp()->cg()->getSupportsAutoSIMD() &&
         isPerfectNest(region, comp()) &&
         checkDataLocality(region, useNodesOfDefsInLoop, defsInLoop, comp(), useDefInfo, reductionHashTab) &&

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -366,7 +366,7 @@ bool
 J9::Power::CodeGenerator::enableAESInHardwareTransformations()
    {
    if ( (TR::Compiler->target.cpu.getPPCSupportsAES() || (TR::Compiler->target.cpu.getPPCSupportsVMX() && TR::Compiler->target.cpu.getPPCSupportsVSX())) &&
-         !self()->comp()->getOptions()->getOption(TR_DisableAESInHardware))
+         !self()->comp()->getOption(TR_DisableAESInHardware))
       return true;
    else
       return false;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -2780,7 +2780,7 @@ static void VMarrayStoreCHKEvaluator(TR::Node *node, TR::Register *src, TR::Regi
    generateTrg1Src2Instruction(cg,TR::InstOpCode::Op_cmpl, node, cndReg, t1Reg, t3Reg);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, toWB, cndReg);
 
-   if ((!TR::Options::getCmdLineOptions()->getOption(TR_DisableArrayStoreCheckOpts)) && node->getArrayComponentClassInNode())
+   if ((!comp->getOption(TR_DisableArrayStoreCheckOpts)) && node->getArrayComponentClassInNode())
       {
       TR_OpaqueClassBlock *castClass = (TR_OpaqueClassBlock *) node->getArrayComponentClassInNode();
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -370,7 +370,7 @@ TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol
    if (TR::Options::sharedClassCache()        // shared classes must be enabled
       && !comp->getOption(TR_DisablePersistIProfile) &&
       isIProfilingEnabled() &&
-      (!SCfull || !TR::Options::getCmdLineOptions()->getOption(TR_DisableUpdateJITBytesSize)))
+      (!SCfull || !comp->getOption(TR_DisableUpdateJITBytesSize)))
       {
       TR_J9VMBase *fej9 = (TR_J9VMBase *)_vm;
       J9SharedClassConfig * scConfig = _compInfo->getJITConfig()->javaVM->sharedClassConfig;
@@ -489,7 +489,7 @@ TR_IProfiler::persistIprofileInfo(TR::ResolvedMethodSymbol *resolvedMethodSymbol
 
                if (SCfull &&
                    bytesToPersist &&
-                   !TR::Options::getCmdLineOptions()->getOption(TR_DisableUpdateJITBytesSize))
+                   !comp->getOption(TR_DisableUpdateJITBytesSize))
                   {
                   _compInfo->increaseUnstoredBytes(0, bytesToPersist);
                   }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1435,8 +1435,8 @@ createMethodMetaData(
 
    int32_t bytecodePCToIAMapOffset = -1;
    if (comp->getPersistentInfo()->isRuntimeInstrumentationEnabled() &&
-       TR::Options::getCmdLineOptions()->getOption(TR_EnableHardwareProfileIndirectDispatch) &&
-       TR::Options::getCmdLineOptions()->getOption(TR_EnableMetadataBytecodePCToIAMap))
+       comp->getOption(TR_EnableHardwareProfileIndirectDispatch) &&
+       comp->getOption(TR_EnableMetadataBytecodePCToIAMap))
       {
       // Array of TR_HWPBytecodePCToIAMap structs
       // The first element is a special; it contains the size of the array and an eyecatcher
@@ -1699,8 +1699,8 @@ createMethodMetaData(
       }
 
    if (comp->getPersistentInfo()->isRuntimeInstrumentationEnabled() &&
-       TR::Options::getCmdLineOptions()->getOption(TR_EnableHardwareProfileIndirectDispatch) &&
-       TR::Options::getCmdLineOptions()->getOption(TR_EnableMetadataBytecodePCToIAMap))
+       comp->getOption(TR_EnableHardwareProfileIndirectDispatch) &&
+       comp->getOption(TR_EnableMetadataBytecodePCToIAMap))
       {
       void *bytecodePCToIAMapLocation = (void *)((uint8_t*)data + bytecodePCToIAMapOffset);
       data->riData = bytecodePCToIAMapLocation;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -387,7 +387,7 @@ J9::X86::CodeGenerator::nopsAlsoProcessedByRelocations()
 bool
 J9::X86::CodeGenerator::enableAESInHardwareTransformations()
    {
-   if (TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() && !self()->comp()->getOptions()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
+   if (TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() && !self()->comp()->getOption(TR_DisableAESInHardware) && !self()->comp()->getCurrentMethod()->isJNINative())
       return true;
    else
       return false;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6439,7 +6439,7 @@ void J9::X86::TreeEvaluator::generateValueTracingCode(
    TR::Register      *valueReg,
    TR::CodeGenerator *cg)
    {
-   if (!TR::Options::getCmdLineOptions()->getOption(TR_EnableValueTracing))
+   if (!cg->comp()->getOption(TR_EnableValueTracing))
       return;
    // the code requires that the caller has vmThread in EBP as well as
    // that the caller has already setup internal control flow
@@ -6468,7 +6468,7 @@ void J9::X86::TreeEvaluator::generateValueTracingCode(
    TR::Register      *valueRegLow,
    TR::CodeGenerator *cg)
    {
-   if (!TR::Options::getCmdLineOptions()->getOption(TR_EnableValueTracing))
+   if (!cg->comp()->getOption(TR_EnableValueTracing))
       return;
 
    // the code requires that the caller has vmThread in EBP as well as
@@ -9709,7 +9709,7 @@ J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(
       // --------------------------------------------
 
 
-      if (!(TR::Options::getCmdLineOptions()->getOption(TR_DisableArrayStoreCheckOpts)) && node->getArrayComponentClassInNode() )
+      if (!(comp->getOption(TR_DisableArrayStoreCheckOpts)) && node->getArrayComponentClassInNode() )
          {
          TR_OpaqueClassBlock *arrayComponentClass = (TR_OpaqueClassBlock *) node->getArrayComponentClassInNode();
          if (TR::Compiler->target.is64Bit())
@@ -12839,7 +12839,7 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(
             TR::DebugCounter::debugCounterName(comp, "helperCalls/%s/(%s)/%d/%d", node->getOpCode().getName(), comp->signature(), node->getByteCodeInfo().getCallerIndex(), node->getByteCodeInfo().getByteCodeIndex()),
             1, TR::DebugCounter::Cheap);
 
-      if (TR::Options::getCmdLineOptions()->getOption(TR_CountWriteBarriersRT))
+      if (comp->getOption(TR_CountWriteBarriersRT))
          {
          TR::MemoryReference *barrierCountMR = generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, debugEventData6), cg);
          generateMemInstruction(INCMem(TR::Compiler->target.is64Bit()), node, barrierCountMR, cg);

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1698,7 +1698,7 @@ void TR::X86CallSite::computeProfiledTargets()
        (callNode->getSymbolReference() != comp()->getSymRefTab()->findObjectNewInstanceImplSymbol()) &&
        callNode->getOpCode().isIndirect())
       {
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling) &&
+      if (!comp()->getOption(TR_DisableInterpreterProfiling) &&
           TR_ValueProfileInfoManager::get(comp()))
          {
          TR::Node *callNode = getCallNode();

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -224,7 +224,7 @@ J9::Z::TreeEvaluator::ud2pdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isVectorBCDEnv)
       {
       targetReg = ud2pdVectorEvaluatorHelper(node, cg);
@@ -350,7 +350,7 @@ J9::Z::TreeEvaluator::udsl2pdEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    //at this point targetReg is PseudoRegister that has converted Packed decimal value.
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    if (TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isVectorBCDEnv)
       {
       TR::Register * pdVectorTargetReg = cg->allocateRegister(TR_VRF);
@@ -392,7 +392,7 @@ J9::Z::TreeEvaluator::pd2udslEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR_StorageReference* pdStorageRef = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !comp->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       // Perform an intermediate vector store. See pd2udVectorEvaluateHelper().
       TR::Register* pdValueReg = cg->evaluate(childNode);
@@ -555,7 +555,7 @@ J9::Z::TreeEvaluator::pd2udEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    cg->traceBCDEntry("pd2ud",node);
    TR::Register* targetReg = NULL;
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pd2udVectorEvaluatorHelper(node, cg);
       }
@@ -1582,7 +1582,7 @@ J9::Z::TreeEvaluator::zd2pdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register* targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = zd2pdVectorEvaluatorHelper(node, cg);
       }
@@ -1959,7 +1959,7 @@ J9::Z::TreeEvaluator::pd2zdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isVectorBCDEnv)
       {
       targetReg = pd2zdVectorEvaluatorHelper(node, cg);
@@ -2568,7 +2568,7 @@ J9::Z::TreeEvaluator::BCDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    bool isEnableVectorBCD = TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility()
-                               && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD)
+                               && !cg->comp()->getOption(TR_DisableVectorBCD)
                                || isVectorBCDEnv;
 
    // Validate PD operations under BCDCHK node
@@ -2768,7 +2768,7 @@ J9::Z::TreeEvaluator::pdcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pdcmpVectorEvaluatorHelper(node, cg);
       }
@@ -2791,7 +2791,7 @@ J9::Z::TreeEvaluator::pdcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pdcmpVectorEvaluatorHelper(node, cg);
       }
@@ -2814,7 +2814,7 @@ J9::Z::TreeEvaluator::pdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pdcmpVectorEvaluatorHelper(node, cg);
       }
@@ -2836,7 +2836,7 @@ TR::Register *J9::Z::TreeEvaluator::pdcmpgeEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pdcmpVectorEvaluatorHelper(node, cg);
       }
@@ -2858,7 +2858,7 @@ TR::Register *J9::Z::TreeEvaluator::pdcmpgtEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pdcmpVectorEvaluatorHelper(node, cg);
       }
@@ -2880,7 +2880,7 @@ TR::Register *J9::Z::TreeEvaluator::pdcmpleEvaluator(TR::Node *node, TR::CodeGen
    TR::Register *targetReg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = pdcmpVectorEvaluatorHelper(node, cg);
       }
@@ -3733,7 +3733,7 @@ J9::Z::TreeEvaluator::pd2iEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = generateVectorPackedToBinaryConversion(node, TR::InstOpCode::VCVB, cg);
       }
@@ -3755,7 +3755,7 @@ J9::Z::TreeEvaluator::pd2lEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = generateVectorPackedToBinaryConversion(node, TR::InstOpCode::VCVBG, cg);
       }
@@ -4067,7 +4067,7 @@ J9::Z::TreeEvaluator::i2pdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = generateVectorBinaryToPackedConversion(node, TR::InstOpCode::VCVD, cg);
       }
@@ -4088,7 +4088,7 @@ J9::Z::TreeEvaluator::l2pdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = generateVectorBinaryToPackedConversion(node, TR::InstOpCode::VCVDG, cg);
       }
@@ -4658,7 +4658,7 @@ TR::Register *J9::Z::TreeEvaluator::pdloadEvaluator(TR::Node *node, TR::CodeGene
    cg->generateDebugCounter(TR::DebugCounter::debugCounterName(cg->comp(), "PD-Op/%s", node->getOpCode().getName()),
                             1, TR::DebugCounter::Cheap);
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if((TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv) &&
+   if((TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv) &&
            (node->getOpCodeValue() == TR::pdload || node->getOpCodeValue() == TR::pdloadi))
       {
       reg = pdloadVectorEvaluatorHelper(node, cg);
@@ -4973,7 +4973,7 @@ J9::Z::TreeEvaluator::pdstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
                             1, TR::DebugCounter::Cheap);
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    if((TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-       !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+       !cg->comp()->getOption(TR_DisableVectorBCD) ||
        isVectorBCDEnv) &&
            (node->getOpCodeValue() == TR::pdstore || node->getOpCodeValue() == TR::pdstorei))
       {
@@ -6217,7 +6217,7 @@ J9::Z::TreeEvaluator::pdSetSignEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    cg->decReferenceCount(signNode);
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       targetReg = vectorPerformSignOperationHelper(node,
                                                    cg,
@@ -6400,7 +6400,7 @@ J9::Z::TreeEvaluator::pdchkEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isVectorBCDEnv)
       {
       pdReg = cg->evaluate(pdloadNode);
@@ -6459,7 +6459,7 @@ J9::Z::TreeEvaluator::pdaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = pdArithmeticVectorEvaluatorHelper(node, TR::InstOpCode::VAP, cg);
       }
@@ -6481,7 +6481,7 @@ J9::Z::TreeEvaluator::pdsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = pdArithmeticVectorEvaluatorHelper(node, TR::InstOpCode::VSP, cg);
       }
@@ -6720,7 +6720,7 @@ J9::Z::TreeEvaluator::pdmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isVectorBCDEnv)
       {
       reg = pdArithmeticVectorEvaluatorHelper(node, TR::InstOpCode::VMP, cg);
@@ -6819,7 +6819,7 @@ J9::Z::TreeEvaluator::pddivremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * reg = NULL;
 
    static char* isVectorBCDEnv = feGetEnv("TR_enableVectorBCD");
-   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
+   if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() && !cg->comp()->getOption(TR_DisableVectorBCD) || isVectorBCDEnv)
       {
       reg = pddivremVectorEvaluatorHelper(node, cg);
       }
@@ -7055,7 +7055,7 @@ J9::Z::TreeEvaluator::pdshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    static char* isEnableVectorBCD = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isEnableVectorBCD)
       {
       targetReg = pdshrVectorEvaluatorHelper(node, cg);
@@ -7266,7 +7266,7 @@ J9::Z::TreeEvaluator::pdModifyPrecisionEvaluator(TR::Node * node, TR::CodeGenera
 
    static char* isEnableVectorBCD = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD)
+           !cg->comp()->getOption(TR_DisableVectorBCD)
            || isEnableVectorBCD)
       {
       int32_t targetPrec = node->getDecimalPrecision();
@@ -7313,7 +7313,7 @@ J9::Z::TreeEvaluator::pdshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    static char* isEnableVectorBCD = feGetEnv("TR_enableVectorBCD");
    if(TR::Compiler->target.cpu.getS390SupportsVectorPackedDecimalFacility() &&
-           !TR::Options::getCmdLineOptions()->getOption(TR_DisableVectorBCD) ||
+           !cg->comp()->getOption(TR_DisableVectorBCD) ||
            isEnableVectorBCD)
       {
       targetReg = pdshlVectorEvaluatorHelper(node, cg);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -164,7 +164,7 @@ J9::Z::CodeGenerator::CodeGenerator() :
       cg->setSupportsBigDecimalLongLookasideVersioning();
 
    // RI support
-   if (TR::Options::getCmdLineOptions()->getOption(TR_HWProfilerDisableRIOverPrivateLinkage)
+   if (comp->getOption(TR_HWProfilerDisableRIOverPrivateLinkage)
        && comp->getPersistentInfo()->isRuntimeInstrumentationEnabled()
        && cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12)
        && TR::Compiler->target.cpu.getS390SupportsRI())

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -2145,8 +2145,8 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
             }
 
          if (!performGuardedDevirtualization &&
-             !TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling) &&
-             TR::Options::getCmdLineOptions()->getOption(TR_enableProfiledDevirtualization) &&
+             !comp()->getOption(TR_DisableInterpreterProfiling) &&
+             comp()->getOption(TR_enableProfiledDevirtualization) &&
              TR_ValueProfileInfoManager::get(comp()) && resolvedMethod
              )
             {


### PR DESCRIPTION
- during compilation, the per-method TR::Options should be used instead of the global one
- mostly happens at the Optimizer and Code Generation stage
- simplify comp()->getOptions()->getOption(TR_XXX) to comp()->getOptions(TR_XXX)

Signed-off-by: Harry Yu <harryyu1994@gmail.com>