### PR TITLE
Use MethodMonitorEntry for inlined callee in OSR

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -987,10 +987,7 @@ TR_J9ByteCodeIlGenerator::prependEntryCode(TR::Block * firstBlock)
       loadMonitorArg();
 
       TR::Node * firstChild = pop();
-      TR::SymbolReference * monEnterSymRef =
-         isOutermostMethod() ?
-           symRefTab()->findOrCreateMethodMonitorEntrySymbolRef(_methodSymbol) :
-           symRefTab()->findOrCreateMonitorEntrySymbolRef(_methodSymbol);
+      TR::SymbolReference * monEnterSymRef = symRefTab()->findOrCreateMethodMonitorEntrySymbolRef(_methodSymbol);
 
       if (TR::Compiler->cls.classesOnHeap())
          {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1538,7 +1538,7 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
             _bcIndex += 3;
             break;
             }
-            
+
          case J9BCgenericReturn:
          case J9BCReturnC:
          case J9BCReturnS:
@@ -6483,10 +6483,9 @@ TR_J9ByteCodeIlGenerator::genMonitorEnter()
 void
 TR_J9ByteCodeIlGenerator::genMonitorExit(bool isReturn)
    {
-   TR::SymbolReference * monitorExitSymbolRef =
-      isReturn && isOutermostMethod() ?
-         symRefTab()->findOrCreateMethodMonitorExitSymbolRef(_methodSymbol) :
-         symRefTab()->findOrCreateMonitorExitSymbolRef(_methodSymbol);
+   TR::SymbolReference * monitorExitSymbolRef = isReturn ?
+      symRefTab()->findOrCreateMethodMonitorExitSymbolRef(_methodSymbol) :
+      symRefTab()->findOrCreateMonitorExitSymbolRef(_methodSymbol);
 
    TR::Node * node = pop();
 
@@ -6853,15 +6852,15 @@ TR_J9ByteCodeIlGenerator::genReturn(TR::ILOpCodes nodeop, bool monitorExit)
          case J9BCReturnC:
             returnChild = TR::Node::create(TR::su2i, 1, TR::Node::create(TR::i2s, 1, returnChild));
             break;
-            
+
          case J9BCReturnS:
             returnChild = TR::Node::create(TR::s2i, 1, TR::Node::create(TR::i2s, 1, returnChild));
             break;
-            
+
          case J9BCReturnB:
             returnChild = TR::Node::create(TR::b2i, 1, TR::Node::create(TR::i2b, 1, returnChild));
             break;
-            
+
          case J9BCReturnZ:
             returnChild = TR::Node::create(TR::iand, 2, returnChild, TR::Node::iconst(1));
             break;


### PR DESCRIPTION
VM expects jitMethodMonitorEntry to be used for monitor enter in
inlined synchronized callee under OSR. Change JIT to call the
correct helper so that VM get the expected stack frame type.

issue: #2139
Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>