### PR TITLE
Implement JavaLangRefAccess.runFinalization()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -68,9 +68,10 @@ public abstract class Reference<T> extends Object {
 			public boolean waitForReferenceProcessing() throws InterruptedException {
 				return waitForReferenceProcessingImpl();
 			}
+
 			/*[IF Java11]*/
 			public void runFinalization() {
-				throw new InternalError("Compile stub invoked! Apart from deliberate reflective access, this should not happen. Please report this to the project so it can be addressed");	//$NON-NLS-1$
+				Finalizer.runFinalization();
 			}
 			/*[ENDIF]*/
 		});


### PR DESCRIPTION
	
	- Implement JavaLangRefAccess.runFinalization for Java 11

Closes: #1351 

Signed-off-by: Lin Hu <linhu@ca.ibm.com>