### PR TITLE
Run sanity.functional in the OMR build

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -251,10 +251,6 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                         TARGET_NAMES.addAll(["extended.functional", "extended.system"])
                     }
                     break
-                // temporary for OMR acceptance. This should be removed once we completely switch to AdoptOpenJDK test Jenkins file
-                case "_sanity.tmp":
-                    TARGET_NAMES.add("Sanity")
-                    break
                 default:
                     TARGET_NAMES.add(target.trim())
             }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-OMR-Acceptance
@@ -34,7 +34,7 @@ def OPENJ9_BRANCH = 'master'
 def OMR_REPO = 'https://github.com/eclipse/openj9-omr.git'
 def OMR_BRANCH = 'master'
 
-TESTS_TARGETS = '_sanity.tmp'
+TESTS_TARGETS = 'sanity.functional'
 
 def JOBS = [:]
 def ALL_SHAS = [:]


### PR DESCRIPTION
- Switch to using jobs that use Adopt test scripts
- All platforms are now supported (including win)

[skip ci]
Issue #1450 #1779 AdoptOpenJDK/openjdk-tests#506

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>