### PR TITLE
Add test for Make -XX:HeapDumpPath an alias for -Xdump:directory

### DIFF
--- a/test/functional/TestUtilities/src/org/openj9/test/util/HelloWorld.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/HelloWorld.java
@@ -1,0 +1,34 @@
+package org.openj9.test.util;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/*
+ * Trivial test program
+ */
+public class HelloWorld {
+
+	public static void main(String[] args) {
+		System.out.println("hello, world");
+	}
+
+}
+


### PR DESCRIPTION
Test for https://github.com/eclipse/openj9/pull/2508
Check that "-XX:HeapDumpPath=" is equivalent to "-Xdump:directory=".

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>