### PR TITLE
Use processor description info for features in J9CPU

### DIFF
--- a/runtime/compiler/z/env/J9CPU.hpp
+++ b/runtime/compiler/z/env/J9CPU.hpp
@@ -180,17 +180,12 @@ public:
 
    static TR_S390MachineType TO_PORTLIB_get390zLinuxMachineType();
    static TR_S390MachineType TO_PORTLIB_get390zOSMachineType();
-   static bool TO_PORTLIB_get390zLinux_cpuinfoFeatureFlag(const char *feature);
-   static bool TO_PORTLIB_get390zLinux_supportsStoreExtendedFacilityList();
    static bool TO_PORTLIB_get390_supportsZNext();
    static bool TO_PORTLIB_get390_supportsZ14();
    static bool TO_PORTLIB_get390_supportsZ13();
    static bool TO_PORTLIB_get390_supportsZ6();
    static bool TO_PORTLIB_get390_supportsZGryphon();
    static bool TO_PORTLIB_get390_supportsZHelix();
-   static bool TO_PORTLIB_get390zLinux_supportsHPRDebug();
-   static bool TO_PORTLIB_get390zLinux_SupportTM();
-   static bool TO_PORTLIB_get390zLinux_supportsVectorFacility();
    static bool TO_PORTLIB_get390zOS_N3Support();
    static bool TO_PORTLIB_get390zOS_ZArchSupport();
    static bool TO_PORTLIB_get390zOS_TrexSupport();


### PR DESCRIPTION
Use processor description information from Port library
for STFLE, High GPRs, TE, and Vector facilities in J9CPU.

Signed-off-by: Daniel Hong <daniel.hong@live.com>