### PR TITLE
Make OpenJ9VirtualMachine public

### DIFF
--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -56,7 +56,7 @@ import static com.ibm.oti.util.Msg.getString;
  * Handles the initiator end of an attachment to a target VM
  * 
  */
-final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
+public final class OpenJ9VirtualMachine extends VirtualMachine implements Response {
 
 	/* 
 	 * The expected string is "ATTACH_CONNECTED <32 bit hexadecimal key>". 


### PR DESCRIPTION
Make com.ibm.tools.attach.attacher.OpenJ9VirtualMachine public to match equivalent HotSpot classes.

Fixes https://github.com/eclipse/openj9/issues/2505.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>