### PR TITLE
Use OMR Compiler's renamed ExternalRelocation APIs

### DIFF
--- a/runtime/compiler/arm/codegen/ARMAOTRelocation.cpp
+++ b/runtime/compiler/arm/codegen/ARMAOTRelocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/arm/codegen/ARMAOTRelocation.cpp
+++ b/runtime/compiler/arm/codegen/ARMAOTRelocation.cpp
@@ -30,7 +30,7 @@ void TR::ARMPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
    
    if (TR::comp()->getOption(TR_AOT))
       {
-      cg->addAOTRelocation(
+      cg->addExternalRelocation(
          new (cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(
             getSourceInstruction()->getBinaryEncoding(),
             NULL,

--- a/runtime/compiler/arm/codegen/ARMHelperCallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMHelperCallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/arm/codegen/ARMHelperCallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMHelperCallSnippet.cpp
@@ -53,7 +53,7 @@ uint8_t *TR::ARMHelperCallSnippet::emitSnippetBody()
    *(int32_t *)buffer = 0xea000000 | ((distance >> 2)& 0x00ffffff);
    if (_restartLabel != NULL)
       *(int32_t *)buffer |= 0x01000000;
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                              buffer,
                              (uint8_t *)getDestination(),
                              TR_HelperAddress, cg()), __FILE__, __LINE__, getNode());

--- a/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
@@ -151,7 +151,7 @@ uint8_t *TR::ARMEDORecompilationSnippet::emitSnippetBody()
 
    // b distance
    *(int32_t *)buffer = 0x48000000 | (distance & 0x03ffffff);
-   cg()->addAOTRelocation(new TR::ExternalRelocation(buffer,
+   cg()->addExternalRelocation(new TR::ExternalRelocation(buffer,
                                                          (uint8_t *)induceRecompilationSymRef,
                                                          TR_HelperAddress), __FILE, __LINE__, getNode());
    buffer += ARM_INSTRUCTION_LENGTH;

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -268,7 +268,7 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(int32_t *)cursor = (intptr_t)getCallRA();
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
         						 cursor,
         						 NULL,
         						 TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
@@ -281,7 +281,7 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
       if (comp->getOption(TR_EnableHCR))
          {
          cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
+         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
                                    TR_HCR, cg()),__FILE__, __LINE__,
                                    getNode());
          }
@@ -291,7 +291,7 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
       *(int32_t *)cursor = (uintptr_t)methodSymbol->getMethodAddress();
       if (comp->getOption(TR_EnableHCR))
          cg()->jitAddPicToPatchOnClassRedefinition((void *)methodSymbol->getMethodAddress(), (void *)cursor);
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)methodSymRef,
+         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)methodSymRef,
                                                                                  getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                  TR_MethodObject, cg()),
                                       __FILE__, __LINE__, callNode);
@@ -301,7 +301,7 @@ uint8_t *TR::ARMCallSnippet::emitSnippetBody()
       recordInfo->data2 = (uintptr_t)(getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1);
       recordInfo->data3 = (uintptr_t)fixedSequence1;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                              cursor,
                              (uint8_t *)recordInfo,
                              TR_MethodObject, cg()), __FILE__, __LINE__, getNode());
@@ -376,7 +376,7 @@ uint8_t *TR::ARMUnresolvedCallSnippet::emitSnippetBody()
       traceMsg(comp, "</relocatableDataTrampolinesCG>\n");
       }
 
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
         						 cursor,
         						 *(uint8_t **)cursor,
         						 getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
@@ -408,7 +408,7 @@ uint8_t *TR::ARMVirtualUnresolvedSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(int32_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
         						 cursor,
         						 NULL,
         						 TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
@@ -417,7 +417,7 @@ uint8_t *TR::ARMVirtualUnresolvedSnippet::emitSnippetBody()
    // CP
    *(int32_t *)cursor = (intptr_t)methodSymRef->getOwningMethod(comp)->constantPool();
 
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                              cursor,
                              *(uint8_t **)cursor,
                              getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
@@ -451,7 +451,7 @@ uint8_t *TR::ARMInterfaceCallSnippet::emitSnippetBody()
 
    // Store the code cache RA
    *(int32_t *)cursor = (intptr_t)getReturnLabel()->getCodeLocation();
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
         						 cursor,
         						 NULL,
         						 TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
@@ -459,7 +459,7 @@ uint8_t *TR::ARMInterfaceCallSnippet::emitSnippetBody()
 
    *(int32_t *)cursor = (intptr_t)methodSymRef->getOwningMethod(cg()->comp())->constantPool();
 
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                              cursor,
                              *(uint8_t **)cursor,
                              getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,

--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -64,9 +64,9 @@ void J9::ARM::AheadOfTimeCompile::processRelocations()
       relocation->mapRelocation(self()->cg());
       }
 
-   for (auto aotIterator = self()->cg()->getAOTRelocationList().begin(); aotIterator != self()->cg()->getAOTRelocationList().end(); ++aotIterator)
+   for (auto aotIterator = self()->cg()->getExternalRelocationList().begin(); aotIterator != self()->cg()->getExternalRelocationList().end(); ++aotIterator)
       {
-	  (*aotIterator)->addAOTRelocation(self()->cg());
+	  (*aotIterator)->addExternalRelocation(self()->cg());
       }
 
    for (r = self()->getAOTRelocationTargets().getFirst();

--- a/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9UnresolvedDataSnippet.cpp
@@ -81,7 +81,7 @@ J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(int32_t *)cursor = (intptr_t)getAddressOfDataReference();   // Code Cache RA
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                cursor,
                NULL,
                TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
@@ -102,7 +102,7 @@ J9::ARM::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(int32_t *)cursor = (intptr_t)getDataSymbolReference()->getOwningMethod(cg()->comp())->constantPool();  // CP
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                cursor,
                *(uint8_t **)cursor,
                getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -94,7 +94,7 @@ J9::AheadOfTimeCompile::dumpRelocationData()
       traceMsg(self()->comp(), "\n\nRelocation Record Generation Info\n");
       traceMsg(self()->comp(), "%-35s %-32s %-5s %-9s %-10s %-8s\n", "Type", "File", "Line","Offset(M)","Offset(PC)", "Node");
 
-      TR::list<TR::Relocation*>& aotRelocations = self()->comp()->cg()->getAOTRelocationList();
+      TR::list<TR::Relocation*>& aotRelocations = self()->comp()->cg()->getExternalRelocationList();
       //iterate over aotRelocations
       if (!aotRelocations.empty())
          {

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2599,7 +2599,7 @@ J9::CodeGenerator::processRelocations()
             case TR_CheckMethodEnter:
             case TR_CheckMethodExit:
             case TR_HCR:
-               self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
+               self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)(*it)->getLocation(),
                                                                                 (uint8_t *)(*it)->getDestination(),
                                                                                 type, self()),
                                 __FILE__, __LINE__, NULL);
@@ -2657,7 +2657,7 @@ J9::CodeGenerator::processRelocations()
 
             TR_ASSERT(siteIndex < (int32_t) self()->comp()->getNumInlinedCallSites(), "did not find AOTClassInfo %p method in inlined site table", *info);
 
-            self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
+            self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
                                                                              (uint8_t *)(intptr_t)siteIndex,
                                                                              (uint8_t *)(*info),
                                                                              (*info)->_reloKind, self()),
@@ -2678,7 +2678,7 @@ J9::CodeGenerator::processRelocations()
 
             while (currentSite)
                {
-               self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(currentSite->location,
+               self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(currentSite->location,
                                                                                 currentSite->destination,
                                                                                 currentSite->guard,
                                                                                 currentSite->reloType, self()),
@@ -2693,7 +2693,7 @@ J9::CodeGenerator::processRelocations()
       self()->getAheadOfTimeCompile()->processRelocations();
       }
 
-   for (auto aotIterator = self()->getAOTRelocationList().begin(); aotIterator != self()->getAOTRelocationList().end(); ++aotIterator)
+   for (auto aotIterator = self()->getExternalRelocationList().begin(); aotIterator != self()->getExternalRelocationList().end(); ++aotIterator)
       {
       // Traverse the AOT/external labels
 	  (*aotIterator)->apply(self());
@@ -2704,9 +2704,9 @@ void J9::CodeGenerator::addProjectSpecializedRelocation(uint8_t *location, uint8
       TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    (target2 == NULL) ?
-         self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(location, target, kind, self()),
+         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(location, target, kind, self()),
                generatingFileName, generatingLineNumber, node) :
-         self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(location, target, target2, kind, self()),
+         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(location, target, target2, kind, self()),
                generatingFileName, generatingLineNumber, node);
    }
 
@@ -2714,16 +2714,16 @@ void J9::CodeGenerator::addProjectSpecializedRelocation(TR::Instruction *instr, 
       TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
    (target2 == NULL) ?
-         self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(instr, target, kind, self()),
+         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(instr, target, kind, self()),
                generatingFileName, generatingLineNumber, node) :
-         self()->addAOTRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(instr, target, target2, kind, self()),
+         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(instr, target, target2, kind, self()),
                generatingFileName, generatingLineNumber, node);
    }
 
 void J9::CodeGenerator::addProjectSpecializedPairRelocation(uint8_t *location, uint8_t *location2, uint8_t *target,
       TR_ExternalRelocationTargetKind kind, char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
    {
-   self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(location, location2, target, kind, self()),
+   self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(location, location2, target, kind, self()),
          generatingFileName, generatingLineNumber, node);
    }
 
@@ -2733,7 +2733,7 @@ J9::CodeGenerator::jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinit
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
    if (self()->comp()->compileRelocatableCode())
       {
-      self()->addAOTRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)firstInstruction, 0, TR_HCR, self()),
+      self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)firstInstruction, 0, TR_HCR, self()),
                                  __FILE__,__LINE__, NULL);
       }
    else

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4844,7 +4844,7 @@ TR_J9VMBase::needsInvokeExactJ2IThunk(TR::Node *callNode, TR::Compilation *comp)
          || method->isArchetypeSpecimen()))
       {
       if (isAOT_DEPRECATED_DO_NOT_USE()) // While we're here... we need an AOT relocation for this call
-         comp->cg()->addAOTRelocation(new (comp->trHeapMemory()) TR::ExternalRelocation(NULL, (uint8_t *)callNode, (uint8_t *)methodSymbol->getMethod()->signatureChars(), TR_J2IThunks, comp->cg()), __FILE__, __LINE__, callNode);
+         comp->cg()->addExternalRelocation(new (comp->trHeapMemory()) TR::ExternalRelocation(NULL, (uint8_t *)callNode, (uint8_t *)methodSymbol->getMethod()->signatureChars(), TR_J2IThunks, comp->cg()), __FILE__, __LINE__, callNode);
 
       // We need a j2i thunk when this call executes, in case the target MH has
       // no invokeExact thunk yet.

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -362,7 +362,7 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
    // we use "b" for induceOSR because we want the helper to think that it's been called from the mainline code and not from the snippet.
    int32_t branchInstruction = (runtimeHelper == TR_induceOSRAtCurrentPC) ? 0x48000000 : 0x48000001;
    *(int32_t *)cursor = branchInstruction | (distance & 0x03fffffc);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
       __FILE__, __LINE__, callNode);
 
    cursor += PPC_INSTRUCTION_LENGTH;
@@ -387,7 +387,7 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
       {
       // Store the code cache RA
       *(intptrj_t *)cursor = (intptrj_t)getCallRA();
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,NULL,TR_AbsoluteMethodAddress, cg()),
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,NULL,TR_AbsoluteMethodAddress, cg()),
             __FILE__, __LINE__, callNode);
 
       cursor += TR::Compiler->om.sizeofReferenceAddress();
@@ -403,7 +403,7 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
          if (comp->getOption(TR_EnableHCR))
             {
             cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,(uint8_t *)needsFullSizeRuntimeAssumption,
                                                                                          TR_HCR, cg()),__FILE__, __LINE__,
                                    getNode());
             }
@@ -414,7 +414,7 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
          if (comp->getOption(TR_EnableHCR))
             cg()->jitAddPicToPatchOnClassRedefinition((void *)methodSymbol->getMethodAddress(), (void *)cursor);
 
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)methodSymRef,
+         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)methodSymRef,
                                                                                  getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                  TR_MethodObject, cg()),
                                       __FILE__, __LINE__, callNode);
@@ -487,7 +487,7 @@ uint8_t *TR::PPCUnresolvedCallSnippet::emitSnippetBody()
       traceMsg(comp, "</relocatableDataTrampolinesCG>\n");
       }
 
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
          *(uint8_t **)cursor,
          getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
          TR_Trampolines, cg()),
@@ -538,13 +538,13 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
 
    // bl glueRef
    *(int32_t *)cursor = 0x48000001 | (distance & 0x03fffffc);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
       __FILE__, __LINE__, callNode);
    cursor += 4;
 
    // Store the code cache RA
    *(intptrj_t *)cursor = (intptrj_t)getReturnLabel()->getCodeLocation();
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,NULL,TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,NULL,TR_AbsoluteMethodAddress, cg()),
          __FILE__, __LINE__, callNode);
 
    cursor += TR::Compiler->om.sizeofReferenceAddress();
@@ -553,7 +553,7 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    *(intptrj_t *)cursor = (intptrj_t)callNode->getSymbolReference()->getOwningMethod(comp)->constantPool();
 
    // Use methodSymRef info to generate thunk relo for AOT shared classes
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                 *(uint8_t **)cursor,
                                                                                 getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                 TR_Thunks, cg()),
@@ -608,7 +608,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
 
    // bl glueRef
    *(int32_t *)cursor = 0x48000001 | (distance & 0x03fffffc);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_HelperAddress, cg()),
                              __FILE__, __LINE__, callNode);
    blAddress = cursor;
    cursor += PPC_INSTRUCTION_LENGTH;
@@ -634,7 +634,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    if (cg()->comp()->compileRelocatableCode())
       {
       // Use methodSymRef info to generate thunk relo for AOT shared classes
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,*(uint8_t **)cursor,
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,*(uint8_t **)cursor,
                                                                                    getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,TR_Thunks, cg()),
                                    __FILE__, __LINE__, callNode);
       }
@@ -684,7 +684,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
             }
          else
             {
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(getUpperInstruction(),
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(getUpperInstruction(),
                (uint8_t *)(addrValue),
                (uint8_t *)fixedSequence4,
                TR_FixedSequenceAddress2,
@@ -702,7 +702,7 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
       *patchAddress2 |= (int32_t)(intptrj_t)cursor & 0x0000ffff;
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data3 = orderedPairSequence1;
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)patchAddress1,
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)patchAddress1,
          (uint8_t *)patchAddress2,
          (uint8_t *)recordInfo,
          TR_AbsoluteMethodAddressOrderedPair, cg()),
@@ -717,11 +717,11 @@ uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
    *(intptrj_t *)(cursor+3*TR::Compiler->om.sizeofReferenceAddress()) = (intptrj_t)blAddress;
 
    // Register for relation of the 1st target addess
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
          __FILE__, __LINE__, callNode);
 
    // Register for relaction of the 2nd target address
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+3*TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor+3*TR::Compiler->om.sizeofReferenceAddress(), NULL, TR_AbsoluteMethodAddress, cg()),
          __FILE__, __LINE__, callNode);
 
    return(cursor + 4*TR::Compiler->om.sizeofReferenceAddress());

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -129,7 +129,7 @@ uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
    // b distance
    *(int32_t *)buffer = 0x48000000 | (distance & 0x03ffffff);
 
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)induceRecompilationSymRef,TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)induceRecompilationSymRef,TR_HelperAddress, cg()),
                           __FILE__,
                           __LINE__,
                           getNode());

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -55,10 +55,10 @@ void J9::Power::AheadOfTimeCompile::processRelocations()
    for (auto iterator = getRelocationList().begin(); iterator != getRelocationList().end(); ++iterator)
       (*iterator)->mapRelocation(_cg);
 
-   auto aotIterator = _cg->getAOTRelocationList().begin();
-   while (aotIterator != _cg->getAOTRelocationList().end())
+   auto aotIterator = _cg->getExternalRelocationList().begin();
+   while (aotIterator != _cg->getExternalRelocationList().end())
       {
-	  (*aotIterator)->addAOTRelocation(_cg);
+	  (*aotIterator)->addExternalRelocation(_cg);
       ++aotIterator;
       }
 

--- a/runtime/compiler/p/codegen/J9PPCInstruction.cpp
+++ b/runtime/compiler/p/codegen/J9PPCInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/J9PPCInstruction.cpp
+++ b/runtime/compiler/p/codegen/J9PPCInstruction.cpp
@@ -138,7 +138,7 @@ uint8_t *TR::PPCDepImmSymInstruction::generateBinaryEncoding()
 
       if (cg()->comp()->compileRelocatableCode() && label == NULL)
          {
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)getSymbolReference(),TR_HelperAddress, cg()),
+         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)getSymbolReference(),TR_HelperAddress, cg()),
                                 __FILE__, __LINE__, getNode());
          }
       }

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -1548,7 +1548,7 @@ uint8_t *TR::PPCReadMonitorSnippet::emitSnippetBody()
 
    if (comp->compileRelocatableCode())
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)getMonitorEnterHelper(),TR_HelperAddress, cg()),
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)getMonitorEnterHelper(),TR_HelperAddress, cg()),
                                 __FILE__, __LINE__, getNode());
       }
 
@@ -1722,7 +1722,7 @@ uint8_t *TR::PPCHeapAllocSnippet::emitSnippetBody()
    *(int32_t *)buffer |= distance & 0x03FFFFFC;
    if (cg()->comp()->compileRelocatableCode())
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer, (uint8_t*) getDestination(), TR_HelperAddress, cg()),
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer, (uint8_t*) getDestination(), TR_HelperAddress, cg()),
                              __FILE__,
                              __LINE__,
                              getNode());

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -6577,7 +6577,7 @@ TR::Register *outlinedHelperNewEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       TR_ExternalRelocationTargetKind reloKind = opCode == TR::New ? TR_VerifyClassObjectForAlloc : TR_VerifyRefArrayForAlloc;
 
       TR::Relocation *r = new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(firstInstruction, (uint8_t *) classSymRef, (uint8_t *) recordInfo, reloKind, cg);
-      cg->addAOTRelocation(r, __FILE__, __LINE__, node);
+      cg->addExternalRelocation(r, __FILE__, __LINE__, node);
       }
 
    return objectReg;
@@ -7129,7 +7129,7 @@ TR::Register *J9::Power::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeG
             reloKind = TR_VerifyRefArrayForAlloc;
             }
 
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(firstInstruction, (uint8_t *) classSymRef, (uint8_t *) recordInfo, reloKind, cg),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(firstInstruction, (uint8_t *) classSymRef, (uint8_t *) recordInfo, reloKind, cg),
                   __FILE__, __LINE__, node);
          }
 
@@ -12450,7 +12450,7 @@ TR::Instruction *loadAddressRAM32(TR::CodeGenerator *cg, TR::Node * node, int32_
          TR_ASSERT(0,"JNI relocation not supported.");
          }
       if(isAOT)
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                   (TR_ExternalRelocationTargetKind) reloType, cg),
                   __FILE__, __LINE__, node);
@@ -12492,7 +12492,7 @@ TR::Instruction *loadAddressRAM(TR::CodeGenerator *cg, TR::Node * node, intptrj_
          TR_ASSERT(0,"JNI relocation not supported.");
          }
       if(isAOT)
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                   (TR_ExternalRelocationTargetKind) reloType, cg),
                   __FILE__,__LINE__, node);
@@ -12538,7 +12538,7 @@ TR::Instruction *loadAddressJNI32(TR::CodeGenerator *cg, TR::Node * node, int32_
          TR_ASSERT(0,"JNI relocation not supported.");
          }
       if(isAOT)
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                   (TR_ExternalRelocationTargetKind) reloType, cg),
                   __FILE__, __LINE__, node);
@@ -12580,7 +12580,7 @@ TR::Instruction *loadAddressJNI(TR::CodeGenerator *cg, TR::Node * node, intptrj_
          TR_ASSERT(0,"JNI relocation not supported.");
          }
       if(isAOT)
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *) node->getSymbolReference(),
                node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                   (TR_ExternalRelocationTargetKind) reloType, cg),
                   __FILE__,__LINE__, node);

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -171,7 +171,7 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
    cursor += 4;
 
    *(intptrj_t *)cursor = (intptrj_t)getDataSymbolReference()->getOwningMethod(comp)->constantPool();
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,*(uint8_t **)cursor,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,*(uint8_t **)cursor,
                                                                           getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                           TR_ConstantPool,
                                                                           cg()),

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilationSnippet.cpp
@@ -61,7 +61,7 @@ uint8_t *TR::PPCRecompilationSnippet::emitSnippetBody()
 
    // bl distance
    *(int32_t *)buffer = 0x48000001 | (distance & 0x03ffffff);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)countingRecompMethodSymRef,TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,(uint8_t *)countingRecompMethodSymRef,TR_HelperAddress, cg()),
                           __FILE__,
                           __LINE__,
                           getNode());

--- a/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
@@ -169,7 +169,7 @@ uint8_t *TR::PPCStackCheckFailureSnippet::emitSnippetBody()
 
    // bl distance
    *(int32_t *)buffer = 0x48000001 | (distance & 0x03ffffff);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                          (uint8_t *)sofRef,
                                                          TR_HelperAddress, cg()),
                         __FILE__, __LINE__, getNode());

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -856,7 +856,7 @@ TR_HWProfiler::createRecords(TR::Compilation *comp)
                                                                 relocationTargetKind,
                                                                 cg);
 
-         cg->addAOTRelocation(relocation, __FILE__, __LINE__, node);
+         cg->addExternalRelocation(relocation, __FILE__, __LINE__, node);
          }
       }
    }

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -90,7 +90,7 @@ uint8_t *TR::X86AllocPrefetchSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(buffer+4, helperSymRef);
       if (fej9->helpersNeedRelocation())
          {
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
+         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                                                 (uint8_t *)helperSymRef,
                                                                                 TR_HelperAddress,
                                                                                 cg()),

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -47,7 +47,7 @@ uint8_t *TR::X86PicDataSnippet::encodeConstantPoolInfo(uint8_t *cursor)
    if (_thunkAddress)
       {
       TR_ASSERT(TR::Compiler->target.is64Bit(), "expecting a 64-bit target for thunk relocations");
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                              *(uint8_t **)cursor,
                                                                              _startOfPicInstruction->getNode() ? (uint8_t *)_startOfPicInstruction->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                              TR_Thunks, cg()),
@@ -57,7 +57,7 @@ uint8_t *TR::X86PicDataSnippet::encodeConstantPoolInfo(uint8_t *cursor)
       }
    else
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                   (uint8_t *)cpAddr,
                                                                                    _startOfPicInstruction->getNode() ? (uint8_t *)_startOfPicInstruction->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                    TR_ConstantPool,
@@ -107,7 +107,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, _dispatchSymRef);
       *(int32_t *)cursor = disp32;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory())
+      cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(cursor,
                                     (uint8_t *)_dispatchSymRef,
                                     TR_HelperAddress,
@@ -249,7 +249,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, _dispatchSymRef);
       *(int32_t *)cursor = disp32;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory())
+      cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(cursor,
                                     (uint8_t *)_dispatchSymRef,
                                     TR_HelperAddress,
@@ -313,7 +313,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor+4, resolveSlotHelperSymRef);
       *(int32_t *)picSlotCursor = disp32;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory())
+      cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(picSlotCursor,
                                     (uint8_t *)resolveSlotHelperSymRef,
                                     TR_HelperAddress,
@@ -329,7 +329,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
             disp32 = cg()->branchDisplacementToHelperOrTrampoline(picSlotCursor+4, populateSlotHelperSymRef);
             *(int32_t *)picSlotCursor = disp32;
 
-            cg()->addAOTRelocation(new (cg()->trHeapMemory())
+            cg()->addExternalRelocation(new (cg()->trHeapMemory())
                TR::ExternalRelocation(picSlotCursor,
                                           (uint8_t *)populateSlotHelperSymRef,
                                           TR_HelperAddress,
@@ -751,7 +751,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, helperSymRef);
       *(int32_t *)cursor = disp32;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory())
+      cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(cursor,
                                     (uint8_t *)helperSymRef,
                                     TR_HelperAddress,
@@ -781,7 +781,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, helperSymRef);
       *(int32_t *)cursor = disp32;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory())
+      cg()->addExternalRelocation(new (cg()->trHeapMemory())
          TR::ExternalRelocation(cursor,
                                     (uint8_t *)helperSymRef,
                                     TR_HelperAddress,
@@ -808,7 +808,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
             TR_ConstantPool,
             cg());
 
-      cg()->addAOTRelocation(relocation, __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
       cursor += sizeof(intptrj_t);
 
       // DD cpIndex
@@ -885,7 +885,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, dispatchSymRef);
       *(int32_t *)cursor = disp32;
 
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                             (uint8_t *)dispatchSymRef,
                                                             TR_HelperAddress,
                                                             cg()),  __FILE__, __LINE__, getNode());
@@ -953,7 +953,7 @@ uint8_t *TR::X86UnresolvedVirtualCallSnippet::emitSnippetBody()
    TR::SymbolReference *glueSymRef =
       cg()->symRefTab()->findOrCreateRuntimeHelper(TR_IA32interpreterUnresolvedVTableSlotGlue, false, false, false);
    uint8_t *glueAddress = (uint8_t *)glueSymRef->getMethodAddress();
-   cg()->addAOTRelocation(new (comp->trHeapMemory()) TR::ExternalRelocation(cursor,
+   cg()->addExternalRelocation(new (comp->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                      (uint8_t *)glueSymRef,
                                                                                      TR_HelperAddress,
                                                                                      cg()),
@@ -970,7 +970,7 @@ uint8_t *TR::X86UnresolvedVirtualCallSnippet::emitSnippetBody()
    //
    uintptrj_t cpAddr = (uintptrj_t)_methodSymRef->getOwningMethod(comp)->constantPool();
    *(intptrj_t *)cursor = cpAddr;
-   cg()->addAOTRelocation(
+   cg()->addExternalRelocation(
       new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                             (uint8_t *)cpAddr,
                                                             getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,

--- a/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
+++ b/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
@@ -157,7 +157,7 @@ uint8_t *TR::X86CheckFailureSnippet::emitCheckFailureSnippetBody(uint8_t *buffer
       }
 
    *(int32_t *)buffer = (int32_t)(destinationAddress - (intptrj_t)(buffer+4));
-   cg()->addAOTRelocation(new (cg()->trHeapMemory())
+   cg()->addExternalRelocation(new (cg()->trHeapMemory())
       TR::ExternalRelocation(
          buffer,
          (uint8_t *)getDestination(),
@@ -285,7 +285,7 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
    //
    *buffer++ = 0x68; // push   imm4
    *(int32_t *)buffer = (int32_t) (intptr_t) getDataSymbolReference()->getOwningMethod(cg()->comp())->constantPool();
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                                            *(uint8_t **)buffer,
                                                                            getCheckInstruction()->getNode() ? (uint8_t *)getCheckInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                            TR_ConstantPool, cg()),
@@ -305,7 +305,7 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
       TR_ASSERT(IS_32BIT_RIP(glueAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
       }
    *(int32_t *)buffer = (int32_t)(glueAddress - (intptrj_t)(buffer+4));
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                          (uint8_t *)glueSymRef,
                                                          TR_HelperAddress, cg()),
                           __FILE__,
@@ -331,7 +331,7 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
       TR_ASSERT(IS_32BIT_RIP(destinationAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
       }
    *(int32_t *)buffer = (int32_t)(destinationAddress - (intptrj_t)(buffer+4));
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                          (uint8_t *)getDestination(),
                                                          TR_HelperAddress,
                                                          cg()),

--- a/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
@@ -57,7 +57,7 @@ uint8_t *TR::X86ForceRecompilationSnippet::emitSnippetBody()
       }
    *(int32_t *)buffer = ((uint8_t*)helperAddress - buffer) - 4;
 
-   cg()->addAOTRelocation(new (cg()->trHeapMemory())
+   cg()->addExternalRelocation(new (cg()->trHeapMemory())
       TR::ExternalRelocation(
          buffer,
          (uint8_t *)helper,

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -51,7 +51,7 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
        && TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines()
        && _cg->getPicSlotCount())
       {
-      _cg->addAOTRelocation(new (_cg->trHeapMemory()) TR::ExternalRelocation(NULL,
+      _cg->addExternalRelocation(new (_cg->trHeapMemory()) TR::ExternalRelocation(NULL,
                                                                                  (uint8_t *)_cg->getPicSlotCount(),
                                                                                  TR_PicTrampolines, _cg),
                             __FILE__,
@@ -60,8 +60,8 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
       }
 
 
-   for (auto aotIterator = _cg->getAOTRelocationList().begin(); aotIterator != _cg->getAOTRelocationList().end(); ++aotIterator)
-	  (*aotIterator)->addAOTRelocation(_cg);
+   for (auto aotIterator = _cg->getExternalRelocationList().begin(); aotIterator != _cg->getExternalRelocationList().end(); ++aotIterator)
+	  (*aotIterator)->addExternalRelocation(_cg);
 
    TR::IteratedExternalRelocation *r;
    for (r = self()->getAOTRelocationTargets().getFirst();

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9500,7 +9500,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
          reloKind = TR_VerifyRefArrayForAlloc;
          }
 
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(startInstr,
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(startInstr,
                                                                                (uint8_t *) classSymRef,
                                                                                (uint8_t *) recordInfo,
                                                                                reloKind, cg),

--- a/runtime/compiler/x/codegen/RecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/RecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/codegen/RecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/RecompilationSnippet.cpp
@@ -98,7 +98,7 @@ uint8_t *TR::X86RecompilationSnippet::emitSnippetBody()
       TR_ASSERT(IS_32BIT_RIP(helperAddress, buffer+4), "Local helper trampoline should be reachable directly.\n");
       }
    *(int32_t *)buffer = ((uint8_t*)helperAddress - buffer) - 4;
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                          (uint8_t *)_destination,
                                                          TR_HelperAddress, cg()),
                                                          __FILE__, __LINE__, getNode());

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/z/codegen/ForceRecompilationSnippet.cpp
@@ -92,7 +92,7 @@ TR::S390ForceRecompilationSnippet::emitSnippetBody()
    *(int32_t *) cursor = (int32_t)((destAddr - (intptrj_t)(cursor - 2)) / 2);
 
    AOTcgDiag1(comp, "add TR_HelperAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t*) glueRef, TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t*) glueRef, TR_HelperAddress, cg()),
                              __FILE__, __LINE__, getNode());
 
    cursor += sizeof(int32_t);
@@ -161,14 +161,14 @@ TR::S390ForceRecompilationDataSnippet::emitSnippetBody()
    // Return Address
    *(intptrj_t *) cursor = (intptrj_t)getRestartLabel()->getCodeLocation();
    AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
                              __FILE__, __LINE__, getNode());
    cursor += sizeof(intptrj_t);
 
    // Start PC
    *(intptrj_t *) cursor = (intptrj_t)cg()->getCodeStart();
    AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
                              __FILE__, __LINE__, getNode());
    cursor += sizeof(intptrj_t);
 

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -67,8 +67,8 @@ void J9::Z::AheadOfTimeCompile::processRelocations()
 	   (*iterator)->mapRelocation(_cg);
       }
 
-   for (auto aotIterator = _cg->getAOTRelocationList().begin(); aotIterator != _cg->getAOTRelocationList().end(); ++aotIterator)
-	  (*aotIterator)->addAOTRelocation(_cg);
+   for (auto aotIterator = _cg->getExternalRelocationList().begin(); aotIterator != _cg->getExternalRelocationList().end(); ++aotIterator)
+	  (*aotIterator)->addExternalRelocation(_cg);
 
    for (r = self()->getAOTRelocationTargets().getFirst();
         r != NULL;

--- a/runtime/compiler/z/codegen/J9S390Snippet.cpp
+++ b/runtime/compiler/z/codegen/J9S390Snippet.cpp
@@ -118,7 +118,7 @@ TR::S390HeapAllocSnippet::emitSnippetBody()
    *(int32_t *) buffer = (int32_t)((destAddr - (intptrj_t)(buffer - 2)) / 2);
    if (cg()->comp()->compileRelocatableCode())
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer, (uint8_t*) getDestination(), TR_HelperAddress, cg()),
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer, (uint8_t*) getDestination(), TR_HelperAddress, cg()),
                                 __FILE__, __LINE__, getNode());
       }
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -8570,7 +8570,7 @@ J9::Z::TreeEvaluator::VMnewEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             reloKind = TR_VerifyRefArrayForAlloc;
             }
 
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(firstInstruction,
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(firstInstruction,
                      (uint8_t *) classSymRef,
                      (uint8_t *) recordInfo,
                      reloKind, cg),

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -291,7 +291,7 @@ J9::Z::UnresolvedDataSnippet::emitSnippetBody()
    // address of constant pool
    *(uintptrj_t *) cursor = (uintptrj_t) getDataSymbolReference()->getOwningMethod(comp)->constantPool();
    AOTcgDiag1(comp, "add TR_ConstantPool cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
                              __FILE__, __LINE__, getNode());
    cursor += sizeof(uintptrj_t);
 

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -35,7 +35,7 @@ void TR::S390PairedRelocation::mapRelocation(TR::CodeGenerator *cg)
    {
    if (cg->comp()->getOption(TR_AOT))
       {
-      cg->addAOTRelocation(
+      cg->addExternalRelocation(
          new (cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(
             getSourceInstruction()->getBinaryEncoding(),
             getSource2Instruction()->getBinaryEncoding(),
@@ -64,25 +64,25 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
          }
 
       *((uintptrj_t*)cursor)=fej9->getPersistentClassPointerFromClassPointer((TR_OpaqueClassBlock*)(*((uintptrj_t*)cursor)));
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, (TR_ExternalRelocationTargetKind)_reloType, cg),
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, (TR_ExternalRelocationTargetKind)_reloType, cg),
                               file, line, node);
       }
    else if (_reloType==TR_RamMethod)
       {
       AOTcgDiag1(  comp, "TR_RamMethod cursor=%x\n", cursor);
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg), file, line, node);
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg), file, line, node);
 
       }
    else if (_reloType==TR_HelperAddress)
       {
       AOTcgDiag1(  comp, "TR_HelperAddress cursor=%x\n", cursor);
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, TR_HelperAddress, cg),
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, TR_HelperAddress, cg),
                            file, line, node);
       }
    else if (_reloType==TR_AbsoluteHelperAddress)
       {
       AOTcgDiag1(  comp, "TR_AbsoluteHelperAddress cursor=%x\n", cursor);
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, TR_AbsoluteHelperAddress, cg),
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, TR_AbsoluteHelperAddress, cg),
                               file, line, node);
       }
    else if (_reloType==TR_ConstantPool)
@@ -90,25 +90,25 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
       AOTcgDiag1(  comp, "TR_ConstantPool cursor=%x\n", cursor);
       if (TR::Compiler->target.is64Bit())
          {
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), (uint8_t *)_inlinedSiteIndex, TR_ConstantPool, cg),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), (uint8_t *)_inlinedSiteIndex, TR_ConstantPool, cg),
                               file, line, node);
          }
       else
          {
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), (uint8_t *)_inlinedSiteIndex, TR_ConstantPool, cg),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), (uint8_t *)_inlinedSiteIndex, TR_ConstantPool, cg),
                               file, line, node);
          }
       }
    else if (_reloType==TR_MethodObject)
       {
       AOTcgDiag1(  comp, "TR_MethodObject cursor=%x\n", cursor);
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_MethodObject, cg),
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_MethodObject, cg),
                               file, line, node);
       }
    else if (_reloType==TR_DataAddress)
       {
       AOTcgDiag1(  comp, "TR_DataAddress cursor=%x\n", cursor);
-      cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_DataAddress, cg),
+      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_DataAddress, cg),
                               file, line, node);
       }
    else if (_reloType==TR_BodyInfoAddress)
@@ -116,12 +116,12 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
       AOTcgDiag1(  comp, "TR_BodyInfoAddress cursor=%x\n", cursor);
       if (TR::Compiler->target.is64Bit())
          {
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_BodyInfoAddress, cg),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_BodyInfoAddress, cg),
                               file, line, node);
          }
       else
          {
-         cg->addAOTRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_BodyInfoAddress, cg),
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_BodyInfoAddress, cg),
                            file, line, node);
          }
       }

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -325,14 +325,14 @@ TR::S390J9CallSnippet::emitSnippetBody()
    // Method address
    *(uintptrj_t *) cursor = (uintptrj_t) glueRef->getMethodAddress();
    AOTcgDiag1(comp, "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_AbsoluteHelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_AbsoluteHelperAddress, cg()),
                              __FILE__, __LINE__, callNode);
    cursor += sizeof(uintptrj_t);
 
    // Store the code cache RA
    *(uintptrj_t *) cursor = (uintptrj_t) getCallRA();
    AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
                           __FILE__, __LINE__, callNode);
    cursor += sizeof(uintptrj_t);
 
@@ -351,7 +351,7 @@ TR::S390J9CallSnippet::emitSnippetBody()
             {
             //TODO check what happens when we pass -1 to jitAddPicToPatchOnClassRedefinition an dif it's correct in this case
             cg()->jitAddPicToPatchOnClassRedefinition((void*)-1, (void *)cursor, true);
-            cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, NULL,
                                     TR_HCR, cg()),__FILE__, __LINE__, getNode());
             }
          }
@@ -361,7 +361,7 @@ TR::S390J9CallSnippet::emitSnippetBody()
          if (comp->getOption(TR_EnableHCR))
             cg()->jitAddPicToPatchOnClassRedefinition((void *)methodSymbol->getMethodAddress(), (void *)cursor);
          AOTcgDiag1(comp, "add TR_MethodObject cursor=%x\n", cursor);
-         cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_MethodObject, cg()),
+         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) callNode->getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_MethodObject, cg()),
                                    __FILE__, __LINE__, callNode);
          }
       }
@@ -421,19 +421,19 @@ TR::S390UnresolvedCallSnippet::emitSnippetBody()
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, 
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, 
          TR_Trampolines, cg()),
          __FILE__, __LINE__,getNode());
       }
 #if defined(J9ZOS390)
    else
       {
-      cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
+      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
          __FILE__, __LINE__, getNode());
       }
 #endif
 #else
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool, cg()),
       __FILE__, __LINE__, getNode());
 #endif
 
@@ -504,21 +504,21 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
    // Method address
    *(uintptrj_t *) cursor = (uintptrj_t) glueRef->getMethodAddress();
    AOTcgDiag1(comp, "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_AbsoluteHelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)glueRef, TR_AbsoluteHelperAddress, cg()),
                              __FILE__, __LINE__, callNode);
    cursor += sizeof(uintptrj_t);
 
    // Store the code cache RA
    *(uintptrj_t *) cursor = (uintptrj_t) getCallRA();
    AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
                              __FILE__, __LINE__, callNode);
    cursor += sizeof(uintptrj_t);
 
    *(uintptrj_t *) cursor = (uintptrj_t) callNode->getSymbolReference()->getOwningMethod(comp)->constantPool();
 
    AOTcgDiag1(comp, "add TR_Thunks cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_Thunks, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, *(uint8_t **)cursor, getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_Thunks, cg()),
                              __FILE__, __LINE__, callNode);
 
    cursor += sizeof(uintptrj_t);
@@ -529,7 +529,7 @@ TR::S390VirtualUnresolvedSnippet::emitSnippetBody()
 
    *(uintptrj_t *) cursor = (uintptrj_t) (getPatchVftInstruction()->getBinaryEncoding());
    AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()),
                           __FILE__, __LINE__, callNode);
    cursor += sizeof(uintptrj_t);
 
@@ -649,7 +649,7 @@ TR::S390InterfaceCallSnippet::emitSnippetBody()
 
    *(int32_t *) cursor = (int32_t)((destAddr - (intptrj_t)(cursor - 2)) / 2);
    AOTcgDiag1(comp, " add TR_HelperAddress cursor=%x\n", cursor);
-   cg()->addAOTRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t*) glueRef, TR_HelperAddress, cg()),
+   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t*) glueRef, TR_HelperAddress, cg()),
             __FILE__, __LINE__, getNode());
    cursor += sizeof(int32_t);
 


### PR DESCRIPTION
This patch primarily changes calls to addAOTRelocation() to addExternalRelocation() as the former will be removed and the latter better reflects that ExternalRelocations are not necessarily AOT-specific. No functionality has changed.