### PR TITLE
Correct LICENSE typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Product: OpenJ9
+﻿Product: OpenJ9
 
-Copyright (c) 2017, 2017 IBM Corp. and others
+Copyright (c) 2017, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 


### PR DESCRIPTION
Correct typo "2017" to "2018" in LICENSE  @pshipton 

Signed-off-by: ChanHoHo <chanho95@hotmail.com>
