### PR TITLE
Revert "Fix signal issue when Java main thread terminates"

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6302,9 +6302,9 @@ predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *g
 		return 1;
 	}
 
-	/* Don't invoke handler if JVM exit has started. */
+	/* Don't invoke handler if JVM exit or shutdown has started. */
 	omrthread_monitor_enter(vm->runtimeFlagsMutex);
-	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED)) {
+	if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED | J9_RUNTIME_SHUTDOWN_STARTED)) {
 		shutdownStarted = TRUE;
 	}
 	omrthread_monitor_exit(vm->runtimeFlagsMutex);


### PR DESCRIPTION
Reverts eclipse/openj9#2650

Extended tests on linux compressedrefs builds in both JDK8 & 10 are failing with this change due to timeouts:

```
00:51:54 ===============================================
00:51:54 Running test threadMXBeanTestSuite2_2 ...
00:51:54 ===============================================
00:51:54 threadMXBeanTestSuite2_2 Start Time: Sun Aug 19 04:51:53 2018 Epoch Time (ms): 1534654313925
00:51:54 test with Mode351
00:51:54 { "/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdkbinary/j2sdk-image/jre/bin/java"  -Xcompressedrefs -Xgcpolicy:metronome -Xcompressedrefs \
00:51:54 -cp "/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/TestConfig/resources:/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/TestConfig/lib/testng.jar:/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/TestConfig/lib/jcommander.jar:/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/functional/Java8andUp/GeneralTest.jar" \
00:51:54 org.testng.TestNG -d "/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../TestConfig/test_output_15346538426588/threadMXBeanTestSuite2_2" "/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/functional/Java8andUp/testng.xml" \
00:51:54 -testnames \
00:51:54 threadMXBeanTestSuite2 \
00:51:54 -groups level.extended \
00:51:54 -excludegroups d.*.linux_x86-64_cmprssptrs,d.*.arch.x86,d.*.os.linux,d.*.bits.64,d.*.generic-all; \
00:51:54 if [ $? -eq 0 ] ; then echo ""; echo "threadMXBeanTestSuite2_2""_PASSED"; echo ""; else echo ""; echo "threadMXBeanTestSuite2_2""_FAILED"; echo ""; fi; } 2>&1 | tee -a "/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../TestConfig/test_output_15346538426588/TestTargetResult";
00:51:54 [IncludeExcludeTestAnnotationTransformer] [INFO] exclude file is /home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../../jvmtest/TestConfig/resources/excludes/latest_exclude_SE80.txt
00:51:54 ...
00:51:54 ... TestNG 6.14.2 by Cédric Beust (cedric@beust.com)
00:51:54 ...
00:51:54 
Cancelling nested steps due to timeout
08:36:45 ...................................Sending interrupt signal to process
08:36:50 autoGen.mk:1335: recipe for target 'threadMXBeanTestSuite2_2' failed
08:36:50 /home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../TestConfig/settings.mk:219: recipe for target 'extended.functional-Java8andUp' failed
08:36:50 make[2]: *** [threadMXBeanTestSuite2_2] Terminated
08:36:50 make[1]: *** wait: No child processes.  Stop.
08:36:50 /home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../TestConfig/settings.mk:219: recipe for target 'extended.functional-Java8andUp' failed
08:36:50 make[1]: *** Waiting for unfinished jobs....
08:36:50 make[1]: *** wait: No child processes.  Stop.
08:36:50 /home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests/TestConfig/scripts/testKitGen/../../../TestConfig/settings.mk:219: recipe for target 'extended.functional-functional' failed
08:36:50 make: *** [extended.functional-functional] Terminated
08:36:50 make: Leaving directory '/home/jenkins/workspace/Test-extended.functional-JDK8-linux_x86-64_cmprssptrs/openjdk-tests'
```