### PR TITLE
Add ValueTypes attribute writing to ROM Class

### DIFF
--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -809,6 +809,19 @@ class NameAndTypeIterator
 	}
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	void valueTypesDo(ConstantPoolIndexVisitor *visitor)
+	{
+		if (NULL != _valueTypeClasses) {
+			U_16 valueTypeClassCount = getValueTypeClassCount();
+			for (U_16 i = 0; i < valueTypeClassCount; i++) {
+				U_16 valueTypeUTF8 = UTF8_INDEX_FROM_CLASS_INDEX(_classFile->constantPool, _valueTypeClasses->classes[i]);
+				visitor->visitConstantPoolIndex(valueTypeUTF8);
+			}
+		}
+	}
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+
 	/*
 	 * Iterate over the bootstrap methods and their arguments.
 	 */
@@ -856,6 +869,9 @@ class NameAndTypeIterator
 	U_16 getNestMembersCount() const { return _nestMembersCount; }
 	U_16 getNestHostNameIndex() const { return _nestHost; }
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	U_16 getValueTypeClassCount() const { return _valueTypeClassCount; }
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	U_16 getMajorVersion() const { return _classFile->majorVersion; }
 	U_16 getMinorVersion() const { return _classFile->minorVersion; }
 	U_32 getMaxBranchCount() const { return _maxBranchCount; }
@@ -976,6 +992,9 @@ private:
 	U_16 _nestMembersCount;
 	U_16 _nestHost;
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	U_16 _valueTypeClassCount;
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	U_32 _maxBranchCount;
 	U_16 _outerClassNameIndex;
 	U_16 _simpleNameIndex;
@@ -1008,6 +1027,9 @@ private:
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	J9CfrAttributeNestMembers *_nestMembers;
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	J9CfrAttributeValueTypeClasses *_valueTypeClasses;
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 	void walkHeader();
 	void walkFields();

--- a/runtime/bcutil/ROMClassWriter.hpp
+++ b/runtime/bcutil/ROMClassWriter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,6 +128,7 @@ private:
 	void writeInterfaces(Cursor *cursor, bool markAndCountOnly);
 	void writeInnerClasses(Cursor *cursor, bool markAndCountOnly);
 	void writeNestMembers(Cursor *cursor, bool markAndCountOnly);
+	void writeValueTypeClasses(Cursor *cursor, bool markAndCountOnly);
 	void writeNameAndSignatureBlock(Cursor *cursor);
 	void writeMethods(Cursor *cursor, Cursor *lineNumberCursor, Cursor *variableInfoCursor, bool markAndCountOnly);
 	void writeMethodDebugInfo(ClassFileOracle::MethodIterator *methodIterator,  Cursor *lineNumberCursor, Cursor *variableInfoCursor, bool markAndCountOnly, bool existHasDebugInformation);
@@ -160,6 +161,9 @@ private:
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	UDATA _nestMembersSRPKey;
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	UDATA _valueTypeClassesSRPKey;
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 	UDATA _optionalInfoSRPKey;
 	UDATA _stackMapsSRPKey;
 	UDATA _enclosingMethodSRPKey;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3232,6 +3232,11 @@ typedef struct J9ROMClass {
 	J9SRP staticSplitMethodRefIndexes;
 	J9SRP specialSplitMethodRefIndexes;
 	J9SRP varHandleMethodTypeLookupTable;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	U_16 valueTypeClassCount;
+	U_16 valueTypePadding;
+	J9SRP valueTypeClasses;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if defined(J9VM_ENV_DATA64)
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	U_32 padding;
@@ -3309,6 +3314,11 @@ typedef struct J9ROMArrayClass {
 	J9SRP staticSplitMethodRefIndexes;
 	J9SRP specialSplitMethodRefIndexes;
 	J9SRP varHandleMethodTypeLookupTable;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	U_16 valueTypeClassCount;
+	U_16 valueTypePadding;
+	J9SRP valueTypeClasses;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if defined(J9VM_ENV_DATA64)
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	U_32 padding;
@@ -3381,6 +3391,11 @@ typedef struct J9ROMReflectClass {
 	J9SRP staticSplitMethodRefIndexes;
 	J9SRP specialSplitMethodRefIndexes;
 	J9SRP varHandleMethodTypeLookupTable;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	U_16 valueTypeClassCount;
+	U_16 valueTypePadding;
+	J9SRP valueTypeClasses;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if defined(J9VM_ENV_DATA64)
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	U_32 padding;


### PR DESCRIPTION
This change adds a couple elements to J9ROMClass, where the ValueTypes
attribute data is then written.

Depends on #2268.

Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>