### PR TITLE
Deprecate Access Register (AR) support in Z codegen

### DIFF
--- a/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
@@ -99,8 +99,7 @@ TR::S390CHelperLinkage::S390CHelperLinkage(TR::CodeGenerator * codeGen,TR_S390Li
       setRegisterFlag(TR::RealRegister::FPR15, Preserved);
       }
 #endif
-   // Following Snippet for marking ARs preserved was taken from System Linkage.
-   // Current linkage do not preserve the ARs
+
    if (TR::Compiler->target.isLinux())
       {
       
@@ -108,15 +107,6 @@ TR::S390CHelperLinkage::S390CHelperLinkage(TR::CodeGenerator * codeGen,TR_S390Li
       setRegisterFlag(TR::RealRegister::GPR6, Preserved);
       setRegisterFlag(TR::RealRegister::GPR7, Preserved);
       setRegisterFlag(TR::RealRegister::GPR12, Preserved);
-
-      setRegisterFlag(TR::RealRegister::AR8, Preserved);
-      setRegisterFlag(TR::RealRegister::AR9, Preserved);
-      setRegisterFlag(TR::RealRegister::AR10, Preserved);
-      setRegisterFlag(TR::RealRegister::AR11, Preserved);
-      setRegisterFlag(TR::RealRegister::AR12, Preserved);
-      setRegisterFlag(TR::RealRegister::AR13, Preserved);
-      setRegisterFlag(TR::RealRegister::AR14, Preserved);
-      setRegisterFlag(TR::RealRegister::AR15, Preserved);
 
       setReturnAddressRegister (TR::RealRegister::GPR14 );
       setIntegerReturnRegister (TR::RealRegister::GPR2 );
@@ -223,10 +213,8 @@ class RealRegisterManager
             _Registers[RealRegister] = _cg->allocateRegister(TR_FPR);
          else if (RealRegister >= TR::RealRegister::FirstVRF && RealRegister <= TR::RealRegister::LastVRF)
             _Registers[RealRegister] = _cg->allocateRegister(TR_VRF);
-         else if (!(RealRegister >= TR::RealRegister::FirstAR && RealRegister <= TR::RealRegister::LastAR))
-            _Registers[RealRegister] = _cg->allocateRegister();
          else
-            return NULL;
+            _Registers[RealRegister] = _cg->allocateRegister();
          _numberOfRegistersInUse++;
          }
       return _Registers[RealRegister];

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -96,18 +96,6 @@ TR::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390Li
    setRegisterFlag(TR::RealRegister::FPR15, Preserved);
 #endif
 
-   if (TR::Compiler->target.isLinux())
-   {
-   setRegisterFlag(TR::RealRegister::AR8, Preserved);
-   setRegisterFlag(TR::RealRegister::AR9, Preserved);
-   setRegisterFlag(TR::RealRegister::AR10, Preserved);
-   setRegisterFlag(TR::RealRegister::AR11, Preserved);
-   setRegisterFlag(TR::RealRegister::AR12, Preserved);
-   setRegisterFlag(TR::RealRegister::AR13, Preserved);
-   setRegisterFlag(TR::RealRegister::AR14, Preserved);
-   setRegisterFlag(TR::RealRegister::AR15, Preserved);
-   }
-
    setIntegerReturnRegister (TR::RealRegister::GPR2 );
    setLongLowReturnRegister (TR::RealRegister::GPR3 );
    setLongHighReturnRegister(TR::RealRegister::GPR2 );
@@ -1072,12 +1060,11 @@ TR::S390PrivateLinkage::mapPreservedRegistersToStackOffsets(int32_t *mapRegsToSt
       return false;
 
    int32_t argSize = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm();
-   int32_t numIntSaved = 0, numFloatSaved = 0, numAccessRegSaved = 0, numHighWordRegSaved = 0, registerSaveDescription = 0;
+   int32_t numIntSaved = 0, numFloatSaved = 0, numHighWordRegSaved = 0, registerSaveDescription = 0;
    int32_t regSaveSize = calculateRegisterSaveSize(firstUsedReg, lastUsedReg,
                                                    firstUsedHighWordReg, lastUsedHighWordReg,
                                                    registerSaveDescription,
-                                                   numIntSaved, numFloatSaved,
-                                                   numAccessRegSaved, numHighWordRegSaved);
+                                                   numIntSaved, numFloatSaved, numHighWordRegSaved);
    // total frame size
    int32_t size = regSaveSize + localSize + argSize;
 
@@ -1178,8 +1165,7 @@ TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum first
                                                  TR::RealRegister::RegNum firstUsedHighWordReg,
                                                  TR::RealRegister::RegNum lastUsedHighWordReg,
                                                  int32_t &registerSaveDescription,
-                                                 int32_t &numIntSaved, int32_t &numFloatSaved,
-                                                 int32_t &numAccessRegSaved, int32_t &numHighWordRegSaved)
+                                                 int32_t &numIntSaved, int32_t &numFloatSaved, int32_t &numHighWordRegSaved)
    {
    int32_t regSaveSize = 0;
    // set up registerSaveDescription which looks the following
@@ -1209,21 +1195,6 @@ TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum first
       }
 #endif
 
-   //  AR8-15 are preserved on ZOS only
-   TR::RealRegister::RegNum lastUsedAccessReg = TR::RealRegister::NoReg;
-   if ( comp()->getOption(TR_Enable390AccessRegs) && !TR::Compiler->target.isLinux() )
-      {
-      lastUsedAccessReg = getLastSavedRegister(TR::RealRegister::AR8,
-                                              TR::RealRegister::AR15);
-
-      for (i = TR::RealRegister::AR8 ; i <= TR::RealRegister::AR15 ; ++i)
-         {
-         if ((getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
-            {
-            numAccessRegSaved++;
-            }
-         }
-      }
    // HPR6-HPR12 are also preserved on 32-bit
    if (cg()->supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is32Bit())
       {
@@ -1233,7 +1204,6 @@ TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum first
    // calculate stackFramesize
    regSaveSize += numIntSaved * cg()->machine()->getGPRSize() +
                           numFloatSaved * cg()->machine()->getFPRSize() +
-                          numAccessRegSaved * cg()->machine()->getGPRSize() +
                           numHighWordRegSaved * 4;
 
 
@@ -1282,7 +1252,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
    TR::RealRegister * epReg = getEntryPointRealRegister();
    TR::Snippet * firstSnippet = NULL;
    TR::Node * firstNode = comp()->getStartTree()->getNode();
-   int32_t size = 0, argSize = 0, regSaveSize = 0, numIntSaved = 0, numFloatSaved = 0, numAccessRegSaved = 0, numHighWordRegSaved =0;
+   int32_t size = 0, argSize = 0, regSaveSize = 0, numIntSaved = 0, numFloatSaved = 0, numHighWordRegSaved =0;
    int32_t registerSaveDescription = 0;
    int32_t firstLocalOffset = getOffsetToFirstLocal();
    int32_t i;
@@ -1297,10 +1267,6 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
    TR::RealRegister::RegNum lastUsedReg  = getLastSavedRegister(TR::RealRegister::GPR6,
                                                               TR::RealRegister::GPR12);
 
-   //  AR8-15 are preserved on ZOS only
-   TR::RealRegister::RegNum lastUsedAccessReg = TR::RealRegister::NoReg;
-
-
    // HPR6-HPR12 are also preserved on 32-bit
    TR::RealRegister::RegNum lastUsedHighWordReg  =  TR::RealRegister::NoReg;
    TR::RealRegister::RegNum firstUsedHighWordReg =  TR::RealRegister::NoReg;
@@ -1313,8 +1279,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
    regSaveSize = calculateRegisterSaveSize(firstUsedReg, lastUsedReg,
                                            firstUsedHighWordReg, lastUsedHighWordReg,
                                            registerSaveDescription,
-                                           numIntSaved, numFloatSaved,
-                                           numAccessRegSaved, numHighWordRegSaved);
+                                           numIntSaved, numFloatSaved, numHighWordRegSaved);
 
    if (regSaveSize != 0)
       {
@@ -1553,15 +1518,6 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
             }
          }
 #endif
-
-      // save ARs
-      if (lastUsedAccessReg != TR::RealRegister::NoReg)
-         {
-         rsa = generateS390MemoryReference(spReg, disp, cg());
-         cursor = generateRSInstruction(cg(), TR::InstOpCode::STAM, firstNode, getS390RealRegister(TR::RealRegister::AR8),
-                  getS390RealRegister(lastUsedAccessReg), rsa, cursor);
-         }
-      disp += numAccessRegSaved * cg()->machine()->getGPRSize();
 
       // save HPRs
       if (0 && cg()->supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is32Bit() &&
@@ -1821,16 +1777,6 @@ TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
          }
       }
 #endif
-
-   TR::RealRegister::RegNum lastUsedAccessReg =
-      getLastRestoredRegister(TR::RealRegister::AR8, TR::RealRegister::AR15);
-   if (lastUsedAccessReg != TR::RealRegister::NoReg)
-      {
-      rsa = generateS390MemoryReference(spReg, offset, cg());
-      cursor = generateRSInstruction(cg(), TR::InstOpCode::LAM, nextNode, getS390RealRegister(TR::RealRegister::AR8),
-               getS390RealRegister(lastUsedAccessReg), rsa, cursor);
-      offset += cg()->machine()->getGPRSize() * (lastUsedAccessReg - TR::RealRegister::GPR8 + 1);
-      }
 
    // Restore HPRs
    TR::RealRegister::RegNum lastUsedHighWordReg =

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
@@ -110,8 +110,7 @@ public:
                                              TR::RealRegister::RegNum fh,
                                              TR::RealRegister::RegNum lh,
                                              int32_t &rsd,
-                                             int32_t &numInts, int32_t &numFloats,
-                                             int32_t &numAccess, int32_t &numHigh);
+                                             int32_t &numInts, int32_t &numFloats, int32_t &numHigh);
 
 protected:
 


### PR DESCRIPTION
The compiler currently has AR support on some minor spectrum of
usability, though in practice the feature has been turned off for
several years, and has never been used outside of niche areas.

Supporting ARs even when disabled (as is the default) does have
technical debt and compile time overhead as we have to query for them
all the time, and in fact we have a separate register allocation pass
just for ARs.

Given these registers were originally envisioned to be spill slots
however times have changed since their original inception:

1. We don't have as many spills due to codegen and RA improvements
2. Storing out the stack is quite cheap
3. There is a lot of weirdness of using ARs around calls (linkage)
4. No support on Linux on Z

With these in mind this commit purges the codebase of all (modulo any
places I may have missed) AR support.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>