### PR TITLE
Fix TLH in Disabled mode path

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.cpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.cpp
@@ -307,7 +307,14 @@ MM_EnvironmentDelegate::isInlineTLHAllocateEnabled()
 {
 	J9VMThread *vmThread = (J9VMThread *)_env->getOmrVMThread()->_language_vmthread;
 	J9ModronThreadLocalHeap *tlh = (J9ModronThreadLocalHeap *)&vmThread->allocateThreadLocalHeap;
-	return NULL != tlh->realHeapAlloc ? false : true;
+	bool result = (NULL == tlh->realHeapAlloc);
+
+#if defined(J9VM_GC_NON_ZERO_TLH)
+	tlh = (J9ModronThreadLocalHeap *)&vmThread->nonZeroAllocateThreadLocalHeap;
+	result = result && (NULL == tlh->realHeapAlloc);
+#endif /* defined(J9VM_GC_NON_ZERO_TLH) */
+
+	return result;
 }
 #endif /* J9VM_GC_THREAD_LOCAL_HEAP */
 

--- a/runtime/gc_modron_startup/mgcalloc.cpp
+++ b/runtime/gc_modron_startup/mgcalloc.cpp
@@ -89,7 +89,7 @@ J9AllocateObjectNoGC(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFla
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-	if (extensions->instrumentableAllocateHookEnabled ) {
+	if (extensions->instrumentableAllocateHookEnabled || !env->isInlineTLHAllocateEnabled()) {
 		/* This function is restricted to only being used for instrumentable allocates so we only need to check that one allocation hook.
 		 * Note that we can't handle hooked allocates since we might be called without a JIT resolve frame and that is required for us to
 		 * report the allocation event.
@@ -282,7 +282,7 @@ J9AllocateIndexableObjectNoGC(J9VMThread *vmThread, J9Class *clazz, uint32_t num
 	
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-	if (extensions->instrumentableAllocateHookEnabled ) {
+	if (extensions->instrumentableAllocateHookEnabled || !env->isInlineTLHAllocateEnabled()) {
 		/* This function is restricted to only being used for instrumentable allocates so we only need to check that one allocation hook.
 		 * Note that we can't handle hooked allocates since we might be called without a JIT resolve frame and that is required for us to
 		 * report the allocation event.


### PR DESCRIPTION
There are two problems fixed:
- env->isInlineTLHAllocateEnabled() should took to consideration both
TLHs in dual-TLH mode and can not based on zeroed TLH only.
- J9AllocateObjectNoGC and J9AllocateIndexableObjectNoGC should not try
to allocate if TLH is in Disabled state. An attempt to do this might
refresh disabled TLH and re-enable it implicitly
 
Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>