### PR TITLE
Fix syntax error in Test_String.java

### DIFF
--- a/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -221,6 +221,7 @@ public class Test_String {
 				"isBlank: failed to return false on non-blank latin1 string with leading white space.");
 		Assert.assertFalse((allWhiteSpace + nonLatin1).isBlank(),
 				"isBlank: failed to return false on non-blank non-latin1 string with leading white space.");
+	}
 	 
 	/*	
 	 * Test Java 11 API String.lines


### PR DESCRIPTION
Added a missing "}" in Test_String.java

Signed-off-by: Charles_Zheng <Juntian.Zheng@ibm.com>