### PR TITLE
CacheList Splitting Configuration Modification

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -768,41 +768,6 @@ gcInitializeCalculatedValues(J9JavaVM *javaVM, IDATA* memoryParameters)
 	extensions->splitAvailableListSplitAmount = extensions->gcThreadCount;
 #endif /* J9VM_GC_REALTIME */
 
-	/* initialize packet lock splitting factor */
-	if (0 == extensions->packetListSplit) {
-		if (16 >= extensions->gcThreadCount) {
-			extensions->packetListSplit = extensions->gcThreadCount;
-		} else if (32 >= extensions->gcThreadCount) {
-			extensions->packetListSplit = 16 + ((extensions->gcThreadCount - 16) / 4);
-		} else {
-			extensions->packetListSplit = 20 + ((extensions->gcThreadCount - 32) / 8);
-		}
-	}
-
-	/* initialize scan cache lock splitting factor */
-	if (0 == extensions->cacheListSplit) {
-		if (16 >= extensions->gcThreadCount) {
-			extensions->cacheListSplit = extensions->gcThreadCount;
-		} else if (32 >= extensions->gcThreadCount) {
-			extensions->cacheListSplit = 16 + ((extensions->gcThreadCount - 16) / 4);
-		} else {
-			extensions->cacheListSplit = 20 + ((extensions->gcThreadCount - 32) / 8);
-		}
-	}
-
-	/* initialize default split freelist split amount */
-	if (0 == extensions->splitFreeListSplitAmount) {
-#if defined(J9VM_GC_MODRON_SCAVENGER)
-		if (extensions->scavengerEnabled) {
-			extensions->splitFreeListSplitAmount = (extensions->gcThreadCount - 1) / 8  +  1;
-		} else
-#endif /* J9VM_GC_MODRON_SCAVENGER */
-		{
-			PORT_ACCESS_FROM_JAVAVM(javaVM);
-			extensions->splitFreeListSplitAmount = (j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE) - 1) / 8  +  1;
-		}
-	}
-
 	/* initialize the size of Local Object Buffer */
 	if (0 == extensions->objectListFragmentCount) {
 		extensions->objectListFragmentCount = (4 * extensions->gcThreadCount) + 4;


### PR DESCRIPTION
CacheList Splitting Configuration Modification. Adding arguments
to verbose logging and remove code duplication.

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>