### PR TITLE
Compiler: Add exclude for OMRVirtualMachineRegister

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -110,6 +110,7 @@ set(REMOVED_OMR_FILES
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRTypeDictionary.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineRegister.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineState.cpp
 )
 


### PR DESCRIPTION
New file was introduced in eclipse/omr#2847
Is not needed & does not compile properly in openj9

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>