### PR TITLE
WIP: Incorporate Intel Transactional Memory (TSX) into OpenJ9 Locking

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1085,7 +1085,7 @@ obj:;
 	enterObjectMonitor(REGISTER_ARGS_LIST, j9object_t obj)
 	{
 		IDATA rc = (IDATA)obj;
-		if (!VM_ObjectMonitor::inlineFastObjectMonitorEnter(_currentThread, obj)) {
+		if (true || !VM_ObjectMonitor::inlineFastObjectMonitorEnter(_currentThread, obj)) {
 			rc = objectMonitorEnterNonBlocking(_currentThread, obj);
 			if (1 == rc) {
 				updateVMStruct(REGISTER_ARGS);

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -32,6 +32,7 @@
 #include "VMHelpers.hpp"
 #include "AtomicSupport.hpp"
 #include "ObjectMonitor.hpp"
+#include <immintrin.h>
 
 extern "C" {
 
@@ -459,6 +460,12 @@ spinOnTryEnter(J9VMThread *currentThread, J9ObjectMonitor *objectMonitor, j9obje
 	UDATA tryEnterSpinCount2 = vm->thrMaxTryEnterSpins2BeforeBlocking;
 	UDATA tryEnterYieldCount = vm->thrMaxTryEnterYieldsBeforeBlocking;
 	UDATA const tryEnterNestedSpinning = vm->thrTryEnterNestedSpinning;
+
+	if (J9_LOCK_IS_INFLATED(*lwEA)) {
+		if (true == startTransaction(monitor, osThread)) {
+			return true;
+		}
+	}
 
 #if defined(J9VM_INTERP_CUSTOM_SPIN_OPTIONS)
 	J9Class *ramClass = J9OBJECT_CLAZZ(currentThread, object);


### PR DESCRIPTION
Transactional Lock Elision

Currently, the J9JIT (with TLE enabled) transforms monenters/monexits
of synchronized blocks to execute transactionally, if analyisis of
the block passes certain conditions.

The issue arises when some synchronized blocks are transformed to
use TLE, while others are not, AND they are synchronized on the same
lock object.

A thread cannot commit a transaction if the lock is also synchronized
by another thread by non-TLE locking. This creates excessive aborts.

This patch is a work-in-progress implementation of Restricted
Transactional Memory (RTM) as applied to OpenJ9 locks and is intended
to replace the TLE implementation in J9JIT. This approach avoids the
aformentioned problems by eliding locks at the lock object level as
opposed to the lock sites.

This patch depends on patch https://github.com/eclipse/omr/pull/2818

See https://github.com/eclipse/openj9/issues/2484

[skip ci]

Signed-off-by: John Xu <xujohn@ca.ibm.com>