### PR TITLE
clean Workspace after libraries are loaded

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -74,7 +74,7 @@ timeout(time: 10, unit: 'HOURS') {
         } else {
             checkout scm
             testFile = load 'buildenv/jenkins/common/test'
-
+            cleanWs()
             if (params.UPSTREAM_JOB_NAME && params.UPSTREAM_JOB_NUMBER) {
                 // test pipeline: fetch resources from upstream job, run tests,
                 // archive results, clean up


### PR DESCRIPTION
- If there is a git repo in the workspace when
  we clone openjdk, the reference repo will not
  be used. This cleans the workspace before the
  openjdk clone to ensure the repo_cache is
  referenced.

[skip ci]
Issue #1906 #1873
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>