### PR TITLE
Disable cmdLineTester_jvmtitests_extended on win

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -136,7 +136,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>cmdLineTester_jvmtitests_extended</testCaseName>
+		<testCaseName>cmdLineTester_jvmtitests_debug</testCaseName>
 		<variations>
 			<variation>Mode100</variation>
 			<variation>Mode107</variation>
@@ -160,7 +160,8 @@
 	-config $(Q)$(TEST_RESROOT)$(D)jvmtitests_extended.xml$(Q) \
 	-explainExcludes -xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)jvmtitests_excludes_$(JAVA_VERSION).xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>^arch.390</platformRequirements>
+		<!-- temporarily disable this test on win until the issue is fixed: https://github.com/eclipse/openj9/issues/2129 -->
+		<platformRequirements>^arch.390,^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- disable cmdLineTester_jvmtitests_extended on win until #2129 is fixed
- rename cmdLineTester_jvmtitests_extended to
cmdLineTester_jvmtitests_debug

Issue: #2129 #2147
[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>