### PR TITLE
Move ddrgen step outside of building VM.

### DIFF
--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -410,26 +410,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</objects>
 	</artifact>
 
-	<artifact type="target" name="omrddrgen">
-		<include-if condition="spec.flags.module_ddr and spec.flags.opt_useOmrDdr"/>
-		<dependencies>
-			<dependency name="phase_core"/>
-			<dependency name="phase_j2se"/>
-			<dependency name="phase_util"/>
-			<dependency name="win">
-				<include-if condition="spec.flags.module_windbg and not spec.flags.J9VM_ENV_DATA64" />
-			</dependency>
-			<dependency name="win_64">
-				<include-if condition="spec.flags.module_windbg and spec.flags.J9VM_ENV_DATA64" />
-			</dependency>
-			<dependency name="jvmtitest">
-				<include-if condition="spec.win_.*"/>
-			</dependency>
-		</dependencies>
-		<commands>
-			<command line="$(MAKE) -C ddr -f run_omrddrgen.mk" type="all"/>
-			<command line="$(MAKE) -C ddr -f run_omrddrgen.mk clean" type="clean"/>
-		</commands>
-	</artifact>
-
 </module>


### PR DESCRIPTION
Move the run ddrgen step outside of the building VM step in order to
resolve DDR dependencies better.

This PR removes the code that runs ddrgen during building the VM, and needs to be delivered together with the extensions repo PRs which move running ddrgen to after the VM is built.
jdk8: https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/110
jdk9: https://github.com/ibmruntimes/openj9-openjdk-jdk9/pull/175
jdk10: https://github.com/ibmruntimes/openj9-openjdk-jdk10/pull/55
jdk11: https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/11
jdk12: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/24

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>