### PR TITLE
Fix unresolve omrsig_handler for j9ddrgen and constgen executables.

### DIFF
--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -307,6 +307,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<library name="j9utilcore"/>
 			<library name="j9ddrautoblob"/>
 			<library name="j9gcautoblob"/>
+			<library name="omrsig">
+				<include-if condition="spec.linux_ztpf.*"/>
+			</library>
 
 			<!-- The following libs are needed to statically link the port library. -->
 			<library name="omrglue" type="external"/>

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -59,6 +59,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<library name="j9pool" type="external"/>
 			<library name="j9exelib"/>
 			<library name="j9utilcore"/>
+			<library name="omrsig">
+				<include-if condition="spec.linux_ztpf.*"/>
+			</library>
 
 			<!-- The following libs are needed to statically link the port library -->
 			<library name="omrglue" type="external"/>


### PR DESCRIPTION
z/TPF has strict unresolve checking.  During the z/TPF build both
j9ddrgen and constgen link checks show omrsig_hanlder as being
unresolved and causes a build failure.  Linking in the omrsig
library fixes this issue.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>