### PR TITLE
Provide alternative API to J9::CodeCache::initialize()

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -118,6 +118,10 @@ J9::CodeCache::allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, 
 
 // Initialize a code cache
 //
+// This function is deprecated in favour of the version that does not take
+// a CodeCacheHashEntrySlab parameter, and will be removed once upstream
+// OMR changes have merged.  It is otherwise identical to that function.
+//
 bool
 J9::CodeCache::initialize(TR::CodeCacheManager *manager,
                          TR::CodeCacheMemorySegment *codeCacheSegment,
@@ -159,6 +163,55 @@ J9::CodeCache::initialize(TR::CodeCacheManager *manager,
       }
 
    if (!self()->OMR::CodeCache::initialize(manager, codeCacheSegment, codeCacheSizeAllocated, hashEntrySlab))
+      return false;
+   self()->setInitialAllocationPointers();
+
+   _manager->reportCodeLoadEvents();
+
+   return true;
+   }
+
+
+bool
+J9::CodeCache::initialize(TR::CodeCacheManager *manager,
+                          TR::CodeCacheMemorySegment *codeCacheSegment,
+                          size_t allocatedCodeCacheSizeInBytes)
+   {
+   // make J9 memory segment look all used up
+   //J9MemorySegment *j9segment = _segment->segment();
+   //j9segment->heapAlloc = j9segment->heapTop;
+
+   TR::CodeCacheConfig & config = manager->codeCacheConfig();
+   if (config.needsMethodTrampolines())
+      {
+      int32_t percentageToUse;
+      if (!(TR::Options::getCmdLineOptions()->getTrampolineSpacePercentage() > 0))
+         {
+#if defined(TR_HOST_X86) && defined(TR_HOST_64BIT)
+         percentageToUse = 7;
+#else
+         percentageToUse = 4;
+#endif
+         // The number of helpers and the trampoline size are both factors here
+         size_t trampolineSpaceSize = config.trampolineCodeSize() * config.numRuntimeHelpers();
+         if (trampolineSpaceSize >= 3400)
+            {
+            // This will be PPC64, AMD64 and 390
+            if (config.codeCacheKB() < 512 && config.codeCacheKB() > 256)
+               percentageToUse = 5;
+            else if (config.codeCacheKB() <= 256)
+               percentageToUse = 6;
+            }
+         }
+      else
+         {
+         percentageToUse = TR::Options::getCmdLineOptions()->getTrampolineSpacePercentage();
+         }
+
+      config._trampolineSpacePercentage = percentageToUse;
+      }
+
+   if (!self()->OMR::CodeCache::initialize(manager, codeCacheSegment, allocatedCodeCacheSizeInBytes))
       return false;
    self()->setInitialAllocationPointers();
 

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -61,6 +61,19 @@ public:
                                          size_t codeCacheSizeAllocated,
                                          OMR::CodeCacheHashEntrySlab *hashEntrySlab);
 
+   /**
+    * @brief Initialize an allocated CodeCache object
+    *
+    * @param[in] manager : the TR::CodeCacheManager
+    * @param[in] codeCacheSegment : the code cache memory segment that has been allocated
+    * @param[in] allocatedCodeCacheSizeInBytes : the size (in bytes) of the allocated code cache
+    *
+    * @return true on a successful initialization; false otherwise.
+    */
+   bool                       initialize(TR::CodeCacheManager *manager,
+                                         TR::CodeCacheMemorySegment *codeCacheSegment,
+                                         size_t allocatedCodeCacheSizeInBytes);
+
    static TR::CodeCache *     allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, int32_t reservingCompThreadID);
 
    bool                       resizeCodeMemory(void *memoryBlock, size_t newSize);
@@ -94,7 +107,7 @@ public:
                                                           int32_t cpIndex);
 
    OMR::CodeCacheHashEntry *  findUnresolvedMethod(void *constPool, int32_t constPoolIndex);
- 
+
 
   /**
    * @brief Restore warmCodeAlloc/coldCodeAlloc and trampoline pointers to their initial positions


### PR DESCRIPTION
Provide a version that does not take a CodeCacheHashEntrySlab parameter and
add a Doxygen comment.  This function is identical in all respects
to the version that does take a CodeCacheHashEntrySlab parameter with the
exception of that passed parameter and a rename of the codeCacheSizeAllocated
parameter to match the new OMR API.  The original version is deprecated.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>