### PR TITLE
Add implementation of String.lines() (jdk11 only)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -42,6 +42,10 @@ import java.util.stream.IntStream;
 import sun.misc.Unsafe;
 /*[ENDIF] Sidecar19-SE*/
 
+/*[IF Java11]*/
+import java.util.stream.Stream;
+/*[ENDIF] Java11*/
+
 /**
  * Strings are objects which represent immutable arrays of characters.
  *
@@ -2583,8 +2587,26 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		
 		return index >= lengthInternal();
 	}
-/*[ENDIF]*/
-	
+
+	/**
+	 * Returns a stream of substrings extracted from this string partitioned by line terminators.
+	 * 
+	 * Line terminators recognized are line feed "\n", carriage return "\r", and carriage return
+	 * followed by line feed "\r\n".
+	 * 
+	 * @return the stream of this string's substrings partitioned by line terminators 
+	 * 
+	 * @since 11
+	 */
+	public Stream<String> lines() {
+		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			return StringLatin1.lines(value);
+		} else {
+			return StringUTF16.lines(value);
+		}
+	}
+/*[ENDIF] Java11*/
+
 	/**
 	 * Copies a range of characters into a new String.
 	 *

--- a/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -28,6 +28,9 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
 
+import java.util.Iterator;
+import java.util.stream.Stream;
+
 /**
  * This test Java.lang.String API added in Java 11 and later version.
  *
@@ -42,6 +45,11 @@ public class Test_String {
 	String allWhiteSpace = "   ";
 	String latin1 = "abc123";
 	String nonLatin1 = "abc\u0153";
+	String latin1WithTerm = "one\ntwo\rthree\r\nfour";
+	String[] latin1LinesArray = {"one", "two", "three", "four"};
+	String nonLatin1WithTerm = "\u0153\n\u0154\r\u0155\r\n\u0156";
+	String[] nonLatin1LinesArray = {"\u0153", "\u0154", "\u0155", "\u0156"};
+	String emptyWithTerm = "\n";
 
 	/*
 	 * Test Java 11 API String.valueOfCodePoint(codePoint)
@@ -213,5 +221,50 @@ public class Test_String {
 				"isBlank: failed to return false on non-blank latin1 string with leading white space.");
 		Assert.assertFalse((allWhiteSpace + nonLatin1).isBlank(),
 				"isBlank: failed to return false on non-blank non-latin1 string with leading white space.");
+	 
+	/*	
+	 * Test Java 11 API String.lines
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testLines() {
+		Stream<String> ss;
+		Iterator<String> iter;
+		String s;
+		int i;
+
+		// ensure latin1 and nonLatin1 properly breaks apart strings by line terminators
+		ss = latin1WithTerm.lines();
+		iter = ss.iterator();
+		i = 0;
+		while (iter.hasNext()) {
+			s = iter.next();
+			Assert.assertEquals(s, latin1LinesArray[i],
+					"lines: Failed to break apart latin1 string by line terminators - failed on " + latin1LinesArray[i]);
+			i++;
+		}
+
+		ss = nonLatin1WithTerm.lines();
+		iter = ss.iterator();
+		i = 0;
+		while (iter.hasNext()) {
+			s = iter.next();
+			Assert.assertEquals(s, nonLatin1LinesArray[i],
+					"lines: Failed to break apart latin1 string by line terminators - failed on " + nonLatin1LinesArray[i]);
+			i++;
+		}
+
+		// pass in string with only one line terminator - should return empty string
+		ss = emptyWithTerm.lines();
+		Assert.assertEquals(ss.findAny().get(), "",
+					"lines: Failed to get empty string from string with a single line terminator.");
+
+		// pass in empty string
+		try {
+			ss = empty.lines();
+			s = ss.findAny().get();
+			Assert.fail("Failed to throw exception on get non-existent value - empty string.");
+		} catch (java.util.NoSuchElementException e) {
+			// Expected exception
+		}
 	}
 }


### PR DESCRIPTION
This change adds an implementation of String.lines(), which returns
a lazily supplied Stream of Strings broken up by line terminators.

This change only affects Java 11.

Closes: #2109 
Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>