### PR TITLE
remove unnecessary import

### DIFF
--- a/test/functional/JIT_Test/src/jit/test/jitt/exceptions/readLineBug.java
+++ b/test/functional/JIT_Test/src/jit/test/jitt/exceptions/readLineBug.java
@@ -22,7 +22,6 @@
 package jit.test.jitt.exceptions;
 
 import jit.test.jitt.*;
-import java.*;
 import java.io.*;
 import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;


### PR DESCRIPTION
- remove unnecessary import as it causes compilation failure in JDK11

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>