### PR TITLE
Add support for gcc-7.3 toolchain to Jenkins Build pipelines

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -120,6 +120,10 @@ linux_390-64_cmprssptrs:
       10: 'hw.arch.s390x && sw.os.ubuntu'
       11: 'hw.arch.s390x && sw.os.ubuntu'
       next: 'hw.arch.s390x && sw.os.ubuntu'
+  build_env:
+    vars:
+      11: 'CC=gcc-7 CXX=g++-7'
+      next: 'CC=gcc-7 CXX=g++-7'
 #========================================#
 # AIX PPC 64bits Compressed Pointers
 #========================================#
@@ -188,6 +192,10 @@ linux_x86-64_cmprssptrs:
       10: 'hw.arch.x86 && sw.os.ubuntu'
       11: 'hw.arch.x86 && sw.os.ubuntu'
       next: 'hw.arch.x86 && sw.os.ubuntu'
+  build_env:
+    vars:
+      11: 'CC=gcc-7 CXX=g++-7'
+      next: 'CC=gcc-7 CXX=g++-7'
 #========================================#
 # Linux x86 64bits Compressed Pointers /w CMake
 #========================================#
@@ -231,6 +239,10 @@ linux_x86-64_cmprssptrs_cmake:
     10: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
     11: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
     next: 'EXTRA_CMAKE_ARGS="-DOMR_WARNINGS_AS_ERRORS=FALSE"'
+  build_env:
+    vars:
+      11: 'CC=gcc-7 CXX=g++-7'
+      next: 'CC=gcc-7 CXX=g++-7'
 #========================================#
 # Linux x86 64bits Large Heap
 #========================================#
@@ -268,6 +280,10 @@ linux_x86-64:
     10: '--with-noncompressedrefs'
     11: '--with-noncompressedrefs'
     next: '--with-noncompressedrefs'
+  build_env:
+    vars:
+      11: 'CC=gcc-7 CXX=g++-7'
+      next: 'CC=gcc-7 CXX=g++-7'
 #========================================#
 # Windows x86 64bits Compressed Pointers
 #========================================#


### PR DESCRIPTION
Add build environment variables for gcc-7.3 for JDK11 and Next on Linux
x86 and 390 platforms. This would override CC and CXX environment
variables.
The build_env map supports vars and cmd collections where:
- vars is expected to be a space separated string of environment
variables per versions, e.g.: VARIABLE1=value1 VARIABLE2=value2 ...
VARIABLEn=valuen
- cmd is expected to be a command or multiple commands (using AND
logical operator) per versions, e.g.: command1 && command2 && ... &&
commandn.
  build_env:
    vars:
      \<version\>: '\<VARIABLE1\>=\<value1\> \<VARIABLE2\>=\<value2\>'
    cmd:
      \<version\>: '\<command1\> && \<command2\>'

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>