### PR TITLE
Fix incorrect format specifier

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ThreadsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ThreadsCommand.java
@@ -216,7 +216,7 @@ public class ThreadsCommand extends  Command
 				J9VMThreadPointer threadCursor = vm.mainThread();
 
 				do {
-					out.append(String.format("    !j9vmthread 0x%s publicFlags=%s privateFlags=%s inNative=%d // %s", 
+					out.append(String.format("    !j9vmthread 0x%s publicFlags=%s privateFlags=%s inNative=%s // %s", 
 							Long.toHexString(threadCursor.getAddress()),
 							Long.toHexString(threadCursor.publicFlags().longValue()),
 							Long.toHexString(threadCursor.privateFlags().longValue()),


### PR DESCRIPTION
Used %d instead of %s by mistake.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>