### PR TITLE
JDK11 nestmate virtual private function call

### DIFF
--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -4,7 +4,7 @@ define(`ZZ',`**')
 define(`ZZ',`##')
 ')dnl
 
-ZZ Copyright (c) 2000, 2017 IBM Corp. and others
+ZZ Copyright (c) 2000, 2018 IBM Corp. and others
 ZZ
 ZZ This program and the accompanying materials are made 
 ZZ available under the terms of the Eclipse Public License 2.0 
@@ -145,6 +145,9 @@ SETVAL(eq_codeRA_inVUCallSnippet,8)
 SETVAL(eq_cp_inVUCallSnippet,16)
 SETVAL(eq_cpindex_inVUCallSnippet,24)
 SETVAL(eq_patchVftInstr_inVUCallSnippet,32)
+SETVAL(eq_privMethod_inVUCallSnippet,40)
+SETVAL(eq_j2i_thunk_inVUCallSnippet,48)
+SETVAL(eq_privateRA_inVUCallSnippet,56)
 
 ZZ These two should really be in codert/jilconsts.inc
 SETVAL(J9TR_MethodConstantPool,8)
@@ -185,6 +188,9 @@ SETVAL(eq_codeRA_inVUCallSnippet,4)
 SETVAL(eq_cp_inVUCallSnippet,8)
 SETVAL(eq_cpindex_inVUCallSnippet,12)
 SETVAL(eq_patchVftInstr_inVUCallSnippet,16)
+SETVAL(eq_privMethod_inVUCallSnippet,20)
+SETVAL(eq_j2i_thunk_inVUCallSnippet,24)
+SETVAL(eq_privateRA_inVUCallSnippet,28)
 
 ZZ Unresolved Data Snippet Layout (31 bit mode)
 SETVAL(eq_methodaddr_inDataSnippet,0)
@@ -1625,7 +1631,14 @@ LABEL(LDataOOLExit)
 
 ZZ ===================================================================
 ZZ  PICBuider routine - _virtualUnresolvedHelper
+ZZ  Handles unresolved virtual and unresolved nestmate private methods
 ZZ
+ZZ  For unresolved virtual call targets, this routine calls VM helper
+ZZ  to resolve and patches the JIT'ed code with its VFT offset. This
+ZZ  function runs only once in this case.
+ZZ
+ZZ  For unresolved nestmate private methods, this routine does
+ZZ  not do any patching.
 ZZ ===================================================================
     START_FUNC(_virtualUnresolvedHelper,virUH)
 
@@ -1643,8 +1656,11 @@ LABEL(_virtualUnresolvedHelper_CONST)
     CONST_4BYTE(FFFF8000) # Max patchable offset
 
 LABEL(_virtualUnresolvedHelper_BODY)
-
-ZZ  # Load address of [idx:CP] pair
+ZZ  Check if it's a resolved private
+    L_GPR   r2,eq_privMethod_inVUCallSnippet(r14)
+    CHI_GPR r2,0
+    JNE     L_privateMethodRemoveTag
+ZZ  # Load address of [idx:CP] pair and RA
     LA      r1,eq_cp_inVUCallSnippet(,r14)
     L_GPR   r2,eq_codeRA_inVUCallSnippet(,r14) # Load code cache RA
     LR_GPR  r0,r14
@@ -1656,6 +1672,10 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveVirtualMethod)
     BASR    r14,r14     # Call to resolution
 
     LR_GPR  r14,r0
+ZZ  Check if it's a private method
+    LR      r1,r2
+    NILL    r1,J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG
+    JNZ     L_privateMethod
 ZZ  Skip patching if vft offset is smaller than -32768
     C       r2,4(rEP)
     JL      L_endPatch
@@ -1689,6 +1709,68 @@ LABEL(L_patchBRASL)
     AHI_GPR r3,-6    # Get the address in main code cache for patching
     LHI     r1,4
     STC     r1,1(,r3) #this will turn BRASL into a NOP BRCL
+    J       L_endPatch
+
+ZZ  -------------------------------------------------------------
+ZZ  Private virtual method handling
+ZZ
+ZZ  Private methods don't get patched
+ZZ  They are invoked either directly or via J2I. After they are done,
+ZZ  return to mainline execution where the private RA points to.
+LABEL(L_privateMethod)
+    ST_GPR  r2,eq_privMethod_inVUCallSnippet(r14)
+LABEL(L_privateMethodRemoveTag)
+
+ZZ  Load bitwise NOT of the direct method flag
+ifdef([J9ZOS390],[dnl
+ZZ zOS
+    LHI_GPR r0,J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG
+    LCR_GPR r0,r0
+    AHI_GPR r0,-1
+],[dnl
+ZZ zLinux
+    LHI_GPR r0,~J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG
+])dnl
+
+    LR_GPR  r1,r2
+    NR_GPR  r1,r0          # Remove low-tag of J9Metod ptr
+    LR_GPR  r3,r14         # free up r14 for RA
+    L_GPR   r14,eq_privateRA_inVUCallSnippet(r14) #load RA
+    TM      eq_methodCompiledFlagOffset(r1),J9TR_MethodNotCompiledBit
+    JZ      L_jitted_private
+    LR_GPR  r0,r2         # low-tagged J9Method ptr in R0
+    L_GPR   rEP,eq_j2i_thunk_inVUCallSnippet(r3) # load J2I thunk
+    J       L_callPrivate_inVU
+
+ZZ  r1 contains J9Method pointer here.
+ZZ  Load jitted code entry
+LABEL(L_jitted_private)
+    L_GPR   r1,J9TR_MethodPCStartOffset(r1)
+
+ifdef([TR_HOST_64BIT],[dnl
+    LGF     r2,-4(r1)     # Load reservedWord
+],[dnl
+    LR_GPR  r2,r1         # Copy PCStart
+    AHI_GPR r2,-4         # Move up to the reservedWord
+    L       r2,0(r2)      # Load reservedWord
+])dnl
+
+ZZ The first half of the reserved word is jit-to-jit offset,
+ZZ so we need to shift it to lower half
+ZZ see use of getReservedWord() in getJitEntryOffset()
+    SRL     r2,16
+    AR_GPR  r1,r2        # Add offset to PCStart
+    LR_GPR  rEP,r1
+
+LABEL(L_callPrivate_inVU)
+    L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Restore R1
+    L_GPR   r2,PTR_SIZE(,J9SP)           # Restore R2
+    L_GPR   r3,0(,J9SP)                  # Restore R3
+    AHI_GPR J9SP,(3*PTR_SIZE)            # Restore JSP
+    BR      rEP       # call private target. Does not return to here
+ZZ
+ZZ            end of private direct dispatch
+ZZ  ---------------------------------------------------------------
 
 LABEL(L_endPatch)
     L_GPR   r1,(2*PTR_SIZE)(,J9SP)       # Restore argument registers
@@ -1716,6 +1798,17 @@ LABEL(_interfaceCallHelper_BODY)
     ST_GPR  r2,PTR_SIZE(J9SP)
     ST_GPR  r1,(2*PTR_SIZE)(J9SP)
     LR_GPR  r0,r14
+
+
+ZZ  Check if it's a previously resolved private target
+    L_GPR   r1,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    NILL    r1,J9TR_J9_ITABLE_OFFSET_DIRECT
+    JZ      ifCH0callResolve
+    L_GPR   r1,eq_intfAddr_inInterfaceSnippet(r14)
+    CHI_GPR r1,0
+    JNZ     ifCHMLTypeCheckIFCPrivate
+
+LABEL(ifCH0callResolve)
     TM      eq_flag_inInterfaceSnippet(r14),1 # method is resolved?
     JNZ     LcontinueLookup
 
@@ -1730,6 +1823,12 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveInterfaceMethod)
     LR_GPR  r14,r0
 ZZ                                # interface class and index in TLS
     MVI     eq_flag_inInterfaceSnippet(r14),1
+
+ZZ  resolve helper fills the class slot and method slot
+ZZ  Check PIC slot to see if the target is private interface method
+    L_GPR   r1,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    NILL    r1,J9TR_J9_ITABLE_OFFSET_DIRECT
+    JNZ     ifCHMLTypeCheckIFCPrivate
 
 LABEL(LcontinueLookup)
 
@@ -1804,6 +1903,16 @@ LABEL(_interfaceCallHelperSingleDynamicSlot_BODY)
     ST_GPR  r3,0(J9SP)
     LR_GPR  r0,r14
 
+
+ZZ  Check if it's a previously resolved private target
+    L_GPR   r1,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    NILL    r1,J9TR_J9_ITABLE_OFFSET_DIRECT
+    JZ      ifCH1LcallResolve
+    L_GPR   r1,eq_intfAddr_inInterfaceSnippet(r14)
+    CHI_GPR r1,0
+    JNZ     ifCHMLTypeCheckIFCPrivate
+
+LABEL(ifCH1LcallResolve)
 ZZ  check if the method is resolved?
     TM      eq_flag_inInterfaceSnippetSingleDynamicSlot(r14),1
     JNZ     ifCH1LcontinueLookup
@@ -1819,6 +1928,12 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveInterfaceMethod)
     LR_GPR  r14,r0
 ZZ                              # interface class and index in TLS
     MVI     eq_flag_inInterfaceSnippetSingleDynamicSlot(r14),1
+
+ZZ  resolve helper fills the class slot and method slot
+ZZ  Check PIC slot to see if the target is private interface method
+    L_GPR   r1,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    NILL    r1,J9TR_J9_ITABLE_OFFSET_DIRECT
+    JNZ     ifCHMLTypeCheckIFCPrivate
 
 LABEL(ifCH1LcontinueLookup)
 
@@ -2033,6 +2148,15 @@ LABEL(_interfaceCallHelperMultiSlots_BODY)
     ST_GPR  r3,0(J9SP)
     LR_GPR  r0,r14
 
+ZZ  Check if it's a previously resolved private target
+    L_GPR   r1,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    NILL    r1,J9TR_J9_ITABLE_OFFSET_DIRECT
+    JZ      ifCMHLcallResolve
+    L_GPR   r1,eq_intfAddr_inInterfaceSnippet(r14)
+    CHI_GPR r1,0
+    JNZ     ifCHMLTypeCheckIFCPrivate
+
+LABEL(ifCMHLcallResolve)
     TM      eq_flag_inInterfaceSnippet(r14),1 # method is resolved?
     JNZ     ifCHMLcontinueLookup
 
@@ -2047,6 +2171,12 @@ LOAD_ADDR_FROM_TOC(r14,TR_S390jitResolveInterfaceMethod)
     LR_GPR  r14,r0
 ZZ                           # interface class and index in TLS
     MVI     eq_flag_inInterfaceSnippet(r14),1
+
+ZZ  resolve helper fills the class slot and method slot
+ZZ  Check PIC slot to see if the target is private interface method
+    L_GPR   r1,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    NILL    r1,J9TR_J9_ITABLE_OFFSET_DIRECT
+    JNZ     ifCHMLTypeCheckIFCPrivate
 
 LABEL(ifCHMLcontinueLookup)
 
@@ -2285,6 +2415,100 @@ ZZ # Load address of the lookup class
     L_GPR   r3,0(J9SP)
     AHI_GPR J9SP,(3*PTR_SIZE)
     BR      rEP                   # Call: does not return here
+
+ZZ ------------------------------------------------------------
+ZZ      private interface method handling
+ZZ
+ZZ  1. do type check by calling fast_jitInstanceOf
+ZZ  2. if the type check passes, remove low tag from method
+ZZ     extract entry and perform direct dispatch.
+ZZ     Otherwise, call lookup helper so that it throws
+ZZ     an error.
+ZZ
+ZZ  Note that this is sharing the JIT direct dispatch with
+ZZ  virtual private method, which does not return to this routine
+
+ZZ  use a shorter name for this offset
+SETVAL(eq_vmThrSSP,J9TR_VMThread_systemStackPointer)
+
+LABEL(ifCHMLTypeCheckIFCPrivate)
+
+ZZ  Call fast_jitInstanceOf
+ZZ  with three args: VMthread, object, and castClass.
+ZZ
+ZZ  The call to this helper follows J9S390CHelperLinakge except
+ZZ  that all volatiles are saved here.
+ZZ  instance of result is indicated in return reg
+ZZ
+ZZ  NOTE: fast_jitInstanceOf has different parameter orders on
+ZZ        different platforms
+ZZ
+ZZ  R1-3 have been saved. just need to save r0, r4-15 here.
+    LR_GPR  r0,r14
+    LR_GPR  CARG1,r13                                  # vmThr
+    L_GPR   CARG2,(2*PTR_SIZE)(J9SP)                   # obj
+    L_GPR   CARG3,eq_intfAddr_inInterfaceSnippet(r14)  # class
+
+    AHI_GPR J9SP,-(13*PTR_SIZE)    # save r0, and r4-r15
+    ST_GPR  r0,0(J9SP)
+    STM_GPR r4,r15,PTR_SIZE(J9SP)
+
+ZZ  Now start to call fast_jitInstanceOf as a C function
+    ST_GPR  J9SP,J9TR_VMThread_sp(r13)
+ifdef([J9ZOS390],[dnl
+    L_GPR   rSSP,eq_vmThrSSP(r13)
+    XC      eq_vmThrSSP(PTR_SIZE,r13),eq_vmThrSSP(r13)
+ifdef([TR_HOST_64BIT],[dnl
+ZZ 64 bit zOS. Do nothing.
+],[dnl
+ZZ 31 bit zOS. See definition of J9TR_CAA_SAVE_OFFSET
+    L_GPR  r12,2080(rSSP)
+])dnl
+
+])dnl
+
+LOAD_ADDR_FROM_TOC(r14,TR_instanceOf)
+
+    BASR    r14,r14        # call instanceOf
+
+ifdef([J9ZOS390],[dnl
+    ST_GPR   rSSP,eq_vmThrSSP(r13)
+])dnl
+
+    L_GPR   J9SP,J9TR_VMThread_sp(r13)
+
+ZZ  restore all regs
+    L_GPR   r0,0(J9SP)
+    LM_GPR  r4,r15,PTR_SIZE(J9SP)
+    AHI_GPR J9SP,(13*PTR_SIZE)
+    LR_GPR  r14,r0
+
+    CHI_GPR CRINT,1
+    JNE     ifCHMLcontinueLookup
+
+LABEL(ifCHMLInovkeIFCPrivate)
+ZZ  remove low tag and call
+    L_GPR   r0,eq_intfMethodIndex_inInterfaceSnippet(r14)
+    LR_GPR  r3,r14         # free r14 for RA
+    LR_GPR  r1,r0          # keep low-tagged in r0
+
+ZZ  bitwise NOT the flag
+ifdef([J9ZOS390],[dnl
+ZZ zOS
+    LHI_GPR r2,J9TR_J9_ITABLE_OFFSET_DIRECT
+    LCR_GPR r2,r2
+    AHI_GPR r2,-1
+],[dnl
+ZZ zLinux
+    LHI_GPR r2,~J9TR_J9_ITABLE_OFFSET_DIRECT
+])dnl
+
+    NR_GPR  r1,r2         # Remove low-tag of J9Metod ptr
+    L_GPR   r14,eq_codeRA_inInterfaceSnippet(r14)    #load RA
+    TM      eq_methodCompiledFlagOffset(r1),J9TR_MethodNotCompiledBit
+    JZ      L_jitted_private
+    L_GPR   rEP,eq_thunk_inInterfaceSnippet(r3)      # load J2I thunk
+    J       L_callPrivate_inVU
 
     END_FUNC(_interfaceCallHelperMultiSlots,ifCHM,7)
 

--- a/runtime/compiler/z/runtime/s390_asdef.inc
+++ b/runtime/compiler/z/runtime/s390_asdef.inc
@@ -1,4 +1,4 @@
-ZZ Copyright (c) 2000, 2017 IBM Corp. and others
+ZZ Copyright (c) 2000, 2018 IBM Corp. and others
 ZZ
 ZZ This program and the accompanying materials are made 
 ZZ available under the terms of the Eclipse Public License 2.0 
@@ -62,6 +62,7 @@ define([LTR_GPR],ltgr)
 define([MSGR_GPR],msgr)
 define([N_GPR],ng)
 define([NIHH_GPR],nihh)
+define([NR_GPR],ngr)
 define([O_GPR],og)
 define([S_GPR],sg)
 define([SL32_GPR],slgf)
@@ -124,6 +125,7 @@ define([LMH_GPR],lmh)
 define([LNR_GPR],lnr)
 define([LTR_GPR],ltr)
 define([N_GPR],n)
+define([NR_GPR],nr)
 define([O_GPR],o)
 define([S_GPR],s)
 define([SL32_GPR],sl)

--- a/runtime/compiler/z/runtime/s390_macros.inc
+++ b/runtime/compiler/z/runtime/s390_macros.inc
@@ -1,4 +1,4 @@
-ZZ Copyright (c) 2000, 2017 IBM Corp. and others
+ZZ Copyright (c) 2000, 2018 IBM Corp. and others
 ZZ
 ZZ This program and the accompanying materials are made 
 ZZ available under the terms of the Eclipse Public License 2.0 
@@ -92,51 +92,57 @@ ifdef([TR_HOST_64BIT],[dnl
 EQUVAL(PTR_SIZE,8)
 
 ZZ Interface Snippet Layout (64-bit mode)
+ZZ Values defined here so they can be included in PicBuilder and
+ZZ ValueProf
+
 SETVAL(eq_codeRA_inInterfaceSnippet,0)
 SETVAL(eq_cp_inInterfaceSnippet,8)
 SETVAL(eq_cpindex_inInterfaceSnippet,16)
 SETVAL(eq_intfAddr_inInterfaceSnippet,24)
 SETVAL(eq_intfMethodIndex_inInterfaceSnippet,32)
+SETVAL(eq_thunk_inInterfaceSnippet,40)
 
 ZZ For Zero or Multi slot case
-SETVAL(eq_flag_inInterfaceSnippet,40)
+SETVAL(eq_flag_inInterfaceSnippet,48)
 
 ZZ For Multi slot case
-SETVAL(eq_lastCachedSlotField_inInterfaceSnippet,48)
-SETVAL(eq_firstSlotField_inInterfaceSnippet,56)
-SETVAL(eq_lastSlotField_inInterfaceSnippet,64)
-SETVAL(eq_firstSlot_inInterfaceSnippet,72)
+SETVAL(eq_lastCachedSlotField_inInterfaceSnippet,56)
+SETVAL(eq_firstSlotField_inInterfaceSnippet,64)
+SETVAL(eq_lastSlotField_inInterfaceSnippet,72)
+SETVAL(eq_firstSlot_inInterfaceSnippet,80)
 
 ZZ For single dynamic slot case
-SETVAL(eq_implementorClass_inInterfaceSnippet,40)
-SETVAL(eq_implementorMethod_inInterfaceSnippet,48)
-SETVAL(eq_flag_inInterfaceSnippetSingleDynamicSlot,56)
-SETVAL(eq_picreg_inInterfaceSnippetSingleDynamicSlot,57)
+SETVAL(eq_implementorClass_inInterfaceSnippet,48)
+SETVAL(eq_implementorMethod_inInterfaceSnippet,56)
+SETVAL(eq_flag_inInterfaceSnippetSingleDynamicSlot,64)
+SETVAL(eq_picreg_inInterfaceSnippetSingleDynamicSlot,65)
 
 ],[dnl
 EQUVAL(PTR_SIZE,4)
 
 ZZ Interface Snippet Layout (31 bit mode)
+
 SETVAL(eq_codeRA_inInterfaceSnippet,0)
 SETVAL(eq_cp_inInterfaceSnippet,4)
 SETVAL(eq_cpindex_inInterfaceSnippet,8)
 SETVAL(eq_intfAddr_inInterfaceSnippet,12)
 SETVAL(eq_intfMethodIndex_inInterfaceSnippet,16)
+SETVAL(eq_thunk_inInterfaceSnippet,20)
 
 ZZ For Zero or Multi slot case
-SETVAL(eq_flag_inInterfaceSnippet,20)
+SETVAL(eq_flag_inInterfaceSnippet,24)
 
 ZZ For Multi slot case
-SETVAL(eq_lastCachedSlotField_inInterfaceSnippet,24)
-SETVAL(eq_firstSlotField_inInterfaceSnippet,28)
-SETVAL(eq_lastSlotField_inInterfaceSnippet,32)
-SETVAL(eq_firstSlot_inInterfaceSnippet,36)
+SETVAL(eq_lastCachedSlotField_inInterfaceSnippet,28)
+SETVAL(eq_firstSlotField_inInterfaceSnippet,32)
+SETVAL(eq_lastSlotField_inInterfaceSnippet,36)
+SETVAL(eq_firstSlot_inInterfaceSnippet,40)
 
 ZZ For Single dynamic slot case
-SETVAL(eq_implementorClass_inInterfaceSnippet,20)
-SETVAL(eq_implementorMethod_inInterfaceSnippet,24)
-SETVAL(eq_flag_inInterfaceSnippetSingleDynamicSlot,28)
-SETVAL(eq_picreg_inInterfaceSnippetSingleDynamicSlot,29)
+SETVAL(eq_implementorClass_inInterfaceSnippet,24)
+SETVAL(eq_implementorMethod_inInterfaceSnippet,28)
+SETVAL(eq_flag_inInterfaceSnippetSingleDynamicSlot,32)
+SETVAL(eq_picreg_inInterfaceSnippetSingleDynamicSlot,33)
 
 ])dnl
 

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -45,4 +45,59 @@
 			<subset>SE110</subset>
 		</subsets>
 	</test>
+	
+	<!-- 
+		The nestmate test specifically exercise the JIT's handling of unresolved virtual and interface private methods.
+		The JIT pibBuilder routines will have to handle virtual and interface private methods that are both JIT compiled and interpreted.
+		These private methods will have to be resolved at runtime and gets handled as a direct dispatch, instead of an indirect virtual/interface
+		dispatch. Hence, the need for -Xjit:rtResolve.
+         
+		 Variation 1:
+			This variation tests the handling of nestmate private instance methods with the callee being interpreted.
+			The -Xjit option limits the compilation to just one method (the caller), which invokes only once an inner class's private method (the callee).
+			The callee is interpreted because it's only invoked once.
+			
+		 Variation 2:
+			This variation tests the handling of nestmate private instance methods that is JIT compiled.
+			The -Xjit option limits the compilation to two methods: a caller (count=0) and a callee (count=100).
+		    The callee is an nestmate private instance method. It's first invoked by the caller 1000 times in a loopy method. The low count=100
+			on the callee ensures that the callee can get JIT compiled early enough so that the last invocation of it jumps to a JIT'ed body.
+			
+		 Variation 3:
+			Similar to variation 1 except that the callee is an interface private method.
+			
+		 Variation 4:
+			Similar to variation 2 except that the callee is an interface private method.
+		 -->
+	<test>
+		<testCaseName>Nestmate_virtual_private</testCaseName>
+		
+		<variations>
+		
+			<variation>'-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmate/NestmateTest.testVirtualUnresolvedInterpreted*},{org/openj9/test/nestmate/NestmateTest.testVirtualUnresolvedInterpreted*}(count=0)'</variation>
+			<variation>'-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmate/NestmateTest.testVirtualUnresolvedJitted*,org/openj9/test/nestmate/NestmateTest$InnerClass.innerPrivateMethod*},{org/openj9/test/nestmate/NestmateTest.testVirtualUnresolvedInterpreted*}(count=0),{org/openj9/test/nestmate/NestmateTest$InnerClass.innerPrivateMethod*}(count=100)'</variation>
+			
+			<variation>'-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmate/NestmateTest.testInterfaceUnresolvedInterpreted*},{org/openj9/test/nestmate/NestmateTest.testInterfaceUnresolvedInterpreted*}(count=0)'</variation>
+			<variation>'-Xjit:rtResolve,disableAsyncCompilation,limit={org/openj9/test/nestmate/NestmateTest.testInterfaceUnresolvedJitted*,org/openj9/test/nestmate/NestmateTest$InnerInterface.innerInterfacePrivateMethod*},{org/openj9/test/nestmate/NestmateTest.testInterfaceUnresolvedJitted*}(count=0),{org/openj9/test/nestmate/NestmateTest$InnerInterface.innerInterfacePrivateMethod*}(count=100)'</variation>
+	
+		</variations>
+			
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames NestmateTest \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+	
 </playlist>

--- a/test/functional/Java11andUp/src/org/openj9/test/nestmate/NestmateTest.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/nestmate/NestmateTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.nestmate;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+public class NestmateTest {
+
+	private static int LOOP_COUNT = 1000;
+
+	private static long KEY1 = 0xdeadbeaf_AL;
+	private static long KEY2 = 0xdeadbeaf_BL;
+	private static long KEY3 = 0xdeadbeaf_CL;
+
+	@Test(groups = { "level.sanity" })
+	public void testVirtualUnresolvedInterpreted() {
+		InnerClass ic = new InnerClass();
+		int randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+		long ret = ic.innerPrivateMethod(randomNum % 3);
+
+		checkReturnAndAssert(randomNum % 3, ret);
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testVirtualUnresolvedJitted() {
+
+		InnerClass ic = new InnerClass();
+		int randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+
+		// innerPrivateMethod() should be interpreted
+		long ret = ic.innerPrivateMethod(randomNum % 3);
+
+		// call loopy method to trigger compilation with global disableAsyncCompilation
+		loopyMethodInnerClassPrivate(ic);
+
+		// the target should have been jit compiled by now.
+		randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+		ret = ic.innerPrivateMethod(randomNum % 3);
+
+		checkReturnAndAssert(randomNum % 3, ret);
+	}
+
+	// run this method with count=0. Also use rtResolve globally.
+	@Test(groups = { "level.sanity" })
+	public void testInterfaceUnresolvedInterpreted() {
+
+		InnerInterface ii = new InnerClass();
+		int randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+
+		long ret = ii.innerInterfacePrivateMethod(randomNum % 3);
+		checkReturnAndAssert(randomNum % 3, ret);
+	}
+
+	// run this method with count=0. Also use rtResolve globally
+	@Test(groups = { "level.sanity" })
+	public void testInterfaceUnresolvedJitted() {
+		InnerInterface ii = new InnerClass();
+		int randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+
+		// the target is not jit compiled yet
+		long ret = ii.innerInterfacePrivateMethod(randomNum % 3);
+
+		// call loopy method to trigger the compilation. make sure
+		// that innerInterfacePrivateMethod() gets a count=100
+		loopyMethodInterfacePrivate(ii);
+
+		// this should have been jit compiled. The
+		randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+		ret = ii.innerInterfacePrivateMethod(randomNum % 3);
+		checkReturnAndAssert(randomNum % 3, ret);
+	}
+
+	private void checkReturnAndAssert(int i, long l) {
+		if ((i == 0) && (l != NestmateTest.KEY1) || (i == 1) && (l != NestmateTest.KEY2)
+				|| (i == 2) && (l != NestmateTest.KEY3)) {
+			Assert.fail("Invalid return for " + i + " " + l);
+		}
+
+		return;
+	}
+
+	/**
+	 * \brief Invoke the target enough times to trigger JIT compilation
+	 */
+	private void loopyMethodInterfacePrivate(InnerInterface ii) {
+		long ret = 0;
+		int randomNum = ThreadLocalRandom.current().nextInt(0, 100);
+
+		for (int i = 0; i < LOOP_COUNT; ++i)
+			ret = ii.innerInterfacePrivateMethod(randomNum % 3);
+	}
+
+	/**
+	 * \brief Invoke the target enough times to trigger JIT compilation
+	 */
+	private void loopyMethodInnerClassPrivate(InnerClass ic) {
+		for (int i = 0; i < LOOP_COUNT; ++i) {
+			ic.innerPrivateMethod(i % 3);
+		}
+	}
+
+	interface InnerInterface {
+
+		public void interface_call1();
+
+		private long innerInterfacePrivateMethod(int i) {
+			long retVal = 0;
+
+			switch (i) {
+			case 0:
+				retVal = NestmateTest.KEY1;
+				break;
+			case 1:
+				retVal = NestmateTest.KEY2;
+				break;
+			default:
+				retVal = NestmateTest.KEY3;
+				break;
+			}
+
+			return retVal;
+		}
+	}
+
+	public class InnerClass implements InnerInterface {
+
+		@Override
+		public void interface_call1() {
+			System.out.println("Not implemented");
+		}
+
+		// This innerPrivateMethod() should have a count=100
+		private long innerPrivateMethod(int i) {
+			long retVal = 0;
+
+			switch (i) {
+			case 0:
+				retVal = NestmateTest.KEY1;
+				break;
+			case 1:
+				retVal = NestmateTest.KEY2;
+				break;
+			default:
+				retVal = NestmateTest.KEY3;
+				break;
+			}
+
+			return retVal;
+		}
+
+	}
+}

--- a/test/functional/Java11andUp/testng.xml
+++ b/test/functional/Java11andUp/testng.xml
@@ -32,4 +32,10 @@
 			<class name="org.openj9.test.java_lang.Test_String" />
 		</classes>
 	</test>
+	
+	<test name="NestmateTest">
+		<classes>
+			<class name="org.openj9.test.nestmate.NestmateTest" />
+		</classes>
+	</test>
 </suite>


### PR DESCRIPTION
- This change enables JIT to handle unresolved invokeVirtual and invokeInterface calls whose
call targets turn out to be private nestmate methods.
The S390VirtualUnresolvedSnippet gets three more data fields to hold
runtime data for private nestmate methods: a J9Method field, a J2I entry
point field, and a private return address field.
The PicBuilder routines are modified to check for private call tags in the
return value of the VM resolve helper. If the resolve helper returns a
low-tagged value, the call is identified as a private nestmate method,
which gets a direct dispatch. Normal virtual/interface call handling does not
change.

- Add tests to exercise this new nestmate private invocation path.

- Create J9S390InterfaceCallDataSnippet to mirror OMR class S390InterfaceCallDataSnippet
