### PR TITLE
Code cleanup related to exception related helpers

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1063,9 +1063,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 #endif
    SET(TR_throwCurrentException,      (void *)jitThrowCurrentException,      TR_Helper);
 
-   SET(TR_IncompatibleClassChangeError,(void *)jitThrowIncompatibleClassChangeError, TR_Helper);
-   SET(TR_AbstractMethodError,        (void *)jitThrowAbstractMethodError,           TR_Helper);
-   SET(TR_IllegalAccessError,         (void *)jitThrowIllegalAccessError,            TR_Helper);
    SET(TR_newInstanceImplAccessCheck, (void *)jitNewInstanceImplAccessCheck,         TR_Helper);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
@@ -1161,7 +1158,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_AMD64icallVMprJavaSendVirtualF,             (void *)icallVMprJavaSendVirtualF, TR_Helper);
    SET(TR_AMD64icallVMprJavaSendVirtualD,             (void *)icallVMprJavaSendVirtualD, TR_Helper);
 
-   SET(TR_AMD64jitThrowCurrentException,              (void *)jitThrowCurrentException,       TR_Helper);
    SET(TR_AMD64jitCollapseJNIReferenceFrame,          (void *)jitCollapseJNIReferenceFrame,   TR_Helper);
 
    SET(TR_AMD64compressString,                        (void *)_compressString,            TR_Helper);
@@ -1231,7 +1227,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_X86interpreterAddressStaticGlue,            (void *)interpreterEAXStaticGlue,        TR_Helper);
    SET(TR_X86interpreterSyncAddressStaticGlue,        (void *)interpreterSyncEAXStaticGlue,    TR_Helper);
 
-   SET(TR_IA32jitThrowCurrentException,               (void *)jitThrowCurrentException,        TR_Helper);
    SET(TR_IA32jitCollapseJNIReferenceFrame,           (void *)jitCollapseJNIReferenceFrame,    TR_Helper);
 
    SET(TR_IA32floatRemainder,                         (void *)_X87floatRemainder,  TR_Helper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -112,7 +112,6 @@ JIT_HELPER(jitRetranslateCaller);  // asm calling-convention helper
 JIT_HELPER(jitRetranslateCallerWithPreparation);  // asm calling-convention helper
 JIT_HELPER(jitRetranslateMethod);  // asm calling-convention helper
 JIT_HELPER(jitStackOverflow);  // asm calling-convention helper
-JIT_HELPER(jitThrowAbstractMethodError);  // asm calling-convention helper
 JIT_HELPER(jitThrowArithmeticException);  // asm calling-convention helper
 JIT_HELPER(jitThrowArrayIndexOutOfBounds);  // asm calling-convention helper
 JIT_HELPER(jitThrowArrayStoreException);  // asm calling-convention helper
@@ -120,8 +119,6 @@ JIT_HELPER(jitThrowArrayStoreExceptionWithIP);  // asm calling-convention helper
 JIT_HELPER(jitThrowCurrentException);  // asm calling-convention helper
 JIT_HELPER(jitThrowException);  // asm calling-convention helper
 JIT_HELPER(jitThrowExceptionInInitializerError);  // asm calling-convention helper
-JIT_HELPER(jitThrowIllegalAccessError);  // asm calling-convention helper
-JIT_HELPER(jitThrowIncompatibleClassChangeError);  // asm calling-convention helper
 JIT_HELPER(jitThrowInstantiationException);  // asm calling-convention helper
 JIT_HELPER(jitThrowNullPointerException);  // asm calling-convention helper
 JIT_HELPER(jitThrowWrongMethodTypeException);  // asm calling-convention helper

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -1282,23 +1282,17 @@ void TR::AMD64JNILinkage::checkForJNIExceptions(TR::Node *callNode)
 
    TR::Instruction *instr = generateLabelInstruction(JNE4, callNode, snippetLabel, cg());
 
-   TR_RuntimeHelper helper;
    uint32_t gcMap = _systemLinkage->getProperties().getPreservedRegisterMapForGC();
    if (TR::Compiler->target.is32Bit())
       {
       gcMap |= (_JNIDispatchInfo.argSize<<14);
-      helper = TR_IA32jitThrowCurrentException;
-      }
-   else
-      {
-      helper = TR_AMD64jitThrowCurrentException;
       }
 
    instr->setNeedsGCMap(gcMap);
 
    TR::Snippet *snippet =
       new (trHeapMemory()) TR::X86CheckFailureSnippet(cg(),
-                                     cg()->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false),
+                                     cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException, false, false, false),
                                      snippetLabel,
                                      instr,
                                      _JNIDispatchInfo.requiresFPstackPop);

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -683,7 +683,7 @@ TR::Register *TR::IA32JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
       TR::Snippet *snippet = new (trHeapMemory()) TR::X86CheckFailureSnippet(
             cg(),
-            cg()->symRefTab()->findOrCreateRuntimeHelper(TR_IA32jitThrowCurrentException, false, false, false),
+            cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException, false, false, false),
             snippetLabel,
             instr,
             requiresFPstackPop

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -888,7 +888,7 @@ TR::Register *TR::IA32PrivateLinkage::buildJNIDispatch(TR::Node *callNode)
 
       TR::Snippet *snippet = new (trHeapMemory()) TR::X86CheckFailureSnippet(
             cg(),
-            cg()->symRefTab()->findOrCreateRuntimeHelper(TR_IA32jitThrowCurrentException, false, false, false),
+            cg()->symRefTab()->findOrCreateRuntimeHelper(TR_throwCurrentException, false, false, false),
             snippetLabel,
             instr,
             requiresFPstackPop


### PR DESCRIPTION
1. Remove following three helpers that is not in-use:
   TR_IncompatibleClassChangeError
   TR_AbstractMethodError
   TR_IllegalAccessError
2. Consolidate TR_throwCurrentException on X86, aligning with other platforms.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>