### PR TITLE
Make -XX:HeapDumpPath an alias for -Xdump:directory

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -265,6 +265,7 @@ enum INIT_STAGE {
 #define VMOPT_XMXCL "-Xmxcl"
 #define VMOPT_XDUMP  "-Xdump"
 #define VMOPT_XDUMP_NONE  "-Xdump:none"
+#define VMOPT_XDUMP_DIRECTORY_EQUALS  "-Xdump:directory="
 #define VMOPT_XARGENCODING "-Xargencoding"
 #define VMOPT_XARGENCODINGCOLON "-Xargencoding:"
 #define VMOPT_XARGENCODINGUTF8 "-Xargencoding:utf8"
@@ -464,6 +465,7 @@ enum INIT_STAGE {
 #define MAPOPT_XSHARECLASSES_NONFATAL "-Xshareclasses:nonfatal"
 #define MAPOPT_XXDISABLEEXPLICITGC "-XX:+DisableExplicitGC"
 #define MAPOPT_XXENABLEEXPLICITGC "-XX:-DisableExplicitGC"
+#define MAPOPT_XXHEAPDUMPPATH_EQUALS "-XX:HeapDumpPath="
 
 #define VMOPT_XXDUMPLOADEDCLASSLIST "-XX:DumpLoadedClassList"
 

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -44,8 +44,6 @@
 #include "ut_j9dmp.h"
 #undef _UTE_STATIC_
 
-#define VMOPT_XDUMP  "-Xdump"
-
 /* Abort data */
 static J9JavaVM *cachedVM = NULL;
 
@@ -632,7 +630,7 @@ configureDumpAgents(J9JavaVM *vm)
 	}
 
 	/* Re-process active agent options (L..R) to do deletes and replace any options killed by a delete that
-	 * preceeded them. */
+	 * preceded them. */
 	for (i = 0; i < agentNum; i++) {
 		if (agentOpts[i].kind == J9RAS_DUMP_OPT_DISABLED) continue;
 		if (agentOpts[i].pass != J9RAS_DUMP_OPTS_PASS_ONE) continue;
@@ -1254,14 +1252,13 @@ initDumpDirectory(J9JavaVM *vm)
 {
 	IDATA xdumpIndex = 0;
 	omr_error_t retVal = OMR_ERROR_NONE;
-	char *optionString = NULL;
-
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	/* -Xdump:directory */
 	xdumpIndex = FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, VMOPT_XDUMP ":directory", NULL);
 	if ( xdumpIndex >= 0 )
 	{
+		char *optionString = NULL;
 		GET_OPTION_VALUE(xdumpIndex, '=', &optionString);
 		if( !optionString ) {
 			printDumpUsage(vm);

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -479,7 +479,7 @@ optionValueOperations(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA
 						}
 						break;
 					case MAP_WITH_INCLUSIVE_OPTIONS :
-						/* Has to build the result from part of the j9Name and then the actual value on the comand-line */
+						/* Has to build the result from part of the j9Name and then the actual value on the command-line */
 						if (bufSize > 0) {
 							char* mapName = MAPPING_MAPNAME(j9vm_args, element);
 							/* To get the value of the *actual* arg specified on the command-line, the delimiter may not be the one specified */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3763,6 +3763,10 @@ registerVMCmdLineMappings(J9JavaVM* vm)
 	if (registerCmdLineMapping(vm, MAPOPT_XXENABLEEXPLICITGC, "-Xenableexplicitgc", EXACT_MAP_NO_OPTIONS) == RC_FAILED) {
 		return RC_FAILED;
 	}
+	/* Map -XX:HeapDumpPath= to -Xdump:directory= */
+	if (registerCmdLineMapping(vm, MAPOPT_XXHEAPDUMPPATH_EQUALS, VMOPT_XDUMP_DIRECTORY_EQUALS, EXACT_MAP_WITH_OPTIONS) == RC_FAILED) {
+		return RC_FAILED;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Map the OpenJDK option -XX:HeapDumpPath= to the existing OpenJ9 option
-Xdump:directory.  Also clean up existing macro definitions
and fix a spelling error while I have the file open.

This fixes (partially) issue #2332.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>