### PR TITLE
Refactor vTable Access

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -285,27 +285,25 @@ jitResetAllMethods(J9VMThread *currentThread)
 	while (clazz != NULL) {
 		/* Interface classes do not have vTables, so skip them */
 		if (!J9ROMCLASS_IS_INTERFACE(clazz->romClass)) {
-			UDATA *vTableWriteCursor = ((UDATA*)clazz) - 1;
-			UDATA *vTableReadCursor = (UDATA*)(clazz + 1);
-			UDATA vTableSize = *vTableReadCursor;
+			UDATA *vTableWriteCursor = JIT_VTABLE_START_ADDRESS(clazz);
 
-			/* JIT vTable does not include the magic 1st method - skip it and the size */
-			vTableReadCursor += 2;
-			vTableSize -= 1;
+			J9VTableHeader *vTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(clazz);
+			J9Method **vTableReadCursor = J9VTABLE_FROM_HEADER(vTableHeader);
+			UDATA vTableSize = vTableHeader->size;
 
 			/* Put invalid entries in the obsolete JIT vTables and reinitialize the current ones */
 			if (J9_IS_CLASS_OBSOLETE(clazz)) {
 				while (0 != vTableSize) {
-					vTableWriteCursor -= 1;
 					*vTableWriteCursor = (UDATA)-1;
+					vTableWriteCursor -= 1;
 					vTableSize -= 1;
 				}
 			} else {
 				while (0 != vTableSize) {
-					J9Method *method = *(J9Method**)vTableReadCursor;
+					J9Method *method = *vTableReadCursor;
 					vTableReadCursor += 1;
-					vTableWriteCursor -= 1;
 					vmFuncs->fillJITVTableSlot(currentThread, vTableWriteCursor, method);
+					vTableWriteCursor -= 1;
 					vTableSize -= 1;
 				}
 			}

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -3272,12 +3272,11 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
       {
       J9Class * superCl = cl->superclasses[classDepth];
 
-      intptrj_t methodCount =  *((intptrj_t *)(superCl +1))-1;      //Vtable starts at end of j9class. First entry is num methods in vtable
-      J9Method ** superVTable = (J9Method **)((char *)superCl + sizeof(J9Class));   // a pointer to an array of j9method pointers (the vtable!)
-      J9Method ** subVTable = (J9Method **)((char *)cl + sizeof(J9Class));
+      J9VTableHeader * superVTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(superCl);
+      intptrj_t methodCount =  (intptrj_t)superVTableHeader->size;
+      J9Method ** superVTable = J9VTABLE_FROM_HEADER(superVTableHeader);
+      J9Method ** subVTable = J9VTABLE_FROM_RAM_CLASS(cl);
 
-      subVTable+=2;                                          // second entry in vtable is magic and want to skip over it as well
-      superVTable+=2;
       intptrj_t methodIndex=0;
 
       while(methodCount--)
@@ -3516,6 +3515,7 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
 
                //Updating all grandparent classes overridden bits
                J9Class * tempsuperCl;
+               J9VTableHeader * tempsuperVTableHeader;
                J9Method ** tempsuperVTable;
                J9Method * tempsuperMethod;
                intptrj_t tempmethodCount;
@@ -3523,11 +3523,13 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
                   {
 
                   tempsuperCl = cl->superclasses[k];
-                  tempmethodCount =  *((intptrj_t *)(tempsuperCl +1))-1;
+                  tempsuperVTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(tempsuperCl);
+                  tempmethodCount =  (intptrj_t)tempsuperVTableHeader->size;
+
                   if(methodIndex>= tempmethodCount)  //we are outside the grandparent's vft slots
                      break;
-                  tempsuperVTable = (J9Method **)((char *)tempsuperCl + sizeof(J9Class));
-                  tempsuperVTable+=2;
+
+                  tempsuperVTable = J9VTABLE_FROM_HEADER(tempsuperVTableHeader);
                   tempsuperVTable = tempsuperVTable + methodIndex;
                   tempsuperMethod= *tempsuperVTable;
                   jitUpdateMethodOverride(vm, cl, tempsuperMethod,subMethod);
@@ -3557,6 +3559,7 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
 
             //Updating all grandparent classes overridden bits
             J9Class * tempsuperCl;
+            J9VTableHeader * tempsuperVTableHeader;
             J9Method ** tempsuperVTable;
             J9Method * tempsuperMethod;
             intptrj_t tempmethodCount;
@@ -3564,11 +3567,13 @@ static void updateOverriddenFlag( J9VMThread *vm , J9Class *cl)
                {
 
                tempsuperCl = cl->superclasses[k];
-               tempmethodCount =  *((intptrj_t *)(tempsuperCl +1))-1;
+               tempsuperVTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(tempsuperCl);
+               tempmethodCount =  (intptrj_t)tempsuperVTableHeader->size;
+
                if(methodIndex >= tempmethodCount) //we are outside the grandparent's vft slots
                   break;
-               tempsuperVTable = (J9Method **)((char *)tempsuperCl + sizeof(J9Class));
-               tempsuperVTable+=2;
+
+               tempsuperVTable = J9VTABLE_FROM_HEADER(tempsuperVTableHeader);
                tempsuperVTable = tempsuperVTable + methodIndex;
                tempsuperMethod= *tempsuperVTable;
 

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1049,10 +1049,10 @@ Java_java_lang_Class_getVirtualMethodCountImpl(JNIEnv *env, jobject recv)
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	J9Class *clazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, J9_JNI_UNWRAP_REFERENCE(recv));
-	/* slot 0 contains size of vtable, slot 1 contains the unresolved method stub */
-	UDATA *vTable = (UDATA*)(clazz + 1);
-	UDATA count = vTable[0] - 1;
-	J9Method **vTableMethods = (J9Method**)(vTable + 2);
+
+	J9VTableHeader *vTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(clazz);
+	UDATA count = vTableHeader->size;
+	J9Method **vTableMethods = J9VTABLE_FROM_HEADER(vTableHeader);
 	/* assuming constant number of public final methods in java.lang.Object */
 	jint result = 6;
 	for (UDATA index = 0; index < count; ++index) {
@@ -1096,10 +1096,9 @@ Java_java_lang_Class_getVirtualMethodsImpl(JNIEnv *env, jobject recv, jobject ar
 
 	/* First walk the vTable */
 	{
-		/* slot 0 contains size of vtable, slot 1 contains the unresolved method stub */
-		UDATA *vTable = (UDATA*)(clazz + 1);
-		UDATA vTableSize = vTable[0] - 1;
-		J9Method **vTableMethods = (J9Method**)(vTable + 2);
+		J9VTableHeader *vTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(clazz);
+		UDATA vTableSize = vTableHeader->size;
+		J9Method **vTableMethods = J9VTABLE_FROM_HEADER(vTableHeader);
 		for (UDATA progress = 0; ((progress < vTableSize) && (numMethodFound < count)); ++progress) {
 			J9Method *currentMethod = vTableMethods[progress];
 			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(currentMethod);

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -301,4 +301,12 @@ static const struct { \
 #define J9_VM_FUNCTION_VIA_JAVAVM(javaVM, function) ((javaVM)->internalVMFunctions->function)
 #endif /* J9_INTERNAL_TO_VM */
 
+#define J9VTABLE_HEADER_FROM_RAM_CLASS(clazz) ((J9VTableHeader *)(((J9Class *)(clazz)) + 1))
+#define J9VTABLE_FROM_HEADER(vtableHeader) ((J9Method **)(((J9VTableHeader *)(vtableHeader)) + 1))
+#define J9VTABLE_FROM_RAM_CLASS(clazz) J9VTABLE_FROM_HEADER(J9VTABLE_HEADER_FROM_RAM_CLASS(clazz))
+#define J9VTABLE_OFFSET_FROM_INDEX(index) (sizeof(J9Class) + sizeof(J9VTableHeader) + ((index) * sizeof(UDATA)))
+
+/* Skip Interpreter VTable header */
+#define JIT_VTABLE_START_ADDRESS(clazz) ((UDATA *)(clazz) - (sizeof(J9VTableHeader) / sizeof(UDATA)))
+
 #endif /* J9_H */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3455,6 +3455,11 @@ typedef struct J9ITable {
 	struct J9ITable* next;
 } J9ITable;
 
+typedef struct J9VTableHeader {
+	UDATA size;
+	J9Method* initialVirtualMethod;
+} J9VTableHeader;
+
 typedef struct J9ClassCastParms {
 	struct J9Class* instanceClass;
 	struct J9Class* castClass;

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -932,12 +932,14 @@ static UDATA
 findMethodInVTable(J9Method *method, UDATA *vTable)
 {
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	UDATA vTableSize = *vTable;
-	UDATA searchIndex;
+	J9VTableHeader *vTableHeader = (J9VTableHeader *)vTable;
+	J9Method **vTableMethods = J9VTABLE_FROM_HEADER(vTableHeader);
+	UDATA vTableSize = vTableHeader->size;
+	UDATA searchIndex = 0;
 
 	/* Search the vTable for a public method of the correct name. */
-	for (searchIndex = 2; searchIndex <= vTableSize; searchIndex++) {
-		J9Method *vTableMethod = (J9Method *)vTable[searchIndex];
+	for (searchIndex = 0; searchIndex < vTableSize; searchIndex++) {
+		J9Method *vTableMethod = vTableMethods[searchIndex];
 		J9ROMMethod *vTableRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(vTableMethod);
 
 		if (vTableRomMethod->modifiers & J9_JAVA_PUBLIC) {
@@ -1001,11 +1003,11 @@ fixITablesForFastHCR(J9VMThread *currentThread, J9HashTable *classPairs)
 						result = hashTableFind(classPairs, &exemplar);
 						if ((NULL != result) && (NULL != result->methodRemap)) {
 							UDATA methodIndex;
-							UDATA *vTable = (UDATA *)(clazz + 1);
+							UDATA *vTableHeader = (UDATA *)J9VTABLE_HEADER_FROM_RAM_CLASS(clazz);
 	
 							for (methodIndex = 0; methodIndex < methodCount; methodIndex++) {
-								UDATA vTableIndex = findMethodInVTable(&interfaceClass->ramMethods[methodIndex], vTable);
-								iTableMethods[methodIndex] = (vTableIndex * sizeof(UDATA)) + sizeof(J9Class);
+								UDATA vTableIndex = findMethodInVTable(&interfaceClass->ramMethods[methodIndex], vTableHeader);
+								iTableMethods[methodIndex] = J9VTABLE_OFFSET_FROM_INDEX(vTableIndex);
 							}
 						}
 						iTableMethods += methodCount;
@@ -1163,8 +1165,10 @@ fixVTables_forNormalRedefine(J9VMThread *currentThread, J9HashTable *classPairs,
 	J9JVMTIClassPair * classPair;
 
 	UDATA i;
-	UDATA * oldVTable;
-	UDATA * newVTable;
+	J9VTableHeader * oldVTableHeader;
+	J9VTableHeader * newVTableHeader;
+	J9Method ** oldVTable;
+	J9Method ** newVTable;
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	UDATA * newJitVTable;
 	UDATA * oldJitVTable;
@@ -1187,18 +1191,18 @@ fixVTables_forNormalRedefine(J9VMThread *currentThread, J9HashTable *classPairs,
 
 		/* Walk the vtable and replace any old method pointer with a new one (redefined) */
 
-		oldVTable = (UDATA *) ((U_8 *) classPair->originalRAMClass + sizeof(J9Class));
+		oldVTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(classPair->originalRAMClass);
 		if (classPair->replacementClass.ramClass) {
-			newVTable = (UDATA *) ((U_8 *) classPair->replacementClass.ramClass + sizeof(J9Class));
+			newVTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(classPair->replacementClass.ramClass);
 		} else {
-			newVTable = oldVTable;
+			newVTableHeader = oldVTableHeader;
 		}
-		vTableSize = *oldVTable;
+		vTableSize = oldVTableHeader->size;
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
-		oldJitVTable = (UDATA *) ((U_8 *) classPair->originalRAMClass - sizeof(UDATA));
+		oldJitVTable = JIT_VTABLE_START_ADDRESS(classPair->originalRAMClass);
 		if (classPair->replacementClass.ramClass) {
-			newJitVTable = (UDATA *) ((U_8 *) classPair->replacementClass.ramClass - sizeof(UDATA));
+			newJitVTable = JIT_VTABLE_START_ADDRESS(classPair->replacementClass.ramClass);
 		} else {
 			newJitVTable = oldJitVTable;
 		}
@@ -1206,32 +1210,32 @@ fixVTables_forNormalRedefine(J9VMThread *currentThread, J9HashTable *classPairs,
 
 		/* Under fastHCR, fix the vTable in place for the redefined class. */
 		if (fastHCR && (0 != (classPair->flags & J9JVMTI_CLASS_PAIR_FLAG_REDEFINED))) {
-			newVTable = oldVTable;
+			newVTableHeader = oldVTableHeader;
 			newJitVTable = oldJitVTable;
 		}
 
 		Trc_hshelp_fixVTables_Shape(currentThread, vTableSize, getClassName(classPair->originalRAMClass));
 
-		/* Skip the first two slots containing vtable size and the resolve method */
+		oldVTable = J9VTABLE_FROM_HEADER(oldVTableHeader);
+		newVTable = J9VTABLE_FROM_HEADER(newVTableHeader);
 
-		for (i = 2; i <= vTableSize; i++) {
-
+		for (i = 0; i < vTableSize; i++) {
 			/* Given the old method, find the corresponding new method and replace
 			 * the old classes vtable entry (for the old method with the new method) */
 
-			methodPair.oldMethod = (J9Method *) oldVTable[i];
+			methodPair.oldMethod = oldVTable[i];
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 			Trc_hshelp_fixVTables_Search(currentThread, i,
 						classPair->replacementClass.ramClass ? classPair->replacementClass.ramClass : classPair->originalRAMClass,
 						methodPair.oldMethod, getMethodName(methodPair.oldMethod),
-						vm->jitConfig ? oldJitVTable[1 - i] : 0, vm->jitConfig ? newJitVTable[1 - i] : 0);
+						vm->jitConfig ? oldJitVTable[-i] : 0, vm->jitConfig ? newJitVTable[-i] : 0);
 #endif
 
 			result = hashTableFind(methodPairs, &methodPair);
 			if (result != NULL) {
 				/* Replace the old method pointer with the redefined one */
-				newVTable[i] = (UDATA) result->newMethod;
+				newVTable[i] = result->newMethod;
 				Trc_hshelp_fixVTables_intVTableReplace(currentThread, i);
 
 #ifdef J9VM_JIT_FULL_SPEED_DEBUG
@@ -1245,10 +1249,10 @@ fixVTables_forNormalRedefine(J9VMThread *currentThread, J9HashTable *classPairs,
 						 * We do not need to remap the order here because we're making the newVTable/newJitVTable
 						 * have the same order of the oldVTable/oldJitVTable.
 						 */
-						newJitVTable[1 - i] = oldJitVTable[1 - i];
+						newJitVTable[-i] = oldJitVTable[-i];
 						Trc_hshelp_fixVTables_jitVTableReplace(currentThread, i);
 					} else {
-						vmFuncs->fillJITVTableSlot(currentThread, &newJitVTable[1 - i], result->newMethod);
+						vmFuncs->fillJITVTableSlot(currentThread, &newJitVTable[-i], result->newMethod);
 					}
 				}
 #endif

--- a/runtime/util/resolvehelp.c
+++ b/runtime/util/resolvehelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,14 +68,15 @@ getMethodForSpecialSend(J9VMThread *vmStruct, J9Class *currentClass, J9Class *re
 					 * 3) Walk the current class vtable backwards to find the most "recent" override of that method
 					 * 4) Lookup the method at vtableIndex in currentClass's super class
 					 */
-					UDATA superVTableSize = (*(UDATA*)(superclass + 1) * sizeof(UDATA)) + sizeof(J9Class);
+					J9VTableHeader * superVTable = J9VTABLE_HEADER_FROM_RAM_CLASS(superclass);
+					UDATA superVTableEnd = J9VTABLE_OFFSET_FROM_INDEX(superVTable->size);
 					method = *(J9Method **)(((UDATA)currentClass) + vTableIndex);
 					vTableIndex = vmFuncs->getVTableIndexForMethod(method, currentClass, vmStruct);
 					/* We may have looked up a J9Method from an interface due to either defender methods
 					 * or the method not being implemented in the class.  If that's the case, we need
 					 * to ensure we don't read a non-existent vtable slot.  The found method is the correct one
 					 */
-					if ((vTableIndex > 0) && (vTableIndex <= superVTableSize)) {
+					if ((vTableIndex > 0) && (vTableIndex < superVTableEnd)) {
 						method = *(J9Method **)(((UDATA)superclass) + vTableIndex);
 					}
 				} else {

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -267,19 +267,20 @@ addITableMethods(J9VMThread* vmStruct, J9Class *ramClass, J9Class *interfaceClas
 	J9ROMClass *interfaceRomClass = interfaceClass->romClass;
 	UDATA count = interfaceRomClass->romMethodCount;
 	if (count != 0) {
-		UDATA *vTable = (UDATA *)(ramClass + 1);
-		UDATA vTableSize = *vTable;
+		J9VTableHeader *vTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(ramClass);
+		UDATA vTableSize = vTableHeader->size;
+		J9Method **vTable = J9VTABLE_FROM_HEADER(vTableHeader);
 		J9Method *interfaceRamMethod = interfaceClass->ramMethods;
 		while (count-- > 0) {
 			J9ROMMethod *interfaceRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(interfaceRamMethod);
 			J9UTF8 *interfaceMethodName = J9ROMMETHOD_NAME(interfaceRomMethod);
 			J9UTF8 *interfaceMethodSig = J9ROMMETHOD_SIGNATURE(interfaceRomMethod);
 			UDATA vTableIndex = 0;
-			UDATA searchIndex = 2;
+			UDATA searchIndex = 0;
 			
 			/* Search the vTable for a public method of the correct name. */
-			while (searchIndex <= vTableSize) {
-				J9Method *vTableRamMethod = (J9Method *)vTable[searchIndex];
+			while (searchIndex < vTableSize) {
+				J9Method *vTableRamMethod = vTable[searchIndex];
 				J9ROMMethod *vTableRomMethod = J9_ROM_METHOD_FROM_RAM_METHOD(vTableRamMethod);
 				J9UTF8 *vTableMethodName = J9ROMMETHOD_NAME(vTableRomMethod);
 				J9UTF8 *vTableMethodSig = J9ROMMETHOD_SIGNATURE(vTableRomMethod);
@@ -290,7 +291,7 @@ addITableMethods(J9VMThread* vmStruct, J9Class *ramClass, J9Class *interfaceClas
 					&& (memcmp(J9UTF8_DATA(interfaceMethodName), J9UTF8_DATA(vTableMethodName), J9UTF8_LENGTH(vTableMethodName)) == 0)
 					&& (memcmp(J9UTF8_DATA(interfaceMethodSig), J9UTF8_DATA(vTableMethodSig), J9UTF8_LENGTH(vTableMethodSig)) == 0)
 					) {
-						vTableIndex = (searchIndex * sizeof(UDATA))	+ sizeof(J9Class);
+						vTableIndex = J9VTABLE_OFFSET_FROM_INDEX(searchIndex);
 						break;
 					}
 				}
@@ -425,6 +426,7 @@ typedef enum {
 static UDATA
 addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *interfaceClass, UDATA vTableWriteIndex, UDATA *vTableAddress, J9Class *superclass, J9ROMClass *romClass, UDATA *defaultConflictCount, J9Pool *equivalentSets, UDATA *equivSetCount, J9OverrideErrorData *errorData)
 {
+	J9Method **vTableMethods = J9VTABLE_FROM_HEADER(vTableAddress);
 	J9ROMClass *interfaceROMClass = interfaceClass->romClass;
 	UDATA count = interfaceROMClass->romMethodCount;
 	if (0 != count) {
@@ -445,10 +447,13 @@ addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *i
 				/* If the vTable already has a public declaration of the method that isn't
 				 * either an abstract interface method or default method conflict, do not
 				 * process the interface method at all. */
-				while (tempIndex > 1) {
+				while (tempIndex > 0) {
+					/* Decrement the index, convert from one based to zero based index */
+					tempIndex -= 1;
+
 					J9ROMClass *methodROMClass = NULL;
 					J9Class *methodClass = NULL;
-					J9ROMMethod *vTableMethod = (J9ROMMethod *)vTableAddress[tempIndex];
+					J9ROMMethod *vTableMethod = (J9ROMMethod *)vTableMethods[tempIndex];
 
 					if (ROM_METHOD_ID_TAG == ((UDATA)vTableMethod & VTABLE_SLOT_TAG_MASK)) {
 						methodClass = NULL;
@@ -492,7 +497,7 @@ addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *i
 							/* conflict detected when building the superclass vtable.  Replace with current interface method
 							 * and allow the conflict to be re-detected if it hasn't been resolved by subsequent interfaces
 							 */
-							vTableAddress[tempIndex] = (UDATA)interfaceMethod;
+							vTableMethods[tempIndex] = interfaceMethod;
 							goto continueInterfaceScan;
 						case SLOT_IS_INTERFACE_RAM_METHOD:
 							/* Here we need to determine if this is a potential conflict or equivalent set */
@@ -501,7 +506,7 @@ addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *i
 								 * was filled in by the super class's vtable build.  Replace with the current method
 								 * and continue.
 								 */
-								vTableAddress[tempIndex] = (UDATA)interfaceMethod;
+								vTableMethods[tempIndex] = interfaceMethod;
 								goto continueInterfaceScan;
 							} else {
 								/* Locally added interface method - look for either a merge, conflict or equivSet */
@@ -519,16 +524,16 @@ addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *i
 											/* OOM will be thrown */
 											goto fail;
 										}
-										entry->method = (J9Method *)vTableAddress[tempIndex];
+										entry->method = vTableMethods[tempIndex];
 										entry->next = NULL;
-										vTableAddress[tempIndex] = (UDATA)entry | EQUIVALENT_SET_ID_TAG;
+										vTableMethods[tempIndex] = (J9Method *)((UDATA)entry | EQUIVALENT_SET_ID_TAG);
 										/* This will either be the single default method or the first abstract method */
 										/* ... and then adding the new method */
 										*equivSetCount += 1;
 										goto add_existing;
 									} else {
 										/* Conflict detected */
-										vTableAddress[tempIndex] |= DEFAULT_CONFLICT_METHOD_ID_TAG;
+										vTableMethods[tempIndex] = (J9Method *)((UDATA)vTableMethods[tempIndex] | DEFAULT_CONFLICT_METHOD_ID_TAG);
 										*defaultConflictCount += 1;
 									}
 								}
@@ -536,7 +541,7 @@ addInterfaceMethods(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *i
 							break;
 						case SLOT_IS_EQUIVSET_TAG: {
 add_existing:
-							J9EquivalentEntry * existing_entry = (J9EquivalentEntry*)((UDATA)vTableAddress[tempIndex] & ~EQUIVALENT_SET_ID_TAG);
+							J9EquivalentEntry * existing_entry = (J9EquivalentEntry*)((UDATA)vTableMethods[tempIndex] & ~EQUIVALENT_SET_ID_TAG);
 							J9EquivalentEntry * previous_entry = existing_entry;
 							while (NULL != existing_entry) {
 								if (isSameOrSuperInterfaceOf(interfaceClass, J9_CLASS_FROM_METHOD(existing_entry->method))) {
@@ -593,10 +598,9 @@ add_existing:
 							goto continueInterfaceScan;
 						}
 					}
-					tempIndex -= 1;
 				}
 				/* Add the interface method as the Local class does not implement a public method of the given name. */
-				vTableWriteIndex = growNewVTableSlot(vTableAddress, vTableWriteIndex, interfaceMethod);
+				vTableWriteIndex = growNewVTableSlot((UDATA *)vTableMethods, vTableWriteIndex, interfaceMethod);
 #if defined(J9VM_TRACE_VTABLE_ACCESS)
 				{
 					PORT_ACCESS_FROM_VMC(vmStruct);
@@ -617,7 +621,7 @@ continueInterfaceScan:
 done:
 	return vTableWriteIndex;
 fail:
-	vTableWriteIndex = 0;
+	vTableWriteIndex = (UDATA)-1;
 	goto done;
 }
 
@@ -649,14 +653,15 @@ interfaceDepthCompare(const void *a, const void *b)
  * 		C) Converted to a 'default conflict method'
  * @param[in] vmStruct The J9VMThread
  * @param[in,out] defaultConflictCount The count of conflict methods.  Possibly updated
- * @param[in] vTableWriteIndex The last written vtable index
+ * @param[in] vTableWriteIndex The number of methods in vtable
  * @param[in] vTableAddress The vtable itself
  */
 static void
 processEquivalentSets(J9VMThread *vmStruct, UDATA *defaultConflictCount, UDATA vTableWriteIndex, UDATA *vTableAddress)
 {
-	for (UDATA i = 1; i <= vTableWriteIndex; i++) {
-		UDATA slotValue = vTableAddress[i];
+	UDATA *vTableMethods = (UDATA *)J9VTABLE_FROM_HEADER(vTableAddress);
+	for (UDATA i = 0; i < vTableWriteIndex; i++) {
+		UDATA slotValue = vTableMethods[i];
 
 		if (EQUIVALENT_SET_ID_TAG == (slotValue & VTABLE_SLOT_TAG_MASK)) {
 			/* Process set and determine if there is a method that satisifies or if this is a conflict */
@@ -667,7 +672,7 @@ processEquivalentSets(J9VMThread *vmStruct, UDATA *defaultConflictCount, UDATA v
 				if (J9_ARE_NO_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(entry->method)->modifiers, J9_JAVA_ABSTRACT)) {
 					if (foundNonAbstract) {
 						/* Two non-abstract methods -> conflict */
-						vTableAddress[i] = ((UDATA)entry->method | DEFAULT_CONFLICT_METHOD_ID_TAG);
+						vTableMethods[i] = ((UDATA)entry->method | DEFAULT_CONFLICT_METHOD_ID_TAG);
 						*defaultConflictCount += 1;
 						goto continueProcessingVTable;
 					}
@@ -677,7 +682,7 @@ processEquivalentSets(J9VMThread *vmStruct, UDATA *defaultConflictCount, UDATA v
 				entry = entry->next;
 			}
 			/* This will either be the single default method or the first abstract method */
-			vTableAddress[i] = (UDATA)candidate;
+			vTableMethods[i] = (UDATA)candidate;
 		}
 
 continueProcessingVTable: ;
@@ -729,17 +734,14 @@ computeVTable(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *supercl
 		/* All methods in the current class might need new slots in the vTable. */
 		maxSlots = romClass->romMethodCount;
 		
-		/* Add in all slots from the superclass. */
-		if (superclass == NULL) {
-			/* reserved method slot */
-			maxSlots += 1;
-		} else {
-			UDATA *superVTable = (UDATA *)(superclass + 1);
-			maxSlots += *superVTable;
+		/* Add in all real method slots from the superclass. */
+		if (superclass != NULL) {
+			J9VTableHeader *superVTable = J9VTABLE_HEADER_FROM_RAM_CLASS(superclass);
+			maxSlots += superVTable->size;
 		}
 		
-		/* size field */
-		maxSlots += 1;
+		/* header slots */
+		maxSlots += (sizeof(J9VTableHeader) / sizeof(UDATA));
 
 		/* For non-array classes, compute the total possible size of implementing all interface methods. */
 		if (J9ROMCLASS_IS_ARRAY(romClass) == 0) {
@@ -757,7 +759,7 @@ computeVTable(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *supercl
 	
 #if defined(J9VM_INTERP_HOT_CODE_REPLACEMENT)
 	if (taggedClass != romClass) {
-		vTableAddress = (UDATA *)((J9Class *)taggedClass + 1);
+		vTableAddress = (UDATA *)J9VTABLE_HEADER_FROM_RAM_CLASS(taggedClass);
 	}
 #endif
 	
@@ -772,21 +774,22 @@ computeVTable(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *supercl
 
 	if (NULL != vTableAddress) {
 		UDATA vTableWriteIndex = 0;
+		J9VTableHeader *vTableHeader = (J9VTableHeader *)vTableAddress;
 
+		/* Write size of 0 */
 		if (J9_JAVA_INTERFACE == (romClass->modifiers & J9_JAVA_INTERFACE)) {
-			*vTableAddress = 0;
+			vTableHeader->size = 0;
 			goto done;
 		}
 
 		if (superclass == NULL) {
-			/* no inherited slots, 1 default slot */
-			vTableWriteIndex = 1;
-			vTableAddress[1] = (UDATA)vm->initialMethods.initialVirtualMethod;
+			/* no inherited slots, write default slot in header */
+			vTableHeader->initialVirtualMethod = (J9Method *)vm->initialMethods.initialVirtualMethod;
 		} else {
-			UDATA *superVTable = (UDATA *)(superclass + 1);
-			vTableWriteIndex = *superVTable;
+			J9VTableHeader *superVTable = J9VTABLE_HEADER_FROM_RAM_CLASS(superclass);
+			vTableWriteIndex = superVTable->size;
 			/* + 1 to account for size slot */
-			memcpy(vTableAddress, superVTable, (vTableWriteIndex + 1) * sizeof(UDATA));
+			memcpy(vTableAddress, superVTable, ((vTableWriteIndex * sizeof(UDATA)) + sizeof(J9VTableHeader)));
 		}
 		
 		if (J9ROMCLASS_IS_ARRAY(romClass) == 0) {
@@ -815,7 +818,7 @@ computeVTable(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *supercl
 					) {
 						vTableWriteIndex = processVTableMethod(vmStruct, classLoader, vTableAddress, superclass, romClass, romMethod,
 								packageID, vTableWriteIndex, (J9ROMMethod *)((UDATA)romMethod + ROM_METHOD_ID_TAG), errorData);
-						if (0 == vTableWriteIndex) {
+						if ((UDATA)-1 == vTableWriteIndex) {
 							goto fail;
 						}
 					}
@@ -889,7 +892,7 @@ computeVTable(J9VMThread *vmStruct, J9ClassLoader *classLoader, J9Class *supercl
 					}
 #endif /* VERBOSE_INTERFACE_METHODS */
 					vTableWriteIndex = addInterfaceMethods(vmStruct, classLoader, interfaces[i - 1], vTableWriteIndex, vTableAddress, superclass, romClass, defaultConflictCount, equivalentSet, &equivSetCount, errorData);
-					if (0 == vTableWriteIndex) {
+					if ((UDATA)-1 == vTableWriteIndex) {
 						if (NULL != equivalentSet) {
 							pool_kill(equivalentSet);
 						}
@@ -932,9 +935,11 @@ fail:
 static void
 copyVTable(J9VMThread *vmStruct, J9Class *ramClass, J9Class *superclass, UDATA *vTable, UDATA defaultConflictCount)
 {
-	UDATA superCount;
+	UDATA superCount = 0;
 	UDATA count;
-	UDATA *vTableAddress;
+	J9VTableHeader *vTableAddress;
+	J9Method **sourceVTable;
+	J9Method **newVTable;
 	UDATA index;
 	J9Method *ramMethods = ramClass->ramMethods;
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)
@@ -951,19 +956,21 @@ copyVTable(J9VMThread *vmStruct, J9Class *ramClass, J9Class *superclass, UDATA *
 	}
 #endif
 	
-	/* skip the virtualMethodResolve pseudo-method */
-	superCount = 1;
 	if (superclass != NULL) {
 		/* add superclass vtable size */
-		superCount += *((UDATA *)(superclass + 1));
+		superCount = J9VTABLE_HEADER_FROM_RAM_CLASS(superclass)->size;
 	}
 	
-	count = *vTable;
-	vTableAddress = (UDATA *)(ramClass + 1);
-	*vTableAddress = count;
-	/* start at 1 to skip the size field */
-	for (index = 1; index <= count; index++) {
-		J9Method *vTableMethod = (J9Method *)vTable[index];
+	count = ((J9VTableHeader *)vTable)->size;
+	vTableAddress = J9VTABLE_HEADER_FROM_RAM_CLASS(ramClass);
+	vTableAddress->size = count;
+	vTableAddress->initialVirtualMethod = ((J9VTableHeader *)vTable)->initialVirtualMethod;
+
+	sourceVTable = J9VTABLE_FROM_HEADER(vTable);
+	newVTable = J9VTABLE_FROM_HEADER(vTableAddress);
+
+	for (index = 0; index < count; index++) {
+		J9Method *vTableMethod = sourceVTable[index];
 		UDATA temp = (UDATA)vTableMethod;
 		
 		if (ROM_METHOD_ID_TAG == (temp & VTABLE_SLOT_TAG_MASK)) {
@@ -1007,12 +1014,12 @@ found:
 			conflictMethodPtr++;
 		}
 		
-		vTableAddress[index] = (UDATA)vTableMethod;
+		newVTable[index] = vTableMethod;
 		/* once we've walked the inherited entries, we can optimize the ramMethod search
 		 * by remembering where the search ended last time. Since the methods occur in
 		 * order in the VTable, we can start searching at the previous method
 		 */
-		if (index > superCount) {
+		if (index >= superCount) {
 			ramMethods = vTableMethod;
 		}
 	}
@@ -1021,38 +1028,35 @@ found:
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)
 	jitConfig = vmStruct->javaVM->jitConfig;
 	if (jitConfig != NULL) {
-		UDATA *vTableWriteCursor = &((UDATA *)ramClass)[-1];
-		UDATA vTableWriteIndex = *vTableAddress;
-		UDATA *vTableReadCursor;
+		UDATA *vTableWriteCursor = JIT_VTABLE_START_ADDRESS(ramClass);
+
+		/* only copy in the real methods */
+		UDATA vTableWriteIndex = vTableAddress->size;
+		J9Method **vTableReadCursor;
 		if (vTableWriteIndex != 0) {
-			/* do not copy in the default method */
-			vTableWriteIndex--;
 			if ((jitConfig->runtimeFlags & J9JIT_TOSS_CODE) != 0) {
 				vTableWriteCursor -= vTableWriteIndex;
 			} else {
 				UDATA superVTableSize;
-				UDATA *superVTableReadCursor;
-				UDATA *superVTableWriteCursor = &((UDATA *)superclass)[-1];
+				J9Method **superVTableReadCursor;
+				UDATA *superVTableWriteCursor = JIT_VTABLE_START_ADDRESS(superclass);
 				if (superclass == NULL) {
 					superVTableReadCursor = NULL;
 					superVTableSize = 0;
 				} else {
-					superVTableReadCursor = (UDATA *)(superclass + 1);
-					superVTableSize = *superVTableReadCursor;
-					/* do not copy in the default method */
-					superVTableSize--;
+					superVTableReadCursor = (J9Method **)J9VTABLE_HEADER_FROM_RAM_CLASS(superclass);
+					superVTableSize = ((J9VTableHeader *)superVTableReadCursor)->size;
+					/* initialize pointer to first real vTable method */
+					superVTableReadCursor = J9VTABLE_FROM_HEADER(superVTableReadCursor);
 				}
 				/* initialize pointer to first real vTable method */
-				superVTableReadCursor = &superVTableReadCursor[2];
-				/* initialize pointer to first real vTable method */
-				vTableReadCursor = &vTableAddress[2];
+				vTableReadCursor = J9VTABLE_FROM_HEADER(vTableAddress);
 				for (; vTableWriteIndex > 0; vTableWriteIndex--) {
-					J9Method *currentMethod = (J9Method *)*vTableReadCursor++;
-					superVTableWriteCursor--;
-					if (superclass != NULL && currentMethod == (J9Method *)*superVTableReadCursor) {
-						*--vTableWriteCursor = *superVTableWriteCursor;
+					J9Method *currentMethod = *vTableReadCursor;
+					if (superclass != NULL && currentMethod == *superVTableReadCursor) {
+						*vTableWriteCursor = *superVTableWriteCursor;
 					} else {
-						fillJITVTableSlot(vmStruct, --vTableWriteCursor, currentMethod);
+						fillJITVTableSlot(vmStruct, vTableWriteCursor, currentMethod);
 					}
 
 					/* Always consume an entry from the super vTable.  Note that once the size hits zero and superclass becomes NULL,
@@ -1065,9 +1069,11 @@ found:
 						superclass = NULL;
 					}
 					superVTableReadCursor++;
+					superVTableWriteCursor--;
+					vTableReadCursor++;
+					vTableWriteCursor--;
 				}
 			}
-			vTableWriteCursor--;
 		}
 		
 		/* The SRP to the start of the RAM class is written by internalAllocateRAMClass() */
@@ -1075,7 +1081,7 @@ found:
 #endif
 	
 #if defined(J9VM_INTERP_HOT_CODE_REPLACEMENT)
-	if (vTable != vTableAddress) {
+	if (vTable != (UDATA *)vTableAddress) {
 		if (vTable != vmStruct->javaVM->vTableScratch) {
 			j9mem_free_memory(vTable);
 		}
@@ -1154,25 +1160,27 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 
 	/* Private methods do not appear in the vTable or take part in any overriding decision */
 	if (J9_ARE_NO_BITS_SET(newModifiers, J9_JAVA_PRIVATE)) {
+		UDATA *vTableMethods = (UDATA *)J9VTABLE_FROM_HEADER(vTableAddress);
 		J9UTF8 *nameUTF = J9ROMMETHOD_NAME(romMethod);
 		J9UTF8 *sigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 		UDATA newSlotRequired = TRUE;
 
 		if (NULL != superclass) {
-			UDATA *superclassVTable = (UDATA *)(superclass + 1);
-			UDATA superclassVTableIndex = *superclassVTable;
+			J9VTableHeader *superclassVTable = J9VTABLE_HEADER_FROM_RAM_CLASS(superclass);
+			UDATA *superclassVTableMethods = (UDATA *)J9VTABLE_FROM_HEADER(superclassVTable);
+			UDATA superclassVTableIndex = superclassVTable->size;
 
 			if (methodIsFinalInObject(J9UTF8_LENGTH(nameUTF), J9UTF8_DATA(nameUTF), J9UTF8_LENGTH(sigUTF), J9UTF8_DATA(sigUTF))) {
 				vmThread->tempSlot = (UDATA)romMethod;
 			}
 
 			/* See if this method overrides any methods from any superclass. */
-			while ((superclassVTableIndex = getVTableIndexForNameAndSigStartingAt(superclassVTable, nameUTF, sigUTF,
-					superclassVTableIndex)) != 0)
+			while ((superclassVTableIndex = getVTableIndexForNameAndSigStartingAt(superclassVTableMethods, nameUTF, sigUTF,
+					superclassVTableIndex)) != (UDATA)-1)
 			{
 				UDATA overridden = FALSE;
 				/* fetch vTable entry */
-				J9Method *superclassVTableMethod = (J9Method *)superclassVTable[superclassVTableIndex];
+				J9Method *superclassVTableMethod = (J9Method *)superclassVTableMethods[superclassVTableIndex];
 				J9Class *superclassVTableMethodClass = J9_CLASS_FROM_METHOD(superclassVTableMethod);
 				J9ROMMethod *superclassVTableROMMethod = J9_ROM_METHOD_FROM_RAM_METHOD(superclassVTableMethod);
 				UDATA modifiers = superclassVTableROMMethod->modifiers;
@@ -1180,12 +1188,13 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 				/* Look at the vTable of each superclass, not just the immediate one */
 				J9Class *currentSuperclass = superclass;
 				do {
-					UDATA *currentSuperclassVTable = (UDATA *)(currentSuperclass + 1);
+					J9VTableHeader *currentSuperclassVTable = J9VTABLE_HEADER_FROM_RAM_CLASS(currentSuperclass);
 					/* Stop the search if the superclass does not contain an entry at the search index */
-					if (currentSuperclassVTable[0] < superclassVTableIndex) {
+					if (currentSuperclassVTable->size <= superclassVTableIndex) {
 						break;
 					}
-					J9Method *currentSuperclassVTableMethod = (J9Method *)currentSuperclassVTable[superclassVTableIndex];
+					J9Method **currentSuperVTableMethods = J9VTABLE_FROM_HEADER(currentSuperclassVTable);
+					J9Method *currentSuperclassVTableMethod = currentSuperVTableMethods[superclassVTableIndex];
 					J9Class *currentSuperclassVTableMethodClass = J9_CLASS_FROM_METHOD(currentSuperclassVTableMethod);
 					J9ROMMethod *currentSuperclassVTableROMMethod = J9_ROM_METHOD_FROM_RAM_METHOD(currentSuperclassVTableMethod);
 					UDATA currentSuperclassModifiers = currentSuperclassVTableROMMethod->modifiers;
@@ -1208,7 +1217,7 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 				} while(NULL != currentSuperclass);
 				if (overridden) {
 					if ((((UDATA)storeValue & VTABLE_SLOT_TAG_MASK) == ROM_METHOD_ID_TAG)
-						|| (vTableAddress[superclassVTableIndex] == (UDATA)superclassVTableMethod)
+						|| (vTableMethods[superclassVTableIndex] == (UDATA)superclassVTableMethod)
 					) {
 						if ((modifiers & J9_JAVA_FINAL) == J9_JAVA_FINAL) {
 							vmThread->tempSlot = (UDATA)romMethod;
@@ -1228,11 +1237,11 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 								errorData->exceptionClassNameUTF = superclassVTableMethodClassNameUTF;
 								errorData->methodNameUTF = superclassVTableMethodNameUTF;
 								errorData->methodSigUTF = superclassVTableMethodSigUTF;
-								vTableWriteIndex = 0;
+								vTableWriteIndex = (UDATA)-1;
 								goto done;
 							}
 						}
-						vTableAddress[superclassVTableIndex] = (UDATA)storeValue;
+						vTableMethods[superclassVTableIndex] = (UDATA)storeValue;
 #if defined(J9VM_TRACE_VTABLE_ACCESS)
 						{
 							PORT_ACCESS_FROM_VMC(vmThread);
@@ -1258,8 +1267,9 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 #endif
 					}
 				}
-				/* Keep checking the rest of the methods in the superclass. */
-				superclassVTableIndex--;
+				/* Keep checking the rest of the methods in the superclass.
+				 * no need to decrease as the search result is zero based and search input is 1 based
+				 */
 			}
 		}
 
@@ -1271,7 +1281,7 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 		/* If the method requires a new slot in the vTable, allocate it */
 		if (newSlotRequired) {
 			/* allocate vTable slot */
-			vTableWriteIndex = growNewVTableSlot(vTableAddress, vTableWriteIndex, storeValue);
+			vTableWriteIndex = growNewVTableSlot(vTableMethods, vTableWriteIndex, storeValue);
 #if defined(J9VM_TRACE_VTABLE_ACCESS)
 			{
 				PORT_ACCESS_FROM_VMC(vmThread);
@@ -1290,17 +1300,17 @@ done:
  * Grow the VTable by 1 slot and add 'storeValue' to that slot.
  *
  * @param vTableAddress[in] A pointer to the buffer that holds the vtable (must be correctly sized)
- * @param vTableWriteIndex[in] The highest used index in the vtable
+ * @param vTableWriteIndex[in] The number of method currently in the vtable
  * @param storeValue[in] the value to store into the vtable slot - either a J9Method* or a tagged J9ROMMethod
  * @return The new vTableWriteIndex
  */
 static VMINLINE UDATA
 growNewVTableSlot(UDATA *vTableAddress, UDATA vTableWriteIndex, void *storeValue)
 {
-	/* allocate vTable slot */
-	vTableWriteIndex++;
 	/* fill in vtable, add new entry */
 	vTableAddress[vTableWriteIndex] = (UDATA)storeValue;
+	vTableWriteIndex += 1;
+
 	return vTableWriteIndex;
 }
 
@@ -1312,7 +1322,10 @@ getVTableIndexForNameAndSigStartingAt(UDATA *vTable, J9UTF8 *name, J9UTF8 *signa
 	U_8 *signatureData = J9UTF8_DATA(signature);
 	UDATA signatureLength = J9UTF8_LENGTH(signature);
 
-	while (vTableIndex != 1) {
+	while (vTableIndex != 0) {
+		/* The vTableIndex passed in is 1 based, converting it to zero based search index */
+		/* move to previous vTable index */
+		vTableIndex--;
 		/* fetch next vTable entry */
 		J9Method *method = (J9Method *)vTable[vTableIndex];
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
@@ -1325,10 +1338,8 @@ getVTableIndexForNameAndSigStartingAt(UDATA *vTable, J9UTF8 *name, J9UTF8 *signa
 		) {
 			return vTableIndex;
 		}
-		/* move to previous vTable index */
-		vTableIndex--;
 	}
-	return 0;
+	return (UDATA)-1;
 }
 
 UDATA
@@ -1340,30 +1351,33 @@ getVTableIndexForMethod(J9Method * method, J9Class *clazz, J9VMThread *vmThread)
 
 	/* If this method came from an interface class, handle it specially. */
 	if ((modifiers & J9_JAVA_INTERFACE) == J9_JAVA_INTERFACE) {
-		UDATA *vTable = (UDATA *)(clazz + 1);
-		UDATA vTableSize = *vTable;
+		J9VTableHeader *vTable = J9VTABLE_HEADER_FROM_RAM_CLASS(clazz);
+		UDATA vTableSize = vTable->size;
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 		J9UTF8 *nameUTF = J9ROMMETHOD_NAME(romMethod);
 		J9UTF8 *sigUTF = J9ROMMETHOD_SIGNATURE(romMethod);
 		if (vTableSize == 0) {
 			return 0;
 		} else {
-			vTableIndex = getVTableIndexForNameAndSigStartingAt(vTable, nameUTF, sigUTF, vTableSize);
-			if (vTableIndex != 0) {
-				return (vTableIndex * sizeof(UDATA)) + sizeof(J9Class);
+			vTableIndex = getVTableIndexForNameAndSigStartingAt((UDATA *)J9VTABLE_FROM_HEADER(vTable), nameUTF, sigUTF, vTableSize);
+			if (vTableIndex != (UDATA)-1) {
+				return J9VTABLE_OFFSET_FROM_INDEX(vTableIndex);
 			}
 		}
 	} else {
 		/* Iterate over the vtable from the end to the beginning, skipping 
-		 * the "magic" first entry.  This ensures that the most "recent" override of the
+		 * the "magic" header entries.  This ensures that the most "recent" override of the
 		 * method is found first.  Critically important for super sends 
 		 * ie: invokespecial) being correct
 		 */
-		UDATA *vTable = (UDATA *)(methodClass + 1);
-		UDATA vTableSize = *vTable;
-		for (vTableIndex = vTableSize; vTableIndex > 1; vTableIndex--) {
-			if (method == (J9Method *)vTable[vTableIndex]) {
-				return (vTableIndex * sizeof(UDATA)) + sizeof(J9Class);
+		J9VTableHeader *vTable = J9VTABLE_HEADER_FROM_RAM_CLASS(methodClass);
+		J9Method **vTableMethods = J9VTABLE_FROM_HEADER(vTable);
+		UDATA vTableIndex = vTable->size;
+
+		while (vTableIndex > 0) {
+			vTableIndex--;
+			if (method == vTableMethods[vTableIndex]) {
+				return J9VTABLE_OFFSET_FROM_INDEX(vTableIndex);
 			}
 		}
 	}
@@ -2025,9 +2039,9 @@ fail:
 				}
 				return internalCreateRAMClassDoneNoMutex(vmThread, romClass, options, state);
 			}
-			vTableSlots = *vTable;
-			/* account for size slot */
-			vTableSlots++;
+			vTableSlots = ((J9VTableHeader *)vTable)->size;
+			/* account for header slots */
+			vTableSlots += (sizeof(J9VTableHeader) / sizeof(UDATA));
 			/* If there is a bad methods, vmThread->tempSlot will be set by computeVTable() - yuck! */
 			badMethod = (J9ROMMethod *)vmThread->tempSlot;
 		}

--- a/runtime/vmchk/checkmethods.c
+++ b/runtime/vmchk/checkmethods.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,12 +116,12 @@ static BOOLEAN
 findMethodInVTable(J9Method *method, J9Class *clazz)
 {
 	UDATA vTableIndex;
-	UDATA *vTable = (UDATA *)(clazz + 1);
-	UDATA vTableSize = DBG_STAR(vTable);
+	J9VTableHeader *vTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(clazz);
+	UDATA vTableSize = vTableHeader->size;
+	J9Method **vTable = J9VTABLE_FROM_HEADER(vTableHeader);
 
-	/* skip magic first entry */
-	for (vTableIndex = 2; vTableIndex <= vTableSize; vTableIndex++) {
-		if (method == (J9Method *)DBG_INDEX(vTable, vTableIndex)) {
+	for (vTableIndex = 0; vTableIndex < vTableSize; vTableIndex++) {
+		if (method == vTable[vTableIndex]) {
 			return TRUE;
 		}
 	}


### PR DESCRIPTION
- add vTable Header structure
- update vtable indexing to be zero based
- modify vtable size field to hold the real method count
- add macro for getting JIT vtable start address
- switch all vtable variable assignment to use new macros
- calculate vtable offset dynamically based on header size
- changed default vtable type to <J9Method**>
- removed old comments on magic indexes

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>