### PR TITLE
Optimize findNativeMethodFrame

### DIFF
--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -38,6 +38,7 @@
 #include "MemorySpace.hpp"
 #include "VMThreadListIterator.hpp"
 #include "ModronAssertions.h"
+#include "VMHelpers.hpp"
 
 
 
@@ -2025,23 +2026,10 @@ MM_ObjectAccessBarrier::setOwnableSynchronizerLink(j9object_t object, j9object_t
 	*ownableSynchronizerLink = convertTokenFromPointer(value);
 }
 
-/**
- * This is copy of function from jnimisc.cpp
- *
- * Find the J9SFJNINativeMethodFrame representing the current native.
- * @param currentThread[in] the current J9VMThread
- * @returns the native method frame
- */
-static J9SFJNINativeMethodFrame*
-findNativeMethodFrame(J9VMThread *currentThread)
-{
-	return (J9SFJNINativeMethodFrame*)((UDATA)currentThread->sp + (UDATA)currentThread->literals);
-}
-
 void
 MM_ObjectAccessBarrier::printNativeMethod(J9VMThread* vmThread)
 {
-	J9SFJNINativeMethodFrame *nativeMethodFrame = findNativeMethodFrame(vmThread);
+	J9SFJNINativeMethodFrame *nativeMethodFrame = VM_VMHelpers::findNativeMethodFrame(vmThread);
 	J9Method *method = nativeMethodFrame->method;
 	J9JavaVM *javaVM = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(javaVM);

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1417,6 +1417,19 @@ exit:
 			}
 		}
 	}
+
+	/**
+	 * Find the J9SFJNINativeMethodFrame representing the current native.
+	 *
+	 * @param currentThread[in] the current J9VMThread
+	 *
+	 * @returns the native method frame
+	 */
+	static VMINLINE J9SFJNINativeMethodFrame*
+	findNativeMethodFrame(J9VMThread *currentThread)
+	{
+		return (J9SFJNINativeMethodFrame*)((UDATA)currentThread->sp + (UDATA)currentThread->literals);
+	}
 };
 
 #endif /* VMHELPERS_HPP_ */

--- a/runtime/vm/jnifield.cpp
+++ b/runtime/vm/jnifield.cpp
@@ -41,7 +41,7 @@ static J9Method*
 findFieldContext(J9VMThread *currentThread, IDATA *pcOffset)
 {
 	IDATA bytecodePCOffset = 0;
-	J9Method *method = findNativeMethodFrame(currentThread)->method;
+	J9Method *method = VM_VMHelpers::findNativeMethodFrame(currentThread)->method;
 	if (NULL == method) {
 		J9StackWalkState *walkState = currentThread->stackWalkState;
 		walkState->walkThread = currentThread;

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -121,12 +121,6 @@ fetchArrayClass(J9VMThread *currentThread, J9Class *elementTypeClass)
 	return resultClass;
 }
 
-J9SFJNINativeMethodFrame*
-findNativeMethodFrame(J9VMThread *currentThread)
-{
-	return (J9SFJNINativeMethodFrame*)((UDATA)currentThread->sp + (UDATA)currentThread->literals);
-}
-
 /**
  * Find the J9ClassLoader to use for the currently-running native method.
  *
@@ -141,7 +135,7 @@ getCurrentClassLoader(J9VMThread *currentThread)
 {
 	J9JavaVM *vm = currentThread->javaVM;
 	J9ClassLoader *classLoader = NULL;
-	J9SFJNINativeMethodFrame *nativeMethodFrame = findNativeMethodFrame(currentThread);
+	J9SFJNINativeMethodFrame *nativeMethodFrame = VM_VMHelpers::findNativeMethodFrame(currentThread);
 	J9Method *nativeMethod = nativeMethodFrame->method;
 	/* JNI 1.2 says: if there is no current native method, use the appClassLoader */
 	if (NULL == nativeMethod) {
@@ -975,7 +969,7 @@ jniResetStackReferences(JNIEnv *env)
 {
 	J9VMThread *currentThread = (J9VMThread*)env;
 	Assert_VM_mustHaveVMAccess(currentThread);
-	J9SFJNINativeMethodFrame *nativeMethodFrame = findNativeMethodFrame(currentThread);
+	J9SFJNINativeMethodFrame *nativeMethodFrame = VM_VMHelpers::findNativeMethodFrame(currentThread);
 	UDATA flags = nativeMethodFrame->specialFrameFlags;
 	if (J9_ARE_ANY_BITS_SET(flags, J9_SSF_CALL_OUT_FRAME_ALLOC)) {
 		jniPopFrame(currentThread, JNIFRAME_TYPE_INTERNAL);

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -97,18 +97,6 @@ fieldIndexTableNew(J9JavaVM* vm, J9PortLibrary *portLib);
 void
 fieldIndexTableFree(J9JavaVM* vm);
 
-/* ---------------- jnimisc.c ---------------- */
-
-/**
- * Find the J9SFJNINativeMethodFrame representing the current native.
- *
- * @param currentThread[in] the current J9VMThread
- *
- * @returns the native method frame
- */
-J9SFJNINativeMethodFrame*
-findNativeMethodFrame(J9VMThread *currentThread);
-
 /* ---------------- jniinv.c ---------------- */
 
 /**


### PR DESCRIPTION
findNativeMethodFrame had two identical implementations, and is so
trivial that it need not be a function call.  Put it in VMHelpers.hpp
instead.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>