### PR TITLE
Revert "Temporarily disable threadMXBeanTestSuite2 due to intermittent hangs"

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1150,7 +1150,6 @@
 			<subset>SE100</subset>
 			<subset>SE110</subset>
 		</subsets>
-		<disabled>https://github.com/eclipse/openj9/issues/2643</disabled>
 	</test>
 
 	<test>


### PR DESCRIPTION
Reverts eclipse/openj9#2666

The fix for this test was released in https://github.com/eclipse/openj9/pull/2677

The test should pass now.