### PR TITLE
shutDownHookWrapper only needed for IBMJ9

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -299,13 +299,16 @@ const U_8 J9Impdep1PC[] = { 0xFE, 0x00, 0x00, 0xFE }; /* impdep1, parm, parm, im
 static jint (JNICALL * vprintfHookFunction)(FILE *fp, const char *format, va_list args) = NULL;
 static IDATA (* portLibrary_file_write_text) (struct OMRPortLibrary *portLibrary, IDATA fd, const char *buf, IDATA nbytes) = NULL;
 
-#if defined(WIN32)
+#if defined(WIN32) && !defined(OPENJ9_BUILD)
+/* Remove the "shutDownHookWrapper" once IBMJ9 uses the JVM_*Signal native functions
+ * in the sun.misc.Signal class. OpenJ9 does not depend on the "shutDownHookWrapper".
+ */
 static UDATA shutDownHookWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo, void* userData);
-#endif
+#endif /* defined(WIN32) && !defined(OPENJ9_BUILD) */
 
 #if !defined(WIN32)
 static UDATA sigxfszHandler(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo, void* userData);
-#endif
+#endif /* !defined(WIN32) */
 
 /* SSE2 support on 32 bit linux_x86 and win_x86 */
 #ifdef J9VM_ENV_SSE2_SUPPORT_DETECTION
@@ -604,7 +607,11 @@ freeJavaVM(J9JavaVM * vm)
 	J9VMThread *currentThread = currentVMThread(vm);
 	IDATA traceDescriptor = 0;
 #if defined(WIN32)
-	/* Install the handler for running the shutdown hooks when the console window is closed
+#if !defined(OPENJ9_BUILD)
+	/* Remove the "shutDownHookWrapper" once IBMJ9 uses the JVM_*Signal native functions
+	 * in the sun.misc.Signal class. OpenJ9 does not depend on the "shutDownHookWrapper".
+	 *
+	 * Install the handler for running the shutdown hooks when the console window is closed
 	 * J2SE/Sidecar builds:
 	 *			This applies to Windows only. Shutdown hooks for all other platforms are handled by the Hursley JCLs
 	 *
@@ -612,9 +619,10 @@ freeJavaVM(J9JavaVM * vm)
 	 * 			This applies to Windows only for now. Since we don't have Hursley JCLs for this, we will need to provide our own support for all other cases/platforms.
 	 */
 	j9sig_set_async_signal_handler(shutDownHookWrapper, vm, 0);
-#else
+#endif /* !defined(OPENJ9_BUILD) */
+#else /* defined(WIN32) */
 	j9sig_set_async_signal_handler(sigxfszHandler, NULL, 0);
-#endif
+#endif /* defined(WIN32) */
 
 	/* Remove the predefinedHandlerWrapper. */
 	j9sig_set_single_async_signal_handler(predefinedHandlerWrapper, vm, 0, NULL);
@@ -5732,8 +5740,11 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 		goto error;
 	}
 
-#if defined(WIN32)
-	/* Install the handler for running the shutdown hooks when the console window is closed
+#if defined(WIN32) && !defined(OPENJ9_BUILD)
+	/* Remove the "shutDownHookWrapper" once IBMJ9 uses the JVM_*Signal native functions
+	 * in the sun.misc.Signal class. OpenJ9 does not depend on the "shutDownHookWrapper".
+	 *
+	 * Install the handler for running the shutdown hooks when the console window is closed
 	 * J2SE/Sidecar builds:
 	 *			This applies to Windows only. Shutdown hooks for all other platforms are handled by the Hursley JCLs
 	 *
@@ -5750,7 +5761,7 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 			goto error;
 		}
 	}
-#endif
+#endif /* defined(WIN32) && !defined(OPENJ9_BUILD) */
 
 #ifndef J9VM_SIZE_SMALL_CODE
 	if (NULL == fieldIndexTableNew(vm, portLibrary)) {
@@ -6476,7 +6487,10 @@ freeClassNativeMemory(J9HookInterface** hook, UDATA eventNum, void* eventData, v
 
 #endif /* GC_DYNAMIC_CLASS_UNLOADING */
 
-#if defined(WIN32)
+#if defined(WIN32) && !defined(OPENJ9_BUILD)
+/* Remove the "shutDownHookWrapper" once IBMJ9 uses the JVM_*Signal native functions
+ * in the sun.misc.Signal class. OpenJ9 does not depend on the "shutDownHookWrapper".
+ */
 static UDATA
 shutDownHookWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo, void* userData)
 {
@@ -6502,7 +6516,7 @@ shutDownHookWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo
 	return 0;
 
 }
-#endif
+#endif /* defined(WIN32) && !defined(OPENJ9_BUILD) */
 
 /**
  * Invoke jdk.internal.misc.Signal.dispatch(int number) in Java 9 and


### PR DESCRIPTION
OpenJ9 does not need the "shutDownHookWrapper". So, the code related to
the shutDownHookWrapper has been disabled in the OpenJ9 builds.

IBMJ9 depends on the "shutDownHookWrapper". Once IBMJ9 uses the
JVM_*Signal native functions in the sun.misc.Signal class, then the code
related to the "shutDownHookWrapper" can be removed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>