### PR TITLE
Adopt OMR's abs evaluators on X86

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -54,8 +54,8 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
    switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
       {
       case TR::java_lang_Integer_rotateLeft:
-      //case TR::java_lang_Math_abs_I: TODO OMR's iabs evaluator does not fully comply Java Specs
-      //case TR::java_lang_Math_abs_L: TODO OMR's labs evaluator does not fully comply Java Specs
+      case TR::java_lang_Math_abs_I:
+      case TR::java_lang_Math_abs_L:
       case TR::java_lang_Math_abs_F:
       case TR::java_lang_Math_abs_D:
          return TR::Compiler->target.cpu.isX86();


### PR DESCRIPTION
PR #1622 adopted OMR's [i/l/f/d]abs evaluators; however #1643 backed-off
[i/l]abs due to spec incompliance for MIN. eclipse/omr #2711 fixed the
issue. Therefore, OpenJ9 should adopt [i/l]abs now.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>