### PR TITLE
Also fetch branches for checks

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheck
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheck
@@ -38,7 +38,7 @@ timeout(time: 6, unit: 'HOURS') {
                                             noTags: false,
                                             reference: '/home/jenkins/openjdk_cache',
                                             shallow: false]],
-                            userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+                            userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/* +refs/heads/${ghprbTargetBranch}:refs/remotes/origin/${ghprbTargetBranch}",
                                                     url: SRC_REPO]]]
                 FILES = sh (
                     script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",

--- a/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck
+++ b/buildenv/jenkins/jobs/infrastructure/lineEndingsCheck
@@ -38,7 +38,7 @@ timeout(time: 6, unit: 'HOURS') {
                                             noTags: false,
                                             reference: '/home/jenkins/openjdk_cache',
                                             shallow: false]],
-                            userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+                            userRemoteConfigs: [[refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/* +refs/heads/${ghprbTargetBranch}:refs/remotes/origin/${ghprbTargetBranch}",
                                                     url: SRC_REPO]]]
                 FILES = sh (
                     script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",


### PR DESCRIPTION
- Since we compare to origin/${ghprbTargetBranch},
  we also need to fetch the branches.

[skip ci]
Issue #2154

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>