### PR TITLE
Remove tag bits during JIT interface resolution

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1554,7 +1554,7 @@ retry:
 		goto retry;
 	} else {
 		indexAndLiteralsEA[2] = (UDATA)interfaceClass;
-		UDATA methodIndex = methodIndexAndArgCount >> 8; /* Remove argCount */
+		UDATA methodIndex = (methodIndexAndArgCount & ~J9_ITABLE_INDEX_TAG_BITS) >> 8;
 		UDATA iTableOffset = 0;
 		if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_METHOD_INDEX)) {
 			/* Direct method - methodIndex is an index into the method list of either Object or interfaceClass */


### PR DESCRIPTION
jitResolveInterfaceMethod is not removing the tag bits from
methodIndexAndArgCount, resulting in wildly large indices.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>