### PR TITLE
Properly link omrsig and enable OMRPORT_OMRSIG_SUPPORT globally

### DIFF
--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -308,7 +308,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<library name="j9ddrautoblob"/>
 			<library name="j9gcautoblob"/>
 			<library name="omrsig">
-				<include-if condition="spec.linux_ztpf.*"/>
+				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
 			</library>
 
 			<!-- The following libs are needed to statically link the port library. -->

--- a/runtime/gc_glue_java/configure_includes/configure_common.mk.ftl
+++ b/runtime/gc_glue_java/configure_includes/configure_common.mk.ftl
@@ -27,6 +27,9 @@ CONFIGURE_ARGS += \
 <#if uma.spec.flags.opt_cuda.enabled>
   --enable-OMR_OPT_CUDA \
 </#if>
+<#if uma.spec.flags.port_omrsigSupport.enabled>
+  --enable-OMRPORT_OMRSIG_SUPPORT \
+</#if>
   --enable-OMR_GC \
   --enable-OMR_PORT \
   --enable-OMR_THREAD \

--- a/runtime/hyvm/module.xml
+++ b/runtime/hyvm/module.xml
@@ -67,7 +67,7 @@
 		</objects>
 		<libraries>
 			<library name="omrsig">
-			<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
+				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
 			</library>
 			<library name="socket" type="macro"/>
 			<library name="j9exelib"/>
@@ -81,7 +81,7 @@
 			<library name="hyprtshim"/>
 			<!--  for advance toolchain pthread must be last in the link order -->
 			<library name="pthread" type="system">
-			<include-if condition="spec.linux.* and not spec.linux_ztpf.*"/>
+				<include-if condition="spec.linux.* and not spec.linux_ztpf.*"/>
 			</library>
 		</libraries>
 	</artifact>

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -60,7 +60,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<library name="j9exelib"/>
 			<library name="j9utilcore"/>
 			<library name="omrsig">
-				<include-if condition="spec.linux_ztpf.*"/>
+				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
 			</library>
 
 			<!-- The following libs are needed to statically link the port library -->

--- a/runtime/port/j9omrport/j9omrport.mk.ftl
+++ b/runtime/port/j9omrport/j9omrport.mk.ftl
@@ -1,6 +1,5 @@
-
-#
-# Copyright (c) 2012, 2017 IBM Corp. and others
+###############################################################################
+# Copyright (c) 2012, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +18,7 @@
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
-#
+###############################################################################
 
 # This makefile is generated using an UMA template.
 
@@ -38,7 +37,6 @@ MODULE_NAME := j9omrport
 ARTIFACT_TYPE := archive
 
 <#if uma.spec.flags.port_omrsigSupport.enabled>
-MODULE_CPPFLAGS += -DOMRPORT_OMRSIG_SUPPORT
 MODULE_INCLUDES += $(UMA_PATH_TO_ROOT)include
 MODULE_SHARED_LIBS += omrsig
 </#if>

--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -349,7 +349,9 @@
 			<library name="j9utilcore"/>
 			<library name="j9avl" type="external"/>
 			<library name="j9hashtable" type="external"/>						
-			<library name="omrsig"/>
+			<library name="omrsig">
+				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
+			</library>
 			<library name="socket" type="macro"/>			
 			<library name="j9pool" type="external"/>
 			<library name="omrglue" type="external"/>

--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -165,9 +165,6 @@
 
 		<flags>
 			<flag name="J9PORT_LIBRARY_DEFINE"/>
-			<flag name="OMRPORT_OMRSIG_SUPPORT">
-				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
-			</flag>
 			<group name="vendor_flags"/>
 		</flags>
 

--- a/runtime/vm/module.xml
+++ b/runtime/vm/module.xml
@@ -161,7 +161,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<library name="j9hookable"/>
 			<library name="j9omr" type="external"/>
 			<library name="j9prt"/>
-			<library name="omrsig"/>
+			<library name="omrsig">
+				<include-if condition="spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
+			</library>
 			<library name="j9bcv"/>
 			<library name="j9dyn"/>
 			<library name="j9simplepool"/>


### PR DESCRIPTION
1) **Properly link omrsig when building constgen and j9ddrgen**

    When building constgen and j9ddrgen, omrsig should be linked when
    J9VM_PORT_OMRSIG_SUPPORT is enabled.

2) **Remove OMRPORT_OMRSIG_SUPPORT definitions**

    Currently, OMRPORT_OMRSIG_SUPPORT is only defined while building the
    port library. But, OMRPORT_OMRSIG_SUPPORT should be defined globally.
    This will allow omrsig macros such as OMRSIG_SIGNAL and OMRSIG_SIGACTION
    to be used consistently across OpenJ9.

    Removing localized definitions of OMRPORT_OMRSIG_SUPPORT before enabling
    it globally. This will prevent redundant definitions of
    OMRPORT_OMRSIG_SUPPORT when it is enabled globally.

3) **Enable OMRPORT_OMRSIG_SUPPORT globally in OpenJ9**

    Currently, OMRPORT_OMRSIG_SUPPORT is only defined while building the
    port library. But, OMRPORT_OMRSIG_SUPPORT should be defined globally.
    This will allow omrsig macros such as OMRSIG_SIGNAL and OMRSIG_SIGACTION
    to be used consistently across OpenJ9. Thus, OMRPORT_OMRSIG_SUPPORT is
    enabled globally.

4) **Fix indentation in hyvm/module.xml**

5) **Link omrsig to port and vm only if J9VM_PORT_OMRSIG_SUPPORT is enabled**

    Currently, omrsig is linked to port and vm unconditionally. omrsig
    should be linked to port and vm only if J9VM_PORT_OMRSIG_SUPPORT is
    enabled.

Closes: #1889

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>