### PR TITLE
Add JProfilingRecompLoopTest.cpp to CMakeLists.txt

### DIFF
--- a/runtime/compiler/optimizer/CMakeLists.txt
+++ b/runtime/compiler/optimizer/CMakeLists.txt
@@ -46,6 +46,7 @@ j9jit_files(
 	optimizer/J9ValuePropagation.cpp
 	optimizer/JProfilingBlock.cpp
 	optimizer/JProfilingValue.cpp
+   optimizer/JProfilingRecompLoopTest.cpp
 	optimizer/JitProfiler.cpp
 	optimizer/LiveVariablesForGC.cpp
 	optimizer/LoopAliasRefiner.cpp


### PR DESCRIPTION
Add JProfilingRecompLoopTest.cpp to CMakeLists.txt that fixes recent failures in CMake builds. 

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>