### PR TITLE
Skip read barriers from hardware generated guarded storage events if …

### DIFF
--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -507,6 +507,7 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_entryLocalStorage", offsetof(J9VMThread, entryLocalStorage)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_stackWalkState", offsetof(J9VMThread, stackWalkState)) |
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
+			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_gsParameters_GSECI", offsetof(J9VMThread, gsParameters) + 2) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_gsParameters_returnAddr", offsetof(J9VMThread, gsParameters.returnAddr)) |
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 

--- a/runtime/oti/zhelpers.m4
+++ b/runtime/oti/zhelpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 1991, 2017 IBM Corp. and others
+dnl Copyright (c) 1991, 2018 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,7 @@ define({C_GPR},cg)
 define({CHI_GPR},cghi)
 define({CDS_GPR},cdsg)
 define({CL_GPR},clg)
+define({CLFI_GPR},clgfi)
 define({CLM_GPR},clmh)
 define({CLR_GPR},clgr)
 define({CR_GPR},cgr)
@@ -124,6 +125,7 @@ define({C_GPR},c)
 define({CHI_GPR},chi)
 define({CDS_GPR},cds)
 define({CL_GPR},cl)
+define({CLFI_GPR},clfi)
 define({CLM_GPR},clm)
 define({CLR_GPR},clr)
 define({CR_GPR},cr)

--- a/runtime/vm/zcinterp.m4
+++ b/runtime/vm/zcinterp.m4
@@ -153,13 +153,10 @@ END_CURRENT
 })
 
 ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
-dnl Helper to handle guarded storage events and
-dnl software read barriers. 
-dnl When event occurs, hardware populates return address in
-dnl vmThread->gsParameters.returnAddr
-dnl For software read barriers gsParameters.returnAddr is set by JIT
+dnl Helper to handle guarded storage events and software read barriers. When
+dnl the event occurs, hardware/software populates the return address in 
+dnl J9VMThread.gsParameters.returnAddr.
 define({HANDLE_GS_EVENT_HELPER},{
-BEGIN_HELPER($1)
     SAVE_ALL_REGS($1)
     ST_GPR J9SP,J9TR_VMThread_sp(J9VMTHREAD)
     LR_GPR CARG1,J9VMTHREAD
@@ -169,45 +166,35 @@ BEGIN_HELPER($1)
     L_GPR J9SP,J9TR_VMThread_sp(J9VMTHREAD)
     ST_GPR J9SP,JIT_GPR_SAVE_SLOT(J9SP)
     RESTORE_ALL_REGS_AND_SWITCH_TO_JAVA_STACK($1)
-dnl Force condition code 2 to be set before the return. This is done to
-dnl ensure that if we are returning to a non-constrained transactional
-dnl memory region that the transaction would abort with a condition code
-dnl indicating a transient transaction abort. The transaction would then
-dnl be re-executed. Note the below CLFI / CLGFI instruction will always 
-dnl produce condition code 2 because the Java stack pointer is always
-dnl non-zero at the return point.
-dnl 
-dnl TODO: When assembler -march changes to z9 update to:
-dnl CLFI_GPR J9SP,0
-ifdef({ASM_J9VM_ENV_DATA64},{
-    ifdef({J9ZOS390},{
-        DC X'C25E0000'
-        DC X'0000'
-    },{
-       .long 0xC25E0000
-       .short 0x0000
-    })
-},{
-    ifdef({J9ZOS390},{
-        DC X'C25F0000'
-        DC X'0000'
-    },{
-       .long 0xC25F0000
-       .short 0x0000
-    })
-})
 })
 
 define({HANDLE_GS_EVENT},{
+BEGIN_FUNC($1)
+dnl Test the TX bit of GSECI (bit 16) to see if the CPU was in transactional-
+dnl execution mode when the guarded storage event was recognized. If this was
+dnl the case do not execute the read barrier and simply return to the fallback
+dnl transaction abort JIT code to handle it by forcing condition code to be 2
+dnl with the below CL(G)FI instruction indicating a transitent transaction
+dnl abort. See eclipse/openj9#2545 for more details.
+    TM J9TR_VMThread_gsParameters_GSECI(J9VMTHREAD),128
+    JZ LABEL_NAME(L_GS_CALLHELPER)
+    CLFI_GPR J9SP,0
+    J LABEL_NAME(L_GS_DONE)
+PLACE_LABEL(L_GS_CALLHELPER)
+    RELOAD_SSP_SAVE_VALUE
+    STM_GPR r0,LAST_REG,JIT_GPR_SAVE_SLOT(0)
+    SWAP_SSP_VALUE
+    SAVE_HIWORD_REGS
+    LOAD_CAA
     HANDLE_GS_EVENT_HELPER($1)
-
+PLACE_LABEL(L_GS_DONE)
 dnl Branch back to the instruction that triggered guarded storage event.
-BRANCH_INDIRECT_ON_CONDITION(15,J9TR_VMThread_gsParameters_returnAddr,0,J9VMTHREAD)
-
+    BRANCH_INDIRECT_ON_CONDITION(15,J9TR_VMThread_gsParameters_returnAddr,0,J9VMTHREAD)
 END_CURRENT
 })
 
 define({HANDLE_SW_READ_BARRIER},{
+BEGIN_HELPER($1)
     HANDLE_GS_EVENT_HELPER($1)
 dnl Branch back to the instruction that called software read barrier hanlder.
     BR r14


### PR DESCRIPTION
…within a transactional region

In the event that the GSECI TX bit indicates that a hardware
generated guarded storage event occured within a transactional
execution region we should abort the read barrier and return back to
the software to abort the transaction. The reason for this is to
avoid the following scenario:

- We have a TX region in which two reference reads happen on o.f
- The first read of object o.f happens via a software read barrier
    - For example from an interpreted method
- The software read barrier will copy the object into the copy cache
- The second read of o.f.g happens via a hardware read barrier
    - This triggers a hardware transaction abort
    - All stores within the transaction are rolled back

In the above scenario before reaching the guarded storage event
handler according to Principles Of Operation S.4 the transaction
will have aborted by the time control is passed off to the event
handler. Because of this the original copy of object o.f in the copy
cache would have been rolled back to what it was prior to the GS
event handler. This location could have arbitrary data, including
a reasonable value which looks like an evacuate address which will
trip up the GC because we are effectively looking at garbage.

The solution here is to skip the read barriers from hardware
generated guarded storage event if we detect that the guarded storage
event was triggered from within a transactional execution region,
which will always result in the transaction aborting before we
reach the GS event handler.

Prior to branching back to the return address (populated by hardware
in this case to point to after the TBEGIN) we set CC=2 to mimic the
behavior of a transient transaction abort, and let the normal TABORT
software path handle the fallback.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>