### PR TITLE
Remove path from sun.boot.library.path

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2140,10 +2140,8 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 				/* Add the default options file */
 				(0 != addOptionsDefaultFile(&j9portLibrary, &vmArgumentsList, optionsDefaultFileLocation, localVerboseLevel))
 				|| (0 != addXjcl(&j9portLibrary, &vmArgumentsList, j2seVersion))
-				|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dcom.ibm.oti.vm.bootstrap.library.path=",
-						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
-				|| (0 != addBootLibraryPath(&j9portLibrary, &vmArgumentsList, "-Dsun.boot.library.path=",
-						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
+				|| (0 != addBootstrapLibraryPath(&j9portLibrary, &vmArgumentsList, jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer)))
+				|| (0 != addSunBootLibraryPath(&j9portLibrary, &vmArgumentsList, jvmBufferData(jrebinBuffer)))
 				|| (0 != addJavaLibraryPath(&j9portLibrary, &vmArgumentsList, argEncoding, jvmInSubdir,
 						jvmBufferData(j9binBuffer), jvmBufferData(jrebinBuffer),
 						libpathValue, ldLibraryPathValue))

--- a/runtime/oti/vmargs_api.h
+++ b/runtime/oti/vmargs_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -122,17 +122,27 @@ IDATA
 addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2seVersion);
 
 /*
- * Add argument to set com.ibm.oti.vm.bootstrap.library.path or sun.boot.library.path
+ * Add argument to set com.ibm.oti.vm.bootstrap.library.path
  * This allocates memory for the options string and contents of the file
  * @param portLib port library
  * @param vmArgumentsList current list of arguments
- * @param propertyNameEquals -D<property name>=
  * @param j9binPath path to library directory
  * @param jrebinPath path to library directory
  * @return 0 on success, negative value on failure
  */
 IDATA
-addBootLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *propertyNameEquals, char *j9binPath, char *jrebinPath);
+addBootstrapLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *j9binPath, char *jrebinPath);
+
+/*
+ * Add argument to set sun.boot.library.path
+ * This allocates memory for the options string and contents of the file
+ * @param portLib port library
+ * @param vmArgumentsList current list of arguments
+ * @param jrebinPath path to library directory
+ * @return 0 on success, negative value on failure
+ */
+IDATA
+addSunBootLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jrebinPath);
 
 /**
  * Add argument to set java.library.path

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -72,6 +72,8 @@
 #endif
 #endif /* !defined(J9JAVA_PATH_SEPARATOR) */
 #define JAVA_HOME_EQUALS "-Djava.home="
+#define IBM_BOOTSTRAP_LIBRARY_PATH_EQUALS "-Dcom.ibm.oti.vm.bootstrap.library.path="
+#define SUN_BOOT_LIBRARY_PATH_EQUALS "-Dsun.boot.library.path="
 #define JAVA_LIB_PATH_EQUALS "-Djava.library.path="
 #define JAVA_EXT_DIRS_EQUALS "-Djava.ext.dirs="
 #define JAVA_USER_DIR_EQUALS "-Duser.dir="
@@ -770,7 +772,32 @@ addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2s
 }
 
 IDATA
-addBootLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *propertyNameEquals, char *j9binPath, char *jrebinPath)
+addSunBootLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *jrebinPath)
+{
+	char *optionsArgumentBuffer = NULL;
+	size_t argumentLength = 0;
+	J9JavaVMArgInfo *optArg = NULL;
+	PORT_ACCESS_FROM_PORT(portLib);
+
+	argumentLength = strlen(SUN_BOOT_LIBRARY_PATH_EQUALS) + strlen(jrebinPath) + 1; /* adds the space for the terminating null */
+	optionsArgumentBuffer = j9mem_allocate_memory(argumentLength, OMRMEM_CATEGORY_VM);
+
+	if (NULL == optionsArgumentBuffer) {
+		return -1;
+	}
+
+	j9str_printf(PORTLIB, optionsArgumentBuffer, argumentLength, "%s%s", SUN_BOOT_LIBRARY_PATH_EQUALS, jrebinPath);
+
+	optArg = newJavaVMArgInfo(vmArgumentsList, optionsArgumentBuffer, ARG_MEMORY_ALLOCATION|CONSUMABLE_ARG);
+	if (NULL == optArg) {
+		j9mem_free_memory(optionsArgumentBuffer);
+		return -1;
+	}
+	return 0;
+}
+
+IDATA
+addBootstrapLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *j9binPath, char *jrebinPath)
 {
 	char *optionsArgumentBuffer = NULL;
 	/* argumentLength include the space for the \0 because of the sizeof() */
@@ -778,14 +805,14 @@ addBootLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 	J9JavaVMArgInfo *optArg = NULL;
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	argumentLength = strlen(propertyNameEquals) + strlen(j9binPath) + sizeof(J9JAVA_PATH_SEPARATOR) + strlen(jrebinPath); /* the sizeof operation adds the space for the terminating null */
+	argumentLength = strlen(IBM_BOOTSTRAP_LIBRARY_PATH_EQUALS) + strlen(j9binPath) + sizeof(J9JAVA_PATH_SEPARATOR) + strlen(jrebinPath); /* the sizeof operation adds the space for the terminating null */
 	optionsArgumentBuffer = j9mem_allocate_memory(argumentLength, OMRMEM_CATEGORY_VM);
 
 	if (NULL == optionsArgumentBuffer) {
 		return -1;
 	}
 
-	j9str_printf(PORTLIB, optionsArgumentBuffer, argumentLength, "%s%s" J9JAVA_PATH_SEPARATOR "%s", propertyNameEquals, j9binPath, jrebinPath);
+	j9str_printf(PORTLIB, optionsArgumentBuffer, argumentLength, "%s%s" J9JAVA_PATH_SEPARATOR "%s", IBM_BOOTSTRAP_LIBRARY_PATH_EQUALS, j9binPath, jrebinPath);
 
 	optArg = newJavaVMArgInfo(vmArgumentsList, optionsArgumentBuffer, ARG_MEMORY_ALLOCATION|CONSUMABLE_ARG);
 	if (NULL == optArg) {


### PR DESCRIPTION
Remove compressedrefs directory from sun.boot.library.path. Our extensions expect this property to have only one path. See full description in #2129.

Fixes: #2129

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>