### PR TITLE
CMake: fix typo in compiler component

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -168,7 +168,7 @@ set(J9_CXXFLAGS
 )
 
 omr_stringify(J9_SHAREDLAGS_STR ${J9_SHAREDFLAGS})
-omr_stringify(J9_CXXFLAGS_STR ${J9_CXX_FLAGS})
+omr_stringify(J9_CXXFLAGS_STR ${J9_CXXFLAGS})
 
 # Note: This is explicitly overriding what's provided by
 #       the VM CMakeLists, as they pass -fno-exceptions


### PR DESCRIPTION
Fix problem where C++ flags are not propogated due to typo

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>