### PR TITLE
added changes to display Cgroup information in a key value pair

### DIFF
--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -651,6 +651,18 @@ typedef struct J9CacheInfoQuery {
 #define SIG_RI_INTERRUPT (SIGRTMIN+SIG_RI_INTERRUPT_INDEX)
 #endif
 
+typedef struct J9CgroupMetricElement {
+	char *key;
+	char value[128];
+	char *units;
+} J9CgroupMetricElement;
+
+typedef struct J9CgroupMetricIteratorState {
+	uint32_t count;
+	uint32_t numElements;
+	uint64_t subsystemid;
+} J9CgroupMetricIteratorState;
+
 /* include the generated Port header here (at the end of the file since it relies on some defines from within this file) */
 #include "j9port_generated.h"
 
@@ -748,6 +760,7 @@ typedef struct J9CacheInfoQuery {
 #define J9PORT_ERROR_VMEM_INSUFFICENT_RESOURCES OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES
 #define J9PORT_ERROR_VMEM_INSUFFICENT_RESOURCES OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES
 #define J9PORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM
+#define J9PORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE
 
 #define J9PORT_TTY_OUT OMRPORT_TTY_OUT
 #define J9PORT_TTY_ERR OMRPORT_TTY_ERR

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -172,6 +172,12 @@ typedef struct J9PortLibrary {
 	int32_t  ( *sysinfo_get_hw_info)(struct J9PortLibrary *portLibrary, uint32_t infoType, char * buf, uint32_t bufLen);
 	/** see @ref j9sysinfo.c::j9sysinfo_get_cache_info "j9sysinfo_get_cache_info"*/
 	int32_t ( *sysinfo_get_cache_info)(struct J9PortLibrary *portLibrary, const J9CacheInfoQuery * query);
+	/** see @ref j9sysinfo.c::j9sysinfo_cgroup_subsystem_iterator_init "j9sysinfo_cgroup_subsystem_iterator_init"*/
+	int32_t ( *sysinfo_cgroup_subsystem_iterator_init)(struct J9PortLibrary *portLibrary, uint64_t subsystem, struct J9CgroupMetricIteratorState *state);
+	/** see @ref j9sysinfo.c::j9sysinfo_cgroup_subsystem_iterator_hasNext "j9sysinfo_cgroup_subsystem_iterator_hasNext"*/
+	BOOLEAN ( *sysinfo_cgroup_subsystem_iterator_hasNext)(struct J9PortLibrary *portLibrary, const struct J9CgroupMetricIteratorState *state);
+	/** see @ref j9sysinfo.c::j9sysinfo_cgroup_subsystem_iterator_next "j9sysinfo_cgroup_subsystem_iterator_next"*/
+	int32_t ( *sysinfo_cgroup_subsystem_iterator_next)(struct J9PortLibrary *portLibrary, struct J9CgroupMetricIteratorState *state, struct J9CgroupMetricElement *metricElement, BOOLEAN *printUnits);
 	/** see @ref j9sock.c::j9sock_startup "j9sock_startup"*/
 	int32_t  ( *sock_startup)(struct J9PortLibrary *portLibrary) ;
 	/** see @ref j9sock.c::j9sock_shutdown "j9sock_shutdown"*/
@@ -630,6 +636,9 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sysinfo_processor_has_feature(param1,param2) privatePortLibrary->sysinfo_processor_has_feature(privatePortLibrary,param1,param2)
 #define j9sysinfo_get_hw_info(param1,param2,param3) privatePortLibrary->sysinfo_get_hw_info(privatePortLibrary,param1,param2,param3)
 #define j9sysinfo_get_cache_info(param1) privatePortLibrary->sysinfo_get_cache_info(privatePortLibrary,param1)
+#define j9sysinfo_cgroup_subsystem_iterator_init(param1,param2) privatePortLibrary->sysinfo_cgroup_subsystem_iterator_init(privatePortLibrary,param1,param2)
+#define j9sysinfo_cgroup_subsystem_iterator_hasNext(param1) privatePortLibrary->sysinfo_cgroup_subsystem_iterator_hasNext(privatePortLibrary,param1)
+#define j9sysinfo_cgroup_subsystem_iterator_next(param1,param2,param3) privatePortLibrary->sysinfo_cgroup_subsystem_iterator_next(privatePortLibrary,param1,param2,param3)
 #define j9file_startup() OMRPORT_FROM_J9PORT(privatePortLibrary)->file_startup(OMRPORT_FROM_J9PORT(privatePortLibrary))
 #define j9file_shutdown() OMRPORT_FROM_J9PORT(privatePortLibrary)->file_shutdown(OMRPORT_FROM_J9PORT(privatePortLibrary))
 #define j9file_write(param1,param2,param3) OMRPORT_FROM_J9PORT(privatePortLibrary)->file_write(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3)

--- a/runtime/port/common/j9port.c
+++ b/runtime/port/common/j9port.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,6 +50,9 @@ static J9PortLibrary MasterPortLibraryTable = {
 	j9sysinfo_processor_has_feature, /* sysinfo_processor_has_feature */
 	j9sysinfo_get_hw_info, /* sysinfo_get_hw_info */
 	j9sysinfo_get_cache_info, /* sysinfo_get_cache_info */
+	j9sysinfo_cgroup_subsystem_iterator_init, /* sysinfo_cgroup_subsystem_iterator_init */
+	j9sysinfo_cgroup_subsystem_iterator_hasNext, /* sysinfo_cgroup_subsystem_iterator_hasNext */
+	j9sysinfo_cgroup_subsystem_iterator_next, /* sysinfo_cgroup_subsystem_iterator_next */
 	j9sock_startup, /* sock_startup */
 	j9sock_shutdown, /* sock_shutdown */
 	j9sock_htons, /* sock_htons */

--- a/runtime/port/common/j9sysinfo.c
+++ b/runtime/port/common/j9sysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -193,4 +193,43 @@ j9sysinfo_get_hw_info(struct J9PortLibrary *portLibrary, uint32_t infoType,
 IDATA
 j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, struct const J9CacheInfoQuery * query) {
 	return J9PORT_ERROR_SYSINFO_NOT_SUPPORTED;
+}
+
+/**
+ * Initiates the J9CgroupMetricIteratorState attributes depending on subsystem
+ * @param[in] portLibrary The Port Library instance
+ * @param[in] subsystem It represents which Cgroup Subsystem state should be initiated
+ * @param[in] state Instance of the struct J9CgroupMetricIteratorState which gets initiated basing on the subsystem
+ * @return 0 on success error code on failure
+ */
+int32_t
+j9sysinfo_cgroup_subsystem_iterator_init(struct J9PortLibrary *portLibrary, uint64_t subsystem, struct J9CgroupMetricIteratorState *state)
+{
+	return J9PORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
+}
+
+/**
+ * Checks if there is any attribute left to be read in the list of subsystem attributes
+ * @param[in] portLibrary The Port Library instance
+ * @param[in] state Instance of the struct J9CgroupMetricIteratorState which is used to check if we reached end of list
+ * @return TRUE if there are any attributes left and FALSE if we reached end of list
+ */
+BOOLEAN
+j9sysinfo_cgroup_subsystem_iterator_hasNext(struct J9PortLibrary *portLibrary, const struct J9CgroupMetricIteratorState *state)
+{
+	return FALSE;
+}
+
+/**
+ * Reads the Cgroup file and loads the key, value and units to the structure J9CgroupMetricElement and updates the state count
+ * @param[in] portLibrary The Port Library instance
+ * @param[in] state Instance of the struct J9CgroupMetricIteratorState which is used to update the count
+ * @param[in] metricElement Instance of the struct J9CgroupMetricElement which holds the key, value and units of the read Cgroup subsystem attribute
+ * @param[in] printUnits updated to TRUE if the attribute is set and can display units, FALSE otherwise
+ * @return 0 on success and error code on failure
+ */
+int32_t
+j9sysinfo_cgroup_subsystem_iterator_next(struct J9PortLibrary *portLibrary, struct J9CgroupMetricIteratorState *state, struct J9CgroupMetricElement *metricElement, BOOLEAN *printUnits)
+{
+	return J9PORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
 }

--- a/runtime/port/portpriv.h
+++ b/runtime/port/portpriv.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,6 +242,12 @@ extern J9_CFUNC int32_t
 j9sysinfo_get_hw_info(struct J9PortLibrary *portLibrary, uint32_t infoType, char * buf, uint32_t bufLen);
 extern J9_CFUNC int32_t
 j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, const J9CacheInfoQuery * query);
+extern J9_CFUNC int32_t
+j9sysinfo_cgroup_subsystem_iterator_init(struct J9PortLibrary *portLibrary, uint64_t subsystem, struct J9CgroupMetricIteratorState *state);
+extern J9_CFUNC BOOLEAN
+j9sysinfo_cgroup_subsystem_iterator_hasNext(struct J9PortLibrary *portLibrary, const struct J9CgroupMetricIteratorState *state);
+extern J9_CFUNC int32_t
+j9sysinfo_cgroup_subsystem_iterator_next(struct J9PortLibrary *portLibrary, struct J9CgroupMetricIteratorState *state, struct J9CgroupMetricElement *metricElement, BOOLEAN *printUnits);
 extern J9_CFUNC uintptr_t
 j9sysinfo_get_processing_capacity (struct J9PortLibrary *portLibrary);
 extern J9_CFUNC uintptr_t

--- a/runtime/port/win32/j9sysinfo.c
+++ b/runtime/port/win32/j9sysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -389,4 +389,22 @@ j9sysinfo_get_cache_info(struct J9PortLibrary *portLibrary, const J9CacheInfoQue
 	}
 	Trc_PRT_sysinfo_get_cache_info_exit(result);
 	return result;
+}
+
+int32_t
+j9sysinfo_cgroup_subsystem_iterator_init(struct J9PortLibrary *portLibrary, uint64_t subsystem, struct J9CgroupMetricIteratorState *state)
+{
+	return J9PORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
+}
+
+BOOLEAN
+j9sysinfo_cgroup_subsystem_iterator_hasNext(struct J9PortLibrary *portLibrary, const struct J9CgroupMetricIteratorState *state)
+{
+	return FALSE;
+}
+
+int32_t
+j9sysinfo_cgroup_subsystem_iterator_next(struct J9PortLibrary *portLibrary, struct J9CgroupMetricIteratorState *state, struct J9CgroupMetricElement *metricElement, BOOLEAN *printUnits)
+{
+	return J9PORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
 }


### PR DESCRIPTION
[To display Container Information in Javadump](https://github.com/eclipse/openj9/issues/1932) An iterator model for displaying Cgroup Information has been added.

These changes are depended on [OMR PR 2767](https://github.com/eclipse/omr/pull/2767)

Doc issue https://github.com/eclipse/openj9-docs/issues/56

Closes #1932

Signed-off-by: bharathappali <bharath.appali@gmail.com>