### PR TITLE
Consolidate math call transformations in recognizedCallTransformer

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4163,8 +4163,6 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
 
    TR_Method * calledMethod = symbol->getMethod();
    int32_t numArgs = calledMethod->numberOfExplicitParameters() + (isStatic ? 0 : 1);
-   static bool disableARMMaxMin = true; // (feGetEnv("TR_DisableARMMaxMin") != NULL);
-   static bool disableARMFMaxMin = true; // (feGetEnv("TR_DisableARMFMaxMin") != NULL);
 
    TR::ILOpCodes opcode = TR::BadILOp;
    switch (symbol->getRecognizedMethod())
@@ -4175,53 +4173,6 @@ TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indi
          break;
       default:
          break;
-      }
-
-   if (TR::Compiler->target.cpu.isPower() || (!disableARMMaxMin && TR::Compiler->target.cpu.isARM())) // TODO: implement max/min opcodes on all platforms
-      {
-
-      switch (symbol->getRecognizedMethod())
-         {
-         case TR::java_lang_Math_max_I:
-            opcode = TR::imax;
-            break;
-         case TR::java_lang_Math_min_I:
-            opcode = TR::imin;
-            break;
-         case TR::java_lang_Math_max_L:
-            opcode = TR::lmax;
-            break;
-         case TR::java_lang_Math_min_L:
-            opcode = TR::lmin;
-            break;
-         case TR::java_lang_Math_max_F:
-            if (!disableARMFMaxMin && TR::Compiler->target.cpu.isARM())
-               opcode = TR::fmax;
-            break;
-         case TR::java_lang_Math_min_F:
-            if (!disableARMFMaxMin && TR::Compiler->target.cpu.isARM())
-               opcode = TR::fmin;
-            break;
-         case TR::java_lang_Math_max_D:
-            if (!disableARMFMaxMin && TR::Compiler->target.cpu.isARM())
-               opcode = TR::dmax;
-            break;
-         case TR::java_lang_Math_min_D:
-            if (!disableARMFMaxMin && TR::Compiler->target.cpu.isARM())
-               opcode = TR::dmin;
-            break;
-         default:
-         	break;
-         }
-      }
-
-   if (opcode != TR::BadILOp)
-      {
-      TR::Node * node = TR::Node::create(opcode, 2);
-      node->setAndIncChild(0, pop());
-      node->setAndIncChild(1, pop());
-      push(node);
-      return node;
       }
 
    if (comp()->cg()->getSupportsBitOpCodes() && !comp()->getOption(TR_DisableBitOpcode))

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -48,7 +48,6 @@ void J9::RecognizedCallTransformer::processIntrinsicFunction(TR::TreeTop* treeto
    TR::TransformUtil::removeTree(comp(), treetop);
    }
 
-
 bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
    {
    auto node = treetop->getNode()->getFirstChild();
@@ -65,11 +64,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Math_min_I:
       case TR::java_lang_Math_max_L:
       case TR::java_lang_Math_min_L:
-         return (TR::Compiler->target.cpu.isX86() ||
-            TR::Compiler->target.cpu.isPower() ||
-            TR::Compiler->target.cpu.isZ() ||
-            TR::Compiler->target.cpu.isARM()) &&
-            !comp()->getOption(TR_DisableMaxMinOptimization);
+         return !comp()->getOption(TR_DisableMaxMinOptimization);
       case TR::java_lang_Math_max_F:
       case TR::java_lang_Math_min_F:
       case TR::java_lang_Math_max_D:

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -51,9 +51,6 @@ void J9::RecognizedCallTransformer::processIntrinsicFunction(TR::TreeTop* treeto
 
 bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
    {
-   static bool disableARMMaxMin = true; // (feGetEnv("TR_DisableARMMaxMin") != NULL);
-   static bool disableARMFMaxMin = true; // (feGetEnv("TR_DisableARMFMaxMin") != NULL);
-
    auto node = treetop->getNode()->getFirstChild();
    switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
       {
@@ -71,13 +68,13 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          return (TR::Compiler->target.cpu.isX86() ||
             TR::Compiler->target.cpu.isPower() ||
             TR::Compiler->target.cpu.isZ() ||
-            TR::Compiler->target.cpu.isARM() && !disableARMMaxMin) &&
+            TR::Compiler->target.cpu.isARM()) &&
             !comp()->getOption(TR_DisableMaxMinOptimization);
       case TR::java_lang_Math_max_F:
       case TR::java_lang_Math_min_F:
       case TR::java_lang_Math_max_D:
       case TR::java_lang_Math_min_D:
-         return (TR::Compiler->target.cpu.isARM() && !disableARMMaxMin && !disableARMFMaxMin) &&
+         return (TR::Compiler->target.cpu.isARM()) &&
             !comp()->getOption(TR_DisableMaxMinOptimization);
       default:
          return false;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -65,12 +65,6 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Math_max_L:
       case TR::java_lang_Math_min_L:
          return !comp()->getOption(TR_DisableMaxMinOptimization);
-      case TR::java_lang_Math_max_F:
-      case TR::java_lang_Math_min_F:
-      case TR::java_lang_Math_max_D:
-      case TR::java_lang_Math_min_D:
-         return (TR::Compiler->target.cpu.isARM()) &&
-            !comp()->getOption(TR_DisableMaxMinOptimization);
       default:
          return false;
       }
@@ -107,18 +101,6 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
          break;
       case TR::java_lang_Math_min_L:
          processIntrinsicFunction(treetop, node, TR::lmin);
-         break;
-      case TR::java_lang_Math_max_F:
-         processIntrinsicFunction(treetop, node, TR::fmax);
-         break;
-      case TR::java_lang_Math_min_F:
-         processIntrinsicFunction(treetop, node, TR::fmin);
-         break;
-      case TR::java_lang_Math_max_D:
-         processIntrinsicFunction(treetop, node, TR::dmax);
-         break;
-      case TR::java_lang_Math_min_D:
-         processIntrinsicFunction(treetop, node, TR::dmin);
          break;
       default:
          break;


### PR DESCRIPTION
Move transformations from java/lang/math calls to opcodes
into recognized call transformer optimization and add
transformations for Z.

Closes: #2045

Signed-off-by: Daniel Hong <daniel.hong@live.com>