### PR TITLE
Fix X86 32-bit opcode bug in wrtbar optimization

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -13069,7 +13069,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
                   }
                else
                   {
-                  generateRegImmInstruction(CMPRegImms(), node, owningObjectReg, (int32_t)che, cg);
+                  generateRegImmInstruction(CMPRegImm4(), node, owningObjectReg, (int32_t)che, cg);
                   }
                }
             else
@@ -13160,7 +13160,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
                }
             else
                {
-               generateRegImmInstruction(CMPRegImms(), node, checkDest ? owningObjectReg : srcReg, (int32_t)che, cg);
+               generateRegImmInstruction(CMPRegImm4(), node, checkDest ? owningObjectReg : srcReg, (int32_t)che, cg);
                }
             }
          else


### PR DESCRIPTION
Fixed CMPRegImm op code that was overlooked on 32-bit.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>