### PR TITLE
Remove unnecessary failure conditions in shared class CML tests

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -723,10 +723,6 @@
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Class debug area % used[\s]*= 0%</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Class LocalVariableTable bytes[\s]*= 0</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Class LineNumberTable bytes[\s]*= 0</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<exec command="rm -f javacore.txt" quiet="false"/>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-3.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-3.xml
@@ -1592,10 +1592,6 @@
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Maximum space for AOT bytes[\s]*= 8388608</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Reserved space for JIT data bytes[\s]*= 2097152</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Maximum space for JIT data bytes[\s]*= 4194304</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
 	<!-- Tests 176-179 are used to ensure cache created without 'enableBCI' is usable with 'enableBCI' option and vice-versa -->

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
@@ -358,10 +358,7 @@
 	<test id="Test 183-b: Ensure BCI Enabled is true" timeout="600" runPath=".">
 		<command>cat javacore.txt</command>				
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">BCI Enabled[\s]*= true</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes" showMatch="yes">BCI Enabled[\s]*= false</output>
 	</test>
 	
 	<test id="Test 183-c: Verify BCI Enabled is true in printStats output" timeout="600" runPath=".">
@@ -389,10 +386,7 @@
 	<test id="Test 183-e: Ensure BCI Enabled is true in generated javacore" timeout="600" runPath=".">
 		<command>cat javacore.txt</command>				
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">BCI Enabled[\s]*= true</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+		<output type="failure" caseSensitive="no" regex="yes" javaUtilPattern="yes" showMatch="yes">BCI Enabled[\s]*= false</output>
 	</test>
 	
 	<test id="Test 183-f: Ensure BCI Enabled is true in printStats output" timeout="600" runPath=".">


### PR DESCRIPTION
"cat" command won't print out the failure messages that are being
currently checked. These checks are sensitive to PR comments (See #1885)
Remove them.

Signed-off-by: hangshao <hangshao@ca.ibm.com>