### PR TITLE
Prep to remove deferredVMAccessRelease

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -143,7 +143,7 @@ public:
 	 */
 	void releaseExclusiveVMAccess();
 
-	uintptr_t relinquishExclusiveVMAccess(bool *deferredVMAccessRelease);
+	uintptr_t relinquishExclusiveVMAccess(bool *deferredVMAccessRelease = NULL);
 
 	void assumeExclusiveVMAccess(uintptr_t exclusiveCount);
 


### PR DESCRIPTION
Now that MasterGCThread does not use deferred VM access mechanism
(https://github.com/eclipse/omr/pull/2696), we can remove it. This is
just a simple preparation step so that OMR call site can use the
delegate without the argument before that argument is actually removed.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>