### PR TITLE
Avoid truncating I64 or U64 values from 32-bit core files

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/I64.java
@@ -34,6 +34,9 @@ public class I64 extends IDATA {
 	// Constructors
 	public I64(long value) {
 		super(value);
+		// When working with 32-bit core files, the constructor for IDATA
+		// will truncate the value to 32 bits: we need all 64-bits here.
+		this.data = value;
 	}
 	
 	public I64(Scalar parameter) {
@@ -144,6 +147,12 @@ public class I64 extends IDATA {
 		}
 
 		return value;
+	}
+
+	public long longValue() {
+		// When working with 32-bit core files, IDATA.longValue() will
+		// truncate the value to 32 bits: we must return all 64-bits here.
+		return data;
 	}
 
 	// bitOr

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U64.java
@@ -33,6 +33,9 @@ public class U64 extends UDATA {
 
 	public U64(long value) {
 		super(value);
+		// When working with 32-bit core files, the constructor for UDATA
+		// will truncate the value to 32 bits: we need all 64-bits here.
+		this.data = value;
 	}
 	
 	public U64(Scalar parameter) {


### PR DESCRIPTION
When working with 32-bit core files, the constructors for IDATA and UDATA will truncate the value to 32 bits: the constructors for I64 and U64 must retain all 64-bits.

I64 must not inherit longValue() from IDATA which would truncate the return value to 32-bits when working with 32-bit core files.