### PR TITLE
Improve jProfiling value sequence trees

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -292,6 +292,12 @@ j9jit_testarossa_err(
             if (fe->isAsyncCompilation())
                return 0; // early return because the method is queued for compilation
             }
+         // If PersistentJittedBody contains the profile Info and has BlockFrequencyInfo, it will set the 
+         // isQueuedForRecompilation field which can be used by the jitted code at runtime to skip the profiling
+         // code if it has made request to recompile this method. 
+         if (jbi->getProfileInfo() != NULL && jbi->getProfileInfo()->getBlockFrequencyInfo() != NULL)
+            jbi->getProfileInfo()->getBlockFrequencyInfo()->setIsQueuedForRecompilation();
+
          event._eventType = TR_MethodEvent::OtherRecompilationTrigger;
          }
       }

--- a/runtime/compiler/optimizer/JProfilingValue.hpp
+++ b/runtime/compiler/optimizer/JProfilingValue.hpp
@@ -56,7 +56,6 @@ class TR_JProfilingValue : public TR::Optimization
       TR::Node *value,
       TR_AbstractHashTableProfilerInfo *table,
       TR::Node *optionalTest = NULL,
-      TR::Node *fallbackValue = NULL,
       bool extendBlocks = true,
       bool trace = false);
 

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1643,7 +1643,8 @@ TR_BlockFrequencyInfo::TR_BlockFrequencyInfo(TR_CallSiteInfo *callSiteInfo, int3
    _blocks(blocks),
    _frequencies(frequencies),
    _counterDerivationInfo(NULL),
-   _entryBlockNumber(-1)
+   _entryBlockNumber(-1),
+   _isQueuedForRecompilation(0)
    {
    }
 
@@ -1668,7 +1669,8 @@ TR_BlockFrequencyInfo::TR_BlockFrequencyInfo(
       NULL
       ),
    _counterDerivationInfo(NULL),
-   _entryBlockNumber(-1)
+   _entryBlockNumber(-1),
+   _isQueuedForRecompilation(0)
    {
    for (size_t i = 0; i < _numBlocks; ++i)
       {

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -637,6 +637,8 @@ class TR_BlockFrequencyInfo
    bool    isJProfilingData() { return _counterDerivationInfo != NULL; }
    static int32_t *getEnableJProfilingRecompilation() { return &_enableJProfilingRecompilation; }
    static void    enableJProfilingRecompilation() { _enableJProfilingRecompilation = -1; }
+   void setIsQueuedForRecompilation() { _isQueuedForRecompilation = -1; }
+   int32_t *getIsQueuedForRecompilation() { return &_isQueuedForRecompilation; }
 
    void dumpInfo(TR::FILE *);
 
@@ -660,6 +662,8 @@ class TR_BlockFrequencyInfo
    TR_BitVector    ** _counterDerivationInfo;
    int32_t         _entryBlockNumber;
    static int32_t  _enableJProfilingRecompilation;
+   // Following flag is checked at runtime to know if we have queued this method for recompilation and skip the profiling code
+   int32_t         _isQueuedForRecompilation;
    };
 
 TR_BlockFrequencyInfo * TR_BlockFrequencyInfo::get(TR_PersistentProfileInfo * profileInfo)


### PR DESCRIPTION
This pull request consists following changes for the jProfiling.
1. Improve jPropfiling Value Sequence 
In compilations which use jProfiling, for each value we decide to profile, we generate a code that does the following.
```
if ( value == table.keys[hash(value)])
   ++freqs[hash(value)];
else if ( table.otherIndex >= 0 )
   ++freqs[otherIndex];
else
   call _jProfile(32/64)BitValue
```
In summary we first check if the value exists in hash table and if exists we increase corresponding frequency counter. In cases when value does not exist in the hash table, we need to check if we can acquire lock on table and add new value to it, other wise we need to increase other frequency. This commit optimizes above sequence by using ternary select operation to decide which frequency counter (hash(value) or otherIndex) we need to increment.

With this change, we now only have three blocks per value we profile instead of six. Also in case of profiling VFT pointer, we used to check if the object whose J9Class we are profilig is NULL or not and in case it is NULL, to avoid dereferencing NULL in profiling code we used to generate a fallBack value block. There is no need to generate this as we can simply skip the profiling code if object whose J9Class pointer we are profiling is NULL.

2. If method is queued for recompilation, we do not need to run the profiling code. This commit adds a check around the profiling code to check if method has been queued for recompilation and skips the profiling code.


