### PR TITLE
Refactor VTable index/offset variable name

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -990,12 +990,12 @@ old_slow_jitLookupInterfaceMethod(J9VMThread *currentThread)
 	UDATA cpIndex = indexAndLiteralsEA[-1];
 	J9Class *interfaceClass = ((J9Class**)indexAndLiteralsEA)[0];
 	UDATA methodIndex = indexAndLiteralsEA[1];
-	UDATA vTableIndex = VM_VMHelpers::convertITableIndexToVTableIndex(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
+	UDATA vTableOffset = VM_VMHelpers::convertITableIndexToVTableOffset(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
 	buildJITResolveFrameWithPC(currentThread, J9_SSF_JIT_RESOLVE_INTERFACE_LOOKUP, parmCount, true, 0, jitEIP);
-	if (0 == vTableIndex) {
+	if (0 == vTableOffset) {
 		setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
 	} else {
-		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableIndex);
+		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
 		TIDY_BEFORE_THROW();
 		currentThread->javaVM->internalVMFunctions->setIllegalAccessErrorNonPublicInvokeInterface(currentThread, method);
 	}
@@ -1018,12 +1018,12 @@ old_fast_jitLookupInterfaceMethod(J9VMThread *currentThread)
 	UDATA cpIndex = indexAndLiteralsEA[-1];
 	J9Class *interfaceClass = ((J9Class**)indexAndLiteralsEA)[0];
 	UDATA methodIndex = indexAndLiteralsEA[1];
-	UDATA vTableIndex = VM_VMHelpers::convertITableIndexToVTableIndex(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
-	if (0 != vTableIndex) {
-		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableIndex);
+	UDATA vTableOffset = VM_VMHelpers::convertITableIndexToVTableOffset(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
+	if (0 != vTableOffset) {
+		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
 		if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)) {
 			slowPath = NULL;
-			JIT_RETURN_UDATA(vTableIndex);
+			JIT_RETURN_UDATA(vTableOffset);
 		}
 	}
 	return slowPath;
@@ -1579,8 +1579,8 @@ retry:
 	J9ConstantPool *ramConstantPool = ((J9ConstantPool**)indexAndLiteralsEA)[0];
 	UDATA cpIndex = indexAndLiteralsEA[1];
 	J9RAMVirtualMethodRef *ramMethodRef = (J9RAMVirtualMethodRef*)ramConstantPool + cpIndex;
-	UDATA vTableIndex = ramMethodRef->methodIndexAndArgCount >> 8;
-	if ((sizeof(J9Class) + sizeof(UDATA)) == vTableIndex) {
+	UDATA vTableOffset = ramMethodRef->methodIndexAndArgCount >> 8;
+	if (J9VTABLE_INITIAL_VIRTUAL_OFFSET == vTableOffset) {
 		buildJITResolveFrameWithPC(currentThread, J9_SSF_JIT_RESOLVE_VIRTUAL_METHOD, parmCount, true, 0, jitEIP);
 		currentThread->javaVM->internalVMFunctions->resolveVirtualMethodRef(currentThread, ramConstantPool, cpIndex, J9_RESOLVE_FLAG_RUNTIME_RESOLVE, NULL);
 		addr = restoreJITResolveFrame(currentThread, jitEIP);
@@ -1589,7 +1589,7 @@ retry:
 		}
 		goto retry;
 	}
-	JIT_RETURN_UDATA(sizeof(J9Class) - vTableIndex);
+	JIT_RETURN_UDATA(sizeof(J9Class) - vTableOffset);
 done:
 	SLOW_JIT_HELPER_EPILOGUE();
 	return addr;
@@ -2421,15 +2421,15 @@ old_slow_icallVMprJavaSendPatchupVirtual(J9VMThread *currentThread)
 	J9JavaVM *vm = currentThread->javaVM;
 	J9JITConfig *jitConfig = vm->jitConfig;
 	void *jitReturnAddress = currentThread->jitReturnAddress;
-	UDATA jitVTableIndex = VM_JITInterface::jitVTableIndex(jitReturnAddress, interfaceVTableIndex);
+	UDATA jitVTableOffset = VM_JITInterface::jitVTableIndex(jitReturnAddress, interfaceVTableIndex);
 	J9Class *clazz = J9OBJECT_CLAZZ(currentThread, receiver);
-	UDATA interpVTableIndex = sizeof(J9Class) - jitVTableIndex;
-	J9Method *method = *(J9Method**)(interpVTableIndex + (UDATA)clazz);
+	UDATA interpVTableOffset = sizeof(J9Class) - jitVTableOffset;
+	J9Method *method = *(J9Method**)((UDATA)clazz + interpVTableOffset);
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
 	J9ROMNameAndSignature *nas = &romMethod->nameAndSignature;
 	UDATA const thunk = (UDATA)jitConfig->thunkLookUpNameAndSig(jitConfig, nas);
 	UDATA const patchup = (UDATA)jitConfig->patchupVirtual;
-	UDATA *jitVTableSlot = (UDATA*)(jitVTableIndex + (UDATA)clazz);
+	UDATA *jitVTableSlot = (UDATA*)((UDATA)clazz + jitVTableOffset);
 	VM_AtomicSupport::lockCompareExchange(jitVTableSlot, patchup, thunk);
 	currentThread->tempSlot = thunk;
 }
@@ -2679,12 +2679,12 @@ fast_jitLookupInterfaceMethod(J9VMThread *currentThread, J9Class *receiverClass,
 	UDATA cpIndex = indexAndLiteralsEA[-1];
 	J9Class *interfaceClass = ((J9Class**)indexAndLiteralsEA)[0];
 	UDATA methodIndex = indexAndLiteralsEA[1];
-	UDATA vTableIndex = VM_VMHelpers::convertITableIndexToVTableIndex(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
-	if (0 != vTableIndex) {
-		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableIndex);
+	UDATA vTableOffset = VM_VMHelpers::convertITableIndexToVTableOffset(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
+	if (0 != vTableOffset) {
+		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
 		if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)) {
 			slowPath = NULL;
-			JIT_RETURN_UDATA(vTableIndex);
+			JIT_RETURN_UDATA(vTableOffset);
 		}
 	}
 	return slowPath;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6005,7 +6005,7 @@ int32_t
 TR_J9VMBase::getInterpreterVTableSlot(TR_OpaqueMethodBlock * mBlock, TR_OpaqueClassBlock * clazz)
    {
    TR::VMAccessCriticalSection getInterpreterVTableSlot(this);
-   int32_t result =  vmThread()->javaVM->internalVMFunctions->getVTableIndexForMethod((J9Method*)mBlock, (J9Class*)clazz, vmThread());
+   int32_t result =  vmThread()->javaVM->internalVMFunctions->getVTableOffsetForMethod((J9Method*)mBlock, (J9Class*)clazz, vmThread());
    return result;
    }
 int32_t

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6068,7 +6068,7 @@ TR_ResolvedJ9Method::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * clas
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    // the classObject is the fixed type of the this pointer.  The result of this method is going to be
    // used to call the interface function directly.
-   UDATA vTableIndex = 0;
+   UDATA vTableOffset = 0;
 #if TURN_OFF_INLINING
    return 0;
 #else
@@ -6077,10 +6077,10 @@ TR_ResolvedJ9Method::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * clas
 
       {
       TR::VMAccessCriticalSection getResolvedInterfaceMethodOffset(fej9());
-      vTableIndex = jitGetInterfaceVTableIndexFromCP(_fe->vmThread(), cp(), cpIndex, TR::Compiler->cls.convertClassOffsetToClassPtr(classObject));
+      vTableOffset = jitGetInterfaceVTableOffsetFromCP(_fe->vmThread(), cp(), cpIndex, TR::Compiler->cls.convertClassOffsetToClassPtr(classObject));
       }
 
-   return (J9JIT_INTERP_VTABLE_OFFSET - vTableIndex);
+   return (J9JIT_INTERP_VTABLE_OFFSET - vTableOffset);
 #endif
    }
 
@@ -6255,29 +6255,29 @@ TR_ResolvedJ9Method::getResolvedVirtualMethod(TR::Compilation * comp, I_32 cpInd
       {
       // only call the resolve if unresolved
       J9Method * ramMethod = 0;
-      UDATA vTableIndex = (((J9RAMVirtualMethodRef*) literals())[cpIndex]).methodIndexAndArgCount;
-      vTableIndex >>= 8;
-      if ((J9JIT_INTERP_VTABLE_OFFSET + sizeof(uintptrj_t)) == vTableIndex)
+      UDATA vTableOffset = (((J9RAMVirtualMethodRef*) literals())[cpIndex]).methodIndexAndArgCount;
+      vTableOffset >>= 8;
+      if (J9VTABLE_INITIAL_VIRTUAL_OFFSET == vTableOffset)
          {
          TR::VMAccessCriticalSection resolveVirtualMethodRef(fej9());
-         vTableIndex = _fe->_vmFunctionTable->resolveVirtualMethodRefInto(_fe->vmThread(), cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, &ramMethod, NULL);
+         vTableOffset = _fe->_vmFunctionTable->resolveVirtualMethodRefInto(_fe->vmThread(), cp(), cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, &ramMethod, NULL);
          }
       else
          {
          // go fishing for the J9Method...
          uint32_t classIndex = ((J9ROMMethodRef *) cp()->romConstantPool)[cpIndex].classRefCPIndex;
          J9Class * classObject = (((J9RAMClassRef*) literals())[classIndex]).value;
-         ramMethod = *(J9Method **)((char *)classObject + vTableIndex);
+         ramMethod = *(J9Method **)((char *)classObject + vTableOffset);
          if (unresolvedInCP)
             *unresolvedInCP = false;
          }
 
-      if (vTableIndex)
+      if (vTableOffset)
          {
          TR_AOTInliningStats *aotStats = NULL;
          if (comp->getOption(TR_EnableAOTStats))
             aotStats = & (((TR_JitPrivateConfig *)_fe->_jitConfig->privateConfig)->aotStats->virtualMethods);
-         resolvedMethod = createResolvedMethodFromJ9Method(comp, cpIndex, vTableIndex, ramMethod, unresolvedInCP, aotStats);
+         resolvedMethod = createResolvedMethodFromJ9Method(comp, cpIndex, vTableOffset, ramMethod, unresolvedInCP, aotStats);
          }
       }
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1128,7 +1128,7 @@ TR_RelocationRecordConstantPoolWithIndex::getVirtualMethodFromCP(TR_RelocationRu
 
       {
       TR::VMAccessCriticalSection getVirtualMethodFromCP(reloRuntime->fej9());
-      UDATA vTableIndex = javaVM->internalVMFunctions->resolveVirtualMethodRefInto(javaVM->internalVMFunctions->currentVMThread(javaVM),
+      UDATA vTableOffset = javaVM->internalVMFunctions->resolveVirtualMethodRefInto(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                                    cp,
                                                                                    cpIndex,
                                                                                    J9_RESOLVE_FLAG_AOT_LOAD_TIME,

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -735,7 +735,7 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle(
 	J9JavaVM *vm = vmThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	jboolean result = JNI_FALSE;
-	UDATA vtableIndex;
+	UDATA vtableOffset;
 	j9object_t specialHandleObject;
 	J9Method *method;
 	j9object_t classObject;
@@ -753,9 +753,9 @@ Java_java_lang_invoke_PrimitiveHandle_setVMSlotAndRawModifiersFromSpecialHandle(
 	if (j9class == NULL) {
 		goto _done;
 	}
-	vtableIndex = vmFuncs->getVTableIndexForMethod(method, j9class, vmThread);
-	if (vtableIndex != 0) {
-		J9VMJAVALANGINVOKEPRIMITIVEHANDLE_SET_VMSLOT(vmThread, J9_JNI_UNWRAP_REFERENCE(handle), vtableIndex);
+	vtableOffset = vmFuncs->getVTableOffsetForMethod(method, j9class, vmThread);
+	if (vtableOffset != 0) {
+		J9VMJAVALANGINVOKEPRIMITIVEHANDLE_SET_VMSLOT(vmThread, J9_JNI_UNWRAP_REFERENCE(handle), vtableOffset);
 		J9VMJAVALANGINVOKEPRIMITIVEHANDLE_SET_RAWMODIFIERS(vmThread, J9_JNI_UNWRAP_REFERENCE(handle), J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers);
 		result = JNI_TRUE;
 	}

--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,9 +79,9 @@ done:
 }
 
 UDATA
-jitGetInterfaceVTableIndexFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex, J9Class* lookupClass)
+jitGetInterfaceVTableOffsetFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex, J9Class* lookupClass)
 {
-	UDATA vTableIndex = 0;
+	UDATA vTableOffset = 0;
 	UDATA iTableIndex = 0;
 	J9Class *interfaceClass = jitGetInterfaceITableIndexFromCP(currentThread, constantPool, cpIndex, &iTableIndex);
 	if (NULL != interfaceClass) {
@@ -94,22 +94,22 @@ jitGetInterfaceVTableIndexFromCP(J9VMThread *currentThread, J9ConstantPool *cons
 			if (interfaceClass == iTable->interfaceClass) {
 				lookupClass->lastITable = iTable;
 foundITable:
-				vTableIndex = ((UDATA*)(iTable + 1))[iTableIndex];
+				vTableOffset = ((UDATA*)(iTable + 1))[iTableIndex];
 				break;
 			}
 			iTable = iTable->next;
 		}
 	}
-	return vTableIndex;
+	return vTableOffset;
 }
 
 J9Method*
 jitGetInterfaceMethodFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex, J9Class* lookupClass)
 {
-	UDATA vTableIndex = jitGetInterfaceVTableIndexFromCP(currentThread, constantPool, cpIndex, lookupClass);
+	UDATA vTableOffset = jitGetInterfaceVTableOffsetFromCP(currentThread, constantPool, cpIndex, lookupClass);
 	J9Method *method = NULL;
-	if (0 != vTableIndex) {
-		method = *(J9Method**)((UDATA)lookupClass + vTableIndex);
+	if (0 != vTableOffset) {
+		method = *(J9Method**)((UDATA)lookupClass + vTableOffset);
 		if (!J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)) {
 			method = NULL;
 		}

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1050,9 +1050,9 @@ done:
 	 * @returns the vTable index (0 indicates the mapping failed)
 	 */
 	static VMINLINE UDATA
-	convertITableIndexToVTableIndex(J9VMThread *currentThread, J9Class *receiverClass, J9Class *interfaceClass, UDATA iTableIndex, J9ConstantPool *ramConstantPool, UDATA cpIndex)
+	convertITableIndexToVTableOffset(J9VMThread *currentThread, J9Class *receiverClass, J9Class *interfaceClass, UDATA iTableIndex, J9ConstantPool *ramConstantPool, UDATA cpIndex)
 	{
-		UDATA vTableIndex = 0;
+		UDATA vTableOffset = 0;
 		J9ITable * iTable = receiverClass->lastITable;
 		if (interfaceClass == iTable->interfaceClass) {
 			goto foundITable;
@@ -1063,7 +1063,7 @@ done:
 			if (interfaceClass == iTable->interfaceClass) {
 				receiverClass->lastITable = iTable;
 foundITable:
-				vTableIndex = ((UDATA*)(iTable + 1))[iTableIndex];
+				vTableOffset = ((UDATA*)(iTable + 1))[iTableIndex];
 				goto done;
 			}
 			iTable = iTable->next;
@@ -1076,10 +1076,10 @@ foundITable:
 				J9ROMMETHODREF_NAMEANDSIGNATURE(((J9ROMMethodRef*)ramConstantPool->romConstantPool + cpIndex)),
 				NULL,
 				J9_LOOK_VIRTUAL);
-			vTableIndex = J9_VM_FUNCTION(currentThread, getVTableIndexForMethod)(method, receiverClass, currentThread);
+			vTableOffset = J9_VM_FUNCTION(currentThread, getVTableOffsetForMethod)(method, receiverClass, currentThread);
 		}
 done:
-		return vTableIndex;
+		return vTableOffset;
 	}
 
 	/**

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -301,10 +301,14 @@ static const struct { \
 #define J9_VM_FUNCTION_VIA_JAVAVM(javaVM, function) ((javaVM)->internalVMFunctions->function)
 #endif /* J9_INTERNAL_TO_VM */
 
+/* Macros for VTable */
 #define J9VTABLE_HEADER_FROM_RAM_CLASS(clazz) ((J9VTableHeader *)(((J9Class *)(clazz)) + 1))
 #define J9VTABLE_FROM_HEADER(vtableHeader) ((J9Method **)(((J9VTableHeader *)(vtableHeader)) + 1))
 #define J9VTABLE_FROM_RAM_CLASS(clazz) J9VTABLE_FROM_HEADER(J9VTABLE_HEADER_FROM_RAM_CLASS(clazz))
 #define J9VTABLE_OFFSET_FROM_INDEX(index) (sizeof(J9Class) + sizeof(J9VTableHeader) + ((index) * sizeof(UDATA)))
+
+/* VTable constants offset */
+#define J9VTABLE_INITIAL_VIRTUAL_OFFSET (sizeof(J9Class) + offsetof(J9VTableHeader, initialVirtualMethod))
 
 /* Skip Interpreter VTable header */
 #define JIT_VTABLE_START_ADDRESS(clazz) ((UDATA *)(clazz) - (sizeof(J9VTableHeader) / sizeof(UDATA)))

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4583,7 +4583,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *jniPopFrame)(struct J9VMThread * vmThread, UDATA type) ;
 	UDATA  ( *resolveVirtualMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags, struct J9Method **resolvedMethod) ;
 	struct J9Method*  ( *resolveInterfaceMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags) ;
-	UDATA  ( *getVTableIndexForMethod)(struct J9Method * method, struct J9Class *clazz, struct J9VMThread *vmThread) ;
+	UDATA  ( *getVTableOffsetForMethod)(struct J9Method * method, struct J9Class *clazz, struct J9VMThread *vmThread) ;
 	IDATA  ( *checkVisibility)(struct J9VMThread* currentThread, struct J9Class* sourceClass, struct J9Class* destClass, UDATA modifiers, UDATA lookupOptions) ;
 	void  (JNICALL *sendClinit)(struct J9VMThread *vmContext, struct J9Class *clazz, UDATA reserved1, UDATA reserved2, UDATA reserved3) ;
 	void  ( *freeStackWalkCaches)(struct J9VMThread * currentThread, J9StackWalkState * walkState) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1122,7 +1122,7 @@ extern J9_CFUNC struct J9Class*  jitGetInterfaceITableIndexFromCP (J9VMThread *v
 extern J9_CFUNC void  jitAcquireClassTableMutex (J9VMThread *vmThread);
 extern J9_CFUNC void*  jitCTResolveStaticFieldRefWithMethod (J9VMThread *vmStruct, J9Method *method, UDATA fieldIndex, UDATA resolveFlags, J9ROMFieldShape **resolvedField);
 extern J9_CFUNC void  jitReleaseClassTableMutex (J9VMThread *vmThread);
-extern J9_CFUNC UDATA  jitGetInterfaceVTableIndexFromCP (J9VMThread *vmThread, J9ConstantPool *constantPool, UDATA cpIndex, J9Class* lookupClass);
+extern J9_CFUNC UDATA  jitGetInterfaceVTableOffsetFromCP (J9VMThread *vmThread, J9ConstantPool *constantPool, UDATA cpIndex, J9Class* lookupClass);
 extern J9_CFUNC void  jitParseSignature (const J9UTF8 *signature, U_8 *paramBuffer, UDATA *paramElements, UDATA *parmSlots);
 extern J9_CFUNC UDATA jitMethodEnterTracingEnabled(J9VMThread *currentThread, J9Method *method);
 extern J9_CFUNC UDATA jitMethodExitTracingEnabled(J9VMThread *currentThread, J9Method *method);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3902,7 +3902,7 @@ fillJITVTableSlot(J9VMThread *vmStruct, UDATA *currentSlot, J9Method *currentMet
  * @return UDATA
  */
 UDATA
-getVTableIndexForMethod(J9Method * method, J9Class *clazz, J9VMThread *vmThread);
+getVTableOffsetForMethod(J9Method * method, J9Class *clazz, J9VMThread *vmThread);
 
 j9object_t
 resolveMethodTypeRef(J9VMThread *vmThread, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags);

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1596,7 +1596,7 @@ reresolveHotSwappedConstantPool(J9ConstantPool * ramConstantPool, J9VMThread * c
 						romMethodRef = ((J9ROMMethodRef *) romConstantPool) + i;
 						nas = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
 						((J9RAMMethodRef *) ramConstantPool)[i].method = vm->initialMethods.initialSpecialMethod;
-						((J9RAMMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = ((sizeof(J9Class) + sizeof(UDATA)) << 8) +
+						((J9RAMMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = (J9VTABLE_INITIAL_VIRTUAL_OFFSET << 8) +
 							getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
 					} else {
 						/* Try to resolve as virtual and as special */
@@ -1615,7 +1615,7 @@ reresolveHotSwappedConstantPool(J9ConstantPool * ramConstantPool, J9VMThread * c
 						romMethodRef = ((J9ROMMethodRef *) romConstantPool) + i;
 						nas = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
 						/* Set methodIndex to initial virtual method, just as we do in internalRunPreInitInstructions() */
-						((J9RAMStaticMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = ((sizeof(J9Class) + sizeof(UDATA)) << 8) +
+						((J9RAMStaticMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = (J9VTABLE_INITIAL_VIRTUAL_OFFSET << 8) +
 							getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
 						((J9RAMStaticMethodRef *) ramConstantPool)[i].method = vm->initialMethods.initialStaticMethod;
 					} else {

--- a/runtime/util/resolvehelp.c
+++ b/runtime/util/resolvehelp.c
@@ -55,9 +55,9 @@ getMethodForSpecialSend(J9VMThread *vmStruct, J9Class *currentClass, J9Class *re
 			 * is not in the vTable cannot be overridden, so we can just run it.
 			 */
 			J9InternalVMFunctions *vmFuncs = vmStruct->javaVM->internalVMFunctions;
-			UDATA vTableIndex = vmFuncs->getVTableIndexForMethod(method, resolvedClass, vmStruct);
+			UDATA vTableOffset = vmFuncs->getVTableOffsetForMethod(method, resolvedClass, vmStruct);
 
-			if (vTableIndex != 0) {
+			if (vTableOffset != 0) {
 				J9Class *superclass = currentClass->superclasses[currentDepth - 1];
 
 				if (isInterfaceMethod) {
@@ -66,18 +66,18 @@ getMethodForSpecialSend(J9VMThread *vmStruct, J9Class *currentClass, J9Class *re
 					 * 1) Find the vtable index for J9Method in the resolved class.
 					 * 2) Using the vtable index to get the J9Method at that index in the current class.
 					 * 3) Walk the current class vtable backwards to find the most "recent" override of that method
-					 * 4) Lookup the method at vtableIndex in currentClass's super class
+					 * 4) Lookup the method at vTableOffset in currentClass's super class
 					 */
 					J9VTableHeader * superVTable = J9VTABLE_HEADER_FROM_RAM_CLASS(superclass);
 					UDATA superVTableEnd = J9VTABLE_OFFSET_FROM_INDEX(superVTable->size);
-					method = *(J9Method **)(((UDATA)currentClass) + vTableIndex);
-					vTableIndex = vmFuncs->getVTableIndexForMethod(method, currentClass, vmStruct);
+					method = *(J9Method **)(((UDATA)currentClass) + vTableOffset);
+					vTableOffset = vmFuncs->getVTableOffsetForMethod(method, currentClass, vmStruct);
 					/* We may have looked up a J9Method from an interface due to either defender methods
 					 * or the method not being implemented in the class.  If that's the case, we need
 					 * to ensure we don't read a non-existent vtable slot.  The found method is the correct one
 					 */
-					if ((vTableIndex > 0) && (vTableIndex < superVTableEnd)) {
-						method = *(J9Method **)(((UDATA)superclass) + vTableIndex);
+					if ((vTableOffset > 0) && (vTableOffset < superVTableEnd)) {
+						method = *(J9Method **)(((UDATA)superclass) + vTableOffset);
 					}
 				} else {
 					/* In order to support non-vTable methods in a super invoke, perform the lookup rather than

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -696,10 +696,10 @@ done:
 	j2iVirtualMethod(REGISTER_ARGS_LIST, j9object_t receiver, UDATA interfaceVTableIndex)
 	{
 		void* const jitReturnAddress = VM_JITInterface::peekJITReturnAddress(_currentThread, _sp);
-		UDATA jitVTableIndex = VM_JITInterface::jitVTableIndex(jitReturnAddress, interfaceVTableIndex);
-		UDATA vTableIndex = sizeof(J9Class) - jitVTableIndex;
+		UDATA jitVTableOffset = VM_JITInterface::jitVTableIndex(jitReturnAddress, interfaceVTableIndex);
+		UDATA vTableOffset = sizeof(J9Class) - jitVTableOffset;
 		J9Class *clazz = J9OBJECT_CLAZZ(_currentThread, receiver);
-		return *(J9Method**)((UDATA)clazz + vTableIndex);
+		return *(J9Method**)((UDATA)clazz + vTableOffset);
 	}
 
 	VMINLINE void
@@ -6414,7 +6414,7 @@ done:
 			/* Resolution exceptions must be thrown first, so check if methodRef 
 			 * is resolved before throwing NPE on receiver.
 			 */
-			if (methodIndex != (sizeof(J9Class) + sizeof(UDATA))) {
+			if (methodIndex != J9VTABLE_INITIAL_VIRTUAL_OFFSET) {
 				rc = THROW_NPE;
 			} else {
 				_sendMethod = (J9Method *)_vm->initialMethods.initialVirtualMethod;

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -349,7 +349,7 @@ internalRunPreInitInstructions(J9Class * ramClass, J9VMThread * vmThread)
 				case J9CPTYPE_INTERFACE_INSTANCE_METHOD:
 					romMethodRef = ((J9ROMMethodRef *) romConstantPool) + i;
 					nas = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
-					((J9RAMMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = ((sizeof(J9Class) + sizeof(UDATA)) << 8) +
+					((J9RAMMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = (J9VTABLE_INITIAL_VIRTUAL_OFFSET << 8) +
 						getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
 					((J9RAMMethodRef *) ramConstantPool)[i].method = vm->initialMethods.initialSpecialMethod;
 					break;
@@ -359,7 +359,7 @@ internalRunPreInitInstructions(J9Class * ramClass, J9VMThread * vmThread)
 					romMethodRef = ((J9ROMMethodRef *) romConstantPool) + i;
 					nas = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
 					/* In case this CP entry is shared with invokevirtual */
-					((J9RAMMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = ((sizeof(J9Class) + sizeof(UDATA)) << 8) +
+					((J9RAMMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = (J9VTABLE_INITIAL_VIRTUAL_OFFSET << 8) +
 						getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
 					((J9RAMStaticMethodRef *) ramConstantPool)[i].method = vm->initialMethods.initialStaticMethod;
 					break;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -112,7 +112,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jniPopFrame,
 	resolveVirtualMethodRef,
 	resolveInterfaceMethodRef,
-	getVTableIndexForMethod,
+	getVTableOffsetForMethod,
 	checkVisibility,
 	sendClinit,
 	freeStackWalkCaches,

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -2087,7 +2087,7 @@ initializeMethodID(J9VMThread * currentThread, J9JNIMethodID * methodID, J9Metho
 			 */
 			vTableIndex = getITableIndexForMethod(method, NULL) | J9_JNI_MID_INTERFACE;
 		} else {
-			vTableIndex = getVTableIndexForMethod(method, declaringClass, currentThread);
+			vTableIndex = getVTableOffsetForMethod(method, declaringClass, currentThread);
 		}
 	}
 


### PR DESCRIPTION
- Change variable name to correctly reflect vtable index/name
- Added new constant for InitialVirtualMethod offset
- change initialVirtual constant to use offsetof() macro
- change convertITableIndexToVTableIndex to convertITableIndexToVTableOffset
- change jitGetInterfaceVTableIndexFromCP to jitGetInterfaceVTableOffsetFromCP
- change getVTableIndexForMethod to getVTableOffsetForMethod

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>