### PR TITLE
WIP: Implement j.l.i.MethodHandle.internalMemberName

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1276,7 +1276,7 @@ public abstract class MethodHandle {
 	}
 	
 	MemberName internalMemberName() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		return null;
 	}
 	
 	BoundMethodHandle rebind() {


### PR DESCRIPTION
Implement `j.l.i.MethodHandle.internalMemberName()`

Return `null` for the function not supported by `OpenJ9`

Verified manually that the test doesn't throw `OpenJDKCompileStubThrowError` for this method.

close #2597 

Reviewer: @gacholio 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>