### PR TITLE
CMake: Remove un-needed excludes from the compiler

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -101,14 +101,7 @@ set(REMOVED_OMR_FILES
 	${omr_SOURCE_DIR}/compiler/infra/OMRMonitor.cpp
 	${omr_SOURCE_DIR}/compiler/runtime/Trampoline.cpp
 	${omr_SOURCE_DIR}/compiler/runtime/Runtime.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/IlBuilder.cpp # Delete me
-	${omr_SOURCE_DIR}/compiler/ilgen/IlValue.cpp # Delete me
 	${omr_SOURCE_DIR}/compiler/ilgen/IlInjector.cpp
-	${omr_SOURCE_DIR}/compiler/ilgen/MethodBuilder.cpp # Delete me
-	${omr_SOURCE_DIR}/compiler/ilgen/BytecodeBuilder.cpp # Delete me
-	${omr_SOURCE_DIR}/compiler/ilgen/TypeDictionary.cpp # Delete me
-	${omr_SOURCE_DIR}/compiler/ilgen/ThunkBuilder.cpp # Delete me
-	${omr_SOURCE_DIR}/compiler/ilgen/VirtualMachineState.cpp # Delete me
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRBytecodeBuilder.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRIlBuilder.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRIlValue.cpp


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>