### PR TITLE
Fix toggling nextSlot value in ConstantPoolObjectSlotIterator.hpp

### DIFF
--- a/runtime/gc_structs/ConstantPoolObjectSlotIterator.hpp
+++ b/runtime/gc_structs/ConstantPoolObjectSlotIterator.hpp
@@ -78,6 +78,7 @@ private:
 		case condy_slot_exception:
 			result = &(((J9RAMConstantDynamicRef *) slotPtr)->exception);
 			_condySlotState = condy_slot_value;
+			*nextSlot = true;
 			break;
 		default:
 			Assert_MM_unreachable();


### PR DESCRIPTION
Added toggling `nextSlot` value back to `true` in `scanCondySlot()` when
`_condySlotState` is `condy_slot_exception`, so that the iterator will
go on to the next slot in constant pool if the value of the condy is
`NULL`

Signed-off-by: Charles_Zheng <Juntian.Zheng@ibm.com>