### PR TITLE
Restore default constructor for use by TestNG

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/gpu/SortTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/gpu/SortTest.java
@@ -333,6 +333,10 @@ public final class SortTest {
 
 	private final Set<ElementType> types;
 
+	public SortTest() {
+		this(new String[0]);
+	}
+
 	public SortTest(String... args) {
 		super();
 		this.lengths = getLengths(args);


### PR DESCRIPTION
Fixes #2644.