### PR TITLE
Support for dynamically adjusting scratch memory space of compilations

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4326,12 +4326,6 @@ TR_J9VMBase::canRecompileMethodWithMatchingPersistentMethodInfo(TR::Compilation 
           );                     // TODO: Why does this assume sometimes fail in HCR mode?
    }
 
-void
-TR_J9VMBase::abortCompilationIfLowFreePhysicalMemory(TR::Compilation *comp, size_t sizeToAllocate)
-   {
-   bool incompleteInfo;
-   _compInfo->computeFreePhysicalLimitAndAbortCompilationIfLow(comp, incompleteInfo, sizeToAllocate);
-   }
 
 //
 // A few predicates describing shadow symbols that we can reason about at

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -801,8 +801,6 @@ public:
    virtual bool methodMayHaveBeenInterpreted( TR::Compilation *comp);
    virtual bool canRecompileMethodWithMatchingPersistentMethodInfo( TR::Compilation *comp);
 
-   virtual void abortCompilationIfLowFreePhysicalMemory(TR::Compilation *comp, size_t sizeToAllocate = 0);
-
    virtual void               revertToInterpreted(TR_OpaqueMethodBlock *method);
 
    virtual bool               argumentCanEscapeMethodCall(TR::MethodSymbol *method, int32_t argIndex);


### PR DESCRIPTION
The JIT is allowed to use up to 256 MB of 'scratch' memory for a compilation
while JSR292 compilations increase this limit to 1.5 GB. These limits create
footprint spikes during an application run which can make resource
provisioning more cumbersome.

This commit adds the following changes:
1) The JIT will use portlib APIs to compute the amount of physical memory
available (taking into consideration any container limits). This value
is cached (to minimize API overhead) and recomputed with a desired
frequency (0.5 sec by default)

2) At the beginning of a compilation the JIT checks the amount of available
physical memory and sets a limit for the scratch space accordingly. If the
amount of physical memory is so low that a relatively cheap compilation cannot
be performed, the compilation request is aborted right there.

3) When a compilation thread needs to allocate a new scratch memory segment
(of size 16 MB) it checks again the available physical memory. If this is low,
the compilation is aborted and will be retried at a lower optimization level.
At the same time a flag will be set which will make one compilation thread
to suspend itself (however, the JIT always makes sure there is at least one
compilation thread active).

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>