### PR TITLE
Reject illegal entries in the bootstrap argument array

### DIFF
--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1423,3 +1423,17 @@ J9NLS_CFR_ERR_LDC_INDEX_INVALID_BEFORE_V55.system_action=The JVM will throw a ve
 J9NLS_CFR_ERR_LDC_INDEX_INVALID_BEFORE_V55.user_response=Contact the provider of the classfile for a corrected version.
 
 # END NON-TRANSLATABLE
+
+#Example: JVMCFRE154 BootstrapMethod (0) arguments contain invalid constantpool entry at index (#20) of type (9); class=Foo, offset=492
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY=BootstrapMethod (%1$d) arguments contain invalid constantpool entry at index (#%2$u) of type (%3$u); class=%5$.*4$s, offset=%6$u
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.sample_input_1=1
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.sample_input_2=3
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.sample_input_3=20
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.sample_input_4=3
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.sample_input_5=Foo
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.sample_input_6=492
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.explanation=Please consult the Java Virtual Machine Specification for a detailed explaination.
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.system_action=The JVM will throw a verification or classloading-related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -453,6 +453,9 @@ typedef struct J9CfrError {
 	I_32 errorFrameIndex;
 	U_32 errorDataIndex;  /* Used to store the invalid index value when the verification error occurs */
 	I_32 verboseErrorType;
+	I_32 errorBsmIndex;
+	U_32 errorBsmArgsIndex;
+	U_32 errorCPType;
 	struct J9CfrMethod* errorMember;
 	struct J9CfrConstantPoolInfo* constantPool;
 } J9CfrError;

--- a/runtime/oti/verutil_api.h
+++ b/runtime/oti/verutil_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,6 +155,19 @@ getJ9CfrErrorDetailMessageForMethod(J9PortLibrary* portLib, J9CfrError* error, c
 
 void
 buildError(J9CfrError * errorStruct, UDATA code, UDATA action, UDATA offset);
+
+/**
+ * Set up bootstrap method errors if the verification error occurs.
+ * @param[in] errorStruct - pointer to J9CfrError
+ * @param[in] code - the error code
+ * @param[in] action - the errorAction
+ * @param[in] offset - the errorOffset
+ * @param[in] bsmIndex - the index of the bootstrap method array
+ * @param[in] bsmArgsIndex - the constant pool index stored in the bootstrap method arguments.
+ * @param[in] cpType - the constant pool type value
+ */
+void
+buildBootstrapMethodError(J9CfrError * errorStruct, UDATA code, UDATA action, UDATA offset, I_32 bsmIndex, U_32 bsmArgsIndex, U_32 cpType);
 
 /**
  * Set up method errors if the verification error occurs.

--- a/runtime/verutil/cfrerr.c
+++ b/runtime/verutil/cfrerr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,23 +35,60 @@ getJ9CfrErrorDescription(J9PortLibrary* portLib, J9CfrError* error)
 }
 
 const char*
-getJ9CfrErrorDetailMessageNoMethod(J9PortLibrary* portLib, J9CfrError* error, const U_8* className, UDATA classNameLength)
+getJ9CfrErrorNormalMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8* className, UDATA classNameLength)
 {
-	PORT_ACCESS_FROM_PORT( portLib );
+	PORT_ACCESS_FROM_PORT(portLib);
 	UDATA allocSize = 0;
-	char *errorString;
-	const char* errorDescription;
-	const char *template;
+	char *errorString = NULL;
+	const char *errorDescription = NULL;
+	const char *template = NULL;
 
 	errorDescription = getJ9CfrErrorDescription(PORTLIB, error);
 
 	/* J9NLS_CFR_ERROR_TEMPLATE_NO_METHOD=%1$s; class=%3$.*2$s, offset=%4$u */
 	template = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERROR_TEMPLATE_NO_METHOD, "%s;%.*s,%u");
 
-	allocSize = strlen(template) + strlen(errorDescription) + MAX_INT_SIZE + classNameLength;
+	allocSize = strlen(template) + strlen(errorDescription) + classNameLength + MAX_INT_SIZE;
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
-	if (errorString != NULL) {
+	if (NULL != errorString) {
 		j9str_printf(PORTLIB, errorString, allocSize, template, errorDescription, classNameLength, className, error->errorOffset);
+	}
+
+	return errorString;
+}
+
+const char*
+getJ9CfrErrorBsmMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8* className, UDATA classNameLength)
+{
+	PORT_ACCESS_FROM_PORT(portLib);
+	UDATA allocSize = 0;
+	char *errorString = NULL;
+
+	/* J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY=BootstrapMethod (%1$d) arguments contain invalid constantpool entry at index (#%2$u) of type (%3$u); class=%5$.*4$s, offset=%6$u */
+	const char *template = j9nls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY, "(%d)(#%u)(%u);%.*s,%u");
+
+	allocSize = strlen(template) + classNameLength + (MAX_INT_SIZE * 4);
+	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
+	if (NULL != errorString) {
+		j9str_printf(PORTLIB, errorString, allocSize, template,
+			error->errorBsmIndex, error->errorBsmArgsIndex, error->errorCPType, classNameLength, className, error->errorOffset);
+	}
+
+	return errorString;
+}
+
+const char*
+getJ9CfrErrorDetailMessageNoMethod(J9PortLibrary* portLib, J9CfrError* error, const U_8* className, UDATA classNameLength)
+{
+	const char *errorString = NULL;
+
+	switch (error->errorCode) {
+	case J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY__ID:
+		errorString = getJ9CfrErrorBsmMessage(portLib, error, className, classNameLength);
+		break;
+	default:
+		errorString = getJ9CfrErrorNormalMessage(portLib, error, className, classNameLength);
+		break;
 	}
 
 	return errorString;
@@ -114,8 +151,20 @@ buildError(J9CfrError * errorStruct, UDATA code, UDATA action, UDATA offset)
 	errorStruct->errorDataIndex = 0;
 	errorStruct->errorFrameIndex = -1;
 	errorStruct->errorFrameBCI = 0;
+
+	errorStruct->errorBsmIndex = -1;
+	errorStruct->errorBsmArgsIndex = 0;
+	errorStruct->errorCPType = 0;
 }
 
+void
+buildBootstrapMethodError(J9CfrError * errorStruct, UDATA code, UDATA action, UDATA offset, I_32 bsmIndex, U_32 bsmArgsIndex, U_32 cpType)
+{
+	buildError(errorStruct, code, action, offset);
+	errorStruct->errorBsmIndex = bsmIndex;
+	errorStruct->errorBsmArgsIndex = bsmArgsIndex;
+	errorStruct->errorCPType = cpType;
+}
 
 void
 buildMethodError(J9CfrError * errorStruct, UDATA code, UDATA action, I_32 methodIndex, U_32 pc, J9CfrMethod* method, J9CfrConstantPoolInfo* constantPoolPointer)
@@ -134,6 +183,10 @@ buildMethodError(J9CfrError * errorStruct, UDATA code, UDATA action, I_32 method
 	errorStruct->errorDataIndex = 0;
 	errorStruct->errorFrameIndex = -1;
 	errorStruct->errorFrameBCI = 0;
+
+	errorStruct->errorBsmIndex = -1;
+	errorStruct->errorBsmArgsIndex = 0;
+	errorStruct->errorCPType = 0;
 }
 
 void


### PR DESCRIPTION
The changes are to validate the entries stored in
the bootstrap argument array to ensure they are
valid constant pool index required in the JVM Spec.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>