### PR TITLE
[Condy] Update invokeWithArguments varargs

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -539,7 +539,7 @@ public abstract class MethodHandle {
 	/**
 	 * Invoke the MethodHandle using an Object[] of arguments.  The array must contain at exactly type().parameterCount() arguments.
 	 * 
-	 * Each of the arguments in the array with be coerced to the appropriate type, if possible, based on the MethodType.
+	 * Each of the arguments in the array will be coerced to the appropriate type, if possible, based on the MethodType.
 	 * 
 	 * @param args An array of Arguments, with length at exactly type().parameterCount() to be used in the call.
 	 * @return An Object

--- a/test/functional/Jsr292/playlist.xml
+++ b/test/functional/Jsr292/playlist.xml
@@ -73,9 +73,34 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
-			<subset>SE110</subset>
 		</subsets>
 	</test>
+
+        <test>
+                <testCaseName>jsr292Test_SE110</testCaseName>
+                <variations>
+                        <variation>NoOptions</variation>
+                        <variation>Mode195</variation>
+                </variations>
+                <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+        --add-opens=java.base/java.lang=ALL-UNNAMED \
+        -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+        -cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+        org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+        -testnames jsr292Test,jsr292Test_B95up,jsr292Test_Java11up,jsr292Test_optional \
+        -groups $(TEST_GROUP) \
+        -excludegroups $(DEFAULT_EXCLUDE); \
+        $(TEST_STATUS)</command>
+                <levels>
+                        <level>extended</level>
+                </levels>
+                <groups>
+                        <group>functional</group>
+                </groups>
+                <subsets>
+                        <subset>SE110</subset>
+                </subsets>
+        </test>
 
 	<test>
 		<testCaseName>jsr292Test_JitCount0_SE80</testCaseName>

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleInvokeWithArgumentsJumboTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleInvokeWithArgumentsJumboTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+
+import org.testng.annotations.Test;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * This class contains version specific tests for the MethodType API. 
+ */
+public class MethodHandleInvokeWithArgumentsJumboTest {
+	
+	/**
+	 * 500 characters: above standard argument limit for a MethodHandle. Additional arguments 
+	 * will be added to the final array argument.
+	 * @throws Throwable
+	 */
+	@Test(groups = { "level.extended" })
+	public void test_invokeWithArguments_VarArgs_LargeArity() throws Throwable {
+		MethodHandle mh = MethodHandles.lookup().findVirtual(MethodHandleInvokeWithArgumentsJumboTest.class, "helperVarArgsMethod", MethodType.methodType(void.class, String.class, int[].class));
+		mh.invokeWithArguments(new MethodHandleInvokeWithArgumentsJumboTest(), "test",
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	}
+
+	private void helperVarArgsMethod(String s, int... i) {}
+}

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/MethodHandleTest.java
@@ -848,9 +848,14 @@ public class MethodHandleTest{
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	}
 	
+	/**
+	 * 252 characters: below character limit for variable arity invokeWithArguments.
+	 * @throws Throwable
+	 */
 	@Test(groups = { "level.extended" })
-	public void test_invokeWithArguments_VarArgs_ArityLimit() throws Throwable {
-		MethodHandle mh = MethodHandles.lookup().findVirtual(MethodHandleTest.class, "helperVarArgsMethod", MethodType.methodType(void.class, String.class, int[].class));
+	public void test_invokeWithArguments_VarArgs_SmallArityLimit() throws Throwable {
+		MethodHandle mh = MethodHandles.lookup().findVirtual(MethodHandleTest.class, "helperVarArgsMethod", 
+				MethodType.methodType(void.class, String.class, int[].class));
 		mh.invokeWithArguments(new MethodHandleTest(), "test",
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -864,9 +869,32 @@ public class MethodHandleTest{
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	}
-	
+
+	/**
+	 * 254 characters: the maximum number of characters for a variable arity MethodHandle.  
+	 * @throws Throwable
+	 */
+	@Test(groups = { "level.extended" })
+	public void test_invokeWithArguments_VarArgs_EdgeArityLimit() throws Throwable {
+		MethodHandle mh = MethodHandles.lookup().findVirtual(MethodHandleTest.class, "helperVarArgsMethod",
+				MethodType.methodType(void.class, String.class, int[].class));
+		mh.invokeWithArguments(new MethodHandleTest(), "test",
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	}
 	
 	/******************************
 	 * Tests for asFixedArity

--- a/test/functional/Jsr292/testng.xml
+++ b/test/functional/Jsr292/testng.xml
@@ -60,6 +60,11 @@
 		</classes>
 	</test>
 
+	<test name="jsr292Test_Java11up">
+		<classes>
+			<class name="com.ibm.j9.jsr292.MethodHandleInvokeWithArgumentsJumboTest"/>
+		</classes>
+	</test>
 <!--
 	The following tests are used to check whether some specific methods are correctly compiled by JIT.
 	If the JIT is not ON or with count=0 parameter, then there is no point to enable these tests.


### PR DESCRIPTION
Allow invokeWithArguments of varargs methods to absorb extra args into trailing array

Fixes: #2562

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>