### PR TITLE
Fix JDK11 test failure by ensuring class not a nestmember

### DIFF
--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/AdaptorTests.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/AdaptorTests.java
@@ -61,17 +61,6 @@ public class AdaptorTests {
 		private static final long serialVersionUID = 1L;
 	}
 	
-	static class PrivateMethod {
-		@SuppressWarnings("unused")
-		private static String method() {
-			return "privateMethod";
-		}
-		
-		public static Lookup getLookup() {
-			return MethodHandles.lookup();
-		}
-	}
-	
 	static class PackageExamplesCrossPackageSubClass extends examples.PackageExamples {
 		public static Lookup getLookup() {
 			return MethodHandles.lookup();

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/PrivateMethod.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/PrivateMethod.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9.jsr292;
+import static java.lang.invoke.MethodHandles.*;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+/**
+ * PrivateMethod is a helper class used in AdaptorTests.  It can't 
+ * be declared in the same class as JDK11 will mark it as a nestmate
+ * and allow the enclosing class to have access to the private method
+ * defeating the `testMethodHandleCachingVisibilityForStaticPrivate()
+ * test.
+ */
+class PrivateMethod {
+	@SuppressWarnings("unused")
+	private static String method() {
+		return "privateMethod";
+	}
+		
+	public static Lookup getLookup() {
+		return MethodHandles.lookup();
+	}
+}


### PR DESCRIPTION
PrivateMethod was declared as an inner class of AdaptorTests
which makes it a nest member in JDK11.  Nest members have private
access in JDK11+ which defeats the point of the nest.

This change makes the two classes siblings rather than nestmates.

issue: #2710

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>