### PR TITLE
Add access check to invokespecialsplit

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6495,11 +6495,11 @@ done:
 						restoreGenericSpecialStackFrame(REGISTER_ARGS);
 						if (immediateAsyncPending()) {
 							rc = GOTO_ASYNC_CHECK;
-							goto exit;
+							goto done;
 						}
 						if (VM_VMHelpers::exceptionPending(_currentThread)) {
 							rc = GOTO_THROW_CURRENT_EXCEPTION;
-							goto exit;
+							goto done;
 						}
 					}
 					/* Check the receiver class is the subtype of the current class [= interface] */
@@ -6519,7 +6519,7 @@ done:
 				}
 			}
 		}
-exit:
+done:
 		return rc;
 	}
 
@@ -6534,7 +6534,8 @@ exit:
 		U_16 cpIndex = *(U_16 *)(J9ROMCLASS_SPECIALSPLITMETHODREFINDEXES(clazz->romClass) + splitTableIndex);
 		J9RAMSpecialMethodRef *ramMethodRef = (J9RAMSpecialMethodRef*)ramConstantPool + cpIndex;
 		/* argCount was initialized when we initialized the class (i.e. it is non-volatile), so no memory barrier is required */
-		if (0 == _sp[ramMethodRef->methodIndexAndArgCount & 0xFF]) {
+		j9object_t receiver = ((j9object_t *)_sp)[ramMethodRef->methodIndexAndArgCount & 0xFF];
+		if (NULL == receiver) {
 			rc = THROW_NPE;
 		} else {
 			_sendMethod = clazz->specialSplitMethodTable[splitTableIndex];
@@ -6546,14 +6547,50 @@ exit:
 				restoreGenericSpecialStackFrame(REGISTER_ARGS);
 				if (immediateAsyncPending()) {
 					rc = GOTO_ASYNC_CHECK;
+					goto done;
 				} else if (VM_VMHelpers::exceptionPending(_currentThread)) {
 					rc = GOTO_THROW_CURRENT_EXCEPTION;
+					goto done;
 				} else {
 					profileCallingMethod(REGISTER_ARGS);
 					_sendMethod = method;
 				}
 			}
+
+			J9Class *currentClass = J9_CLASS_FROM_CP(ramConstantPool);
+			/* hostClass is exclusively defined only in Unsafe.defineAnonymousClass.
+			 * For all other cases, clazz->hostClass points to itself (clazz).
+			 */
+			currentClass = currentClass->hostClass;
+
+			if (J9_ARE_ALL_BITS_SET(currentClass->romClass->modifiers, J9AccInterface)) {
+				J9ROMMethodRef *romMethodRef = (J9ROMMethodRef *)&ramConstantPool->romConstantPool[cpIndex];
+				J9ROMNameAndSignature *nameAndSig = J9ROMFIELDREF_NAMEANDSIGNATURE(romMethodRef);
+				J9UTF8 *nameUTF = J9ROMNAMEANDSIGNATURE_NAME(nameAndSig);
+				U_8 *name = J9UTF8_DATA(nameUTF);
+				UDATA nameLength = J9UTF8_LENGTH(nameUTF);
+
+				/* Ignore <init> or <clinit> methods */
+				if ((0 != nameLength) && (name[0] != '<')) {
+					/* Check the receiver class is the subtype of the current class [= interface] */
+					J9Class *resolvedClass = J9_CLASS_FROM_METHOD(_sendMethod);
+					J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_sendMethod);
+					/* Skip the check for final methods in java.lang.Object (resolvedClassDepth == 0) */
+					if ((0 != J9CLASS_DEPTH(resolvedClass)) || J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccFinal)) {
+						J9Class *receiverClass = J9OBJECT_CLAZZ(_currentThread, receiver);
+
+						if (!instanceOfOrCheckCast(receiverClass, currentClass)) {
+							buildMethodFrame(REGISTER_ARGS, _sendMethod, 0);
+							updateVMStruct(REGISTER_ARGS);
+							setIllegalAccessErrorReceiverNotSameOrSubtypeOfCurrentClass(_currentThread, receiverClass, currentClass);
+							VMStructHasBeenUpdated(REGISTER_ARGS);
+							rc = GOTO_THROW_CURRENT_EXCEPTION;
+						}
+					}
+				}
+			}
 		}
+done:
 		return rc;
 	}
 


### PR DESCRIPTION
Ensure the receiver class is sub class of the current class for
`JBinvokespecialsplit` bytecode to be consistent with `invokespecial`

Close: #2577 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>