### PR TITLE
Move interface tag bits

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1554,7 +1554,7 @@ retry:
 		goto retry;
 	} else {
 		indexAndLiteralsEA[2] = (UDATA)interfaceClass;
-		UDATA methodIndex = (methodIndexAndArgCount & ~J9_ITABLE_INDEX_TAG_BITS) >> 8;
+		UDATA methodIndex = methodIndexAndArgCount >> J9_ITABLE_INDEX_SHIFT;
 		UDATA iTableOffset = 0;
 		if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_METHOD_INDEX)) {
 			/* Direct method - methodIndex is an index into the method list of either Object or interfaceClass */

--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -56,6 +56,53 @@ jitGetCountingSendTarget(J9VMThread *vmThread, J9Method *ramMethod)
 	return J9_BCLOOP_ENCODE_SEND_TARGET(J9_BCLOOP_SEND_TARGET_COUNT_NON_SYNC);
 }
 
+/* Only returns non-null if the method is resolved and not to be dispatched by
+ * itable, i.e. if it is:
+ * - private, using direct dispatch;
+ * - a final method of Object, using direct dispatch; or
+ * - a non-final method of Object, using virtual dispatch.
+ */
+J9Method*
+jitGetImproperInterfaceMethodFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex)
+{
+	J9RAMInterfaceMethodRef *ramMethodRef = (J9RAMInterfaceMethodRef*)constantPool + cpIndex;
+	/* interfaceClass is used to indicate 'resolved'. Make sure to read it first */
+	J9Class* volatile interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
+	VM_AtomicSupport::readBarrier();
+	UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
+	J9Method *improperMethod = NULL;
+	/* If the ref is resolved, do not call the resolve helper, as it will currently fail if the interface class is not initialized */
+	if (NULL == interfaceClass) {
+		J9RAMInterfaceMethodRef localEntry;
+		if (NULL == currentThread->javaVM->internalVMFunctions->resolveInterfaceMethodRefInto(currentThread, constantPool, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, &localEntry)) {
+			goto done;
+		}
+		interfaceClass = (J9Class*)localEntry.interfaceClass;
+		methodIndexAndArgCount = localEntry.methodIndexAndArgCount;
+	}
+	if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_TAG_BITS)) {
+		UDATA methodIndex = methodIndexAndArgCount >> J9_ITABLE_INDEX_SHIFT;
+		J9Class *jlObject = J9VMJAVALANGOBJECT_OR_NULL(currentThread->javaVM);
+		if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_METHOD_INDEX)) {
+			if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_OBJECT)) {
+				/* Object method not in the vTable */
+				improperMethod = jlObject->ramMethods + methodIndex;
+			} else {
+				/* Private interface method */
+				improperMethod = interfaceClass->ramMethods + methodIndex;
+			}
+		} else {
+			/* Object method in the vTable. Return the Object method since we
+			 * don't know the receiver. The JIT will find its vTable offset and
+			 * generate a virtual dispatch.
+			 */
+			improperMethod = *(J9Method**)((UDATA)jlObject + methodIndex);
+		}
+	}
+done:
+	return improperMethod;
+}
+
 /* jitGetInterfaceITableIndexFromCP, jitGetInterfaceVTableOffsetFromCP and jitGetInterfaceMethodFromCP
  * apply only to normal interface invocations, any special-case invocation will cause the calls to fail
  * (i.e. special cases will be treated as unresolved).
@@ -82,56 +129,9 @@ jitGetInterfaceITableIndexFromCP(J9VMThread *currentThread, J9ConstantPool *cons
 	if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_TAG_BITS)) {
 		interfaceClass = NULL;
 	}
-	*pITableIndex = methodIndexAndArgCount >> 8;
+	*pITableIndex = methodIndexAndArgCount >> J9_ITABLE_INDEX_SHIFT;
 done:
 	return interfaceClass;
-}
-
-/* Only returns non-null if the method is resolved and not to be dispatched by
- * itable, i.e. if it is:
- * - private, using direct dispatch;
- * - a final method of Object, using direct dispatch; or
- * - a non-final method of Object, using virtual dispatch.
- */
-J9Method*
-jitGetImproperInterfaceMethodFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex)
-{
-	J9RAMInterfaceMethodRef *ramMethodRef = (J9RAMInterfaceMethodRef*)constantPool + cpIndex;
-	/* interfaceClass is used to indicate 'resolved'. Make sure to read it first */
-	J9Class* volatile interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
-	VM_AtomicSupport::readBarrier();
-	UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
-	J9Method *improperMethod = NULL;
-	/* If the ref is resolved, do not call the resolve helper, as it will currently fail if the interface class is not initialized */
-	if (NULL == interfaceClass) {
-		J9RAMInterfaceMethodRef localEntry;
-		if (NULL == currentThread->javaVM->internalVMFunctions->resolveInterfaceMethodRefInto(currentThread, constantPool, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, &localEntry)) {
-			goto done;
-		}
-		interfaceClass = (J9Class*)localEntry.interfaceClass;
-		methodIndexAndArgCount = localEntry.methodIndexAndArgCount;
-	}
-	if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_TAG_BITS)) {
-		UDATA methodIndex = (methodIndexAndArgCount & ~J9_ITABLE_INDEX_TAG_BITS) >> 8;
-		J9Class *jlObject = J9VMJAVALANGOBJECT_OR_NULL(currentThread->javaVM);
-		if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_METHOD_INDEX)) {
-			if (J9_ARE_ANY_BITS_SET(methodIndexAndArgCount, J9_ITABLE_INDEX_OBJECT)) {
-				/* Object method not in the vTable */
-				improperMethod = jlObject->ramMethods + methodIndex;
-			} else {
-				/* Private interface method */
-				improperMethod = interfaceClass->ramMethods + methodIndex;
-			}
-		} else {
-			/* Object method in the vTable. Return the Object method since we
-			 * don't know the receiver. The JIT will find its vTable offset and
-			 * generate a virtual dispatch.
-			 */
-			improperMethod = *(J9Method**)((UDATA)jlObject + methodIndex);
-		}
-	}
-done:
-	return improperMethod;
 }
 
 UDATA

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -822,21 +822,22 @@ extern "C" {
 #define J9_VTABLE_INDEX_DIRECT_METHOD_FLAG 0x1
 
 /* Tag bits for J9RAMInterfaceMethodRef->methodIndexAndArgCount:
-*
-*	J9_ITABLE_INDEX_METHOD_INDEX - index represents a direct method index
-*	J9_ITABLE_INDEX_OBJECT		 - use Object rather than the targetted interfaceClass
-*
-* Private methods in interface will have only J9_ITABLE_INDEX_METHOD_INDEX set, indicating that
-* the underlying index is a method index into the interfaceClass of the ref.
-*
-* vTable methods in Object will have only J9_ITABLE_INDEX_OBJECT set, indicating that
-* the underlying index is a vTable index in Object.
-*
-* Non-vTable methods in Object will have J9_ITABLE_INDEX_OBJECT and J9_ITABLE_INDEX_METHOD_INDEX set,
-* indicating that the underlying index is a method index in Object.
-*/
-#define J9_ITABLE_INDEX_METHOD_INDEX ((UDATA)1 << ((8 * sizeof(UDATA)) - 1))
-#define J9_ITABLE_INDEX_OBJECT ((UDATA)1 << ((8 * sizeof(UDATA)) - 2))
+ *
+ *	J9_ITABLE_INDEX_METHOD_INDEX - index represents a direct method index
+ *	J9_ITABLE_INDEX_OBJECT       - use Object rather than the targetted interfaceClass
+ *
+ * Private methods in interface will have only J9_ITABLE_INDEX_METHOD_INDEX set, indicating that
+ * the underlying index is a method index into the interfaceClass of the ref.
+ *
+ * vTable methods in Object will have only J9_ITABLE_INDEX_OBJECT set, indicating that
+ * the underlying index is a vTable offset in Object.
+ *
+ * Non-vTable methods in Object will have J9_ITABLE_INDEX_OBJECT and J9_ITABLE_INDEX_METHOD_INDEX set,
+ * indicating that the underlying index is a method index in Object.
+ */
+#define J9_ITABLE_INDEX_SHIFT 10
+#define J9_ITABLE_INDEX_METHOD_INDEX ((UDATA)1 << 8)
+#define J9_ITABLE_INDEX_OBJECT ((UDATA)1 << 9)
 #define J9_ITABLE_INDEX_TAG_BITS (J9_ITABLE_INDEX_METHOD_INDEX | J9_ITABLE_INDEX_OBJECT)
 
 /* Tag bits for iTableOffset field in JIT interface snippet data:

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1701,7 +1701,7 @@ fixRAMConstantPoolForFastHCR(J9ConstantPool *ramConstantPool, J9HashTable *class
 			}
 			case J9CPTYPE_INTERFACE_METHOD: {
 				J9RAMInterfaceMethodRef *methodRef = (J9RAMInterfaceMethodRef *) &ramConstantPool[cpIndex];
-				UDATA methodIndex = ((methodRef->methodIndexAndArgCount & ~255) >> 8);
+				UDATA methodIndex = methodRef->methodIndexAndArgCount >> J9_ITABLE_INDEX_SHIFT;
 				J9Class *resolvedClass = (J9Class *) methodRef->interfaceClass;
 				/* Don't fix unresolved entries */
 				if (NULL != resolvedClass) {
@@ -1728,7 +1728,7 @@ fixRAMConstantPoolForFastHCR(J9ConstantPool *ramConstantPool, J9HashTable *class
 										UDATA argCount = (methodRef->methodIndexAndArgCount & 255);
 										UDATA newMethodIndex = getITableIndexForMethod(methodResult->newMethod, resolvedClass);
 										/* Fix the index in the resolved CP entry, retaining the argCount */
-										methodRef->methodIndexAndArgCount = ((newMethodIndex << 8) | argCount);
+										methodRef->methodIndexAndArgCount = ((newMethodIndex << J9_ITABLE_INDEX_SHIFT) | argCount);
 									}
 								}
 							}

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -6677,7 +6677,7 @@ resolve:
 			rc = THROW_NPE;
 		} else {
 			J9Class *receiverClass = J9OBJECT_CLAZZ(_currentThread, receiver);
-			UDATA methodIndex = (methodIndexAndArgCount & ~J9_ITABLE_INDEX_TAG_BITS) >> 8;
+			UDATA methodIndex = methodIndexAndArgCount >> J9_ITABLE_INDEX_SHIFT;
 			J9ROMMethod *romMethod = NULL;
 
 			/* Run search in receiverClass->lastITable */

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1089,8 +1089,9 @@ resolveInterfaceMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA
 				}
 				tagBits |= J9_ITABLE_INDEX_OBJECT;
 			}
-			methodIndex <<= 8;
-			Assert_VM_true(J9_ARE_NO_BITS_SET(methodIndex, J9_ITABLE_INDEX_TAG_BITS));
+			/* Ensure methodIndex can be shifted without losing any bits */
+			Assert_VM_true(methodIndex < ((UDATA)1 << ((sizeof(UDATA) * 8) - J9_ITABLE_INDEX_SHIFT)));
+			methodIndex <<= J9_ITABLE_INDEX_SHIFT;
 			methodIndex = methodIndex | tagBits | oldArgCount;
 			ramCPEntry->methodIndexAndArgCount = methodIndex;
 			/* interfaceClass is used to indicate resolved. Make sure to write it last */


### PR DESCRIPTION
Move the tag bits in J9RAMInterfaceMethodRef->methodIndexAndArgCount to
the low end so that the encoded index can be retrieved with a single
shift, rather than the mask and shift that is currently used.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>