### PR TITLE
Set environment in Jenkins Build pipeline

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -246,8 +246,9 @@ def checkoutRef (REF) {
 def build() {
     stage('Compile') {
         timestamps {
-            sh "bash ./configure --with-freemarker-jar='$FREEMARKER' --with-boot-jdk='$BOOT_JDK' $EXTRA_CONFIGURE_OPTIONS"
-            sh "make $EXTRA_MAKE_OPTIONS all"
+            withEnv(BUILD_ENV_VARS_LIST) {
+                sh "${BUILD_ENV_CMD} bash configure --with-freemarker-jar='$FREEMARKER' --with-boot-jdk='$BOOT_JDK' $EXTRA_CONFIGURE_OPTIONS && make $EXTRA_MAKE_OPTIONS all"
+            }
         }
     }
     stage('Java Version') {

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -342,6 +342,40 @@ def set_build_variables() {
     SDK_SUFFIX = ".tar.gz"
     TEST_PREFIX = "test-"
     TEST_SUFFIX = ".tar.gz"
+
+    // set variables for the build environment configuration
+    // check job parameters, if not provided default to variables file
+    BUILD_ENV_VARS = params.BUILD_ENV_VARS
+    if (!BUILD_ENV_VARS && VARIABLES."${SPEC}".build_env) {
+        BUILD_ENV_VARS = get_value(VARIABLES."${SPEC}".build_env.vars, SDK_VERSION)
+    }
+
+    BUILD_ENV_VARS_LIST = []
+    if (BUILD_ENV_VARS) {
+        // expect BUILD_ENV_VARS to be a space separated list of environment variables
+        // e.g. <variable1>=<value1> <variable2>=<value2> ... <variableN>=<valueN>
+        // convert space separated list to array
+        BUILD_ENV_VARS_LIST.addAll(BUILD_ENV_VARS.tokenize(' '))
+    }
+
+    EXTRA_BUILD_ENV_VARS = params.EXTRA_BUILD_ENV_VARS
+    if (EXTRA_BUILD_ENV_VARS) {
+        BUILD_ENV_VARS_LIST.addAll(EXTRA_BUILD_ENV_VARS.tokenize(' '))
+    }
+
+    BUILD_ENV_CMD = params.BUILD_ENV_CMD
+    if (!BUILD_ENV_CMD && VARIABLES."${SPEC}".build_env) {
+        BUILD_ENV_CMD = get_value(VARIABLES."${SPEC}".build_env.cmd, SDK_VERSION)
+    }
+
+    if (BUILD_ENV_CMD) {
+        // BUILD_ENV_CMD is used as preamble command
+        BUILD_ENV_CMD += ' && '
+    } else {
+        BUILD_ENV_CMD = ''
+    }
+
+    echo "Using BUILD_ENV_CMD = ${BUILD_ENV_CMD}, BUILD_ENV_VARS_LIST = ${BUILD_ENV_VARS_LIST.toString()}"
 }
 
 /*


### PR DESCRIPTION
Update groovy scripts to set new environment variables or to override
more common variables, e.g. CC, CXX. This can be achieved by setting
BUILD_ENV_VARS as space separated list of variables or by executing a
shell script when BUILD_ENV_CMD is set.

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>