### PR TITLE
Fix and optimize split bytecodes

### DIFF
--- a/runtime/jit_vm/ctsupport.c
+++ b/runtime/jit_vm/ctsupport.c
@@ -622,8 +622,14 @@ jitGetJ9MethodUsingIndex(J9VMThread *currentThread, J9ConstantPool *constantPool
 
 		if (J9_IS_STATIC_SPLIT_TABLE_INDEX(cpOrSplitIndex)) {
 			method = clazz->staticSplitMethodTable[splitTableIndex];
+			if (method == (J9Method*)currentThread->javaVM->initialMethods.initialStaticMethod) {
+				method = NULL;
+			}
 		} else {
 			method = clazz->specialSplitMethodTable[splitTableIndex];
+			if (method == (J9Method*)currentThread->javaVM->initialMethods.initialSpecialMethod) {
+				method = NULL;
+			}
 		}
 	} else {
 		method = ((J9RAMStaticMethodRef*)(constantPool + cpOrSplitIndex))->method;

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1817,6 +1817,7 @@ unresolveAllClasses(J9VMThread * currentThread, J9HashTable * classPairs, J9Hash
 	clazz = vmFuncs->allClassesStartDo(&state, vm, NULL);
 
 	while (clazz != NULL) {
+		U_16 i = 0;
 
 		if (extensionsUsed) {
 
@@ -1835,12 +1836,16 @@ unresolveAllClasses(J9VMThread * currentThread, J9HashTable * classPairs, J9Hash
 			}
 		}
 
-		/* zero out split table entries */
+		/* unresolve split table entries */
 		if (NULL != clazz->staticSplitMethodTable) {
-			memset((void *)clazz->staticSplitMethodTable, 0, clazz->romClass->staticSplitMethodRefCount * sizeof(J9Method *));
+			for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; ++i) {
+				clazz->staticSplitMethodTable[i] = (J9Method*)vm->initialMethods.initialStaticMethod;
+			}
 		}
 		if (NULL != clazz->specialSplitMethodTable) {
-			memset((void *)clazz->specialSplitMethodTable, 0, clazz->romClass->specialSplitMethodRefCount * sizeof(J9Method *));
+			for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; ++i) {
+				clazz->specialSplitMethodTable[i] = (J9Method*)vm->initialMethods.initialSpecialMethod;
+			}
 		}
 
 		clazz = vmFuncs->allClassesNextDo(&state);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2280,7 +2280,13 @@ fail:
 				ramClass->methodTypes = (j9object_t *) allocationRequests[RAM_METHOD_TYPES_FRAGMENT].address;
 				ramClass->varHandleMethodTypes = (j9object_t *) allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].address;
 				ramClass->staticSplitMethodTable = (J9Method **) allocationRequests[RAM_STATIC_SPLIT_TABLE_FRAGMENT].address;
+				for (U_16 i = 0; i < romClass->staticSplitMethodRefCount; ++i) {
+					ramClass->staticSplitMethodTable[i] = (J9Method*)javaVM->initialMethods.initialStaticMethod;
+				}
 				ramClass->specialSplitMethodTable = (J9Method **) allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].address;
+				for (U_16 i = 0; i < romClass->specialSplitMethodRefCount; ++i) {
+					ramClass->specialSplitMethodTable[i] = (J9Method*)javaVM->initialMethods.initialSpecialMethod;
+				}
 			}
 		}
 		

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -580,7 +580,7 @@ resolveStaticSplitMethodRef(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA s
 	U_16 cpIndex = *(J9ROMCLASS_STATICSPLITMETHODREFINDEXES(ramCP->ramClass->romClass) + splitTableIndex);
 	J9Method *method = ramCP->ramClass->staticSplitMethodTable[splitTableIndex];
 
-	if (NULL == method) {
+	if (method == (J9Method*)vmStruct->javaVM->initialMethods.initialStaticMethod) {
 		method = resolveStaticMethodRefInto(vmStruct, ramCP, cpIndex, resolveFlags, ramStaticMethodRef);
 
 		if (NULL != method) {
@@ -1221,7 +1221,7 @@ resolveSpecialSplitMethodRef(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA 
 	U_16 cpIndex = *(U_16 *)(J9ROMCLASS_SPECIALSPLITMETHODREFINDEXES(ramCP->ramClass->romClass) + splitTableIndex);
 	J9Method *method = ramCP->ramClass->specialSplitMethodTable[splitTableIndex];
 	
-	if (NULL == method) {
+	if (method == (J9Method*)vmStruct->javaVM->initialMethods.initialSpecialMethod) {
 		method = resolveSpecialMethodRefInto(vmStruct, ramCP, cpIndex, resolveFlags, NULL);
 
 		if (NULL != method) {


### PR DESCRIPTION
- commonize logic for invokespecial and invokespecialsplit
- use initial methods instead of NULL for unresolved split bytecodes
- invokespecial/split throw resolve errors before NPE
- add missing profile call to invokespecialsplit

Fixes: #2602

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>