### PR TITLE
-Djava.security.manager=default should create java.lang.SecurityManager

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -268,7 +268,7 @@ public abstract class ClassLoader {
 		jdk.internal.misc.VM.initLevel(2);
 		String javaSecurityManager = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
 		if (null != javaSecurityManager) {
-			if (javaSecurityManager.isEmpty()) {
+			if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) {
 				System.setSecurityManager(new SecurityManager());
 			} else {
 				try {


### PR DESCRIPTION
Setting -Djava.security.manager=default should create an instance of
java.lang.SecurityManager

Fixes #2541

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>