### PR TITLE
Update bootJDK links in JDK11 Dockerfiles

### DIFF
--- a/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
@@ -83,7 +83,7 @@ RUN cd /root \
 
 # Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
-  && wget -O bootjdk10.tar.gz https://api.adoptopenjdk.net/openjdk10-openj9/nightly/ppc64le_linux/latest/binary \
+  && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=ppc64le&release=latest&type=jdk" \
   && tar -xzf bootjdk10.tar.gz \
   && rm -f bootjdk10.tar.gz \
   && mv $(ls | grep -i jdk) bootjdk10

--- a/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
@@ -82,7 +82,7 @@ RUN cd /root \
 
 # Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
-  && wget -O bootjdk10.tar.gz https://api.adoptopenjdk.net/openjdk10-openj9/nightly/s390x_linux/latest/binary \
+  && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk" \
   && tar -xzf bootjdk10.tar.gz \
   && rm -f bootjdk10.tar.gz \
   && mv $(ls | grep -i jdk) bootjdk10

--- a/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
@@ -78,7 +78,7 @@ RUN cd /root \
 
 # Download and install boot JDK from AdoptOpenJDK
 RUN cd /root \
-  && wget -O bootjdk10.tar.gz https://api.adoptopenjdk.net/openjdk10-openj9/nightly/x64_linux/latest/binary \
+  && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk" \
   && tar -xzf bootjdk10.tar.gz \
   && rm -f bootjdk10.tar.gz \
   && mv $(ls | grep -i jdk) bootjdk10


### PR DESCRIPTION
[ci skip]

Now, AdoptOpenJDK supports releases for JDK10:
https://adoptopenjdk.net/archive.html?variant=openjdk10&jvmVariant=openj9.

BootJDKs are changed from JDK10 nightly to JDK10 release builds. The
release version is more stable.

Also, AdoptOpenJDK API v2 (https://api.adoptopenjdk.net/README) is used
to get the bootJDK since AdoptOpenJDK API v1 is deprecated.

Closes: https://github.com/eclipse/openj9/issues/2190

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>