### PR TITLE
Limiting Trace Logging by P Codegen

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2766,13 +2766,13 @@ J9::CodeGenerator::compressedReferenceRematerialization()
       }
 
    // no need to rematerialize for lowMemHeap
-   //
    if (self()->comp()->useCompressedPointers() &&
          ((TR::Compiler->vm.heapBaseAddress() != 0) ||
          (TR::Compiler->om.compressedReferenceShift() != 0)) &&
          !disableRematforCP)
       {
-      self()->comp()->dumpMethodTrees("Trees before this remat phase", self()->comp()->getMethodSymbol());
+      if (self()->comp()->getOption(TR_TraceCG))
+         self()->comp()->dumpMethodTrees("Trees before this remat phase", self()->comp()->getMethodSymbol());
 
       List<TR::Node> rematerializedNodes(self()->trMemory());
       vcount_t visitCount = self()->comp()->incVisitCount();
@@ -2866,8 +2866,8 @@ J9::CodeGenerator::compressedReferenceRematerialization()
             rematerializedNodes.deleteAll();
             }
          }
-
-      self()->comp()->dumpMethodTrees("Trees after this remat phase", self()->comp()->getMethodSymbol());
+      if (self()->comp()->getOption(TR_TraceCG))
+         self()->comp()->dumpMethodTrees("Trees after this remat phase", self()->comp()->getMethodSymbol());
 
       if (self()->shouldYankCompressedRefs())
          {
@@ -2881,7 +2881,8 @@ J9::CodeGenerator::compressedReferenceRematerialization()
             self()->yankCompressedRefs(tt, NULL, -1, node, visitCount, secondVisitCount);
             }
 
-         self()->comp()->dumpMethodTrees("Trees after this yank phase", self()->comp()->getMethodSymbol());
+         if (self()->comp()->getOption(TR_TraceCG))
+            self()->comp()->dumpMethodTrees("Trees after this yank phase", self()->comp()->getMethodSymbol());
          }
       }
 

--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -243,7 +243,8 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
    //
    else if (castClassSymRef->isUnresolved())
       {
-      traceMsg(cg->comp(),"Cast Class unresolved\n");
+      if (cg->comp()->getOption(TR_TraceCG))
+         traceMsg(cg->comp(),"Cast Class unresolved\n");
       if (mayBeNull)
          sequences[i++] = NullTest;
       sequences[i++] = ClassEqualityTest;

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -945,8 +945,8 @@ static int32_t calculateFrameSize(TR::RealRegister::RegNum &intSavedFirst,
          comp->failCompilation<TR::CompilationInterrupted>("Overflowed or underflowed bounds of regSaveOffset in calculateFrameSize.");
          }
 
-      //pramod
-      traceMsg(comp, "PPCLinkage calculateFrameSize registerSaveDescription: 0x%x regSaveOffset: %x\n", registerSaveDescription, regSaveOffset);
+      if (cg->comp()->getOption(TR_TraceCG))
+         traceMsg(comp, "PPCLinkage calculateFrameSize registerSaveDescription: 0x%x regSaveOffset: %x\n", registerSaveDescription, regSaveOffset);
       registerSaveDescription |= (regSaveOffset << 17); // see above for details
       cg->setFrameSizeInBytes(size+firstLocalOffset);
       TR_ASSERT((size-argSize+firstLocalOffset)<2048*1024, "Descriptor overflowed.\n");
@@ -2074,11 +2074,9 @@ int32_t TR::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                 
             }
          }
       }
-   else
-      {
+   else if (cg()->comp()->getOption(TR_TraceCG))
       traceMsg(comp(), "Omitting CCR save/restore for helper calls\n");
-      }
-
+   
    if (memArgs > 0)
       {
       for (argIndex = 0; argIndex < memArgs; argIndex++)


### PR DESCRIPTION
Unnecessary output is produced unconditionally during tracing which clogs trace-files. This is an issue specially when profiling for performance.

I've limited some functions in the power codegen to only write to the log if the user is tracing the codegen specifically.

Signed-off-by: Alen Badel <Alen.Badel@ibm.com>