### PR TITLE
Add test for decompiling synchronized method

### DIFF
--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -103,6 +103,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "decomp001", decomp001, "com.ibm.jvmti.tests.decompResolveFrame.decomp001",             "Decompile method resolve frame with stacked args" },
 	{ "decomp002", decomp002, "com.ibm.jvmti.tests.decompResolveFrame.decomp002",             "Intermittent single stepping throught some code" },
 	{ "decomp003", decomp003, "com.ibm.jvmti.tests.decompResolveFrame.decomp003",             "Decompile at exception catch at various levels of inlining" },
+	{ "decomp004", decomp004, "com.ibm.jvmti.tests.decompResolveFrame.decomp004",             "Decompile a synchronized method" },
 	{ "vmd001",    vmd001,    "com.ibm.jvmti.tests.vmDump.vmd001",                            "VM Dump tests" },
 	{ "glc001",    glc001,    "com.ibm.jvmti.tests.getLoadedClasses.glc001",                  "Verify correct return of all relevant loaded classes" },
 	{ "rtc001",    rtc001,    "com.ibm.jvmti.tests.retransformClasses.rtc001",                "RetransformClasses on a class loaded by sun.misc.Unsafe" },

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -218,6 +218,7 @@ jint JNICALL gmcpn001(agentEnv * env, char * args);
 jint JNICALL decomp001(agentEnv * env, char * args);
 jint JNICALL decomp002(agentEnv * env, char * args);
 jint JNICALL decomp003(agentEnv * env, char * args);
+jint JNICALL decomp004(agentEnv * env, char * args);
 jint JNICALL vmd001(agentEnv * env, char * args);
 jint JNICALL glc001(agentEnv * env, char * args);
 jint JNICALL rtc001(agentEnv * env, char * args);

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -144,6 +144,7 @@
 		<export name="Java_com_ibm_jvmti_tests_decompResolveFrame_decomp002_singleStep"/>
 		<export name="Java_com_ibm_jvmti_tests_decompResolveFrame_decomp003_startStepping"/>
 		<export name="Java_com_ibm_jvmti_tests_decompResolveFrame_decomp003_stopStepping"/>
+		<export name="Java_com_ibm_jvmti_tests_decompResolveFrame_decomp004_triggerDecompile"/>
 		<export name="Java_com_ibm_jvmti_tests_vmDump_vmd001_tryQueryDumpSmallBuffer"/>
 		<export name="Java_com_ibm_jvmti_tests_vmDump_vmd001_tryQueryDumpBigBuffer"/>
 		<export name="Java_com_ibm_jvmti_tests_vmDump_vmd001_tryQueryDumpInvalidBufferSize"/>

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/decompResolveFrame/decomp001.c
 	com/ibm/jvmti/tests/decompResolveFrame/decomp002.c
 	com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
+	com/ibm/jvmti/tests/decompResolveFrame/decomp004.c
 
 	com/ibm/jvmti/tests/eventClassFileLoadHook/ecflh001.c
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp004.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp004.c
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "jvmti_test.h"
+#include <string.h>
+
+
+static agentEnv * env;
+ 
+static void JNICALL
+cbSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread, jmethodID method, jlocation location)
+{
+
+}
+
+
+jint JNICALL
+decomp004(agentEnv * _env, char * args)
+{
+	JVMTI_ACCESS_FROM_AGENT(_env);
+	jvmtiError err;                	
+	jvmtiEventCallbacks callbacks;
+	jvmtiCapabilities capabilities;                
+
+	env = _env;
+
+	if (!ensureVersion(env, JVMTI_VERSION_1_1)) {
+		return JNI_ERR;
+	}   
+    
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_generate_single_step_events = 1;
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to add capabilities");
+		return JNI_ERR;
+	}	
+	
+	memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
+	callbacks.SingleStep = cbSingleStep;
+	err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to set callback for SingleStep events");
+		return JNI_ERR;
+	}	
+
+	return JNI_OK;
+}
+
+
+
+jboolean JNICALL
+Java_com_ibm_jvmti_tests_decompResolveFrame_decomp004_triggerDecompile(JNIEnv *jni_env, jclass cls)
+{
+	JVMTI_ACCESS_FROM_AGENT(env);
+	jvmtiError err;                	
+
+    err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL);
+    if ( err != JVMTI_ERROR_NONE ) {
+        error(env, err, "SetEventNotificationMode failed");
+        return JNI_FALSE;
+    }
+
+	return JNI_TRUE;
+}
+

--- a/test/functional/cmdLineTests/jvmtitests/decompilationtests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/decompilationtests.xml
@@ -50,4 +50,14 @@
 		<return type="success" value="0"/>
 	</test>
 
+	<test id="decomp004">
+		<command>$EXE$ $JVM_OPTS$ -Xjit:count=0,limit={*.jit*} $AGENTLIB$=test:decomp004 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="decomp004-mimic">
+		<command>$EXE$ $JVM_OPTS$ -Xjit:count=0,limit={*.jit*},mimicinterpreterframeshape $AGENTLIB$=test:decomp004 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
 </suite>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp004.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp004.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.decompResolveFrame;
+
+public class decomp004
+{
+	private static native boolean triggerDecompile();
+	
+	public synchronized void jitMe() {
+		if (!triggerDecompile()) {
+			throw new Error("failed to enable single step");
+		}
+	}
+
+	public boolean testSyncDecompile()
+	{
+		try {
+			new decomp004().jitMe();
+		} catch(Throwable t) {
+			System.out.println("exception during test: " + t);
+			return false;
+		}
+		return true;
+	}
+
+	public String helpSyncDecompile()
+	{
+		return "decompile a synchronized method"; 
+	}
+}


### PR DESCRIPTION
Test runs in two modes, normal and mimicinterpreterframeshape (which
previously crashed, motivating this test).

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>