### PR TITLE
Update nestmates jni calls for new spec

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -326,33 +326,6 @@
 	</configuration>
 
 	<configuration
-		  label="VALHALLA"
-		  outputpath="VALHALLA/src"
-		  flags="Valhalla, Valhalla-NestMates"
-		  dependencies="SIDECAR19-SE-B136"
-		  jdkcompliance="1.8">
-		<classpathentry kind="src" path="src/java.base/share/classes"/>
-		<classpathentry kind="src" path="src/java.management/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
-		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dataaccess/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfj/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.dtfjview/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.gpu/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.sharedclasses/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
-		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
-		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sun190.jar"/>
-		<source path="src"/>
-		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
-		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>
-		<parameter name="jxerules:outputdir" value="java/lang"/>
-	</configuration>
-
-	<configuration
 		  label="SIDECAR19-SE_RAWPLUSJ9"
 		  outputpath="SIDECAR19-SE_RAWPLUSJ9/src"
 		  flags="Sidecar19-SE_RAWPLUSJ9"

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -4360,7 +4360,7 @@ static byte[] getExecutableTypeAnnotationBytes(Executable exec) {
 }
 /*[ENDIF] Sidecar19-SE*/
 
-/*[IF Valhalla-NestMates]*/
+/*[IF Java11]*/
 /**
  * Answers the host class of the receiver's nest.
  *
@@ -4408,5 +4408,5 @@ public boolean isNestmateOf(Class<?> that) {
 public Class<?>[] getNestMembers() {
 	return getNestMembersImpl();
 }
-/*[ENDIF] Valhalla-NestMates*/
+/*[ENDIF] Java11 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -418,9 +418,9 @@ public class MethodHandles {
 				return;
 			} else if (Modifier.isPrivate(memberModifiers)) {
 				if (Modifier.isPrivate(accessMode) && ((targetClass == accessClass)
-/*[IF Valhalla-NestMates]*/
+/*[IF Java11]*/
 						|| targetClass.isNestmateOf(accessClass)
-/*[ENDIF] Valhalla-NestMates*/	
+/*[ENDIF] Java11*/	
 				)) {
 					return;
 				}

--- a/runtime/jcl/cl_se11/module.xml
+++ b/runtime/jcl/cl_se11/module.xml
@@ -84,6 +84,7 @@
 			<group name="se8"/>
 			<group name="se829"/>
 			<group name="se9" />
+			<group name="se11" />
 		</exports>
 		
 		<flags>

--- a/runtime/nls/j9cl/j9jcl.nls
+++ b/runtime/nls/j9cl/j9jcl.nls
@@ -436,3 +436,36 @@ J9NLS_JCL_NEST_MEMBER_CLAIMS_DIFFERENT_NEST_HOST.system_action=The JVM will thro
 J9NLS_JCL_NEST_MEMBER_CLAIMS_DIFFERENT_NEST_HOST.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
 
+# First argument is class name length
+# Second argument is class name
+# Third argument is nest host name length
+# Fourth argument is nest host name
+J9NLS_JCL_NESTMATES_CLASS_FAILED_TO_LOAD=Nest member %2$.*1$s must be able to load nest host %4$.*3$s
+# START NON-TRANSLATABLE
+J9NLS_JCL_NESTMATES_CLASS_FAILED_TO_LOAD.explanation=Nest member class and nest host class were loaded with different class loaders.
+J9NLS_JCL_NESTMATES_CLASS_FAILED_TO_LOAD.system_action=The JVM will throw an IncompatibleClassChangeError
+J9NLS_JCL_NESTMATES_CLASS_FAILED_TO_LOAD.user_response=Load class and nest host class with same classloader.
+# END NON-TRANSLATABLE
+
+# First argument is class name length
+# Second argument is class name
+# Third argument is nest host name length
+# Fourth argument is nest host name
+J9NLS_JCL_NEST_HOST_HAS_DIFFERENT_PACKAGE=Nest member class %2$.*1$s must be in the same package as nest host class %4$.*3$s
+# START NON-TRANSLATABLE
+J9NLS_JCL_NEST_HOST_HAS_DIFFERENT_PACKAGE.explanation=Nest member class and nest host class were loaded in different packages
+J9NLS_JCL_NEST_HOST_HAS_DIFFERENT_PACKAGE.system_action=The JVM will throw an IncompatibleClassChangeError
+J9NLS_JCL_NEST_HOST_HAS_DIFFERENT_PACKAGE.user_response=Load class and nest host class in same package
+# END NON-TRANSLATABLE
+
+# First argument is class name length
+# Second argument is class name
+# Third argument is nest host name length
+# Fourth argument is nest host name
+J9NLS_JCL_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST=Class %2$.*1$s must be claimed by its nest host %4$.*3$s
+# START NON-TRANSLATABLE
+J9NLS_JCL_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST.explanation=Class was not claimed by its nest host class.
+J9NLS_JCL_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST.system_action=The JVM will throw an IncompatibleClassChangeError
+J9NLS_JCL_NEST_MEMBER_NOT_CLAIMED_BY_NEST_HOST.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -893,6 +893,10 @@ jobject JNICALL Java_java_security_AccessController_getCallerPD(JNIEnv* env, jcl
 jobject JNICALL Java_com_ibm_oti_vm_VM_getClassNameImpl(JNIEnv *env, jclass recv, jclass jlClass);
 jobject JNICALL Java_java_lang_Class_getDeclaredFieldImpl(JNIEnv *env, jobject recv, jstring jname);
 jarray JNICALL Java_java_lang_Class_getDeclaredFieldsImpl(JNIEnv *env, jobject recv);
+#if defined(J9VM_OPT_VALHALLA_NESTMATES)
+jobject JNICALL Java_java_lang_Class_getNestHostImpl(JNIEnv *env, jobject recv);
+jobject JNICALL Java_java_lang_Class_getNestMembersImpl(JNIEnv *env, jobject recv);
+#endif /* J9VM_OPT_VALHALLA_NESTMATES */
 
 /* sun_misc_Perf.c */
 void JNICALL Java_sun_misc_Perf_registerNatives(JNIEnv *env, jclass klass);


### PR DESCRIPTION
Update nestmates jni calls for new spec

Nestmates JNI calls now triggered classloading for the hostClass
and for the nest members. This PR is based on Talia's work in
https://github.com/eclipse/openj9/pull/1501.

Also added new testcases.

Signed-off-by: tajila <atobia@ca.ibm.com>