### PR TITLE
Implement j.l.i.MethodHandleNatives.mapLookupExceptionToError

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -25,14 +25,23 @@
 
 package java.lang.invoke;
 
-/*
- * Stub class for compilation
- */
-
 class MethodHandleNatives {
 
 	static LinkageError mapLookupExceptionToError(ReflectiveOperationException roe) {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		String exMsg = roe.getMessage();
+		LinkageError linkageErr;
+		if (roe instanceof IllegalAccessException) {
+			linkageErr = new IllegalAccessError(exMsg);
+		} else if (roe instanceof NoSuchFieldException) {
+			linkageErr = new NoSuchFieldError(exMsg);
+		} else if (roe instanceof NoSuchMethodException) {
+			linkageErr = new NoSuchMethodError(exMsg);
+		} else {
+			linkageErr = new IncompatibleClassChangeError(exMsg);
+		}
+		Throwable th = roe.getCause();
+		linkageErr.initCause(th == null ? roe : th);
+		return linkageErr;
 	}
 }
 


### PR DESCRIPTION
Implement `j.l.i.MethodHandleNatives.mapLookupExceptionToError`

Mapped incoming `ReflectiveOperationException` to specific `LinkageError` as per known test failures.

Verified manually that there is no `OpenJDKCompileStubThrowError` caused by `mapLookupExceptionToError`, and the test either pass or failed due to known issues.

close: #2596 

Reviewer: @gacholio 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>