### PR TITLE
Remove Thread.destroy() and Thread.stop(Throwable) from JAVA11

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Thread.java
+++ b/jcl/src/java.base/share/classes/java/lang/Thread.java
@@ -538,6 +538,7 @@ public int countStackFrames() {
  */
 public static native Thread currentThread();
 
+/*[IF !Java11]*/
 /**
  * 	Destroys the receiver without any monitor cleanup. Not implemented.
  * 
@@ -552,6 +553,7 @@ public void destroy() {
 	/*[PR 121318] Should throw NoSuchMethodError */
 	throw new NoSuchMethodError();
 }
+/*[ENDIF]*/
 
 
 /**
@@ -1126,6 +1128,7 @@ public final void stop() {
 	}
 }
 
+/*[IF !Java11]*/
 /**
  * Throws UnsupportedOperationException.
  *
@@ -1141,6 +1144,7 @@ public final void stop() {
 public final void stop(Throwable throwable) {
 	throw new UnsupportedOperationException();
  }
+/*[ENDIF]*/
 
 private final synchronized void stopWithThrowable(Throwable throwable) {
 	checkAccess();


### PR DESCRIPTION
Removed `destroy()` and `stop(Throwable)` from JAVA11 in `Thread.java`

Closes: #2267

Signed-off-by: Charles_Zheng <Juntian.Zheng@ibm.com>