### PR TITLE
Set default variables from extensions

### DIFF
--- a/runtime/makelib/mkconstants.mk.ftl
+++ b/runtime/makelib/mkconstants.mk.ftl
@@ -24,15 +24,11 @@
 </#list>
 
 # Define the Java Version we are compiling
-ifndef VERSION_MAJOR
-$(error VERSION_MAJOR is not set from extensions code)
-endif
+VERSION_MAJOR?=8
 export VERSION_MAJOR
 
 # Define full Java Version
-ifndef OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
-$(error OPENJDK_VERSION_NUMBER_FOUR_POSITIONS is not set from extensions code)
-endif
+OPENJDK_VERSION_NUMBER_FOUR_POSITIONS?=8.0.0.0
 export OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
 
 # Define a default target of the root directory for all targets.


### PR DESCRIPTION
Having this value as 8 I think makes more sense than 9 as before or 11 since our version numbers are changing at such a rapid rate.

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>

Reviewer: @pshipton 