### PR TITLE
Print error reason when AOT load fails

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9273,7 +9273,11 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
 
                         if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompileEnd, TR_VerbosePerformance, TR_VerboseCompFailure))
                            {
-                           TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,"Failure while relocating for %s", comp->signature());
+                           TR_VerboseLog::writeLineLocked(TR_Vlog_FAILURE,
+                                                          "Failure while relocating for %s, return code = %d [%s]\n",
+                                                          comp->signature(),
+                                                          returnCode,
+                                                          (returnCode >= 0) && (returnCode < compilationMaxError) ? compilationErrorNames[returnCode] : "unknown error");
                            }
                         }
                      }


### PR DESCRIPTION
Error message now includes prepareRelocateAOTCodeAndData() return code and its meaning.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>