### PR TITLE
soft/phantom verbose GC for Metronome

### DIFF
--- a/runtime/gc_realtime/RealtimeMarkingScheme.cpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.cpp
@@ -1148,7 +1148,7 @@ MM_RealtimeMarkingScheme::scanSoftReferenceObjects(MM_EnvironmentRealtime *env)
 		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_gcExtensions->referenceObjectLists[listIndex];
 			referenceObjectList->startSoftReferenceProcessing();
-			processReferenceList(env, NULL, referenceObjectList->getPriorSoftList(), &gcEnv->_markJavaStats._weakReferenceStats);
+			processReferenceList(env, NULL, referenceObjectList->getPriorSoftList(), &gcEnv->_markJavaStats._softReferenceStats);
 			_scheduler->condYieldFromGC(env);
 		}
 	}
@@ -1166,7 +1166,7 @@ MM_RealtimeMarkingScheme::scanPhantomReferenceObjects(MM_EnvironmentRealtime *en
 		if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 			MM_ReferenceObjectList *referenceObjectList = &_gcExtensions->referenceObjectLists[listIndex];
 			referenceObjectList->startPhantomReferenceProcessing();
-			processReferenceList(env, NULL, referenceObjectList->getPriorPhantomList(), &gcEnv->_markJavaStats._weakReferenceStats);
+			processReferenceList(env, NULL, referenceObjectList->getPriorPhantomList(), &gcEnv->_markJavaStats._phantomReferenceStats);
 			_scheduler->condYieldFromGC(env);
 		}
 	}


### PR DESCRIPTION
Fix stats gathering for soft/phantom processing in Metronome GC to use
appropriate stats structure for soft and phantom (instead of always for
weak). Eventually, this stats struct is used for verbose GC and
consequently will be not reported correctly for all 3 of them.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>