### PR TITLE
Make MethodType.lastParameter() public

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -679,11 +679,8 @@ public abstract class MethodHandle {
 		if (isVarArityNeeded) {
 			/* Convert the handle if initially not with variable arity */
 			if (!this.isVarargsCollector()) {
-				Class<?> lastClass = null;
-				try {
-					/* An exception is thrown if the MethodType has no arguments */
-					lastClass = this.type.lastParameterType();
-				} catch(RuntimeException e) {
+				Class<?> lastClass = this.type.lastParameterType();
+				if (void.class == lastClass) { /* there were no arguments */
 					throw new IllegalArgumentException();
 				}
 				/* IllegalArgumentException will be thrown out from asVarargsCollector 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -901,14 +901,21 @@ public final class MethodType implements Serializable {
 		return returnType;
 	}
 	
-	/* Return the last class in the parameterType array.
+	/**
+	 * Return the last class in the parameterType array.
 	 * This is equivalent to:
 	 * 		type.parameterType(type.parameterCount() - 1)
-	 * Will throw ArrayIndexOutOfBounds on bad indexes.  This is a subclass of IndexOutOfBoundsException
-	 * so this is valid when JCKs expect certain exceptions.
+	 * @return class of final parameter, or void.class if there are no parameters
 	 */
-	/* package */ Class<?> lastParameterType() {
-		 return arguments[arguments.length - 1];
+	/*[IF Java10]*/
+	public
+	/*[ENDIF]*/
+	Class<?> lastParameterType() {
+		Class<?> result = void.class;
+		if (arguments.length > 0) {
+			result = arguments[arguments.length - 1];
+		}
+		return result;
 	}
 	
 	/**


### PR DESCRIPTION
Make the method public to comply with the API spec.  Return void instead of
throwing an exception if the parameter list is empty and update callers who
catch the exception.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>