### PR TITLE
Excluded Thread.destroy() and Thread.stop(Throwable) test cases in Java11

### DIFF
--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -197,6 +197,12 @@
 							<pathelement location="${TEST_ROOT}/TestConfig/lib/javassist.jar" />
 						</classpath>
 					</javac>
+					<javac srcdir="${src_80}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+						<include name="org/openj9/test/java/lang/Test_Thread_Extra.java" />
+						<classpath>
+							<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
+						</classpath>
+					</javac>
 				</then>
 			</elseif>
 			<else>

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_Thread.java
@@ -370,19 +370,6 @@ public class Test_Thread {
 	}
 
 	/**
-	 * @tests java.lang.Thread#destroy()
-	 */
-	@Test
-	public void test_destroy() {
-		try {
-			new Thread().destroy();
-			Assert.fail("NoSuchMethodError expected");
-		} catch (NoSuchMethodError e) {
-			// expected
-		}
-	}
-
-	/**
 	 * @tests java.lang.Thread#enumerate(java.lang.Thread[])
 	 */
 	@Test
@@ -1218,85 +1205,6 @@ public class Test_Thread {
 	 * @tests java.lang.Thread#stop(java.lang.Throwable)
 	 */
 	@Test
-	public void test_stop3() {
-		/* [PR CMVC 94728] AccessControlException on dead Thread */
-		Thread t = new Thread("t");
-		class MySecurityManager extends SecurityManager {
-			public boolean intest = false;
-			public boolean checkAccess = false;
-
-			public void checkAccess(Thread t) {
-				if (intest) {
-					checkAccess = true;
-				}
-			}
-		}
-		MySecurityManager sm = new MySecurityManager();
-		System.setSecurityManager(sm);
-		try {
-			sm.intest = true;
-			try {
-				t.stop(new ThreadDeath());
-			} catch (UnsupportedOperationException e) {
-				// Expected
-			} catch (Throwable e) {
-				Assert.fail("unexpected exception: " + e);
-			}
-			sm.intest = false;
-			AssertJUnit.assertFalse("checkAccess 1", sm.checkAccess);
-			t.start();
-			try {
-				t.join(2000);
-			} catch (InterruptedException e) {
-			}
-			sm.intest = true;
-			sm.checkAccess = false;
-			try {
-				t.stop(new ThreadDeath());
-			} catch (UnsupportedOperationException e) {
-				// Expected
-			} catch (Throwable e) {
-				Assert.fail("unexpected exception: " + e);
-			}
-			AssertJUnit.assertFalse("checkAccess 2", sm.checkAccess);
-			sm.intest = false;
-		} finally {
-			System.setSecurityManager(null);
-		}
-	}
-
-
-	/**
-	 * @tests java.lang.Thread#stop(java.lang.Throwable)
-	 */
-	@Test
-	public void test_stop4() {
-		ResSupThread t = new ResSupThread(Thread.currentThread());
-		synchronized (t) {
-			st = new Thread(t, "StopThread");
-			st.setPriority(Thread.MAX_PRIORITY);
-			st.start();
-			try {
-				t.wait();
-			} catch (InterruptedException e) {
-			}
-		}
-		try {
-			st.stop(new BogusException("Bogus"));
-		} catch (UnsupportedOperationException e) {
-			AssertJUnit.assertTrue("Stopped child with exception not alive", st.isAlive());
-			st.interrupt();
-			return;
-		}
-		st.interrupt();
-		AssertJUnit.assertTrue("Stopped child did not throw exception", false);
-	}
-
-
-	/**
-	 * @tests java.lang.Thread#stop(java.lang.Throwable)
-	 */
-	@Test
 	public void test_stop5() {
 		class StopBeforeStartThread extends Thread {
 			public boolean failed = false;
@@ -1319,23 +1227,6 @@ public class Test_Thread {
 			Assert.fail("Unexpected exception:" + e);
 		}
 	}
-
-
-	/**
-	 * @tests java.lang.Thread#stop(java.lang.Throwable)
-	 */
-	@Test
-	public void test_stop6() {
-		try {
-			new Thread().stop(new ThreadDeath());
-			Assert.fail("should throw UnsupportedOperationException");
-		} catch (UnsupportedOperationException e) {
-			// expected
-		} catch (Throwable e) {
-			Assert.fail("unexpected exception: " + e);
-		}
-	}
-
 
 	/**
 	 * @tests java.lang.Thread#suspend()

--- a/test/functional/Java8andUp/src_110/org/openj9/test/java/lang/Test_Thread_Extra.java
+++ b/test/functional/Java8andUp/src_110/org/openj9/test/java/lang/Test_Thread_Extra.java
@@ -1,0 +1,28 @@
+
+package org.openj9.test.java.lang;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+public class Test_Thread_Extra {
+/*Empty as there are currently no extra tests for Thread in jdk11*/
+}

--- a/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Thread_Extra.java
+++ b/test/functional/Java8andUp/src_80/org/openj9/test/java/lang/Test_Thread_Extra.java
@@ -1,0 +1,85 @@
+
+package org.openj9.test.java.lang;
+
+/*******************************************************************************
+ * Copyright (c) 1998, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import java.lang.ref.WeakReference;
+
+@Test(groups = { "level.sanity" })
+public class Test_Thread_Extra {
+
+	/**
+	 * @tests java.lang.Thread#destroy()
+	 */
+	@Test
+	public void test_destroy() {
+		try {
+			new Thread().destroy();
+			Assert.fail("NoSuchMethodError expected");
+		} catch (NoSuchMethodError e) {
+			// expected
+		}
+	}
+
+	/**
+	 * @tests java.lang.Thread#stop(java.lang.Throwable)
+	 */
+	@Test
+	public void test_stop6() {
+		try {
+			new Thread().stop(new ThreadDeath());
+			Assert.fail("should throw UnsupportedOperationException");
+		} catch (UnsupportedOperationException e) {
+			// expected
+		} catch (Throwable e) {
+			Assert.fail("unexpected exception: " + e);
+		}
+	}
+
+	/**
+	 * Tears down the fixture, for example, close a network connection. This
+	 * method is called after a test is executed.
+	 */
+	@AfterMethod
+	protected void tearDown() {
+		
+		try {
+			System.runFinalization();
+		} catch (Exception e) {
+		}
+
+		/*Make sure that the current thread is not interrupted. If it is, set it back to false.*/
+		/*Otherwise any call to join, wait, sleep from the current thread throws either InterruptedException or IllegalMonitorStateException*/
+		if (Thread.currentThread().isInterrupted()) {
+			try {
+				Thread.currentThread().join(10);
+			} catch (InterruptedException e) {
+				//If we are here, current threads interrupted status is set to false.
+			}
+		}
+	}
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -159,6 +159,7 @@
 			<class name="org.openj9.test.java.lang.Test_StringBuilder"/>
 			<class name="org.openj9.test.java.lang.Test_System"/>
 			<class name="org.openj9.test.java.lang.Test_Thread"/>
+			<class name="org.openj9.test.java.lang.Test_Thread_Extra"/>			
 			<class name="org.openj9.test.java.lang.Test_ThreadGroup"/>
 			<class name="org.openj9.test.java.lang.Test_Throwable"/>
 			<class name="org.openj9.test.java.lang.Test_VMAccess"/>


### PR DESCRIPTION
Excluded `destroy()` and `stop(Throwable)`  test cases from JAVA11 in `Thread.java`

[ci skip]

Related: https://github.com/eclipse/openj9/pull/2482

Signed-off-by: Charles_Zheng <Juntian.Zheng@ibm.com>