### PR TITLE
Decimal Format Peephole incorrectly detecting opportunity

### DIFF
--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -798,7 +798,7 @@ TR::TreeTop *TR_StringPeepholes::detectFormatPattern(TR::TreeTop *tt, TR::TreeTo
                                  SPH_DecimalFormatHelper_formatAsFloat;
 
          TR::SymbolReference *callSymRef = findSymRefForOptMethod (bdMethod);
-         if (callSymRef && performTransformation(comp(), "%ssimplified number format pattern from node [%p] to [%p] \n", optDetailString(), firstTree->getNode(), tt->getNode()))
+         if (nextNode->getSecondChild() == node && callSymRef && performTransformation(comp(), "%ssimplified number format pattern from node [%p] to [%p] \n", optDetailString(), firstTree->getNode(), tt->getNode()))
             {
             TR::TreeTop *prevTree = firstTree->getPrevTreeTop();
             TR::TreeTop *treeAfterLast = tt->getNextTreeTop();


### PR DESCRIPTION
Decimal Format Peephole was not correctly verifying that the
child of the format() call is the direct result of the
BigDecimal.{double/float}Value() call allowing for some
operations to be removed.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>