### PR TITLE
Fix JVMTI issues related to DisposeEnvironment

### DIFF
--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -549,20 +549,33 @@ typedef struct jvmtiGcp_translation {
 #define IBMJVMTI_EXTENDED_CALLSTACK     1
 #define IBMJVMTI_UNEXTENDED_CALLSTACK   0
 
+/* The brace mismatches in the macros below are due to the usage pattern:
+ *
+ * JVMTI_ENVIRONMENTS_DO(jvmtiData, j9env) {
+ * 		...use j9env...
+ * 		JVMTI_ENVIRONMENTS_NEXT_DO(jvmtiData, j9env);
+ * }
+ *
+ */
+
 #define JVMTI_ENVIRONMENTS_DO(jvmtiData, j9env) \
 	(j9env) = (jvmtiData)->environmentsHead; \
-	while (((j9env) != NULL) && (0 == ((j9env)->flags & J9JVMTIENV_FLAG_DISPOSED)))
+	while ((j9env) != NULL) { \
+		if (0 == ((j9env)->flags & J9JVMTIENV_FLAG_DISPOSED))
 
 #define JVMTI_ENVIRONMENTS_NEXT_DO(jvmtiData, j9env) \
-	(j9env) = (j9env)->linkNext
+		} \
+		(j9env) = (j9env)->linkNext
 	
 #define JVMTI_ENVIRONMENTS_REVERSE_DO(jvmtiData, j9env) \
 	(j9env) = (jvmtiData)->environmentsTail; \
-	while (((j9env) != NULL) && (0 == ((j9env)->flags & J9JVMTIENV_FLAG_DISPOSED)))
+	while ((j9env) != NULL) { \
+		if (0 == ((j9env)->flags & J9JVMTIENV_FLAG_DISPOSED))
 
 #define JVMTI_ENVIRONMENTS_REVERSE_NEXT_DO(jvmtiData, j9env) \
-	(j9env) = (j9env)->linkPrevious
-	
+		} \
+		(j9env) = (j9env)->linkPrevious
+
 #define PORT_ACCESS_FROM_JVMTI(env) PORT_ACCESS_FROM_JAVAVM(((J9JVMTIEnv *) (env))->vm)
 
 #endif     /* jvmtiInternal_h */

--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -124,6 +124,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "rbc001",   rbc001,   "com.ibm.jvmti.tests.redefineBreakpointCombo.rbc001", "Test Redefine-breakpoint combination"},
 	{ "mt001",   mt001,   "com.ibm.jvmti.tests.modularityTests.mt001", "Test Modularity functions"},
 	{ "nmr001",     nmr001,    "com.ibm.jvmti.tests.nestMatesRedefinition.nmr001", "Test nestmates redefinition"},
+	{ "snmp001",     snmp001,    "com.ibm.jvmti.tests.setNativeMethodPrefix.snmp001", "Tests setting a native method prefix and disposing a subsequent environment"},
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -239,5 +239,6 @@ jint JNICALL rnwr001(agentEnv * agent_env, char * args);
 jint JNICALL aln001(agentEnv * agent_env, char * args);
 jint JNICALL mt001(agentEnv * agent_env, char * args);
 jint JNICALL nmr001(agentEnv * agent_env, char * args);
+jint JNICALL snmp001(agentEnv * agent_env, char * args);
 
 #endif /*JVMTI_TEST_H_*/

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -199,6 +199,8 @@
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleOpens" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleProvides" />
 		<export name="Java_com_ibm_jvmti_tests_nestMatesRedefinition_nmr001_redefineClass" />
+		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_setPrefix" />
+		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat" />
 	</exports>
 
 	<artifact type="shared" name="jvmtitest" bundle="jvmti_test" appendrelease="false">

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -164,6 +164,8 @@ add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/verboseGC/vgc001.c
 
 	com/ibm/jvmti/tests/vmDump/vmd001.c
+
+	com/ibm/jvmti/tests/setNativeMethodPrefix/snmp001.c
 )
 
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/setNativeMethodPrefix/snmp001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/setNativeMethodPrefix/snmp001.c
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <string.h>
+
+#include "jvmti_test.h"
+
+static agentEnv * env;
+ 
+jint JNICALL
+snmp001(agentEnv * agent_env, char * args)
+{
+	jvmtiError err;
+	jvmtiCapabilities capabilities;
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+
+	env = agent_env; 
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_set_native_method_prefix = 1;	
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to AddCapabilities");
+		return JNI_ERR;
+	}						
+
+	return JNI_OK;
+}
+
+jboolean JNICALL
+Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_setPrefix(JNIEnv * jni_env, jclass klass)
+{
+	JVMTI_ACCESS_FROM_AGENT(env);
+	jvmtiError err; 
+	jvmtiEnv *disposeEnv;
+	JavaVM *vm;
+	
+	err = (*jvmti_env)->SetNativeMethodPrefix(jvmti_env, "$$J9$$");
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Unable to set prefix");
+		return JNI_FALSE;
+	}
+
+	if (JNI_OK != (*jni_env)->GetJavaVM(jni_env, &vm)) {
+		error(env, err, "Unable to get VM");
+		return JNI_FALSE;
+	}
+	if (JNI_OK != (*vm)->GetEnv(vm, (void **) &disposeEnv, JVMTI_VERSION_1_2)) {
+		error(env, err, "Unable to get new JVMTI env");
+		return JNI_FALSE;
+	}
+	err = (*disposeEnv)->DisposeEnvironment(disposeEnv);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Unable dispose JVMTI env");
+		return JNI_FALSE;
+	}
+	return JNI_TRUE;
+}
+
+void JNICALL
+Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat(JNIEnv * jni_env, jclass klass)
+{
+}

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -274,6 +274,11 @@
 		<return type="success" value="0"/>
 	</test>
 
+	<test id="snmp001">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:snmp001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
 	<test id="ts001">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:ts001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/setNativeMethodPrefix/snmp001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/setNativeMethodPrefix/snmp001.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.setNativeMethodPrefix;
+
+import com.ibm.jvmti.tests.util.Util;
+
+public class snmp001 {
+
+	public static native boolean setPrefix();
+	public static void nat() {
+		$$J9$$nat();
+	}
+	public static native void $$J9$$nat();
+
+	public boolean testPrefixWithDispose() throws Throwable {
+		if (!setPrefix()) {
+			System.out.println("error in prefixing native");
+			return false;
+		}
+		try {
+			nat();
+			System.out.println("found prefixed native");			
+		} catch(UnsatisfiedLinkError e) {
+			System.out.println("unable to find prefixed native");
+			return false;
+		}
+		return true;
+	}
+
+	public String helpPrefixWithDispose() {
+		return "Tests setting a native method prefix and disposing a subsequent environment";
+	}
+}


### PR DESCRIPTION
The logic used to iterate JVMTI environments is incorrect in the
presence of disposed environments.  Rather than excluding disposed
environments from iteration, the old logic would terminate the iteration
entirely as soon as a disposed environment is encountered.

Add a test for SetNativeMethodPrefix (which iterates environments) in
the presence of a disposed environment.

Fixes: #2350

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>