### PR TITLE
JIT: Handle resolved private invokevirtual

### DIFF
--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -376,7 +376,8 @@ public:
 
    virtual TR_ResolvedMethod *   getResolvedStaticMethod ( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP);
    virtual TR_ResolvedMethod *   getResolvedSpecialMethod( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP);
-   virtual TR_ResolvedMethod *   getResolvedVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreReResolve, bool * unresolvedInCP);
+   virtual TR_ResolvedMethod *   getResolvedVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP);
+   virtual TR_ResolvedMethod *   getResolvedPossiblyPrivateVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP);
    virtual TR_OpaqueClassBlock * getResolvedInterfaceMethod(int32_t cpIndex, uintptrj_t * pITableIndex);
 
    virtual TR_ResolvedMethod *   getResolvedDynamicMethod( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP);
@@ -385,7 +386,7 @@ public:
 
    virtual uint32_t              getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock * classObject, int32_t cpIndex);
    virtual TR_ResolvedMethod *   getResolvedInterfaceMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
-   virtual TR_ResolvedMethod *   getResolvedVirtualMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t cpIndex,bool ignoreReResolve = true);
+   virtual TR_ResolvedMethod *   getResolvedVirtualMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t virtualCallOffset, bool ignoreRtResolve = true);
 
    virtual bool                  virtualMethodIsOverridden();
    virtual void                  setVirtualMethodIsOverridden();
@@ -490,6 +491,8 @@ public:
    virtual char *                staticSignatureChars(int32_t cpIndex, int32_t & len);
 
    virtual TR_OpaqueClassBlock * classOfStatic(int32_t cpIndex, bool returnClassForAOT = false);
+
+   virtual TR_ResolvedMethod *   getResolvedPossiblyPrivateVirtualMethod( TR::Compilation *, int32_t cpIndex, bool ignoreRtResolve, bool * unresolvedInCP);
 
    virtual bool                  getUnresolvedFieldInCP(int32_t cpIndex);
    virtual bool                  getUnresolvedStaticMethodInCP(int32_t cpIndex);

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -810,15 +810,8 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
             if (thisOnStack)
                hasThisCalls = true;
             cpIndex = bci.next2Bytes();
-            resolvedMethod = calltarget->_calleeMethod->getResolvedVirtualMethod(comp(),cpIndex, true, &isUnresolvedInCP);
-            bool isIndirectCall = (!resolvedMethod
-                  || !resolvedMethod->isFinal());
-            bool isInterface = false;
-            TR_Method *interfaceMethod = 0;
-            TR::TreeTop *callNodeTreeTop = 0;
-            TR::Node *parent = 0;
-            TR::Node *callNode = 0;
-            TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+            auto calleeMethod = (TR_ResolvedJ9Method*)calltarget->_calleeMethod;
+            resolvedMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, true, &isUnresolvedInCP);
 
             ///if (!resolvedMethod || isUnresolvedInCP || resolvedMethod->isCold(comp(), true))
             if ((isUnresolvedInCP && !resolvedMethod) || (resolvedMethod
@@ -1399,8 +1392,11 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                if (thisOnStack)
                   hasThisCalls = true;
                cpIndex = bci.next2Bytes();
-               resolvedMethod = calltarget->_calleeMethod->getResolvedVirtualMethod(comp(), cpIndex, true, &isUnresolvedInCP);
-               bool isIndirectCall = (!resolvedMethod || !resolvedMethod->isFinal());
+               auto calleeMethod = (TR_ResolvedJ9Method*)calltarget->_calleeMethod;
+               resolvedMethod = calleeMethod->getResolvedPossiblyPrivateVirtualMethod(comp(), cpIndex, true, &isUnresolvedInCP);
+               bool isIndirectCall =
+                  resolvedMethod == NULL
+                  || (!resolvedMethod->isFinal() && !resolvedMethod->isPrivate());
                bool isInterface = false;
                TR_Method *interfaceMethod = 0;
                TR::TreeTop *callNodeTreeTop = 0;


### PR DESCRIPTION
TR_ResolvedJ9Method::getResolvedPossiblyPrivateVirtualMethod() allows
the compiler to query a VirtualMethodRef constant pool entry to
determine whether it has been resolved to a private method. The existing
getResolvedVirtualMethod() refuses to return private methods, so that
the possibility of a private method is only exposed to callers prepared
to deal with it.

When generating intermediate language for an invokevirtual bytecode
instruction, the compiler checks for a private method, and if one is
found, it generates a direct call.

When the inliner encounters an invokevirtual bytecode instruction, it
checks for a private method in order to correctly determine which call
target(s) to consider.

Private invokevirtual is not yet handled in cases where the constant
pool entry is unresolved at compile time. Nor is it handled in AOT
compilations, where for the time being these calls will be treated as
though their constant pool entries are unresolved.