### PR TITLE
Allow relocation of ClassUnload assumptions

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -740,7 +740,8 @@ uint32_t J9::ARM::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    0,                                        // TR_NativeMethodAbsolute                = 56,
    0,                                        // TR_NativeMethodRelative                = 57,
    16,                                       // TR_ArbitraryClassAddress               = 58,
-   28                                        // TR_DebugCounter                        = 59
+   28,                                        // TR_DebugCounter                        = 59
+   4,                                        // TR_ClassUnloadAssumption               = 60
    };
 
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1052,6 +1052,14 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   }
                }
             break;
+         case TR_ClassUnloadAssumption:
+            cursor++;        // unused field
+            if (is64BitTarget)
+               {
+               cursor +=4; 
+               }
+            traceMsg(self()->comp(), "\n ClassUnloadAssumption \n");
+            break;
 
          default:
             traceMsg(self()->comp(), "Unknown Relocation type = %d\n", kind);

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -890,6 +890,7 @@ uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_
    0,                                        // TR_NativeMethodRelative                = 57,
    32,                                       // TR_ArbitraryClassAddress               = 58,
    56,                                       // TR_DebugCounter                        = 59
+   8,                                        // TR_ClassUnloadAssumption               = 60
    };
 #else
 uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds] =
@@ -953,7 +954,8 @@ uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_
    0,                                        // TR_NativeMethodAbsolute                = 56,
    0,                                        // TR_NativeMethodRelative                = 57,
    16,                                       // TR_ArbitraryClassAddress               = 58,
-   28                                        // TR_DebugCounter                        = 59
+   28,                                        // TR_DebugCounter                        = 59
+   4,                                        // TR_ClassUnloadAssumption               = 60
    };
 
 #endif

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -230,6 +230,8 @@ struct TR_RelocationRecordDebugCounterBinaryTemplate : public TR_RelocationRecor
    };
 
 
+typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordClassUnloadAssumptionBinaryTemplate;
+
 // TR_RelocationRecordGroup
 
 void
@@ -463,6 +465,9 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
          break;
       case TR_DebugCounter:
          reloRecord = new (storage) TR_RelocationRecordDebugCounter(reloRuntime, record);
+         break;
+      case TR_ClassUnloadAssumption:
+         reloRecord = new (storage) TR_RelocationRecordClassUnloadAssumption(reloRuntime, record);
          break;
       default:
          // TODO: error condition
@@ -3532,4 +3537,24 @@ TR_RelocationRecordDebugCounter::findOrCreateCounter(TR_RelocationRuntime *reloR
       }
 
    return counter;
+   }
+
+// ClassUnloadAssumption
+char *
+TR_RelocationRecordClassUnloadAssumption::name()
+   {
+   return "TR_ClassUnloadAssumption";
+   }
+
+int32_t
+TR_RelocationRecordClassUnloadAssumption::bytesInHeaderAndPayload()
+   {
+   return sizeof(TR_RelocationRecordClassUnloadAssumptionBinaryTemplate);
+   }
+
+int32_t
+TR_RelocationRecordClassUnloadAssumption::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   reloTarget->addPICtoPatchPtrOnClassUnload((TR_OpaqueClassBlock *) -1, reloLocation);
+   return 0;
    }

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1103,5 +1103,18 @@ class TR_RelocationRecordDebugCounter : public TR_RelocationRecordWithInlinedSit
       TR::DebugCounterBase *findOrCreateCounter(TR_RelocationRuntime *reloRuntime);
    };
 
+class TR_RelocationRecordClassUnloadAssumption : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordClassUnloadAssumption() {}
+      TR_RelocationRecordClassUnloadAssumption(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual char *name();
+
+      virtual int32_t bytesInHeaderAndPayload();
+
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
 #endif   // RELOCATION_RECORD_INCL
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -686,6 +686,7 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    0,                                               // TR_NativeMethodRelative                = 57,
    32,                                              // TR_ArbitraryClassAddress               = 58,
    56,                                              // TR_DebugCounter                        = 59
+   8,                                               // TR_ClassUnloadAssumption               = 60
 #else
 
    12,                                              // TR_ConstantPool                        = 0
@@ -747,7 +748,8 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    0,                                               // TR_NativeMethodAbsolute                = 56,
    0,                                               // TR_NativeMethodRelative                = 57,
    16,                                              // TR_ArbitraryClassAddress               = 58,
-   28                                               // TR_DebugCounter                        = 59
+   28,                                               // TR_DebugCounter                        = 59
+   4,                                               // TR_ClassUnloadAssumption               = 60
 #endif
    };
 

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -1008,6 +1008,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    0,                                         // TR_NativeMethodRelative                = 57,
    32,                                        // TR_ArbitraryClassAddress               = 58,
    56,                                        // TR_DebugCounter                        = 59
+   8,                                         // TR_ClassUnloadAssumption               = 60
    };
 
 #else
@@ -1073,7 +1074,8 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    0,                                         // TR_NativeMethodAbsolute                = 56,
    0,                                         // TR_NativeMethodRelative                = 57,
    16,                                        // TR_ArbitraryClassAddress               = 58,
-   28                                         // TR_DebugCounter                        = 59
+   28,                                         // TR_DebugCounter                        = 59
+   4,                                         // TR_ClassUnloadAssumption               = 60
    };
 
 #endif


### PR DESCRIPTION
AOT and JITaaS require assumptions to be relocated.
Add a new kind of ExternalRelocation to relocate
ClassUnload assumptions.

Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>