### PR TITLE
Implement j.l.i.MethodHandle.internalMemberName

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1258,6 +1258,7 @@ K0671=Index location out of range
 K0672=Invalid entry void.class found in argument list valueTypes
 K0673=Invalid entry null found in argument list valueTypes
 K0674=Original handle types does not match given types at location
+K0675=Unexpected MethodHandle instance: {0} with {1}
 
 #java.lang.StackWalker
 K0639="Stack walker not configured with RETAIN_CLASS_REFERENCE"

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2009 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,5 +95,10 @@ abstract class FieldHandle extends PrimitiveHandle {
 		c.compareStructuralParameter(left.vmSlot, this.vmSlot);
 	}
 
+	/*[IF Java11]*/
+	boolean isFinal() {
+		return Modifier.isFinal(this.rawModifiers);
+	}
+	/*[ENDIF] Java11 */
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -34,6 +34,17 @@ final class MemberName {
 		public static Factory INSTANCE = null;
 	}
 	/*[ENDIF]*/
+	
+	/*[IF Java11]*/
+	private MethodHandle mh;
+
+	public MemberName() {
+	}
+
+	public MemberName(MethodHandle methodHandle) {
+		mh = methodHandle;
+	}
+	/*[ENDIF] Java11 */
 
 	public boolean isVarargs() {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
@@ -72,7 +83,11 @@ final class MemberName {
 	}
 	/*[IF Java11]*/
 	public boolean isFinal() {
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		if (mh instanceof FieldHandle) {
+			return ((FieldHandle)mh).isFinal();
+		}
+		/*[MSG "K0675", "Unexpected MethodHandle instance: {0} with {1}"]*/
+		throw new InternalError(com.ibm.oti.util.Msg.getString("K0675", mh, mh.getClass())); //$NON-NLS-1$
 	}
 	/*[ENDIF]*/
 	/*[ENDIF]*/

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1276,7 +1276,14 @@ public abstract class MethodHandle {
 	}
 	
 	MemberName internalMemberName() {
+		/*[IF Java11]*/
+		/* Note: so far this method is only invoked by java.lang.invoke.ConstantBootstraps.getStaticFinal() 
+		 * to return a MemberName object, and only MemberName.isFinal() is invoked.
+		 */
+		return new MemberName(this);
+		/*[ELSE]
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		/*[ENDIF] Java11 */
 	}
 	
 	BoundMethodHandle rebind() {


### PR DESCRIPTION
Implement `j.l.i.MethodHandle.internalMemberName`

Added a method `isFinal()` within `j.l.i.FieldHandle`;
Added a `MemberName` constructor which takes a `MethodHandle`;
Also added a MemberName constructor without parameter which is generated
by default when there is no constructor defined;
`MemberName.isFinal()` expects a `FieldHandle` for a `isFinal()` call;
`MethodHandle.internalMemberName()` constructs a `MemberName` object with current `MethodHandle` instance;

Verified manually that the test failed previously can pass with PR.

close: #2597 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>