### PR TITLE
Do not allow NODE to be null

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -199,9 +199,12 @@ def get_user_credentials_id(KEY) {
 */
 def set_node(job_type) {
     // fetch labels for given platform/spec
-    NODE = (!params.NODE) ? get_value(VARIABLES."${SPEC}".node_labels."${job_type}", SDK_VERSION) : params.NODE
+    NODE = params.NODE
     if (!NODE) {
-        error("Cannot find label value matching JOB_TYPE:'${job_type}' SPEC:'${SPEC}' and SDK_VERSION:'${SDK_VERSION}'")
+        NODE = get_value(VARIABLES."${SPEC}".node_labels."${job_type}", SDK_VERSION)
+        if (!NODE) {
+            error("Cannot find label value matching JOB_TYPE:'${job_type}' SPEC:'${SPEC}' and SDK_VERSION:'${SDK_VERSION}'")
+        }
     }
 }
 


### PR DESCRIPTION
- If NODE is set as a build parameter but is not set,
  the current logic will set NODE to params.node which
  will be null. This will produce an IllegalArgumentException
  'Null value not allowed as an environment variable: NODE'.
  The updated logic should first look to the param,
  then fetch from the variable file if it is not passed.
  It will then throw an error if neither can be determined.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>