### PR TITLE
Fix recognition of hashCode function on Power

### DIFF
--- a/runtime/compiler/env/ProcessorDetection.cpp
+++ b/runtime/compiler/env/ProcessorDetection.cpp
@@ -562,6 +562,16 @@ TR_J9VMBase::getPPCProcessorType()
    return portLibCall_getProcessorType();
    }
 
+bool
+TR_J9VMBase::getPPCSupportsVSXRegisters()
+   {
+#if defined(TR_TARGET_POWER)
+   return TR::Compiler->target.cpu.getPPCSupportsVSX();
+#else
+   return false;
+#endif // TR_TARGET_POWER
+   }
+
 // -----------------------------------------------------------------------------
 
 extern TR_X86CPUIDBuffer *queryX86TargetCPUID(void * javaVM);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -273,6 +273,7 @@ public:
    static TR_J9VMBase * get(J9JITConfig *, J9VMThread *, VM_TYPE vmType=DEFAULT_VM);
    static char *getJ9FormattedName(J9JITConfig *, J9PortLibrary *, char *, int32_t, char *, char *, bool suffix=false);
    static TR_Processor getPPCProcessorType();
+   virtual bool getPPCSupportsVSXRegisters();
    static void initializeX86ProcessorInfo(J9JITConfig *);
 
    static bool isBigDecimalClass(J9UTF8 * className);

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12112,7 +12112,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          return true;
 
       case TR::java_lang_String_hashCodeImplDecompressed:
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX() && !cg->comp()->compileRelocatableCode())
+         if (!TR::Compiler->om.canGenerateArraylets() && TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX() && !cg->comp()->compileRelocatableCode())
             {
             resultReg = inlineStringHashcode(node, cg);
             return true;


### PR DESCRIPTION
This change set fixes two issues related to recognizing the function
hashCodeImplDecompressed for String on Power.

The first issue is sometimes hashCodeImplDecompressed would get inlined.
This prevents the function for being recognized and replaced with hand
optimized assembly. This is being changed so that the function does not
get inlined if the JIT thinks it will be able to replace it with the
assembly later on.

The second issue is the hand optimized assembly for
hashCodeImplDecompressed does not work with arraylets. This was not being
checked for before and could lead to an incorrect result. This is being
changed to check if the generation of arraylets is possible. If so, the
JIT will not try to use the hand optimized assembly.

Issue: #2410
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>