### PR TITLE
Handle errors deleting attach API files

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE100.txt
@@ -26,4 +26,3 @@ org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	AN-https://
 org.openj9.test.java.lang.management.TestRuntimeMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.java.lang.management.TestThreadMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
-org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2047 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE80.txt
@@ -24,4 +24,3 @@
 
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
-org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2047 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_SE90.txt
@@ -27,4 +27,3 @@ org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
-org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2047 generic-all 

--- a/test/functional/TestUtilities/src/org/openj9/test/util/FileUtilities.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/FileUtilities.java
@@ -24,6 +24,7 @@ package org.openj9.test.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 public class FileUtilities {
 
@@ -34,20 +35,31 @@ public class FileUtilities {
 	 * @throws IOException if the directory is inaccessible or cannot be deleted.
 	 */
 	public static void deleteRecursive(File root) throws IOException {
+		deleteRecursive(root, true);
+	}
+	
+	/**
+	 * Delete root and its contents, if root is a directory.
+	 * If root does not exist, this exits silently.
+	 * @param root Starting point of the deletion.
+	 * @param failOnError throw exception if there is a failure
+	 * @throws IOException if the directory is inaccessible or cannot be deleted and failOnError is true.
+	 */
+	public static void deleteRecursive(File root, boolean failOnError) throws IOException {
 		final String rootPath = root.getAbsolutePath();
-		if (root.exists()) {
+		if (Objects.nonNull(rootPath) && root.exists()) {
 			if (root.isDirectory()) {
 				File[] children = root.listFiles();
 				if (null != children) {
 					for (File c : children) {
-						deleteRecursive(c);
+						deleteRecursive(c, failOnError);
 					}
-				} else {
+				} else if (failOnError) {
 					throw new IOException("Error listing files in  "  //$NON-NLS-1$
 							+ rootPath);
 				}
 			}
-			if (!root.delete()) {
+			if (!root.delete() && failOnError) {
 				throw new IOException("Error deleting "  //$NON-NLS-1$
 						+ rootPath);			
 			}


### PR DESCRIPTION
Add null checks where necessary. Suppress exceptions in deleteRecursive() if
errors are possible and acceptable.

Fixes issue #2047 and issue #2141 

Tested in a manual build.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>