### PR TITLE
Set Maximum Old Space size default value properly

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2075,12 +2075,11 @@ combinationMemoryParameterVerification(J9JavaVM *javaVM, IDATA* memoryParameters
 		}
 
 		/* Reset Xmox if applicable */
-		if (extensions->oldSpaceSize > extensions->maxOldSpaceSize) {
-			if (!opt_XmoxSet) {
+		if (!opt_XmoxSet) {
+			/* We know initial Nursery size now so adjust maximum Tenure size */
+			extensions->maxOldSpaceSize = extensions->memoryMax - extensions->newSpaceSize;
+			if (extensions->oldSpaceSize > extensions->maxOldSpaceSize) {
 				extensions->maxOldSpaceSize = extensions->oldSpaceSize;
-			} else {
-				/* Should have already been verified */
-				assume0(0);
 			}
 		}
 


### PR DESCRIPTION
We noticed that maxOldSpaceSize is set to memoryMax by default
This is not correct for Gencon heap geometry where it should be set to
maximum heap memory minus initial Nursery size - obviously the ultimate
case when Nursery never expands and stays on it's initial size and all
remaining memory might be taken for Tenure.
This change is not applicable for case if -Xmox is specified in command
line explicitly.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>