### PR TITLE
 Add String.isBlank() implementation (jdk11 only)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -2563,6 +2563,26 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		
 		return (result == null) ? this : result;
 	}
+
+	/**
+	 * Determine if the string contains only white space characters. 
+	 * 
+	 * @return true if the string is empty or contains only white space
+	 * characters, otherwise false.
+	 * 
+	 * @since 11
+	 */
+	public boolean isBlank() {
+		int index;
+
+		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			index = StringLatin1.indexOfNonWhitespace(value);
+		} else {
+			index = StringUTF16.indexOfNonWhitespace(value);
+		}
+		
+		return index >= lengthInternal();
+	}
 /*[ENDIF]*/
 	
 	/**

--- a/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -189,4 +189,29 @@ public class Test_String {
 		Assert.assertEquals((allWhiteSpace + nonLatin1 + allWhiteSpace).stripTrailing(), allWhiteSpace + nonLatin1, 
 				"stripTrailing: Value of striped string with leading/trailing white space with non-Latin1 characters was unexpected.");
 	}
+
+	/*
+	 * Test Java 11 API String.isBlank
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testIsblank() {
+		// pass empty string
+		Assert.assertTrue(empty.isBlank(),
+				"isBlank: failed to return true on empty string.");
+
+		// pass string with all white space
+		Assert.assertTrue(allWhiteSpace.isBlank(),
+				"isBlank: failed to return true on all white space string.");
+
+		// pass non-blank strings
+		Assert.assertFalse(latin1.isBlank(),
+				"isBlank: failed to return false on non-blank latin1 string.");
+		Assert.assertFalse(nonLatin1.isBlank(),
+				"isBlank: failed to return false on non-blank non-latin1 string.");
+
+		Assert.assertFalse((allWhiteSpace + latin1).isBlank(),
+				"isBlank: failed to return false on non-blank latin1 string with leading white space.");
+		Assert.assertFalse((allWhiteSpace + nonLatin1).isBlank(),
+				"isBlank: failed to return false on non-blank non-latin1 string with leading white space.");
+	}
 }


### PR DESCRIPTION
This change implements String.isBlank(), a function that determines
whether or not a String contains non-whitespace characters.

This change only affects Java 11.

Issue: #2109 
Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>