### PR TITLE
Add new svtRaised label

### DIFF
--- a/doc/processes/labels.md
+++ b/doc/processes/labels.md
@@ -100,3 +100,5 @@ End User issues
 To indicate an issue has been raised by an end user or affects the User-experience rather than being a developer-centric issue.
 
 * `userRaised`
+* `svtRaised`: Indicate an issue was raised for an AdoptOpenJDK 3rd party issue or the OpenJ9 system verification test (svt).
+


### PR DESCRIPTION
New label for Adopt's 3rd party tests and system verification tests.
This helps to differentiate between an end user raised and a test
failure.

The label is grouped with the user raised one as the expectation is
that one of these failures affects the end user experience running
OpenJ9

[skip ci]
Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>