### PR TITLE
Bring up DDR on AIX

### DIFF
--- a/buildspecs/aix_ppc-64.spec
+++ b/buildspecs/aix_ppc-64.spec
@@ -276,6 +276,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="thr_lockNursery" value="true"/>
 		<flag id="thr_lockReservation" value="true"/>
 		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_gnuDebugSymbols" value="true"/>
 		<flag id="uma_supportsIpv6" value="true"/>
 	</flags>
 </spec>

--- a/buildspecs/aix_ppc-64_cmprssptrs.spec
+++ b/buildspecs/aix_ppc-64_cmprssptrs.spec
@@ -274,6 +274,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="thr_lockNursery" value="true"/>
 		<flag id="thr_lockReservation" value="true"/>
 		<flag id="thr_smartDeflation" value="true"/>
+		<flag id="uma_gnuDebugSymbols" value="true"/>
 		<flag id="uma_supportsIpv6" value="true"/>
 	</flags>
 </spec>

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ThreadMonitorHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ThreadMonitorHelper.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.j9;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ThreadAbstractMonitorPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ThreadMonitorPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ThreadPointer;
+
+import static com.ibm.j9ddr.vm29.events.EventManager.raiseCorruptDataEvent;
+
+public class J9ThreadMonitorHelper {
+
+	public static J9ThreadPointer getBlockingField(J9ThreadMonitorPointer monitor) throws CorruptDataException {
+		Exception exception;
+		try {
+			Class<?> monitorClazz = J9ThreadMonitorPointer.class;
+			Method getBlocking = monitorClazz.getDeclaredMethod("blocking");
+			J9ThreadPointer blocking = (J9ThreadPointer) getBlocking.invoke(monitor);
+			return blocking;
+		} catch (NoSuchMethodException e) {
+			exception = e;
+		} catch (IllegalAccessException e) {
+			exception = e;
+		} catch (InvocationTargetException e) {
+			Throwable cause = e.getCause();
+
+			if (cause instanceof CorruptDataException) {
+				throw (CorruptDataException) cause;
+			}
+
+			exception = e;
+		}
+
+		// unexpected exception using reflection
+		CorruptDataException cd = new CorruptDataException(exception.toString(), exception);
+		raiseCorruptDataEvent("Error accessing J9ThreadMonitorPointer", cd, true);
+
+		return null;
+	}
+
+	public static J9ThreadPointer getBlockingField(J9ThreadAbstractMonitorPointer monitor) throws CorruptDataException {
+		Exception exception;
+		try {
+			Class<?> monitorClazz = J9ThreadAbstractMonitorPointer.class;
+			Method getBlocking = monitorClazz.getDeclaredMethod("blocking");
+			J9ThreadPointer blocking = (J9ThreadPointer) getBlocking.invoke(monitor);
+			return blocking;
+		} catch (NoSuchMethodException e) {
+			exception = e;
+		} catch (IllegalAccessException e) {
+			exception = e;
+		} catch (InvocationTargetException e) {
+			Throwable cause = e.getCause();
+
+			if (cause instanceof CorruptDataException) {
+				throw (CorruptDataException) cause;
+			}
+
+			exception = e;
+		}
+
+		// unexpected exception using reflection
+		CorruptDataException cd = new CorruptDataException(exception.toString(), exception);
+		raiseCorruptDataEvent("Error accessing J9ThreadAbstractMonitorPointer", cd, true);
+
+		return null;
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectMonitor_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectMonitor_V1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -224,7 +224,7 @@ class ObjectMonitor_V1 extends ObjectMonitor
 		blockedThreads = new ArrayList<J9VMThreadPointer>();
 		if(isInflated) {
 			if(OmrBuildFlags.OMR_THR_THREE_TIER_LOCKING) {
-				J9ThreadPointer thread = monitor.blocking();
+				J9ThreadPointer thread = J9ThreadMonitorHelper.getBlockingField(monitor);
 				while(thread.notNull()) {
 					J9VMThreadPointer vmThread = J9ThreadHelper.getVMThread(thread);
 					if(vmThread.notNull()) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/SystemMonitorThreeTier_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/SystemMonitorThreeTier_V1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,8 @@ public class SystemMonitorThreeTier_V1 extends SystemMonitor
 	@Override
 	public boolean isContended() throws CorruptDataException
 	{
-		return monitor.blocking().notNull();
+		J9ThreadPointer blocking = J9ThreadMonitorHelper.getBlockingField(monitor);
+		return blocking.notNull();
 	}
 
 	private static List<J9ThreadPointer> threadListHelper(J9ThreadPointer thread) throws CorruptDataException
@@ -61,7 +62,7 @@ public class SystemMonitorThreeTier_V1 extends SystemMonitor
 	@Override
 	public List<J9ThreadPointer> getBlockedThreads() throws CorruptDataException
 	{
-		return threadListHelper(monitor.blocking());
+		J9ThreadPointer blocking = J9ThreadMonitorHelper.getBlockingField(monitor);
+		return threadListHelper(blocking);
 	}
-	
 }

--- a/runtime/ddr/blacklist
+++ b/runtime/ddr/blacklist
@@ -79,3 +79,7 @@ type:SOCKADDR_STORAGE_XP
 type:UINT
 type:ULONG
 type:WSADATA
+
+# problem names on AIX
+type:Enum
+type:signed char

--- a/runtime/ddr/gcddr.cpp
+++ b/runtime/ddr/gcddr.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "AllocateDescription.hpp"
+#include "AllocationCategory.hpp"
 #include "ConcurrentCardTable.hpp"
 #include "CopyScanCacheStandard.hpp"
 #include "FreeHeapRegionList.hpp"
@@ -54,6 +55,7 @@
 
 GC_DdrDebugLink(J9ModronAllocateHint)
 GC_DdrDebugLink(MM_AllocateDescription)
+GC_DdrDebugLink(MM_AllocationCategory)
 GC_DdrDebugLink(MM_ConcurrentCardTable)
 GC_DdrDebugLink(MM_CopyScanCacheStandard)
 GC_DdrDebugLink(MM_FreeHeapRegionList)

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -400,6 +400,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 				<include-if condition="spec.linux_ppc.*_gcc"/>
 				<include-if condition="spec.linux_x86.*"/>
 			</makefilestub>
+			<makefilestub data="UMA_DLL_LINK_FLAGS += -bexpall">
+				<include-if condition="spec.aix_ppc.*"/>
+			</makefilestub>
 		</makefilestubs>
 		<objects>
 			<object name="algorithm_versions"/>

--- a/runtime/ddr/omrddr.cpp
+++ b/runtime/ddr/omrddr.cpp
@@ -24,6 +24,7 @@
 #include "../compiler/env/jittypes.h"
 #include "hashtable_api.h"
 #include "omr.h"
+#include "omrthread_generated.h"
 #include "omrtrace.h"
 #include "ute_core.h"
 #include "ddrhelp.h"
@@ -32,6 +33,7 @@
 
 #define OMR_DdrDebugLink(type) DdrDebugLink(omr, type)
 
+OMR_DdrDebugLink(J9AbstractThread)
 OMR_DdrDebugLink(J9HashTable)
 OMR_DdrDebugLink(J9HashTableState)
 OMR_DdrDebugLink(OMR_TraceThread)

--- a/runtime/ddr/overrides-omr
+++ b/runtime/ddr/overrides-omr
@@ -35,6 +35,10 @@ fieldoverride.CLimits.DDR_UINT_MAX=UINT_MAX
 fieldoverride.CLimits.DDR_ULONG_MAX=ULONG_MAX
 fieldoverride.CLimits.DDR_USHRT_MAX=USHRT_MAX
 
+#AIX perf objects
+fieldoverride.perfstat_cpu_t.wait=wait_field
+fieldoverride.perfstat_cpu_total_t.wait=wait_field
+
 typeoverride.semun.__buf=UDATA
 typeoverride.semun.buf=UDATA
 

--- a/runtime/ddr/vmddr.cpp
+++ b/runtime/ddr/vmddr.cpp
@@ -32,6 +32,7 @@
 
 #define VM_DdrDebugLink(type) DdrDebugLink(vm, type)
 
+VM_DdrDebugLink(CacheletHints)
 VM_DdrDebugLink(CacheletWrapper)
 VM_DdrDebugLink(CharArrayWrapper)
 VM_DdrDebugLink(J9DbgROMClassBuilder)

--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -33,6 +33,9 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(VMLINK) $(UMA_LINK_PATH) -o $(UMA_DLLTARGET) \
 		$(UMA_OBJECTS) \
 		$(UMA_DLL_LINK_POSTFLAGS)
+ifdef j9vm_uma_gnuDebugSymbols
+	cp $(UMA_DLLTARGET) $(UMA_DLLTARGET).dbg
+endif
 </#assign>
 
 <#assign exe_target_rule>
@@ -73,6 +76,11 @@ ifdef j9vm_uma_supportsIpv6
   CFLAGS += -DIPv6_FUNCTION_SUPPORT
   CXXFLAGS += -DIPv6_FUNCTION_SUPPORT
   CPPFLAGS += -DIPv6_FUNCTION_SUPPORT
+endif
+
+ifdef j9vm_uma_gnuDebugSymbols
+CFLAGS += -g
+CXXFLAGS += -g
 endif
 
 ifdef I5_VERSION

--- a/runtime/port/unix/j9sock.c
+++ b/runtime/port/unix/j9sock.c
@@ -1857,8 +1857,8 @@ j9sock_getopt_sockaddr(struct J9PortLibrary *portLibrary, j9socket_t socketP, in
 
 	/* if IPv4 the OS returns in_addr, if IPv6, value of interface index is returned */
 	typedef union byte_or_int {
-		uint8_t byte;
-		uint32_t integer;
+		uint8_t byte_val;
+		uint32_t integer_val;
 	} value;
 	value val;
 	socklen_t optlen = sizeof(val);
@@ -1888,13 +1888,13 @@ j9sock_getopt_sockaddr(struct J9PortLibrary *portLibrary, j9socket_t socketP, in
 	if (J9ADDR_FAMILY_AFINET6 == portableFamily) {
 		if (optlen == sizeof(uint8_t)) {
 			/* lookup the address with the interface index */
-			int32_t result = lookupIPv6AddressFromIndex(portLibrary, val.byte, (j9sockaddr_t) sockaddr);
+			int32_t result = lookupIPv6AddressFromIndex(portLibrary, val.byte_val, (j9sockaddr_t) sockaddr);
 			if (0 != result){
 				return result;
 			}
 		} else if (optlen == sizeof(struct in_addr)){
 			/* if optlen is 4, address is IPv4 */
-			sockaddr->sin_addr.s_addr = val.integer;
+			sockaddr->sin_addr.s_addr = val.integer_val;
 		} else {
 			Trc_PRT_sock_j9sock_getopt_sockaddr_address_length_invalid_Exit(portableFamily);
 			return J9PORT_ERROR_SOCKET_OPTARGSINVALID;
@@ -1902,7 +1902,7 @@ j9sock_getopt_sockaddr(struct J9PortLibrary *portLibrary, j9socket_t socketP, in
 	} else if (J9ADDR_FAMILY_AFINET4 == portableFamily) {
 		/* portableFamily is AFINET4 when preferIPv4Stack=true */
 		if (optlen == sizeof(struct in_addr)) {
-			sockaddr->sin_addr.s_addr = val.integer;
+			sockaddr->sin_addr.s_addr = val.integer_val;
 		} else {
 			Trc_PRT_sock_j9sock_getopt_sockaddr_address_length_invalid_Exit(portableFamily);
 			return J9PORT_ERROR_SOCKET_OPTARGSINVALID;


### PR DESCRIPTION
This pull request, in conjunction with the corresponding OMR pull request #[2719](https://github.com/eclipse/omr/pull/2719), enables DDR on AIX as well as the DDR tests on AIX, addressing #1769.

Testing was done by generating core dumps and using `jdmpview` to run various commands on them on AIX. Also ran the OpenJ9 functional test suite locally. 

The OMR PR should be merged before this one.
