### PR TITLE
Guard X86-only helper with TR_HOST_X86

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1049,7 +1049,9 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_releaseVMAccess,            (void *)jitReleaseVMAccess,            TR_Helper);
 #endif
    SET(TR_throwCurrentException,      (void *)jitThrowCurrentException,      TR_Helper);
+#if defined (TR_HOST_X86)
    SET(TR_throwClassCastException,    (void *)jitThrowClassCastException,    TR_Helper);
+#endif
 
    SET(TR_newInstanceImplAccessCheck, (void *)jitNewInstanceImplAccessCheck,         TR_Helper);
 


### PR DESCRIPTION
jitThrowClassCastException is only available on X86 and hence guarding it with #ifdef TR_HOST_X86.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>