### PR TITLE
Revert jsig.c change as it breaks zOS

### DIFF
--- a/runtime/jsigWrapper/jsig.c
+++ b/runtime/jsigWrapper/jsig.c
@@ -74,13 +74,7 @@ getFunction(void **tableAddress, char *name)
 		void *handle = dlopen("libomrsig.so", RTLD_LAZY);
 		*tableAddress = dlsym(handle, name);
 #else /* defined(WIN32) */
-		void *handle = dlopen(
-#if defined(OSX)
-			"libomrsig.dylib"
-#else /* OSX */
-			"libomrsig.so"
-#endif /* OSX */
-			, RTLD_GLOBAL | RTLD_LAZY);
+		void *handle = dlopen("libomrsig.so", RTLD_GLOBAL | RTLD_LAZY);
 		*tableAddress = dlsym(handle, name);
 #endif /* defined(WIN32) */
 	}


### PR DESCRIPTION
```
ERROR CCN3191 ./jsig.c:78    The character # is not a valid C source character.
```
Not sure why yet but reverting this unblocks other platforms.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>