### PR TITLE
Add pre RA peephole phase to Z code generation

### DIFF
--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -48,6 +48,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/S390HelperCallSnippet.cpp \
     omr/compiler/z/codegen/S390Instruction.cpp \
     omr/compiler/z/codegen/S390OutOfLineCodeSection.cpp \
+    omr/compiler/z/codegen/S390Peephole.cpp \
     omr/compiler/z/codegen/S390Snippets.cpp \
     omr/compiler/z/codegen/SystemLinkage.cpp \
     omr/compiler/z/codegen/TranslateEvaluator.cpp \

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -57,6 +57,7 @@
     InstructionSelectionPhase,
     CreateStackAtlasPhase,
 
+    PreRAPeepholePhase,
     RegisterAssigningPhase,
     MapStackPhase,
     ShrinkWrappingPhase,


### PR DESCRIPTION
Add peephole phase before register allocation to Z codegen.

Signed-off-by: Daniel Hong <daniel.hong@live.com>