### PR TITLE
Remove deprecated file on X86

### DIFF
--- a/runtime/compiler/build/files/target/x.mk
+++ b/runtime/compiler/build/files/target/x.mk
@@ -22,7 +22,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/BinaryCommutativeAnalyser.cpp \
     omr/compiler/x/codegen/BinaryEvaluator.cpp \
     omr/compiler/x/codegen/CompareAnalyser.cpp \
-    omr/compiler/x/codegen/ConstantDataSnippet.cpp \
     omr/compiler/x/codegen/ControlFlowEvaluator.cpp \
     omr/compiler/x/codegen/DataSnippet.cpp \
     omr/compiler/x/codegen/DivideCheckSnippet.cpp \


### PR DESCRIPTION
OMR has deprecated source file ConstantDataSnippet.cpp, and now it is an empty file;
therefore, OpenJ9 should no longer compile or reference it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>