### PR TITLE
Always do equality test for jitCheckAssignable on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -4715,7 +4715,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node* node, TR_Opaq
    generateLoadJ9Class(node, j9class, j9class, cg);
 
    // Equality test
-   if (!fej9->isAbstractClass(clazz))
+   if (!fej9->isAbstractClass(clazz) || node->getOpCodeValue() == TR::icall/*TR_checkAssignable*/)
       {
       if (use64BitClasses)
          {


### PR DESCRIPTION
Inlined jitCheckAssignable for Class should always do equality test
even if the cast class is abstract.

Closes #2540 

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>