### PR TITLE
CMake: Update exclude list in the compiler component

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -101,14 +101,23 @@ set(REMOVED_OMR_FILES
 	${omr_SOURCE_DIR}/compiler/infra/OMRMonitor.cpp
 	${omr_SOURCE_DIR}/compiler/runtime/Trampoline.cpp
 	${omr_SOURCE_DIR}/compiler/runtime/Runtime.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/IlBuilder.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/IlValue.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/IlBuilder.cpp # Delete me
+	${omr_SOURCE_DIR}/compiler/ilgen/IlValue.cpp # Delete me
 	${omr_SOURCE_DIR}/compiler/ilgen/IlInjector.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/MethodBuilder.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/BytecodeBuilder.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/TypeDictionary.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/ThunkBuilder.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/VirtualMachineOperandStack.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/MethodBuilder.cpp # Delete me
+	${omr_SOURCE_DIR}/compiler/ilgen/BytecodeBuilder.cpp # Delete me
+	${omr_SOURCE_DIR}/compiler/ilgen/TypeDictionary.cpp # Delete me
+	${omr_SOURCE_DIR}/compiler/ilgen/ThunkBuilder.cpp # Delete me
+	${omr_SOURCE_DIR}/compiler/ilgen/VirtualMachineState.cpp # Delete me
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRBytecodeBuilder.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRIlBuilder.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRIlValue.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRMethodBuilder.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRThunkBuilder.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRTypeDictionary.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineState.cpp
 )
 
 # Extra defines not provided by the create_omr_compiler_library call


### PR DESCRIPTION
Fixes error in omr acceptance build caused by eclipse/omr#2515
Files marked "# Delete me" should be removed when omr changes are merged

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>