### PR TITLE
Remove unused buildPICParameters on X86-64

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -1157,32 +1157,6 @@ int32_t TR::AMD64PrivateLinkage::buildPrivateLinkageArgs(TR::Node               
    }
 
 
-
-
-void TR::AMD64PrivateLinkage::buildPICParameters(TR::Node             *callNode,
-                                                TR::SymbolReference  *methodSymRef,
-                                                TR::LabelSymbol       *resolveLabel,
-                                                TR::CodeGenerator *cg,
-                                                uint8_t *thunk)
-   {
-   void           *cpAddress = methodSymRef->getOwningMethod(comp())->constantPool();
-   const int32_t   cpIndex   = methodSymRef->getCPIndex();
-
-   generateImm64SymInstruction(DQImm64, callNode, (uintptrj_t)cpAddress, methodSymRef, cg, thunk);
-
-   if (VM_NEEDS_8_BYTE_CPINDEX)
-      {
-      generateImm64Instruction(DQImm64, callNode, (uint64_t)cpIndex, cg);
-      }
-   else
-      {
-      generateImmInstruction(DDImm4, callNode, (uint32_t)cpIndex, cg);
-      }
-
-   generateLabelInstruction(LABEL, callNode, resolveLabel, cg);
-   }
-
-
 static TR_AtomicRegion X86PicSlotAtomicRegion[] =
    {
    { 0x0, 8 }, // Maximum instruction size that can be patched atomically.

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,13 +80,6 @@ class AMD64PrivateLinkage : public TR::X86PrivateLinkage
          TR::RegisterDependencyConditions *dependencies,
          bool rightToLeftHelperLinkage,
          bool passArgsOnStack = false);
-
-   void buildPICParameters(
-         TR::Node *callNode,
-         TR::SymbolReference *methodSymRef,
-         TR::LabelSymbol *resolveLabel,
-         TR::CodeGenerator *codeGen,
-         uint8_t *thunk);
 
    virtual void buildVirtualOrComputedCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk);
    virtual TR::Instruction *buildPICSlot(TR::X86PICSlot picSlot, TR::LabelSymbol *mismatchLabel, TR::LabelSymbol *doneLabel, TR::X86CallSite &site);


### PR DESCRIPTION
TR::AMD64PrivateLinkage::buildPICParameters() has been long deprecated, removing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>