### PR TITLE
Re-enable threadMXBeanTestSuite2

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1150,7 +1150,6 @@
 			<subset>SE100</subset>
 			<subset>SE110</subset>
 		</subsets>
-		<disabled>https://github.com/eclipse/openj9/issues/2643</disabled>
 	</test>
 
 	<test>


### PR DESCRIPTION
[ci skip]

threadMXBeanTestSuite2 has been re-enabled since a fix is available for
the intermittent hangs. Fix for intermittent hangs: https://github.com/eclipse/openj9/pull/2677.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>