### PR TITLE
Clear resolveFrameFlags after each frame walk

### DIFF
--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -346,8 +346,9 @@ UDATA  walkStackFrames(J9VMThread *currentThread, J9StackWalkState *walkState)
 		if (walkFrame(walkState) != J9_STACKWALK_KEEP_ITERATING) {
 			goto terminationPoint;
 		}
-		walkState->previousFrameFlags = walkState->frameFlags;
 resumeInterpreterWalk:
+		walkState->previousFrameFlags = walkState->frameFlags;
+		walkState->resolveFrameFlags = 0;
 
 		/* Call the JIT walker if the current frame is a transition from the JIT to the interpreter */
 


### PR DESCRIPTION
Clear resolveFrameFlags in the interpreter stack walker after reporting
the frame. This is consistent with the JIT stack walker and avoids
leaving invalid flags set on entry to the JIT walker in very rare cases.

Also fix a small error in the resumeable stack walker, which has no
effect on the only current consumer of the feature.

Fixes: #2472

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>