### PR TITLE
Accelerate java/lang/StringUTF16.toBytes for performance

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -200,6 +200,7 @@
    java_lang_String_getChars_byteArray,
 
    java_lang_StringUTF16_getChar,
+   java_lang_StringUTF16_toBytes,
 
    java_lang_StringBuffer_append,
    java_lang_StringBuffer_capacityInternal,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3285,6 +3285,7 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
       case TR::com_ibm_jit_JITHelpers_getJ9ClassFromObject64:
       case TR::com_ibm_jit_JITHelpers_getClassInitializeStatus:
       case TR::java_lang_StringUTF16_getChar:
+      case TR::java_lang_StringUTF16_toBytes:
       case TR::java_lang_invoke_MethodHandle_asType_instance:
             return DontInline_Callee;
       default:

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3325,6 +3325,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
    static X StringUTF16Methods[] =
       {
       { x(TR::java_lang_StringUTF16_getChar,                                  "getChar", "([BI)C")},
+      { x(TR::java_lang_StringUTF16_toBytes,                                  "toBytes", "([CII)[B")},
       { TR::unknownMethod }
       };
 

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -66,6 +66,8 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Math_max_L:
       case TR::java_lang_Math_min_L:
          return !comp()->getOption(TR_DisableMaxMinOptimization);
+      case TR::java_lang_StringUTF16_toBytes:
+         return true;
       default:
          return false;
       }
@@ -106,7 +108,46 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
       case TR::java_lang_Math_min_L:
          processIntrinsicFunction(treetop, node, TR::lmin);
          break;
+      case TR::java_lang_StringUTF16_toBytes:
+         process_java_lang_StringUTF16_toBytes(treetop, node);
+         break;
       default:
          break;
       }
+   }
+
+void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node)
+   {
+   TR_J9VMBase* fej9 = static_cast<TR_J9VMBase*>(comp()->fe());
+
+   TR::Node* valueNode = node->getChild(0);
+   TR::Node* offNode = node->getChild(1);
+   TR::Node* lenNode = node->getChild(2);
+
+   anchorAllChildren(node, treetop);
+   prepareToReplaceNode(node);
+
+   int32_t byteArrayType = fej9->getNewArrayTypeFromClass(reinterpret_cast<TR_OpaqueClassBlock*>(fej9->getJ9JITConfig()->javaVM->byteArrayClass));
+
+   TR::Node::recreateWithoutProperties(node, TR::newarray, 2, 
+      TR::Node::create(TR::ishl, 2,
+         lenNode, 
+         TR::Node::iconst(1)),
+      TR::Node::iconst(byteArrayType), 
+
+      getSymRefTab()->findOrCreateNewArraySymbolRef(node->getSymbolReference()->getOwningMethodSymbol(comp())));
+
+   TR::Node* newByteArrayNode = node;
+   newByteArrayNode->setCanSkipZeroInitialization(true);
+   newByteArrayNode->setIsNonNull(true);
+
+   TR::Node* newCallNode = TR::Node::createWithSymRef(node, TR::call, 5, 
+      getSymRefTab()->methodSymRefFromName(comp()->getMethodSymbol(), "java/lang/String", "decompressedArrayCopy", "([CI[BII)V", TR::MethodSymbol::Static));
+   newCallNode->setAndIncChild(0, valueNode);
+   newCallNode->setAndIncChild(1, offNode);
+   newCallNode->setAndIncChild(2, newByteArrayNode);
+   newCallNode->setAndIncChild(3, TR::Node::iconst(0));
+   newCallNode->setAndIncChild(4, lenNode);
+
+   treetop->insertAfter(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, newCallNode)));
    }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -48,6 +48,42 @@ void J9::RecognizedCallTransformer::processIntrinsicFunction(TR::TreeTop* treeto
    TR::TransformUtil::removeTree(comp(), treetop);
    }
 
+void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node)
+   {
+   TR_J9VMBase* fej9 = static_cast<TR_J9VMBase*>(comp()->fe());
+
+   TR::Node* valueNode = node->getChild(0);
+   TR::Node* offNode = node->getChild(1);
+   TR::Node* lenNode = node->getChild(2);
+
+   anchorAllChildren(node, treetop);
+   prepareToReplaceNode(node);
+
+   int32_t byteArrayType = fej9->getNewArrayTypeFromClass(reinterpret_cast<TR_OpaqueClassBlock*>(fej9->getJ9JITConfig()->javaVM->byteArrayClass));
+
+   TR::Node::recreateWithoutProperties(node, TR::newarray, 2, 
+      TR::Node::create(TR::ishl, 2,
+         lenNode, 
+         TR::Node::iconst(1)),
+      TR::Node::iconst(byteArrayType), 
+
+      getSymRefTab()->findOrCreateNewArraySymbolRef(node->getSymbolReference()->getOwningMethodSymbol(comp())));
+
+   TR::Node* newByteArrayNode = node;
+   newByteArrayNode->setCanSkipZeroInitialization(true);
+   newByteArrayNode->setIsNonNull(true);
+
+   TR::Node* newCallNode = TR::Node::createWithSymRef(node, TR::call, 5, 
+      getSymRefTab()->methodSymRefFromName(comp()->getMethodSymbol(), "java/lang/String", "decompressedArrayCopy", "([CI[BII)V", TR::MethodSymbol::Static));
+   newCallNode->setAndIncChild(0, valueNode);
+   newCallNode->setAndIncChild(1, offNode);
+   newCallNode->setAndIncChild(2, newByteArrayNode);
+   newCallNode->setAndIncChild(3, TR::Node::iconst(0));
+   newCallNode->setAndIncChild(4, lenNode);
+
+   treetop->insertAfter(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, newCallNode)));
+   }
+
 bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
    {
    auto node = treetop->getNode()->getFirstChild();
@@ -114,40 +150,4 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
       default:
          break;
       }
-   }
-
-void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node)
-   {
-   TR_J9VMBase* fej9 = static_cast<TR_J9VMBase*>(comp()->fe());
-
-   TR::Node* valueNode = node->getChild(0);
-   TR::Node* offNode = node->getChild(1);
-   TR::Node* lenNode = node->getChild(2);
-
-   anchorAllChildren(node, treetop);
-   prepareToReplaceNode(node);
-
-   int32_t byteArrayType = fej9->getNewArrayTypeFromClass(reinterpret_cast<TR_OpaqueClassBlock*>(fej9->getJ9JITConfig()->javaVM->byteArrayClass));
-
-   TR::Node::recreateWithoutProperties(node, TR::newarray, 2, 
-      TR::Node::create(TR::ishl, 2,
-         lenNode, 
-         TR::Node::iconst(1)),
-      TR::Node::iconst(byteArrayType), 
-
-      getSymRefTab()->findOrCreateNewArraySymbolRef(node->getSymbolReference()->getOwningMethodSymbol(comp())));
-
-   TR::Node* newByteArrayNode = node;
-   newByteArrayNode->setCanSkipZeroInitialization(true);
-   newByteArrayNode->setIsNonNull(true);
-
-   TR::Node* newCallNode = TR::Node::createWithSymRef(node, TR::call, 5, 
-      getSymRefTab()->methodSymRefFromName(comp()->getMethodSymbol(), "java/lang/String", "decompressedArrayCopy", "([CI[BII)V", TR::MethodSymbol::Static));
-   newCallNode->setAndIncChild(0, valueNode);
-   newCallNode->setAndIncChild(1, offNode);
-   newCallNode->setAndIncChild(2, newByteArrayNode);
-   newCallNode->setAndIncChild(3, TR::Node::iconst(0));
-   newCallNode->setAndIncChild(4, lenNode);
-
-   treetop->insertAfter(TR::TreeTop::create(comp(), TR::Node::create(node, TR::treetop, 1, newCallNode)));
    }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -103,7 +103,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
       case TR::java_lang_Math_min_L:
          return !comp()->getOption(TR_DisableMaxMinOptimization);
       case TR::java_lang_StringUTF16_toBytes:
-         return true;
+         return !comp()->compileRelocatableCode();
       default:
          return false;
       }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -41,6 +41,25 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
 
    private:
    void processIntrinsicFunction(TR::TreeTop* treetop, TR::Node* node, TR::ILOpCodes opcode);
+
+   /** \brief
+    *     Transforms java/lang/StringUTF16.toBytes([CII)[B into a fast allocate and arraycopy sequence with equivalent
+    *     semantics. 
+    *
+    *  \param treetop
+    *     The treetop which anchors the call node.
+    
+    *  \param node
+    *     The call node representing a call to java/lang/StringUTF16.toBytes([CII)[B which has the following shape:
+    *
+    *     \code
+    *     acall <java/lang/StringUTF16.toBytes([CII)[B>
+    *       <value>
+    *       <off>
+    *       <len>
+    *     \endcode
+    */
+   void process_java_lang_StringUTF16_toBytes(TR::TreeTop* treetop, TR::Node* node);
    };
 
 }


### PR DESCRIPTION
Use the recognized call transformer to reduce
java.lang.StringUTF16.toBytes down to an equivalent tree sequence
taking advantage of already recognized arraycopy helpers for copying
char[] into the memory-equivalent byte[].

Note because of #2381 we do not need to emit HCR guards for this
transformation.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>