### PR TITLE
Rework getJimModules()

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -129,7 +129,6 @@
 	<classref name="java/lang/Module" jcl="se9,se10,se11" flags="opt_module"/>
 	<classref name="java/lang/invoke/VarHandle" jcl="se9_before_b165,se9,se10,se11"/>
 	<classref name="java/lang/invoke/VarHandleInvokeHandle" jcl="se9_before_b165,se9,se10,se11"/>
-	<classref name="jdk/internal/module/Modules" jcl="se9,se10,se11" flags="opt_module"/>
 
 	<fieldref class="java/lang/ClassLoader" name="parent" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/ClassLoader" name="vmRef" signature="J" cast="struct J9ClassLoader *"/>


### PR DESCRIPTION
- inline single-use function
- handle errors consistently
- load instrument module before adding to classpath
- remove unnecessary use of VM constant pool

Fixes: #2437

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>