### PR TITLE
load java.instrument module when loading agent

### DIFF
--- a/runtime/jvmti/jvmtiModules.c
+++ b/runtime/jvmti/jvmtiModules.c
@@ -640,36 +640,18 @@ jvmtiAddModuleProvides(jvmtiEnv* jvmtiEnv,
 
 		if ((rc == JVMTI_ERROR_NONE) && (FALSE == isUnnamed)) {
 			JNIEnv *env = (JNIEnv *) currentThread;
-			if (NULL == vm->jimModules) {
-				omrthread_monitor_enter(vm->jlmModulesInitMutex);
-				if (NULL == vm->jimModules) {
-					jclass globalModules = NULL;
-					jclass jimModules = (*env)->FindClass(env, "jdk/internal/module/Modules");
-					if (NULL == jimModules) {
-						rc = JVMTI_ERROR_INTERNAL;
-						omrthread_monitor_exit(vm->jlmModulesInitMutex);
-						goto done;
-					}
-
-					globalModules = (*env)->NewGlobalRef(env, jimModules);
-					if (NULL == globalModules) {
-						rc = JVMTI_ERROR_OUT_OF_MEMORY;
-						omrthread_monitor_exit(vm->jlmModulesInitMutex);
-						goto done;
-					}
-
-					vm->jimModules = globalModules;
-				}
-				omrthread_monitor_exit(vm->jlmModulesInitMutex);
+			jclass jimModules = vmFuncs->getJimModules(currentThread);
+			if (NULL == jimModules) {
+				rc = JVMTI_ERROR_INTERNAL;
+				goto done;
 			}
-
 			if (NULL == vm->addProvides) {
 				jmethodID addProvides = NULL;
 
 				if(J2SE_SHAPE(vm) < J2SE_SHAPE_B165) {
-					addProvides = (*env)->GetStaticMethodID(env, vm->jimModules, "addProvides", "(Ljava/lang/reflect/Module;Ljava/lang/Class;Ljava/lang/Class;)V");
+					addProvides = (*env)->GetStaticMethodID(env, jimModules, "addProvides", "(Ljava/lang/reflect/Module;Ljava/lang/Class;Ljava/lang/Class;)V");
 				} else {
-					addProvides = (*env)->GetStaticMethodID(env, vm->jimModules, "addProvides", "(Ljava/lang/Module;Ljava/lang/Class;Ljava/lang/Class;)V");
+					addProvides = (*env)->GetStaticMethodID(env, jimModules, "addProvides", "(Ljava/lang/Module;Ljava/lang/Class;Ljava/lang/Class;)V");
 				}
 				if (NULL == addProvides) {
 					rc = JVMTI_ERROR_INTERNAL;
@@ -678,7 +660,7 @@ jvmtiAddModuleProvides(jvmtiEnv* jvmtiEnv,
 
 				vm->addProvides = addProvides;
 			}
-			(*env)->CallStaticVoidMethod(env, vm->jimModules, vm->addProvides, module, service, implClass);
+			(*env)->CallStaticVoidMethod(env, jimModules, vm->addProvides, module, service, implClass);
 		}
 	}
 

--- a/runtime/oti/classloadersearch.h
+++ b/runtime/oti/classloadersearch.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,6 +49,7 @@ extern "C" {
 #define CLS_ERROR_INTERNAL 					JVMTI_ERROR_INTERNAL
 #define CLS_ERROR_CLASS_LOADER_UNSUPPORTED	JVMTI_ERROR_CLASS_LOADER_UNSUPPORTED
 #define CLS_ERROR_ILLEGAL_ARGUMENT			JVMTI_ERROR_ILLEGAL_ARGUMENT
+#define CLS_ERROR_NOT_FOUND					JVMTI_ERROR_NOT_FOUND
 
 #ifdef __cplusplus
 }

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4815,6 +4815,7 @@ typedef struct J9InternalVMFunctions {
 	struct J9Module* ( *findModuleForPackage)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, U_8 *packageName, U_32 packageNameLen);
 	struct J9ModuleExtraInfo* ( *findModuleInfoForModule)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, J9Module *j9module);
 	struct J9ClassLocation* ( *findClassLocationForClass)(struct J9VMThread *currentThread, struct J9Class *clazz);
+	jclass ( *getJimModules) (struct J9VMThread *currentThread);
 	UDATA ( *initializeClassPath)(struct J9JavaVM *vm, char *classPath, U_8 classPathSeparator, U_16 cpFlags, BOOLEAN initClassPathEntry, struct J9ClassPathEntry **classPathEntries);
 	IDATA ( *initializeClassPathEntry) (struct J9JavaVM * javaVM, struct J9ClassPathEntry *cpEntry);
 	BOOLEAN ( *setBootLoaderModulePatchPaths)(struct J9JavaVM * javaVM, struct J9Module * j9module, const char * moduleName);
@@ -5468,7 +5469,6 @@ typedef struct J9JavaVM {
 	struct J9Module *javaBaseModule;
 	struct J9Module *unamedModuleForSystemLoader;
 	J9ClassPathEntry *modulesPathEntry;
-	omrthread_monitor_t jlmModulesInitMutex;
 	jclass jimModules;
 	jmethodID addReads;
 	jmethodID addExports;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -472,6 +472,14 @@ addToBootstrapClassLoaderSearch(J9JavaVM * vm, const char * pathSegment, UDATA c
 UDATA
 addToSystemClassLoaderSearch(J9JavaVM * vm, const char* pathSegment, UDATA classLoaderType, BOOLEAN enforceJarRestriction);
 
+/**
+ * @brief Get a reference to jdk.internal.module.Modules.
+ * @param *currentThread
+ * @return class reference or null if error.
+ */
+
+jclass
+getJimModules(J9VMThread *currentThread);
 /* ---------------- description.c ---------------- */
 
 /**

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -129,6 +129,7 @@
 	<classref name="java/lang/Module" jcl="se9,se10,se11" flags="opt_module"/>
 	<classref name="java/lang/invoke/VarHandle" jcl="se9_before_b165,se9,se10,se11"/>
 	<classref name="java/lang/invoke/VarHandleInvokeHandle" jcl="se9_before_b165,se9,se10,se11"/>
+	<classref name="jdk/internal/module/Modules" jcl="se9,se10,se11" flags="opt_module"/>
 
 	<fieldref class="java/lang/ClassLoader" name="parent" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/ClassLoader" name="vmRef" signature="J" cast="struct J9ClassLoader *"/>

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -344,6 +344,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	findModuleForPackage,
 	findModuleInfoForModule,
 	findClassLocationForClass,
+	getJimModules,
 	initializeClassPath,
 	initializeClassPathEntry,
 	setBootLoaderModulePatchPaths,

--- a/runtime/vm/vmthinit.c
+++ b/runtime/vm/vmthinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,8 +75,6 @@ UDATA initializeVMThreading(J9JavaVM *vm)
 		omrthread_monitor_init_with_name(&vm->osrGlobalBufferLock, 0, "OSR global buffer lock") ||
 
 		omrthread_monitor_init_with_name(&vm->nativeLibraryMonitor, 0, "JNI native library loading lock") ||
-
-		omrthread_monitor_init_with_name(&vm->jlmModulesInitMutex, 0, "Lock for jlmModules global ref") ||
 
 		omrthread_monitor_init_with_name(&vm->vmRuntimeStateListener.runtimeStateListenerMutex, 0, "VM state notification mutex") ||
 
@@ -154,7 +152,6 @@ void terminateVMThreading(J9JavaVM *vm)
 	if (vm->asyncEventMutex) omrthread_monitor_destroy(vm->asyncEventMutex);
 	if (vm->osrGlobalBufferLock) omrthread_monitor_destroy(vm->osrGlobalBufferLock);
 	if (vm->nativeLibraryMonitor) omrthread_monitor_destroy(vm->nativeLibraryMonitor);
-	if (vm->jlmModulesInitMutex) omrthread_monitor_destroy(vm->jlmModulesInitMutex);
 	if (vm->vmRuntimeStateListener.runtimeStateListenerMutex) omrthread_monitor_destroy(vm->vmRuntimeStateListener.runtimeStateListenerMutex);
 
 	destroyMonitorTable(vm);


### PR DESCRIPTION
Java 9 and above need the java.instrument module loaded when
using -javaagent or loading an instrumentation agent via late attach.
Avoid this on legacy versions of Java 9.

Fixes #2030 

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>