### PR TITLE
Fix signal issue when Java main thread terminates

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6302,9 +6302,9 @@ predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *g
 		return 1;
 	}
 
-	/* Don't invoke handler if JVM exit or shutdown has started. */
+	/* Don't invoke handler if JVM exit has started. */
 	omrthread_monitor_enter(vm->runtimeFlagsMutex);
-	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED | J9_RUNTIME_SHUTDOWN_STARTED)) {
+	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED)) {
 		shutdownStarted = TRUE;
 	}
 	omrthread_monitor_exit(vm->runtimeFlagsMutex);


### PR DESCRIPTION
When the Java main thread terminates, DestroyJavaVM gets executed.
DestroyJavaVM sets the J9_RUNTIME_SHUTDOWN_STARTED flag and it invokes
protectedDestroyJavaVM. protectedDestroyJavaVM waits until one
non-daemon thread is alive. So, Java threads can still be alive when
J9_RUNTIME_SHUTDOWN_STARTED is set.

predefinedHandlerWrapper is used to execute Java signal handlers. It
must execute Java signal handlers until Java threads are alive.
Currently, it won't invoke Java signal handlers if
J9_RUNTIME_SHUTDOWN_STARTED is set. Now onwards,
predefinedHandlerWrapper will execute Java signal handlers when
J9_RUNTIME_SHUTDOWN_STARTED is set. It will stop invoking Java signal
handlers only if J9_RUNTIME_EXIT_STARTED is set.

Fixes: #2571

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>