### PR TITLE
Optimized checkcast and instanceof on X86

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -858,6 +858,16 @@ done:
 }
 
 void* J9FASTCALL
+impl_jitClassCastException(J9VMThread *currentThread)
+{
+    SLOW_JIT_HELPER_PROLOGUE();
+    J9Class* castClass = (J9Class*)currentThread->floatTemp1;
+    J9Class* instanceClass = (J9Class*)currentThread->floatTemp2;
+    buildJITResolveFrameForRuntimeHelper(currentThread, 0);
+    return setClassCastExceptionFromJIT(currentThread, instanceClass, castClass);
+}
+
+void* J9FASTCALL
 old_slow_jitCheckCast(J9VMThread *currentThread)
 {
 	SLOW_JIT_HELPER_PROLOGUE();

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -471,6 +471,17 @@ UNUSED(jitFindFieldSignatureClass)
 UNUSED(icallVMprJavaSendInvokeWithArgumentsHelperL)
 UNUSED(j2iInvokeWithArguments)
 
+START_PROC(jitThrowClassCastException)
+	FASTCALL_EXTERN(impl_jitClassCastException,1)
+	pop uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
+	pop uword ptr J9TR_VMThread_floatTemp1[_rbp]
+	pop uword ptr J9TR_VMThread_floatTemp2[_rbp]
+	SWITCH_TO_C_STACK
+	SAVE_ALL_REGS
+	FASTCALL_C_WITH_VMTHREAD(impl_jitClassCastException)
+	jmp _rax
+END_PROC(jitThrowClassCastException)
+
 dnl Switch from the C stack to the java stack and jump via tempSlot
 
 START_PROC(jitRunOnJavaStack)

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1049,6 +1049,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_releaseVMAccess,            (void *)jitReleaseVMAccess,            TR_Helper);
 #endif
    SET(TR_throwCurrentException,      (void *)jitThrowCurrentException,      TR_Helper);
+   SET(TR_throwClassCastException,    (void *)jitThrowClassCastException,    TR_Helper);
 
    SET(TR_newInstanceImplAccessCheck, (void *)jitNewInstanceImplAccessCheck,         TR_Helper);
 

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -118,6 +118,7 @@ JIT_HELPER(jitThrowArrayStoreException);  // asm calling-convention helper
 JIT_HELPER(jitThrowArrayStoreExceptionWithIP);  // asm calling-convention helper
 JIT_HELPER(jitThrowCurrentException);  // asm calling-convention helper
 JIT_HELPER(jitThrowException);  // asm calling-convention helper
+JIT_HELPER(jitThrowClassCastException);  // asm calling-convention helper
 JIT_HELPER(jitThrowExceptionInInitializerError);  // asm calling-convention helper
 JIT_HELPER(jitThrowInstantiationException);  // asm calling-convention helper
 JIT_HELPER(jitThrowNullPointerException);  // asm calling-convention helper

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -97,6 +97,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *VMmonexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *VMnewEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *VMarrayCheckEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *checkcastinstanceofEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static void asyncGCMapCheckPatching(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *snippetLabel);
    static void inlineRecursiveMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *startLabel, TR::LabelSymbol *snippetLabel, TR::LabelSymbol *JITMonitorEnterSnippetLabel, TR::Register *objectReg, int lwoffset, TR::LabelSymbol *snippetRestartLabel, bool reservingLock);
    static void transactionalMemoryJITMonitorEntry(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *startLabel, TR::LabelSymbol *snippetLabel, TR::LabelSymbol *JITMonitorEnterSnippetLabel, TR::Register *objectReg, int lwoffset);


### PR DESCRIPTION
1. Introduced a call site cache to cache last J9Class encountered for Interface;
2. Inlined iTable lookup for Interface, eliminating the need calling JIT helper;
3. Reduced number of branches needed for Class.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>