### PR TITLE
Enabled DDR_Test in openJ9

### DIFF
--- a/test/functional/DDR_Test/.project
+++ b/test/functional/DDR_Test/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>DDR_Test</name>
+	<comment></comment>
+	<projects></projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>com.ibm.ive.j9.CustomNature</nature>
+	</natures>
+</projectDescription>

--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="DDR_Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		DDR_Test
+	</description>
+	<import file="${TEST_ROOT}/functional/build.xml"/>
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/DDR_Test" />
+
+	<!--Properties for this particular build-->
+	<property name="src" location="./src" />
+	<property name="build" location="./bin" />
+	<property name="transformerListener" location="${TEST_ROOT}/Utils/src"/>
+	<if>
+		<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+		<then>
+			<property name="j9ddr" location="${JDK_HOME}/jre/lib/ddr/j9ddr.jar" />
+		</then>
+		<else>
+			<property name="j9ddr" location="${JDK_HOME}/lib/ddr/j9ddr.jar" />
+		</else>
+	</if>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source  ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+			<src path="${transformerListener}" />
+			<classpath>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/junit4.jar" />
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar" />
+				<pathelement location="${j9ddr}" />
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/ddrplugin.jar" filesonly="true">
+			<fileset dir="${build}" >
+				<include name="j9vm/test/ddrext/plugin/**"/>
+			</fileset>
+			<fileset dir="${src}" >
+				<include name="j9vm/test/ddrext/plugin/**"/>
+			</fileset>
+		</jar>
+		<jar jarfile="${DEST}/DDR_Test.jar" filesonly="true">
+			<fileset dir="${build}" >
+				<exclude name="j9vm/test/ddrext/plugin/**"/>
+			</fileset>
+			<fileset dir="${src}" >
+				<exclude name="j9vm/test/ddrext/plugin/**"/>
+			</fileset>
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.mk" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<!-- Temporarily disable compilation on zos and aix until ddr is supported; github.com/eclipse/openj9/issues/1511 -->
+	<target name="build" >
+		<if>
+			<and>
+				<not>
+					<equals arg1="${os.name}" arg2="z/OS" />
+				</not>
+				<not>
+					<matches string="${os.name}" pattern="AIX" />
+				</not>
+			</and>
+			<then>
+				<antcall target="clean" inheritall="true" />
+			</then>
+		</if>
+	</target>
+</project>

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>testDDRExt_General_ibm</testCaseName>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DJDK_HOME=${JDK_HOME} -DJAVA_VERSION=${JAVA_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>^os.win</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>ibm</impl>
+		</impls>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>testDDRExt_General_openj9</testCaseName>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DJDK_HOME=${JDK_HOME} -DJAVA_VERSION=${JAVA_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.aix,^os.zos,^os.win</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>testDDRExt_General_win</testCaseName>
+		<command>$(MKTREE) $(REPORTDIR); \
+	cd $(REPORTDIR); \
+	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_ROOT=${TEST_ROOT} -DJDK_HOME=${JDK_HOME} -DJAVA_VERSION=${JAVA_VERSION} \
+	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
+	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.win</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/test/functional/DDR_Test/src/ddrext_excludes.xml
+++ b/test/functional/DDR_Test/src/ddrext_excludes.xml
@@ -1,0 +1,25 @@
+<!--
+  Copyright (c) 2016, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<excludes>	
+	<exclude name="testSym" domain="native"/>
+	<exclude name="testDclibs" domain="native"/>
+</excludes>

--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/DeadlockCoreGenerator.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/DeadlockCoreGenerator.java
@@ -1,0 +1,296 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.corehelper;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class DeadlockCoreGenerator {
+
+	/*
+	 * **********
+	 *   Legend:
+	 * **********
+	 *
+	 * JOO: Java thread has object monitor, wants object monitor.
+	 * JOS: Java thread has object monitor, wants system monitor.
+	 * JSO: Java thread has system monitor, wants object monitor.
+	 * JSS: Java thread has system monitor, wants system monitor.
+	 * NSS: Native thread has system monitor, wants system monitor.
+	 *
+	 * N.B. A native thread can never hold/want an object monitor,
+	 * because it must be attached first (i.e. it's a J9VMThread / Java thread).
+	 *
+	 */	
+	
+	public static final long WAIT_TIME_MILIS = 5000; // 5 seconds.
+	
+	static 
+	{
+		try {
+			System.loadLibrary("j9ben");
+		} catch (UnsatisfiedLinkError e) {
+			System.out.println(e.getMessage());
+			System.out.println("No natives for j9vm.test.ddrext.TestMonitors!");
+			System.out.println("java.library.path: " + System.getProperty("java.library.path"));
+			System.exit(1);
+		}
+	}
+	
+	public static void main(final String[] args) throws InterruptedException, NoSuchMethodException, 
+		SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		
+		System.out.println("Running deadlock tester...");
+		
+		final Method testCase = DeadlockCoreGenerator.class.getDeclaredMethod("testCase"  + args[0]);
+		
+		Thread testThread = new Thread() {
+			
+			public void run() {
+				try {
+					
+					testCase.invoke(null, new Object[] {});
+					
+				} catch (IllegalAccessException e) {
+					e.printStackTrace();
+				} catch (IllegalArgumentException e) {
+					e.printStackTrace();
+				} catch (InvocationTargetException e) {
+					e.printStackTrace();
+				}	
+			}
+		};
+		
+		testThread.setName("Java Deadlock Test Thread");
+		testThread.start();
+				
+		System.out.println("Waiting...");
+		Thread.sleep(WAIT_TIME_MILIS); // This is a guesstimate, but should be long enough to reach the desired state.
+		
+		try {
+			throw new HelperExceptionForCoreGeneration();
+		} catch (HelperExceptionForCoreGeneration e) {
+			System.out.println("HelperExceptionForCoreGeneration is thrown and caught successfuly.");
+			System.out.println("Forcefully terminating process.");
+			// In all but the native-only deadlock, the JVM won't quit since not all threads died.
+			System.exit(0); // Note that this will only run once the dump is done (exclusive!).
+		}
+		
+	}
+	
+	/* *****************************
+	 * Utility Methods for all Tests
+	 * *****************************/
+	
+	public static native void setup();
+	public static native void enterFirstMonitor();
+	public static native void enterSecondMonitor();
+	public static native void spawnNativeThread();
+	public static native void createNativeDeadlock();
+	
+	private static final Object mutex = new Object();
+	
+	/* *****************************
+	 *         Test Case #1
+	 *	     JOO, JOO deadlock.
+	 * *****************************/
+	
+	public static void testCase1() throws InterruptedException 
+	{
+		final Object firstLock = new Object();
+		final Object secondLock = new Object();
+		
+		synchronized (firstLock) {
+
+			Thread otherThread = new Thread() {
+				public void run() {
+					System.out.println("testCase1 :: Secondary thread trying to acquire lock on secondLock");
+					synchronized (secondLock) {
+						synchronized(mutex) {
+							mutex.notify();
+						}
+						System.out.println("testCase1 :: Secondary thread trying to acquire lock on firstLock");
+						synchronized(firstLock) {
+							System.out.println("Should not see me, testCase1()");
+						}
+					}
+				}
+			};
+			
+			synchronized(mutex) {
+				otherThread.start();
+				mutex.wait();
+				System.out.println("testCase1 :: Main thread trying to acquire lock on secondLock");
+				synchronized (secondLock) {
+					System.out.println("Should not see me, testCase1().");
+				}
+			}
+		}
+	}
+	
+	/* *****************************
+	 *         Test Case #2
+	 *	     JOS, JSO deadlock.
+	 * *****************************/
+	
+	public static void testCase2() throws InterruptedException 
+	{
+		setup();
+		
+		final Object javaObjMon = new Object();
+		
+		synchronized (javaObjMon) {
+			
+			Thread otherThread = new Thread() {
+				public void run() {
+					System.out.println("testCase2 :: Secondary thread trying to acquire lock on native monitor.");
+						enterFirstMonitor();
+						synchronized(mutex) {
+							mutex.notify();
+						}
+						System.out.println("testCase2 :: Secondary thread trying to acquire lock on Java object monitor.");
+						synchronized(javaObjMon) {
+							System.out.println("Should not see me, testCase2()");
+						}
+				}
+			};
+			
+			synchronized(mutex) {
+				otherThread.start();
+				mutex.wait();
+				System.out.println("testCase2 :: Main thread trying to acquire lock on native monitor.");
+				enterFirstMonitor(); // Deadlock
+				System.out.println("Should not see me, testCase2().");
+			}	
+		}
+	}
+	
+	/* *****************************
+	 *         Test Case #3
+	 *	     JSS, JSS deadlock.
+	 * *****************************/
+	
+	public static void testCase3() throws InterruptedException 
+	{
+		setup();
+		
+		enterFirstMonitor();
+
+		Thread otherThread = new Thread() {
+			public void run() {
+				System.out.println("testCase3 :: Secondary thread trying to acquire lock on secondLock");
+					enterSecondMonitor();
+					synchronized(mutex) {
+						mutex.notify();
+					}
+					System.out.println("testCase3 :: Secondary thread trying to acquire lock on firstLock");
+					enterFirstMonitor(); // Deadlock
+					System.out.println("Should not see me, testCase3()");
+			}
+		};
+
+		synchronized(mutex) {	
+			otherThread.start();
+			mutex.wait(); // Make sure the other thread has the monitor we want to block on first.
+			System.out.println("testCase3 :: Main thread trying to acquire lock on secondLock");
+			enterSecondMonitor(); // Deadlock
+			System.out.println("Should not see me, testCase3().");	
+		}
+	}
+	
+	/* *****************************
+	 *         Test Case #4
+	 *	     JSS, NSS deadlock.
+	 * *****************************/
+	
+	public static void testCase4() 
+	{
+		setup();
+		enterFirstMonitor();
+		spawnNativeThread(); // Will return once second monitor has been acquired by the new native thread.
+		enterSecondMonitor(); // Deadlock.
+	}
+	
+	/* *****************************
+	 *         Test Case #5
+	 *	     NSS, NSS deadlock.
+	 * *****************************/
+	
+	public static void testCase5() 
+	{
+		setup();
+		createNativeDeadlock();
+	}
+	
+	/* *****************************
+	 *         Test Case #6
+	 * Test JOS, NSS, JSO deadlock.
+	 * *****************************/
+	
+	private static final Object lock1Test6 = new Object();
+	
+	public static void testCase6() 
+	{
+		setup(); // Initializes native monitors.
+		
+		Thread thread1test6 = new Thread() {
+			public void run() {
+				synchronized (lock1Test6) { // Get O1
+					System.out.println("spawnFirstThreadtest6 :: run()");
+					spawnSecondThreadtest6();
+					try {
+						synchronized(mutex) {
+							mutex.wait(); // Make sure second Java thread has the system monitor first!
+						}
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+					spawnNativeThread();
+					// At this point the native thread acquired S2 and wants S1.
+					System.out.println("spawnFirstThreadtest6 :: wait() indefinitely on enterSecondMonitor()");
+					enterSecondMonitor(); // Deadlock
+					System.out.println("Should not see me, spawnFirstThreadtest6().");
+				}
+			}
+		};
+		thread1test6.start();
+	}
+	
+	private static void spawnSecondThreadtest6()
+	{
+		Thread thread2test6 = new Thread() {
+			public void run() {
+				System.out.println("spawnSecondThreadtest6 :: run()");
+				enterFirstMonitor();
+				synchronized(mutex) {
+					mutex.notify();
+				}
+				System.out.println("spawnSecondThreadtest6 :: block indefinitely on lock1test6");
+				synchronized(lock1Test6) { // Deadlock
+					System.out.println("Should not see me, spawnSecondThreadtest6().");
+				}
+			}
+		};
+		thread2test6.start();
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/HelperExceptionForCoreGeneration.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/HelperExceptionForCoreGeneration.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.corehelper;
+
+/**
+ * 
+ * @author fkaraman
+ * 
+ *         This exception class will be used to throw specific exception to
+ *         generate core file.
+ * 
+ *         Basically this exception name will be captured to generate core files
+ *         in -Xdump option
+ * 
+ *         -Xdump:system:events=throw,filter=HelperExceptionForCoreGeneration
+ */
+public class HelperExceptionForCoreGeneration extends Exception {
+
+	private static final long serialVersionUID = 1775248368703939533L;
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/corehelper/StackMapCoreGenerator.java
+++ b/test/functional/DDR_Test/src/j9vm/test/corehelper/StackMapCoreGenerator.java
@@ -1,0 +1,239 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.corehelper;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+
+/**
+ * 
+ * @author fkaraman
+ * 
+ *         This class is used to generate core file in a specific method. This
+ *         way, stackmap info of the methods in the stacklist will be known.
+ * 
+ *         Stack map values are generated depending on the value being primitive
+ *         or non-primitive.
+ * 
+ *         Primitive types are represented by '0' in the stack map.
+ *         Non-primitive types are represented by '1' in the stack map.
+ * 
+ *         Assume that method_1 calls method_2 and method_2 throws exception and
+ *         core is generated. See below:
+ * 
+ *         public void method_1 { method_2(1, new Object()); }
+ * 
+ *         public void method_2(int i, Object o) { // Throws exception and
+ *         causes core generation }
+ * 
+ *         In this case, stackmap for method_1 will be :
+ * 
+ *         101 1 is for 'Object o' non-primitive type, 0 is for int primitive
+ *         type 1 is for function call
+ * 
+ *         PS: long and double primitive types use 2 stacks since they are using
+ *         64 bit. So double zero (00) printed for them in the stackmap.
+ * 
+ * 
+ * 
+ */
+public class StackMapCoreGenerator {
+
+	enum WeekDays {
+		MON, TUE, WED, THU, FRI, SAT, SUN
+	};
+
+	/**
+	 * main method of this class to generate core file.
+	 * 
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		StackMapCoreGenerator stackMapTest = new StackMapCoreGenerator();
+		stackMapTest.stackMapTestMethod_1();
+	}
+
+	/**
+	 * Stack map of this method should be 111
+	 */
+	public void stackMapTestMethod_1() {
+		stackMapTestMethod_2(null, WeekDays.MON);
+
+	}
+
+	/**
+	 * Stack map of this method should be 100101
+	 * 
+	 * @param o
+	 *            dummy arg
+	 * @param monday
+	 *            dummy arg
+	 */
+	public void stackMapTestMethod_2(Object o, WeekDays monday) {
+		char[] charArray = { 't', 'e', 's', 't' };
+		stackMapTestMethod_3(1, "test", 9, charArray);
+
+	}
+
+	/**
+	 * Stack map of this method should be 1011001
+	 * 
+	 * @param i
+	 *            Dummy arg
+	 * @param s
+	 *            Dummy arg
+	 * @param l
+	 *            Dummy arg
+	 * @param charArray
+	 *            Dummy arg
+	 */
+	public void stackMapTestMethod_3(int i, String s, long l, char[] charArray) {
+		int[] intArray = new int[10];
+		stackMapTestMethod_4('0', false, new Integer("1"), new Exception(), 1,
+				intArray);
+
+	}
+
+	/**
+	 * Stack map of this method should be 01000111
+	 * 
+	 * @param c
+	 *            Dummy arg
+	 * @param b
+	 *            Dummy arg
+	 * @param intObj
+	 *            Dummy arg
+	 * @param e
+	 *            Dummy arg
+	 * @param i
+	 *            Dummy arg
+	 * @param intArray
+	 *            Dummy arg
+	 */
+	public void stackMapTestMethod_4(char c, boolean b, Integer intObj,
+			Exception e, int i, int[] intArray) {
+		String[] stringArray = { "dummy", "String", "Array" };
+		stackMapTestMethod_5(stringArray, "test", 1.5, 1,
+				new LinkedList<Object>(), (short) 2);
+
+	}
+
+	/**
+	 * Stack map of this method should be 11
+	 * 
+	 * @param stringArray
+	 *            dummy arg
+	 * @param s
+	 *            Dummy arg
+	 * @param d
+	 *            Dummy arg
+	 * @param f
+	 *            Dummy arg
+	 * @param o
+	 *            Dummy arg
+	 * @param sh
+	 *            dummy arg
+	 */
+	public void stackMapTestMethod_5(String[] stringArray, String s, double d,
+			float f, Object o, short sh) {
+		stackMapTestMethod_6(new HashMap<String, Object>());
+
+	}
+
+	/**
+	 * Stack map of this method should be 00100011011
+	 * 
+	 * @param h
+	 *            Dummy arg
+	 */
+	public void stackMapTestMethod_6(HashMap<String, Object> h) {
+		stackMapTestMethod_7(null, false, "stackmap", "test", 0, 1, this, 'c',
+				'h');
+
+	}
+
+	/**
+	 * Stack map of this method should be 01
+	 * 
+	 * @param ll
+	 *            Dummy arg
+	 * @param b
+	 *            Dummy arg
+	 * @param s1
+	 *            Dummy arg
+	 * @param s2
+	 *            Dummy arg
+	 * @param i
+	 *            Dummy arg
+	 * @param l
+	 *            Dummy arg
+	 * @param o
+	 *            Dummy arg
+	 * @param c1
+	 *            Dummy arg
+	 * @param c2
+	 *            Dummy arg
+	 */
+	public void stackMapTestMethod_7(LinkedList<Integer> ll, boolean b,
+			String s1, String s2, int i, long l, Object o, char c1, char c2) {
+		stackMapTestMethod_8(5);
+
+	}
+
+	/**
+	 * Stack map of this method should be 1
+	 * 
+	 * @param i
+	 *            Dummy arg
+	 */
+	public void stackMapTestMethod_8(int i) {
+		stackMapTestMethod_9();
+
+	}
+
+	/**
+	 * Stack map of this method should be 001
+	 * 
+	 */
+	public void stackMapTestMethod_9() {
+		stackMapTestMethod_throwException(1);
+
+	}
+
+	/**
+	 * This is the method that throws HelperExceptionForCoreGeneration. By using
+	 * this exception and Xdump filters for this specific exception, core file
+	 * is generated one this method throws this specific exception.
+	 * 
+	 * @param l
+	 *            Dummy arg
+	 */
+	public void stackMapTestMethod_throwException(long l) {
+		try {
+			throw new HelperExceptionForCoreGeneration();
+		} catch (HelperExceptionForCoreGeneration e) {
+			System.out
+					.println("HelperExceptionForCoreGeneration is thrown and caught successfuly!");
+		}
+
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/AutoRun.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/AutoRun.java
@@ -1,0 +1,530 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext;
+
+import j9vm.test.ddrext.junit.DDRTestSuite;
+import j9vm.test.ddrext.junit.TestCallsites;
+import j9vm.test.ddrext.junit.TestClassExt;
+import j9vm.test.ddrext.junit.TestCollisionResilientHashtable;
+import j9vm.test.ddrext.junit.TestDDRExtensionGeneral;
+import j9vm.test.ddrext.junit.TestFindExt;
+import j9vm.test.ddrext.junit.TestJITExt;
+import j9vm.test.ddrext.junit.TestMonitors;
+import j9vm.test.ddrext.junit.TestRTSpecificDDRExt;
+import j9vm.test.ddrext.junit.TestSharedClassesExt;
+import j9vm.test.ddrext.junit.TestStackMap;
+import j9vm.test.ddrext.junit.TestTenants;
+import j9vm.test.ddrext.junit.TestThread;
+import j9vm.test.ddrext.junit.TestTypeResolution;
+import j9vm.test.ddrext.junit.deadlock.*;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import junit.framework.AssertionFailedError;
+import junit.framework.Test;
+import junit.framework.TestListener;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
+
+import org.testng.log4testng.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+
+public class AutoRun {
+
+	private static Logger log = Logger.getLogger(AutoRun.class);
+	private static int dumpCount = 0;
+	private static int successDump = 0;
+	private static int failDump = 0;
+	private static int errCount;
+	private static int failCount;
+	private static HashMap<String, Enumeration<?>> failedCoreFileResult = new HashMap<String, Enumeration<?>>();
+	private static ArrayList<String> successCoreFile = new ArrayList<String>();
+	public static String ddrPluginJar = null;
+	private static int totalExcluded = 0;
+	private static String excludesForCurrentSuite = null;
+
+	/*
+	 * system exit code -1: no dump found system exit code -2: at least one test
+	 * cases fail system exit code -3: DDR initialization failed system exit
+	 * code -4: wrong test case name system exit code 0: all test cases pass
+	 */
+	public static void main(String[] args) {
+
+		File dir = null;
+		String testCaseList = null;
+		
+		if (args.length == 1) {
+			dir = new File(args[0]);
+			testCaseList = "ALL";
+		} else if (args.length == 2) {
+			dir = new File(args[0]);
+			testCaseList = args[1];
+		} else if (args.length == 3) {
+			dir = new File(args[0]);
+			testCaseList = args[1];
+			ddrPluginJar = args[2];
+		} else {
+			log.error("AutoRun usage:");
+			log.error(" args[0]---required, a dump file e.g. /bluebird/javatest/j9unversioned/dump4ddrext/Java7_GA/linux_x86-64.7ga.core.dmp");
+			log.error(" args[1]---optional, ALL or specific test case name(s) e.g.TestClassExt,TestThread. default to ALL ");
+			log.error(" args[2]---optional, javatestVMHome which is used for getting the path of ddr plugins, default to NULL");
+			System.exit(-1);
+		}
+
+		if (dir.isFile()) {
+			if (dir.getName().contains(".dmp")
+					|| dir.getName().contains(".DMP")) {
+				if (testCaseList == "" || testCaseList == null) {
+					testCaseList = "ALL";
+				}
+				runTest(dir.getAbsolutePath(), testCaseList);
+				if (failDump > 0) {
+					for (String failFile : failedCoreFileResult.keySet()) {
+						Enumeration<?> failures = failedCoreFileResult
+								.get(failFile);
+						while (failures.hasMoreElements()) {
+							String f = failures.nextElement().toString();
+							String testCaseName = f
+									.substring(0, f.indexOf(':'));
+							log.error(testCaseName);
+							log.debug(f);
+						}
+					}
+				}
+			} else {
+				log.error(dir.getName() + " is not .dmp file!");
+				System.exit(-1);
+			}
+		}// end of if (dir.isFile()
+			// if args[0] is directory, recursively search for .dmp or .DMP
+			// files under dir and its subdir, run test for each dump.
+		else {
+			log.debug("search for .dmp files under " + args[0]);
+			searchAllDumps(dir);
+			if (dumpCount == 0) {
+				log.error("No dump file under " + args[0]);
+				System.exit(-1);
+			} else {
+				log.info("Total number of dump file under " + args[0] + ":"
+						+ dumpCount);
+				log.info("Total number of success dump file under " + args[0]
+						+ ":" + successDump);
+				log.info("Total number of failed dump file under " + args[0]
+						+ ":" + failDump);
+				log.info("==========List of success dump file under " + args[0]
+						+ "==========");
+				if (successDump > 0) {
+					for (String sucFile : successCoreFile) {
+						log.info(sucFile);
+					}
+				}
+				if (failDump > 0) {
+					log.error("==========List of failed dump file under "
+							+ args[0] + "==========");
+					for (String failFile : failedCoreFileResult.keySet()) {
+						log.error("--Failures in " + failFile + "--");
+						Enumeration<?> failures = failedCoreFileResult
+								.get(failFile);
+						while (failures.hasMoreElements()) {
+							String f = failures.nextElement().toString();
+							String testCaseName = f
+									.substring(0, f.indexOf(':'));
+							log.error(testCaseName);
+							log.debug(f);
+						}
+					}
+					// TO-DO: provide instruction to rerun failed test cases
+					// log.error("You can rerun failed test cases in Eclipse.");
+				}
+			}
+		}
+		// print out success/failure info
+		log.info("Total Error/Failures: " + (errCount + failCount));
+		if ((errCount + failCount) > 0) {
+			System.exit(-2);
+		} else {
+			System.exit(0);
+		}
+	}
+
+	/**
+	 * Given the path to a folder containing core dumps, this method iterates through the dump files and invokes runTest()
+	 * on each core dump to run the DDR test suites on each dump. 
+	 * @param dir - Full path to the folder containing core dumps, if path to a core dump is given instead, that dump only is used
+	 */
+	public static void searchAllDumps(File dir) {
+		if (dir.isDirectory()) {
+			String[] subDirFiles = dir.list();
+			if (subDirFiles != null) {
+				for (String sub : subDirFiles) {
+					searchAllDumps(new File(dir, sub));
+				}
+			} else {
+				log.warn("Warning: " + dir.getPath() + " is empty!");
+				return;
+			}
+		} else if (dir.isFile()) {
+			if (dir.getName().contains(".dmp")
+					|| dir.getName().contains(".DMP")) {
+				runTest(dir.getAbsolutePath(), "ALL");
+				dumpCount++;
+			} else
+				log.info(dir.getName() + " is not .dmp file!");
+		} else {
+			log.info("Warning: " + dir.getPath() + " is not directory or file!");
+		}
+	}
+	
+	/**
+	 * This method is responsible for running the test suite in regular DDR testing
+	 * @param coreFilePath - Full path to the core file with with to Initialize DDR
+	 * @param testCaseList - Comma separated list of test suite classes to execute
+	 */
+	public static void runTest(String coreFilePath, String testCaseList) {
+
+		// initiate DDRInteractive instance
+		boolean setupSuccess = SetupConfig.init(coreFilePath);
+		if (setupSuccess == false) {
+			log.error("DDR initialization failed, can not proceed with tests");
+			System.exit(-3);
+		}
+
+		Test suite = null;
+		
+		//Get the overall list of tests to ignore for regular DDR tests as defined in ddrext_excludes.xml 
+		String excludeList = getExcludesFor(Constants.TESTDOMAIN_REGULAR);
+		
+		if (coreFilePath.contains(Constants.RT_PREFIX)) {
+			suite = getTestSuiteRT(excludeList);
+		} else {
+			suite = getTestSuite(testCaseList,excludeList);
+		}
+
+		if (suite == null) {
+			log.error("At least one test cases in your test case list "
+					+ testCaseList + " doesn't exist in DDRTestSuite.");
+			log.error("Please check your test case list and DDRTestSuite.java.");
+			System.exit(-4);
+		}
+
+		//Based on the excludes defined in ddrext_excludes.xml, construct the list of tests to ignore from the full list of tests in 
+		//the current test suite.
+		getExcludesForCurrentSuites(suite,excludeList);
+		
+		int numberOfExcludesForCurrentSuite = 0 ; 
+		
+		if ( excludesForCurrentSuite != null ) {
+			if ( excludesForCurrentSuite.contains(",") == false ) {
+				numberOfExcludesForCurrentSuite = 1;
+			} else {
+				numberOfExcludesForCurrentSuite = excludesForCurrentSuite.split(",").length;
+			}
+		}
+		
+		log.info("Running " + (suite.countTestCases() - numberOfExcludesForCurrentSuite ) + " tests for "
+				+ coreFilePath);
+
+		TestResult result = new TestResult();
+		result.addListener(new TestListener() {
+			public void addError(Test test, Throwable t) {
+				t.printStackTrace(System.err);
+			}
+
+			public void addFailure(Test test, AssertionFailedError t) {
+				t.printStackTrace(System.err);
+			}
+
+			public void endTest(Test test) {
+				log.info("Finished " + test + Constants.NL);
+			}
+
+			public void startTest(Test test) {
+				log.info("Starting " + test);
+			}
+		});
+		suite.run(result);
+		errCount = errCount + result.errorCount();
+		failCount = failCount + result.failureCount();
+		// log test result
+		if (result.errorCount() == 0 & result.failureCount() == 0) {
+			successCoreFile.add(coreFilePath);
+			successDump++;
+		} else {
+			failedCoreFileResult.put(coreFilePath, result.failures());
+			failDump++;
+		}
+		log.info("================Test Result for " + coreFilePath
+				+ "==================");
+		log.info("Errors:   " + result.errorCount() + " out of "
+				+ (suite.countTestCases() - numberOfExcludesForCurrentSuite) + " test cases.");
+		log.info("Failures: " + result.failureCount() + " out of "
+				+ (suite.countTestCases() - numberOfExcludesForCurrentSuite) + " test cases.");
+
+		if ( numberOfExcludesForCurrentSuite != 0 ){
+			log.info("Total tests excluded = " + numberOfExcludesForCurrentSuite + " [" + excludesForCurrentSuite + "]");
+		}
+		
+		// After run test on the core file, reset DDRInteractive,outputString
+		// and ddrResultCache to null
+		SetupConfig.reset();
+		DDRExtTesterBase.resetList();
+
+	}
+
+	/**
+	 * This method is responsible for running the test suite in Native Debugger based DDR testing
+	 * @param ctx - The context object 
+	 * @param out - The PrintStream object to be used to output logs  
+	 * @param testCaseList - Comma separated list of test suite classes to run
+	 */
+	public static void runTest(Context ctx, PrintStream out, String testCaseList) {
+
+		//initiate DDRInteractive instance
+		SetupConfig.init(ctx, out);
+
+		log.info("Executing test cases : " + testCaseList);
+		
+		//Get the overall list of tests to ignore for native DDR tests as found in ddrext_excludes.xml
+		String excludeList = getExcludesFor(Constants.TESTDOMAIN_NATIVE);
+		
+		Test suite = getTestSuite(testCaseList,excludeList);
+		
+		//Based on the excludes defined in ddrext_excludes.xml, construct the list of tests to ignore from the full list of tests in 
+		//the current test suite.
+		getExcludesForCurrentSuites(suite,excludeList);
+		
+		int numberOfExcludesForCurrentSuite = 0 ; 
+		
+		if ( excludesForCurrentSuite != null ) {
+			if ( excludesForCurrentSuite.contains(",") == false ) {
+				numberOfExcludesForCurrentSuite = 1;
+			} else {
+				numberOfExcludesForCurrentSuite = excludesForCurrentSuite.split(",").length;
+			}
+		}
+				
+		log.info("Running " + (suite.countTestCases() - numberOfExcludesForCurrentSuite ) 
+				+ " tests from ddrjunit plugin");
+
+		TestResult result = new TestResult();
+		result.addListener(new TestListener() {
+			public void addError(Test test, Throwable t) {
+				t.printStackTrace(System.err);
+			}
+
+			public void addFailure(Test test, AssertionFailedError t) {
+				t.printStackTrace(System.err);
+			}
+
+			public void endTest(Test test) {
+				log.info("Finished " + test + Constants.NL);
+			}
+
+			public void startTest(Test test) {
+				log.info("Starting " + test);
+			}
+		});
+		
+		suite.run(result);
+
+		errCount = errCount + result.errorCount();
+		failCount = failCount + result.failureCount();
+
+		log.info("================Test Result==================");
+		log.info("Errors:   " + result.errorCount() + " out of "
+				+ (suite.countTestCases() - numberOfExcludesForCurrentSuite) + " test cases.");
+		log.info("Failures: " + result.failureCount() + " out of "
+				+ (suite.countTestCases() - numberOfExcludesForCurrentSuite) + " test cases.");
+
+		if ( numberOfExcludesForCurrentSuite !=0 ){
+			log.info("Total tests excluded = " + numberOfExcludesForCurrentSuite + " [" + excludesForCurrentSuite + "]");
+		}
+		
+		// After run test on the core file, reset DDRInteractive,outputString
+		// and ddrResultCache to null
+		SetupConfig.reset();
+		DDRExtTesterBase.resetList();
+		// print out success/failure info
+		log.info("Total Error/Failures: " + (errCount + failCount));
+		if ((errCount + failCount) > 0) {
+			System.exit(-2);
+		} else {
+			System.exit(0);
+		}
+	}
+	
+	/**
+	 * Given a test suite, the method constructs the list of excluded test cases which may be a subset of the total 
+	 * list of tests excluded in ddrext_excludes.xml for a given domain (regular or native).
+	 * @param suite - The test suite to run in this given run.
+	 * @param excludeList - A comma separated list of excluded tests from the current test suite to run.
+	 */
+	@SuppressWarnings("rawtypes")
+	private static void getExcludesForCurrentSuites( Test suite, String excludeList ) {
+		TestSuite s = (TestSuite)suite;
+		
+		Enumeration en = s.tests();
+		while (en.hasMoreElements()) {
+			junit.framework.Test test = (junit.framework.Test)en.nextElement();
+			if (test instanceof junit.framework.TestSuite) {
+				getExcludesForCurrentSuites((junit.framework.TestSuite)test, excludeList);
+			} else {
+				junit.framework.TestCase testCase = (junit.framework.TestCase)test;
+				if ( excludeList.contains(testCase.getName()) ){
+					if ( excludesForCurrentSuite == null ) {
+						excludesForCurrentSuite = testCase.getName(); 
+					} else {
+						excludesForCurrentSuite = excludesForCurrentSuite + "," + testCase.getName();
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Creates a new j9vm.test.ddr.ext.junit.DDRTestSuite using a given list of tests 
+	 * @param testCaseList - A comma separated list of test suites to run. To run everything, pass the string - "ALL"
+	 * @param ignoreTestList - A comma separated list of test cases to ignore
+	 * @return A new instance of DDRTestSuite object containing DDR test suites
+	 * */
+	public static Test getTestSuite(String testCaseList, String ignoreTestList) {
+		DDRTestSuite suite = new DDRTestSuite("Test for j9vm.test.ddrext.junit", ignoreTestList);
+		// $JUnit-BEGIN$
+		if (testCaseList.equalsIgnoreCase("ALL")) {
+			suite.addTestSuite(TestThread.class);
+			//suite.addTestSuite(TestJITExt.class);
+			suite.addTestSuite(TestSharedClassesExt.class);
+			suite.addTestSuite(TestClassExt.class);
+			suite.addTestSuite(TestCallsites.class);
+			suite.addTestSuite(TestDDRExtensionGeneral.class);
+			suite.addTestSuite(TestFindExt.class);
+			suite.addTestSuite(TestTypeResolution.class);
+		} else {
+			String[] testCases = testCaseList.split(",");
+			for (String aTest : testCases) {
+				if (aTest.trim().equalsIgnoreCase("TestThread")) {
+					suite.addTestSuite(TestThread.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestJITExt")) {
+					suite.addTestSuite(TestJITExt.class);
+				} else if (aTest.trim()
+						.equalsIgnoreCase("TestSharedClassesExt")) {
+					suite.addTestSuite(TestSharedClassesExt.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestClassExt")) {
+					suite.addTestSuite(TestClassExt.class);
+				} else if (aTest.trim().equalsIgnoreCase("CollisionResilientHashtable")) {
+					suite.addTestSuite(TestCollisionResilientHashtable.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestCallsites")) {
+					suite.addTestSuite(TestCallsites.class);
+				} else if (aTest.trim().equalsIgnoreCase(
+						"TestDDRExtensionGeneral")) {
+					suite.addTestSuite(TestDDRExtensionGeneral.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestFindExt")) {
+					suite.addTestSuite(TestFindExt.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestStackMap")) {
+					suite.addTestSuite(TestStackMap.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestTenants")) {
+					suite.addTestSuite(TestTenants.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestTypeResolution")) {
+					suite.addTestSuite(TestTypeResolution.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestMonitors")) {
+					suite.addTestSuite(TestMonitors.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestDeadlockCase1")) {
+					suite.addTestSuite(TestDeadlockCase1.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestDeadlockCase2")) {
+					suite.addTestSuite(TestDeadlockCase2.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestDeadlockCase3")) {
+					suite.addTestSuite(TestDeadlockCase3.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestDeadlockCase4")) {
+					suite.addTestSuite(TestDeadlockCase4.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestDeadlockCase5")) {
+					suite.addTestSuite(TestDeadlockCase5.class);
+				} else if (aTest.trim().equalsIgnoreCase("TestDeadlockCase6")) {
+					suite.addTestSuite(TestDeadlockCase6.class);
+				} else {
+					return null;
+				}
+			}
+		}
+		// $JUnit-END$
+		return suite;
+	}
+	
+	/**
+	 * Creates a new j9vm.test.ddr.ext.junit.DDRTestSuite using the real-time specific test suite
+	 * @param ignoreTestList - A comma separated list of test cases to ignore 
+	 * @return A new instance of DDRTestSuite object containing the real-time specific DDR test suite 
+	 */
+	public static Test getTestSuiteRT(String ignoreTestList) {
+		DDRTestSuite suite = new DDRTestSuite("Test for j9vm.test.ddrext.junit", ignoreTestList);
+		// $JUnit-BEGIN$
+		suite.addTestSuite(TestRTSpecificDDRExt.class);
+		// $JUnit-END$
+		return suite;
+	}
+	
+	/**
+	 * Given a test type, returns a comma separated list of test cases to ignore by parsing the excludes.xml
+	 * @param testType - regular or native 
+	 * @return A comma separated list of tests cases to ignore for the given type
+	 */
+	public static String getExcludesFor(String testType){
+		try{
+			Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new AutoRun().getClass().getResourceAsStream("/" + Constants.DDREXT_EXCLUDES));
+			Node mainBlock = doc.getChildNodes().item(0);
+			NodeList excludeList = mainBlock.getChildNodes();
+			String excludeListStr = "";
+			for ( int i = 0 ; i < excludeList.getLength() ; i++ ){
+				Node anExclude = excludeList.item(i);
+				if(anExclude.getNodeName().equals(Constants.DDREXT_EXCLUDES_PROPERTY_EXCLUDE)){
+					NamedNodeMap attributes = anExclude.getAttributes();
+					String name = attributes.getNamedItem(Constants.DDREXT_EXCLUDES_PROPERTY_NAME).getNodeValue();
+					String type = attributes.getNamedItem(Constants.DDREXT_EXCLUDES_PROPERTY_DOMAIN).getNodeValue();
+					if ( type.equalsIgnoreCase( testType ) ){
+						if ( excludeListStr.length() == 0){
+							excludeListStr = name;
+						}
+						else{
+							excludeListStr = excludeListStr + "," + name;
+						}
+						totalExcluded++;
+					}
+				}
+			}
+			return excludeListStr;
+		}
+		catch(Exception error){
+			error.printStackTrace();
+			return null;
+		}
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -1,0 +1,724 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext;
+
+public class Constants {
+	
+	public static final String HEXADDRESS_HEADER = "0x";
+	public static final int HEXADECIMAL_RADIX = 16;
+	public static final int DECIMAL_RADIX = 10;
+	
+	// properties file
+	public static final String DDREXT_PROPERTIES = "ddrext.properties";
+	
+	public static final String DDREXT_EXCLUDES = "ddrext_excludes.xml";
+	
+	public static final String TESTDOMAIN_NATIVE = "native";
+	
+	public static final String TESTDOMAIN_REGULAR = "regular"; 
+
+	public static final String DDREXT_EXCLUDES_PROPERTY_NAME = "name";
+	
+	public static final String DDREXT_EXCLUDES_PROPERTY_DOMAIN = "domain";
+	
+	public static final String DDREXT_EXCLUDES_PROPERTY_EXCLUDE = "exclude";
+	
+	// Common Error Messages
+	public static final String UNRECOGNIZED_CMD = "Unrecognised command";
+
+	/*
+	 * This comma separated list of tokens are common failure keys that will be
+	 * searched in all command outputs during validation
+	 */
+	public static final String COMMON_FAILURE_KEYS = "DDRInteractiveCommandException,<FAULT>,com.ibm.j9ddr.corereaders.memory.MemoryFault,unable to read,could not read,dump event";
+
+	public static final String CORE_GEN_VM_XDUMP_OPTIONS = " -Xdump:system:defaults:file=";
+	public static final String CORE_GEN_VM_OPTIONS = " -Xshareclasses -Xjit:count=0 -Xaot:forceaot,count=0";
+	public static final String CORE_GEN_CLASS = "j9vm.test.ddrext.util.CoreDumpUtil";
+	public static final String CORE_DUMP_FOLDER = "CoreForDDRTest";
+
+	public static final String FS = System.getProperty("file.separator");
+	public static final String NL = System.getProperty("line.separator");
+
+	public static final String RT_PREFIX = "ddrjunit_rt";
+
+	/*
+	 * Following are success / failure criteria for ddr junit tests. Note
+	 * regarding validation keys and wild cards: The keys support Java regular
+	 * expression. Any occurrence of the following characters in the keys will
+	 * be treated as Regex meta-characters : ^ $ + * ? . | ( ) { } [ ] \ To
+	 * search for these meta-characters 'literally', please precede them with a
+	 * backslash (\\)
+	 */
+
+	/* Constants related to thread & stack tests */
+	public static final String THREAD_CMD = "threads";
+	// public static final String THREAD_SUCCESS_KEYS =
+	// "stack,j9vmthread,j9thread";
+	public static final String THREAD_SUCCESS_KEYS = "!stack 0x.*,!j9vmthread 0x.*";
+	public static final String THREAD_FAILURE_KEY = "";
+
+	public static final String THREAD_HELP_SUCCESS_KEY = "list all threads in the VM,list stacks for all threads in the VM";
+	public static final String THREAD_STACK_SUCCESS_KEY = "java/lang/Thread,com/ibm/dtfj/tck/harness/Configure\\$DumpThread\\.generateDump\\(\\),!j9method 0x.*,!stack 0x.*";
+	public static final String THREAD_FLAGS_SUCCESS_KEY = "main,!j9vmthread 0x.*,publicFlags";
+	public static final String THREAD_DEBUGEVENTDATA_SUCCESS_KEYS = "!j9vmthread 0x.*";
+	public static final String THREAD_MONITORS_SUCCESS_KEY = "itemCount=[1-9][0-9]*,!j9thread 0x.*,!j9threadmonitor 0x.*";
+	public static final String THREAD_TRACE_SUCCESS_KEY = "main,!stack 0x.*,!j9vmthread 0x.*";
+	public static final String THREAD_SEARCH_SUCCESS_KEY = "j9vmthread,!j9thread";
+
+	public static final String LOCALMAP_CMD = "localmap";
+	public static final String LOCALMAP_SUCCESS_KEY = "j9method";
+	public static final String LOCALMAP_FAILURE_KEY = "Not found";
+
+	public static final String STACK_CMD = "stack";
+	public static final String STACK_SUCCESS_KEYS = "!j9method 0x.*";
+	public static final String STACK_FAILURE_KEY = "";
+
+	public static final String STACKSLOTS_CMD = "stackslots";
+	public static final String STACKSLOTS_SUCCESS_KEY = "BEGIN STACK WALK,flags,walkThread,PC,A0";
+	public static final String STACKSLOTS_FAILURE_KEY = "";
+
+	public static final String J9VMTHREAD_CMD = "j9vmthread";
+	public static final String J9VMTHREAD_SUCCESS_KEYS = "J9VMThread,J9Method,!j9javavm 0x0*[1-9a-fA-F][0-9a-fA-F]*";// make
+																														// sure
+																														// j9javavm's
+																														// address
+																														// is
+																														// not
+																														// 0
+	public static final String J9VMTHREAD_FAILURE_KEY = "";
+	
+	public static final String J9POOL_CMD = "j9pool";
+	public static final String J9POOLPUDDLE_CMD = "j9poolpuddle"; 
+	public static final String J9POOLPUDDLELIST_CMD = "j9poolpuddlelist";
+	
+	public static final String WALKJ9POOL_CMD = "walkj9pool";
+	public static final String WALKJ9POOL_SUCCESS_KEYS = "J9Pool at";
+	public static final String WALKJ9POOL_FAILURE_KEY = "Either address is not a valid pool address or pool itself is corrupted";
+	
+
+	public static final String J9THREAD_CMD = "j9thread";
+	public static final String J9THREAD_SUCCESS_KEYS = "J9ThreadTracing,J9ThreadMonitor";
+	public static final String J9THREAD_FAILURE_KEY = "";
+
+	/* Constants related to jit stack tests */
+	public static final String JITSTACK_CMD = "jitstack";
+	public static final String JITSTACKSLOTS_CMD = "jitstackslots";
+	public static final String JITMETADATAFROMPC = "jitmetadatafrompc";
+	public static final String JIT_CMD_SUCCESS_KEY = "JIT frame,I2J values";
+	public static final String JIT_CMD_FAILURE_KEY = "STACK_CORRUPT,corruptData,CorruptDataException";
+	public static final String JITMETADATAFROMPC_SUCCESS_KEY = "className,methodName";
+	public static final String JITMETADATAFROMPC_FAILURE_KEY = "";
+
+	/* Constants for shared classes tests */
+	public static final String SHRC_CMD = "shrc";
+	public static final String SHRC_SUCCESS_KEY = "!shrc stats,!shrc allstats,!shrc rcstats,!shrc cpstats,!shrc aotstats,!shrc orphanstats,!shrc jitpfor <address>,!shrc write <dir> \\[<name>\\]";
+	public static final String SHRC_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_STATS = "stats";
+	public static final String SHRC_STATS_SUCCESS_KEY = "JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*,ROMClass data [1-9][0-9]* metadata [1-9][0-9]*,cache size       : [1-9][0-9]*,free bytes,read write area,segment area,metadata area,class debug area";
+	public static final String SHRC_STATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_ALLSTATS = "allstats";
+	public static final String SHRC_ALLSTATS_SUCCESS_KEY = "vm.jar,charsets.jar,CLASSPATH,java/lang/Object,JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*,ROMClass data [1-9][0-9]* metadata [1-9][0-9]*";
+	public static final String SHRC_ALLSTATS_SUCCESS_KEY_JAVA9 = "lib[[/\\\\]]modules,CLASSPATH,java/lang/Object,JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*,ROMClass data [1-9][0-9]* metadata [1-9][0-9]*";
+	public static final String SHRC_ALLSTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_RCSTATS = "rcstats";
+	public static final String SHRC_RCSTATS_SUCCESS_KEY = "java/lang/Object,java/lang/Thread,JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*,ROMClass data [1-9][0-9]* metadata [1-9][0-9]*";
+	public static final String SHRC_RCSTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_CPSTATS = "cpstats";
+	public static final String SHRC_CPSTATS_SUCCESS_KEY = "vm.jar,CLASSPATH,JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*";
+	public static final String SHRC_CPSTATS_SUCCESS_KEY_JAVA9 = "lib[[/\\\\]]modules,CLASSPATH,JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*";
+	public static final String SHRC_CPSTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_AOTSTATS = "aotstats";
+	public static final String SHRC_AOTSTATS_SUCCESS_KEY = "Ljava/lang/Object,AOT data !j9x 0x.*,AOT data length [1-9][0-9]*";
+	public static final String SHRC_AOTSTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_ORPHANSTATS = "orphanstats";
+	public static final String SHRC_ORPHANSTATS_SUCCESS_KEY = "ORPHAN,j9romclass"; // may
+																					// needs
+																					// expansion
+																					// -
+																					// seems
+																					// like
+																					// the
+																					// orphan
+																					// output
+																					// is
+																					// very
+																					// much
+																					// tied
+																					// with
+																					// the
+																					// dump
+																					// produced
+	public static final String SHRC_ORPHANSTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_SCOPESTATS = "scopestats";
+	public static final String SHRC_SCOPESTATS_SUCCESS_KEY = "SCOPE,vm.jar,j9utf8,BYTEDATA Summary,ROMClass"; // may
+																												// needs
+																												// expansion
+																												// -
+																												// seems
+																												// like
+																												// the
+																												// orphan
+																												// output
+																												// is
+																												// very
+																												// much
+																												// tied
+																												// with
+																												// the
+																												// dump
+																												// produced
+	public static final String SHRC_SCOPESTATS_SUCCESS_KEY_JAVA9 = "SCOPE,lib[[/\\\\]]modules,j9utf8,BYTEDATA Summary,ROMClass"; // may
+	// needs
+	// expansion
+	// -
+	// seems
+	// like
+	// the
+	// orphan
+	// output
+	// is
+	// very
+	// much
+	// tied
+	// with
+	// the
+	// dump
+	// produced
+	public static final String SHRC_SCOPESTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_BYTESTATS = "bytestats";
+	public static final String SHRC_BYTESTATS_SUCCESS_KEY = "vm.jar";
+	public static final String SHRC_BYTESTATS_SUCCESS_KEY_JAVA9 = "BYTEDATA !j9x";
+	public static final String SHRC_BYTESTATS_FAILURE_KEY = "UNKNOWN\\(,no shared cache";
+
+	public static final String SHRC_UBYTESTATS = "ubytestats";
+	public static final String SHRC_UBYTESTATS_SUCCESS_KEY = "UNINDEXEDBYTE"; // currently
+																				// our
+																				// dump
+																				// does
+																				// not
+																				// contain
+																				// any
+																				// data
+																				// for
+																				// this
+	public static final String SHRC_UBYTESTATS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_CLSTATS = "clstats";
+	public static final String SHRC_CLSTATS_SUCCESS_KEY_NONRTP = "No entry found in the cache"; // In
+																								// case
+																								// of
+																								// non-real-time
+																								// platforms
+																								// we
+																								// should
+																								// not
+																								// see
+																								// any
+																								// cachelet
+																								// info
+	public static final String SHRC_CLSTATS_FAILURE_KEY_NONRTP = "no shared cache";
+	public static final String SHRC_CLSTATS_SUCCESS_KEY_RTP = "CACHELET count,CACHELET,!shrc cachelet"; // In
+																										// case
+																										// of
+																										// real-time
+																										// platforms
+																										// we
+																										// should
+																										// see
+																										// cachelet
+																										// info
+	public static final String SHRC_CLSTATS_FAILURE_KEY_RTP = "No entry found in the cache,no shared cache";
+
+	public static final String SHRC_CACHELET = "cachelet";
+	public static final String SHRC_CACHELET_ADDR_NONRTP = "100";
+	public static final String SHRC_CACHELET_SUCCESS_KEY_NONRTP = "Memory Fault";
+	public static final String SHRC_CACHELET_FAILURE_KEY_NONRTP = "no shared cache";
+	public static final String SHRC_CACHELET_SUCCESS_KEY_RTP = "CACHELET,!shrc cachelet,segment area,metadata area, class debug area";
+	public static final String SHRC_CACHELET_FAILURE_KEY_RTP = "Memory Fault,no shared cache";
+
+	public static final String SHRC_CP = "classpath";
+	public static final String SHRC_CP_SUCCESS_KEY = "vm.jar";
+	public static final String SHRC_CP_SUCCESS_KEY_JAVA9 = "lib[[/\\\\]]modules";
+	public static final String SHRC_CP_FAILIRE_KEY = "no shared cache";
+
+	public static final String SHRC_FINDCLASS = "findclass";
+	public static final String SHRC_FINDCLASS_NAME = "java/lang/Object";
+	public static final String SHRC_FINDCLASS_SUCCESS_KEY = "ROMCLASS: java/lang/Object";
+	public static final String SHRC_FINDCLASS_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_FINDCLASSP = "findclassp";
+	public static final String SHRC_FINDCLASSP_PATTERN = "java/lang/O";
+	public static final String SHRC_FINDCLASSP_SUCCESS_KEY = "java/lang/Object,java/lang/OutOfMemoryError";
+	public static final String SHRC_FINDCLASSP_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_FINDAOT = "findaot";
+	public static final String SHRC_FINDAOT_METHODNAME = "getSecurityManager";
+	public static final String SHRC_FINDAOT_NO_ENTRY_KEY = "No entry found in the cache";
+	public static final String SHRC_FINDAOT_SUCCESS_KEY = "java/lang/System,getSecurityManager";
+	public static final String SHRC_FINDAOT_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_FINDAOTP = "findaotp";
+	public static final String SHRC_FINDAOTP_PATTERN = "getSecurity";
+	public static final String SHRC_FINDAOTP_NO_ENTRY_KEY = "No entry found in the cache";
+	public static final String SHRC_FINDAOTP_SUCCESS_KEY = "java/lang/System,getSecurityManager";
+	public static final String SHRC_FINDAOTP_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_AOTFOR = "aotfor";
+	public static final String SHRC_AOTFOR_SUCCESS_KEY = "java/lang/System,getSecurityManager";
+	public static final String SHRC_AOTFOR_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_RCFOR = "rcfor";
+	public static final String SHRC_RCFOR_SUCCESS_KEY = "ROMCLASS,java/lang/System";
+	public static final String SHRC_RCFOR_FAILURE_KEY = "no shared cache";
+
+	public static final String SHRC_METHOD = "method";
+	public static final String SHRC_METHOD_SUCCESS_KEY = "found in java/lang/System";
+	public static final String SHRC_METHOD_FAILURE_KEY = "not found in cache,no shared cache";
+
+	public static final String SHRC_INCACHE = "incache";
+	public static final String SHRC_INCACHE_SUCCESS_KEY = "is in the cache header";
+	public static final String SHRC_INCACHE_FAILURE_KEY = "no shared cache";
+
+	/* JIT profile information */
+	public static final String SHRC_JITPSTATS = "jitpstats";
+	public static final String SHRC_JITPSTATS_SUCCESS_KEY = "JITPROFILE data length [1-9][0-9]* metadata [1-9][0-9]*,!j9x,java/lang/String,!j9romclass";
+	public static final String SHRC_JITPSTATS_FAILURE_KEY = "no shared cache,JITPROFILE data length 0 metadata 0";
+	public static final String SHRC_JITP_SUCCESS_KEY = "JITPROFILE data !j9x";	
+	
+	public static final String SHRC_FINDJITP = "findjitp";
+	public static final String SHRC_FINDJITP_METHODNAME = "toString";
+	public static final String SHRC_FINDJITP_FAILURE_KEY = "No entry found in the cache";
+
+	public static final String SHRC_FINDJITPP = "findjitpp";
+	public static final String SHRC_FINDJITPP_METHODPREFIX = "to";
+	public static final String SHRC_FINDJITPP_FAILURE_KEY = "No entry found in the cache";
+
+	public static final String SHRC_JITPFOR = "jitpfor";
+	public static final String SHRC_JITPFOR_METHODNAME = "toString";
+	public static final String SHRC_JITPFOR_FAILURE_KEY = "No entry found in the cache";
+	
+	/* JIT hint information */
+	public static final String SHRC_JITHSTATS = "jithstats";
+	public static final String SHRC_JITHSTATS_SUCCESS_KEY = "JITHINT data length [1-9][0-9]* metadata [1-9][0-9]*,!j9x,java/util/HashMap,!j9romclass";
+	public static final String SHRC_JITHSTATS_FAILURE_KEY = "no shared cache,JITPROFILE data length 0 metadata 0";
+
+	public static final String SHRC_FINDJITH = "findjith";
+	public static final String SHRC_FINDJITH_METHODNAME = "run";
+	public static final String SHRC_FINDJITH_SUCCESS_KEY = "run\\(\\)Ljava/lang/.*,JITHINT data !j9x,.*/Object";
+	public static final String SHRC_FINDJITH_FAILURE_KEY = "No entry found in the cache";
+
+	public static final String SHRC_FINDJITHP = "findjithp";
+	public static final String SHRC_FINDJITHP_METHODPREFIX = "r";
+	public static final String SHRC_FINDJITHP_SUCCESS_KEY = "run\\(\\)Ljava/lang/.*,JITHINT data !j9x,.*/Object";
+	public static final String SHRC_FINDJITHP_FAILURE_KEY = "No entry found in the cache";
+
+	public static final String SHRC_JITHFOR = "jithfor";
+	public static final String SHRC_JITHFOR_METHODNAME = "run";
+	public static final String SHRC_JITHFOR_SUCCESS_KEY = "run\\(\\)Ljava/lang/.*,JITHINT data !j9x,.*/Object";
+	public static final String SHRC_JITHFOR_FAILURE_KEY = "No entry found in the cache";
+
+	public static final String SHRC_RTFLAGS = "rtflags";
+	public static final String SHRC_RTFLAGS_SUCCESS_KEY = "Printing the shared classes runtime flags 0x.*";
+	public static final String SHRC_RTFLAGS_FAILURE_KEY = "Type !shrc to see all the valid options,no shared cache";
+
+	public static final String SHRC_WRITE_CACHE = "write";
+	public static final String SHRC_WRITE_CACHE_SUCCESS_KEY = "Writing cache to,Cache name is";
+	public static final String SHRC_WRITE_CACHE_FAILURE_KEY = null; // need to
+																	// determine
+	/* The following are constants related to Class related extensions */
+	public static final String ALL_CLASSES_CMD = "allclasses";
+	public static final String ALL_CLASSES_SUCCESS_KEY = "com/ibm/dtfj/tck/tests/javaruntime/TestJavaRuntime_getHeapRoots,com/ibm/dtfj/tck/tests/javaruntime/TestJavaStackFrame_getHeapRoots,"
+			+ "com/ibm/dtfj/tck/tests/javaruntime/TestJavaThreadInspection,com/ibm/dtfj/tests/junit/JavaFieldTest,com/ibm/dtfj/tests/junit/JavaObjectTest";
+	public static final String ALL_CLASSESS_FAILURE_KEY = "";
+
+	public static final String J9CLASSSHAPE_CMD = "j9classshape";
+	public static final String J9CLASSSHAPE_TEST_CLASS = "com/ibm/dtfj/tests/junit/JavaObjectTest";
+	public static final String J9CLASSSHAPE_SUCCESS_KEY = "_object,"+J9CLASSSHAPE_TEST_CLASS;
+
+	public static final String J9VTABLES_CMD = "j9vtables";
+	public static final String J9VTABLES_SUCCESS_KEY = "j9class,j9method,"+J9CLASSSHAPE_TEST_CLASS;
+
+	public static final String J9STATICS_CMD = "j9statics";
+	public static final String J9STATICS_SUCCESS_KEY = "j9romstaticsinglefieldshape,"+J9CLASSSHAPE_TEST_CLASS;
+
+	public static final String CL_FOR_NAME_CMD = "classforname";
+	public static final String CL_FOR_NAME_CLASS = "java/lang/Object";
+	public static final String CL_FOR_NAME_SUCCESS_KEY = "!j9class,Found 1 class\\(es\\) named java/lang/Object";
+	public static final String CL_FOR_NAME_FAILURE_KEY = "Found 0 class(es) named java/lang/Object";
+	public static final String CL_FOR_NAME_CLASS_WC = "\\*Object\\*";
+	public static final String CL_FOR_NAME_SUCCESS_KEY_WC = "!j9class,java/lang/reflect/AccessibleObject";
+	public static final String CL_FOR_NAME_FAILURE_KEY_WC = "Found 0 class\\(es\\) named \\*Object\\*";
+
+	public static final String ROM_CLASS_SUMMARY_CMD = "romclasssummary";
+	public static final String ROM_CLASS_SUMMARY_SUCCESS_KEY = "classes, using:,romHeader,constantPool,fields,methods,method,methodAnnotation,"
+			+ "cpShapeDescription,enclosingObject,optionalInfo,UTF8,Padding,variableInfos";
+	public static final String ROM_CLASS_SUMMARY_FAILURE_KEY = "";
+
+	public static final String RAM_CLASS_SUMMARY_CMD = "ramclasssummary";
+	public static final String RAM_CLASS_SUMMARY_SUCCESS_KEY = "jitVTables,ramHeader,vTable,RAM methods,Constant Pool,J9CPTYPE_CLASS,J9CPTYPE_FLOAT,J9CPTYPE_INSTANCE_FIELD|J9CPTYPE_FIELD,J9CPTYPE_INT,"
+			+ "J9CPTYPE_INTERFACE_METHOD,J9CPTYPE_SPECIAL_METHOD|J9CPTYPE_INSTANCE_METHOD,J9CPTYPE_STATIC_FIELD|J9CPTYPE_FIELD,J9CPTYPE_STATIC_METHOD,J9CPTYPE_STRING,J9CPTYPE_UNUSED,J9CPTYPE_VIRTUAL_METHOD|J9CPTYPE_INSTANCE_METHOD,Ram static,Superclasses,iTable";
+	public static final String RAM_CLASS_SUMMARY_FAILURE_KEY = "";
+
+	public static final String CL_LOADERS_SUMMARY_CMD = "classloaderssummary";
+	public static final String CL_LOADERS_SUMMARY_SUCCESS_KEY = "Number of Classloaders: [0-9]+,\\*System\\*";
+	public static final String CL_LOADERS_SUMMARY_FAILURE_KEY = "";
+
+	public static final String DUMP_ALL_ROM_CLASS_LINEAR_CMD = "dumpallromclasslinear";
+	public static final String DUMP_ALL_ROM_CLASS_LINEAR_NESTING_THRESHOLD = "1";
+	public static final String DUMP_ALL_ROM_CLASS_LINEAR_SUCCESS_KEY = "java/lang/Object,!dumpromclasslinear,ROM Class,romHeader";
+	public static final String DUMP_ALL_ROM_CLASS_LINEAR_FAILURE_KEY = "";
+
+	public static final String DUMP_ROM_CLASS_LINEAR_CMD = "dumpromclasslinear";
+	public static final String DUMP_ROM_CLASS_LINEAR_SUCCESS_KEY = "romHeader,constantPool,methods,cpShapeDescription,optionalInfo";
+	public static final String DUMP_ROM_CLASS_LINEAR_FAILURE_KEY = "";
+
+	public static final String DUMP_ROM_CLASS_CMD = "dumpromclass";
+	public static final String DUMP_ROM_CLASS_SUCCESS_KEY = "ROM Size,Class Name: java/lang/Object,Superclass Name,Source File Name,Methods,Interfaces \\(0\\),Fields \\(0\\),CP Shape Description,Methods \\(13\\)";
+	public static final String DUMP_ROM_CLASS_FAILURE_KEY = "";
+
+	public static final String DUMP_ROM_CLASS_NAME_CMD = "name:";
+	public static final String DUMP_ROM_CLASS_NAME = "java/lang/Object";
+	public static final String DUMP_ROM_CLASS_NAME_SUCCESS_KEY = "ROM Size,Class Name: java/lang/Object,Superclass Name,Source File Name: Object.java,Methods,Interfaces \\(0\\),Fields \\(0\\),CP Shape Description,Methods \\(13\\),Found 1 class\\(es\\) with name java/lang/Object";
+	public static final String DUMP_ROM_CLASS_NAME_FAILURE_KEY = "Found 0 class\\(es\\) with name java/lang/Object";
+
+	public static final String DUMP_ROM_CLASS_NAME_WC = "*Object*";
+	public static final String DUMP_ROM_CLASS_NAME_WC_SUCCESS_KEY = "ROM Size,Class Name: java/lang/Object,Superclass Name,Source File Name: Object.java,Methods,Interfaces \\(0\\),Fields \\(0\\),CP Shape Description,Methods \\(13\\),Found [1-9][0-9]* class\\(es\\) with name \\*Object\\*";
+	public static final String DUMP_ROM_CLASS_NAME_WC_FAILURE_KEY = "Found 0 class\\(es\\) with name \\*Object\\*";
+
+	public static final String DUMP_ROM_CLASS_MAPS_CMD = "maps";
+	public static final String DUMP_ROM_CLASS_MAPS_SUCCESS_KEY = "ROM Size,Class Name: java/lang/Object,Superclass Name,Source File Name: Object.java,Interfaces \\(0\\),Fields \\(0\\),CP Shape Description,Methods \\(13\\),lmap,dmap,smap";
+	public static final String DUMP_ROM_CLASS_MAPS_FAILURE_KEY = "";
+
+	public static final String DUMP_ROM_CLASS_NAME_MAPS_SUCCESS_KEY = "ROM Size,Class Name: java/lang/Object,Superclass Name,Source File Name: Object.java,Interfaces \\(0\\),Fields \\(0\\),CP Shape Description,Methods \\(13\\),lmap,dmap,smap,Found 1 class\\(es\\) with name java/lang/Object";
+	public static final String DUMP_ROM_CLASS_NAME_MAPS_FAILURE_KEY = "Found 0 class\\(es\\) with name java/lang/Object";
+
+	public static final String DUMP_ROM_CLASS_INVALID_ADDR_SUCCESS_KEY = "Problem running command";//"DDRInteractiveCommandException";
+	public static final String DUMP_ROM_CLASS_INVALID_ADDR_FAILURE_KEY = "Class Name,Superclass Name,Source File Name,Methods,Interfaces";
+
+	public static final String DUMP_ROM_CLASS_INVALID_NAME = "ABCDEFGH";
+	public static final String DUMP_ROM_CLASS_INVALID_NAME_SUCCESS_KEY = "Found 0 class\\(es\\) with name ABCDEFGH";
+	public static final String DUMP_ROM_CLASS_INVALID_NAME_FAILURE_KEY = "";
+
+	public static final String QUERY_ROM_CLASS_CMD = "queryromclass";
+	public static final String QUERY_ROM_CLASS_QUERY = "/romHeader"; // may add
+																		// more
+																		// queries
+																		// later
+																		// like
+																		// /romHeader/className,/methods,
+	public static final String QUERY_ROM_CLASS_SUCCESS_KEY = "romSize,className,Section Start: romHeader,Section End: romHeader,optionalInfo";
+	public static final String QUERY_ROM_CLASS_FAILURE_KEY = "matched nothing";
+
+	public static final String ANALYSE_ROM_CLASS_UTF8_CMD = "analyseromClassutf8";
+	public static final String ANALYSE_ROM_CLASS_UTF8_SUCCESS_KEY = "Global Unique UTF-8,Global Duplicated UTF-8,Distribution of Global Duplicated UTF-8";
+	public static final String ANALYSE_ROM_CLASS_UTF8_FAILURE_KEY = "";
+
+	public static final String DUMP_ALL_RAM_CLASS_LINEAR_CMD = "dumpallramclasslinear";
+	public static final String DUMP_ALL_RAM_CLASS_LINEAR_NESTING_THRESHOLD = "1";
+	public static final String DUMP_ALL_RAM_CLASS_LINEAR_SUCCESS_KEY = "java/lang/Object,!dumpramclasslinear,RAM Class,ramHeader,RAM methods";
+	public static final String DUMP_ALL_RAM_CLASS_LINEAR_FAILURE_KEY = "";
+
+	public static final String DUMP_RAM_CLASS_LINEAR_CMD = "dumpramclasslinear";
+	public static final String DUMP_RAM_CLASS_LINEAR_SUCCESS_KEY = "RAM methods,jitVTables,ramHeader,vTable,Constant Pool";
+	public static final String DUMP_RAM_CLASS_LINEAR_FAILURE_KEY = "";
+
+	public static final String DUMP_ALL_REGIONS_CMD = "dumpallregions";
+	public static final String DUMP_ALL_REGIONS_SUCCESS_KEY = "region,start,end";
+	public static final String DUMP_ALL_REGIONS_FAILURE_KEY = "";
+
+	public static final String DUMP_ALL_SEGMENTS_CMD = "dumpallsegments";
+	public static final String DUMP_ALL_SEGMENTS_COMMON_SUCCESS_KEY = "memorySegments.+!j9memorysegmentlist 0x[0-9a-f]+,segment.+start.+alloc.+end.+type.+size.+,([0-9a-f]+ +){5}[0-9a-f]+,classMemorySegments,jit code segments,jit data segments,";
+	public static final String DUMP_ALL_SEGMENTS_64BITCORE_SUCCESS_KEY = "segment.+start.+warmAlloc.+coldAlloc.+end.+size.+";
+	public static final String DUMP_ALL_SEGMENTS_32BITCORE_SUCCESS_KEY = "segment.+start.+warm.+cold.+end.+size.+";
+																																													// dump
+	public static final String DUMP_ALL_SEGMENTS_FAILURE_KEY = "";
+
+	public static final String DUMP_SEGMENTS_IN_LIST_CMD = "dumpsegmentsinlist";
+	public static final String DUMP_SEGMENTS_LIST_NAME = "classMemorySegments";
+	public static final String DUMP_SEGMENTS_IN_LIST_SUCCESS_KEY = "segment,start,alloc,end,type,size";
+	public static final String DUMP_SEGMENTS_IN_LIST_FAILURE_KEY = "";
+
+	/* Below are constants for callsite related ddr extensions */
+	public static final String FINDALLCALLSITES_CMD = "findallcallsites";
+	public static final String FINDALLCALLSITES_SUCCESS_KEYS = "jvminit.c";
+	public static final String FINDALLCALLSITES_FAILURE_KEY = "";
+
+	public static final String FINDCALLSITE_CMD = "findcallsite";
+	public static final String FINDCALLSITE_SUCCESS_KEYS = "j9x";
+	public static final String FINDCALLSITE_FAILURE_KEY = "";
+
+	public static final String FINDFREEDCALLSITE_CMD = "findfreedcallsite";
+	public static final String FINDFREEDCALLSITE_SUCCESS_KEYS = "j9x";
+	public static final String FINDFREEDCALLSITE_FAILURE_KEY = "";
+
+	public static final String PRINTALLCALLSITES_CMD = "printallcallsites";
+	public static final String PRINTALLCALLSITES_SUCCESS_KEYS = "jvminit.c";
+	public static final String PRINTALLCALLSITES_FAILURE_KEY = "";
+
+	public static final String FINDFREEDCALLSITES_CMD = "findfreedcallsites";
+	public static final String FINDFREEDCALLSITES_SUCCESS_KEYS = "Searching for all freed memory block callsites...";
+	public static final String FINDFREEDCALLSITES_FAILURE_KEY = "";
+
+	public static final String PRINTFREEDCALLSITES_CMD = "printfreedcallsites";
+	public static final String PRINTFREEDCALLSITES_SUCCESS_KEYS = "Searching for all freed memory block callsites...";
+	public static final String PRINTFREEDCALLSITES_FAILURE_KEY = "";
+
+	/* constants for ddr extensions in general category */
+	public static final String VMCHECK_CMD = "vmcheck";
+	public static final String VMCHECK_SUCCESS_KEY = "<vm check: Checking threads>,<vm check: Checking classes>,<vm check: Checking ROM classes>,<vm check: Checking methods>,<vm check: Checking ROM intern string nodes>";
+	public static final String VMCHECK_FAILURE_KEY = null; // not sure
+
+	public static final String WALKINTERNTABLE_CMD = "!walkinterntable";
+	public static final String WALKINTERNTABLE_MENU_SUCCESS_KEY = "1,2,3,4,5,6,Walkinterntable Sub Menu Options :,To Print Shared Table Structural Info,To Print Local Table Structural Info,To Walk Shared Intern Table \\(From: Most recently used To: Least recently used\\),To Walk Local Intern Table \\(From: Most recently used To: Least recently used\\),To Walk Both Shared&Local Intern Table \\(From: Most recently used To; Least recently used\\),To go into !walkinterntable sub menu";
+	public static final String WALKINTERNTABLE_OPT1_SUCCESS_KEY = "J9SharedInvariantInternTable,Total Shared Weight,J9SRPHashTable,J9SRPHashTableInternal";
+	public static final String WALKINTERNTABLE_OPT2_SUCCESS_KEY = "J9DbgStringInternTable";
+	public static final String WALKINTERNTABLE_OPT3_SUCCESS_KEY = "WALKING SHARED INTERN SRP HASHTABLE,Total Weight,Shared Table Entry,java/lang/Object,java/lang/reflect/Method,WALKING SHARED INTERN SRP HASHTABLE COMPLETED";
+	public static final String WALKINTERNTABLE_OPT4_SUCCESS_KEY = "WALKING LOCAL INTERN HASHTABLE,Local Table Entry,Total Weight,WALKING LOCAL INTERN HASHTABLE COMPLETED";
+	public static final String WALKINTERNTABLE_OPT5_SUCCESS_KEY = WALKINTERNTABLE_OPT3_SUCCESS_KEY
+			+ "," + WALKINTERNTABLE_OPT4_SUCCESS_KEY;
+
+	public static final String WHATISSETDEPTH_CMD = "whatissetdepth";
+	public static final String WHATISSETDEPTH_DEPTHVALUE = "2";
+	public static final String WHATISSETDEPTH_SUCCESS_KEY = "Max depth set to "
+			+ WHATISSETDEPTH_DEPTHVALUE;
+
+	public static final String WHATIS_CMD = "whatis";
+	public static final String WHATIS_SUCCESS_KEY_FOR_CLASS = "!j9class,Match found";
+	public static final String WHATIS_FAILURE_KEY = "Bad or missing search value,Skip count reset to 0";
+	public static final String WHATIS_SUCCESS_KEY_FOR_METHOD = "!void,Match found,!j9vmthread";
+
+	public static final String METHODFORNAME_CMD = "methodforname";
+	public static final String METHODFORNAME_METHOD = "sleep";
+	public static final String METHODFORNAME_SUCCESS_KEY = "java/lang/Thread.sleep,!j9method";
+	public static final String METHODFORNAME_FAILURE_KEY = "Found 0 method\\(s\\)";
+
+	public static final String BYTECODES_CMD = "bytecodes";
+	public static final String BYTECODES_SUCCESS_KEY = "Name: "
+			+ METHODFORNAME_METHOD + ",Signature:,Access Flags";
+	public static final String BYTECODES_FAILURE_KEY = "bad or missing ram method addr";
+
+	public static final String VMCONSTANTPOOL_CMD = "vmconstantpool";
+	public static final String VMCONSTANTPOOL_SUCCESS_KEY = "J9ROMFieldRef,Unused,j9romclassref";
+	public static final String VMCONSTANTPOOL_FAILURE_KEY = null;
+
+	public static final String SNAPTRACE_CMD = "snaptrace";
+	public static final String SNAPTRACE_SUCCESS_KEY = "Writing snap trace to,firstBuffer,nextBuffer";
+	public static final String SNAPTRACE_FAILURE_KEY = null;
+
+	public static final String J9EXTENDEDMETHODFLAGINFO_CMD = "j9extendedmethodflaginfo";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY1 = "J9_RAS_METHOD_SEEN";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY2 = "J9_RAS_METHOD_TRACING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY3 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRACING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY4 = "J9_RAS_METHOD_TRACE_ARGS";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY5 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRACE_ARGS";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY6 = "J9_RAS_METHOD_TRACING,J9_RAS_METHOD_TRACE_ARGS";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY7 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRACING,J9_RAS_METHOD_TRACE_ARGS";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY8 = "J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY9 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY10 = "J9_RAS_METHOD_TRACING,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY11 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRACING,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY12 = "J9_RAS_METHOD_TRACE_ARGS,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY13 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRACE_ARGS,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY14 = "J9_RAS_METHOD_TRACING,J9_RAS_METHOD_TRACE_ARGS,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY15 = "J9_RAS_METHOD_SEEN,J9_RAS_METHOD_TRACING,J9_RAS_METHOD_TRACE_ARGS,J9_RAS_METHOD_TRIGGERING";
+	public static final String J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY = "J9_JVMTI_METHOD_SELECTIVE_ENTRY_EXIT";
+
+	public static final String CONTEXT_CMD = "context";
+	public static final String CONTEXT_SUCCESS_KEY = "j9javavm";
+	public static final String CONTEXT_FAILURE_KEY = null;
+
+	/* Constants for Find related extensions */
+	public static final String FINDMETHODFROMPC_CMD = "findmethodfrompc";
+	public static final String FINDMETHODFROMPC_SUCCESS_KEY = METHODFORNAME_METHOD
+			+ ",Searching for PC,j9method,Bytecode PC offset";
+	public static final String FINDMETHODFROMPC_FAILURE_KEY = "Not found";
+
+	/* Below are constants for general find related ddr extensions */
+	public static final String FIND_CMD = "find";
+	public static final String FIND_SUCCESS_KEY = "Match found at";
+	public static final String FIND_FAILURE_KEY = "Search pattern too long, Search term not found";
+
+	public static final String FINDNEXT_CMD = "findnext";
+	public static final String FINDNEXT_SUCCESS_KEY = "Match found at";
+	public static final String FINDNEXT_FAILURE_KEY = null;
+
+	public static final String FINDHEADER_CMD = "findheader";
+	public static final String FINDHEADER_SUCCESS_KEY = "Found memory allocation header";
+	public static final String FINDHEADER_FAILURE_KEY = "No memory allocation header found";
+
+	public static final String FINDVM_CMD = "findvm";
+	public static final String FINDVM_SUCCESS_KEY = "!j9javavm";
+	public static final String FINDVM_FAILURE_KEY = null;
+
+	public static final String FINDPATTERN_CMD = "findpattern";
+	public static final String FINDPATTERN_SUCCESS_KEY = "Result = 0x";
+	public static final String FINDPATTERN_FAILURE_KEY = null;
+
+	public static final String FINDSTACKVALUE_CMD = "findstackvalue";
+	public static final String FINDSTACKVALUE_SUCCESS_KEY = "!j9vmthread, Found at";
+	public static final String FINDSTACKVALUE_FAILURE_KEY = "Problem running command";
+
+	public static final String RANGES_CMD = "ranges";
+	public static final String RANGES_SUCCESS_KEY = "Base, Top, Size";
+	public static final String RANGES_FAILURE_KEY = null;
+
+	public static final String J9X_CMD = "j9x";
+	// success key is the passing in address, it is dynamic
+	// public static final String J9X_SUCCESS_KEY = "";
+	public static final String J9X_FAILURE_KEY = "Problem running command, Memory Fault reading";
+
+	public static final String J9XX_CMD = "j9xx";
+	// success key is the passing in address, it is dynamic
+	// public static final String J9XX_SUCCESS_KEY = "";
+	public static final String J9XX_FAILURE_KEY = "Problem running command, Memory Fault reading";
+
+	public static final String FJ9OBJECT_CMD = "fj9object";
+	public static final String FJ9OBJECTTOJ9OBJECT_CMD = "fj9objecttoj9object";
+	public static final String FJ9OBJECT_SUCCESS_KEY = "fj9object,j9object";
+	public static final String J9OBJECT_CMD = "j9object";
+	public static final String J9OBJECT_SUCCESS_KEY = "struct J9Class\\* clazz,Object flags,java/lang/Object";
+
+	public static final String PLUGINS_CMD = "plugins";
+	public static final String PLUGINS_LIST_CMD = "list";
+	public static final String PLUGINS_LIST_SUCCESS_KEY = "j9vm.test.ddrext.plugin.DDRPluginsTestCmd";
+	public static final String PLUGINS_LIST_FAILURE_KEY = "No plugins are currently loaded";
+	public static final String PLUGINS_SETPATH_CMD = "setpath";
+	public static final String PLUGINS_SETPATH_SUCCESS_KEY = "Plugin search path set to : ";
+	public static final String PLUGINS_SETPATH_FAILURE_KEY = null;
+	public static final String PLUGINS_RELOAD_CMD = "reload";
+	public static final String PLUGINS_RELOAD_SUCCESS_KEY = "Plugins reloaded";
+	public static final String PLUGINS_RELOAD_FAILURE_KEY = null;
+	public static final String PLUGINS_TEST_CMD = "test";
+	public static final String PLUGINS_TEST_SUCCESS_KEY = "j9vm.test.ddrext.plugin.DDRPluginsTestCmd";
+	public static final String PLUGINS_TEST_FAILURE_KEY = null;
+
+	public static final String STACKMAP_CMD = "stackmap";
+	public static final String STACKMAP_SUCCESS_KEYS_1 = "calculate the stack slot map for the specified PC";
+	public static final String STACKMAP_FAILURE_KEYS_1 = "Stack map";
+
+	public static final String STACKMAP_SUCCESS_KEYS_SEARCHING_FOR = "Searching for PC=";
+	public static final String STACKMAP_SUCCESS_KEYS_FOUND_METHOD = "Found method";
+	public static final String STACKMAP_SUCCESS_KEYS_RELATIVE_PC = "Relative PC =";
+	public static final String STACKMAP_SUCCESS_KEYS_METHOD_INDEX_IS = "Method index is";
+	public static final String STACKMAP_SUCCESS_KEYS_USING_ROM_METHOD = "Using ROM method";
+	public static final String STACKMAP_SUCCESS_KEYS_MSTACK_MAP = "Stack map";
+	public static final String STACKMAP_SUCCESS_KEYS_2 = STACKMAP_SUCCESS_KEYS_SEARCHING_FOR
+			+ ","
+			+ STACKMAP_SUCCESS_KEYS_FOUND_METHOD
+			+ ","
+			+ STACKMAP_SUCCESS_KEYS_RELATIVE_PC
+			+ ","
+			+ STACKMAP_SUCCESS_KEYS_METHOD_INDEX_IS
+			+ ","
+			+ STACKMAP_SUCCESS_KEYS_USING_ROM_METHOD
+			+ ","
+			+ STACKMAP_SUCCESS_KEYS_MSTACK_MAP;
+	public static final String STACKMAP_FAILURE_KEYS_2 = "Not found";
+	
+	public static final String SETVM_CMD = "setvm";
+	public static final String SETVM_SUCCESS_KEYS = "VM set to ";
+	public static final String SETVM_FAILURE_KEY_1 = "Error: Specified value \\(=";
+	public static final String SETVM_FAILURE_KEY_2 = "\\) is not a javaVM or vmThread pointer, VM not set";
+	public static final String SETVM_FAILURE_KEY_3 = "Address value is not a number :";
+	public static final String SETVM_FAILURE_KEYS = SETVM_FAILURE_KEY_1 
+			+ ","
+			+ SETVM_FAILURE_KEY_2 
+			+ "," 
+			+ SETVM_FAILURE_KEY_3;	
+	
+	public static final String J9JAVAVM_CMD = "j9javavm";
+	
+	public static final String SHOWDUMPAGENTS_CMD = "showdumpagents";
+	// create dump with option:
+	// -Xdump:system:defaults:file=${system.dump},request=exclusive+compact+prepwalk,
+	// expect to see the info in showdumpagents. refer to tck_ddrext.xml for
+	// detail.
+	public static final String SHOWDUMPAGENTS_SUCCESS_KEYS = "-Xdump,request=exclusive\\+compact\\+prepwalk,events=systhrow,"
+			+ "filter=java/lang/OutOfMemoryError";
+	public static final String SHOWDUMPAGENTS_FAILURE_KEYS = "No dump agent";
+	
+	public static final String DUMPALLCLASSLOADERS_CMD = "dumpallclassloaders";
+	public static final String DUMPALLCLASSLOADERS_SUCCESS_KEYS = "ClassLoader,Address,SharedLibraries,Pool,ClassHashTable,jniIDs Pool,used,capacity,0x[0-9a-fA-F]";
+	public static final String DUMPALLCLASSLOADERS_FAILURE_KEYS = "";
+	
+	public static final String SYM_CMD = "sym";
+	public static final String SYM_TEST_METHOD = "java/lang/System.arraycopy";
+	public static final String SYM_SUCCESS_KEYS = "Closest match,java_lang_System_arraycopy\\+0x.+";
+	public static final String SYM_FAILURE_KEYS = "unknown location";
+	
+	public static final String DCLIBS_CMD = "dclibs";
+	public static final String DCLIBS_SUCCESS_KEYS = "Showing library list for,(Lib.+)+";
+	public static final String DCLIBS_FAILURE_KEYS = "Problem running command";
+	public static final String DCLIBS_LIB_COLLENTED = "Library has been collected";
+	public static final String DCLIBS_EXTRACT_SUCCESS_KEYS = "Extracting libraries to,(Extracting.+)+";
+	
+	public static final String J9METHOD_CMD = "j9method";
+	
+	public static final String J9REG_CMD = "j9reg";
+	public static final String J9REG_SUCCESS_KEYS = "vmStruct,sp,arg0EA,pc,literals";
+	public static final String J9REG_FAILURE_KEYS = "Problem running command";
+
+	public static final String COREINFO_CMD = "coreinfo";
+	public static final String COREINFO_SUCCESS_KEYS = "COMMANDLINE,JAVA VERSION INFO,PLATFORM INFO,Platform Name,OS Level,Processors,Architecture,How Many";
+	public static final String COREINFO_FAILURE_KEYS = "Problem running command";
+	
+	public static final String NATIVEMEMINFO_CMD = "nativememinfo";
+	public static final String NATIVEMEMINFO_SUCCESS_KEYS = "JRE:,VM:,Classes:,Memory Manager,Java Heap:,Other:,Threads:,Java Stack:, bytes, allocations";
+	public static final String NATIVEMEMINFO_FAILURE_KEYS = "Problem running command";
+	
+	public static final String MONITORS_CMD = "monitors";
+	
+	public static final String TENANTREGIONS_CMD = "tenantregions";
+	
+	public static final String TENANTCHECK_CMD = "tenantcheck";
+	
+	/* Constants related to testing of deadlock detection */
+	public static final String DEADLOCK_THREAD = "Thread:";
+	public static final String DEADLOCK_OS_THREAD = "OS Thread:";
+	public static final String DEADLOCK_BLOCKING_ON = "is blocking on:";
+	public static final String DEADLOCK_OWNED_BY = "which is owned by:";
+	public static final String DEADLOCK_FIRST_MON = "First Monitor lock";
+	public static final String DEADLOCK_SECOND_MON = "Second Monitor lock";
+	public static final String DEADLOCK_JAVA_OBJ = "java/lang/Object";
+	public static final String DEADLOCK_CMD = "deadlock";
+	
+	/* Constants related to testing of runtime type resolution */
+	public static final String DUMP_HRD_CMD = "MM_HeapRegionDescriptor";
+	public static final String TYPERES_HRD_SUCCESS_KEYS = "Fields for MM_Base,Fields for MM_HeapRegionDescriptor";
+	public static final String TYPERES_HRD_FAILURE_KEYS = "null,Problem running command";
+	public static final String TYPERES_SUBSPACE_STRUCT_CMD = "mm_memorysubspace";
+	public static final String TYEPERES_LOCK_STRUCT_CMD = "mm_lightweightnonreentrantlock";
+	public static final String TYPERES_LOCK_SUCCESS_KEYS = "Fields for MM_Base,Fields for MM_LightweightNonReentrantLock";
+	public static final String TYPERES_LOCK_FAILURE_KEYS = "null,Problem running command";
+	
+	public static final String ROMCLASS_FOR_NAME_CMD = "romclassforname";
+	
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/DDRExtTesterBase.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/DDRExtTesterBase.java
@@ -1,0 +1,597 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext;
+
+import j9vm.test.ddrext.util.DDROutputStream;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import junit.framework.TestCase;
+
+import org.testng.log4testng.Logger;
+
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractive;
+
+public class DDRExtTesterBase extends TestCase {
+	private static Logger log = Logger.getLogger(DDRExtTesterBase.class);
+	public static ArrayList<String> coveredStructures = new ArrayList<String>();
+	private String currentCommand = null;
+	private String[] coreinfoOutput = null;
+	private int javaVersion = -1;
+	private int javaSr = -1;
+	private String vmVersion = null;
+
+	/**
+	 * Executes a given DDR extension and returns its output 
+	 * @param ddrExtCmd - DDR command to execute 
+	 * @param arg - Argument of the DDR command 
+	 * @return - Output of the DDR command 
+	 */
+	protected String exec(String ddrExtCmd, String[] arg) {
+		String output = null;
+		if (SetupConfig.getDDRContxt() != null) { // this means we are
+			// running from ddr
+			// plugin
+			DDROutputStream mps = SetupConfig.getPrintStream();
+			String argStr = "";
+			for (int i = 0; i < arg.length; i++) {
+				argStr = argStr + " " + arg[i];
+			}
+			log.debug("Execute command: !" + ddrExtCmd + " " + argStr);
+			if (ddrExtCmd.startsWith("!") == false) {
+				ddrExtCmd = "!" + ddrExtCmd;
+			}
+			currentCommand = "'" + ddrExtCmd + " " + argStr + "'";
+			SetupConfig.getDDRContxt().execute(ddrExtCmd, arg,
+					SetupConfig.getPrintStream());
+			output = mps.getOutBuffer().toString();
+			mps.clear();
+		} else {
+			DDRInteractive app = SetupConfig.getDDRInstance();
+			// if app is null, then we try to initialize it using the dump
+			// in the ddrext.properties file
+			if (app == null) {
+				String coreFilePath = getCoreFilePath();
+				if (coreFilePath != null) {
+					if (SetupConfig.init(coreFilePath)) {
+						app = SetupConfig.getDDRInstance();
+					} else {
+						System.exit(-2);
+					}
+				}
+			}
+			if (app != null) {
+				DDROutputStream mps = SetupConfig.getPrintStream();
+				String argStr = "";
+				for (int i = 0; i < arg.length; i++) {
+					argStr = argStr + " " + arg[i];
+				}
+				log.debug("Execute command: !" + ddrExtCmd + " " + argStr);
+				if (ddrExtCmd.startsWith("!") == false) {
+					ddrExtCmd = "!" + ddrExtCmd;
+				}
+				currentCommand = "'" + ddrExtCmd + " " + argStr + "'";
+				app.execute(ddrExtCmd, arg);
+				output = mps.getOutBuffer().toString();
+				mps.clear();
+			} else {
+				fail("DDRInterative is null. Please check CoreFilePath in ddrext.properties file.");
+				return null;
+			}
+		}
+		return output;
+	}
+
+	/**
+	 * Validation method for DDR extension output
+	 * Performs basic validation on a given DDR extension output. Basic validation includes
+	 * checking if output is null, empty or contains 'unrecognized command' error.
+	 * @param output - The DDR extension output string to validate
+	 * @return - True if validation passes,false otherwise
+	 */
+	private boolean basicValidation(String output) {
+		if (output == null || output.isEmpty()) {
+			log.error(currentCommand + " output is null or empty");
+			return false;
+		} else if (output.contains(Constants.UNRECOGNIZED_CMD)) {
+			log.error(currentCommand + " is not recognized");
+			return false;
+		}
+		return true;
+	}
+	
+	/**
+	 * Validation method for DDR extension output. Check that successKey appears expectedMatches number of times
+	 * 
+	 * @param output - DDR extension output to validate.
+	 * @param successKey - Comma separated list of tokens that must be available in the output for it to be valid.
+	 * @param expectedMatches - number of times successKey must be seen
+	 * @return True if validation passes, false otherwise. 
+	 */
+	protected boolean validate(String output, String successKey, int expectedMatches) {
+		
+		int matchesFound = 0;
+		
+		Pattern pattern = Pattern.compile(successKey.trim(), Pattern.CASE_INSENSITIVE);
+		Matcher matcher = pattern.matcher(output);
+		
+		while (matcher.find()) {
+			matchesFound = matchesFound + 1;
+		}
+		
+		return (matchesFound == expectedMatches);
+	}
+	
+	/**
+	 * Validation method for DDR extension output
+	 * @param output - DDR extension output to validate.
+	 * @param successKeys - Comma separated list of tokens that must be available in the output for it to be valid.
+	 * @param failureKeys - Comma separated list of tokens that must NOT be available in the output for it to be valid.
+	 * @return True if validation passes, false otherwise. 
+	 */
+	protected boolean validate(String output, String successKeys,
+			String failureKeys) {
+		return validate(output, successKeys, failureKeys, false, false);
+	}
+
+	/**
+	 * Validation method for DDR extension output
+	 * @param output - DDR extension output to validate.
+	 * @param successKeys - Comma separated list of tokens that must be available in the output for it to be valid.
+	 * @param failureKeys - Comma separated list of tokens that must NOT be available in the output for it to be valid.
+	 * @param goNextStep - Flag indicating whether or not we will perform exhaustive validation using all extension outputs available in this output.
+	 * @return True if validation passes, false otherwise. 
+	 */
+	protected boolean validate(String output, String successKeys,
+			String failureKeys, boolean goNextStep) {
+		return validate(output, successKeys, failureKeys, goNextStep, false);
+	}
+
+	/**
+	 * Validation method for DDR extension output
+	 * @param output - DDR extension output to validate.
+	 * @param successKeys - Comma separated list of tokens that must be available in the output for it to be valid.
+	 * @param failureKeys - Comma separated list of tokens that must NOT be available in the output for it to be valid.
+	 * @param goNextStep - Flag indicating whether or not we will perform exhaustive validation using all extension outputs available in this output.
+	 * @param isNegativeTest - Flag indicating whether or not this is a negative test. If set, it will not fail validation if it sees a failure key in output.
+	 * @return True if validation passes, false otherwise. 
+	 */
+	protected boolean validate(String output, String successKeys,
+			String failureKeys, boolean goNextStep, boolean isNegativeTest) {
+		log.info("Validation started for : " + currentCommand);
+		if (basicValidation(output) == false) {
+			return false;
+		}
+
+		if (!isNegativeTest) {
+			if (runCommonFailureTest(output) == false) {
+				return false;
+			}
+		}
+
+		if (successKeys != null && successKeys.length() != 0) {
+			String[] sKeys = successKeys.split(",");
+			for (String successKey : sKeys) {
+				Pattern pattern = Pattern.compile(successKey.trim(),
+						Pattern.CASE_INSENSITIVE);
+				Matcher matcher = pattern.matcher(output);
+				if (matcher.find() == false) {
+					log.error(currentCommand
+							+ " output does not contain success key : "
+							+ successKey);
+					log.error(currentCommand + " output :"
+							+ output);
+					return false;
+				}
+			}
+		}
+
+		if (failureKeys != null && failureKeys.length() != 0) {
+			String[] fKeys = failureKeys.split(",");
+			for (String failKey : fKeys) {
+				Pattern pattern = Pattern.compile(failKey.trim(),
+						Pattern.CASE_INSENSITIVE);
+				Matcher matcher = pattern.matcher(output);
+				if (matcher.find()) {
+					log.error(currentCommand
+							+ " output contains failure key : " + failKey);
+					log.error(currentCommand + " output :" + Constants.NL
+							+ output);
+					return false;
+				}
+			}
+		}
+
+		/*Performing exhaustive validation using all available structures (subcommands) in the output*/
+		if (goNextStep) {
+			int firstIndex = output.indexOf("!");
+			String parentCmd = currentCommand;
+			boolean allNextCmdAlreadyCovered = true;
+			if (firstIndex != -1) { // if this output contains any !subcommand
+				ArrayList<String> structuresToRun = new ArrayList<String>();
+				output = output.substring(output.indexOf("!") + 1); // chop off
+				Scanner scanner = new Scanner(output).useDelimiter("!");
+				String structToRun = null;
+				String structAddress = null;
+				while (scanner.hasNext()) {
+					String nextToken = scanner.next();
+					String tokens[] = nextToken.split(" ");
+					if (tokens.length > 1) {
+						structToRun = tokens[0].trim();
+						if (coveredStructures.contains(structToRun) == false) {
+							if (structToRun.equals("void") == false) {
+								coveredStructures.add(structToRun);
+								structAddress = cleanse(tokens[1].trim());
+								if (structToRun != null
+										&& structAddress != null) {
+									structuresToRun.add(structToRun + " "
+											+ structAddress);
+								}
+								allNextCmdAlreadyCovered = false;
+							}
+						}
+					}
+				}
+				if (allNextCmdAlreadyCovered == false) {
+					log.info("Starting exhaustive DDR structure test for parent command : "
+							+ parentCmd);
+					for (int i = 0; i < structuresToRun.size(); i++) {
+						currentCommand = structuresToRun.get(i);
+						log.info("Runing structure test with : !"
+								+ currentCommand);
+						String[] tokens = currentCommand.trim().split(" ");
+						String cmd = tokens[0];
+						String argument = tokens[1];
+
+						String nxtOutput = exec(cmd, new String[] { argument });
+
+						if (basicValidation(nxtOutput) == false) {
+							log.error("Structure validation failed");
+							log.error(nxtOutput);
+							continue;
+						}
+
+						if (nxtOutput.contains("{")
+								&& nxtOutput.contains("}")
+								&& nxtOutput.indexOf("{") < nxtOutput
+								.indexOf("}")) {
+							String structPropertyPattern = ".*=.* 0x.*|<FAULT>";
+							Pattern pattern = Pattern
+							.compile(structPropertyPattern);
+							Matcher matcher = pattern.matcher(nxtOutput);
+							if (matcher.find()
+									&& runCommonFailureTestForSubCmd(nxtOutput)) {
+								log.info("Structure validation passed");
+								log.debug(nxtOutput);
+							} else {
+								log.error("Structure validation failed");
+								log.error(nxtOutput);
+							}
+						} else {
+							log.info("Can not validate: " + currentCommand
+									+ " output is not a structure");
+							log.debug(nxtOutput);
+						}
+					}
+					currentCommand = parentCmd;
+				}
+			}
+		}
+		log.debug(output);
+		log.info("Validation passed for : " + currentCommand);
+		return true;
+	}
+
+	/**
+	 * Helper method to perform cleanup on a parsed address string
+	 * @param address
+	 * @return
+	 */
+	private String cleanse(String address) {
+		if (address.contains(Constants.NL)) {
+			address = address.substring(0, address.indexOf(Constants.NL));
+		}
+
+		/* We make sure we are in fact dealing with a hex value string */
+		if (address.startsWith("0x") == false) {
+			return null;
+		}
+
+		if (address.contains(",")) {
+			address = address.split(",")[0];
+		}
+
+		if (address.contains("\t")) {
+			address = address.split("\t")[0];
+		}
+	
+		if (address.endsWith(")") || address.endsWith(">")) {
+			address = address.substring(0, address.length() - 1);
+		}
+		return address;
+	}
+
+	/**
+	 * Method to run validation using the Constants.COMMON_FAILURE_KEYS
+	 * @param output
+	 * @return
+	 */
+	private boolean runCommonFailureTest(String output) {
+		String[] cFailKeys = Constants.COMMON_FAILURE_KEYS.split(",");
+		for (String cfKey : cFailKeys) {
+			Pattern pattern = Pattern.compile(cfKey, Pattern.CASE_INSENSITIVE
+					| Pattern.LITERAL);
+			Matcher matcher = pattern.matcher(output);
+			if (matcher.find()) {
+				log.error(currentCommand
+						+ " output contains common failure key : " + cfKey);
+				log.error(currentCommand + " output :" + Constants.NL + output);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Common failure test for subcommands. Used during exhaustive validation of a ddr extension. 
+	 * @param output
+	 * @return
+	 */
+	private boolean runCommonFailureTestForSubCmd(String output) {
+		String[] cFailKeys = Constants.COMMON_FAILURE_KEYS.split(",");
+		for (String cfKey : cFailKeys) {
+			if (output.contains(cfKey.trim())) {
+				if (cfKey.trim().equals("<FAULT>")) {
+					log.warn(currentCommand
+							+ " output contains <FAULT> references");
+					// log.warn(currentCommand+ " output :" + Constants.NL +
+					// output);
+					return true;
+				}
+				log.error(currentCommand
+						+ " output contains common failure key : " + cfKey);
+				log.error(currentCommand + " output :" + Constants.NL + output);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	
+	/**
+	 * Get the address corresponding to the cmd in threadOutput
+	 * 
+	 * For example, if we wanted the address 0x03596100 corresponding to j9vmthread in the following string:
+	 * 
+	 * !stack 0x03596100	!j9vmthread 0x03596100	!j9thread 0x2aaab7c72b10	tid 0x5221 (21025) // (Thread-3)
+	 * 
+	 * 	we would call getAddressFor with:
+	 * 
+	 *  	threadOuput = the string
+	 *  	eyeCatcher 	= "(Thread-3"
+	 *  	cmd  		= "j9vmthread"
+	 *  	cmdDelimiter= "\t"
+	 *  
+	 * @param threadOutput	the output to parses
+	 * @param eyeCatcher	only search this string if eyeCatcher is present
+	 * @param cmd			the cmd who's address we are after
+	 * @param cmdDelimiter	the delimiter that separates multiples commands in the output
+	 * @return 	the string representation of the address as it appears in threadOutput 
+	 */
+	public String getAddressFor(String threadOutput, String eyeCatcher, String cmd, String cmdDelimiter) {
+		String[] lines = threadOutput.split(Constants.NL);
+		for (int i = 0; i < lines.length; i++) {
+			if ((null == eyeCatcher) || (lines[i].contains(eyeCatcher))) {
+				String[] tokens = lines[i].split(cmdDelimiter);
+				for (int j = 0; j < tokens.length; j++) {
+					if (tokens[j].contains(cmd)) {
+						return tokens[j].trim().split(" ")[1];
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+
+	/**
+	 * Helper function that looks for the address cmd in threadOutput
+	 * 
+	 * See {@link DDRExtTesterBase#getAddressFor(String, String, String, String)}
+	 * 
+	 * @param cmd
+	 * @param threadOutput
+	 * @return the address corresponding to the command
+	 */
+	public String getAddressForThreads(String cmd, String threadOutput) {
+		return getAddressFor(threadOutput, "(Thread-", cmd, "\t");
+	}
+	
+	/**Used to get the full core file path from the ddrext.properties file
+	 * @return
+	 */
+	private String getCoreFilePath() {
+		String path = null;
+		Properties ddrExtPros = new Properties();
+		String key = "CoreFilePath";
+		InputStream in;
+		try {
+			in = getClass().getResourceAsStream(
+					"/" + Constants.DDREXT_PROPERTIES);
+			log.debug("Loading File" + Constants.DDREXT_PROPERTIES + "...");
+			ddrExtPros.load(in);
+			path = ddrExtPros.getProperty(key);
+			log.debug("key : " + key);
+			log.debug("value : " + path);
+			in.close();
+		} catch (FileNotFoundException e) {
+			log.error("Not able to find file " + Constants.DDREXT_PROPERTIES);
+			log.error(e.toString());
+		} catch (IOException e) {
+			log.error("Not able to read file " + Constants.DDREXT_PROPERTIES);
+			log.error(e.toString());
+		}
+		if (path.equals("")) {
+			log.error("Please provide your dump location in "
+					+ Constants.DDREXT_PROPERTIES);
+			return null;
+		}
+		return path;
+	}
+
+	public static void resetList() {
+		coveredStructures.clear();
+	}
+	
+	/* Check whether core is generated on 64 bit platform or not. 
+	 * Run setvm with the address that can exist only on 64 bit platform 
+	 */
+	public boolean is64BitPlatform(){
+		String setVMOutput = exec(Constants.SETVM_CMD, new String[] {CommandUtils.UDATA_MAX_64BIT.toString()});
+		boolean is64BitPlatform = true;
+		/* If it is 32 bit platform, than it will complain about address being too large */
+		if (validate(setVMOutput, "is larger than the max available memory address: 0xFFFFFFFF", null)) {
+			is64BitPlatform = false;
+		} 
+		return is64BitPlatform;
+	}
+	
+	/**
+	 * get and save the output from !coreinfo
+	 * @return array of strings
+	 */
+	protected String[] getCoreInfo() {
+		if (null == coreinfoOutput) {
+			String execOutput = exec(Constants.COREINFO_CMD, new String[] {});
+			coreinfoOutput = execOutput.split("\n");
+		}
+		return coreinfoOutput;
+	}
+
+	/**
+	 * @return the service release number.  GA versions returns 0, unknown returns -2
+	 */
+	protected int getJavaSr() {
+		if (javaSr != -1) {
+			return javaSr;
+		}
+		String[] coreInfo = getCoreInfo();
+		Pattern versionMatcher = Pattern.compile(".*\\(SR(\\d+)\\).*"); /* look for (SRn), where "n" is a string of digits */
+		for (int i = 0; i < (coreInfo.length+1); ++i) {
+			if (coreInfo[i].matches("JAVA SERVICE LEVEL INFO.*")) {
+				Matcher m = versionMatcher.matcher(coreInfo[i+1]);
+				if (m.matches()) {
+					String version = m.group(1); /* get the "n" described above */
+					javaSr = Integer.parseInt(version);
+				} else {
+					javaSr = 0;
+				}
+				return javaSr;
+			}
+		}
+		javaSr = -2;
+		return javaSr;
+	}
+
+	/**
+	 * Does lazy evaluation and returns the result.
+	 * Returns 0 if the version cannot be determined, e.g. for Java 5, 6 (R24).
+	 * @return the java version, i.e. Java 6, 7, etc.
+	 */
+	protected int getJavaVersion() {
+		if (javaVersion != -1) {
+			return javaVersion;
+		}
+		String[] coreInfo = getCoreInfo();
+		Pattern versionMatcher = Pattern.compile("JRE\\s+1\\.(\\d+).*"); /* look for JRE 1.n, where "n" is a string of digits */
+		Pattern versionMatcherForJava9 = Pattern.compile("JRE\\s(\\d+).*"); /* look for JRE 9 */
+
+		for (int i = 0; i < (coreInfo.length+1); ++i) {
+			if (coreInfo[i].matches("JAVA VERSION INFO.*")) {
+				Matcher m = versionMatcher.matcher(coreInfo[i+1]); /* look on the next line */
+				if (m.matches()) {
+					String version = m.group(1); /* get the "n" described above */
+					javaVersion = Integer.parseInt(version);
+					return javaVersion;
+				} else {
+					m = versionMatcherForJava9.matcher(coreInfo[i+1]);
+					if(m.matches()) {
+						String version = m.group(1); /* get the "n" described above */
+						javaVersion = Integer.parseInt(version);
+						return javaVersion;
+					}
+				}
+				break; /* cannot get Java version */
+			}
+		}
+		javaVersion = 0;
+		return javaVersion;
+	}
+	
+	/**
+	 * @return the version string for the J9 VM, e.g. "2.6", or "unknown"
+	 */
+	protected String getVmVersion() {
+		if (vmVersion != null) {
+			return vmVersion;
+		}
+		String[] coreInfo = getCoreInfo();
+		Pattern versionMatcher = Pattern.compile("JAVA VM VERSION\\s*-\\s*(.*)");
+		for (int i = 0; i < (coreInfo.length+1); ++i) {
+			if (coreInfo[i].matches("JAVA VM VERSION.*")) {
+				Matcher m = versionMatcher.matcher(coreInfo[i]);
+				if (m.matches()) {
+					vmVersion = m.group(1); /* get the "n" described above */
+					return vmVersion;
+				}
+				break;
+			}
+		}
+		vmVersion = "unknown";
+		return vmVersion;	
+	}
+	
+	/**
+	 * @return a human-friendly description of the Java version, release, and VM stream.
+	 */
+	protected String getVersionString() {
+		String javaVer = (javaVersion > 0)? ("Java "+Integer.toString(javaVersion)): "unknown Java version";
+		String sr ;
+		if (javaSr < 0) {
+			sr = "unknown release";
+		} else if (0 == javaSr) {
+			sr = "GA";
+		} else {
+			sr = "SR"+Integer.toString(javaSr); 
+		}
+		String vmVer = (null != vmVersion)? ("VM R"+vmVersion): "unknown VM";
+		return javaVer+" "+sr+" "+vmVer;
+	}
+	}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/SetupConfig.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/SetupConfig.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext;
+
+import j9vm.test.ddrext.util.CoreDumpGenerator;
+import j9vm.test.ddrext.util.DDROutputStream;
+import java.io.PrintStream;
+import org.testng.log4testng.Logger;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractive;
+
+public class SetupConfig {
+	private static Logger log = Logger.getLogger(SetupConfig.class);
+
+	/* Handle for DDROutputStream class that manages the output buffer */
+	private static DDROutputStream ps = null;
+
+	/* Handle for DDRInteractive */
+	private static DDRInteractive ddrInstance = null;
+
+	/* Handle for DDR Context, used when we initiate the test suite as a ddr plugin*/
+	private static Context ddrContext = null;
+
+	public static synchronized DDROutputStream getPrintStream() {
+		if (ps == null) {
+			ps = new DDROutputStream(System.out);
+		}
+		return ps;
+	}
+
+	public static synchronized void setPrintStream(DDROutputStream ddrOutput) {
+		ps = ddrOutput;
+		return;
+	}
+
+	public static synchronized DDRInteractive getDDRInstance() {
+		return ddrInstance;
+	}
+
+	public static synchronized void setDDRInstance(DDRInteractive ddr) {
+		ddrInstance = ddr;
+		return;
+	}
+
+	/**Creates a new DDRInteractive instance using the given core file
+	 * @param coreFile - The full path of the core dump file to use
+	 */
+	private static synchronized void initDDRInteractive(String coreFile) {
+		if (ddrInstance == null) {
+			if (coreFile != null) {
+				try {
+					DDROutputStream ps = getPrintStream();
+					ddrInstance = new DDRInteractive(coreFile, ps);
+					log.info("Created new DDR Interactive instance using core file : "
+							+ coreFile);
+				} catch (Exception e) {
+					log.error("Error loading core dump");
+					ddrInstance = null;
+					log.error(e.getMessage());
+				}
+			}
+		}
+	}
+
+	public static synchronized boolean init(String javaHome, String j9vmSE60Jar) {
+		// deleteCoreFile();
+		CoreDumpGenerator dumpGenerator = new CoreDumpGenerator(javaHome,
+				j9vmSE60Jar);
+		String generatedCoreFile = dumpGenerator.generateDump();
+		if (generatedCoreFile == null) {
+			log.fatal("No dynamic dump created");
+			return false;
+		}
+		initDDRInteractive(generatedCoreFile);
+		if (ddrInstance == null) {
+			log.fatal("Can not load dump file using DDR");
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * This method is to be invoked when DDR Junit test framework is to be launched as a stand alone Java application
+	 * @param core - Full path to the core file to launch DDR with
+	 * @return - True if DDR was initialized correctly
+	 */
+	public static synchronized boolean init(String core) {
+		if (core == null) {
+			log.fatal("Core file is null");
+			return false;
+		}
+
+		initDDRInteractive(core);
+		if (ddrInstance == null) {
+			log.fatal("Can not load dump file using DDR");
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * This method is to be invoked when DDR Junit test framework is to be launched from a DDR Plugin implementation 
+	 * @param ctx - DDR context 
+	 * @param out - PrintStream object to which DDR output will be flushed
+	 * @return
+	 */
+	public static synchronized boolean init(Context ctx, PrintStream out) {
+		ddrContext = ctx;
+		DDROutputStream ps = new DDROutputStream(out);
+		setPrintStream(ps);
+		return true;
+	}
+
+	public static synchronized void reset() {
+		if (ddrInstance != null ) {
+			try {
+				ddrInstance.close();
+			} catch (Exception e) {
+				log.error("Error closing DDRInteractive");
+				log.error(e.getMessage());
+			}
+		}
+		ddrInstance = null;
+	}
+
+	public static Context getDDRContxt() {
+		return ddrContext;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/DDRTestSuite.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/DDRTestSuite.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import java.util.Enumeration;
+
+import junit.framework.TestResult;
+
+/**
+ * @author mesbaha
+ * This class extends the default junit.framework.TestSuite class and redefines the run() method 
+ * in order to run only the test cases that are not in a given exclude list for this test suite.
+ */
+public class DDRTestSuite extends junit.framework.TestSuite{
+
+	private String excludeList;
+	
+	/**
+	 * Default constructor
+	 * @param name - Name of the test suite 
+	 * @param ignoreTestCaseList - A comma separated list of test cases to ignore
+	 */
+	public DDRTestSuite(String name, String excludeList) {
+		super(name);
+		this.excludeList = excludeList;
+		// TODO Auto-generated constructor stub
+	}
+	
+	/* (non-Javadoc)
+	 * @see junit.framework.TestSuite#run(junit.framework.TestResult)
+	 * Overridden version of TestSuite.run() method which invokes the new run(TestSuite,TestResult) method 
+	 * in order to ensure we use test filtering.
+	 * @param result - This TestResult object to use for result reporting 
+	 */
+	public void run(TestResult result) {
+		run(this, result);
+	}
+	
+	/**
+	 * This method runs all test cases from this test suite but the ones found in the given ignore list  
+	 * @param suite - This TestSuite object 
+	 * @param result - The TestResult object to use
+	 */
+	public void run(junit.framework.TestSuite suite,TestResult result) {
+		@SuppressWarnings("rawtypes")
+		Enumeration en = suite.tests();
+		while (en.hasMoreElements()) {
+			junit.framework.Test test = (junit.framework.Test)en.nextElement();
+			if (test instanceof junit.framework.TestSuite) {
+				run((junit.framework.TestSuite)test, result);
+			} else {
+				junit.framework.TestCase testCase = (junit.framework.TestCase)test;
+				//Ignore test cases from the exclude list
+				if ( excludeList.contains(testCase.getName()) == false ){
+					super.runTest(testCase, result);
+				}
+			}
+		}
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestCallsites.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestCallsites.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+import org.testng.log4testng.Logger;
+
+public class TestCallsites extends DDRExtTesterBase {
+	private Logger log = Logger.getLogger(TestCallsites.class);
+
+	public void testFindallcallsites() {
+		String findAllCallsitesOutput = exec(Constants.FINDALLCALLSITES_CMD,
+				new String[0]);
+		assertTrue(validate(findAllCallsitesOutput,
+				Constants.FINDALLCALLSITES_SUCCESS_KEYS,
+				Constants.FINDALLCALLSITES_FAILURE_KEY, true));
+	}
+
+	public void testPrintallcallsites() {
+		String printAllCallsitesOutput = exec(Constants.PRINTALLCALLSITES_CMD,
+				new String[0]);
+		assertTrue(validate(printAllCallsitesOutput,
+				Constants.PRINTALLCALLSITES_SUCCESS_KEYS,
+				Constants.PRINTALLCALLSITES_FAILURE_KEY, true));
+	}
+
+	public void testFindfreedcallsites() {
+		String findFreedCallSitesOutput = exec(
+				Constants.FINDFREEDCALLSITES_CMD, new String[0]);
+		assertTrue(validate(findFreedCallSitesOutput,
+				Constants.FINDFREEDCALLSITES_SUCCESS_KEYS,
+				Constants.FINDFREEDCALLSITES_FAILURE_KEY, true));
+	}
+
+	public void testPrintfreedcallsites() {
+		String printFreedCallsitesOutput = exec(
+				Constants.PRINTFREEDCALLSITES_CMD, new String[0]);
+		assertTrue(validate(printFreedCallsitesOutput,
+				Constants.PRINTFREEDCALLSITES_SUCCESS_KEYS,
+				Constants.PRINTFREEDCALLSITES_FAILURE_KEY, true));
+	}
+
+	public void testFindcallsite() {
+		String findAllCallsitesOutput = exec(Constants.FINDALLCALLSITES_CMD,
+				new String[0]);
+		if (findAllCallsitesOutput == null) {
+			fail("findallcallsites output is null. Can not proceed with testFindcallsite");
+			return;
+		}
+		String callsite = getCallsite(Constants.FINDALLCALLSITES_SUCCESS_KEYS,
+				findAllCallsitesOutput);
+		if (callsite == null) {
+			fail("Error parsing findallcallsites output for "
+					+ Constants.FINDALLCALLSITES_SUCCESS_KEYS);
+			return;
+		}
+
+		String findCallsiteOutput = exec(Constants.FINDCALLSITE_CMD,
+				new String[] { callsite });
+		assertTrue(validate(findCallsiteOutput,
+				Constants.FINDCALLSITE_SUCCESS_KEYS,
+				Constants.FINDCALLSITE_FAILURE_KEY, true));
+	}
+
+	public void testFindfreedcallsite() {
+		String findFreedCallsitesOutput = exec(
+				Constants.FINDFREEDCALLSITES_CMD, new String[0]);
+		if (findFreedCallsitesOutput == null) {
+			fail("findfreedcallsites output is null. Can not proceed with testFindfreedcallsite");
+			return;
+		}
+
+		// check whether the output from findfreedcallsites contains .c or .cpp.
+		// If not, warning message will display
+		// and the findfreedcallsite test will not be executed due to
+		// insufficient information.
+		String freedCallsite = getCallsite(".c", findFreedCallsitesOutput);
+		if (freedCallsite == null) {
+			log.warn("Not able to find findfreedcallsites that end with .c");
+			freedCallsite = getCallsite(".cpp", findFreedCallsitesOutput);
+			if (freedCallsite == null) {
+				log.warn("Not able to find findfreedcallsites that end with .cpp");
+				log.warn("Not able to test findfreedcallsite due to insufficient information");
+				return;
+			}
+		}
+		String findFreedCallSiteOutput = exec(Constants.FINDFREEDCALLSITE_CMD,
+				new String[] { freedCallsite });
+		assertTrue(validate(findFreedCallSiteOutput,
+				Constants.FINDFREEDCALLSITE_SUCCESS_KEYS,
+				Constants.FINDFREEDCALLSITE_FAILURE_KEY, true));
+	}
+
+	private String getCallsite(String value, String output) {
+		String[] lines = output.split(Constants.NL);
+		for (int i = 0; i < lines.length; i++) {
+			if (lines[i].contains(value)) {
+				String[] tokens = lines[i].split(" ");
+				for (int j = 0; j < tokens.length; j++) {
+					if (tokens[j].contains(value)) {
+						return tokens[j].trim();
+					}
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestClassExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestClassExt.java
@@ -1,0 +1,374 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+import org.testng.log4testng.Logger;
+
+public class TestClassExt extends DDRExtTesterBase {
+
+	private Logger log = Logger.getLogger(TestClassExt.class);
+
+	public void testAllClassesExt() {
+		String allClassesOutput = exec(Constants.ALL_CLASSES_CMD,
+				new String[] {});
+		assertTrue(validate(allClassesOutput,
+				Constants.ALL_CLASSES_SUCCESS_KEY,
+				Constants.ALL_CLASSESS_FAILURE_KEY, true));
+	}
+
+	public void testJ9ClassShapeExt() {
+		
+		String ramAddr = getRAMClassAddress(Constants.J9CLASSSHAPE_TEST_CLASS);
+		if (ramAddr == null) {
+			fail("getRAMClassAddress returns null. Can not proceed with testJ9ClassShapeExt");
+			return;
+		}
+		String j9ClassChapeOutput = exec(Constants.J9CLASSSHAPE_CMD,
+				new String[] { ramAddr });
+		assertTrue(validate(j9ClassChapeOutput,
+				Constants.J9CLASSSHAPE_SUCCESS_KEY, null, true));
+	}
+
+	public void testJ9VTablesExt() {
+		
+		String ramAddr = getRAMClassAddress(Constants.J9CLASSSHAPE_TEST_CLASS);
+		if (ramAddr == null) {
+			fail("getRAMClassAddress returns null. Can not proceed with testJ9VTablesExt");
+			return;
+		}
+		String j9vtablesOutput = exec(Constants.J9VTABLES_CMD,
+				new String[] { ramAddr });
+		assertTrue(validate(j9vtablesOutput, Constants.J9VTABLES_SUCCESS_KEY,
+				null, true));
+	}
+
+	public void testJ9StaticsExt() {
+		
+		String ramAddr = getRAMClassAddress(Constants.J9CLASSSHAPE_TEST_CLASS);
+		if (ramAddr == null) {
+			fail("getRAMClassAddress returns null. Can not proceed with testJ9StaticsExt");
+			return;
+		}
+		String j9ClassChapeOutput = exec(Constants.J9STATICS_CMD,
+				new String[] { ramAddr });
+		assertTrue(validate(j9ClassChapeOutput,
+				Constants.J9STATICS_SUCCESS_KEY, null, true));
+	}
+
+	public void testROMClassSummaryExt() {
+		String romClassSummaryOutput = exec(Constants.ROM_CLASS_SUMMARY_CMD,
+				new String[] {});
+		assertTrue(validate(romClassSummaryOutput,
+				Constants.ROM_CLASS_SUMMARY_SUCCESS_KEY,
+				Constants.ROM_CLASS_SUMMARY_FAILURE_KEY, true));
+	}
+
+	public void testRAMClassSummaryExt() {
+		String ramClassSummaryOutput = exec(Constants.RAM_CLASS_SUMMARY_CMD,
+				new String[] {});
+		assertTrue(validate(ramClassSummaryOutput,
+				Constants.RAM_CLASS_SUMMARY_SUCCESS_KEY,
+				Constants.RAM_CLASS_SUMMARY_FAILURE_KEY, true));
+	}
+
+	public void testClassForNameExt() {
+		String classForNameOutput = exec(Constants.CL_FOR_NAME_CMD,
+				new String[] { Constants.CL_FOR_NAME_CLASS });
+		assertTrue(validate(classForNameOutput,
+				Constants.CL_FOR_NAME_SUCCESS_KEY,
+				Constants.CL_FOR_NAME_FAILURE_KEY, true));
+	}
+
+	public void testClassLoadersSummaryExt() {
+		String classLoaderSummaryOutput = exec(
+				Constants.CL_LOADERS_SUMMARY_CMD, new String[] {});
+		assertTrue(validate(classLoaderSummaryOutput,
+				Constants.CL_LOADERS_SUMMARY_SUCCESS_KEY,
+				Constants.CL_LOADERS_SUMMARY_FAILURE_KEY, true));
+	}
+
+	public void testDumpAllROMClassLinearExt() {
+		String dumpAllROMClassLinearOutput = exec(
+				Constants.DUMP_ALL_ROM_CLASS_LINEAR_CMD,
+				new String[] { Constants.DUMP_ALL_ROM_CLASS_LINEAR_NESTING_THRESHOLD });
+		assertTrue(validate(dumpAllROMClassLinearOutput,
+				Constants.DUMP_ALL_ROM_CLASS_LINEAR_SUCCESS_KEY,
+				Constants.DUMP_ALL_ROM_CLASS_LINEAR_FAILURE_KEY, true));
+	}
+
+	public void testDumpROMClassLinearExt() {
+		String romClassAddress = getAddress("!j9romclass");
+		if (romClassAddress != null && romClassAddress != "") {
+			String dumpROMClassLinearOutput = exec(
+					Constants.DUMP_ROM_CLASS_LINEAR_CMD,
+					new String[] { romClassAddress });
+			assertTrue(validate(dumpROMClassLinearOutput,
+					Constants.DUMP_ROM_CLASS_LINEAR_SUCCESS_KEY,
+					Constants.DUMP_ROM_CLASS_LINEAR_FAILURE_KEY, true));
+		}
+	}
+
+	public void testDumpROMClassExt() {
+		String dumpROMClassOutput = null;
+		String romClassAddress = getAddress("!j9romclass");
+
+		/* test for !dumpromclass <address> */
+		if (romClassAddress != null && romClassAddress != "") {
+			dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD,
+					new String[] { romClassAddress });
+			assertTrue(validate(dumpROMClassOutput,
+					Constants.DUMP_ROM_CLASS_SUCCESS_KEY,
+					Constants.DUMP_ROM_CLASS_FAILURE_KEY, true));
+		}
+
+		/* test for !dumpromclass <address> maps */
+		if (romClassAddress != null && romClassAddress != "") {
+			dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD,
+					new String[] { romClassAddress,
+							Constants.DUMP_ROM_CLASS_MAPS_CMD });
+			assertTrue(validate(dumpROMClassOutput,
+					Constants.DUMP_ROM_CLASS_MAPS_SUCCESS_KEY,
+					Constants.DUMP_ROM_CLASS_MAPS_FAILURE_KEY, true));
+		}
+
+		/* test for !dumpromclass <invalid address> */
+		String invalidROMClassAddress = "0x100";
+		dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD,
+				new String[] { invalidROMClassAddress });
+		assertTrue(validate(dumpROMClassOutput,
+				Constants.DUMP_ROM_CLASS_INVALID_ADDR_SUCCESS_KEY,
+				Constants.DUMP_ROM_CLASS_INVALID_ADDR_FAILURE_KEY, true, true));
+
+		/* test for !dumpromclass name:<classname> */
+		dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD,
+				new String[] { Constants.DUMP_ROM_CLASS_NAME_CMD
+						+ Constants.DUMP_ROM_CLASS_NAME });
+		assertTrue(validate(dumpROMClassOutput,
+				Constants.DUMP_ROM_CLASS_NAME_SUCCESS_KEY,
+				Constants.DUMP_ROM_CLASS_NAME_FAILURE_KEY, true));
+
+		/* test for !dumpromclass name:<classname with wild card> */
+		dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD,
+				new String[] { Constants.DUMP_ROM_CLASS_NAME_CMD
+						+ Constants.DUMP_ROM_CLASS_NAME_WC });
+		assertTrue(validate(dumpROMClassOutput,
+				Constants.DUMP_ROM_CLASS_NAME_WC_SUCCESS_KEY,
+				Constants.DUMP_ROM_CLASS_NAME_WC_FAILURE_KEY, true));
+
+		/* test for !dumpromclass name:<classname> maps */
+		dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD, new String[] {
+				Constants.DUMP_ROM_CLASS_NAME_CMD
+						+ Constants.DUMP_ROM_CLASS_NAME,
+				Constants.DUMP_ROM_CLASS_MAPS_CMD });
+		assertTrue(validate(dumpROMClassOutput,
+				Constants.DUMP_ROM_CLASS_NAME_MAPS_SUCCESS_KEY,
+				Constants.DUMP_ROM_CLASS_NAME_MAPS_FAILURE_KEY, true));
+
+		/* test for !dumpromclass name:<invalid classname> */
+		dumpROMClassOutput = exec(Constants.DUMP_ROM_CLASS_CMD,
+				new String[] { Constants.DUMP_ROM_CLASS_NAME_CMD
+						+ Constants.DUMP_ROM_CLASS_INVALID_NAME });
+		assertTrue(validate(dumpROMClassOutput,
+				Constants.DUMP_ROM_CLASS_INVALID_NAME_SUCCESS_KEY,
+				Constants.DUMP_ROM_CLASS_INVALID_NAME_FAILURE_KEY, true));
+
+	}
+
+	public void testQueryROMClassExt() {
+		String romClassAddress = getAddress("!j9romclass");
+		String queryROMClassOutput = exec(Constants.QUERY_ROM_CLASS_CMD,
+				new String[] { romClassAddress + ","
+						+ Constants.QUERY_ROM_CLASS_QUERY });
+		assertTrue(validate(queryROMClassOutput,
+				Constants.QUERY_ROM_CLASS_SUCCESS_KEY,
+				Constants.QUERY_ROM_CLASS_FAILURE_KEY, true));
+	}
+
+	public void testAnalyzeROMClassUTF8Ext() {
+		String output = exec(Constants.ANALYSE_ROM_CLASS_UTF8_CMD,
+				new String[] {});
+		assertTrue(validate(output,
+				Constants.ANALYSE_ROM_CLASS_UTF8_SUCCESS_KEY,
+				Constants.ANALYSE_ROM_CLASS_UTF8_FAILURE_KEY, true));
+	}
+
+	public void testDumpAllRAMClassLinearExt() {
+		String dumpAllRAMClassLinearOutput = exec(
+				Constants.DUMP_ALL_RAM_CLASS_LINEAR_CMD,
+				new String[] { Constants.DUMP_ALL_RAM_CLASS_LINEAR_NESTING_THRESHOLD });
+		assertTrue(validate(dumpAllRAMClassLinearOutput,
+				Constants.DUMP_ALL_RAM_CLASS_LINEAR_SUCCESS_KEY,
+				Constants.DUMP_ALL_RAM_CLASS_LINEAR_FAILURE_KEY, true));
+	}
+
+	public void testDumpRAMClassLinearExt() {
+		String dumpAllRAMClassLinearOutput = exec(
+				Constants.DUMP_ALL_RAM_CLASS_LINEAR_CMD, new String[] { "1" });
+		String ramclassAddress = null;
+		for (String outLine : dumpAllRAMClassLinearOutput.split(Constants.NL)) {
+			if (outLine.contains(Constants.DUMP_RAM_CLASS_LINEAR_CMD)) {
+				ramclassAddress = outLine
+						.split(Constants.DUMP_RAM_CLASS_LINEAR_CMD)[1].trim();
+			}
+		}
+		if (ramclassAddress != null && ramclassAddress != "") {
+			String dumpRAMClassLinearOutput = exec(
+					Constants.DUMP_RAM_CLASS_LINEAR_CMD,
+					new String[] { ramclassAddress });
+			assertTrue(validate(dumpRAMClassLinearOutput,
+					Constants.DUMP_RAM_CLASS_LINEAR_SUCCESS_KEY,
+					Constants.DUMP_RAM_CLASS_LINEAR_FAILURE_KEY, true));
+		} else {
+			fail("Failed to retrieve ram class address");
+		}
+	}
+
+	public void testDumpAllRegionsExt() {
+		String dumpAllRegionsOutput = exec(Constants.DUMP_ALL_REGIONS_CMD,
+				new String[] {});
+		assertTrue(validate(dumpAllRegionsOutput,
+				Constants.DUMP_ALL_REGIONS_SUCCESS_KEY,
+				Constants.DUMP_ALL_REGIONS_FAILURE_KEY, true));
+	}
+
+	public void testDumpAllSegmentsExt() {
+		String dumpAllSegmentsOutput = exec(Constants.DUMP_ALL_SEGMENTS_CMD,
+				new String[] {});
+		String successKeys = null;
+		if (is64BitPlatform()) {
+			successKeys = Constants.DUMP_ALL_SEGMENTS_COMMON_SUCCESS_KEY
+					+ Constants.DUMP_ALL_SEGMENTS_64BITCORE_SUCCESS_KEY;
+		} else {
+			successKeys = Constants.DUMP_ALL_SEGMENTS_COMMON_SUCCESS_KEY
+					+ Constants.DUMP_ALL_SEGMENTS_32BITCORE_SUCCESS_KEY;
+		}
+		assertTrue(validate(dumpAllSegmentsOutput, successKeys,
+				Constants.DUMP_ALL_SEGMENTS_FAILURE_KEY, true));
+	}
+
+	public void testDumpSegmentsInListExt() {
+		String dumpAllSegmentsOutput = exec(Constants.DUMP_ALL_SEGMENTS_CMD,
+				new String[] {});
+		String[] outputLines = null;
+		String listAddress = null;
+		if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+			outputLines = dumpAllSegmentsOutput.split("\n");
+		} else {
+			outputLines = dumpAllSegmentsOutput.split(Constants.NL);
+		}
+
+		for (String aLine : outputLines) {
+			if (aLine.contains(Constants.DUMP_SEGMENTS_LIST_NAME)) {
+				listAddress = aLine.split("j9memorysegmentlist")[1].trim();
+			}
+		}
+		if (listAddress != null && listAddress != "") {
+			String dumpSegmentsInListOutput = exec(
+					Constants.DUMP_SEGMENTS_IN_LIST_CMD,
+					new String[] { listAddress });
+			assertTrue(validate(dumpSegmentsInListOutput,
+					Constants.DUMP_SEGMENTS_IN_LIST_SUCCESS_KEY,
+					Constants.DUMP_SEGMENTS_IN_LIST_FAILURE_KEY, true));
+		} else {
+			fail("Failed to retrieve list address for segment list : "
+					+ Constants.DUMP_SEGMENTS_LIST_NAME);
+		}
+	}
+
+	public void testFJ9ObjectExt() {
+		String objAddr = getAddress("!j9object");
+		if (objAddr == null) {
+			fail("Not able to find object address. Can not proceed with testFJ9ObjectExt");
+			return;
+		}
+
+		// Output should be same as j9object now.
+		String fj9objectOutput = exec(Constants.FJ9OBJECT_CMD,
+				new String[] { objAddr });
+		assertTrue(validate(fj9objectOutput, Constants.J9OBJECT_SUCCESS_KEY,
+				null, false));		
+		
+		// Test the address conversion only.
+		String fj9objecttoj9objectOutput = exec(
+				Constants.FJ9OBJECTTOJ9OBJECT_CMD, new String[] { objAddr });
+		assertTrue(validate(fj9objecttoj9objectOutput,
+				Constants.FJ9OBJECT_SUCCESS_KEY, null, true));
+	}
+
+	public void testDumpAllClassLoadersExt() {
+		String dumpAllClassLoadersOutput = exec(Constants.DUMPALLCLASSLOADERS_CMD,
+				new String[] {});
+		assertTrue(validate(dumpAllClassLoadersOutput,
+				Constants.DUMPALLCLASSLOADERS_SUCCESS_KEYS,
+				Constants.DUMPALLCLASSLOADERS_FAILURE_KEYS, true));
+	}
+	
+	private String getRAMClassAddress(String className) {
+		String allClassesOutput = exec(Constants.ALL_CLASSES_CMD,
+				new String[] {});
+		if (allClassesOutput != null) {
+			for (String strLine : allClassesOutput.split(Constants.NL)) {
+				if (strLine.contains(className)) {
+					return strLine.split("\t")[0].trim();
+				}
+			}
+			log.error("Can not find " + className + " in allclasses output");
+		} else {
+			fail("allclasses output is null.");
+			return null;
+		}
+		return null;
+	}
+
+	private String getAddress(String key) {
+		String classForNameOutput = exec(Constants.CL_FOR_NAME_CMD,
+				new String[] { Constants.CL_FOR_NAME_CLASS });
+		String j9classAddr = null;
+		String objAddr = null;
+		for (String outLine : classForNameOutput.split(Constants.NL)) {
+			if (outLine.contains("!j9class")) {
+				j9classAddr = outLine.split(" ")[1].trim(); // change the blank
+															// space to platform
+															// independent
+				break;
+			}
+		}
+		String j9classOutput = exec("j9class", new String[] { j9classAddr });
+		for (String outLine : j9classOutput.split(Constants.NL)) {
+			if (outLine.contains(key)) {
+				objAddr = outLine.split(key)[1].trim();
+				objAddr = objAddr.split(" ")[0].trim();
+				break;
+			}
+		}
+		if (objAddr != null && objAddr != "") {
+			return objAddr;
+		} else {
+			fail("Can not extract " + key + " address");
+			return null;
+		}
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestCollisionResilientHashtable.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestCollisionResilientHashtable.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This test should run on a java core that was generated with hashtable backed by list and tree.
+ * i.e 27+ => -XX:stringTableListToTreeThreshold=64
+ * i.e 23, 24, 26 => -XXgc:stringTableListToTreeThreshold=64
+ */
+public class TestCollisionResilientHashtable extends DDRExtTesterBase
+{
+
+	public void testCollisionResilientHashtable() {
+		String dumpStringTableOutput = exec("dumpstringtable", new String[] {});
+		
+		Pattern dumpStringTablePattern = Pattern.compile("!j9object (0x[0-9a-f]+) value = <(.*)>");
+		Pattern searchStringTablePattern = Pattern.compile("!j9object (0x[0-9a-f]+) <(.*)>");
+		Pattern dumpStringTableSummaryPattern = Pattern.compile("Table Size = (\\d+)");
+
+		Matcher dumpStringTableMatcher = dumpStringTablePattern.matcher(dumpStringTableOutput);
+		Matcher dumpStringTableSummaryMatcher = dumpStringTableSummaryPattern.matcher(dumpStringTableOutput);
+		
+		assertTrue("Summary string not found in the output", dumpStringTableSummaryMatcher.find());
+		int stringTableSize = 0;
+		
+		while (dumpStringTableMatcher.find()) {
+			stringTableSize += 1;
+						
+			String stringAddress = dumpStringTableMatcher.group(1);
+			String stringValue = dumpStringTableMatcher.group(2);
+			
+			String searchStringTableResult = exec("searchstringtable", new String[] {stringAddress});
+			
+			if(searchStringTableResult.equals("Search not supported for HASH_TABLE_VERSION == 0")) {
+				break; // ignore old core files, without CollisionResilientHashtable
+			}
+			
+			Matcher searchStringTableMatcher = searchStringTablePattern.matcher(searchStringTableResult);
+			assertTrue("Matching string not found: " + searchStringTableResult, searchStringTableMatcher.find());
+			
+			String searchStringTableAddress = searchStringTableMatcher.group(1);
+			String searchStringTableValue = searchStringTableMatcher.group(2);
+			
+			assertEquals(stringAddress, searchStringTableAddress);			
+			assertEquals(stringValue, searchStringTableValue);
+		}
+		assertTrue(stringTableSize > 0);
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestDDRExtensionGeneral.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestDDRExtensionGeneral.java
@@ -1,0 +1,637 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.AutoRun;
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+import j9vm.test.ddrext.SetupConfig;
+import j9vm.test.ddrext.util.parser.ClassForNameOutputParser;
+import j9vm.test.ddrext.util.parser.FindVMOutputParser;
+import j9vm.test.ddrext.util.parser.J9JavaVmOutputParser;
+import j9vm.test.ddrext.util.parser.J9MethodOutputParser;
+import j9vm.test.ddrext.util.parser.J9PoolOutputParser;
+import j9vm.test.ddrext.util.parser.J9PoolPuddleListOutputParser;
+import j9vm.test.ddrext.util.parser.MethodForNameOutputParser;
+import j9vm.test.ddrext.util.parser.ParserUtil;
+
+import java.math.BigInteger;
+
+import org.testng.log4testng.Logger;
+
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+
+public class TestDDRExtensionGeneral extends DDRExtTesterBase {
+	private Logger log = Logger.getLogger(TestDDRExtensionGeneral.class);
+
+	public void testVMCheck() {
+		String vmCheckOutput = exec(Constants.VMCHECK_CMD, new String[] {});
+		assertTrue(validate(vmCheckOutput, Constants.VMCHECK_SUCCESS_KEY,
+				Constants.VMCHECK_FAILURE_KEY, false));
+	}
+
+	/*
+	 * runs !walkinterntable first, validate output of options, then runs
+	 * !walkinterntable with options 1-5, validates output for each option
+	 */
+	public void testWalkInternTable() {
+		String menuOutput = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] {});
+		assertTrue(validate(menuOutput,
+				Constants.WALKINTERNTABLE_MENU_SUCCESS_KEY, null, true));
+		
+		String helpOutput = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] {"help"});
+		assertTrue(validate(helpOutput,
+				Constants.WALKINTERNTABLE_MENU_SUCCESS_KEY, null, true));
+
+		String opt1Output = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] { "1" });
+		assertTrue(validate(opt1Output,
+				Constants.WALKINTERNTABLE_OPT1_SUCCESS_KEY, null, true));
+
+		String opt2Output = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] { "2" });
+		assertTrue(validate(opt2Output,
+				Constants.WALKINTERNTABLE_OPT2_SUCCESS_KEY, null, true));
+
+		String opt3Output = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] { "3" });
+		assertTrue(validate(opt3Output,
+				Constants.WALKINTERNTABLE_OPT3_SUCCESS_KEY, null, true));
+
+		String opt4Output = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] { "4" });
+		assertTrue(validate(opt4Output,
+				Constants.WALKINTERNTABLE_OPT4_SUCCESS_KEY, null, true));
+
+		String opt5Output = exec(Constants.WALKINTERNTABLE_CMD,
+				new String[] { "5" });
+		assertTrue(validate(opt5Output,
+				Constants.WALKINTERNTABLE_OPT5_SUCCESS_KEY, null, true));
+	}
+
+	public void testWhatIsSetDepth() {
+		String output = exec(Constants.WHATISSETDEPTH_CMD,
+				new String[] { Constants.WHATISSETDEPTH_DEPTHVALUE });
+		assertTrue(validate(output, Constants.WHATISSETDEPTH_SUCCESS_KEY, null,
+				true));
+	}
+
+	/*
+	 * Performs 2 tests: runs !classforname java/lang/Object first, then uses
+	 * the address of j9class to run !whatis runs !methodforname sleep first,
+	 * then uses the address of the j9method to run !what is
+	 */
+	public void testWhatis() {
+		String classForNameOutput = exec(Constants.CL_FOR_NAME_CMD,
+				new String[] { Constants.CL_FOR_NAME_CLASS });
+		String classAddr = ClassForNameOutputParser.extractClassAddress(classForNameOutput);
+		String output = exec(Constants.WHATIS_CMD, new String[] { classAddr });
+		assertTrue(validate(output, Constants.WHATIS_SUCCESS_KEY_FOR_CLASS,
+				Constants.WHATIS_FAILURE_KEY, true));
+		/*
+		 * String methodForNameOutput = exec(Constants.METHODFORNAME_CMD, new
+		 * String[]{Constants.METHODFORNAME_METHOD},false); String methodAddr =
+		 * extractMethodAddress(methodForNameOutput); output =
+		 * exec(Constants.WHATIS_CMD, new String[]{methodAddr},false);
+		 * assertTrue
+		 * (validate(Constants.WHATIS_CMD+" "+methodAddr,output,Constants
+		 * .WHATIS_SUCCESS_KEY_FOR_METHOD,Constants.WHATIS_FAILURE_KEY,false));
+		 */
+	}
+
+	/* searches for method named sleep */
+	public void testMethodForName() {
+		String output = exec(Constants.METHODFORNAME_CMD,
+				new String[] { Constants.METHODFORNAME_METHOD });
+		assertTrue(validate(output, Constants.METHODFORNAME_SUCCESS_KEY,
+				Constants.METHODFORNAME_FAILURE_KEY, true));
+	}
+
+	/*
+	 * runs !methodforname sleep, gets !j9method <addr>, runs it, gets
+	 * !bytecodes <addr>, runs it and validates result
+	 */
+	public void testByteCodes() {
+		String methodForNameOutput = exec(Constants.METHODFORNAME_CMD,
+				new String[] { Constants.METHODFORNAME_METHOD });
+		String methodAddr = MethodForNameOutputParser.extractMethodAddress(methodForNameOutput, null);
+		if (methodAddr == null || methodAddr == "") {
+			fail("Failed to obtain method address for method : "
+					+ Constants.METHODFORNAME_METHOD
+					+ ". Can not proceed further with test");
+			return;
+		}
+		String j9methodOutput = exec("j9method", new String[] { methodAddr });
+		String byteCodesAddr = J9MethodOutputParser.extractByteCodesAddress(j9methodOutput);
+		if (byteCodesAddr == null || byteCodesAddr == "") {
+			fail("Failed to obtain bytecodes address for method : "
+					+ Constants.METHODFORNAME_METHOD
+					+ ". Can not proceed further with test");
+			return;
+		}
+		String byteCodesOutput = exec(Constants.BYTECODES_CMD,
+				new String[] { byteCodesAddr });
+		assertTrue(validate(byteCodesOutput, Constants.BYTECODES_SUCCESS_KEY,
+				Constants.BYTECODES_FAILURE_KEY, true));
+	}
+
+	public void testVMConstantPool() {
+		String output = exec(Constants.VMCONSTANTPOOL_CMD, new String[] {});
+		assertTrue(validate(output, Constants.VMCONSTANTPOOL_SUCCESS_KEY,
+				Constants.VMCONSTANTPOOL_FAILURE_KEY, true));
+	}
+
+	public void testSnapTrace() {
+		String output = exec(Constants.SNAPTRACE_CMD, new String[] {});
+		assertTrue(validate(output, Constants.SNAPTRACE_SUCCESS_KEY,
+				Constants.SNAPTRACE_FAILURE_KEY, true));
+	}
+
+	public void testRanges() {
+		if (SetupConfig.getDDRContxt() != null
+				&& SetupConfig.getDDRInstance() == null) {
+			log.info("This test is not applicable in context of DDR pluigin for native debuggers");
+			return;
+		}
+		String output = exec(Constants.RANGES_CMD, new String[] {});
+		assertTrue(validate(output, Constants.RANGES_SUCCESS_KEY,
+				Constants.RANGES_FAILURE_KEY, true));
+	}
+
+	public void testJ9x() {
+		String classForNameOutput = exec(Constants.CL_FOR_NAME_CMD,
+				new String[] { Constants.CL_FOR_NAME_CLASS });
+		String classAddr = ClassForNameOutputParser.extractClassAddress(classForNameOutput);
+		String output = exec(Constants.J9X_CMD, new String[] { classAddr });
+		// j9x output contains last 32bit of the address,
+		// e.g.classAddr=0x000000001AD9F600, output will contains 1AD9F600
+		String classAddr2 = classAddr.substring(classAddr.length() - 7);
+		assertTrue(validate(output, classAddr2, Constants.J9X_FAILURE_KEY, true));
+	}
+
+	public void testJ9xx() {
+		String classForNameOutput = exec(Constants.CL_FOR_NAME_CMD,
+				new String[] { Constants.CL_FOR_NAME_CLASS });
+		String classAddr = ClassForNameOutputParser.extractClassAddress(classForNameOutput);
+		String output = exec(Constants.J9XX_CMD, new String[] { classAddr });
+		// j9x output contains last 32bit of the address,
+		// e.g.classAddr=0x000000001AD9F600, output will contains 1AD9F600
+		String classAddr2 = classAddr.substring(classAddr.length() - 7);
+		assertTrue(validate(output, classAddr2, Constants.J9XX_FAILURE_KEY,
+				true));
+	}
+
+	public void testContext() {
+		if (SetupConfig.getDDRContxt() != null
+				&& SetupConfig.getDDRInstance() == null) {
+			log.info("This test is not applicable in context of DDR pluigin for native debuggers");
+			return;
+		}
+		String output = exec(Constants.CONTEXT_CMD, new String[] {});
+		assertTrue(validate(output, Constants.CONTEXT_SUCCESS_KEY,
+				Constants.CONTEXT_FAILURE_KEY, true));
+	}
+
+	public void testJ9ExtendedMethodFlagInfo() {
+		for (int i = 1; i < 16; i++) {
+			String output = exec(Constants.J9EXTENDEDMETHODFLAGINFO_CMD,
+					new String[] { String.valueOf(i) });
+			switch (i) {
+			case 1:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY1,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 2:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY2,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 3:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY3,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 4:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY4,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 5:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY5,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 6:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY6,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 7:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY7,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 8:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY8,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 9:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY9,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 10:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY10,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 11:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY11,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 12:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY12,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 13:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY13,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 14:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY14,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			case 15:
+				assertTrue(validate(output,
+						Constants.J9EXTENDEDMETHODFLAGINFO_SUCCESS_KEY15,
+						Constants.J9EXTENDEDMETHODFLAGINFO_FAILURE_KEY, true));
+				break;
+			}
+		}
+	}
+
+	/*
+	 * In this test, we set the plugin path, reload the plugin, list the plugin,
+	 * then run cmd for reloaded plugin.
+	 */
+	public void testPlugins() {
+		if (SetupConfig.getDDRContxt() != null
+				&& SetupConfig.getDDRInstance() == null) {
+			log.info("This test is not applicable in context of DDR plugin for native debuggers");
+			return;
+		}
+		
+		if (AutoRun.ddrPluginJar == null || AutoRun.ddrPluginJar.isEmpty()) {
+			fail("Not able to find ddrPlugin.");
+			return;
+		}
+		String path = AutoRun.ddrPluginJar.replace("\\", "/");
+
+		log.debug("Plugin path: " + path);
+
+		String pluginsSetpathOutput = exec(Constants.PLUGINS_CMD, new String[] {
+				Constants.PLUGINS_SETPATH_CMD, path });
+		assertTrue(validate(pluginsSetpathOutput,
+				Constants.PLUGINS_SETPATH_SUCCESS_KEY + path,
+				Constants.PLUGINS_SETPATH_FAILURE_KEY, false));
+
+		String pluginsReloadOutput = exec(Constants.PLUGINS_CMD,
+				new String[] { Constants.PLUGINS_RELOAD_CMD });
+		assertTrue(validate(pluginsReloadOutput,
+				Constants.PLUGINS_RELOAD_SUCCESS_KEY,
+				Constants.PLUGINS_RELOAD_FAILURE_KEY, false));
+
+		String pluginsListOutput = exec(Constants.PLUGINS_CMD,
+				new String[] { Constants.PLUGINS_LIST_CMD });
+		assertTrue(validate(pluginsListOutput,
+				Constants.PLUGINS_LIST_SUCCESS_KEY,
+				Constants.PLUGINS_LIST_FAILURE_KEY, false));
+
+		String pluginsTestOutput = exec(Constants.PLUGINS_TEST_CMD,
+				new String[] {});
+		assertTrue(validate(pluginsTestOutput,
+				Constants.PLUGINS_TEST_SUCCESS_KEY,
+				Constants.PLUGINS_TEST_FAILURE_KEY, false));
+	}
+	
+	/**
+	 * This junit method tests the !setvm DDR extension functionality
+	 */
+	public void testSetVM()
+	{
+		BigInteger vmAddr;
+		BigInteger mainThreadAddr;
+		
+		/* Get the vm address from core file by using !findvm extension */
+		String findVMOutput = exec(Constants.FINDVM_CMD, new String[] {});
+		String j9javavmAddr = FindVMOutputParser.getJ9JavaVMAddress(findVMOutput);
+		if (null == j9javavmAddr) {
+			fail("j9javavm address could not be found in the !findvm output");
+			return;
+		} 
+		
+		try {
+			vmAddr = ParserUtil.toBigInteger(j9javavmAddr);
+		} catch (NumberFormatException e) {
+			/* We should never be here */
+			fail(j9javavmAddr + " is not a valid number.");
+			return;
+		}
+		
+		String customSetVMSuccessKey = Constants.SETVM_SUCCESS_KEYS + Constants.HEXADDRESS_HEADER + "[0]*" + vmAddr.toString(Constants.HEXADECIMAL_RADIX);
+		
+		/* Try to set the vm to its actual address */
+		validate(exec(Constants.SETVM_CMD, new String[] {vmAddr.toString()}), customSetVMSuccessKey, Constants.SETVM_FAILURE_KEYS);
+		validate(exec(Constants.SETVM_CMD, new String[] {Constants.HEXADDRESS_HEADER + vmAddr.toString(Constants.HEXADECIMAL_RADIX)}), customSetVMSuccessKey, Constants.SETVM_FAILURE_KEYS);
+		
+		/* Find the mainThread address */
+		String j9javavmOutput = exec(Constants.J9JAVAVM_CMD, new String[] {j9javavmAddr});
+		String mainThreadAddress = J9JavaVmOutputParser.getMainThreadAddress(j9javavmOutput);
+		if (null == mainThreadAddress) {
+			fail("mainThread address could not be found in the !j9javavm output");
+			return;
+		}
+		
+		try {
+			mainThreadAddr = ParserUtil.toBigInteger(mainThreadAddress);
+		} catch (NumberFormatException e) {
+			/* We should never be here */
+			fail(mainThreadAddress + " is not a valid number.");
+			return;
+		}
+		
+		/* Try to set the vm to the mainThread  address */
+		validate(exec(Constants.SETVM_CMD, new String[] {mainThreadAddr.toString()}), customSetVMSuccessKey, Constants.SETVM_FAILURE_KEYS);
+		validate(exec(Constants.SETVM_CMD, new String[] {Constants.HEXADDRESS_HEADER + mainThreadAddr.toString(Constants.HEXADECIMAL_RADIX)}), customSetVMSuccessKey, Constants.SETVM_FAILURE_KEYS);
+		
+		/* Try to set the vm to the invalid j9javavm address. 
+		 * j9javavm address + 8 can be used as an invalid since 
+		 * it is still in the j9javavm structure and 
+		 * can not be another valid j9javavm structure
+		 */
+		validate(exec(Constants.SETVM_CMD, new String[] {vmAddr.add(new BigInteger("8")).toString()}), Constants.SETVM_FAILURE_KEY_1 + "," + Constants.SETVM_FAILURE_KEY_2, Constants.SETVM_SUCCESS_KEYS);
+		validate(exec(Constants.SETVM_CMD, new String[] {Constants.HEXADDRESS_HEADER + vmAddr.add(new BigInteger("8")).toString(Constants.HEXADECIMAL_RADIX)}),  Constants.SETVM_FAILURE_KEY_1 + "," + Constants.SETVM_FAILURE_KEY_2, Constants.SETVM_SUCCESS_KEYS);
+		
+	}
+	
+	/**
+	 * This junit method tests the !showdumpagents DDR extension functionality
+	 */
+	public void testShowdumpagents() {
+
+		String output = exec(Constants.SHOWDUMPAGENTS_CMD, new String[] {});
+		assertTrue(validate(output, Constants.SHOWDUMPAGENTS_SUCCESS_KEYS,
+				Constants.SHOWDUMPAGENTS_FAILURE_KEYS, false));
+	}
+
+	/**
+	 * This junit method tests the !sym DDR extension functionality
+	 * 
+	 * run !methodforname to gets !j9method <addr>, run j9method to get
+	 * methodRunAddress, then run sym with the methodRunAddress
+	 */
+	/* CMVC 192844 - temporarily remove sub test until I can find decent replacement for array copy
+	public void testSym() {
+
+		String methodForNameOutput = exec(Constants.METHODFORNAME_CMD,
+				new String[] { Constants.SYM_TEST_METHOD });
+		String methodAddr = MethodForNameOutputParser
+				.extractMethodAddress(methodForNameOutput);
+		String j9methodOutput = exec(Constants.J9METHOD_CMD,
+				new String[] { methodAddr });
+		String methodRunAddr = J9MethodOutputParser
+				.extractMethodAddress(j9methodOutput);
+		String output = exec(Constants.SYM_CMD, new String[] { methodRunAddr });
+		assertTrue(validate(output, Constants.SYM_SUCCESS_KEYS,
+				Constants.SYM_FAILURE_KEYS, false));
+	}
+	*/
+
+	/**
+	 * This junit method tests the !dclibs DDR extension functionality
+	 */
+	public void testDclibs() {
+
+		String output = exec(Constants.DCLIBS_CMD, new String[] { });
+		assertTrue(validate(output, Constants.DCLIBS_SUCCESS_KEYS,
+				Constants.DCLIBS_FAILURE_KEYS, false));
+		
+		//if library is collected to the core, then test "!dclibs extrac" command to extract libs to temp folder
+		if (output.contentEquals(Constants.DCLIBS_LIB_COLLENTED)){
+			String output2 = exec(Constants.DCLIBS_CMD, new String[] {"extract" });
+			assertTrue(validate(output2, Constants.DCLIBS_EXTRACT_SUCCESS_KEYS,
+					Constants.DCLIBS_FAILURE_KEYS, false));
+		}
+	}
+
+	/**
+	 * This junit method tests the !walkj9pool DDR extension functionality
+	 */
+	public void testWalkJ9Pool() 
+	{	
+		/* Get the vm address from core file by using !findvm extension */
+		String findVMOutput = exec(Constants.FINDVM_CMD, new String[] {});
+		String j9javavmAddr = FindVMOutputParser.getJ9JavaVMAddress(findVMOutput);
+		if (null == j9javavmAddr) {
+			fail("j9javavm address could not be found in the !findvm output");
+			return;
+		} 
+		
+		String j9javavmOutput = exec(Constants.J9JAVAVM_CMD, new String[] {j9javavmAddr});
+		
+		/* Test !walkj9pool with the pool used for classLoaderBlocks in J9JavaVm */
+		String classLoaderBlocks = J9JavaVmOutputParser.getClassLoaderBlocksAddress(j9javavmOutput);
+		testWalkJ9PoolFor(classLoaderBlocks);
+
+		/* Test !walkj9pool with the pool used for classLoadingStackPool in J9JavaVm */
+		String classLoadingStackPool = J9JavaVmOutputParser.getClassLoadingStackPoolAddress(j9javavmOutput);
+		testWalkJ9PoolFor(classLoadingStackPool);
+
+		/* Test !walkj9pool with the pool used for dllLoadTable in J9JavaVm */
+		String dllLoadTable = J9JavaVmOutputParser.getDllLoadTableAddress(j9javavmOutput);
+		testWalkJ9PoolFor(dllLoadTable);
+
+		/* Test !walkj9pool with the pool used for systemProperties in J9JavaVm */
+		String systemProperties = J9JavaVmOutputParser.getSystemPropertiesAddress(j9javavmOutput);
+		testWalkJ9PoolFor(systemProperties);
+	}
+	
+	/**
+	 * This method tests the !walkj9pool DDR extension with the given pool address
+	 * @param poolAddr
+	 */
+	private void testWalkJ9PoolFor(String poolAddr) 
+	{
+		String j9poolOutput = exec(Constants.J9POOL_CMD, new String[] {poolAddr});
+		String puddleListAddress = J9PoolOutputParser.getPuddleListAddress(j9poolOutput);
+		if (null == puddleListAddress) {
+			fail("Failed to get puddleList address value from !j9pool output: \n" + j9poolOutput);
+		}
+		String j9poolpuddlelistOutput = exec(Constants.J9POOLPUDDLELIST_CMD, new String[] {puddleListAddress});
+		String numElementsValue = J9PoolPuddleListOutputParser.getnumElementsValue(j9poolpuddlelistOutput);
+		if (null == numElementsValue) {
+			fail("Failed to get numElements field value from !j9poolpuddlelist output: \n" + j9poolpuddlelistOutput);
+		}
+		
+		String walkJ9PoolOutput = exec(Constants.WALKJ9POOL_CMD, new String[] {poolAddr});
+		validate(walkJ9PoolOutput, Constants.WALKJ9POOL_SUCCESS_KEYS, Constants.WALKJ9POOL_FAILURE_KEY);
+		
+		/* Get the number of elements printed in !walkj9pool output */
+		long numElementsInWalkJ9Pool = getNumElementsInWalkJ9PoolOutput(walkJ9PoolOutput);
+		if (-1 == numElementsInWalkJ9Pool) {
+			/* Should never be here after being successful in above validate call */
+			fail("Unexpected !walkj9pool output : \n" + walkJ9PoolOutput);
+		}
+		
+		try {
+			long numElementsInPuddleList = CommandUtils.parseNumber(numElementsValue).longValue();
+			/* Check whether number of elements printed is same as number of elements in the poolpuddlelist */
+			if (numElementsInWalkJ9Pool != numElementsInPuddleList) {
+				fail("Number of elements printed is not same as the number of elements in poolpuddlelist (" + numElementsInPuddleList + ")");
+			}
+		} catch (DDRInteractiveCommandException e) {
+			fail(e.getMessage());
+		}
+		
+	}
+	
+	/**
+	 * This method calculates the number of elements printed in !walkj9pool address
+	 * @param walkJ9PoolOutput Output of !walkj9pool <address> DDR extension
+	 * @return
+	 */
+	private long getNumElementsInWalkJ9PoolOutput(String walkJ9PoolOutput) 
+	{
+		long numElements = -1;
+		String lastInfoLine = null;
+		String [] lines = walkJ9PoolOutput.split("\n");
+		for (int i = 0; i < lines.length; i++) {
+			String currentLine = lines[i].trim();
+			if (currentLine.startsWith("[")) {
+				lastInfoLine = currentLine;
+			} else if (currentLine.equals("}")) {
+				/* Closing parenthesis in !walkj9pool output is encountered.*/
+				break;
+			} else if (currentLine.startsWith("J9Pool at")) {
+				numElements = 0;
+			}
+		}
+		
+		if(null != lastInfoLine) {
+			int lastIndex = lastInfoLine.indexOf("]");
+			if (-1 != lastIndex) {
+				numElements = Long.parseLong(lastInfoLine.substring(1, lastIndex));
+				numElements++; /*Index starts from 0, so add 1 to get the element number */
+			} 
+		}	
+		return numElements;
+	}
+
+	/**
+	 * This junit method tests the !j9reg DDR extension functionality
+	 */
+	public void testJ9Reg()
+	{
+		String j9regLevel0Output = exec(Constants.J9REG_CMD, new String[] {});
+		String j9regLevel1Output = exec(Constants.J9REG_CMD, new String[] {"1"});
+		String j9regLevel2Output = exec(Constants.J9REG_CMD, new String[] {"2"});
+		String j9regLevel3Output = exec(Constants.J9REG_CMD, new String[] {"3"});
+		String j9regLevel4Output = exec(Constants.J9REG_CMD, new String[] {"4"});
+		
+		if (null == j9regLevel0Output) {
+			fail("\"!j9reg\" output is null");
+		}
+		
+		if (null == j9regLevel1Output) {
+			fail("\"!j9reg 1\" output is null");
+		}
+
+		if (null == j9regLevel2Output) {
+			fail("\"!j9reg 2\" output is null");
+		}
+
+		if (null == j9regLevel3Output) {
+			fail("\"!j9reg 3\" output is null");
+		}
+
+		if (null == j9regLevel4Output) {
+			fail("\"!j9reg 4\" output is null");
+		}
+		
+		assertTrue(validate(j9regLevel0Output, Constants.J9REG_SUCCESS_KEYS,
+				Constants.J9REG_FAILURE_KEYS, false));		
+		
+		/* Default level to print is 1. So j9reg and j9reg 1 output should be exactly the same.*/
+		if (!j9regLevel0Output.equals(j9regLevel1Output)) {
+			fail("\"j9reg\" and \"j9reg 1\" output is not same.");
+		}
+		
+		if (!j9regLevel2Output.startsWith(j9regLevel1Output)) {
+			fail("\"j9reg 1\" output is not a subset of \"j9reg 2\" output.");
+		}
+		
+		if (!j9regLevel3Output.startsWith(j9regLevel2Output)) {
+			fail("\"j9reg 2\" output is not a subset of \"j9reg 3\" output.");
+		}
+		
+		if (!j9regLevel4Output.startsWith(j9regLevel3Output)) {
+			fail("\"j9reg 3\" output is not a subset of \"j9reg 4\" output.");
+		}	
+	}
+
+	
+	/**
+	 * This junit method tests the !coreinfo DDR extension functionality
+	 */
+	public void testCoreInfo()
+	{
+		String coreInfoOutput = exec(Constants.COREINFO_CMD, new String[] {});
+		
+		if (null == coreInfoOutput) {
+			fail("\"!coreinfo\" output is null");
+		}
+		
+		assertTrue(validate(coreInfoOutput, Constants.COREINFO_SUCCESS_KEYS,
+				Constants.COREINFO_FAILURE_KEYS, false));	
+	}
+	
+	/**
+	 * This junit method tests the !nativememinfo DDR extension functionality
+	 */
+	public void testNativeMemInfo()
+	{
+		String nativeMemInfoOutput = exec(Constants.NATIVEMEMINFO_CMD, new String[] {});
+		if (null == nativeMemInfoOutput) {
+			fail("\"!nativememinfo\" output is null");
+		}
+		assertTrue(validate(nativeMemInfoOutput, Constants.NATIVEMEMINFO_SUCCESS_KEYS, Constants.NATIVEMEMINFO_FAILURE_KEYS));
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestFindExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestFindExt.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import org.testng.log4testng.Logger;
+
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+import j9vm.test.ddrext.util.parser.MethodForNameOutputParser;
+
+public class TestFindExt extends DDRExtTesterBase {
+
+	private Logger log = Logger.getLogger(TestFindExt.class);
+
+	public void testFindMethodFromPC() {
+		String methodForNameOut = exec(Constants.METHODFORNAME_CMD,
+				new String[] { Constants.METHODFORNAME_METHOD });
+		String j9methodAddr = MethodForNameOutputParser.extractMethodAddress(methodForNameOut, null);
+		String j9methodOut = exec("j9method", new String[] { j9methodAddr });
+		String j9rommethodAddr = extractJ9RomMethodAddress(j9methodOut);
+
+		long longAddr = 0;
+		try {
+			boolean is64BitPlatform = is64BitPlatform();
+			longAddr = CommandUtils.parsePointer(j9rommethodAddr,
+					is64BitPlatform);
+			longAddr = longAddr + 1;
+			String findMethodFromPCOut = exec(Constants.FINDMETHODFROMPC_CMD,
+					new String[] { String.valueOf(longAddr) });
+			assertTrue(validate(findMethodFromPCOut,
+					Constants.FINDMETHODFROMPC_SUCCESS_KEY,
+					Constants.FINDMETHODFROMPC_FAILURE_KEY, true));
+		} catch (DDRInteractiveCommandException e) {
+			e.printStackTrace();
+			fail("Failed processing provided PC address value");
+		}
+	}
+
+	// Findnext command will find match in the search initiated by find, it must
+	// issue right after find command
+	public void testFindAndFindnext() {
+		// !find udata b1234567 will return the address of first occurrence of
+		// string "b1234567"
+		String findOutput = exec(Constants.FIND_CMD, new String[] { "u32",
+				"b1234567" });
+		assertTrue(validate(findOutput, Constants.FIND_SUCCESS_KEY,
+				Constants.FIND_FAILURE_KEY));
+
+		String findnextOutput = exec(Constants.FINDNEXT_CMD, new String[0]);
+		assertTrue(validate(findnextOutput, Constants.FINDNEXT_SUCCESS_KEY,
+				Constants.FINDNEXT_FAILURE_KEY, true));
+	}
+
+	public void testFindheader() {
+		// find address of j9vmthread
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadOutput == null) {
+			fail("threads output is null. Can not proceed with testStack");
+			return;
+		}
+		String threadAddress = getAddressForThreads(Constants.J9VMTHREAD_CMD,
+				threadOutput);
+
+		// locate the memory allocation header for the specified address
+		if (threadAddress == null) {
+			fail("Error parsing Threads output for stack address");
+			return;
+		} else {
+			String findheaderOutput = exec(Constants.FINDHEADER_CMD,
+					new String[] { threadAddress });
+			assertTrue(validate(findheaderOutput,
+					Constants.FINDHEADER_SUCCESS_KEY,
+					Constants.FINDHEADER_FAILURE_KEY, true));
+		}
+
+	}
+
+	public void testFindvm() {
+		String findvmOutput = exec(Constants.FINDVM_CMD, new String[0]);
+		assertTrue(validate(findvmOutput, Constants.FINDVM_SUCCESS_KEY,
+				Constants.FINDVM_FAILURE_KEY, true));
+	}
+
+	public void testFindpattern() {
+
+		String findOutput = exec(Constants.FIND_CMD,
+				new String[] { "u32", "b1" });
+		if (findOutput == null) {
+			fail("find output is null. Can not proceed with Findpattern");
+			return;
+		}
+		String patternAddress = extractPatternAddr(findOutput,
+				Constants.FIND_SUCCESS_KEY, 3);
+
+		if (patternAddress == null) {
+			fail("Can't get address of hexstring b1");
+			return;
+		} else {
+			// replace pattern address' last 3 digits with "000"
+			patternAddress = patternAddress.substring(0,
+					patternAddress.length() - 3)
+					+ "000";
+			// searching pattern on AIX core dump is very slow, provide start
+			// address and search byte to speed up searching.
+			// start to search pattern b1 at patternAddress and only search
+			// 10000000000
+			// byte. Since UDATA.MAX (32bit)=4294967295, expect it will search
+			// on all memory space.
+			String findpatternOutput = exec(Constants.FINDPATTERN_CMD,
+					new String[] { "b1,4," + patternAddress + ",10000000000" });
+			assertTrue(validate(findpatternOutput,
+					Constants.FINDPATTERN_SUCCESS_KEY,
+					Constants.FINDPATTERN_FAILURE_KEY, true));
+		}
+	}
+
+	public void testFindstackvalue() {
+
+		String methodForNameOut = exec(Constants.METHODFORNAME_CMD,
+				new String[] { Constants.METHODFORNAME_METHOD });
+
+		String j9methodAddr = MethodForNameOutputParser.extractMethodAddress(methodForNameOut, "JI");
+
+		if (j9methodAddr == null) {
+			log.info("Get an address from '!methodforname sleep' output: ");
+			log.info(methodForNameOut);
+			fail("Error parsing methodforname sleep output.");
+			return;
+		} else {
+			String findstackvalueOutput = exec(Constants.FINDSTACKVALUE_CMD,
+					new String[] { j9methodAddr });
+			assertTrue(validate(findstackvalueOutput,
+					Constants.FINDSTACKVALUE_SUCCESS_KEY,
+					Constants.FINDSTACKVALUE_FAILURE_KEY, true));
+		}
+	}
+
+	private String extractJ9RomMethodAddress(String j9methodOut) {
+		String[] outputLines = j9methodOut.split("!j9rommethod");
+		String[] lineSplit = outputLines[1].split(System.getProperty("line.separator"));
+		return lineSplit[0].trim();
+	}
+
+
+	public String extractPatternAddr(String output, String key, int addrIndex) {
+
+		String[] outputLines = output.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.contains(key)) {
+				return aLine.split(" ")[addrIndex].trim();
+			}
+		}
+		return null;
+	}
+	/*
+	 * private String defaultPattern(){
+	 * 
+	 * String pattern = null; if (java.nio.ByteOrder.nativeOrder() ==
+	 * ByteOrder.LITTLE_ENDIAN){ pattern = "674523b1" ; }else{ pattern =
+	 * "b1234567"; }
+	 * 
+	 * return pattern; }
+	 */
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestJITExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestJITExt.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import org.testng.log4testng.Logger;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestJITExt extends DDRExtTesterBase {
+	private Logger log = Logger.getLogger(TestJITExt.class);
+	
+	/*
+	 * Tests the following extensions:
+	 *		jitstack <thread>,<sp>,<pc>			Dump JIT stack
+	 *		jitstackslots <thread>,<sp>,<pc>	Dump JIT stack slots
+	 *		jitmetadatafrompc <pc>				Show JIT method metadata for PC
+	 */
+	public void testJITStack() {
+		String stackAddress = null;
+		String j9vmthreadAddress = null;
+		String stackslotsOutput = null;
+		
+		String threadsOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadsOutput == null) {
+			fail("Setup failed. Threads output is null. Can not proceed with JIT extension tests");
+			return;
+		}
+		
+		// Find a thread that has a JIT frame. To do this we run the !stackslots command on each thread.
+		String[] lines = threadsOutput.split(Constants.NL);
+		for (int i = 0; i < lines.length; i++) {
+			String[] tokens = lines[i].split("\t");
+			for (int j = 0; j < tokens.length; j++) {
+				if (tokens[j].contains("stack")) {
+					stackAddress = tokens[j].trim().split(" ")[1];
+				}
+				if (tokens[j].contains("j9vmthread")) {
+					j9vmthreadAddress = tokens[j].trim().split(" ")[1];
+				}
+			}
+			if (stackAddress != null && j9vmthreadAddress != null) {
+				// Got a stack address and a j9vmthread address, now run !stackslots
+				stackslotsOutput = exec(Constants.STACKSLOTS_CMD, new String[] {stackAddress});
+				if (stackslotsOutput.contains("JIT frame")) {
+					break; // Found a thread stack containing a JIT frame, we are done
+				}
+			}
+		}
+
+		if (stackslotsOutput == null) {
+			fail("TestJITExt failed. Unable to find a threads contained a JIT frame. Cannot proceed with JIT extension tests");
+			return;
+		}
+		
+		String sp = getSP(stackslotsOutput);
+		if (sp == null) {
+			log.error("Missing JIT frame or unwindSP in !stackslots output:\n" + stackslotsOutput);
+			fail("Error parsing stackslots output for sp value");
+			return;
+		}
+
+		String pc = getPC(stackslotsOutput);
+		if (pc == null) {
+			fail("Error parsing stackslots output for pc value");
+			return;
+		}
+
+		String args = j9vmthreadAddress + "," + sp + "," + pc;
+
+		String jitstackOutput = exec(Constants.JITSTACK_CMD,
+				new String[] { args });
+		String jitstacklotsOutput = exec(Constants.JITSTACKSLOTS_CMD,
+				new String[] { args });
+		String jitmetadatafrompcOutput = exec(Constants.JITMETADATAFROMPC,
+				new String[] { pc });
+		assertTrue(validate(jitstackOutput, Constants.JIT_CMD_SUCCESS_KEY,
+				Constants.JIT_CMD_FAILURE_KEY, true));
+		assertTrue(validate(jitstacklotsOutput, Constants.JIT_CMD_SUCCESS_KEY,
+				Constants.JIT_CMD_FAILURE_KEY, true));
+		assertTrue(validate(jitmetadatafrompcOutput,
+				Constants.JITMETADATAFROMPC_SUCCESS_KEY,
+				Constants.JITMETADATAFROMPC_FAILURE_KEY, true));
+	}
+
+	private String getSP(String stackslotsOutput) {
+		String[] lines = stackslotsOutput.split(Constants.NL);
+		for (int i = 0; i < lines.length; i++) {
+			if (lines[i].contains("JIT frame")) {
+				String[] tokens = lines[i].split(",");
+				for (int j = 0; j < tokens.length; j++) {
+					if (tokens[j].contains("unwindSP")) {
+						return tokens[j].split("=")[1].trim();
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private String getPC(String stackslotsOutput) {
+		String[] lines = stackslotsOutput.split(Constants.NL);
+		for (int i = 0; i < lines.length; i++) {
+			if (lines[i].contains("JIT frame")) {
+				String[] tokens = lines[i].split(",");
+				for (int j = 0; j < tokens.length; j++) {
+					if (tokens[j].contains("pc")) {
+						return tokens[j].split("=")[1].trim();
+					}
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestMonitors.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestMonitors.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestMonitors extends DDRExtTesterBase
+{
+	/**
+	 * Test !monitors help
+	 */
+	public void testMonitorsHelp()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { "help" });
+		
+		if (null == output) {
+			fail("\"!monitors help\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output,
+				"monitors tables,monitors system,monitors object,monitors objects," +
+				"monitors thread,monitors j9thread,monitors j9vmthread,monitors deadlock," +
+				"monitors [ owned | waiting | blocked | active | all ]", "unrecog,exception,error,null", false));
+	}
+	
+	/**
+	 * Test !monitors all
+	 */
+	public void testMonitorsAll()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { "all" });
+		
+		if (null == output) {
+			fail("\"!monitors all\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, "Object Monitors:,System Monitors:,j9threadmonitor", "unrecog,exception,error,null", false));
+	}
+	
+	/**
+	 * Test !monitors tables and !monitors table
+	 */
+	public void testMonitorsTables()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { "tables" });
+		
+		if (null == output) {
+			fail("\"!monitors tables\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		// If we're running on a core with some active (object) monitors:
+		if (false == output.isEmpty()) {
+			assertTrue(validate(output,"j9monitortablelistentry", "exception,error,null", false));
+			
+			String tableAddr = getAddressFor(output, null, "j9monitortablelistentry", "\t");
+			tableAddr = tableAddr.substring(0, tableAddr.indexOf('>')); // getAddressFor(...) has some issues.
+			
+			String tableOutput = exec(Constants.MONITORS_CMD, new String[] { "table", tableAddr });
+			
+			assertTrue((null != tableOutput) && (false == tableOutput.isEmpty()));
+		}
+	}
+
+	/**
+	 * Test !monitors objects && !monitors object
+	 */
+	public void testMonitorsObject()
+	{
+		String objectsOutput = exec(Constants.MONITORS_CMD, new String[] { "objects" });
+		
+		if (null == objectsOutput) {
+			fail("\"!monitors objects\"output is null. Can not proceed with test");
+			return;
+		}
+		
+		String eyecatcher = "Object monitor for ";
+		objectsOutput = objectsOutput.substring(objectsOutput.indexOf(eyecatcher) + eyecatcher.length());
+		String address = getAddressFor(objectsOutput, null, Constants.J9OBJECT_CMD, "\t");
+				
+		System.out.println("getAddressFor returned: " + address);
+		
+		if (null != address) { // If we're running on a core with some active (object) monitors:
+			String objOutput = exec(Constants.MONITORS_CMD, new String[] { "object", address });
+			assertTrue(validate(objOutput, "j9objectmonitor,j9threadmonitor,j9vmthread,j9thread", "unrecog,exception,error,null", false));
+		}
+	}
+	
+	/**
+	 * Test !monitors system
+	 */
+	public void testMonitorsSystem()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { "system", "all" });
+		
+		if (null == output) {
+			fail("\"!monitors system\"output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, "!j9thread", "unrecog,exception,error,null", false));	
+	}
+	
+	/**
+	 * Test !monitors thread, !monitors j9thread, !monitors j9vmthread
+	 */
+	public void testMonitorsThread()
+	{
+		String threadOutput = exec(Constants.THREAD_CMD, new String[] {} );
+		String j9threadAddr = getAddressFor(threadOutput, null, Constants.J9THREAD_CMD, "\t");
+		String j9vmthreadAddr = getAddressFor(threadOutput, null, Constants.J9VMTHREAD_CMD, "\t");
+		
+		String j9threadOutput = exec(Constants.MONITORS_CMD, new String[] { Constants.J9THREAD_CMD, j9threadAddr });
+		assertTrue(validate(j9threadOutput, Constants.J9THREAD_CMD, "unrecog,exception,error,null", false));
+		
+		String j9vmthreadOutput = exec(Constants.MONITORS_CMD, new String[] { Constants.J9VMTHREAD_CMD, j9vmthreadAddr });
+		assertTrue(validate(j9vmthreadOutput, Constants.J9VMTHREAD_CMD, "unrecog,exception,error,null", false));
+		
+		String findj9threadOutput = exec(Constants.MONITORS_CMD, new String[] { "thread", j9threadAddr });
+		assertTrue(validate(findj9threadOutput, Constants.J9THREAD_CMD, "unrecog,exception,error,null", false));
+		
+		String findj9vmthreadOutput = exec(Constants.MONITORS_CMD, new String[] { "thread", j9vmthreadAddr });
+		assertTrue(validate(findj9vmthreadOutput, Constants.J9VMTHREAD_CMD, "unrecog,exception,error,null", false));
+	}
+	
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestRTSpecificDDRExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestRTSpecificDDRExt.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestRTSpecificDDRExt extends DDRExtTesterBase {
+	public void testShrcCLStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_CLSTATS });
+		assertTrue(validate(statsOutput,
+				Constants.SHRC_CLSTATS_SUCCESS_KEY_RTP,
+				Constants.SHRC_CLSTATS_FAILURE_KEY_RTP, true));
+	}
+
+	public void testShrcCacheletExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_CLSTATS });
+		String lines[] = statsOutput.split(Constants.NL);
+		String address = null;
+		for (String line : lines) {
+			if (line.contains("CACHELET !shrc")) {
+				address = line.split("!shrc cachelet")[1];
+			}
+		}
+		if (address == null) {
+			fail("Can not obtain cachelet address");
+		} else {
+			String cacheletOutput = exec(Constants.SHRC_CMD, new String[] {
+					Constants.SHRC_CACHELET, address });
+			assertTrue(validate(cacheletOutput,
+					Constants.SHRC_CACHELET_SUCCESS_KEY_RTP,
+					Constants.SHRC_CACHELET_FAILURE_KEY_RTP, true));
+		}
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestSharedClassesExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestSharedClassesExt.java
@@ -1,0 +1,599 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+import j9vm.test.ddrext.util.parser.ParserUtil;
+
+import org.testng.log4testng.Logger;
+
+public class TestSharedClassesExt extends DDRExtTesterBase {
+	private Logger log = Logger.getLogger(TestSharedClassesExt.class);
+	public void testShrcExt() {
+		String shrcOutput = exec(Constants.SHRC_CMD, new String[] {});
+		assertTrue(validate(shrcOutput, Constants.SHRC_SUCCESS_KEY,
+				Constants.SHRC_FAILURE_KEY, true));
+	}
+
+	public void testShrcStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_STATS });
+		assertTrue(validate(statsOutput, Constants.SHRC_STATS_SUCCESS_KEY,
+				Constants.SHRC_STATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcAllStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_ALLSTATS });
+		if (getJavaVersion() > 8) {
+			assertTrue(validate(statsOutput, Constants.SHRC_ALLSTATS_SUCCESS_KEY_JAVA9,
+					Constants.SHRC_ALLSTATS_FAILURE_KEY, true));
+		} else {
+			assertTrue(validate(statsOutput, Constants.SHRC_ALLSTATS_SUCCESS_KEY,
+					Constants.SHRC_ALLSTATS_FAILURE_KEY, true));
+		}
+	}
+
+	public void testShrcRcStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_RCSTATS });
+		assertTrue(validate(statsOutput, Constants.SHRC_RCSTATS_SUCCESS_KEY,
+				Constants.SHRC_RCSTATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcCpStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_CPSTATS });
+		if (getJavaVersion() > 8) {
+			assertTrue(validate(statsOutput, Constants.SHRC_CPSTATS_SUCCESS_KEY_JAVA9,
+					Constants.SHRC_CPSTATS_FAILURE_KEY, true));
+		} else {
+			assertTrue(validate(statsOutput, Constants.SHRC_CPSTATS_SUCCESS_KEY,
+					Constants.SHRC_CPSTATS_FAILURE_KEY, true));
+		}
+	}
+
+	public void testShrcAOTStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_AOTSTATS });
+		assertTrue(validate(statsOutput, Constants.SHRC_AOTSTATS_SUCCESS_KEY,
+				Constants.SHRC_AOTSTATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcOrphanStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_ORPHANSTATS });
+		assertTrue(validate(statsOutput,
+				Constants.SHRC_ORPHANSTATS_SUCCESS_KEY,
+				Constants.SHRC_ORPHANSTATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcScopeStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_SCOPESTATS });
+		if (getJavaVersion() > 8) {
+			assertTrue(validate(statsOutput, Constants.SHRC_SCOPESTATS_SUCCESS_KEY_JAVA9,
+					Constants.SHRC_SCOPESTATS_FAILURE_KEY, true));
+		} else {
+			assertTrue(validate(statsOutput, Constants.SHRC_SCOPESTATS_SUCCESS_KEY,
+					Constants.SHRC_SCOPESTATS_FAILURE_KEY, true));
+		}
+	}
+
+	public void testShrcByteStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_BYTESTATS });
+		if (getJavaVersion() > 8) {
+			assertTrue(validate(statsOutput, Constants.SHRC_BYTESTATS_SUCCESS_KEY_JAVA9,
+					Constants.SHRC_BYTESTATS_FAILURE_KEY, true));
+		} else {
+			assertTrue(validate(statsOutput, Constants.SHRC_BYTESTATS_SUCCESS_KEY,
+					Constants.SHRC_BYTESTATS_FAILURE_KEY, true));
+		}
+	}
+
+	public void testShrcUByteStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_UBYTESTATS });
+		assertTrue(validate(statsOutput, Constants.SHRC_UBYTESTATS_SUCCESS_KEY,
+				Constants.SHRC_UBYTESTATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcCLStatsExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_CLSTATS });
+		assertTrue(validate(statsOutput,
+				Constants.SHRC_CLSTATS_SUCCESS_KEY_NONRTP,
+				Constants.SHRC_CLSTATS_FAILURE_KEY_NONRTP, true));
+	}
+
+	/*
+	 * !shrc classpath <address>-- Print classpath at address we extract
+	 * <address> by first running !shrc cpstats
+	 */
+	public void testShrcClassPathExt() {
+		String cpstatsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_CPSTATS });
+		String cpAddr = cpstatsOutput.substring(cpstatsOutput.indexOf("1:") + 2,
+				cpstatsOutput.indexOf("CLASSPATH")).trim();
+		if (cpAddr == null || cpAddr == "") {
+			fail("Failed to retrieve class path address");
+		} else {
+			cpAddr = cpAddr.trim();
+			String cpOutput = exec(Constants.SHRC_CMD, new String[] {
+					Constants.SHRC_CP, cpAddr });
+			if (getJavaVersion() > 8) {
+				assertTrue(validate(cpOutput, Constants.SHRC_CP_SUCCESS_KEY_JAVA9,
+						Constants.SHRC_CP_FAILIRE_KEY, true));
+			} else {
+				assertTrue(validate(cpOutput, Constants.SHRC_CP_SUCCESS_KEY,
+						Constants.SHRC_CP_FAILIRE_KEY, true));
+			}
+		}
+	}
+
+	/*
+	 * !shrc findclass <name> -- Find named class We are looking for
+	 * java/lang/Object
+	 */
+	public void testShrcFindClassExt() {
+		String findClassOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDCLASS, Constants.SHRC_FINDCLASS_NAME });
+		assertTrue(validate(findClassOutput,
+				Constants.SHRC_FINDCLASS_SUCCESS_KEY,
+				Constants.SHRC_FINDCLASS_FAILURE_KEY, true));
+	}
+
+	/*
+	 * !shrc findclassp <name>-- Find named class prefix We are using prefix
+	 * java/lang/O
+	 */
+	public void testShrcFindClasspExt() {
+		String findClasspOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDCLASSP, Constants.SHRC_FINDCLASSP_PATTERN });
+		assertTrue(validate(findClasspOutput,
+				Constants.SHRC_FINDCLASSP_SUCCESS_KEY,
+				Constants.SHRC_FINDCLASSP_FAILURE_KEY, true));
+	}
+
+	/*
+	 * !shrc findaot <name> -- Find AOT for named method (see j9vm.test.ddrext.Constants)
+	 */
+	public void testShrcFindAOTExt() {
+		String findAotOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDAOT, Constants.SHRC_FINDAOT_METHODNAME });
+		if (!validate(findAotOutput, Constants.SHRC_FINDAOT_NO_ENTRY_KEY,
+				Constants.SHRC_FINDAOT_FAILURE_KEY, true)) {
+			assertTrue(validate(findAotOutput, Constants.SHRC_FINDAOT_SUCCESS_KEY,
+					Constants.SHRC_FINDAOT_FAILURE_KEY, true));
+		}
+	}
+
+	/*
+	 * !shrc findaotp <name> -- Find AOT for named method prefix (see j9vm.test.ddrext.Constants)
+	 */
+	public void testShrcFindAOTpExt() {
+		String findAotpOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDAOTP, Constants.SHRC_FINDAOTP_PATTERN });
+		if (!validate(findAotpOutput, Constants.SHRC_FINDAOTP_NO_ENTRY_KEY,
+				Constants.SHRC_FINDAOTP_FAILURE_KEY, true)) {
+			assertTrue(validate(findAotpOutput,
+					Constants.SHRC_FINDAOTP_SUCCESS_KEY,
+					Constants.SHRC_FINDAOTP_FAILURE_KEY, true));
+		}
+	}
+
+	/*
+	 * !shrc aotfor <address>-- Find AOT for rom method. We first run !shrc findaot for the named
+	 * method (see j9vm.test.ddrext.Constants), then extract the j9rommethod address and use that
+	 * address as target for the !shrc aotfor command.
+	 */
+	public void testShrcAOTForExt() {
+		String findAotOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDAOT, Constants.SHRC_FINDAOT_METHODNAME });
+		if (findAotOutput == null || findAotOutput == "") {
+			fail("Prerequisite command shrc findaot output is null");
+		} else if (!validate(findAotOutput, Constants.SHRC_FINDAOT_NO_ENTRY_KEY,
+				Constants.SHRC_FINDAOT_FAILURE_KEY, true)) {
+			// extract the j9rommethod address
+			String address = null;
+			String[] outputLines = null;
+			if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+				outputLines = findAotOutput.split("\n");
+			} else {
+				outputLines = findAotOutput.split(Constants.NL);
+			}
+			for (int i = 0; i < outputLines.length; i++) {
+				if (outputLines[i].contains("j9rommethod")) {
+					address = outputLines[i].split("j9rommethod")[1];
+					break;
+				}
+			}
+			if (address != null && address != "") {
+				String aotForOutput = exec(Constants.SHRC_CMD, new String[] {
+						Constants.SHRC_AOTFOR, address });
+				assertTrue(validate(aotForOutput,
+						Constants.SHRC_AOTFOR_SUCCESS_KEY,
+						Constants.SHRC_AOTFOR_FAILURE_KEY, true));
+			} else {
+				fail("Failed to retrieve method address to use in shrc aotfor command");
+			}
+		}
+	}
+
+	/*
+	 * !shrc rcfor <address>-- Find romclass metadata from romclass address. We first run !shrc findaot
+	 * for the named method (see j9vm.test.ddrext.Constants), then extract the j9romclass address for
+	 * the class and use that address as target for the !shrc rcfor command.
+	 */
+	public void testShrcRCForExt() {
+		String findAotOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDAOT, Constants.SHRC_FINDAOT_METHODNAME });
+		if (findAotOutput == null || findAotOutput == "") {
+			fail("Prerequisite command shrc findaot output is null");
+		} else if (!validate(findAotOutput,Constants.SHRC_FINDAOT_NO_ENTRY_KEY, 
+				Constants.SHRC_FINDAOT_FAILURE_KEY, true)) {
+			// extract the j9rommethod address for ThreadWorker.run()
+			String address = null;
+			String[] outputLines = findAotOutput.split(Constants.NL);
+			for (int i = 0; i < outputLines.length; i++) {
+				if (outputLines[i].contains("j9romclass")) {
+					address = outputLines[i].split("j9romclass")[1].trim();
+					break;
+				}
+			}
+			if (address != null && address != "") {
+				String rcForOutput = exec(Constants.SHRC_CMD, new String[] {
+						Constants.SHRC_RCFOR, address });
+				assertTrue(validate(rcForOutput,
+						Constants.SHRC_RCFOR_SUCCESS_KEY,
+						Constants.SHRC_RCFOR_FAILURE_KEY, true));
+			} else {
+				fail("Failed to retrieve j9romclass address to use in shrc rcfor command");
+			}
+		}
+	}
+
+	/*
+	 * !shrc method <address> -- Lookup rom method in cache. We first run !shrc findaot for the named
+	 * method (see j9vm.test.ddrext.Constants), then extract the j9rommethod address for the method
+	 * and use that address as target for the !shrc method command.
+	 */
+	public void testShrcMethodExt() {
+		String findAotOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDAOT, Constants.SHRC_FINDAOT_METHODNAME });
+		if (findAotOutput == null || findAotOutput == "") {
+			fail("Prerequisite command shrc findaot output is null");
+		} else if (!validate(findAotOutput,Constants.SHRC_FINDAOT_NO_ENTRY_KEY, 
+				Constants.SHRC_FINDAOT_FAILURE_KEY, true)) {
+			// extract the j9rommethod address
+			String address = null;
+			String[] outputLines = null;
+			if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+				outputLines = findAotOutput.split("\n");
+			} else {
+				outputLines = findAotOutput.split(Constants.NL);
+			}
+			for (int i = 0; i < outputLines.length; i++) {
+				if (outputLines[i].contains("j9rommethod")) {
+					address = outputLines[i].split("j9rommethod")[1];
+					break;
+				}
+			}
+			if (address != null && address != "") {
+				String methodForOutput = exec(Constants.SHRC_CMD, new String[] {
+						Constants.SHRC_METHOD, address });
+				assertTrue(validate(methodForOutput,
+						Constants.SHRC_METHOD_SUCCESS_KEY,
+						Constants.SHRC_METHOD_FAILURE_KEY, true));
+			} else {
+				fail("Failed to retrieve method address to use in shrc aotfor command");
+			}
+		}
+	}
+
+	/*
+	 * We first run !shrc stats and get the cache header address, then run !shrc
+	 * incache with that address to look for the success string - <address> is
+	 * in the cache header
+	 */
+	public void testShrcIncacheExt() {
+		String statsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_STATS });
+		if (statsOutput == null || statsOutput == "") {
+			fail("Prerequisite command shrc stats output is null");
+		} else {
+			String[] statsOutputLines = null;
+			if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+				statsOutputLines = statsOutput.split("\n");
+			} else {
+				statsOutputLines = statsOutput.split(Constants.NL);
+			}
+			String headerAddress = null;
+			for (String line : statsOutputLines) {
+				if (line.startsWith("!j9sharedcacheheader")) {
+					headerAddress = line.split(" ")[1].trim();
+					break;
+				}
+			}
+			if (headerAddress == null || headerAddress == "") {
+				fail("Failed to retrieve header address");
+			} else {
+				String incacheOutput = exec(Constants.SHRC_CMD, new String[] {
+						Constants.SHRC_INCACHE, headerAddress });
+				assertTrue(validate(incacheOutput,
+						Constants.SHRC_INCACHE_SUCCESS_KEY,
+						Constants.SHRC_INCACHE_FAILURE_KEY, true));
+			}
+		}
+	}
+
+	/*
+	 * Removing this test from non-realtime bucket Please refer to CMVC : 184417
+	 */
+	/*
+	 * public void testShrcCacheletExt(){ String cacheletOutput =
+	 * exec(Constants.SHRC_CMD,new String[] {
+	 * Constants.SHRC_CACHELET,Constants.SHRC_CACHELET_ADDR_NONRTP},false);
+	 * assertTrue
+	 * (validate(cacheletOutput,Constants.SHRC_CACHELET_SUCCESS_KEY_NONRTP
+	 * ,Constants.SHRC_CACHELET_FAILURE_KEY_NONRTP,true,true)); }
+	 */
+
+	/* JIT profile tests */
+	public void testShrcJITPStatsExt() {
+		String jitpstatsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_JITPSTATS });
+		assertTrue(validate(jitpstatsOutput,
+				Constants.SHRC_JITPSTATS_SUCCESS_KEY,
+				Constants.SHRC_JITPSTATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcFindJITPext() {
+
+		String jitpStatsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_JITPSTATS });
+		if (jitpStatsOutput.contains("JITPROFILE data") == false) {
+			fail("No jit profile information found.");
+			return;
+		}
+
+		String methodFindInJitpStats = ParserUtil
+				.getMethodNameFromJITPStats(jitpStatsOutput);
+		if (methodFindInJitpStats == null) {
+			fail("Failed to extract j9rommethod name for JITPROFILE. Can not proceed with test");
+			return;
+		}
+
+		String j9rommethodAddr = ParserUtil.getMethodAddrForName(
+				jitpStatsOutput, methodFindInJitpStats);
+		if (j9rommethodAddr == null) {
+			fail("Failed to extract j9rommethod address for JITPROFILE. Can not proceed with test");
+			return;
+		}
+
+		String findjitpOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDJITP, methodFindInJitpStats });
+
+		String successKey = methodFindInJitpStats + "," + j9rommethodAddr + ","
+				+ Constants.SHRC_JITP_SUCCESS_KEY;
+		assertTrue(validate(findjitpOutput, successKey,
+				Constants.SHRC_FINDJITP_FAILURE_KEY, true));
+	}
+
+	public void testShrcFindJITPPext() {
+
+		String jitpStatsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_JITPSTATS });
+		if (jitpStatsOutput.contains("JITPROFILE data") == false) {
+			fail("No jit profile information found.");
+			return;
+		}
+
+		String methodFindInJitpStats = ParserUtil
+				.getMethodNameFromJITPStats(jitpStatsOutput);
+		if (methodFindInJitpStats == null) {
+			fail("Failed to extract j9rommethod name for JITPROFILE. Can not proceed with test");
+			return;
+		}
+
+		String j9rommethodAddr = ParserUtil.getMethodAddrForName(
+				jitpStatsOutput, methodFindInJitpStats);
+		if (j9rommethodAddr == null) {
+			fail("Failed to extract j9rommethod address for JITPROFILE. Can not proceed with test");
+			return;
+		}
+
+		String methodPre;
+		if (methodFindInJitpStats.length() > 1) {
+			methodPre = methodFindInJitpStats.substring(0, 2);
+		} else {
+			methodPre = methodFindInJitpStats.substring(0, 1);
+		}
+
+		String findjitppOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDJITPP, methodPre });
+
+		String successKey = methodFindInJitpStats + "," + j9rommethodAddr + ","
+				+ Constants.SHRC_JITP_SUCCESS_KEY;
+		assertTrue(validate(findjitppOutput, successKey,
+				Constants.SHRC_FINDJITPP_FAILURE_KEY, true));
+	}
+
+	public void testShrcJITPForExt() {
+
+		String jitpStatsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_JITPSTATS });
+		if (jitpStatsOutput.contains("JITPROFILE data") == false) {
+			fail("No jit profile information found.");
+			return;
+		}
+
+		String methodFindInJitpStats = ParserUtil
+				.getMethodNameFromJITPStats(jitpStatsOutput);
+		if (methodFindInJitpStats == null) {
+			fail("Failed to extract j9rommethod name for JITPROFILE. Can not proceed with test");
+			return;
+		}
+
+		String j9rommethodAddr = ParserUtil.getMethodAddrForName(
+				jitpStatsOutput, methodFindInJitpStats);
+		if (j9rommethodAddr == null) {
+			fail("Failed to extract j9rommethod address for JITPROFILE. Can not proceed with test");
+			return;
+		}
+
+		String jitpForOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_JITPFOR, j9rommethodAddr });
+
+		String successKey = methodFindInJitpStats + "," + j9rommethodAddr + ","
+				+ Constants.SHRC_JITP_SUCCESS_KEY;
+
+		assertTrue(validate(jitpForOutput, successKey,
+				Constants.SHRC_JITPFOR_FAILURE_KEY, true));
+	}
+
+	/* JIT hint tests */
+	public void testShrcJITHStatsExt() {
+		if (!isJitHintSupported()) {
+			log.info(getName()+" is not applicable for java version "+getVersionString());	
+			return;
+		}
+		String jitpstatsOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_JITHSTATS });
+		assertTrue(validate(jitpstatsOutput,
+				Constants.SHRC_JITHSTATS_SUCCESS_KEY,
+				Constants.SHRC_JITHSTATS_FAILURE_KEY, true));
+	}
+
+	public void testShrcFindJITHext() {
+		if (!isJitHintSupported()) {
+			log.info(getName()+" is not applicable for java version "+getVersionString());	
+			return;
+		}
+		String findjitpOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDJITH, Constants.SHRC_FINDJITH_METHODNAME });
+		assertTrue(validate(findjitpOutput,
+				Constants.SHRC_FINDJITH_SUCCESS_KEY,
+				Constants.SHRC_FINDJITH_FAILURE_KEY, true));
+	}
+
+	public void testShrcFindJITHPext() {
+		if (!isJitHintSupported()) {
+			log.info(getName()+" is not applicable for java version "+getVersionString());	
+			return;
+		}
+		String findjitppOutput = exec(Constants.SHRC_CMD,
+				new String[] { Constants.SHRC_FINDJITHP,
+						Constants.SHRC_FINDJITHP_METHODPREFIX });
+		assertTrue(validate(findjitppOutput,
+				Constants.SHRC_FINDJITHP_SUCCESS_KEY,
+				Constants.SHRC_FINDJITHP_FAILURE_KEY, true));
+	}
+
+	public void testShrcJITHForExt() {
+		if (!isJitHintSupported()) {
+			log.info(getName()+" is not applicable for java version "+getVersionString());	
+			return;
+		}
+		String findjitpOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_FINDJITH, Constants.SHRC_FINDJITH_METHODNAME });
+		if (findjitpOutput.contains("JITHINT data") == false) {
+			fail("No jit hint information found for the method :"
+					+ Constants.SHRC_FINDJITH_METHODNAME
+					+ ". Can not proceed with test");
+			return;
+		}
+		String j9rommethodAddr = null;
+		String lines[] = null;
+		lines = findjitpOutput.split(Constants.NL);
+
+		if (lines.length == 1) {
+			lines = findjitpOutput.split("\n");
+		}
+
+		for (int i = 0; i < lines.length; i++) {
+			if (lines[i].contains("java/lang/Object")) {
+				if (lines.length > 1) {
+					j9rommethodAddr = lines[i].split("j9rommethod")[1].trim();
+				} else {
+					j9rommethodAddr = null;
+				}
+				break;
+			}
+		}
+
+		if (j9rommethodAddr == null) {
+			fail("Failed to extract j9rommethod address. Can not proceed with test");
+			return;
+		}
+
+		String jitpForOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_JITHFOR, j9rommethodAddr });
+		assertTrue(validate(jitpForOutput, Constants.SHRC_JITHFOR_SUCCESS_KEY,
+				Constants.SHRC_JITHFOR_FAILURE_KEY, true));
+	}
+	
+	/*
+	 * sample output of !shrc write on zOS core: 
+	 * Writing snap trace to: snap.trc
+	 * !j9sharedclassconfig 0x000000483A05E290
+	 * 
+	 * Cache name is C260M3A64_memory_ddrextjunitSCC_G21 Cache start
+	 * 0x20000000000 size 16777216 Writing cache to
+	 * /team/sshi/temp/C260M3A64_memory_ddrextjunitSCC_G21 Unable to write
+	 * complete cache: Memory Fault reading 0x2000025C0C0 : Attempting to write
+	 * only populated areas of cache. Cache name is
+	 * C260M3A64_memory_ddrextjunitSCC_G21 Cache start 0x20000000000 size
+	 * 16777216 Writing cache to
+	 * /team/sshi/temp/C260M3A64_memory_ddrextjunitSCC_G21 Cache successfully
+	 * written to /team/sshi/temp/C260M3A64_memory_ddrextjunitSCC_G21
+	 * 
+	 * sample output of !shrc write on zLinux core: 
+	 * !j9sharedclassconfig 0x00000000800ED920
+	 * 
+	 * Cache name is C260M3A64P_ddrextjunitSCC_G21 Cache start 0x200230c8000
+	 * size 16777216 Writing cache to
+	 * /team/sshi/temp/C260M3A64P_ddrextjunitSCC_G21
+	 */
+	public void testShrcWriteExt() {
+		String writeOutput = exec(Constants.SHRC_CMD, new String[] {
+				Constants.SHRC_WRITE_CACHE, "." });
+		assertTrue(validate(writeOutput,
+				Constants.SHRC_WRITE_CACHE_SUCCESS_KEY,
+				Constants.SHRC_WRITE_CACHE_FAILURE_KEY, true));
+	}
+	/**
+	 * @return true if the core file has been generated by a VM supporting JIT hints.
+	 */
+	protected boolean isJitHintSupported() {
+		if (getJavaVersion() > 7) {
+			return true;
+		} else if ((getJavaVersion() == 7) && (getJavaSr() > 0)) {
+			return true;
+		} else if ((getJavaVersion() == 6) && (getVmVersion().equalsIgnoreCase("2.6")) && (getJavaSr() > 1)) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestStackMap.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestStackMap.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+import j9vm.test.ddrext.util.parser.StackSlotsOutputParser;
+import j9vm.test.ddrext.util.parser.ThreadsOutputParser;
+
+import org.testng.log4testng.Logger;
+
+/**
+ * DDR extension test class to validate !stackmap functionality.
+ */
+public class TestStackMap extends DDRExtTesterBase {
+	private Logger log = Logger.getLogger(TestStackMap.class);
+
+	/* Number of test methods in StackMapCoreGenerator */
+	private final int testMethodCount = 9;
+
+	/* Test method name suffix from StackMapCoreGenerator */
+	private final String methodNameSuffix = "stackMapTestMethod_";
+
+	/*
+	 * Expected stack mapping for each method in StackMapCoreGenerator See
+	 * StackMapCoreGenerator.java for more details.
+	 */
+	private final String[] methodStackMaps = { "111", "100101", "1011001",
+			"01000111", "11", "00100011011", "01", "1", "001" };
+
+	/**
+	 * Runs !stackmap tests
+	 */
+	public void testStackMap() {
+		String mainThreadAddr;
+		String stackSlotsOutput;
+		String stackMapOutput;
+
+		/*
+		 * Test !stackmap command without argument
+		 * 
+		 * Expected output: > !stackmap stackmap <pc> - calculate the stack slot
+		 * map for the specified PC
+		 */
+		stackMapOutput = exec(Constants.STACKMAP_CMD, new String[0]);
+		assertTrue(validate(stackMapOutput, Constants.STACKMAP_SUCCESS_KEYS_1,
+				Constants.STACKMAP_FAILURE_KEYS_1, true));
+
+		/*
+		 * Get the main threads address by using !threads DDR extension
+		 * 
+		 * Sample output:
+		 * 
+		 * !threads !stack 0x000d2d00 !j9vmthread 0x000d2d00 !j9thread
+		 * 0x003c5788 tid 0x1700 (5888) // (main) !stack 0x00136b00 !j9vmthread
+		 * 0x00136b00 !j9thread 0x003c59f4 tid 0x16d4 (5844) // (JIT Compilation
+		 * Thread-0) !stack 0x00172100 !j9vmthread 0x00172100 !j9thread
+		 * 0x003c5ecc tid 0xb90 (2960) // (IProfiler) !stack 0x633c0a00
+		 * !j9vmthread 0x633c0a00 !j9thread 0x003c6138 tid 0x10b0 (4272) //
+		 * (Signal Dispatcher) !stack 0x63361100 !j9vmthread 0x63361100
+		 * !j9thread 0x637d0078 tid 0x144 (324) // (Concurrent Mark Helper)
+		 * !stack 0x633ce300 !j9vmthread 0x633ce300 !j9thread 0x637d02e4 tid
+		 * 0xe38 (3640) // (GC Slave) !stack 0x63432200 !j9vmthread 0x63432200
+		 * !j9thread 0x637d07bc tid 0x154c (5452) // (Attach API wait loop)
+		 * !stack 0x633f7a00 !j9vmthread 0x633f7a00 !j9thread 0x637d0550 tid
+		 * 0x15e0 (5600) // (Finalizer thread)
+		 */
+		String threadsOutput = exec(Constants.THREAD_CMD, new String[0]);
+		mainThreadAddr = ThreadsOutputParser.getJ9VMThreadAddress(
+				threadsOutput, "main");
+
+		if (null == mainThreadAddr) {
+			fail("VM thread address could not be found for the thread named \"main\" in the !threads output :\n"
+					+ threadsOutput);
+		}
+
+		/*
+		 * Get stackslots for each method in the stack list by using !stackslots
+		 * <vmthread> DDR extension. Stackslots output is used to get the PC for
+		 * each method.
+		 * 
+		 * Sample output:
+		 * 
+		 * > !stackslots 0x000d2d00 <d2d00> *** BEGIN STACK WALK, flags =
+		 * 00400001 walkThread = 0x000D2D00 *** <d2d00> ITERATE_O_SLOTS <d2d00>
+		 * RECORD_BYTECODE_PC_OFFSET <d2d00> Initial values: walkSP =
+		 * 0x00107070, PC = 0x00000001, literals = 0x00000000, A0 = 0x0010707C,
+		 * j2iFrame = 0x00000000, ELS = 0x0088FDC8, decomp = 0x00000000 <d2d00>
+		 * Generic special frame: bp = 0x0010707C, sp = 0x00107070, pc =
+		 * 0x00000001, cp = 0x00000000, arg0EA = 0x0010707C, flags = 0x00000000
+		 * <d2d00> Bytecode frame: bp = 0x00107088, sp = 0x00107080, pc =
+		 * 0x634635DB, cp = 0x63483130, arg0EA = 0x00107098, flags = 0x00000000
+		 * <d2d00> Method: j9vm/test/corehelper/StackMapCoreGenerator.
+		 * stackMapTestMethod_throwException(J)V !j9method 0x6348347C <d2d00>
+		 * Bytecode index = 7 <d2d00> Using local mapper <d2d00> Locals starting
+		 * at 0x00107098 for 0x00000004 slots <d2d00> I-Slot: a0[0x00107098] =
+		 * 0x60D4D1C8 <d2d00> I-Slot: a1[0x00107094] = 0x00000000 <d2d00>
+		 * I-Slot: a2[0x00107090] = 0x00000001 <d2d00> I-Slot: t3[0x0010708C] =
+		 * 0x001070AA <d2d00> Bytecode frame: bp = 0x001070A4, sp = 0x0010709C,
+		 * pc = 0x634635AA, cp = 0x63483130, arg0EA = 0x001070A8, flags =
+		 * 0x00000000 <d2d00> Method:
+		 * j9vm/test/corehelper/StackMapCoreGenerator.stackMapTestMethod_9()V
+		 * !j9method 0x6348346C <d2d00> Bytecode index = 2 <d2d00> Using local
+		 * mapper <d2d00> Locals starting at 0x001070A8 for 0x00000001 slots
+		 * <d2d00> I-Slot: a0[0x001070A8] = 0x60D4D1C8 <d2d00> Bytecode frame:
+		 * bp = 0x001070B4, sp = 0x001070AC, pc = 0x6346357D, cp = 0x63483130,
+		 * arg0EA = 0x001070BC, flags = 0x00000000 <d2d00> Method:
+		 * j9vm/test/corehelper/StackMapCoreGenerator.stackMapTestMethod_8(I)V
+		 * !j9method 0x6348345C <d2d00> Bytecode index = 1 <d2d00> Using local
+		 * mapper <d2d00> Locals starting at 0x001070BC for 0x00000002 slots
+		 * <d2d00> I-Slot: a0[0x001070BC] = 0x60D4D1C8 <d2d00> I-Slot:
+		 * a1[0x001070B8] = 0x00000005
+		 */
+		stackSlotsOutput = exec(Constants.STACKSLOTS_CMD,
+				new String[] { mainThreadAddr });
+
+		for (int i = 0; i < testMethodCount; i++) {
+			String methodName = methodNameSuffix + Integer.toString(i + 1);
+			String methodPC = StackSlotsOutputParser.getPCForMethodName(
+					stackSlotsOutput, methodName);
+
+			if (null == methodPC) {
+				fail("PC value could not found for the method named \""
+						+ methodName + "\" in !stackslots output :\n"
+						+ stackSlotsOutput);
+			}
+
+			stackMapOutput = exec(Constants.STACKMAP_CMD,
+					new String[] { methodPC });
+
+			/*
+			 * Check whether fix strings are in the output for !stackmap
+			 * 
+			 * Sample !stackmap output:
+			 * 
+			 * Searching for PC=1665545248 in VM=0x000BAE18... Found method
+			 * j9vm/
+			 * test/corehelper/StackMapCoreGenerator.stackMapTestMethod_2(Ljava
+			 * /lang
+			 * /Object;Lj9vm/test/corehelper/StackMapCoreGenerator$WeekDays;)V
+			 * !j9method 0x634833FC Relative PC = 32 Method index is 3 Using ROM
+			 * method 0x634633EC Stack map (6 slots mapped): 100101
+			 */
+			assertTrue(validate(stackMapOutput,
+					Constants.STACKMAP_SUCCESS_KEYS_2,
+					Constants.STACKMAP_FAILURE_KEYS_2, false));
+
+			/* Build the stack map info string to check in the output */
+			String stackMapCustomSuccessStr = new String("Stack map \\("
+					+ methodStackMaps[i].length() + " slots mapped\\): "
+					+ methodStackMaps[i]);
+			assertTrue(validate(stackMapOutput, stackMapCustomSuccessStr,
+					Constants.STACKMAP_FAILURE_KEYS_2, false));
+
+		}
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestTenants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestTenants.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestTenants extends DDRExtTesterBase {
+
+	/**
+	 * Test !monitors tables
+	 */
+	public void testMonitorsTables() {
+		String output = exec(Constants.MONITORS_CMD, new String[] { "tables" });
+		
+		if (output == null) {
+			fail("\"!monitors tables\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, "Tenant 0,Tenant 1,Tenant 2", null, false));
+		
+		/* Now test that the string objects we expect are being waited on. */
+		
+		String lines[] = output.split(Constants.NL);
+		
+		for(int i = 0; i < lines.length; i++) {
+			
+			String currentLine = lines[i];
+			assertTrue(validate(currentLine,"j9monitortablelistentry", "exception,error", false));
+			
+			if (currentLine.contains("Tenant")) {
+				
+				// Grab the the details for that table.
+				String tableAddr = getAddressFor(currentLine, null, "j9monitortablelistentry", "\t");
+				tableAddr = tableAddr.substring(0, tableAddr.indexOf('>')); // getAddressFor(...) has some issues.
+				String tableOutput = exec(Constants.MONITORS_CMD, new String[] { "table", tableAddr });
+				assertTrue((null != tableOutput) && (false == tableOutput.isEmpty()));
+				
+				// Adjust the string so it can work with getAddressFor.
+				String eyecatcher = "Object monitor for ";
+				tableOutput = tableOutput.substring(tableOutput.indexOf(eyecatcher) + eyecatcher.length());
+				
+				// Grab the object details for that table.
+				String objectAddr = getAddressFor(tableOutput, null, "j9object", "\t");
+				String objectOutput = exec(Constants.J9OBJECT_CMD, new String[] { objectAddr });
+				
+				assertTrue(validate(objectOutput,"foo",1));
+				
+			}
+		}
+	}
+	
+	/**
+	 * Test !tenantsregions
+	 */
+	public void testTenantsRegions() {
+		String output = exec(Constants.TENANTREGIONS_CMD, new String[] {});
+		
+		if (output == null) {
+			fail("\"!tenantsregions\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, "_ROOT_TENANT_,Tenant 0,Tenant 1,Tenant 2,total", null, false));
+	}
+	
+	/**
+	 * Test !tenantcheck
+	 */
+	public void testTenantscheck() {
+		String output = exec(Constants.TENANTCHECK_CMD, new String[] {});
+		
+		if (output == null) {
+			fail("\"!tenantcheck\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, "checking class->tenant mappings,ok", null, false));
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestThread.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestThread.java
@@ -1,0 +1,287 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestThread extends DDRExtTesterBase {
+	public void testThread() {
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		assertTrue(validate(threadOutput, Constants.THREAD_SUCCESS_KEYS,
+				Constants.THREAD_FAILURE_KEY, true));
+	}
+
+	/* tests extension !stack thread */
+	public void testStack() {
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadOutput == null) {
+			fail("threads output is null. Can not proceed with testStack");
+			return;
+		}
+		String address = getAddressForThreads(Constants.STACK_CMD, threadOutput);
+		if (address == null) {
+			fail("Error parsing Threads output for stack address");
+			return;
+		}
+		String stackOutput = exec(Constants.STACK_CMD,
+				new String[] { address });
+		assertTrue(validate(stackOutput, Constants.STACK_SUCCESS_KEYS,
+				Constants.STACK_FAILURE_KEY, true));
+	}
+
+	/*
+	 * tests !stackslots extension with all options !stackslots thread
+	 * !stackslots thread,sp,a0,pc,literals !stackslots
+	 * thread,sp,a0,pc,literals,els
+	 */
+	public void testStackSlots() {
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadOutput == null) {
+			fail("threads output is null. Can not proceed with testStack");
+			return;
+		}
+		String threadAddress = getAddressForThreads(Constants.STACK_CMD, threadOutput);
+		if (threadAddress == null) {
+			fail("Error parsing Threads output for stack address");
+			return;
+		}
+		/* test !stackslots thread */
+		String stackSlotsOutput = exec(Constants.STACKSLOTS_CMD,
+				new String[] { threadAddress });
+		assertTrue(validate(stackSlotsOutput, Constants.STACKSLOTS_SUCCESS_KEY,
+				Constants.STACKSLOTS_FAILURE_KEY, true));
+
+		/* test !stackslots thread,sp,a0,pc,literals */
+		String paramSet1 = getStackSlotsParamSet(stackSlotsOutput,
+				threadAddress, false);
+		if (paramSet1 == null) {
+			fail("Failed to construct parameter list for command : !stackslots thread,sp,a0,pc,literals\nStackSlots Output being used : \n"
+					+ stackSlotsOutput);
+		} else {
+			String stackSlotsOutputParam1 = exec(Constants.STACKSLOTS_CMD,
+					new String[] { paramSet1 });
+			assertTrue(validate(stackSlotsOutputParam1,
+					Constants.STACKSLOTS_SUCCESS_KEY,
+					Constants.STACKSLOTS_FAILURE_KEY, true));
+		}
+
+		/* test !stackslots thread,sp,a0,pc,literals,els */
+		String paramSet2 = getStackSlotsParamSet(stackSlotsOutput,
+				threadAddress, true);
+		if (paramSet2 == null) {
+			fail("Failed to construct parameter list for command : !stackslots thread,sp,a0,pc,literals,els\nStackSlots Output being used : \n"
+					+ stackSlotsOutput);
+		} else {
+			String stackSlotsOutputParam2 = exec(Constants.STACKSLOTS_CMD,
+					new String[] { paramSet2 });
+			assertTrue(validate(stackSlotsOutputParam2,
+					Constants.STACKSLOTS_SUCCESS_KEY,
+					Constants.STACKSLOTS_FAILURE_KEY, true));
+		}
+	}
+
+	public void testJ9VMThread() {
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadOutput == null) {
+			fail("threads output is null. Can not proceed with testJ9VMThread");
+			return;
+		}
+		String address = getAddressForThreads(Constants.J9VMTHREAD_CMD, threadOutput);
+		if (address == null) {
+			fail("Error parsing Threads output for j9vmthread address");
+			return;
+		}
+		String j9vmthreadOutput = exec(Constants.J9VMTHREAD_CMD,
+				new String[] { address });
+		assertTrue(validate(j9vmthreadOutput,
+				Constants.J9VMTHREAD_SUCCESS_KEYS,
+				Constants.J9VMTHREAD_FAILURE_KEY, true));
+	}
+
+	public void testJ9Thread() {
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadOutput == null) {
+			fail("threads output is null. Can not proceed with testJ9Thread");
+			return;
+		}
+		String address = getAddressForThreads(Constants.J9THREAD_CMD, threadOutput);
+		if (address == null) {
+			fail("Error parsing Threads output for j9thread address");
+			return;
+		}
+		String j9threadOutput = exec(Constants.J9THREAD_CMD,
+				new String[] { address });
+		assertTrue(validate(j9threadOutput, Constants.J9THREAD_SUCCESS_KEYS,
+				Constants.J9THREAD_FAILURE_KEY, true));
+	}
+
+	/* Tests all !thread options */
+	public void testThreadOptions() {
+		String threadHelpOutput = exec(Constants.THREAD_CMD,
+				new String[] { "help" });
+		assertTrue(validate(threadHelpOutput,
+				Constants.THREAD_HELP_SUCCESS_KEY, null, true));
+
+		String threadStackOutput = exec(Constants.THREAD_CMD,
+				new String[] { "stack" });
+		assertTrue(validate(threadStackOutput,
+				Constants.THREAD_STACK_SUCCESS_KEY, null, true));
+
+		String threadStackSlotsOutput = exec(Constants.THREAD_CMD,
+				new String[] { "stackslots" });
+		assertTrue(validate(threadStackSlotsOutput,
+				Constants.THREAD_STACK_SUCCESS_KEY, null, true));
+
+		String threadFlagsOutput = exec(Constants.THREAD_CMD,
+				new String[] { "flags" });
+		assertTrue(validate(threadFlagsOutput,
+				Constants.THREAD_FLAGS_SUCCESS_KEY, null, true));
+
+		String threadDebugEventDataOutput = exec(Constants.THREAD_CMD,
+				new String[] { "debugEventData" });
+		assertTrue(validate(threadDebugEventDataOutput,
+				Constants.THREAD_DEBUGEVENTDATA_SUCCESS_KEYS, null, true));
+
+		String threadMonitorsOutput = exec(Constants.THREAD_CMD,
+				new String[] { "monitors" });
+		assertTrue(validate(threadMonitorsOutput,
+				Constants.THREAD_MONITORS_SUCCESS_KEY, null, true));
+
+		String threadTraceOutput = exec(Constants.THREAD_CMD,
+				new String[] { "trace" });
+		assertTrue(validate(threadTraceOutput,
+				Constants.THREAD_TRACE_SUCCESS_KEY, null, true));
+
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		String tid = getAddressForThreads("tid", threadOutput);
+		String threadSearchOutput = exec(Constants.THREAD_CMD, new String[] {
+				"search", tid });
+		assertTrue(validate(threadSearchOutput,
+				Constants.THREAD_SEARCH_SUCCESS_KEY, null, true));
+	}
+
+	public void testLocalmap() {
+		String threadOutput = exec(Constants.THREAD_CMD, new String[0]);
+		if (threadOutput == null) {
+			fail("threads output is null. Can not proceed with testLocalmap");
+			return;
+		}
+		String threadAddress = getAddressForThreads(Constants.STACK_CMD, threadOutput);
+		String stackSlotsOutput = exec(Constants.STACKSLOTS_CMD,
+				new String[] { threadAddress });
+		if (stackSlotsOutput == null) {
+			fail("stackslots output is null. Can not proceed with testLocalmap");
+			return;
+		}
+		String results = getStackSlotsValues(stackSlotsOutput);
+		if (results == null) {
+			fail("Not able to get pc and method values from stackslots output. Can not proceed with testLocalmap");
+			return;
+		}
+		String tokens[] = results.split(",");
+		String localmapOutput = exec(Constants.LOCALMAP_CMD,
+				new String[] { tokens[0] });
+		String successKeys = Constants.LOCALMAP_SUCCESS_KEY
+				+ ","
+				+ tokens[1].replace(".", "\\.").replace("(", "\\(")
+						.replace(")", "\\)").replace("$", "\\$");
+		assertTrue(validate(localmapOutput, successKeys,
+				Constants.LOCALMAP_FAILURE_KEY, true));
+	}
+
+	private String getStackSlotsValues(String stackslotOutput) {
+		String results = null;
+		String output[] = stackslotOutput.split(Constants.NL);
+		boolean found = false;
+		for (String aLine : output) {
+			if (aLine.contains("Bytecode frame")) {
+				String tokens[] = aLine.split(",");
+				for (int i = 0; i < tokens.length; i++) {
+					String token = tokens[i].trim();
+					if (token.contains("pc")) {
+						results = token.split("=")[1].trim();
+						found = true;
+						break;
+					}
+				}
+			}
+			if (found && aLine.contains("Method:")) {
+				String tokens[] = aLine.split(" ");
+				results = results + "," + tokens[2].trim();
+				break;
+			}
+		}
+		String tokens[] = results.split(",");
+		if (tokens.length < 2 || tokens[0].isEmpty() || tokens[1].isEmpty()) {
+			return null;
+		}
+		return results;
+	}
+
+	/*
+	 * If needELS, we return the second param list for stackslots:
+	 * thread,sp,a0,pc,literals,elsElse,we return the first param list for
+	 * stackslots : thread,sp,a0,pc,literals
+	 */
+	private String getStackSlotsParamSet(String stackOutput,
+			String threadAddress, boolean needELS) {
+		String output[] = stackOutput.split(Constants.NL);
+		String paramList = threadAddress;
+		for (String aLine : output) {
+			if (aLine.contains("Initial values")) {
+				String sp = null, pc = null, literals = null, a0 = null, els = null;
+				String tokens[] = aLine.split(",");
+				for (int i = 0; i < tokens.length; i++) {
+					String token = tokens[i].trim();
+					if (token.contains("walkSP")) {
+						sp = tokens[i].split("=")[1].trim();
+					} else if (token.startsWith("PC")) {
+						pc = token.split("=")[1].trim();
+					} else if (token.startsWith("literals")) {
+						literals = token.split("=")[1].trim();
+					} else if (token.startsWith("A0")) {
+						a0 = token.split("=")[1].trim();
+					} else if (token.startsWith("ELS")) {
+						els = token.split("=")[1].trim();
+					}
+				}
+				if (needELS) {
+					if (sp == null || a0 == null || pc == null
+							|| literals == null || els == null) {
+						return null;
+					}
+					return paramList + "," + sp + "," + a0 + "," + pc + ","
+							+ literals + "," + els;
+				} else {
+					if (sp == null || a0 == null || pc == null
+							|| literals == null) {
+						return null;
+					}
+					return paramList + "," + sp + "," + a0 + "," + pc + ","
+							+ literals;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestTypeResolution.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestTypeResolution.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+import j9vm.test.ddrext.util.parser.ParserUtil;
+
+public class TestTypeResolution extends DDRExtTesterBase
+{
+	
+	public void testSubtypeDetection()
+	{
+		String output = exec(Constants.DUMP_ALL_REGIONS_CMD, new String[] {});
+		
+		if (output == null) {
+			fail("\"!dumpallregions\" output is null. Cannot proceed with test!");
+			return;
+		}
+		
+		String regionAddr = getFirstRegionAddress(output);
+		
+		if (regionAddr == null) {
+			fail("\"!dumpallregions\" output is malformed. Cannot proceed with test!");
+			return;
+		}
+		
+		// Test a subtype of MM_BaseVirtual:
+		output = exec(Constants.DUMP_HRD_CMD, new String[] {regionAddr});
+		assertTrue(validate(output, Constants.TYPERES_HRD_SUCCESS_KEYS, Constants.TYPERES_HRD_FAILURE_KEYS, false));
+		
+		String subspaceCmd  = ParserUtil.getFieldAddressOrValue(Constants.TYPERES_SUBSPACE_STRUCT_CMD, null, output);
+		String subspaceAddr = ParserUtil.getFieldAddressOrValue(Constants.TYPERES_SUBSPACE_STRUCT_CMD, Constants.TYPERES_SUBSPACE_STRUCT_CMD, output);
+		
+		// Check that we actually got a subtype (i.e. more specific type name, or same for older cores)
+		assertTrue(subspaceCmd.toLowerCase().indexOf(Constants.TYPERES_SUBSPACE_STRUCT_CMD) >= 0);
+	
+		output = exec(subspaceCmd, new String[] { subspaceAddr });
+		
+		// Test a subtype of MM_BaseNonVirtual:
+		String lockCmd = ParserUtil.getFieldAddressOrValue(Constants.TYEPERES_LOCK_STRUCT_CMD, null, output);
+		String lockAddr = ParserUtil.getFieldAddressOrValue(Constants.TYEPERES_LOCK_STRUCT_CMD, Constants.TYEPERES_LOCK_STRUCT_CMD, output);
+		
+		output = exec(lockCmd, new String[] { lockAddr });
+		
+		assertTrue(validate(output, Constants.TYPERES_LOCK_SUCCESS_KEYS, Constants.TYPERES_LOCK_FAILURE_KEYS, false));
+		
+	}
+	
+	
+	private String getFirstRegionAddress(String output)
+	{
+		String[] lines = output.split("\n");
+		if (lines.length > 2) {
+			String firstRegionLine = lines[3].trim();
+			int endIdx = firstRegionLine.indexOf(' ');
+			if (endIdx <= 0) {
+				return null;
+			}
+			String firstRegionAddr = firstRegionLine.substring(0,endIdx);
+			return "0x" + firstRegionAddr;
+		}
+		return null;
+	}
+	
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase1.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase1.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit.deadlock;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestDeadlockCase1 extends DDRExtTesterBase
+{
+	/**
+	 * Test !monitors deadlock
+	 *      Test Case #1
+	 *	  JOO, JOO deadlock.
+	 */
+	
+	public void testDeadlock1()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
+		
+		if (null == output) {
+			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
+		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 2));
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase2.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase2.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit.deadlock;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestDeadlockCase2 extends DDRExtTesterBase
+{
+	/**
+	 * Test !monitors deadlock
+	 *     Test Case #2
+	 *	 JOS, JSO deadlock.
+	 */
+	
+	public void testDeadlock2()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
+		
+		if (null == output) {
+			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
+		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase3.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase3.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit.deadlock;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestDeadlockCase3 extends DDRExtTesterBase
+{
+	/**
+	 * Test !monitors deadlock
+	 *     Test Case #3
+	 *  JSS, JSS deadlock.
+	 */
+	
+	public void testDeadlock3()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
+		
+		if (null == output) {
+			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
+		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_SECOND_MON, 1));
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase4.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase4.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit.deadlock;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestDeadlockCase4 extends DDRExtTesterBase
+{
+	/**
+	 * Test !monitors deadlock
+	 *     Test Case #4
+	 *   JSS, NSS deadlock.
+	 */
+	
+	public void testDeadlock4()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
+		
+		if (null == output) {
+			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		// N.B. The order in which the threads are found is not well defined,
+		// thus in this case we may have "OS Thread" or "Thread" appear twice.
+		
+		assertTrue(validate(output, Constants.DEADLOCK_THREAD, null));
+		assertTrue(validate(output, Constants.DEADLOCK_OS_THREAD, null));
+		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_SECOND_MON, 1));
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase5.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase5.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit.deadlock;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestDeadlockCase5 extends DDRExtTesterBase
+{
+	/**
+	 * Test !monitors deadlock
+	 *     Test Case #5
+	 *	 NSS, NSS deadlock.
+	 */
+	
+	public void testDeadlock5()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
+		
+		if (null == output) {
+			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		assertTrue(validate(output, Constants.DEADLOCK_THREAD, 3));
+		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 2));
+		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_SECOND_MON, 1));
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase6.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/deadlock/TestDeadlockCase6.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.junit.deadlock;
+
+import j9vm.test.ddrext.Constants;
+import j9vm.test.ddrext.DDRExtTesterBase;
+
+public class TestDeadlockCase6 extends DDRExtTesterBase
+{
+	/**
+	 *   Test !monitors deadlock
+	 *        Test Case #6
+	 * Test JOS, NSS, JSO deadlock.
+	 */
+	
+	public void testDeadlock6()
+	{
+		String output = exec(Constants.MONITORS_CMD, new String[] { Constants.DEADLOCK_CMD });
+		
+		if (null == output) {
+			fail("\"!monitors deadlock\" output is null. Can not proceed with test");
+			return;
+		}
+		
+		// N.B. The order in which the threads are found is not well defined,
+		// thus in this case we may have "OS Thread" or "Thread" appear twice.
+		
+		assertTrue(validate(output, Constants.DEADLOCK_THREAD, null));
+		assertTrue(validate(output, Constants.DEADLOCK_OS_THREAD, null));
+		assertTrue(validate(output, Constants.DEADLOCK_BLOCKING_ON, 3));
+		assertTrue(validate(output, Constants.DEADLOCK_OWNED_BY, 3));
+		assertTrue(validate(output, Constants.DEADLOCK_FIRST_MON, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_SECOND_MON, 1));
+		assertTrue(validate(output, Constants.DEADLOCK_JAVA_OBJ, 1));
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/plugin/DDRJunitRunnerPlugin.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/plugin/DDRJunitRunnerPlugin.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.plugin;
+
+import j9vm.test.ddrext.AutoRun;
+import java.io.PrintStream;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.tools.ddrinteractive.annotations.DebugExtension;
+
+@DebugExtension(VMVersion = "*")
+public class DDRJunitRunnerPlugin extends Command {
+	public DDRJunitRunnerPlugin() {
+		addCommand("ddrjunit", "", "DDR Junit test runner plugin");
+
+	}
+
+	public void run(String command, String[] arguments, Context context,
+			PrintStream out) throws DDRInteractiveCommandException {
+		String testCaseList = "";
+		if (arguments.length == 0) {
+			testCaseList = "ALL";
+		} else {
+			testCaseList = arguments[0];
+		}
+		AutoRun.runTest(context, out, testCaseList);
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/plugin/DDRPluginsTestCmd.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/plugin/DDRPluginsTestCmd.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.plugin;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.tools.ddrinteractive.annotations.DebugExtension;
+
+@DebugExtension(VMVersion="*")
+public class DDRPluginsTestCmd extends Command
+{
+	public DDRPluginsTestCmd() {
+		addCommand("test", "", "DDRPluginsTestCmd");
+	}
+
+	public void run(String command, String[] arguments, Context context, PrintStream out)
+		throws DDRInteractiveCommandException
+	{
+		out.println(getClass().getName());
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/plugin/dumpsegments/DumpSegmentsVM29.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/plugin/dumpsegments/DumpSegmentsVM29.java
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.plugin.dumpsegments;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.tools.ddrinteractive.annotations.DebugExtension;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.gc.GCHeapRegionDescriptor;
+import com.ibm.j9ddr.vm29.j9.gc.GCHeapRegionIterator;
+import com.ibm.j9ddr.vm29.j9.walkers.MemorySegmentIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9MemorySegmentListPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9MemorySegmentPointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+
+@DebugExtension(VMVersion="29")
+public class DumpSegmentsVM29 extends Command {
+	private J9JavaVMPointer jvm = J9JavaVMPointer.NULL;
+//	private J9JavaVMPointer jvm = null;
+	
+	{
+		CommandDescription cd = addCommand("dumpsegs", "<segname(s)>", "Dumps out the segments for a given name");
+		cd.addSubCommand("all", "", "Dumps all memory segments");
+		cd.addSubCommand("int", "", "Internal Memory");
+		cd.addSubCommand("obj", "", "Object Memory");
+		cd.addSubCommand("class", "", "Class Memory");
+		cd.addSubCommand("jitc", "", "JIT code cache");
+		cd.addSubCommand("Ex", "", "shortcut for !dumpsegs obj,jitc,jitd");
+	}
+	
+	public void run(String command, String[] args, Context context, PrintStream out)
+		throws DDRInteractiveCommandException {
+			// TODO Auto-generated method stub
+
+			try {
+				jvm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+			} catch (Exception e) {
+				e.printStackTrace();
+				throw new DDRInteractiveCommandException("Could not locate the JVM pointer", e);
+			}
+			if (command.equalsIgnoreCase("!dumpallsegments")) {
+				try {
+					printAllMemorySegments(out);
+					return;
+				} catch (CorruptDataException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+			if( args.length == 0) {
+				printError("Syntax error!", out);
+				return;
+			}
+			for(int i=0 ; i< args.length; i++) {
+				String argument = args[i].toLowerCase();
+				int flag = 0;
+
+				if(argument.contains("all"))
+					try {
+						printAllMemorySegments(out);
+						return;
+					} catch (CorruptDataException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
+					if(argument.contains("obj"))
+						try {
+							printObjectMemory(out);
+							flag = 1;
+							out.println();
+						} catch (CorruptDataException e) {
+							// TODO Auto-generated catch block
+							e.printStackTrace();
+						}
+						if(argument.contains("int"))
+							try {
+								printInternalMemory(out);
+								flag = 1;
+								out.println();
+							} catch (CorruptDataException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+							if(argument.contains("class"))
+								try {
+									printClassMemory(out);
+									flag = 1;
+									out.println();
+								} catch (CorruptDataException e) {
+									// TODO Auto-generated catch block
+									e.printStackTrace();
+								}
+								if(argument.contains("jitc"))
+									try {
+										printJitCodeCache(out);
+										flag = 1;
+										out.println();
+									} catch (CorruptDataException e) {
+										// TODO Auto-generated catch block
+										e.printStackTrace();
+									}
+									if(argument.contains("jitd"))
+										try {
+											printJitDataCache(out);
+											flag = 1;
+											out.println();
+										} catch (CorruptDataException e) {
+											// TODO Auto-generated catch block
+											e.printStackTrace();
+										}
+										if(flag!=1) {
+											printError("Unknown argument "+args[i],out);
+											return;
+										}
+			}
+		}
+
+		private void printError(String errString, PrintStream out) {
+			// TODO Auto-generated method stub
+			out.println("Err! : "+errString);
+		}
+
+		private void printObjectMemory(PrintStream out) throws CorruptDataException {
+			//		out.println("--Object memory unavailable. Please use !dumpallregions--");
+			try {
+				objectSegmentIterateAndPrint(jvm.objectMemorySegments().longValue(), out, "Object Memory");
+			} catch (DDRInteractiveCommandException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+
+		private void printInternalMemory(PrintStream out) throws CorruptDataException {
+			segmentIterateAndPrint(jvm.memorySegments(), out, "Internal Memory");
+		}
+
+		private void printClassMemory(PrintStream out) throws CorruptDataException {
+			segmentIterateAndPrint(jvm.classMemorySegments(), out, "Class Memory");
+		}
+
+		private void printJitCodeCache(PrintStream out) throws CorruptDataException {
+			if (J9BuildFlags.interp_nativeSupport) {
+				if (jvm.jitConfig().isNull() == false) {
+					segmentIterateAndPrint(jvm.jitConfig().codeCacheList(), out, "JIT Code Cache");
+				}
+			}
+		}
+
+		private void printJitDataCache(PrintStream out) throws CorruptDataException {
+			if (J9BuildFlags.interp_nativeSupport) {
+				if (jvm.jitConfig().isNull() == false) {
+					segmentIterateAndPrint(jvm.jitConfig().dataCacheList(), out, "JIT Data Cache");
+				}
+			}
+		}
+
+		private void printAllMemorySegments(PrintStream out) throws CorruptDataException {
+			printInternalMemory(out);
+			out.println();
+			printObjectMemory(out);
+			out.println();
+			printClassMemory(out);
+			out.println();
+			printJitCodeCache(out);
+			out.println();
+			printJitDataCache(out);
+			out.println();
+		}
+
+		private void segmentIterateAndPrint(J9MemorySegmentListPointer segmentListPointer, PrintStream out, String memoryDescription) {
+			if(segmentListPointer == null) {
+				return ;
+			}
+			boolean reportFlag = false;
+			MemorySegmentIterator segmentIterator = new MemorySegmentIterator(segmentListPointer, MemorySegmentIterator.MEMORY_ALL_TYPES, false);
+			while (segmentIterator.hasNext()) {
+				J9MemorySegmentPointer nextSegment = (J9MemorySegmentPointer) segmentIterator.next();
+				try {
+					long start = nextSegment.heapBase().longValue();
+					long end = nextSegment.heapTop().longValue();
+					long segment = nextSegment.getAddress();
+					long alloc = nextSegment.heapAlloc().longValue();
+					long type = nextSegment.type().longValue();
+					long size = nextSegment.size().longValue();
+					if(!reportFlag) {
+						reportHeader(segment,out,memoryDescription,J9BuildFlags.env_data64);
+						reportFlag = true;
+					}
+					report(segment, start, alloc, end, type, size, out, memoryDescription, J9BuildFlags.env_data64);
+				} catch (CorruptDataException e) {
+					e.printStackTrace(out);
+				}
+			}
+
+			return ;
+		}
+
+		private void objectSegmentIterateAndPrint(long addr, PrintStream out, String memoryDescription) 
+		throws DDRInteractiveCommandException
+		{
+			boolean reportFlag = false;
+			try {
+				GCHeapRegionIterator gcHeapRegionIterator = GCHeapRegionIterator.from();
+				while(gcHeapRegionIterator.hasNext()) {
+					GCHeapRegionDescriptor heapRegionDescriptorPointer = gcHeapRegionIterator.next();
+
+					long start = heapRegionDescriptorPointer.getLowAddress().getAddress();
+					long end = heapRegionDescriptorPointer.getHighAddress().getAddress();
+					long region = heapRegionDescriptorPointer.getHeapRegionDescriptorPointer().getAddress();
+					long subspace = heapRegionDescriptorPointer.getHeapRegionDescriptorPointer()._memorySubSpace().getAddress();
+					long type = heapRegionDescriptorPointer.getRegionType();
+					long size = heapRegionDescriptorPointer.getSize().longValue();
+					if(!reportFlag) {
+						reportObjectHeader(out, J9BuildFlags.env_data64);
+						reportFlag = true;
+					}
+					reportObjectRegion(region, start, end, subspace, type, size, addr, out, J9BuildFlags.env_data64);
+
+				}
+			} catch (CorruptDataException e) {
+				throw new DDRInteractiveCommandException(e);
+			}
+			return ;
+		}
+
+		private void reportObjectRegion(long region, long start, long end, long subspace, long type, long size, long addr, PrintStream out, boolean is64Bit) 
+		{
+			if (is64Bit == true) {
+				out.append(String.format(" 0x%016X 0x%016X 0x%016X 0x%016X 0x%016X 0x%016X\n",  region, start, end, subspace, type, size));
+			} else {
+				out.append(String.format(" 0x%08X 0x%08X 0x%08X 0x%08X 0x%08X 0x%08X\n",  region, start, end, subspace, type, size));
+			}
+		}
+		
+		private void reportObjectHeader(PrintStream out, boolean is64Bit) 
+		{
+			out.append(String.format("%s \n", "Object Memory"));
+			if (is64Bit == true) {
+				
+				out.append("+------------------+------------------+------------------+------------------+------------------+------------------+\n");
+				out.append("|     region       |      start       |       end        |     subspace     |      type        |        size      |\n");
+				out.append("+------------------+------------------+------------------+------------------+------------------+------------------+\n");
+				
+			} else {
+				
+				out.append("+----------+----------+----------+----------+----------+----------+\n");
+				out.append("|  region  |  start   |   end    | subspace |   type   |   size   |\n");
+				out.append("+----------+----------+----------+----------+----------+----------+\n");
+				
+			}
+		}
+		
+		private void reportHeader(long segment, PrintStream out, String memoryDescription, boolean is64Bit) 
+		{
+			if (is64Bit == true) {
+				out.append(String.format("%s : - !j9memorysegment 0x%016X\n", memoryDescription, segment));
+				out.append("+------------------+------------------+------------------+------------------+------------------+------------------+\n");
+				out.append("|     segment      |      start       |      alloc       |       end        |      type        |        size      |\n");
+				out.append("+------------------+------------------+------------------+------------------+------------------+------------------+\n");
+			} else {
+				out.append(String.format("%s : - !j9memorysegment 0x%08X\n", memoryDescription, segment));
+				out.append("+----------+----------+----------+----------+----------+----------+\n");
+				out.append("| segment  |  start   |  alloc   |   end    |   type   |   size   |\n");
+				out.append("+----------+----------+----------+----------+----------+----------+\n");
+			}
+		}
+
+
+		private void report(long segment, long start, long alloc, long end, long type, long size, PrintStream out, String memoryDescription, boolean is64Bit) 
+		{
+			if (is64Bit == true) {
+				out.append(String.format(" 0x%016X 0x%016X 0x%016X 0x%016X 0x%016X 0x%016X\n",  segment, start, alloc,end,type, size));
+			} else {
+				out.append(String.format(" 0x%08X 0x%08X 0x%08X 0x%08X 0x%08X 0x%08X\n",  segment, start, alloc,end,type, size));
+			}
+		}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/CoreDumpGenerator.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/CoreDumpGenerator.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util;
+
+import j9vm.test.ddrext.Constants;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import org.testng.log4testng.Logger;
+
+public class CoreDumpGenerator {
+
+	private String command = null;
+	private String generatedCoreFile = null;
+	private static Logger log = Logger.getLogger(CoreDumpGenerator.class);
+	private String dumpName = null;
+
+	public CoreDumpGenerator(String javaHome, String j9vmSE60Jar) {
+		setDumpName(javaHome);
+		command = javaHome + Constants.FS + "java "
+				+ Constants.CORE_GEN_VM_XDUMP_OPTIONS + dumpName
+				+ Constants.CORE_GEN_VM_OPTIONS + " -cp " + j9vmSE60Jar
+				+ " j9vm.test.ddrext.util.CoreDumpUtil";
+	}
+
+	public String generateDump() {
+		String currentDir = System.getProperty("user.dir");
+		String dumpFileDir = currentDir + Constants.FS + dumpName;
+
+		// check if the dump file with the same name exists. If it does, delete
+		// it.
+		if (new File(dumpFileDir).exists()) {
+			new File(dumpFileDir).delete();
+			log.info("Deleted dump file :" + dumpFileDir);
+		}
+		log.debug("Current Dir: " + currentDir);
+		log.debug("Command: " + command);
+		try {
+			runCommand(command);
+
+		} catch (Exception e) {
+			log.error("Not able to execute command " + command);
+			e.printStackTrace();
+		}
+
+		// check if the dump file is actually generated
+		if (new File(dumpFileDir).exists()) {
+			return dumpFileDir;
+		} else {
+			return null;
+		}
+	}
+
+	public String generateDump(String dumpLocation) {
+
+		String os = System.getProperty("os.name");
+		String currentDir = System.getProperty("user.dir");
+		log.debug("Current Dir: " + currentDir);
+
+		try {
+			if (os.contains("windows") || os.contains("Windows")) {
+				// TO_DO:Change drive from C: to L:
+				// String drive = dumpLocation.substring(0,
+				// dumpLocation.indexOf(":")+1);
+				// log.debug("cd /D " + drive);
+				// runCommand("cd /D " + drive);
+				// change dir to dumpLocation
+				log.debug("mkdir -p " + dumpLocation);
+				runCommand("mkdir -p " + dumpLocation);
+				log.debug("cd /D " + dumpLocation);
+				runCommand("cd /D " + dumpLocation);
+				// generate dump in dumpLocation
+				log.debug("dump the core to " + dumpLocation);
+				log.debug("Command: " + command);
+				runCommand(command);
+			} else {
+				String[] commands = { "mkdir -p " + dumpLocation,
+						"cd " + dumpLocation, command };
+				runShellCommand(commands);
+			}
+
+		} catch (Exception e) {
+			log.error("Not able to execute command! ");
+			log.error(e.getMessage());
+			e.printStackTrace();
+		}
+
+		File f = new File(dumpLocation);
+		if (f.exists()) {
+			String[] files = f.list();
+			for (int i = 0; i < files.length; i++) {
+				if (files[i].contains(".dmp")) {
+					generatedCoreFile = dumpLocation + Constants.FS + files[i];
+					return generatedCoreFile;
+				}
+			}
+		} else {
+			log.error(dumpLocation + " doesn't exist!");
+		}
+		return null;
+	}
+
+	public void runCommand(String command) throws IOException {
+		Runtime runtime = Runtime.getRuntime();
+		Process process = null;
+
+		try {
+			process = runtime.exec(command);
+			process.waitFor();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		BufferedReader stdInput = new BufferedReader(new InputStreamReader(
+				process.getInputStream()));
+		BufferedReader stdError = new BufferedReader(new InputStreamReader(
+				process.getErrorStream()));
+		String s = null;
+		while ((s = stdInput.readLine()) != null) {
+			log.info(s);
+		}
+		while ((s = stdError.readLine()) != null) {
+			log.error(s);
+		}
+		stdInput.close();
+		stdError.close();
+	}
+
+	// command "cd " doesn't work in runCommand(String command) method, we have
+	// to start an instance of the shell,
+	// send its commands via the Process's OutputStream
+	public void runShellCommand(String[] commands) throws IOException {
+		Runtime runtime = Runtime.getRuntime();
+		Process process = null;
+
+		try {
+
+			/*
+			 * if (System.getProperty("os.name").contains("windows")||System.
+			 * getProperty("os.name").contains("Windows")){ process =
+			 * runtime.exec("cmd /c start run.bat"); }else{
+			 */
+			File workDir = new File("/bin");
+			process = runtime.exec("/bin/bash", null, workDir);
+			// process.waitFor();
+			// }
+
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		if (process != null) {
+			BufferedReader stdInput = new BufferedReader(new InputStreamReader(
+					process.getInputStream()));
+			BufferedReader stdError = new BufferedReader(new InputStreamReader(
+					process.getErrorStream()));
+			PrintWriter out = new PrintWriter(new BufferedWriter(
+					new OutputStreamWriter(process.getOutputStream())), true);
+			for (String cmd : commands) {
+				out.println(cmd);
+				log.info(cmd);
+			}
+			out.println("exit");
+
+			try {
+				String s = null;
+				while ((s = stdInput.readLine()) != null) {
+					log.info(s);
+				}
+				while ((s = stdError.readLine()) != null) {
+					log.error(s);
+				}
+
+				process.waitFor();
+				out.close();
+				stdInput.close();
+				stdError.close();
+				process.destroy();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	private void setDumpName(String javaHome) {
+		String platform = null;
+		if (javaHome.contains("sdk") && javaHome.contains("jre")) {
+			platform = javaHome.substring(javaHome.indexOf("sdk") + 4,
+					javaHome.indexOf("jre") - 1);
+		} else if (javaHome.contains("sdk")) {
+			platform = javaHome.substring(javaHome.indexOf("sdk") + 4);
+		} else {
+			log.warn("Not able to get the platform. Set the dump name to j9core");
+			platform = "j9core";
+		}
+		platform.replace(Constants.FS, "");
+		dumpName = platform + ".dmp";
+		log.debug("dumpName: " + dumpName);
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/CoreDumpUtil.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/CoreDumpUtil.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util;
+
+public class CoreDumpUtil {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		try {
+			ThreadWorker w1 = new ThreadWorker();
+			ThreadWorker w2 = new ThreadWorker();
+			w1.start();
+			w2.start();
+			Thread.sleep(4000);
+			com.ibm.jvm.Dump.SystemDump();
+			w1.interrupt();
+			w2.interrupt();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+}
+
+class ThreadWorker extends Thread {
+	public void run() {
+		int i = 0;
+		while (true) {
+			try {
+				i = i + 1;
+				sleep(1000);
+			} catch (InterruptedException e) {
+				// System.out.println("Closing thread : "+Thread.currentThread().getName());
+				break;
+			}
+		}
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/DDROutputStream.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/DDROutputStream.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util;
+
+import j9vm.test.ddrext.Constants;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class DDROutputStream extends PrintStream {
+	private StringBuffer outBuff;
+
+	public DDROutputStream(OutputStream out) {
+		super(out);
+		outBuff = new StringBuffer();
+	}
+
+	@Override
+	public void print(String x) {
+		outBuff.append(x);
+	}
+
+	@Override
+	public void println() {
+		print(Constants.NL);
+	}
+
+	public void println(String x) {
+		print(x + Constants.NL);
+	}
+
+	@Override
+	public PrintStream printf(String format, Object... args) {
+		outBuff.append(String.format(format, args));
+		return this;
+	}
+	
+	public StringBuffer getOutBuffer() {
+		return outBuff;
+	}
+
+	public void clear() {
+		outBuff.delete(0, outBuff.length());
+	}
+
+	@Override
+	public PrintStream append(char c) {
+		outBuff.append(c);
+		return this;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/GenerateCore.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/GenerateCore.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util;
+
+import j9vm.test.ddrext.Constants;
+
+import java.net.URL;
+import org.testng.log4testng.Logger;
+
+public class GenerateCore {
+
+	private static Logger log = Logger.getLogger(GenerateCore.class);
+
+	/**
+	 * @param args
+	 *            args[0] -- Java home e.g./bluebird/builds/bld_87583/SDK
+	 *            args[1] -- Optional, core dump locatiion.If not specify, store
+	 *            the core dump to the default location e.g. under current build
+	 *            folder
+	 */
+	public static void main(String[] args) {
+
+		if (args.length == 2 || args.length == 1) {
+			String javaHome = args[0];
+			String dumpLocation = null;
+			// find j9vm_SE60.jar path
+			String j9vmSE60Jar = findJ9vmSE60Jar(Constants.CORE_GEN_CLASS);
+
+			String os = System.getProperty("os.name");
+			log.debug("Run Test on " + os);
+
+			// find platform name e.g. ap3270 in java home path
+			// e.g./bluebird/builds/bld_87722/sdk/ap3270/jre/bin
+			log.debug("Java Home: " + javaHome);
+			String platform = javaHome.substring(javaHome.indexOf("sdk") + 4,
+					javaHome.indexOf("jre") - 1);
+
+			if (args.length == 2) {
+				dumpLocation = args[1] + Constants.FS + platform;
+			} else {
+				String beforeSDK = javaHome.substring(0,
+						javaHome.indexOf("sdk"));
+				String coreFolder = Constants.CORE_DUMP_FOLDER;
+				log.debug("beforeSDK:  " + beforeSDK + ",core folder:"
+						+ coreFolder + ", platform:" + platform);
+				dumpLocation = beforeSDK + coreFolder + Constants.FS + platform;
+			}
+
+			log.debug("dumpLocation: " + dumpLocation);
+			log.info("Start to Generate Core using: " + javaHome + " and "
+					+ Constants.CORE_GEN_CLASS + " in " + dumpLocation);
+			CoreDumpGenerator dumpGenerator = new CoreDumpGenerator(javaHome,
+					j9vmSE60Jar);
+			String generatedCoreFile = dumpGenerator.generateDump(dumpLocation);
+			if (generatedCoreFile == null) {
+				log.error("FAIL! No dynamic dump created");
+			} else {
+				log.info("SUCCESS! Ddynamic dump is created:"
+						+ generatedCoreFile);
+			}
+		} else {
+			log.error("Please provide java_home and the locatin to store the generated core dump(option, the default location is java_home\\[platform])");
+		}
+	}
+
+	// provide class name, find the jar location
+	public static String findJ9vmSE60Jar(String aClassInJar) {
+		URL location = aClassInJar.getClass()
+				.getResource(
+						'/' + CoreDumpUtil.class.getName().replace(".", "/")
+								+ ".class");
+		String jarPath = location.getPath();
+		log.info("Jar path:" + jarPath);
+		return jarPath.substring("file:".length(), jarPath.lastIndexOf("!"));
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ClassForNameOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ClassForNameOutputParser.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+package j9vm.test.ddrext.util.parser;
+
+
+import java.util.ArrayList;
+
+import org.testng.log4testng.Logger;
+import j9vm.test.ddrext.Constants;
+
+public class ClassForNameOutputParser {
+	
+	private static Logger log = Logger.getLogger(ClassForNameOutputParser.class);
+
+	/*
+	 * Sample !classforname output :
+	 * 
+	 * >!classforname java/lang/Object 
+	 * Searching for classes named 'java/lang/Object' in VM=1006d2f8 
+	 * !j9class 0x101B8300 named java/lang/Object 
+	 * Found 1 class(es) named java/lang/Object
+	 */
+	/**
+	 * This method is used to extract the j9class address from !classforname output. 
+	 * 
+	 * @param fineClassForNameOutput !classforname output  
+	 * @return String representation of extracted j9class address from !classforname extension. 
+	 *         return null, if any error occurs or address can not be found in given !findVM output. 	
+	 */
+	public static String extractClassAddress(String classForNameOutput) {
+		if (null == classForNameOutput) {
+			log.error("!classforname output is null");
+			return null;
+		}
+		
+		String[] outputLines = classForNameOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("!j9class")) {
+				String[] tokens = aLine.split(" ");
+				return tokens[1].trim();
+			}
+		}
+		return null;
+	}
+	
+	/*
+	 * Sample !classforname output :
+	 * 
+	 * >!classforname java/lang/Object 
+	 * Searching for classes named 'java/lang/Object' in VM=1006d2f8 
+	 * !j9class 0x101B8300 named java/lang/Object
+	 * !j9class 0x102A9400 names java/lang/Object
+	 * Found 2 class(es) named java/lang/Object
+	 */
+	/**
+	 * This method is used to extract list of all j9class addresses from !classforname output. 
+	 * 
+	 * @param fineClassForNameOutput !classforname output  
+	 * @return ArrayList containing all extracted j9class addresses from !classforname extension. 
+	 *         return null, if any error occurs or address can not be found in given !findVM output. 	
+	 */
+	public static ArrayList<String> extractClassAddressList(String classForNameOutput) {
+		if (null == classForNameOutput) {
+			log.error("!classforname output is null");
+			return null;
+		}
+		ArrayList<String> addrList = new ArrayList<String>();
+		String[] outputLines = classForNameOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("!j9class")) {
+				String[] tokens = aLine.split("\\s");
+				addrList.add(tokens[1].trim());
+			}
+		}
+		if (addrList.size() != 0) {
+			return addrList;
+		}
+		return null;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/DumpRomClassOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/DumpRomClassOutputParser.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import org.testng.log4testng.Logger;
+
+/**
+ * This class is used to extract info from !dumpromclass <address> DDR extension output
+ * @author ashutosh
+ *
+ */
+public class DumpRomClassOutputParser {
+	private static Logger log = Logger.getLogger(DumpRomClassOutputParser.class);
+	private String[] outputLines;
+	
+	public DumpRomClassOutputParser(String dumpRomClassOutput) {
+		if (null == dumpRomClassOutput) {
+			log.error("!dumpromclass output is null");
+		}
+		outputLines = dumpRomClassOutput.split(Constants.NL);
+	}
+	
+	/**
+	 * This method finds the address of intermediate class data from !dumpromclass output.
+	 * 
+	 * Sample output:
+	 * 	Intermediate Class Data (50434 bytes): 7fef1ef6a0f8
+	 * 
+	 * @return
+	 */
+	public String extractIntermediateDataAddr() {
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("Intermediate Class Data")) {
+				String[] tokens = aLine.split("\\s");
+				return "0x" + tokens[tokens.length-1];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * This method finds the size of intermediate class data from !dumpromclass output.
+	 * 
+	 * Sample output:
+	 * 	Intermediate Class Data (50434 bytes): 7fef1ef6a0f8
+	 * 
+	 * @return
+	 */
+	public int extractIntermediateDataLength() {
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("Intermediate Class Data")) {
+				String size = aLine.substring(aLine.indexOf("(")+1, aLine.indexOf(" ", aLine.indexOf("(")));
+				int intermediateDataLength = Integer.parseInt(size);
+				return intermediateDataLength;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * This method finds the size of J9ROMClass class data from !dumpromclass output.
+	 * 
+	 * Sample output:
+	 * 	ROM Size: 0x138 (312)
+	 * 
+	 * @return
+	 */
+	public int extractROMClassSize() {
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("ROM Size")) {
+				String size = aLine.substring(aLine.indexOf("(")+1, aLine.indexOf(")"));
+				int intermediateDataLength = Integer.parseInt(size);
+				return intermediateDataLength;
+			}
+		}
+		return 0;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/FindVMOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/FindVMOutputParser.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import java.util.StringTokenizer;
+import org.testng.log4testng.Logger;
+
+
+/**
+ * @author fkaraman
+ *
+ * This class parses the !findVM DDR extension output and finds/returns the specific value from the output. 
+ * 
+ * Sample output of !findVM
+ * 
+ * !j9javavm 0x000BAE08
+ * 
+ */
+public class FindVMOutputParser {
+	
+	private static Logger log = Logger.getLogger(FindVMOutputParser.class);
+	
+	/**
+	 * This method is used to extract the j9javavm address from !findvm output. 
+	 * 
+	 * @param findVMOutput Output of !findvm extension run.  
+	 * @return String representation of extracted java vm address from !findvm extension. 
+	 *         return null, if any error occurs or address can not be found in given !findVM output. 	
+	 */
+	public static String getJ9JavaVMAddress(String findVMOutput) {
+		if (null == findVMOutput) {
+			log.error("!findvm output is null");
+			return null;
+		}
+		StringTokenizer tokenizer = new StringTokenizer(findVMOutput);
+		String token; 
+		/**
+		 * Check whether !findvm output starts with !j9javavm 
+		 */
+		if (tokenizer.hasMoreTokens()) {
+			token = tokenizer.nextToken();
+			/*Do sanity check for the first token. It should be !j9javavm */
+			if (!token.equals("!" + Constants.J9JAVAVM_CMD)) {
+				log.error("Unexpected start of !findVM output. Expected : !" + Constants.J9JAVAVM_CMD + "Found: " + token + "\nOutput: \n" + findVMOutput);
+				return null;
+			}
+		} else {
+			log.error("!" + Constants.FINDVM_CMD + " output is empty.");
+			return null;
+		}
+		
+		/* Next token after !j9javavm should be the vm address */
+		if (tokenizer.hasMoreTokens()) {
+			token = tokenizer.nextToken();
+			return token;
+		} else {
+			log.error("j9javavm address is missing in the output : " + findVMOutput);
+			return null;	
+		}
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ClassOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ClassOutputParser.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import org.testng.log4testng.Logger;
+
+/**
+ * This class is used to extract info from !j9class <address> DDR extension output
+ * @author ashutosh
+ *
+ */
+public class J9ClassOutputParser {
+	private static Logger log = Logger.getLogger(J9ClassOutputParser.class);
+
+	/**
+	 * This method finds the address of J9ROMClass from !j9class output.
+	 * 
+	 * Sample output:
+	 * 	0x8: struct J9ROMClass * romClass = !j9romclass 0x00007FECADCF23A0
+	 * 
+	 * @param j9ClassOutput
+	 * @return
+	 */
+	public static String extractRomClassAddr(String j9ClassOutput) {
+		if (null == j9ClassOutput) {
+			log.error("!j9class output is null");
+			return null;
+		}
+		
+		String[] outputLines = j9ClassOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.indexOf("struct J9ROMClass * romClass") != -1) {
+				/* split around whitespace and use the last token to get romClass address */
+				String tokens[] = aLine.split("\\s");
+				String addr = tokens[tokens.length-1];
+				/* remove leading zeroes if any */
+				return ParserUtil.removeExtraZero(addr);
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * This method finds the address of arrayClass from !j9class output.
+	 * 
+	 * Sample output:
+	 * 	0x50: struct J9Class * arrayClass = !j9class 0x0000000001DE8500 // [Ljava/lang/Object;
+	 * 
+	 * @param j9ClassOutput
+	 * @return
+	 */
+	public static String extractArrayClassAddr(String j9ClassOutput) {
+		if (null == j9ClassOutput) {
+			log.error("!j9class output is null");
+			return null;
+		}
+		
+		String[] outputLines = j9ClassOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.indexOf("struct J9Class * arrayClass") != -1) {
+				/* split around whitespace and use the token next to "!j9class" to get arrayClass address */
+				String tokens[] = aLine.split("\\s");
+				int i = 0;
+				while (!tokens[i].equals("!j9class")) {
+					i++;
+				}
+				/* remove leading zeroes if any */
+				return ParserUtil.removeExtraZero(tokens[i+1]);
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * This method finds the address of replacedClass from !j9class output.
+	 * 
+	 * Sample output:
+	 * 	0x50: struct J9Class * replacedClass = !j9class 0x0000000001DE8500 // [Ljava/lang/Object;
+	 * 
+	 * @param j9ClassOutput
+	 * @return
+	 */
+	public static String extractReplacedClassAddr(String j9ClassOutput) {
+		if (null == j9ClassOutput) {
+			log.error("!j9class output is null");
+			return null;
+		}
+		
+		String[] outputLines = j9ClassOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.indexOf("struct J9Class * replacedClass") != -1) {
+				/* split around whitespace and use the token next to "!j9class" to get replacedClass address */
+				String tokens[] = aLine.split("\\s");
+				int i = 0;
+				while (!tokens[i].equals("!j9class")) {
+					i++;
+				}
+				/* remove leading zeroes if any */
+				return ParserUtil.removeExtraZero(tokens[i+1]);
+			}
+		}
+		return null;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9JavaVmOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9JavaVmOutputParser.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+/**
+ * This class is being used to extract info from !j9javavm <address> DDR extension output 
+ * @author fkaraman
+ *
+ */
+public class J9JavaVmOutputParser {
+	private static final String FIELDSIGNATURE_MAINTHREAD = "* mainThread";
+	private static final String FIELDSIGNATURE_DLLLOADTABLE = "* dllLoadTable";
+	private static final String FIELDSIGNATURE_SYSTEMPROPERTIES = "* systemProperties";
+	private static final String FIELDSIGNATURE_CLASSLOADINGSTACKPOOL = "* classLoadingStackPool";
+	private static final String FIELDSIGNATURE_VMTHREADPOOL = "* vmThreadPool";
+	private static final String FIELDSIGNATURE_CLASSLOADERSBLOCKS = "* classLoaderBlocks";
+	
+	
+	/**
+	 * This method finds the address of mainThread from !j9javavm output
+	 * 
+	 * @param j9javavmOutput
+	 * @return address of mainThread. 
+	 */
+	public static String getMainThreadAddress(String j9javavmOutput) {
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_MAINTHREAD, Constants.J9VMTHREAD_CMD, j9javavmOutput);
+	}
+
+	/**
+	 * This method finds the address of dllLoadTable from !j9javavm output
+	 * 
+	 * @param j9javavmOutput
+	 * @return address of dllLoadTable. 
+	 */
+	public static String getDllLoadTableAddress(String j9javavmOutput) 
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_DLLLOADTABLE, Constants.J9POOL_CMD, j9javavmOutput);	
+	}
+	
+	/**
+	 * This method finds the address of systemProperties from !j9javavm output
+	 * 
+	 * @param j9javavmOutput
+	 * @return address of systemProperties. 
+	 */
+	public static String getSystemPropertiesAddress(String j9javavmOutput) 
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_SYSTEMPROPERTIES, Constants.J9POOL_CMD, j9javavmOutput);	
+	}
+
+	/**
+	 * This method finds the address of vmThreadPool from !j9javavm output
+	 * 
+	 * @param j9javavmOutput
+	 * @return address of vmThreadPool. 
+	 */
+	public static String getVmThreadPoolAddress(String j9javavmOutput) 
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_VMTHREADPOOL, Constants.J9POOL_CMD, j9javavmOutput);	
+	}
+
+	/**
+	 * This method finds the address of classLoaderBlocks from !j9javavm output
+	 * 
+	 * @param j9javavmOutput
+	 * @return address of classLoaderBlocks. 
+	 */
+	public static String getClassLoaderBlocksAddress(String j9javavmOutput) 
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_CLASSLOADERSBLOCKS, Constants.J9POOL_CMD, j9javavmOutput);	
+	}
+
+	/**
+	 * This method finds the address of classLoadingStackPool from !j9javavm output
+	 * 
+	 * @param j9javavmOutput
+	 * @return address of classLoadingStackPool. 
+	 */
+	public static String getClassLoadingStackPoolAddress(String j9javavmOutput) 
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_CLASSLOADINGSTACKPOOL, Constants.J9POOL_CMD, j9javavmOutput);	
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9MethodOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9MethodOutputParser.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package j9vm.test.ddrext.util.parser;
+
+
+import org.testng.log4testng.Logger;
+import j9vm.test.ddrext.Constants;
+
+public class J9MethodOutputParser {
+	
+	private static Logger log = Logger.getLogger(J9MethodOutputParser.class);
+
+	/*
+	 * Sample !j9method output :
+	 * 
+	 *  > !j9method 0x41FCDB04
+	 *  J9Method at 0x41fcdb04 {
+     *  0x0: U8 * bytecodes = !j9x 0x42D0DA60
+     *  0x4: struct J9ConstantPool * constantPool = !j9constantpool 0x41FCD4A0
+     *  0x8: void * methodRunAddress = !j9x 0x7F9ACA10
+     *  0xc: void * extra = !j9x 0x7F9ACA11
+	 */
+	 /** This method is used to extract the methodRunAddress from !j9method output.
+	  * 
+	 * @param j9methodOutput !j9method output
+	 * 
+	 * @return String representation of extracted methodRunAddress from
+	 * !j9method extension. return null, if any error occurs or address
+	 * can not be found in given !j9method output.
+	 */
+	public static String extractMethodAddress(String j9methodOutput) {
+		if (null == j9methodOutput) {
+			log.error("!j9method output is null");
+			return null;
+		}
+
+		String[] outputLines = j9methodOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.contains("methodRunAddress")) {
+				String[] tokens = aLine.split("methodRunAddress");
+				System.out.println(tokens[1].trim().split(" ")[2].trim());
+				return tokens[1].trim().split(" ")[2].trim();
+			}
+		}
+		return null;
+	}
+
+	/** This method is used to extract the bytecode from !j9method output.
+	  * 
+	 * @param j9methodOutput !j9method output
+	 * 
+	 * @return String representation of extracted bytecode from
+	 * !j9method extension. return null, if any error occurs or address
+	 * can not be found in given !j9method output.
+	 */
+	public static String extractByteCodesAddress(String j9methodOutput) {
+		if (null == j9methodOutput) {
+			log.error("!j9method output is null");
+			return null;
+		}
+		
+		String[] outputLines = j9methodOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.contains("!bytecodes")) {
+				return aLine.split("bytecodes")[1].trim();
+			}
+		}
+		return null;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9PoolOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9PoolOutputParser.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+/**
+ * This class is used to extract info from !j9pool <address> DDR extension output
+ * @author fkaraman
+ *
+ */
+public class J9PoolOutputParser {
+	private static final String FIELDSIGNATURE_PUDDLELIST = "J9WSRP(struct J9PoolPuddle) puddleList";
+	private static final String FIELDSIGNATURE_PUDDLELIST_v1 = "J9WSRP(struct J9PoolPuddleList) puddleList";
+	
+	
+	/**
+	 * This method finds the address of j9poolpuddlelist from !j9pool output
+	 * @param j9poolOutput
+	 * @return
+	 */
+	public static String getPuddleListAddress(String j9poolOutput) {
+		String addr = ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_PUDDLELIST_v1, Constants.J9POOLPUDDLELIST_CMD, j9poolOutput);
+		/* If it is old shipped vm, then use the old signature to extract the info */
+		if (null == addr) {
+			addr = ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_PUDDLELIST, Constants.J9POOLPUDDLE_CMD, j9poolOutput);
+		}
+		
+		return addr;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9PoolPuddleListOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9PoolPuddleListOutputParser.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+/**
+ * This class is being used to extract info from !j9poolpuddlelist <address> DDR extension output 
+ * @author fkaraman
+ *
+ */
+public class J9PoolPuddleListOutputParser {
+	private static final String FIELDNAME_NUMELEMENTS = "numElements";
+	
+	/**
+	 * This method finds the value of the field numElements from !j9poolpuddlelist output
+	 * @param j9poolPuddeListOutput
+	 * @return
+	 */
+	public static String getnumElementsValue(String j9poolPuddeListOutput) {
+		return ParserUtil.getFieldAddressOrValue(FIELDNAME_NUMELEMENTS, null, j9poolPuddeListOutput);
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9RomClassOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9RomClassOutputParser.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import org.testng.log4testng.Logger;
+
+/**
+ * This class is used to extract info from !j9romclass <address> DDR extension output
+ * @author ashutosh
+ *
+ */
+public class J9RomClassOutputParser {
+	private static Logger log = Logger.getLogger(J9RomClassOutputParser.class);
+	
+	/**
+	 * This method finds the address of J9UTF8 representing the className from !j9romclass output.
+	 * 
+	 * Sample output:
+	 * 	0x8: J9SRP(struct J9UTF8) className = !j9utf8 0x00007FECADCD107A
+	 * 
+	 * @param j9RomClassOutput
+	 * @return
+	 */
+	public static String extractClassNameAddr(String j9RomClassOutput) {
+		if (null == j9RomClassOutput) {
+			log.error("!j9romclass output is null");
+			return null;
+		}
+		
+		String[] outputLines = j9RomClassOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.indexOf("className =") != -1) {
+				/* split around whitespace and use the last token to get class name address */
+				String tokens[] = aLine.split("\\s");
+				String addr = tokens[tokens.length-1];
+				return addr;
+			}
+		}
+		return null;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/MethodForNameOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/MethodForNameOutputParser.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package j9vm.test.ddrext.util.parser;
+
+
+import org.testng.log4testng.Logger;
+import j9vm.test.ddrext.Constants;
+
+public class MethodForNameOutputParser {
+	
+	private static Logger log = Logger.getLogger(MethodForNameOutputParser.class);
+
+	/*
+	 * Sample !methodforname output :
+	 * 
+	 * > !methodforname java/lang/System.arraycopy 
+	 * Searching for methods named 'java/lang/System.arraycopy' in VM=0x000BAEE8... 
+	 * !j9method 0x41FCDB04 -->
+	 * java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V
+	 * !j9method 0x41FCDB14 -->
+	 * java/lang/System.arraycopy([Ljava/lang/Object;I[Ljava/lang/Object;II)V
+	 * !j9method 0x41FCDB04 -->
+	 * java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V
+	 * !j9method 0x41FCDB14 -->
+	 * java/lang/System.arraycopy([Ljava/lang/Object;I[Ljava/lang/Object;II)V
+	 * Found 4 method(s) named java/lang/System.arraycopy
+	 * 
+	 * /** This method is used to extract the j9method address from
+	 * !methodforname output.
+	 * 
+	 * @param fineMethodForNameOutput !methodforname output
+	 * @param methodArguments JVM signature of the arguments to the method, e.g. "JI". 
+	 * 			This must be the full set of arguments or "null" to take the first matching method.
+	 * 
+	 * @return String representation of extracted j9metod address from
+	 * !methodforname extension. return null, if any error occurs or address
+	 * can not be found in given !methodforname output.
+	 */
+	public static String extractMethodAddress(String methodForNameOutput, String methodArguments) {
+		if (null == methodForNameOutput) {
+			log.error("!methodforname output is null");
+			return null;
+		}
+		
+		String[] outputLines = methodForNameOutput.split("!j9method");
+		for (String aLine : outputLines) {
+			if (aLine.contains("-->")) {
+				String[] tokens = aLine.split("-->");
+				String method = tokens[1].trim();
+				if (null == methodArguments 
+				|| method.substring(method.indexOf('(') + 1, method.indexOf(')')).equals(methodArguments)
+				) {
+					String address = tokens[0].trim();
+					return address;
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ParserUtil.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ParserUtil.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import java.math.BigInteger;
+import java.util.StringTokenizer;
+
+import org.testng.log4testng.Logger;
+
+/**
+ * This class offers utilities for parsing DDR extension outputs to extract info. 
+ * @author fkaraman
+ *
+ */
+public class ParserUtil {
+	private static Logger log = Logger.getLogger(FindVMOutputParser.class);
+	
+	/**
+	 * This method is being used to convert the given string into a BigInteger instance.
+	 * This method does not do check for value being null, 
+	 * it is callers responsibility to make it sure that it is not null.
+	 * 
+	 * @param value String representation of a number
+	 * @throws NumberFormatException If the given string value is not a decimal or hexadecimal number
+	 */
+	public static BigInteger toBigInteger(String value) throws NumberFormatException {
+		BigInteger bigInt;
+		
+		/* get rid of the spaces at the beginning and end if there is any */
+		value = value.trim();
+		
+		/* Check whether the value is hex or not */
+		if (value.startsWith(Constants.HEXADDRESS_HEADER)) {				
+			bigInt = new BigInteger(value.substring(Constants.HEXADDRESS_HEADER.length()), Constants.HEXADECIMAL_RADIX);
+		} else {
+			bigInt = new BigInteger(value, Constants.DECIMAL_RADIX);
+		}
+		
+		return bigInt;
+	}
+
+	/**
+	 *	This method finds the address of the field with specified signature and structureType.
+	 *	struct J9VMThread* mainThread = !j9vmthread 0x7cc8900
+	 *
+	 *	In the case where structureType is null, then it finds the value for the field with specified signature.
+	 *  UDATA parm->j2seVersion = 0x111700;
+	 * 
+	 * @param signature
+	 * @param structureType
+	 * @param extensionOutput !j9javavm output.
+	 * @return address or value for the field with specified signature
+	 */
+	public static String getFieldAddressOrValue(String signature, String structureType, String extensionOutput ) {
+		if (null == extensionOutput) {
+			log.error("!j9javavm output is null");
+			return null;
+		}
+		
+		String [] lines = extensionOutput.split("\n");
+		for (int i = 0; i < lines.length; i++) {
+			String currentLine = lines[i];
+			/* The line for <signature> is found. */
+			if (currentLine.trim().indexOf(signature) != -1) {
+				StringTokenizer tokenizer = new StringTokenizer(currentLine);
+				while (tokenizer.hasMoreElements()) {
+					String token = tokenizer.nextToken();
+					if (null != structureType) {
+						/*
+						 * The next token after !<structureType> token is the address of the field with the specified signature.
+						 */
+						if (token.startsWith("!" + structureType)) {
+							if (tokenizer.hasMoreElements()) {
+								return tokenizer.nextToken();
+							} else {
+								/* Should never happen */
+								log.error("!" + structureType + " address is missing in !j9javavm output : " + currentLine);
+								return null;
+							}
+						}		
+					} else {
+						/*
+						 * The value after '=' is the value for the field with the specified signature
+						 */
+						if (token.equals("=")) {
+							if (tokenizer.hasMoreElements()) {
+								return tokenizer.nextToken();
+							} else {
+								/* Should never happen */
+								log.error("Value is missing after = in !j9javavm output : " + currentLine);
+								return null;
+							}
+						}		
+					}
+				}
+				log.error("Unexpected info line in !j9javavm output. Missing string !" + structureType + "j9vmthread in : " + currentLine);
+				return null;
+			}
+		}
+		log.error("ParserUtil: missing line " + signature + ", structure type " + structureType + ", in debug extension output:\n " + extensionOutput);
+		return null;
+	}
+
+	/**
+	 * This method is being used to extract the first method name from !shrc
+	 * jitpstats output
+	 */
+	public static String getMethodNameFromJITPStats(String jitpStatsOutput) {
+		String[] lines = jitpStatsOutput.split(Constants.NL);
+
+		if (lines.length == 1) {
+			lines = jitpStatsOutput.split("\n");
+		}
+
+		for (int i = 0; i < lines.length; i++) {
+			int index = lines[i].indexOf("(");
+			if ((index != -1) && (lines[i].indexOf("!j9rommethod") != -1)) {
+				return lines[i].substring(0, index).trim();
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * This method is being used to extract the first method name from !shrc
+	 * jitpstats output
+	 */
+	public static String getMethodAddrForName(String jitpStatsOutput,
+			String methodFindInjitpStats) {
+		String[] lines = jitpStatsOutput.split(Constants.NL);
+
+		if (lines.length == 1) {
+			lines = jitpStatsOutput.split("\n");
+		}
+
+		for (int i = 0; i < lines.length; i++) {
+			if ((lines[i].indexOf(methodFindInjitpStats) != -1)
+					&& (lines[i].indexOf("!j9rommethod") != -1)) {
+				return lines[i].split("j9rommethod")[1].trim();
+			}
+		}
+
+		return null;
+	}
+	
+	/**
+	 * This method is used to remove leading zeroes in an address.
+	 * Eg input = 0x00007FECADCF23A0
+	 *    output = 0x7FECADCF23A0
+	 */
+	public static String removeExtraZero(String address) {
+		int nonZeroIndex = 2;
+		for (int j = 2; j < address.length(); j++) {
+			if (address.charAt(j) != '0') {
+				nonZeroIndex = j;
+				break;
+			}
+		}
+		return "0x" + address.substring(nonZeroIndex);
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/RomclassForNameOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/RomclassForNameOutputParser.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+package j9vm.test.ddrext.util.parser;
+
+
+import java.util.ArrayList;
+
+import org.testng.log4testng.Logger;
+import j9vm.test.ddrext.Constants;
+
+public class RomclassForNameOutputParser {
+	
+	private static Logger log = Logger.getLogger(RomclassForNameOutputParser.class);
+
+	/*
+	 * Sample !romclassforname output :
+	 * 
+	 * >!romclassforname java/lang/Object 
+	 * Searching for classes named 'java/lang/Object' in VM=1006d2f8 
+	 * !j9romclass 0x101B8300 named java/lang/Object
+	 * !j9romclass 0x102A9400 names java/lang/Object
+	 * Found 2 class(es) named java/lang/Object
+	 */
+	/**
+	 * This method is used to extract list of all j9class addresses from !romclassforname output. 
+	 * 
+	 * @param classForNameOutput !romclassforname output  
+	 * @return ArrayList containing all extracted j9class addresses from !romclassforname extension. 
+	 *         return null, if any error occurs or address can not be found in given !findVM output. 	
+	 */
+	public static ArrayList<String> extractRomclassAddressList(String romclassForNameOutput) {
+		if (null == romclassForNameOutput) {
+			log.error("!romclassforname output is null");
+			return null;
+		}
+		ArrayList<String> addrList = new ArrayList<String>();
+		String[] outputLines = romclassForNameOutput.split(Constants.NL);
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("!j9romclass")) {
+				String[] tokens = aLine.split("\\s");
+				addrList.add(tokens[1].trim());
+			}
+		}
+		if (addrList.size() != 0) {
+			return addrList;
+		}
+		return null;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ShrcStatsOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ShrcStatsOutputParser.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import java.util.ArrayList;
+
+import org.testng.log4testng.Logger;
+
+public class ShrcStatsOutputParser {
+	private static Logger log = Logger.getLogger(ShrcStatsOutputParser.class);
+	
+	/*
+	 * Sample output:
+	 * 	segment area     : 0x00007FADA701C000 - 0x00007FADA717CE28 size 1445416
+	 */
+	/**
+	 * This method is used to extract start address of ROMClass segment area in shared cache.
+	 * 
+	 * @param output
+	 * @return
+	 */
+	public static String extractROMClassSegmentStartAddr(String output) {
+		if (null == output) {
+			log.error("!shrc stats output is null");
+			return null;
+		}
+		
+		String[] outputLines = output.split("\n");
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("segment area")) {
+				int indexOfColon = aLine.indexOf(':');
+				String startAddr = aLine.substring(indexOfColon+1, aLine.indexOf("-", indexOfColon)).trim();
+				return startAddr;
+			}
+		}
+		return null;
+	}
+	
+	/*
+	 * Sample output:
+	 * 	segment area     : 0x00007FADA701C000 - 0x00007FADA717CE28 size 1445416
+	 */
+	/**
+	 * This method is used to extract end address of ROMClass segment area in shared cache.
+	 * 
+	 * @param output
+	 * @return
+	 */
+	public static String extractROMClassSegmentEndAddr(String output) {
+		if (null == output) {
+			log.error("!shrc stats output is null");
+			return null;
+		}
+		
+		String[] outputLines = output.split("\n");
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("segment area")) {
+				int indexOfHyphen = aLine.indexOf('-');
+				String endAddr = aLine.substring(indexOfHyphen+1, aLine.indexOf("size", indexOfHyphen)).trim();
+				return endAddr;
+			}
+		}
+		return null;
+	}
+	
+	public static String extractRawClassDataAreaStartAddr(String output) {
+		if (null == output) {
+			log.error("!shrc stats output is null");
+			return null;
+		}
+		
+		String[] outputLines = output.split("\n");
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("raw class area")) {
+				int indexOfColon = aLine.indexOf(':');
+				String startAddr = aLine.substring(indexOfColon+1, aLine.indexOf("-", indexOfColon)).trim();
+				return startAddr;
+			}
+		}
+		return null;
+	}
+	
+	public static String extractRawClassDataAreaEndAddr(String output) {
+		if (null == output) {
+			log.error("!shrc stats output is null");
+			return null;
+		}
+		
+		String[] outputLines = output.split("\n");
+		for (String aLine : outputLines) {
+			if (aLine.startsWith("raw class area")) {
+				int indexOfHyphen = aLine.indexOf('-');
+				String endAddr = aLine.substring(indexOfHyphen+1, aLine.indexOf("size", indexOfHyphen)).trim();
+				return endAddr;
+			}
+		}
+		return null;
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/StackSlotsOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/StackSlotsOutputParser.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import org.testng.log4testng.Logger;
+
+import j9vm.test.ddrext.Constants;
+
+public class StackSlotsOutputParser {
+
+	private static Logger log = Logger.getLogger(FindVMOutputParser.class);
+	private static final String pc = "pc = ";
+	
+	/*
+	 * Sample output of !stackslots <thread> command :
+	 * 
+	 * > !stackslots 0x05583400 
+	 * <5583400> *** BEGIN STACK WALK, flags = 00400001 walkThread = 0x0000000005583400 *** 
+	 * <5583400> ITERATE_O_SLOTS 
+	 * <5583400> RECORD_BYTECODE_PC_OFFSET 
+	 * <5583400> Initial values: walkSP = 0x00000000057A1BE8, PC = 0x0000000000000001, literals = 0x0000000000000000, A0 = 0x00000000057A1C00, j2iFrame = 0x0000000000000000, ELS = 0x0000000042118BE8, decomp = 0x0000000000000000
+	 * <5583400> Generic special frame: bp = 0x00000000057A1C00, sp = 0x00000000057A1BE8, pc = 0x0000000000000001, cp = 0x0000000000000000, arg0EA = 0x00000000057A1C00, flags = 0x0000000000000000 
+	 * <5583400> Bytecode frame: bp = 0x00000000057A1C18, sp = 0x00000000057A1C08, pc = 0x00002AAACE34F11E, cp = 0x000000000587B450, arg0EA = 0x00000000057A1C38, flags = 0x0000000000000000 
+	 * <5583400> Method: j9vm/test/corehelper/StackMapCoreGenerator.stackMapTestMethod_4()V !j9method 0x000000000587B678 
+	 * <5583400> Bytecode index = 14 
+	 * <5583400> Using local mapper 
+	 * <5583400> Locals starting at 0x00000000057A1C38 for 0x0000000000000004 slots 
+	 * <5583400> I-Slot: a0[0x00000000057A1C38] = 0x00002AAACCB7E3A0 
+	 * <5583400> I-Slot: t1[0x00000000057A1C30] = 0x0000000000000000 
+	 * <5583400> I-Slot: t2[0x00000000057A1C28] = 0x00002AAACCB7E3B0 
+	 * <5583400> I-Slot: t3[0x00000000057A1C20] = 0x000000000587B658 
+	 * <5583400> Bytecode frame: bp = 0x00000000057A1C50, sp = 0x00000000057A1C40, pc = 0x00002AAACE34F0F1, cp = 0x000000000587B450, arg0EA = 0x00000000057A1C60, flags = 0x0000000000000000 
+	 * <5583400> Method: j9vm/test/corehelper/StackMapCoreGenerator.stackMapTestMethod_3(I)V !j9method 0x000000000587B658 <5583400> Bytecode index = 1 
+	 * <5583400> Using local mapper 
+	 * <5583400> Locals starting at 0x00000000057A1C60 for 0x0000000000000002 slots 
+	 * <5583400> I-Slot: a0[0x00000000057A1C60] = 0x00002AAACCB7E3A0 
+	 * <5583400> I-Slot: a1[0x00000000057A1C58] = 0x000000000000000C 
+	 * <5583400> Bytecode frame: bp = 0x00000000057A1C78, sp = 0x00000000057A1C68, pc = 0x00002AAACE34F0D3, cp = 0x000000000587B450, arg0EA = 0x00000000057A1C98, flags = 0x0000000000000000 
+	 * <5583400> Method: j9vm/test/corehelper/StackMapCoreGenerator.stackMapTestMethod_2(ILj9vm/test/corehelper/StackMapCoreGenerator;)I !j9method 0x000000000587B638
+	 * <5583400> Bytecode index = 7 
+	 * <5583400> Using local mapper 
+	 * <5583400> Locals starting at 0x00000000057A1C98 for 0x0000000000000004 slots 
+	 * <5583400> I-Slot: a0[0x00000000057A1C98] = 0x00002AAACCB7E3A0 
+	 * <5583400> I-Slot: a1[0x00000000057A1C90] = 0x00002AAA0000000C 
+	 * <5583400> I-Slot: a2[0x00000000057A1C88] = 0x00002AAACCB7E3A0 
+	 * <5583400> I-Slot: t3[0x00000000057A1C80] = 0x00000000021D0F01
+	 */
+	
+	/**
+	 * This methods find out the PC value for the method names <methodName>
+	 * 
+	 * @arg stackSlotsOutput Output of !stackslots <vmthread> command.
+	 * @arg methodName Name of the method for which PC value will be found.
+	 * @return String of PC value.
+	 */
+	public static String getPCForMethodName(String stackSlotsOutput,
+			String methodName) {
+		String result;
+		int tempIndex;
+		
+		if (null == stackSlotsOutput) {
+			log.error("!stackslots output is null");
+			return null;
+		}
+		
+		if (null == methodName) {
+			log.error("method name is null");
+			return null;
+		}
+
+		/* Get the index of the method from the stackSlots string */
+		tempIndex = stackSlotsOutput.indexOf(methodName);
+
+		/* If the method is not in this stackslots, then return null */
+		if (-1 == tempIndex) {
+			log.error("method name (" + methodName + ") can not be found in !stackslots output: " + stackSlotsOutput);
+			return null;
+		}
+
+		/*
+		 * <5583400> Bytecode frame: bp = 0x00000000057A1C18, sp =
+		 * 0x00000000057A1C08, pc = 0x00002AAACE34F11E, cp = 0x000000000587B450,
+		 * arg0EA = 0x00000000057A1C38, flags = 0x0000000000000000 <5583400>
+		 * Method:
+		 * j9vm/test/corehelper/StackMapCoreGenerator.stackMapTestMethod_4()V
+		 * !j9method 0x000000000587B678
+		 * 
+		 * Since pc value for the method is written before the method name, then
+		 * trim the stackslots string after the method name index.
+		 */
+		result = stackSlotsOutput.substring(0, tempIndex);
+
+		/*
+		 * Get the pc start index of the one just before the method name. This
+		 * should be the pc corresponds to the method name.
+		 */
+		tempIndex = result.lastIndexOf(pc);
+
+		/* Do sanity check to see whether pc exist in the remaining string. */
+		if (-1 == tempIndex) {
+			log.error("pc value is missing for the method name (" + methodName + ") : " + result);
+			return null;
+		}
+
+		/*
+		 * Trim the beginning of the results string until the start of the pc
+		 * value
+		 */
+		result = result.substring(tempIndex + pc.length());
+
+		/*
+		 * Check whether the start of the remaining string corresponds to pc
+		 * value which starts with 0x
+		 */
+		if (!result.startsWith(Constants.HEXADDRESS_HEADER)) {
+			log.error("pc value do not start with 0x");
+			return null;
+		}
+
+		/*
+		 * PC value ends with comma, so trim the string until comma and that
+		 * should be the PC value string
+		 */
+		result = result.substring(0, result.indexOf(","));
+
+		return result;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ThreadsOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/ThreadsOutputParser.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.ddrext.util.parser;
+
+import java.util.StringTokenizer;
+
+import org.testng.log4testng.Logger;
+
+import j9vm.test.ddrext.Constants;
+
+public class ThreadsOutputParser {
+	
+	private static Logger log = Logger.getLogger(FindVMOutputParser.class);
+	/**
+	 * Following index values represents the indexes when thread string is split
+	 * by whitespaces Sample string : !stack 0x05583400 !j9vmthread 0x05583400
+	 * !j9thread 0x0553cb90 tid 0x3f00 (16128) // (main)
+	 */
+	private static final int THREAD_STACK_INDEX = 0;
+	private static final int THREAD_STACK_ADDR_INDEX = 1;
+	private static final int THREAD_J9VMTHREAD_INDEX = 2;
+	private static final int THREAD_J9VMTHREAD_ADDR_INDEX = 3;
+	private static final int THREAD_J9THREAD_INDEX = 4;
+	private static final int THREAD_J9THREAD_ADDR_INDEX = 5;
+	private static final int THREAD_TID_INDEX = 6;
+	private static final int THREAD_TID_VALUE_INDEX = 7;
+	private static final int THREAD_TID_VALUE_DECIMAL_INDEX = 8;
+	private static final int THREAD_NAME_INDEX = 10;
+
+	/*
+	 * Sample !threads output :
+	 * 
+	 * > !threads 
+	 * !stack 0x05583400 !j9vmthread 0x05583400 !j9thread 0x0553cb90 tid 0x3f00 (16128) // (main) 
+	 * !stack 0x0562d700 !j9vmthread 0x0562d700 !j9thread 0x056294f0 tid 0x3f02 (16130) // (JIT Compilation Thread-0)
+	 * !stack 0x05636f00 !j9vmthread 0x05636f00 !j9thread 0x05629a70 tid 0x3f03 (16131) // (JIT Compilation Thread-1) 
+	 * !stack 0x05641800 !j9vmthread 0x05641800 !j9thread 0x0563d580 tid 0x3f04 (16132) // (JIT Compilation Thread-2) 
+	 * !stack 0x0564b000 !j9vmthread 0x0564b000 !j9thread 0x0563db00 tid 0x3f05 (16133) // (JIT Compilation Thread-3) !stack 0x0566e100
+	 * !j9vmthread 0x0566e100 !j9thread 0x0566a270 tid 0x3f07 (16135) (IProfiler) 
+	 * !stack 0x2aaad0092000 !j9vmthread 0x2aaad0092000 !j9thread 0x2aaad008de60 tid 0x3f08 (16136) // (Signal Dispatcher) 
+	 * !stack 0x0588e400 !j9vmthread 0x0588e400 !j9thread 0x2aaad00aea50 tid 0x3f0a (16138) // (Concurrent Mark Helper) 
+	 * !stack 0x05b0a100 !j9vmthread 0x05b0a100 !j9thread 0x2aaad00aefd0 tid 0x3f0b (16139) // (GC Slave)
+	 * !stack 0x05b14300 !j9vmthread 0x05b14300 !j9thread 0x2aaad00afa60 tid 0x3f0c (16140) // (GC Slave) 
+	 * !stack 0x05b2e600 !j9vmthread 0x05b2e600 !j9thread 0x2aaad00affe0 tid 0x3f0d (16141) // (GC Slave) 
+	 * !stack 0x05b49800 !j9vmthread 0x05b49800 !j9thread 0x05b35690 tid 0x3f0e (16142) // (GC Slave) 
+	 * !stack 0x2aaad01faf00 !j9vmthread 0x2aaad01faf00 !j9thread 0x05b1a5d0 tid 0x3f1b (16155) // (Attach API wait loop) 
+	 * !stack 0x05b1e200 !j9vmthread 0x05b1e200 !j9thread 0x05b1a050 tid 0x3f1c (16156) // (Finalizer thread)
+	 */
+
+	/**
+	 * This method splits the !threads output into seperate thread info arrays.
+	 * !threads output prints one line per thread in the DDR output.
+	 * 
+	 * @param threadsOutput
+	 * @return array of strings for each thread in the !threads output.
+	 */
+	public static String[] getThreadsArray(String threadsOutput) {
+		String threadsArray[] = threadsOutput.split("\n");
+		for (int i = 0; i < threadsArray.length; i++) {
+			threadsArray[i] = threadsArray[i].trim();
+		}
+		return threadsArray;
+	}
+
+	/**
+	 * This methods returns the corresponding line from !threads output for the
+	 * specified thread name.
+	 * 
+	 * @param threadsOutput
+	 *            !threads output from DDR extensions
+	 * @param threadName
+	 *            Name of the thread whose thread info line is searched for in
+	 *            !threads output
+	 * @return A line of !threads output which corresponds to the searched
+	 *         threads name.
+	 */
+	private static String getThreadStringForThreadName(String threadsOutput,
+			String threadName) {
+		
+		if (null == threadsOutput) {
+			log.error("!threads output is null");
+			return null;
+		}
+		
+		String threadString = null;
+		String threadsArray[] = getThreadsArray(threadsOutput);
+
+		/* Find the thread line for the threadName */
+		for (int i = 0; i < threadsArray.length; i++) {
+			/* Thread names are printed in between (<threadName>) */
+			if (threadsArray[i].endsWith("(" + threadName + ")")) {
+				threadString = threadsArray[i];
+				break;
+			}
+		}
+		return threadString;
+	}
+
+	/**
+	 * This method finds the thread address of a specific thread by searching
+	 * its name in !threads output.
+	 * 
+	 * @param threadsOutput
+	 *            !threads output from DDR extensions
+	 * @param threadName
+	 *            Name of the thread whose thread address is being searched for
+	 * @return String representation of the thread address
+	 */
+	public static String getJ9ThreadAddress(String threadsOutput,
+			String threadName) {
+		
+		if (null == threadsOutput) {
+			log.error("!threads output is null");
+			return null;
+		}
+
+		/* Find the thread line for the threadName */
+		String threadString = getThreadStringForThreadName(threadsOutput, threadName);
+
+		/* Check whether the thread is found or not */
+		if (null == threadString) {
+			/* Thread does not exist in this !threads output */
+			return null;
+		}
+
+		/* Split thread string by using whitespaces */
+		StringTokenizer tokenizer = new StringTokenizer(threadString);
+
+		/* Find the j9thread address by using its index in the tokens list */
+		String token = null;
+		for (int i = 0; i <= THREAD_J9THREAD_ADDR_INDEX; i++) {
+			if (tokenizer.hasMoreElements()) {
+				token = tokenizer.nextToken();
+			} else {
+				return null;
+			}
+		}
+		return token;
+	}
+
+	/**
+	 * This method finds the VM thread address of a specific thread by searching
+	 * its name in !threads output.
+	 * 
+	 * @param threadsOutput
+	 *            !threads output from DDR extensions
+	 * @param threadName
+	 *            name of the thread whose VM thread address is being searched
+	 *            for
+	 * @return String representation of the VM thread address
+	 */
+	public static String getJ9VMThreadAddress(String threadsOutput,
+			String threadName) {
+		
+		if (null == threadsOutput) {
+			log.error("!threads output is null");
+			return null;
+		}
+		/* Find the thread line for the threadName */
+		String threadString = getThreadStringForThreadName(threadsOutput, threadName);
+
+		/* Check whether the thread is found or not */
+		if (null == threadString) {
+			/* Thread does not exist in this !threads output */
+			return null;
+		}
+
+		/* Split thread string by using whitespaces */
+		StringTokenizer tokenizer = new StringTokenizer(threadString);
+
+		/* Find the j9thread address by using its index in the tokens list */
+		String token = null;
+		for (int i = 0; i <= THREAD_J9VMTHREAD_ADDR_INDEX; i++) {
+			if (tokenizer.hasMoreElements()) {
+				token = tokenizer.nextToken();
+			} else {
+				return null;
+			}
+		}
+		return token;
+	}
+
+}

--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2016, 2018 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="DDR Extension Test" default="clean">
+	<taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+	<property name="JAVA_COMMAND" value="${JAVA_COMMAND}" />
+	<property name="TEST_ROOT" value="${TEST_ROOT}" />
+	<property name="JDK_HOME" value="${JDK_HOME}" />
+	<property name="TEST_RESROOT" value="${TEST_RESROOT}" />
+	<property name="REPORTDIR" value="${REPORTDIR}" />
+	<if>
+		<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+		<then>
+			<property name="j9ddr" location="${JDK_HOME}/jre/lib/ddr/j9ddr.jar" />
+		</then>
+		<else>
+			<property name="j9ddr" location="${JDK_HOME}/lib/ddr/j9ddr.jar" />
+		</else>
+	</if>
+	<property name="dump.name" value="DDREXT.J9CORE.DMP" />
+	<property name="system.dump" value="${REPORTDIR}/${dump.name}" />
+	<if>
+		<equals arg1="${OS}" arg2="os.zos"/>
+		<then>
+			<property name="DUMP_OPTION" value="-Xdump:system:events=vmstop,label=%uid.${dump.name},request=exclusive+compact+prepwalk -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M -version" />
+				<if>
+				<equals arg1="${BITS}" arg2="bits.64"/>
+				<then>
+					<property name="zos.core.suffix" value=".X001" />
+				</then>
+				<else>
+					<property name="zos.core.suffix" value="" />
+				</else>
+			</if>
+		</then>
+		<else>
+			<property name="DUMP_OPTION" value="-Xdump:system:events=vmstop,label=${system.dump},request=exclusive+compact+prepwalk -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M -version" />
+		</else>
+	</if>
+
+	<path id="tck.class.path">
+		<pathelement location="${TEST_ROOT}/TestConfig/lib/junit4.jar" />
+		<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar" />
+		<pathelement location="${TEST_ROOT}/TestConfig/lib/commons-exec.jar" />
+		<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar" />
+		<pathelement location="${TEST_ROOT}/TestConfig/lib/commons-cli.jar" />
+		<pathelement location="${RESOURCES_DIR}" />
+		<pathelement location="${TEST_RESROOT}/DDR_Test.jar" />
+		<pathelement location="${j9ddr}" />
+	</path>
+
+	<target name="TCK.destroy.cache" depends="TCK.generate.dump" description="Destroy the cache">
+			<echo>Destroying cache</echo>
+			<echo>Running j9vm.test.corehelper.StackMapCoreGenerator to destroy the cache</echo>
+			<echo>Using JVM : ${JAVA_COMMAND}</echo>
+			<echo>classname = "j9vm.test.corehelper.StackMapCoreGenerator"</echo>
+			<echo>Java VM Args:</echo>
+			<echo>	jvmarg = -Xshareclasses:name=ddrextjunitSCC,destroy</echo>
+			<echo></echo>
+			<java fork="true" jvm="${JAVA_COMMAND}" classname="j9vm.test.corehelper.StackMapCoreGenerator"
+				timeout="1200000" failonerror="false">
+				<jvmarg value="-Xshareclasses:name=ddrextjunitSCC,destroy"/>
+				<classpath refid="tck.class.path" />
+			</java>
+	</target>
+
+	<target name="TCK.run.tests.ddrext" depends="TCK.destroy.cache">
+		<echo>Running the DDR Extension Test</echo>
+		<java fork="true" jvm="${JAVA_COMMAND}" classname="j9vm.test.ddrext.AutoRun"
+			timeout="1200000" failonerror="true">
+			<jvmarg value="${ADDITIONALEXPORTS}" />
+			<arg value="${system.dump}" />
+			<arg value="${test.list}"/>	
+			<arg value="${TEST_RESROOT}/ddrplugin.jar" />
+			<classpath refid="tck.class.path" />
+		</java>
+	</target>
+
+	<target name="TCK.generate.dump">
+		<echo>Generate dump file</echo>
+		<exec executable="${JAVA_COMMAND}" failonerror="true">
+			<arg line="${DUMP_OPTION}" />
+		</exec>
+		<if>
+			<equals arg1="${OS}" arg2="os.zos"/>
+			<then>
+				<antcall target ="TCK.move.dump.ddrext" />
+			</then>
+		</if>
+	</target>
+
+	<target name="TCK.move.dump.ddrext" description="Move core file from MVS to HFS">
+			<echo>Moving core file from MVS [${dump.name}${zos.core.suffix}] to HFS [${system.dump}]</echo>
+			<exec executable="/bin/mv" failonerror="true">
+				<arg line="&quot;//${dump.name}${zos.core.suffix}&quot; ${system.dump}"/>
+			</exec>
+	</target>
+
+	<target name="clean" depends="TCK.run.tests.ddrext" description="clean">
+		<delete file="${system.dump}" />
+	</target>
+</project>


### PR DESCRIPTION
- Migrated tck_ddrext test suite into openJ9
- Removed DTFJ_TCK from the test framework
- Added core generation part into tck_ddrext.xml
- Fixed and enbaled testDDREx_General

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>