### PR TITLE
Include j9cfg.h for JAVA_SPEC_VERSION

### DIFF
--- a/runtime/oti/j2sever.h
+++ b/runtime/oti/j2sever.h
@@ -22,6 +22,8 @@
 #ifndef j2sever_h
 #define j2sever_h
 
+#include "j9cfg.h" /* for JAVA_SPEC_VERSION */
+
 /**
  * Constants for supported J2SE versions.
  */
@@ -38,7 +40,6 @@
 /* Shared class cache is using JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) to get the Java version.
  * So bits 9 to 16 of the J2SE constant should match the java version number.
  */
-
 
 #if JAVA_SPEC_VERSION == 8
 	#define J2SE_LATEST  J2SE_18
@@ -105,7 +106,7 @@
 
 /**
  * Macro to extract J2SE version given a JNIEnv.
- */ 
+ */
 #define J2SE_VERSION_FROM_ENV(env) J2SE_VERSION(((J9VMThread*)env)->javaVM)
 
 /**
@@ -115,7 +116,7 @@
 
 /**
  * Macro to extract J2SE shape given a JNIEnv.
- */ 
+ */
 #define J2SE_SHAPE_FROM_ENV(env) J2SE_SHAPE(((J9VMThread*)env)->javaVM)
 
 /**
@@ -123,5 +124,4 @@
  */
 #define JAVA_SPEC_VERSION_FROM_J2SE(j2seVersion) 	((j2seVersion) >> J2SE_JAVA_SPEC_VERSION_SHIFT)
 
-#endif     /* j2sever_h */
-
+#endif /* j2sever_h */


### PR DESCRIPTION
j2sever.h relied on j9cfg.h being included before it: today that is true, but we'll avoid possible future subtle problems by removing that assumption.