### PR TITLE
Re-include SCURLClassLoaderNPTests on Windows

### DIFF
--- a/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/FindStore_win.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/FindStore_win.xml
@@ -70,6 +70,7 @@
 	<test id="FindStore.BuildVerify" timeout="$TMOUT$" runPath="$TESTDIR$">
 		<command>$TESTDIR$\buildVerify.bat $TOOLSDIR$ $NETDIR$</command>
 		<output type="success" caseSensitive="yes" regex="no">A.jar</output>
+		<output type="failure" caseSensitive="no" regex="no">0 file(s) copied</output>
 		<output type="failure" caseSensitive="yes" regex="no">Usage:</output>
 		<output type="failure" caseSensitive="yes" regex="no">no such</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/buildVerify.bat
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/FindStore/buildVerify.bat
@@ -20,10 +20,6 @@ rem
 rem SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 rem
 
-# ensure the new jar files are not created in the same second as the originals,
-# otherwise the shared cache will not be able to determine the jar files have
-# been modified
-sleep 2
 cd FindStore
 del /Q *.jar
 del /Q %2\I.jar %2\J.jar %2\K.jar %2\L.jar
@@ -32,6 +28,10 @@ del /Q N_Classes\jnurlcldr\shared\findstore\*.class
 del /Q O_Classes\jnurlcldr\shared\findstore\*.class
 del /Q P_Classes\jnurlcldr\shared\findstore\*.class
 cd VerifyClasses
+# ensure the new jar files are not created in the same second as the originals,
+# otherwise the shared cache will not be able to determine the jar files have
+# been modified
+sleep 2
 %1\javac jnurlcldr\shared\findstore\*.java
 %1\jar -cvf ..\A.jar jnurlcldr\shared\findstore\A*.class
 %1\jar -cvf ..\B.jar jnurlcldr\shared\findstore\B*.class

--- a/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests.xml
@@ -132,6 +132,7 @@
 	<test id="FindStore.BuildVerify" timeout="$TMOUT$" runPath=".">
 		<command>$RUN_SCRIPT$ .$PATHSEP$FindStore$PATHSEP$buildVerify$SCRIPT_SUFFIX$ $JAVAC_DIR$ ..$PATHSEP$.$NETUSEDIR$</command>
 		<output type="success" caseSensitive="yes" regex="no">A.jar</output>
+		<output type="failure" caseSensitive="no" regex="no">0 file(s) copied</output>
 		<output type="failure" caseSensitive="yes" regex="no">Usage:</output>
 		<output type="failure" caseSensitive="yes" regex="no">no such</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests_Java8.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/URLClassLoaderTests_Java8.xml
@@ -134,6 +134,7 @@
 	<test id="FindStore.BuildVerify" timeout="$TMOUT$" runPath=".">
 		<command>$RUN_SCRIPT$ .$PATHSEP$FindStore$PATHSEP$buildVerify$SCRIPT_SUFFIX$ $JAVAC_DIR$ ..$PATHSEP$.$NETUSEDIR$</command>
 		<output type="success" caseSensitive="yes" regex="no">A.jar</output>
+		<output type="failure" caseSensitive="no" regex="no">0 file(s) copied</output>
 		<output type="failure" caseSensitive="yes" regex="no">Usage:</output>
 		<output type="failure" caseSensitive="yes" regex="no">no such</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/playlist.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/playlist.xml
@@ -131,36 +131,7 @@
 		</groups>
 		<subsets>
 			<subset>SE90</subset>
+			<subset>SE100</subset>
 			<subset>SE110</subset>
 		</subsets>
 	</test>
-
-	<!-- Separate SE100 and exclude it on windows for issue https://github.com/eclipse/openj9/issues/1814-->
-	<test>
-		<testCaseName>cmdLineTester_SCURLClassLoaderNPTests_SE100</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
-		</variations>
-		<command>$(MKTREE) $(REPORTDIR); \
-	$(CD) $(REPORTDIR); \
-	cp -r $(Q)$(TEST_RESROOT)$(D)URLClassLoaderTests.jar$(Q) .; \
-	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) -xf URLClassLoaderTests.jar; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_HOME='$(JDK_HOME)' -DPATHSEP=$(Q)$(D)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) -DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DCPDL=$(Q)$(P)$(Q) -DSCMODE=211 -DTEST_JVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)URLClassLoaderTests.xml$(Q) -xids all,$(PLATFORM),$(JCL_VERSION),$(JAVA_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
-	-nonZeroExitWhenError \
-	-outputLimit 300; \
-	$(TEST_STATUS)</command>
-		<platformRequirements>^os.zos,^os.win</platformRequirements>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>SE100</subset>
-		</subsets>
-	</test>	
-</playlist>


### PR DESCRIPTION
1. Re-include SCURLClassLoaderNPTests on Windows on Java 10.
2. Put sleep cmd after the class/jar files are deleted.

Fixes #2653

Signed-off-by: hangshao <hangshao@ca.ibm.com>