### PR TITLE
Revert "Implement JVM_AreNestMates public native"

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1797,8 +1797,6 @@ JVM_BeforeHalt()
 {
 	/* To be implemented via https://github.com/eclipse/openj9/issues/1459 */
 }
-#endif /* J9VM_JCL_SE11 */
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
 JNIEXPORT jclass JNICALL
 JVM_GetNestHost(JNIEnv *env, jclass clz)
 {
@@ -1811,56 +1809,10 @@ JVM_GetNestMembers(JNIEnv *env, jclass clz)
 	assert(!"JVM_GetNestMembers unimplemented");
 	return NULL;
 }
-/**
- * Check if two classes belong to the same nest
- *
- * @param [in] env pointer to JNIEnv
- * @param [in] jClassOne Class object 1
- * @param [in] jClassTwo Class object 2
- *
- * @return JNI_TRUE if classes belong to the same nest, JNI_FALSE otherwise
- */
 JNIEXPORT jboolean JNICALL
-JVM_AreNestMates(JNIEnv *env, jclass jClassOne, jclass jClassTwo)
+JVM_AreNestMates(JNIEnv *env, jclass clzOne, jclass clzTwo)
 {
-	jboolean result = JNI_FALSE;
-
-	if ((NULL != jClassOne) && (NULL != jClassTwo)) {
-		j9object_t clazzObjectOne = NULL;
-		j9object_t clazzObjectTwo = NULL;
-		J9VMThread *currentThread = (J9VMThread*)env;
-		J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
-
-		vmFuncs->internalEnterVMFromJNI(currentThread);
-		clazzObjectOne = J9_JNI_UNWRAP_REFERENCE(jClassOne);
-		clazzObjectTwo = J9_JNI_UNWRAP_REFERENCE(jClassTwo);
-
-		if (clazzObjectOne == clazzObjectTwo) {
-			result = JNI_TRUE;
-		} else {
-			J9Class *clazzOne = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, clazzObjectOne);
-			J9Class *clazzTwo = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, clazzObjectTwo);
-
-			if (NULL == clazzOne->nestHost) {
-				if (J9_VISIBILITY_ALLOWED != vmFuncs->loadAndVerifyNestHost(currentThread, clazzOne, J9_LOOK_NO_THROW)) {
-					goto done;
-				}
-			}
-
-			if (NULL == clazzTwo->nestHost) {
-				if (J9_VISIBILITY_ALLOWED != vmFuncs->loadAndVerifyNestHost(currentThread, clazzTwo, J9_LOOK_NO_THROW)) {
-					goto done;
-				}
-			}
-
-			if (clazzOne->nestHost == clazzTwo->nestHost) {
-				result = JNI_TRUE;
-			}
-		}
-done:
-		vmFuncs->internalExitVMToJNI(currentThread);
-	}
-
-	return result;
+	assert(!"JVM_AreNestMates unimplemented");
+	return JNI_FALSE;
 }
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#endif /* J9VM_JCL_SE11 */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4837,9 +4837,6 @@ typedef struct J9InternalVMFunctions {
 	IDATA ( *registerOSHandler)(struct J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
 	void ( *throwNativeOOMError)(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
 	void ( *throwNewJavaIoIOException)(JNIEnv *env, const char *message);
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	UDATA ( *loadAndVerifyNestHost)(struct J9VMThread *vmThread, struct J9Class *clazz, UDATA options);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3053,24 +3053,6 @@ trace(J9VMThread *vmStruct);
 
 #endif /* J9VM_INTERP_TRACING || INTERP_UPDATE_VMCTRACING */ /* End File Level Build Flags */
 
-/* ---------------- visible.c ---------------- */
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
-/**
- * Loads the nest host and ensures that the nest host belongs
- * to the same runtime package as the class. This function requires
- * VMAccess
- *
- * @param vmThread handle to vmThread
- * @param clazz the class to search the nest host
- * @param options lookup options
- *
- * @return 	J9_VISIBILITY_ALLOWED if success,
- * 			J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR if failed to load nesthost,
- * 			J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR if nesthost is not in the same runtime package
- */
-UDATA
-loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options);
-#endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
 /* ---------------- VMAccess.cpp ---------------- */
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -366,7 +366,4 @@ J9InternalVMFunctions J9InternalFunctions = {
 	registerOSHandler,
 	throwNativeOOMError,
 	throwNewJavaIoIOException,
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
-	loadAndVerifyNestHost,
-#endif
 };

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -30,6 +30,11 @@
 #include "vm_internal.h"
 #include "j9protos.h"
 
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+static UDATA loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options);
+#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+
+
 IDATA
 checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions)
 {
@@ -185,55 +190,52 @@ _exit:
 }
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-UDATA
+static UDATA
 loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options)
 {
+	J9Class *nestHost = NULL;
 	UDATA result = J9_VISIBILITY_ALLOWED;
-	if (NULL == clazz->nestHost) {
-		J9Class *nestHost = NULL;
-		J9ROMClass *romClass = clazz->romClass;
-		J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
+	J9ROMClass *romClass = clazz->romClass;
+	J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
 
-		/* If no nest host is named, class is own nest host */
-		if (NULL == nestHostName) {
-			nestHost = clazz;
+	/* If no nest host is named, class is own nest host */
+	if (NULL == nestHostName) {
+		nestHost = clazz;
+	} else {
+		UDATA classLoadingFlags = 0;
+		if (J9_ARE_NO_BITS_SET(options, J9_LOOK_NO_THROW)) {
+			classLoadingFlags = J9_FINDCLASS_FLAG_THROW_ON_FAIL;
+		}
+
+		nestHost = internalFindClassUTF8(vmThread, J9UTF8_DATA(nestHostName), J9UTF8_LENGTH(nestHostName), clazz->classLoader, classLoadingFlags);
+
+		/* Nest host must be successfully loaded by the same classloader in the same package & verify the nest member */
+		if (NULL == nestHost) {
+			result = J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR;
+		} else if (clazz->packageID != nestHost->packageID) {
+			result = J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR;
 		} else {
-			UDATA classLoadingFlags = 0;
-			if (J9_ARE_NO_BITS_SET(options, J9_LOOK_NO_THROW)) {
-				classLoadingFlags = J9_FINDCLASS_FLAG_THROW_ON_FAIL;
-			}
+			/* The nest host must have a nestmembers attribute that claims this class. */
+			J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
+			J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(nestHost->romClass);
+			U_16 nestMemberCount = nestHost->romClass->nestMemberCount;
+			U_16 i = 0;
 
-			nestHost = internalFindClassUTF8(vmThread, J9UTF8_DATA(nestHostName), J9UTF8_LENGTH(nestHostName), clazz->classLoader, classLoadingFlags);
-
-			/* Nest host must be successfully loaded by the same classloader in the same package & verify the nest member */
-			if (NULL == nestHost) {
-				result = J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR;
-			} else if (clazz->packageID != nestHost->packageID) {
-				result = J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR;
-			} else {
-				/* The nest host must have a nestmembers attribute that claims this class. */
-				J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
-				J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(nestHost->romClass);
-				U_16 nestMemberCount = nestHost->romClass->nestMemberCount;
-				U_16 i = 0;
-
-				result = J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR;
-				for (i = 0; i < nestMemberCount; i++) {
-					J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
-					if (J9UTF8_EQUALS(className, nestMemberName)) {
-						result = J9_VISIBILITY_ALLOWED;
-						break;
-					}
+			result = J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR;
+			for (i = 0; i < nestMemberCount; i++) {
+				J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
+				if (J9UTF8_EQUALS(className, nestMemberName)) {
+					result = J9_VISIBILITY_ALLOWED;
+					break;
 				}
 			}
 		}
-
-		/* If a problem occurred in nest host verification then the nest host value is invalid */
-		if  ((J9_VISIBILITY_ALLOWED == result) && (NULL != nestHost)) {
-			clazz->nestHost = nestHost;
-		}
 	}
 
+	/* If a problem occurred in nest host verification then the nest host value is invalid */
+	if  ((J9_VISIBILITY_ALLOWED == result) && (nestHost != NULL)) {
+		clazz->nestHost = nestHost;
+	}
 	return result;
 }
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */


### PR DESCRIPTION
Reverts eclipse/openj9#2421

Builds are failing on Windows (perhaps all platforms with recent changes to jdk8) because the redirector claims to export nestmate functions but they're not included unless compiling for Java 11.