### PR TITLE
Catch aborted et al cases when downstream job doesn't pass

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -194,17 +194,17 @@ def build_with_slack(JOB_NAME, PARAMETERS) {
             echo "Couldn't retrieve downstream failed job url"
         }
         
-        if (JOB.result == "FAILURE"){
+        if (JOB.result == "UNSTABLE") {
+            echo "WARNING: Downstream job ${JOB_NAME} is unstable. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
+            currentBuild.result = "UNSTABLE"
+            if (SLACK_CHANNEL) {
+                slackSend channel: SLACK_CHANNEL, color: 'warning', message: "Unstable: ${env.JOB_NAME} #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)\nDownstream Job: ${JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)"
+            }
+        } else {
         	if (SLACK_CHANNEL) {
         		slackSend channel: SLACK_CHANNEL, color: 'danger', message: "Failure in: ${env.JOB_NAME} #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)\nDownstream Job: ${JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)"
         	}
         	error "Downstream job ${JOB_NAME} did not pass. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
-        } else if (JOB.result == "UNSTABLE") {
-        	echo "WARNING: Downstream job ${JOB_NAME} is unstable. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
-        	currentBuild.result = "UNSTABLE"
-        	if (SLACK_CHANNEL) {
-        		slackSend channel: SLACK_CHANNEL, color: 'warning', message: "Unstable: ${env.JOB_NAME} #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)\nDownstream Job: ${JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)"
-        	}
         }
     } 
     return JOB


### PR DESCRIPTION
- If the downstream job is aborted it will not fall into one of
  the existing IF cases. Since we only want to have the parent
  job unstable else fail, we should structure the IF that way.
- Change the IF to UNSTABLE ELSE FAIL

[skip ci]
Issue #2347

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>