### PR TITLE
[mac] Use J9PORT_LIBRARY_SUFFIX instead of ".so" when possible

### DIFF
--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -240,15 +240,11 @@ void mapLibraryToPlatformName(const char *inPath, char *outPath) {
 #else
 	strcpy(outPath, "lib");
 	strcat(outPath,inPath);
-#ifdef HP720
-	strcat(outPath, ".sl");
-#else
-#ifdef AIXPPC
+#if defined(AIXPPC)
 	strcat(outPath, ".a");
-#else
-	strcat(outPath, ".so");
-#endif
-#endif
+#else /* AIXPPC */
+	strcat(outPath, J9PORT_LIBRARY_SUFFIX);
+#endif /* AIXPPC */
 #endif
 }
 

--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jsigWrapper/jsig.c
+++ b/runtime/jsigWrapper/jsig.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/jsigWrapper/jsig.c
+++ b/runtime/jsigWrapper/jsig.c
@@ -74,7 +74,13 @@ getFunction(void **tableAddress, char *name)
 		void *handle = dlopen("libomrsig.so", RTLD_LAZY);
 		*tableAddress = dlsym(handle, name);
 #else /* defined(WIN32) */
-		void *handle = dlopen("libomrsig.so", RTLD_GLOBAL | RTLD_LAZY);
+		void *handle = dlopen(
+#if defined(OSX)
+			"libomrsig.dylib"
+#else /* OSX */
+			"libomrsig.so"
+#endif /* OSX */
+			, RTLD_GLOBAL | RTLD_LAZY);
 		*tableAddress = dlsym(handle, name);
 #endif /* defined(WIN32) */
 	}

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -68,6 +68,17 @@
 #define J9PORT_CAPABILITY_CAN_RESERVE_SPECIFIC_ADDRESS 2
 #define J9PORT_CAPABILITY_ALLOCATE_TOP_DOWN 4
 
+#if defined(WIN32)
+#define J9PORT_LIBRARY_SUFFIX ".dll"
+#elif defined(OSX)
+#define J9PORT_LIBRARY_SUFFIX ".dylib"
+#elif defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390)
+#define J9PORT_LIBRARY_SUFFIX ".so"
+#else
+#error "J9PORT_LIBRARY_SUFFIX must be defined"
+#endif
+
+
 /**
  * @name Shared Semaphore Success flags
  * @anchor PortSharedSemaphoreSuccessFlags

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -1142,7 +1142,7 @@ openLibraries(const char *libraryDir)
 	}
 
 #else
-	buffer = jvmBufferCat(buffer, "/libjvm.so");
+	buffer = jvmBufferCat(buffer, "/libjvm" J9PORT_LIBRARY_SUFFIX);
 	/* open the DLL and look up the symbols */
 #if defined(AIXPPC)
 	/* CMVC 137341:
@@ -1449,7 +1449,7 @@ getjvmBin(BOOLEAN removeSubdir)
 #if defined(J9ZOS390)
 	buffer = findDirUplevelToDirContainingFile(buffer, "LIBPATH", ':', "libjvm.so", 0);
 #else
-	buffer = findDirUplevelToDirContainingFile(buffer, "LD_LIBRARY_PATH", ':', "libjvm.so", 0);
+	buffer = findDirUplevelToDirContainingFile(buffer, "LD_LIBRARY_PATH", ':', "libjvm" J9PORT_LIBRARY_SUFFIX, 0);
 #endif
 
 	if (NULL != buffer) {

--- a/runtime/tests/jsig/main.c
+++ b/runtime/tests/jsig/main.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/tests/jsig/main.c
+++ b/runtime/tests/jsig/main.c
@@ -48,7 +48,11 @@
 #define sigsetjmp(env, savesigs) setjmp(env)
 #define siglongjmp(env, val) longjmp(env, val)
 #else /* defined(WIN32) */
+#if defined(OSX)
+#define JVMLIB "libjvm.dylib"
+#else /* OSX */
 #define JVMLIB "libjvm.so"
+#endif /* OSX */
 #define PATHSEP "/"
 #endif /* defined(WIN32) */
 


### PR DESCRIPTION
OSX and Unix versions are mostly compatible if .dylib replaces
.so in sharedlibrary names.  Some of the code, ie jsig,
can't see j9port.h and so has been changed by hand

issue: #36
