### PR TITLE
Introduce platform-independent query for hash code

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -392,6 +392,16 @@ public:
     */
    void setSupportsInlineStringIndexOf() { return _j9Flags.set(SupportsInlineStringIndexOf);}
 
+   /** \brief
+   *    Determines whether the code generator supports inlining of java/lang/String.hashCode()
+   */
+   bool getSupportsInlineStringHashCode() { return _j9Flags.testAny(SupportsInlineStringHashCode); }
+
+   /** \brief
+   *    The code generator supports inlining of java/lang/String.hashCode()
+   */
+   void setSupportsInlineStringHashCode() { return _j9Flags.set(SupportsInlineStringHashCode); }
+
    /**
     * \brief
     *    The number of nodes between a monext and the next monent before
@@ -407,6 +417,7 @@ private:
       SupportsMaxPrecisionMilliTime       = 0x00000002,
       SupportsInlineStringCaseConversion  = 0x00000004, /*! codegen inlining of Java string case conversion */
       SupportsInlineStringIndexOf         = 0x00000008, /*! codegen inlining of Java string index of */
+      SupportsInlineStringHashCode        = 0x00000010, /*! codegen inlining of Java string hash code */
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3144,13 +3144,10 @@ bool TR_J9VMBase::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, 
                   }
             // Intentional fallthrough here.
          case TR::java_lang_String_hashCodeImplCompressed:
-            if (!TR::Compiler->om.canGenerateArraylets()){
-               if ((TR::Compiler->target.cpu.isX86() && getX86SupportsSSE4_1()) ||
-                   (TR::Compiler->target.cpu.isZ() && comp->cg()->getSupportsVectorRegisters()))
-                  {
-                  dontInlineRecognizedMethod = true;
-                  }
-            }
+            if (comp->cg()->getSupportsInlineStringHashCode())
+               {
+               dontInlineRecognizedMethod = true;
+               }
             break;
          default:
             break;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -91,6 +91,13 @@ J9::X86::CodeGenerator::CodeGenerator() :
       cg->setSupportsInlineStringIndexOf();
       }
 
+   if (cg->getX86ProcessorInfo().supportsSSE4_1() &&
+       !comp->getOption(TR_DisableSIMDStringHashCode) &&
+       !TR::Compiler->om.canGenerateArraylets())
+      {
+      cg->setSupportsInlineStringHashCode();
+      }
+
    if (comp->generateArraylets() && !comp->getOptions()->realTimeGC())
       {
       cg->setSupportsStackAllocationOfArraylets();

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -8939,7 +8939,7 @@ inlineMathSQRT(
 // end_label
 static TR::Register* inlineStringHashCode(TR::Node* node, bool isCompressed, TR::CodeGenerator* cg)
    {
-   if (cg->comp()->getOption(TR_DisableSIMDStringHashCode) || TR::Compiler->om.canGenerateArraylets() || !cg->getX86ProcessorInfo().supportsSSE4_1())
+   if (!cg->getSupportsInlineStringHashCode())
       {
       return NULL;
       }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -115,6 +115,12 @@ J9::Z::CodeGenerator::CodeGenerator() :
       cg->setSupportsInlineStringIndexOf();
       }
 
+   if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringHashCode) &&
+       !TR::Compiler->om.canGenerateArraylets())
+      {
+      cg->setSupportsInlineStringHashCode();
+      }
+
    // Let's turn this on.  There is more work needed in the opt
    // to catch the case where the BNDSCHK is inserted after
    //
@@ -4146,19 +4152,17 @@ J9::Z::CodeGenerator::inlineDirectCall(
          break;
        // HashCode routine for Compressed and Decompressed String Shares lot of code so combining them.
       case TR::java_lang_String_hashCodeImplDecompressed:
-         if (!comp->getOption(TR_DisableSIMDStringHashCode))
+         if (cg->getSupportsInlineStringHashCode())
             {
-            if (cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets())
-               return resultReg = inlineStringHashCode(node, cg, false);
+            return resultReg = inlineStringHashCode(node, cg, false);
             }
          break;
 
       case TR::java_lang_String_hashCodeImplCompressed:
-         if (!comp->getOption(TR_DisableSIMDStringHashCode)){
-            if (cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets()){
-                return resultReg = inlineStringHashCode(node, cg, true);
+         if (cg->getSupportsInlineStringHashCode())
+            {
+            return resultReg = inlineStringHashCode(node, cg, true);
             }
-         }
         break;
 
       case TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Big:


### PR DESCRIPTION
A platform-independent query for whether CodeGen supports
inlining of java/lang/String.hashCode() is introduced so
that Optimizer and other components can adjust their policies.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>