### PR TITLE
Store iTable offset intead of index in interface snippet data

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -999,7 +999,8 @@ old_slow_jitLookupInterfaceMethod(J9VMThread *currentThread)
 	J9ConstantPool *ramConstantPool = ((J9ConstantPool**)indexAndLiteralsEA)[-2];
 	UDATA cpIndex = indexAndLiteralsEA[-1];
 	J9Class *interfaceClass = ((J9Class**)indexAndLiteralsEA)[0];
-	UDATA methodIndex = indexAndLiteralsEA[1];
+	// convert offset back to index for now
+	UDATA methodIndex = (indexAndLiteralsEA[1] - sizeof(J9ITable)) / sizeof(UDATA);
 	UDATA vTableOffset = VM_VMHelpers::convertITableIndexToVTableOffset(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
 	buildJITResolveFrameWithPC(currentThread, J9_SSF_JIT_RESOLVE_INTERFACE_LOOKUP, parmCount, true, 0, jitEIP);
 	if (0 == vTableOffset) {
@@ -1027,7 +1028,8 @@ old_fast_jitLookupInterfaceMethod(J9VMThread *currentThread)
 	J9ConstantPool *ramConstantPool = ((J9ConstantPool**)indexAndLiteralsEA)[-2];
 	UDATA cpIndex = indexAndLiteralsEA[-1];
 	J9Class *interfaceClass = ((J9Class**)indexAndLiteralsEA)[0];
-	UDATA methodIndex = indexAndLiteralsEA[1];
+	// convert offset back to index for now
+	UDATA methodIndex = (indexAndLiteralsEA[1] - sizeof(J9ITable)) / sizeof(UDATA);
 	UDATA vTableOffset = VM_VMHelpers::convertITableIndexToVTableOffset(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
 	if (0 != vTableOffset) {
 		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
@@ -1516,7 +1518,8 @@ retry:
 		goto retry;
 	}
 	indexAndLiteralsEA[2] = (UDATA)interfaceClass;
-	indexAndLiteralsEA[3] = methodIndexAndArgCount >> 8; /* remove argCount */
+	// store iTable offset instead of index
+	indexAndLiteralsEA[3] = ((methodIndexAndArgCount >> 8) * sizeof(UDATA)) + sizeof(J9ITable);
 	JIT_RETURN_UDATA(1);
 done:
 	SLOW_JIT_HELPER_EPILOGUE();
@@ -2707,7 +2710,8 @@ fast_jitLookupInterfaceMethod(J9VMThread *currentThread, J9Class *receiverClass,
 	J9ConstantPool *ramConstantPool = ((J9ConstantPool**)indexAndLiteralsEA)[-2];
 	UDATA cpIndex = indexAndLiteralsEA[-1];
 	J9Class *interfaceClass = ((J9Class**)indexAndLiteralsEA)[0];
-	UDATA methodIndex = indexAndLiteralsEA[1];
+	// convert offset back to index for now
+	UDATA methodIndex = (indexAndLiteralsEA[1] - sizeof(J9ITable)) / sizeof(UDATA);
 	UDATA vTableOffset = VM_VMHelpers::convertITableIndexToVTableOffset(currentThread, receiverClass, interfaceClass, methodIndex, ramConstantPool, cpIndex);
 	if (0 != vTableOffset) {
 		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -1,4 +1,4 @@
-!! Copyright (c) 2000, 2017 IBM Corp. and others
+!! Copyright (c) 2000, 2018 IBM Corp. and others
 !!
 !! This program and the accompanying materials are made available under
 !! the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2953,13 +2953,7 @@ _interfaceSlotsUnavailable:
         cmpl    cr0, CmpAddr, r12, r0
         bne     .L.callHelper
         ! lastITable is a match
-        laddr   r12, 4*ALen(r11)                                ! Load the itable index from the snippet
-#ifdef TR_HOST_64BIT
-        sldi    r12, r12, 3
-#else
-        slwi    r12, r12, 2
-#endif
-        addi    r12, r12, J9TR_ITableOffset                     ! Convert the itable index into an offset into the ITable
+        laddr   r12, 4*ALen(r11)                                ! Load the itable offset from the snippet
         laddrx  r12, r9, r12                                    ! Load the interpretre vft offset
         neg     r12, r12
         addi    r12, r12, J9TR_InterpVTableOffset               ! Convert to a JIT vft offset


### PR DESCRIPTION
In preparation for invokeinterface of private methods, store the iTable
offset instead of the index in the resolved interface snippet data. This
frees up low bits for use to indicate direct rather than virtual methods
in invokeinterface.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>