### PR TITLE
Implement JIT hook for static final field modification

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -166,6 +166,7 @@ J9::Compilation::Compilation(
    _monitorAutos(m),
    _monitorAutoSymRefsInCompiledMethod(getTypedAllocator<TR::SymbolReference*>(self()->allocator())),
    _classForOSRRedefinition(m),
+   _classForStaticFinalFieldModification(m),
    _profileInfo(NULL),
    _skippedJProfilingBlock(false)
    {
@@ -1193,6 +1194,23 @@ J9::Compilation::addClassForOSRRedefinition(TR_OpaqueClassBlock *clazz)
          return;
 
    _classForOSRRedefinition.add(clazz);
+   }
+
+/*
+ * Adds the provided TR_OpaqueClassBlock to the set of those to trigger OSR Guard patching
+ * on a static final field modification.
+ */
+void
+J9::Compilation::addClassForStaticFinalFieldModification(TR_OpaqueClassBlock *clazz)
+   {
+   // Class redefinition can also modify static final fields
+   addClassForOSRRedefinition(clazz);
+
+   for (uint32_t i = 0; i < _classForStaticFinalFieldModification.size(); ++i)
+      if (_classForStaticFinalFieldModification[i] == clazz)
+         return;
+
+   _classForStaticFinalFieldModification.add(clazz);
    }
 
 /*

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -270,6 +270,9 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void addClassForOSRRedefinition(TR_OpaqueClassBlock *clazz);
    TR_Array<TR_OpaqueClassBlock*> *getClassesForOSRRedefinition() { return &_classForOSRRedefinition; }
 
+   void addClassForStaticFinalFieldModification(TR_OpaqueClassBlock *clazz);
+   TR_Array<TR_OpaqueClassBlock*> *getClassesForStaticFinalFieldModification() { return &_classForStaticFinalFieldModification; }
+
    TR::list<TR::AOTClassInfo*>* _aotClassInfo;
 
    J9VMThread *j9VMThread() { return _j9VMThread; }
@@ -350,6 +353,8 @@ private:
    TR::list<TR::SymbolReference*>             _monitorAutoSymRefsInCompiledMethod;
 
    TR_Array<TR_OpaqueClassBlock*>       _classForOSRRedefinition;
+   // Classes that have their static final fields folded and need assumptions
+   TR_Array<TR_OpaqueClassBlock*>       _classForStaticFinalFieldModification;
 
    // cache profile information
    TR_AccessedProfileInfo *_profileInfo;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -596,13 +596,6 @@ jitExclusiveVMShutdownPending(J9VMThread * vmThread)
    #endif
    }
 
-// Placeholder for JIT callback of final field notification
-extern "C" void
-jitIllegalFinalFieldModification(struct J9VMThread *currentThread, struct J9Class *fieldClass)
-   {
-      // TODO - Initial Stub for final field callback
-   }
-
 // -----------------------------------------------------------------------------
 // JIT control
 // -----------------------------------------------------------------------------
@@ -1076,7 +1069,6 @@ onLoadInternal(
    jitConfig->doSha256InHardware = doSha256InHardware;
    jitConfig->doSha512InHardware = doSha512InHardware;
 #endif
-   jitConfig->jitIllegalFinalFieldModification = jitIllegalFinalFieldModification;
 
    //set up our vlog Manager
    TR_VerboseLog::initialize(jitConfig);

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,6 +165,29 @@ class TR_PatchMultipleNOPedGuardSitesOnClassRedefinition : public TR::PatchMulti
       TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, TR::PatchSites *sites, OMR::RuntimeAssumption **sentinel);
    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnClassRedefinitionNOP; }
    void setKey(uintptrj_t newKey) {_key = newKey;}
+   };
+
+class TR_PatchNOPedGuardSiteOnStaticFinalFieldModification : public TR::PatchNOPedGuardSite
+   {
+   protected:
+   TR_PatchNOPedGuardSiteOnStaticFinalFieldModification(TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz,
+                                             uint8_t *loc, uint8_t *dest)
+      : TR::PatchNOPedGuardSite(pm, (uintptrj_t)clazz, RuntimeAssumptionOnStaticFinalFieldModification, loc, dest) {}
+   public:
+   static TR_PatchNOPedGuardSiteOnStaticFinalFieldModification *make(
+      TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *loc, uint8_t *dest, OMR::RuntimeAssumption **sentinel);
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnStaticFinalFieldModification; }
+   };
+
+class TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification : public TR::PatchMultipleNOPedGuardSites
+   {
+   protected:
+   TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification(TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, TR::PatchSites *sites)
+      : TR::PatchMultipleNOPedGuardSites(pm, (uintptrj_t)clazz, RuntimeAssumptionOnStaticFinalFieldModification, sites) {}
+   public:
+   static TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification *make(
+      TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, TR::PatchSites *sites, OMR::RuntimeAssumption **sentinel);
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnStaticFinalFieldModification; }
    };
 
 class TR_PatchNOPedGuardSiteOnMutableCallSiteChange : public TR::PatchNOPedGuardSite

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -152,6 +152,13 @@ bool
 J9::ClassEnv::isClassInitialized(TR::Compilation *comp, TR_OpaqueClassBlock *clazz)
    {
    return comp->fej9()->isClassInitialized(clazz);
+   }
+
+bool
+J9::ClassEnv::classHasIllegalStaticFinalFieldModification(TR_OpaqueClassBlock * clazzPointer)
+   {
+   J9Class* j9clazz = TR::Compiler->cls.convertClassOffsetToClassPtr(clazzPointer);
+   return J9_ARE_ANY_BITS_SET(j9clazz->classFlags, J9ClassHasIllegalFinalFieldModifications);
    }
 
 bool

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,6 +66,7 @@ public:
 
    bool isStringClass(uintptrj_t objectPointer);
 
+   bool classHasIllegalStaticFinalFieldModification(TR_OpaqueClassBlock * clazzPointer);
    bool isAbstractClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isPrimitiveClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -44,6 +44,7 @@ enum TR_RuntimeAssumptionKind
    RuntimeAssumptionOnClassRedefinitionPIC,
    RuntimeAssumptionOnClassRedefinitionUPIC,
    RuntimeAssumptionOnClassRedefinitionNOP,
+   RuntimeAssumptionOnStaticFinalFieldModification,
    RuntimeAssumptionOnMutableCallSiteChange,
    RuntimeAssumptionOnMethodBreakPoint,
    LastAssumptionKind,
@@ -61,6 +62,7 @@ char const * const runtimeAssumptionKindNames[LastAssumptionKind] =
    "ClassRedefinitionPIC",
    "ClassRedefinitionUPIC",
    "ClassRedefinitionNOP",
+   "StaticFinalFieldModification",
    "MutableCallSiteChange",
    "OnMethodBreakpoint",
    };
@@ -104,6 +106,7 @@ class TR_RuntimeAssumptionTable
    void notifyClassUnloadEvent(TR_FrontEnd *vm, bool isSMP,
                                TR_OpaqueClassBlock *classOwningAssumption,
                                TR_OpaqueClassBlock *picKey);
+   void notifyIllegalStaticFinalFieldModificationEvent(TR_FrontEnd *vm, void *key);
    void notifyClassRedefinitionEvent(TR_FrontEnd *vm, bool isSMP, void *oldKey, void *newKey);
    void notifyMutableCallSiteChangeEvent(TR_FrontEnd *vm, uintptrj_t cookie);
 

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -100,6 +100,8 @@ extern "C" void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount
 
 extern "C" void jitMethodBreakpointed(J9VMThread * currentThread, J9Method *j9method);
 
+extern "C" void jitIllegalFinalFieldModification(J9VMThread *currentThread, J9Class *fieldClass);
+
 extern "C" void jitDiscardPendingCompilationsOfNatives(J9VMThread *vmThread, J9Class *clazz);
 
 #if defined(J9VM_JIT_DYNAMIC_LOOP_TRANSFER)
@@ -480,6 +482,7 @@ void codert_init_helpers_and_targets(J9JITConfig * jitConfig, char isSMP)
 #endif
    jitConfig->jitDiscardPendingCompilationsOfNatives = jitDiscardPendingCompilationsOfNatives;
    jitConfig->jitMethodBreakpointed = jitMethodBreakpointed;
+   jitConfig->jitIllegalFinalFieldModification = jitIllegalFinalFieldModification;
 
    initializeCodertFunctionTable(javaVM);
 


### PR DESCRIPTION
Add the JIT infrastructure of registering assumptions for static final
field folding and implement the JIT hook to patch guards for violated
assumptions.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>