### PR TITLE
Replace DataSnippet type with auto on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -253,7 +253,7 @@ J9::X86::CodeGenerator::beginInstructionSelection()
    //
    if (self()->enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR::IA32ConstantDataSnippet * cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
+      auto cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, startNode, generateX86MemoryReference(cds, self()), self());
       }
    }
@@ -278,7 +278,7 @@ J9::X86::CodeGenerator::endInstructionSelection()
       TR_ASSERT(self()->getLastCatchAppendInstruction(),
              "endInstructionSelection() ==> Could not find the dummy finally block!\n");
 
-      TR::IA32ConstantDataSnippet * cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      auto cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(self()->getLastCatchAppendInstruction(), LDCWMem, generateX86MemoryReference(cds, self()), self());
       }
    }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -6205,7 +6205,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
 
 #if defined(TRACE_LOCK_RESERVATION)
       {
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, (int)node);
+      auto cds = cg->findOrCreate4ByteConstant(node, (int)node);
       TR::MemoryReference *tempMR = generateX86MemoryReference(cds, cg);
 
       TR::X86MemImmInstruction  * instr;
@@ -6226,7 +6226,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
       generateMemRegInstruction(SMemReg(),node, tempMR, eaxReal, cg);
       generateMemRegInstruction(SMemReg(),node, tempMR1, eaxReal, cg);
 
-      TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
+      auto cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
       TR::MemoryReference *tempMR3 = generateX86MemoryReference(cds1, cg);
       TR::SymbolReference *tempRef2 = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR_UInt32);
       TR::MemoryReference *tempMR2 = generateX86MemoryReference(tempRef2, cg);
@@ -6461,7 +6461,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
 
 #if defined(TRACE_LOCK_RESERVATION)
    {
-   TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, (int)node+1);
+   auto cds = cg->findOrCreate4ByteConstant(node, (int)node+1);
    TR::MemoryReference *tempMR = generateX86MemoryReference(cds, cg);
 
    TR::X86RegMemInstruction  *instr;
@@ -6479,7 +6479,7 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    generateMemRegInstruction(SMemReg(),node, tempMR, eaxReal, cg);
    generateMemRegInstruction(SMemReg(),node, tempMR1, eaxReal, cg);
 
-   TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
+   auto cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
    TR::MemoryReference *tempMR3 = generateX86MemoryReference(cds1, cg);
    TR::SymbolReference *tempRef2 = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR_UInt32);
    TR::MemoryReference *tempMR2 = generateX86MemoryReference(tempRef2, cg);
@@ -6883,7 +6883,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
       if (reservingLock)
          {
 #if defined(TRACE_LOCK_RESERVATION)
-         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, (int)node);
+         auto cds = cg->findOrCreate4ByteConstant(node, (int)node);
          TR::MemoryReference *tempMR = generateX86MemoryReference(cds, cg);
 
          if (TR::Compiler->target.is64Bit() && fej9->generateCompressedLockWord())
@@ -6900,7 +6900,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
          generateMemRegInstruction(SMemReg(),node, tempMR, tempReg, cg);
          generateMemRegInstruction(SMemReg(),node, tempMR1, tempReg, cg);
 
-         TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
+         auto cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
          TR::MemoryReference *tempMR3 = generateX86MemoryReference(cds1, cg);
          TR::SymbolReference *tempRef2 = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR_UInt32);
          TR::MemoryReference *tempMR2 = generateX86MemoryReference(tempRef2, cg);
@@ -7035,7 +7035,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
 #if defined(TRACE_LOCK_RESERVATION)
    if (reservingLock)
       {
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, (int)node+1);
+      auto cds = cg->findOrCreate4ByteConstant(node, (int)node+1);
       TR::MemoryReference *tempMR = generateX86MemoryReference(cds, cg);
 
       cg->setImplicitExceptionPoint(generateRegMemInstruction(
@@ -7048,7 +7048,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
       generateMemRegInstruction(SMemReg(),node, tempMR, tempReg, cg);
       generateMemRegInstruction(SMemReg(),node, tempMR1, tempReg, cg);
 
-      TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
+      auto cds1 = cg->findOrCreate4ByteConstant(node, (int)node+2);
       TR::MemoryReference *tempMR3 = generateX86MemoryReference(cds1, cg);
       TR::SymbolReference *tempRef2 = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR_UInt32);
       TR::MemoryReference *tempMR2 = generateX86MemoryReference(tempRef2, cg);
@@ -10716,7 +10716,7 @@ inlineMathSQRT(
          d.doubleVal = sqrt(d.doubleVal);
          }
 
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(operand, d.rawBits);
+      auto cds = cg->findOrCreate8ByteConstant(operand, d.rawBits);
 
       if (cg->useSSEForDoublePrecision())
          {

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -2297,7 +2297,7 @@ TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X
    if (cg()->enableSinglePrecisionMethods() &&
        comp()->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR::IA32ConstantDataSnippet *cds = cg()->findOrCreate2ByteConstant(callNode, DOUBLE_PRECISION_ROUND_TO_NEAREST);
+      auto cds = cg()->findOrCreate2ByteConstant(callNode, DOUBLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, callNode, generateX86MemoryReference(cds, cg()), cg());
       }
 
@@ -2387,7 +2387,7 @@ TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X
    if (cg()->enableSinglePrecisionMethods() &&
        comp()->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR::IA32ConstantDataSnippet *cds = cg()->findOrCreate2ByteConstant(callNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
+      auto cds = cg()->findOrCreate2ByteConstant(callNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
       generateMemInstruction(LDCWMem, callNode, generateX86MemoryReference(cds, cg()), cg());
       }
 
@@ -2775,7 +2775,7 @@ void TR::X86PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86CallSi
       {
       TR_ASSERT(TR::Compiler->target.is64Bit(), "Only 64-bit path should reach here.");
       TR::Register *interfaceClassReg = vtableIndexReg;
-      TR::IA32ConstantDataSnippet *cds = cg()->findOrCreate8ByteConstant(site.getCallNode(), (intptrj_t)declaringClass);
+      auto cds = cg()->findOrCreate8ByteConstant(site.getCallNode(), (intptrj_t)declaringClass);
       TR::MemoryReference *interfaceClassAddr = generateX86MemoryReference(cds, cg());
       generateRegMemInstruction(LRegMem(), callNode, interfaceClassReg, interfaceClassAddr, cg());
       generateMemRegInstruction(CMPMemReg(),


### PR DESCRIPTION
In case if OMR changes the type of DateSnippet, it is safer to auto instead of the raw type.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>