### PR TITLE
Add and use j9sig_is_signal_ignored in OpenJ9

### DIFF
--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -786,6 +786,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sig_map_portlib_signal_to_os_signal(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_map_portlib_signal_to_os_signal((OMRPortLibrary*)privatePortLibrary,param1)
 #define j9sig_register_os_handler(param1,param2,param3) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_register_os_handler((OMRPortLibrary*)privatePortLibrary,param1,(void *)param2,param3)
 #define j9sig_is_master_signal_handler(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_is_master_signal_handler((OMRPortLibrary*)privatePortLibrary,(void *)param1)
+#define j9sig_is_signal_ignored(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_is_signal_ignored((OMRPortLibrary*)privatePortLibrary,param1,param2)
 #define j9sig_info(param1,param2,param3,param4,param5) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4,param5)
 #define j9sig_info_count(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_info_count(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9sig_set_options(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sig_set_options(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)


### PR DESCRIPTION
1) **Add j9sig_is_master_signal_handler macro**

    j9sig_is_master_signal_handler is wrapper for invoking
    omrsig_is_master_signal_handler.

2) **Use j9sig_is_signal_ignored in jvm.c**

    Local implementation of isSignalIgnoredByOS is replaced with
    j9sig_is_signal_ignored.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>