### PR TITLE
Fix incorrectly-held mutex

### DIFF
--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -2446,9 +2446,9 @@ jvmtiHookCheckForDataBreakpoint(J9HookInterface** hook, UDATA eventNum, void* ev
 		}
 		j9env = pool_nextDo(&envPoolState);
 	}
+done:
 	omrthread_monitor_exit(jvmtiData->mutex);
 
-done:
 	TRACE_JVMTI_EVENT_RETURN(jvmtiHookCheckForDataBreakpoint);
 }
 


### PR DESCRIPTION
The JVMTI "check for data breakpoint" hook exits with the JVMTI global
mutex held in cases where the compilation is forced to fail.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>