### PR TITLE
Skip parameter access check for reflect objects

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleInfoImpl.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleInfoImpl.java
@@ -93,7 +93,7 @@ final class MethodHandleInfoImpl implements MethodHandleInfo {
 			throw new NullPointerException();
 		}
 		try {
-			lookup.checkAccess(mh);
+			lookup.checkAccess(mh, false);
 		} catch (IllegalAccessException e) {
 			/*[MSG "K0583", "The Member is not accessible to the Lookup object"]*/
 			IllegalArgumentException x = new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0583")); //$NON-NLS-1$


### PR DESCRIPTION
Skip parameter access check for reflect objects

Introduced a boolean flag to indicate that MethodType parameters should be skipped for access checking;
Skip parameter access check for reflect objects;
Adopted this extra parameter in other APIs.

Manually verified that this PR fixes #2355 

Peer reviewer: @tajila 
Senior reviewer: @gacholio 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>