### PR TITLE
Fix for incorrect test generated by ZEROCHK on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -2136,7 +2136,7 @@ TR::Register *J9::X86::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::CodeG
    else
       {
       TR::Register *value = cg->evaluate(node->getFirstChild());
-      generateRegRegInstruction(TESTRegReg(!value->areUpperBitsZero()), node, value, value, cg);
+      generateRegRegInstruction(TEST4RegReg, node, value, value, cg);
       cg->decReferenceCount(node->getFirstChild());
       generateLabelInstruction(JE4, node, slowPathLabel, cg);
       }


### PR DESCRIPTION
ZEROCHK incorrectly generated 64-bit test instruction on X86-32.
In fact, it should always use 32-bit test instruction on both 32-bit and 64-bit,
since its only child must has type TR::Int32.
This changeset fixes the above defect..

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>