### PR TITLE
Add getEnvironment() API to runtime helper table

### DIFF
--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1246,18 +1246,7 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_S390jitProfileStringValueC,           (void *)_jitProfileStringValue,     TR_Helper);
    SET(TR_S390induceRecompilation,              (void *)_induceRecompilation,       TR_Helper);
    SET_CONST(TR_S390induceRecompilation_unwrapper, (void *) induceRecompilation_unwrapper);
-
-// Set the Address Enviroment pointer.  Same for all routines from
-// same library, so doesn't matter which routine, but currently only
-// used when calling jitProfile* in zOS, so use one of them
-#ifdef J9ZOS390
-#define TRS390_TOC_UNWRAP_ENV(wrappedPointer) (((J9FunctionDescriptor_T *) (wrappedPointer))->ada)
-#else
-#define TRS390_TOC_UNWRAP_ENV(wrappedPointer) 0xdeafbeef
-#endif
-   SET_CONST(TR_S390CEnvironmentAddress,(void *)TRS390_TOC_UNWRAP_ENV((void *)_jitProfileValue));
-
-
+   SET_CONST(TR_S390CEnvironmentAddress,(void *)TOC_UNWRAP_ENV((void *)_jitProfileValue));
 
 #endif
 

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -283,7 +283,7 @@ J9::Recompilation::methodHasBeenRecompiled(void * oldStartPC, void * newStartPC,
 
       patchAddr = (intptrj_t *) ((uint8_t *) oldStartPC + -(startPCToAsmOffset + requiredPad));
       oldAsmAddr = *patchAddr;
-      newAsmAddr = (intptrj_t) runtimeHelpers.getAddress(TR_S390samplingPatchCallSite);
+      newAsmAddr = (intptrj_t) runtimeHelpers.getFunctionEntryPointOrConst(TR_S390samplingPatchCallSite);
 
       if (debug("traceRecompilation"))
          {


### PR DESCRIPTION
Add a getEnvironment() API to the runtime helper table for PPC and
Z. The idea is to store function pointers on JIT initialization instead of storing unwrapped raw function entry addresses. In doing so, the JIT compiler is able to extract and use helper functions' environment pointers via the new getEnvironment() API. This is important for JITCODE to C function calls on PPC AIX and z/OS.

Also, rename TRS390_TOC_UNWRAP_ENV to TOC_UNWRAP_ENV so that the naming is
consistent with TOC_UNWRAP_ADDRESS.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>