### PR TITLE
Add implementation for JVM_AreNestMates

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4837,6 +4837,9 @@ typedef struct J9InternalVMFunctions {
 	IDATA ( *registerOSHandler)(struct J9JavaVM *vm, U_32 signal, void *newOSHandler, void **oldOSHandler);
 	void ( *throwNativeOOMError)(JNIEnv *env, U_32 moduleName, U_32 messageNumber);
 	void ( *throwNewJavaIoIOException)(JNIEnv *env, const char *message);
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+	UDATA ( *loadAndVerifyNestHost)(struct J9VMThread *vmThread, struct J9Class *clazz, UDATA options);
+#endif /* J9VM_OPT_VALHALLA_NESTMATES */
 } J9InternalVMFunctions;
 
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3053,6 +3053,24 @@ trace(J9VMThread *vmStruct);
 
 #endif /* J9VM_INTERP_TRACING || INTERP_UPDATE_VMCTRACING */ /* End File Level Build Flags */
 
+/* ---------------- visible.c ---------------- */
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+/**
+ * Loads the nest host and ensures that the nest host belongs
+ * to the same runtime package as the class. This function requires
+ * VMAccess
+ *
+ * @param vmThread handle to vmThread
+ * @param clazz the class to search the nest host
+ * @param options lookup options
+ *
+ * @return 	J9_VISIBILITY_ALLOWED if success,
+ * 			J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR if failed to load nesthost,
+ * 			J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR if nesthost is not in the same runtime package
+ */
+UDATA
+loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options);
+#endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
 /* ---------------- VMAccess.cpp ---------------- */
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -366,4 +366,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	registerOSHandler,
 	throwNativeOOMError,
 	throwNewJavaIoIOException,
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+	loadAndVerifyNestHost,
+#endif
 };

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -30,11 +30,6 @@
 #include "vm_internal.h"
 #include "j9protos.h"
 
-#if defined(J9VM_OPT_VALHALLA_NESTMATES)
-static UDATA loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options);
-#endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
-
-
 IDATA
 checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomClass, J9Module* srcModule, J9ROMClass* destRomClass, J9Module* destModule, UDATA destPackageID, UDATA lookupOptions)
 {
@@ -190,52 +185,55 @@ _exit:
 }
 
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
-static UDATA
+UDATA
 loadAndVerifyNestHost(J9VMThread *vmThread, J9Class *clazz, UDATA options)
 {
-	J9Class *nestHost = NULL;
 	UDATA result = J9_VISIBILITY_ALLOWED;
-	J9ROMClass *romClass = clazz->romClass;
-	J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
+	if (NULL == clazz->nestHost) {
+		J9Class *nestHost = NULL;
+		J9ROMClass *romClass = clazz->romClass;
+		J9UTF8 *nestHostName = J9ROMCLASS_NESTHOSTNAME(romClass);
 
-	/* If no nest host is named, class is own nest host */
-	if (NULL == nestHostName) {
-		nestHost = clazz;
-	} else {
-		UDATA classLoadingFlags = 0;
-		if (J9_ARE_NO_BITS_SET(options, J9_LOOK_NO_THROW)) {
-			classLoadingFlags = J9_FINDCLASS_FLAG_THROW_ON_FAIL;
-		}
-
-		nestHost = internalFindClassUTF8(vmThread, J9UTF8_DATA(nestHostName), J9UTF8_LENGTH(nestHostName), clazz->classLoader, classLoadingFlags);
-
-		/* Nest host must be successfully loaded by the same classloader in the same package & verify the nest member */
-		if (NULL == nestHost) {
-			result = J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR;
-		} else if (clazz->packageID != nestHost->packageID) {
-			result = J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR;
+		/* If no nest host is named, class is own nest host */
+		if (NULL == nestHostName) {
+			nestHost = clazz;
 		} else {
-			/* The nest host must have a nestmembers attribute that claims this class. */
-			J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
-			J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(nestHost->romClass);
-			U_16 nestMemberCount = nestHost->romClass->nestMemberCount;
-			U_16 i = 0;
+			UDATA classLoadingFlags = 0;
+			if (J9_ARE_NO_BITS_SET(options, J9_LOOK_NO_THROW)) {
+				classLoadingFlags = J9_FINDCLASS_FLAG_THROW_ON_FAIL;
+			}
 
-			result = J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR;
-			for (i = 0; i < nestMemberCount; i++) {
-				J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
-				if (J9UTF8_EQUALS(className, nestMemberName)) {
-					result = J9_VISIBILITY_ALLOWED;
-					break;
+			nestHost = internalFindClassUTF8(vmThread, J9UTF8_DATA(nestHostName), J9UTF8_LENGTH(nestHostName), clazz->classLoader, classLoadingFlags);
+
+			/* Nest host must be successfully loaded by the same classloader in the same package & verify the nest member */
+			if (NULL == nestHost) {
+				result = J9_VISIBILITY_NEST_HOST_LOADING_FAILURE_ERROR;
+			} else if (clazz->packageID != nestHost->packageID) {
+				result = J9_VISIBILITY_NEST_HOST_DIFFERENT_PACKAGE_ERROR;
+			} else {
+				/* The nest host must have a nestmembers attribute that claims this class. */
+				J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
+				J9SRP *nestMembers = J9ROMCLASS_NESTMEMBERS(nestHost->romClass);
+				U_16 nestMemberCount = nestHost->romClass->nestMemberCount;
+				U_16 i = 0;
+
+				result = J9_VISIBILITY_NEST_MEMBER_NOT_CLAIMED_ERROR;
+				for (i = 0; i < nestMemberCount; i++) {
+					J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
+					if (J9UTF8_EQUALS(className, nestMemberName)) {
+						result = J9_VISIBILITY_ALLOWED;
+						break;
+					}
 				}
 			}
 		}
+
+		/* If a problem occurred in nest host verification then the nest host value is invalid */
+		if  ((J9_VISIBILITY_ALLOWED == result) && (NULL != nestHost)) {
+			clazz->nestHost = nestHost;
+		}
 	}
 
-	/* If a problem occurred in nest host verification then the nest host value is invalid */
-	if  ((J9_VISIBILITY_ALLOWED == result) && (nestHost != NULL)) {
-		clazz->nestHost = nestHost;
-	}
 	return result;
 }
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */


### PR DESCRIPTION
Add implementation for JVM_AreNestMates 

Same as #2421 except it is under the J9VM_JCL_SE11

Signed-off-by: tajila <atobia@ca.ibm.com>