### PR TITLE
Improve attach API access checking

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1283,5 +1283,13 @@ K0800="Invalid Unicode code point - {0}"
 K0801="Last character in replacement string can't be \, character to be escaped is required."
 K0802="Last character in replacement string can't be $, group index is required."
 
+# attach API
+K0803="File {0} is owned by {1}, should be owned by current user"
+K0804="Illegal file {0} found in target directory"
+K0805="{0} has permissions {1}, should have owner access only"
+K0806="Cannot verify permissions {0}"
+K0807="Cannot delete file {0}"
+K0808="Cannot create new file {0}"
+
 #java.lang.ref.Reference
 K0900="Create a new Reference, since a Reference cannot be cloned."

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Advertisement.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Advertisement.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2009, 2010 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -189,7 +189,7 @@ public final class Advertisement {
 	 * This is called during initialization or after successful initialization only.
 	 * @param vmId ID of this VM
 	 * @param displayName display name of this VM
-	 * @throws IOException if cannot open the advertisement file
+	 * @throws IOException if cannot open the advertisement file or cannot delete an existing one
 	 */
 	static void createAdvertisementFile(String vmId, String displayName) throws IOException {
 
@@ -198,13 +198,13 @@ public final class Advertisement {
 			return;
 		}
 		File advertFile = TargetDirectory.getAdvertisementFileObject();
-		IPC.createFileWithPermissions(advertFile.getAbsolutePath(), TargetDirectory.ADVERTISEMENT_FILE_PERMISSIONS);
 		/* AttachHandler.terminate() will delete this file on shutdown */ 
-		FileOutputStream advertOutputStream = new FileOutputStream(advertFile);
-		try {
+		IPC.createNewFileWithPermissions(advertFile, TargetDirectory.ADVERTISEMENT_FILE_PERMISSIONS);
+		/* we have a brand new, empty file with correct ownership and permissions */
+		try (FileOutputStream advertOutputStream = new FileOutputStream(advertFile);){
 			StringBuilder advertContent = createAdvertContent(vmId, displayName);
 			if (null == advertContent) {
-				IPC.logMessage("createAdvertisementFile failed to create advertisement file : file objects null"); //$NON-NLS-1$
+				IPC.logMessage("createAdvertisementFile failed to create advertisement file : file object is null"); //$NON-NLS-1$
 				return;
 			}
 			
@@ -212,8 +212,6 @@ public final class Advertisement {
 			if (IPC.loggingEnabled ) {
 				IPC.logMessage("createAdvertisementFile ", advertFile.getAbsolutePath()); //$NON-NLS-1$
 			}
-		} finally {
-			advertOutputStream.close(); /* cleanup from findbugs */
 		}
 	}
 	

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
@@ -144,8 +144,12 @@ public class AttachHandler extends Thread {
 		/*[PR Jazz 59196 LIR: Disable attach API by default on z/OS (31972)]*/
 		boolean enableAttach = true;
 		String osName = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("os.name"); //$NON-NLS-1$
-		if ((null != osName) && (osName.equalsIgnoreCase("z/OS"))) { //$NON-NLS-1$
-			enableAttach = false;
+		if (null != osName) {
+			if (osName.equalsIgnoreCase("z/OS")) { //$NON-NLS-1$
+				enableAttach = false;
+			} else if (osName.startsWith("Windows")) { //$NON-NLS-1$
+				IPC.isWindows = true;
+			}
 		}
 		/* the system property overrides the default */
 		String enableAttachProp = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("com.ibm.tools.attach.enable");  //$NON-NLS-1$
@@ -335,7 +339,9 @@ public class AttachHandler extends Thread {
 	 * @throws IOException if there is a problem reading the reply file.
 	 */
 	public Attachment connectToAttacher() throws IOException {
-		Reply attacherReply = Reply.readReply(TargetDirectory.getTargetDirectoryPath(AttachHandler.getVmId()));
+		String targetDirectoryPath = TargetDirectory.getTargetDirectoryPath(AttachHandler.getVmId());
+		IPC.checkOwnerAccessOnly(targetDirectoryPath);
+		Reply attacherReply = Reply.readReply(targetDirectoryPath);
 		Attachment at = null;
 		if (null != attacherReply) {
 			int portNumber = attacherReply.getPortNumber();

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
@@ -328,10 +328,10 @@ public abstract class CommonDirectory {
 				|| MASTER_NOTIFIER.equalsIgnoreCase(dirMemberName));
 	}
 
-	/*
-	 * look for leftover files and directories from previous VMs
+	/**
+	 * Look for and delete leftover files and directories from previous VMs
+	 * @param myId VMID of the current.  Set to non-null to prevent deleting own directory.
 	 */
-	/*[PR Jazz 37778 deleteStaleDirectories was always called with checkProcess=true */
 	static void deleteStaleDirectories(String myId) {
 		long myUid = IPC.getUid();
 		File[] vmDirs = getCommonDirFileObject().listFiles(new DirectorySampler());

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Reply.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Reply.java
@@ -34,7 +34,6 @@ public final class Reply {
 	 * Manages the file created by an attaching process
 	 *
 	 */
-	private RandomAccessFile replyChannelRAF;
 	private  String key;
 	private  Integer portNumber;
 	private final File replyFile;
@@ -68,31 +67,30 @@ public final class Reply {
 
 	/**
 	 * Write data to the reply file.  Must be matched with an eraseReply()
-	 * @param keyText Security key to validate transaction
-	 * @param portNumberText to be written to file. Virtual machine ID, name, semaphore name etc.
-	 * @throws IOException if files are not accessible
+	 * keyText is a security key to validate transaction
+	 * portNumberText is text to be written to file. Virtual machine ID, name, semaphore name etc.
+	 * @throws IOException if file are not accessible or cannot be created with correct permissions
 	 */
 	public void writeReply() throws IOException {
-		/* replyFIle has been created by the constructor */
-		try {
-			IPC.logMessage("writing reply file port=", portNumber.intValue(), " file path=", replyFile.getAbsolutePath());  //$NON-NLS-1$//$NON-NLS-2$
-			
-			replyChannelRAF = new RandomAccessFile(replyFile, "rw"); //$NON-NLS-1$
-			replyChannelRAF.setLength(0); /* delete whatever crud was there before */
+		/* replyFile has been created by the constructor */
+		final String replyFileAbsolutePath = replyFile.getAbsolutePath();
+		IPC.logMessage("writing reply file port=", portNumber.intValue(), " file path=", replyFileAbsolutePath);  //$NON-NLS-1$//$NON-NLS-2$
+		IPC.createNewFileWithPermissions(replyFile, TargetDirectory.ADVERTISEMENT_FILE_PERMISSIONS);
+		/* we have a brand new, empty file with correct ownership and permissions */
+		try (RandomAccessFile replyChannelRAF = new RandomAccessFile(replyFile, "rw")) { //$NON-NLS-1$
 			replyChannelRAF.writeBytes(key);
 			replyChannelRAF.writeByte('\n');
 			replyChannelRAF.writeBytes(portNumber.toString());
 			replyChannelRAF.writeByte('\n');
 			replyChannelRAF.close();
 
-			IPC.chmod(replyFile.getAbsolutePath(), REPLY_PERMISSIONS);
 			long myUid = IPC.getUid();
 			if ((ROOT_UID == myUid) && (ROOT_UID != targetUid)) {
-				IPC.chownFileToTargetUid(replyFile.getAbsolutePath(), targetUid);
+				IPC.chownFileToTargetUid(replyFileAbsolutePath, targetUid);
 			}
 		} catch (FileNotFoundException e) {
 			/*[MSG "K0552", "File not found exception thrown in writeReply for file {0}"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0552", replyFile.getAbsolutePath()), e); //$NON-NLS-1$
+			throw new IOException(com.ibm.oti.util.Msg.getString("K0552", replyFileAbsolutePath), e); //$NON-NLS-1$
 		}
 	}
 
@@ -102,12 +100,12 @@ public final class Reply {
 	 */
 	static Reply readReply(String path) throws IOException {
 		Reply rply = new Reply(path);
+		String replyFileAbsolutePath = rply.replyFile.getAbsolutePath();
 		if (rply.fileDoesNotExist()) {
 			return null;
 		}
-		BufferedReader replyStream;
-		try {
-			replyStream = new BufferedReader(new FileReader(rply.replyFile));
+		IPC.checkOwnerAccessOnly(replyFileAbsolutePath);
+		try (BufferedReader replyStream = new BufferedReader(new FileReader(rply.replyFile));) {
 			rply.key = replyStream.readLine();
 			String line = replyStream.readLine();
 			replyStream.close();
@@ -119,7 +117,7 @@ public final class Reply {
 			}
 		} catch (FileNotFoundException e) {
 			/*[MSG "K0548", "Cannot read reply file {0}"]*/
-			throw new IOException(com.ibm.oti.util.Msg.getString("K0548", rply.replyFile.getAbsolutePath()), e); //$NON-NLS-1$
+			throw new IOException(com.ibm.oti.util.Msg.getString("K0548", replyFileAbsolutePath), e); //$NON-NLS-1$
 		}
 		return rply;
 	}

--- a/runtime/jcl/common/attach.c
+++ b/runtime/jcl/common/attach.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2016 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,7 +117,7 @@ Java_com_ibm_tools_attach_target_IPC_chmod(JNIEnv *env, jclass clazz, jstring pa
 {
 	PORT_ACCESS_FROM_VMC( ((J9VMThread *) env) );
 
-	jint result = JNI_OK;
+	jint result = JNI_ERR;
 	const char *pathUTF;
 
 	pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
@@ -127,8 +127,6 @@ Java_com_ibm_tools_attach_target_IPC_chmod(JNIEnv *env, jclass clazz, jstring pa
 			Trc_JCL_attach_chmod(env, pathUTF, mode, result);
 		}
 		(*env)->ReleaseStringUTFChars(env, path, pathUTF);
-	} else {
-		result = JNI_ERR;
 	}
 	return result;
 }
@@ -286,7 +284,7 @@ Java_com_ibm_tools_attach_target_IPC_createFileWithPermissionsImpl(JNIEnv *env, 
 	const char *pathUTF = (*env)->GetStringUTFChars(env, path, NULL);
 
 	if (NULL != pathUTF) {
-		IDATA fd = j9file_open(pathUTF, EsOpenCreate | EsOpenWrite | EsOpenTruncate, mode);
+		IDATA fd = j9file_open(pathUTF, EsOpenCreateNew | EsOpenWrite | EsOpenTruncate , mode);
 		if (-1 == fd) {
 			status = JNI_ERR;
 		} else {


### PR DESCRIPTION
Ensure that files have the correct owner and access permissions,
delete suspect directories instead of re-using them.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>