### PR TITLE
Add a test suite for SCC nested jar support

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassAbstractHelper.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/SharedClassAbstractHelper.java
@@ -95,7 +95,7 @@ public abstract class SharedClassAbstractHelper extends SharedAbstractHelper imp
 			return null;
 
 		boolean startsWithJar = jarName.startsWith("jar:"); //$NON-NLS-1$
-		boolean endsWithBang = jarName.endsWith("!/");//$NON-NLS-1$
+		boolean endsWithBang = jarName.endsWith("!/") || jarName.endsWith("!\\");//$NON-NLS-1$ //$NON-NLS-2$
 		int subStringStart = startsWithJar ? 4 : 0;
 		int len = jarName.length();
 		/*
@@ -118,6 +118,10 @@ public abstract class SharedClassAbstractHelper extends SharedAbstractHelper imp
 	private static URL getURLToCheck(URL url) {
 		String pathString = url.toString();
 		int indexBang = pathString.indexOf("!/"); //$NON-NLS-1$
+		if (-1 == indexBang) {
+			indexBang = pathString.indexOf("!\\"); //$NON-NLS-1$
+		}
+
 		if (-1 != indexBang) {
 			/* For a nested jar (e.g. /path/A.jar!/lib/B.jar), validate the external jar file only (/path/A.jar), 
 			 * so trim the entry within the jar after "!/" 

--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -561,7 +561,7 @@ getCpeTypeForProtocol(char* protocol, jsize protocolLen, const char* pathChars, 
 	}
 	if (strncmp(protocol, "file", 5)==0) {
 		char* endsWith = (char*)(pathChars + (pathLen-4));
-		if ((strncmp(endsWith, ".jar", 4)==0) || (strncmp(endsWith, ".zip", 4)==0) || strstr(pathChars,"!/")) {
+		if ((strncmp(endsWith, ".jar", 4)==0) || (strncmp(endsWith, ".zip", 4)==0) || strstr(pathChars,"!/") || strstr(pathChars,"!\\")) {
 			Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJAR();
 			return CPE_TYPE_JAR;
 		} else {

--- a/runtime/shared_common/ClasspathItem.cpp
+++ b/runtime/shared_common/ClasspathItem.cpp
@@ -60,6 +60,9 @@ ClasspathEntryItem::initialize(const char* path_, U_16 pathLen_, UDATA protocol_
 	if (protocol == PROTO_JAR) {
 		if (NULL != path) {
 			char* jarPath = strstr(path,"!/");
+			if (NULL == jarPath) {
+				jarPath = strstr(path,"!\\");
+			}
 			if (NULL != jarPath) {
 				locationPathLen = jarPath - path;
 			}

--- a/test/functional/VM_Test/src/j9vm/test/nestedjar/NestedJarFileTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/nestedjar/NestedJarFileTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.nestedJar;
+
+import java.net.URL;
+import j9vm.test.invalidclasspath.SetClasspathTest.CustomClassLoader;
+
+public class NestedJarFileTest {
+	private static final String MSG_PREFIX = NestedJarFileTest.class.getSimpleName() + "> ";
+	
+	public static void main(String args[]) throws Exception {
+		URL nestedURLs[] = new URL[] {
+			/* The urls are jar:file:/Path_To_VM_Test/VM_Test.jar!/InvalidClasspathResource1.jar
+			 *				jar:file:/Path_To_VM_Test/VM_Test.jar!/InvalidClasspathResource2.jar
+			 *				jar:file:/Path_To_VM_Test/VM_Test.jar!/InvalidClasspathResource3.jar
+			 */
+			NestedJarFileTest.class.getClassLoader().getResource("InvalidClasspathResource1.jar"),
+			NestedJarFileTest.class.getClassLoader().getResource("InvalidClasspathResource2.jar"),
+			NestedJarFileTest.class.getClassLoader().getResource("InvalidClasspathResource3.jar"),
+		};
+
+		CustomClassLoader loader = new CustomClassLoader(nestedURLs);
+		
+		if (args[0].equals("load3Classes")) {
+			/* TestA1 is from VM_Test.jar!/InvalidClasspathResource1.jar */
+			Class.forName("TestA1", true, loader);
+			System.err.println("\n" + MSG_PREFIX + "loadded TestA1");
+			
+			/* TestA2 is from VM_Test.jar!/InvalidClasspathResource1.jar */
+			Class.forName("TestA2", true, loader);
+			System.err.println("\n" + MSG_PREFIX + "loadded TestA2");
+		
+			/* TestC1 is from VM_Test.jar!/InvalidClasspathResource3.jar */
+			Class.forName("TestC1", true, loader);
+			System.err.println("\n" + MSG_PREFIX + "loadded TestC1");
+		}
+		if (args[0].equals("load1Class")) {
+			/* TestC1 is from VM_Test.jar!/InvalidClasspathResource2.jar */
+			Class.forName("TestB1", true, loader);
+			System.err.println("\n" + MSG_PREFIX + "loadded TestB1");
+		}
+	}
+}

--- a/test/functional/VM_Test/src/j9vm/test/nestedjar/NestedJarFileTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/nestedjar/NestedJarFileTestRunner.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package j9vm.test.nestedJar;
+
+import j9vm.runner.Runner;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * This test is to ensure correct behavior of shared classes on nested jars.
+ */
+public class NestedJarFileTestRunner extends Runner {
+	private static final int NUM_COMMANDS = 5;
+	private static int commandIndex = 0;
+	
+	public NestedJarFileTestRunner(String className, String exeName,
+			String bootClassPath, String userClassPath, String javaVersion) throws IOException {
+		super(className, exeName, bootClassPath, userClassPath, javaVersion);
+	}
+
+	/* Overrides method in j9vm.runner.Runner. */
+	public String getCustomCommandLineOptions() {
+		String customOptions = super.getCustomCommandLineOptions();
+		switch(commandIndex) {
+		case 0:
+			/* The classes from nested jar should be stored to the shared cache */
+			customOptions += "-Xshareclasses:name=nestedjarfiletest,reset,verboseHelper ";
+			break;
+		case 1:
+			/* The classes from nested jar should be found in the shared cache */
+			customOptions += "-Xshareclasses:name=nestedjarfiletest,verboseIO ";
+			break;
+		case 2:
+			/* touch the jar file and load another class */
+			customOptions += "-Xshareclasses:name=nestedjarfiletest,verboseHelper ";
+			break;
+		case 3:
+			/* Check stale classes */
+			customOptions += "-Xshareclasses:name=nestedjarfiletest,printStats=stale+classpath ";
+			break;
+		case 4:
+			/* cleanup - destroy the cache */
+			customOptions += "-Xshareclasses:name=nestedjarfiletest,destroy ";
+			break;
+		}
+		return customOptions;
+	}
+	
+	/* Overrides method in j9vm.runner.Runner. */
+	public String getTestClassArguments() {
+		String arguments = "";
+		switch(commandIndex) {
+		case 0:
+		case 1:
+			arguments += "load3Classes";
+			break;
+		case 2:
+			arguments += "load1Class";
+			break;
+		default:
+			break;
+		}
+		return arguments;
+	}
+	
+	public boolean touchCurrentJar() {
+		URI JarPath;
+		try {
+			JarPath = NestedJarFileTestRunner.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+		} catch (NullPointerException | URISyntaxException e) {
+			e.printStackTrace();
+			System.out.println("Error: Exception: Failed to get the path of the current jar");	
+			return false;
+		}
+		if (null != JarPath) {
+			Path p = Paths.get(JarPath);
+			try {
+				FileTime fileTime = Files.getLastModifiedTime(p);
+				long newTime = fileTime.toMillis() + 1000;
+				Files.setLastModifiedTime(p, FileTime.fromMillis(newTime));
+			} catch (IOException e) {
+				e.printStackTrace();
+				System.out.println("Error: IOException: Failed to touch " + JarPath);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/* Overrides method in j9vm.runner.Runner. */
+	public boolean run() {
+		boolean success = false;
+		for (int i = 0; i < NUM_COMMANDS; i++) {
+			commandIndex = i;
+			if (2 == i) {
+				touchCurrentJar();
+			}
+			success = super.run();
+			if ((commandIndex == NUM_COMMANDS -2) || (commandIndex == NUM_COMMANDS - 1)) {
+				/* -Xshareclasses:printStats and -Xshareclasses:destroy returns non-zero exit code */
+				if (!success) {
+					success = true;
+				}
+			}
+			if ((success == true) && (commandIndex != NUM_COMMANDS - 1)) {
+				byte[] stdOut = inCollector.getOutputAsByteArray();
+				byte[] stdErr = errCollector.getOutputAsByteArray();
+				try {
+					success = analyze(stdOut, stdErr);
+				} catch (Exception e) {
+					success = false;
+					System.out.println("Unexpected Exception:");
+					e.printStackTrace();
+				}
+			}
+			if (success == false) {
+				break;
+			}
+		}
+		return success;
+	}
+
+	public boolean analyze(byte[] stdOut, byte[] stdErr) throws IOException {
+		BufferedReader in = new BufferedReader(new InputStreamReader(
+				new ByteArrayInputStream(stdErr)));
+		boolean result = true;
+		String line = in.readLine();
+		if (1 == commandIndex) {
+			String romClassList[] = {"TestA2"};
+			/* Check class TestA2 only here. Because classes TestA1, TestC1 are the first class from their URL entry. The first class from a URL will always be 
+			 * loaded from disk even it is in the shared cache. 
+			 */ 
+			boolean romClassFound[] = new boolean[romClassList.length];
+
+			while (line != null) {
+				for (int i = 0; i < romClassList.length; i++) {
+					if (line.indexOf("Found class " + romClassList[i] + " in shared cache") != -1) {
+						romClassFound[i] = true;
+					}	
+				}
+				line = in.readLine();
+			}
+			for (int i = 0; i < romClassList.length; i++) {
+				if (!romClassFound[i]) {
+					System.out.println("Error: Class " + romClassList[i] + " should be found in the shared cache");
+					result = false;
+				}
+			}
+		} else if (2 == commandIndex) {
+			boolean loadedTestB1 = false;
+			while (line != null) {
+				if (line.indexOf("loadded TestB1") != -1) {
+					loadedTestB1 = true;
+				}
+				line = in.readLine();
+			}
+			if (!loadedTestB1) {
+				System.out.println("Error: Failed to load class TestB1");
+				result = false;
+			}
+		} else if (3 == commandIndex) {
+			String nestJarURLs[] = {"VM_Test.jar!/InvalidClasspathResource1.jar", "VM_Test.jar!/InvalidClasspathResource2.jar", "VM_Test.jar!/InvalidClasspathResource3.jar"};
+			String staleRomClassList[] = {"TestA1", "TestA2", "TestC1"};
+			String NonStaleRomClass = "TestB1";
+			boolean staleClassFound[] = new boolean[staleRomClassList.length];
+			boolean nestJarURLsFound[] = new boolean[nestJarURLs.length];
+
+			while (line != null) {
+				if (line.indexOf("ROMCLASS: " + NonStaleRomClass) != -1) {
+					System.out.println("Error: Class " + NonStaleRomClass + " should not be marked as stale");
+					result = false;
+				} else {
+					for (int i = 0; i < staleRomClassList.length; i++) {
+						if (line.indexOf("ROMCLASS: " + staleRomClassList[i]) != -1) {
+							staleClassFound[i] = true;
+						}	
+					}
+					for (int i = 0; i < nestJarURLs.length; i++) {
+						if (File.separatorChar != '/') {
+							nestJarURLs[i] = nestJarURLs[i].replace('/', '\\');
+						}
+						if (line.indexOf(nestJarURLs[i]) != -1) {
+							nestJarURLsFound[i] = true;
+						}	
+					}
+				}
+				line = in.readLine();
+			}
+			for (int i = 0; i < staleRomClassList.length; i++) {
+				if (!staleClassFound[i]) {
+					System.out.println("Error: Class " + staleRomClassList[i] + " should be marked as stale");
+					result = false;
+				}
+			}
+			for (int i = 0; i < nestJarURLs.length; i++) {
+				if (!nestJarURLsFound[i]) {
+					System.out.println("Error: Classpath " + nestJarURLs[i] + " should be found in the cache");
+					result = false;
+				}
+			}
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
We should also check for "!\\" in the nested jar string. Add this missing
check.

The following test cases are added:
1. Store classes from the nested jar to SCC
2. Load classes nested jar classes from SCC
3. Change the time stamp of the nested jar. Check classes are marked
stale in the SCC.

Fixes #1519

Signed-off-by: hangshao <hangshao@ca.ibm.com>