### PR TITLE
Check for RAS dump options overflow

### DIFF
--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -505,4 +505,12 @@ J9NLS_DMP_INVALID_OR_RESERVED.system_action=The JVM exits.
 J9NLS_DMP_INVALID_OR_RESERVED.user_response=select a different value.
 J9NLS_DMP_INVALID_OR_RESERVED.sample_input_1=suspendwith
 J9NLS_DMP_INVALID_OR_RESERVED.link=
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_TOO_MANY_DUMP_OPTIONS=The number of dump options must be less than %d, including options set by default.
+# START NON-TRANSLATABLE
+J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.explanation=The number of -Xdump: options exceeds the VM limit
+J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.system_action=The JVM exits.
+J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.user_response=Combine dump types, event types, and filters using '+' into a single option
+J9NLS_DMP_TOO_MANY_DUMP_OPTIONS.link=
 # END NON-TRANSLATABLE

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -561,6 +561,10 @@ configureDumpAgents(J9JavaVM *vm)
 	xdumpIndex = FIND_ARG_IN_VMARGS_FORWARD(OPTIONAL_LIST_MATCH, VMOPT_XDUMP, NULL);
 	while (xdumpIndex >= 0)
 	{
+		if (agentNum >= MAX_DUMP_OPTS) {
+			j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_DMP_TOO_MANY_DUMP_OPTIONS, MAX_DUMP_OPTS);
+			return J9VMDLLMAIN_FAILED;
+		}
 		/* HeapDumpOnOutOfMemoryError before current -Xdump. */
 		if (processXXHeapDump && (heapDumpIndex < xdumpIndex)) {
 			/* process the -XX:[+-]HeapDumpOnOutOfMemoryError option first */


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/2567

Tested manually:
```
$ java -Xoptionsfile=xdump_small.txt HelloWorld
Hello, world!

$ java -Xoptionsfile=xdump.txt HelloWorld
Too many dump options specified
JVMJ9VM015W Initialization error for library j9dmp29(0): JVMJ9VM009E J9VMDllMain failed
```

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>