### PR TITLE
Enable/disable dumps on OOM if -XX:[+-]HeapDumpOnOutOfMemoryError

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -324,6 +324,8 @@ enum INIT_STAGE {
 #define VMOPT_XXDEBUGINTERPRETER "-XX:+DebugInterpreter"
 #define VMOPT_XXNOHANDLESIGXFSZ "-XX:-HandleSIGXFSZ"
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
+#define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
+#define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
 
 #define VMOPT_XSOFTREFTHRESHOLD "-XSoftRefThreshold"
 #define VMOPT_XAGGRESSIVE "-Xaggressive"

--- a/runtime/rasdump/dmpmap.c
+++ b/runtime/rasdump/dmpmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,8 +46,12 @@ static const DgDumpCondition dgConditions[] = {
 	/* note that 'ONANYSIGNAL' is handled explicitly in the mapDumpOptions) code below */ 
 };
 
-static const int numDumpConditions = ( sizeof(dgConditions) / sizeof(DgDumpCondition) );
+static const int numDumpConditions = sizeof(dgConditions) / sizeof(dgConditions[0]);
 
+#define HEAP_KIND "heap"
+#define JAVA_KIND "java"
+#define SNAP_KIND "snap"
+#define SYSTEM_KIND "system"
 
 typedef struct DgDumpAction
 {
@@ -57,8 +61,8 @@ typedef struct DgDumpAction
 
 /* Mapping for JAVA_DUMP_OPTS actions */
 static const DgDumpAction dgActions[] = {
-	{ "JAVADUMP",  "java" },
-	{ "HEAPDUMP",  "heap" },
+	{ "JAVADUMP",  JAVA_KIND },
+	{ "HEAPDUMP",  HEAP_KIND },
 	{ "SYSDUMP",   DG_SYSTEM_DUMPS },
 	{ "ALL",       DG_SYSTEM_DUMPS "+heap+java+jit" },
 	{ "NONE",      "none" },
@@ -68,8 +72,10 @@ static const DgDumpAction dgActions[] = {
 #endif
 };
 
-static const int numDumpActions = ( sizeof(dgActions) / sizeof(DgDumpAction) );
+static const int numDumpActions = sizeof(dgActions) / sizeof(dgActions[0]);
 
+/* Filter string used for some default OutOfMemory dump options */
+#define  SYSTHROW_OOM_1_4 "events=systhrow,range=1..4,filter=java/lang/OutOfMemoryError"
 
 typedef struct DgDumpEnvSwitch
 {
@@ -85,33 +91,33 @@ typedef struct DgDumpEnvSwitch
 static const DgDumpEnvSwitch dgSwitches[] = {
 			{
 /* name */		"DISABLE_JAVADUMP",
-/* kind */		"java",
+/* kind */		JAVA_KIND,
 /* on */		"none",
 /* off */		NULL
 			},{
 /* name */		"IBM_HEAPDUMP",
-/* kind */		"heap",
+/* kind */		HEAP_KIND,
 /* on */		"events=user+gpf",
 /* off */		"none"
 			},{
 /* name */		"IBM_HEAP_DUMP",
-/* kind */		"heap",
+/* kind */		HEAP_KIND,
 /* on */		"events=user+gpf",
 /* off */		"none"
 			},{
 /* name */		"IBM_JAVADUMP_OUTOFMEMORY",
-/* kind */		"java",
-/* on */		"events=systhrow,range=1..4,filter=java/lang/OutOfMemoryError",
+/* kind */		JAVA_KIND,
+/* on */		SYSTHROW_OOM_1_4,
 /* off */		"none"
 			},{
 /* name */		"IBM_HEAPDUMP_OUTOFMEMORY",
-/* kind */		"heap",
-/* on */		"events=systhrow,range=1..4,filter=java/lang/OutOfMemoryError",
+/* kind */		HEAP_KIND,
+/* on */		SYSTHROW_OOM_1_4,
 /* off */		"none"
 			},{
 /* name */		"IBM_SNAPDUMP_OUTOFMEMORY",
-/* kind */		"snap",
-/* on */		"events=systhrow,range=1..4,filter=java/lang/OutOfMemoryError",
+/* kind */		SNAP_KIND,
+/* on */		SYSTHROW_OOM_1_4,
 /* off */		"none"
 			},{
 /* name */		"J9NO_DUMPS",
@@ -121,7 +127,33 @@ static const DgDumpEnvSwitch dgSwitches[] = {
 			}
 };
 
-static const int numDumpEnvSwitches = ( sizeof(dgSwitches) / sizeof(DgDumpEnvSwitch) );
+typedef struct OomDefaultSetting
+{
+	const char *typeString;
+	const char *onOpt;
+} OomDefaultSetting;
+
+static const OomDefaultSetting oomDefaultTable[] = {
+	{
+		HEAP_KIND,
+		SYSTHROW_OOM_1_4
+	},
+	{
+		JAVA_KIND,
+		SYSTHROW_OOM_1_4
+	},
+	{
+		SNAP_KIND,
+		SYSTHROW_OOM_1_4
+	},
+	{
+		SYSTEM_KIND,
+		"events=systhrow,range=1..1,filter=java/lang/OutOfMemoryError,request=exclusive+compact+prepwalk"
+	}
+};
+
+static const UDATA numDumpEnvSwitches = sizeof(dgSwitches) / sizeof(dgSwitches[0]);
+static const UDATA numOomSettings = sizeof(oomDefaultTable) / sizeof(oomDefaultTable[0]);
 
 
 typedef struct DgDumpEnvSetting
@@ -154,11 +186,11 @@ typedef struct DgDumpEnvDefault
 static const DgDumpEnvDefault dgDefaults[] = {
 					{
 /* name */		"IBM_JAVA_HEAPDUMP_TEXT",
-/* kind */			"heap",
+/* kind */			HEAP_KIND,
 /* default */		"opts=CLASSIC"
 					},{
 /* name */		"IBM_JAVA_HEAPDUMP_TEST",
-/* kind */			"heap",
+/* kind */			HEAP_KIND,
 /* default */		"opts=PHD+CLASSIC"
 					},
 };
@@ -413,7 +445,7 @@ mapDumpActions(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum, char 
 omr_error_t
 mapDumpSwitches(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum)
 {
-	IDATA i, kind;
+	UDATA i = 0;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
@@ -453,7 +485,7 @@ mapDumpSwitches(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum)
 			/* The "off" option for these variables should only disable the default dump */
 			/* agents that match the option values. Other agents for the same dump type  */
 			/* should remain untouched.                                                  */
-			int j;
+			IDATA j = 0;
 			IDATA disableKind = scanDumpType(&typeString);
 
 			/* walk through the agentOpts and disable those that match the type and options */
@@ -467,6 +499,7 @@ mapDumpSwitches(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum)
 				}
 			}
 		} else {
+			IDATA kind = -1;
 			/* set up the dump type and event string for multiple dump actions */
 			while ( optionString && (kind = scanDumpType(&typeString)) >= 0 ) {
 				agentOpts[*agentNum].kind = kind;
@@ -478,6 +511,55 @@ mapDumpSwitches(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum)
 	}
 
 	return OMR_ERROR_NONE;
+}
+
+/**
+ * Master disable heap, java, snap, and system dumps on out of memory
+ * @param @agentOpts dump agent options
+ * @param agentNum number of agents
+ */
+void
+disableDumpOnOutOfMemoryError(J9RASdumpOption agentOpts[], IDATA agentNum)
+{
+	UDATA kindCursor = 0;
+
+	for (kindCursor = 0; kindCursor < numOomSettings; ++kindCursor) {
+		char *typeString = (char *) oomDefaultTable[kindCursor].typeString;
+		IDATA disableKind = scanDumpType(&typeString);
+		IDATA j = 0;
+		for (j = 0; j < agentNum; j++) {
+			if ((NULL != agentOpts[j].args) 
+					&& (agentOpts[j].kind == disableKind) 
+					&& (strcmp(agentOpts[j].args, oomDefaultTable[kindCursor].onOpt) == 0)) {
+				agentOpts[j].kind = J9RAS_DUMP_OPT_DISABLED;
+			}
+		}
+	}
+}
+
+/**
+ * Master enable heap, java, snap, and system dumps on out of memory
+ * @param @agentOpts dump agent options
+ * @param agentNum pointer to number of agents, updated by reference
+ */
+void
+enableDumpOnOutOfMemoryError(J9RASdumpOption agentOpts[], IDATA *agentNum)
+{
+	UDATA kindCursor = 0;
+
+	for (kindCursor = 0; kindCursor < numOomSettings; ++kindCursor) {
+		char *typeString = (char *) oomDefaultTable[kindCursor].typeString;
+		IDATA enableKind = scanDumpType(&typeString);
+		if (enableKind < 0) {
+			continue;
+		}
+
+		agentOpts[*agentNum].kind = enableKind;
+		agentOpts[*agentNum].args = (char *) oomDefaultTable[kindCursor].onOpt;
+		agentOpts[*agentNum].flags = J9RAS_DUMP_OPT_ARGS_STATIC;
+		agentOpts[*agentNum].pass = J9RAS_DUMP_OPTS_PASS_ONE;
+		*agentNum += 1;
+	}
 }
 #endif /* J9VM_RAS_DUMP_AGENTS */
 

--- a/runtime/rasdump/rasdump_internal.h
+++ b/runtime/rasdump/rasdump_internal.h
@@ -103,6 +103,8 @@ omr_error_t mapDumpOptions(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *age
 omr_error_t mapDumpActions(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum, char *buf, IDATA condition);
 omr_error_t mapDumpDefaults(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum);
 omr_error_t mapDumpSettings(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum);
+void disableDumpOnOutOfMemoryError(J9RASdumpOption agentOpts[], IDATA agentNum);
+void enableDumpOnOutOfMemoryError(J9RASdumpOption agentOpts[], IDATA *agentNum);
 UDATA parseAllocationRange(char *range, UDATA *min, UDATA *max);
 omr_error_t rasDumpEnableHooks(J9JavaVM *vm, UDATA eventFlags);
 void rasDumpFlushHooks(J9JavaVM *vm, IDATA stage);


### PR DESCRIPTION
Fixes issue 2332.

Functional code is complete and manually tested.  Waiting for 
https://github.com/eclipse/openj9/pull/2526 to add tests.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>