### PR TITLE
Remove deferredVMAccessRelease

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -143,7 +143,7 @@ public:
 	 */
 	void releaseExclusiveVMAccess();
 
-	uintptr_t relinquishExclusiveVMAccess(bool *deferredVMAccessRelease = NULL);
+	uintptr_t relinquishExclusiveVMAccess();
 
 	void assumeExclusiveVMAccess(uintptr_t exclusiveCount);
 


### PR DESCRIPTION
Remove deferredVMAccessRelease option in relinquishExclusiveVMAccess,
since there are not more users of it.


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>