### PR TITLE
Add .gitattributes for zos platform

### DIFF
--- a/.gitattributes.zos
+++ b/.gitattributes.zos
@@ -1,0 +1,42 @@
+# Copyright (c) 2000, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+# This .gitattributes file will cause all text files EXCEPT for
+# those specifically listed below to be encoded as EBCDIC.
+# Selected binary files will not be translated at all.
+
+# The default for text files
+* git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+
+# Specific types of files remain as ASCII
+*.xml git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+*.dtd git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+*.xsd git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+buildspecs/* git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# git's files (which MUST be ASCII)
+.gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+.gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# Binary files
+*.jpg git-encoding=BINARY working-tree-encoding=BINARY
+*.png git-encoding=BINARY working-tree-encoding=BINARY
+*.gif git-encoding=BINARY working-tree-encoding=BINARY
+*.zip git-encoding=BINARY working-tree-encoding=BINARY

--- a/.gitattributes.zos
+++ b/.gitattributes.zos
@@ -33,6 +33,7 @@ buildspecs/* git-encoding=iso8859-1 working-tree-encoding=iso8859-1
 
 # git's files (which MUST be ASCII)
 .gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+.gitattributes.zos git-encoding=iso8859-1 working-tree-encoding=iso8859-1
 .gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
 
 # Binary files


### PR DESCRIPTION
The .gitattributes.zos file will not be picked up by the latest versions of git, so git will not attempt to encode/decode files. 

On a zos platform the openjdk extensions file ./closed/get_j9_source.sh will be modified to copy this .gitattributes.zos file to .git/info/attributes and the files refreshed. This will then emncode/decode the files. 

Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>