### PR TITLE
Remove obsolete addPropertiesForOptionAddModsArg()

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -508,7 +508,6 @@ enum INIT_STAGE {
 #define SYSPROP_JDK_MODULE_UPGRADE_PATH "jdk.module.upgrade.path"
 #define SYSPROP_JDK_MODULE_PATH "jdk.module.path"
 #define SYSPROP_JDK_MODULE_ADDMODS "jdk.module.addmods."
-#define SYSPROP_JDK_MODULE_ADDMODS_B136 "jdk.module.addmods"	/* to be removed when b148+ become default level */
 #define SYSPROP_JDK_MODULE_LIMITMODS "jdk.module.limitmods"
 #define SYSPROP_JDK_MODULE_ADDREADS "jdk.module.addreads."
 #define SYSPROP_JDK_MODULE_ADDEXPORTS "jdk.module.addexports."

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -67,7 +67,6 @@ static char * getOptionArg(J9JavaVM *vm, IDATA argIndex, UDATA optionNameLen);
 static UDATA addPropertyForOptionWithPathArg(J9JavaVM *vm, const char *optionName, UDATA optionNameLen, const char *propName);
 static UDATA addPropertyForOptionWithModuleListArg(J9JavaVM *vm, const char *optionName, IDATA optionNameLen, const char *propName);
 static UDATA addPropertiesForOptionWithAssignArg(J9JavaVM *vm, const char *optionName, UDATA optionNameLen, const char *basePropName, UDATA basePropNameLen);
-static UDATA addPropertiesForOptionAddModsArg(J9JavaVM *vm, const char *optionName, UDATA optionNameLen, const char *basePropName, UDATA basePropNameLen);
 static UDATA addPropertyForOptionWithEqualsArg(J9JavaVM *vm, const char *optionName, UDATA optionNameLen, const char *propName);
 static UDATA addModularitySystemProperties(J9JavaVM * vm);
 
@@ -419,97 +418,6 @@ _end:
 	return rc;
 }
 
-/**
- * This function is a temporary fix to allow both b13[6-7] and b138+ working for command line options --add-modules
- * When b148+ becomes default level, this function can be removed and the call to this function should be replaced
- * with addPropertiesForOptionWithAssignArg().
- *
- * This function is the combination of addPropertyForOptionWithModuleListArg() and addPropertiesForOptionWithAssignArg().
- * i.e., it will set system properties "jdk.module.addmods" for b13[6-7], and "jdk.module.addmods.x" for b138+
- *
- * @param [in] vm the J9JavaVM
- * @param [in] optionName name of the modularity command line option
- * @param [in] optionNameLen length of the modularity command line option
- * @param [in] basePropName base name to be used for the property to be set
- * @param [in] basePropNameLen length of the base name
- *
- * @return returns J9SYSPROP_ERROR_NONE on success, any other J9SYSPROP_ERROR code on failure
- */
-static UDATA
-addPropertiesForOptionAddModsArg(J9JavaVM *vm, const char *optionName, UDATA optionNameLen, const char *basePropName, UDATA basePropNameLen)
-{
-	IDATA argIndex = -1;
-	UDATA rc = J9SYSPROP_ERROR_NONE;
-	J9VMInitArgs *j9vm_args	= vm->vmArgsArray;
-	PORT_ACCESS_FROM_JAVAVM(vm);
-
-	argIndex = FIND_ARG_IN_VMARGS_FORWARD(OPTIONAL_LIST_MATCH_USING_EQUALS, optionName, NULL);
-	if (argIndex >= 0) {
-		UDATA index = 0;
-		UDATA indexLen = 1;
-		char *modulesList = NULL;
-
-		do {
-			char *optionArg = getOptionArg(vm, argIndex, optionNameLen);
-
-			if (NULL != optionArg) {
-				char *propName = NULL;
-				IDATA propNameLen = basePropNameLen + indexLen + 1; /* +1 for '\0' */
-				IDATA listSize = strlen(optionArg);
-
-				if (NULL == modulesList) {
-					modulesList = j9mem_allocate_memory(listSize + 1, OMRMEM_CATEGORY_VM); /* +1 for '\0' */
-					if (NULL != modulesList) {
-						strncpy(modulesList, optionArg, listSize + 1);
-					} else {
-						rc = J9SYSPROP_ERROR_OUT_OF_MEMORY;
-						goto _end;
-					}
-				} else {
-					char *prevList = modulesList;
-
-					listSize += strlen(prevList);
-					modulesList = j9mem_allocate_memory(listSize + 2, OMRMEM_CATEGORY_VM); /* +1 for ',' and +1 for '\0' */
-					if (NULL != modulesList) {
-						j9str_printf(PORTLIB, modulesList, listSize + 2, "%s,%s", prevList, optionArg);
-						j9mem_free_memory(prevList);
-					} else {
-						j9mem_free_memory(prevList);
-						rc = J9SYSPROP_ERROR_OUT_OF_MEMORY;
-						goto _end;
-					}
-				}
-
-				propName = j9mem_allocate_memory(propNameLen, OMRMEM_CATEGORY_VM);
-				if (NULL == propName) {
-					rc = J9SYSPROP_ERROR_OUT_OF_MEMORY;
-					goto _end;
-				}
-				j9str_printf(PORTLIB, propName, propNameLen, "%s%zu", basePropName, index);
-				rc = addSystemProperty(vm, propName, optionArg, J9SYSPROP_FLAG_NAME_ALLOCATED);
-				if (J9SYSPROP_ERROR_NONE != rc) {
-					goto _end;
-				}
-				CONSUME_ARG(j9vm_args, argIndex);
-			} else {
-				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_PROPERTY_MODULARITY_OPTION_REQUIRES_MODULES, optionName);
-				rc = J9SYSPROP_ERROR_ARG_MISSING;
-				goto _end;
-			}
-
-			argIndex = FIND_NEXT_ARG_IN_VMARGS_FORWARD(OPTIONAL_LIST_MATCH_USING_EQUALS, optionName, NULL, argIndex);
-			index += 1;
-			indexLen = (IDATA)floor(log10((double)index) + 1); /* get number of digits in 'index' */
-		} while (argIndex >= 0);
-
-		if (NULL != modulesList) {
-			rc = addSystemProperty(vm, SYSPROP_JDK_MODULE_ADDMODS_B136, modulesList, J9SYSPROP_FLAG_VALUE_ALLOCATED);
-		}
-	}
-
-_end:
-	return rc;
-}
 
 /**
  * Process modularity related command line options and corresponding system properties.
@@ -535,9 +443,8 @@ addModularitySystemProperties(J9JavaVM * vm)
 		goto _end;
 	}
 
-	/* When b148+ becomes default level, this method call should be replaced with addPropertiesForOptionWithAssignArg() */
 	/* Find all --add-modules options */
-	rc = addPropertiesForOptionAddModsArg(vm, VMOPT_ADD_MODULES, LITERAL_STRLEN(VMOPT_ADD_MODULES), SYSPROP_JDK_MODULE_ADDMODS, LITERAL_STRLEN(SYSPROP_JDK_MODULE_ADDMODS));
+	rc = addPropertiesForOptionWithAssignArg(vm, VMOPT_ADD_MODULES, LITERAL_STRLEN(VMOPT_ADD_MODULES), SYSPROP_JDK_MODULE_ADDMODS, LITERAL_STRLEN(SYSPROP_JDK_MODULE_ADDMODS));
 	if (J9SYSPROP_ERROR_NONE != rc) {
 		goto _end;
 	}


### PR DESCRIPTION
Per comments, this is no longer required.

This is in preparation to fixing https://github.com/eclipse/openj9/issues/2030.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>