### PR TITLE
Remove obsolete test paths for non-Adopt test builds

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -238,18 +238,10 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
                 //  - there is no need to enable JDK9 as it is not supported anymore (https://github.com/eclipse/openj9/issues/2020)
                 //  - OpenJ9 test pipelines will be completely removed once we switch to use AdoptOpenJDK test pipelines
                 case "_sanity":
-                    if (SPEC.contains("win") || SDK_VERSION == "9") {
-                        TARGET_NAMES.add("Sanity")
-                    } else {
-                        TARGET_NAMES.addAll(["sanity.functional", "sanity.system"])
-                    }
+                    TARGET_NAMES.addAll(["sanity.functional", "sanity.system"])
                     break
                 case "_extended":
-                    if (SPEC.contains("win") || SDK_VERSION == "9") {
-                        TARGET_NAMES.add("Extended")
-                    } else {
-                        TARGET_NAMES.addAll(["extended.functional", "extended.system"])
-                    }
+                    TARGET_NAMES.addAll(["extended.functional", "extended.system"])
                     break
                 // temporary for OMR acceptance. This should be removed once we completely switch to AdoptOpenJDK test Jenkins file
                 case "_sanity.tmp":


### PR DESCRIPTION
- We no longer run JDK9 so we can remove this case.
  If we need to run 9 at some point in the future, test
  jobs will need to be created using the Adopt test scripts.
- Windows is now supported using the Adopt test scripts

[skip ci]
Issue #1450 #1779 AdoptOpenJDK/openjdk-tests#506

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>