### PR TITLE
Add a comment for instanceof/checkcast inlining X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -4977,6 +4977,9 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node* node, TR_Opaq
    // Equality test
    if (!fej9->isAbstractClass(clazz) || node->getOpCodeValue() == TR::icall/*TR_checkAssignable*/)
       {
+      // For instanceof and checkcast, LHS is obtained from an instance, which cannot be abstract or interface;
+      // however, LHS for TR_checkAssignable may be abstract or interface as it may be an arbitrary class;
+      // therefore, equality test can be safely skipped for instanceof and checkcast.
       if (use64BitClasses)
          {
          generateRegMemInstruction(CMP8RegMem, node, j9class, generateX86MemoryReference(clazzData, cg), cg);


### PR DESCRIPTION
Added a comment to explain why the equality test can be skipped for abstract classes but is required for TR_checkAssignable.

Closes #2559

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>