### PR TITLE
Address diagnostics from gcc 8

### DIFF
--- a/runtime/gc_trace/TgcExtensions.cpp
+++ b/runtime/gc_trace/TgcExtensions.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +36,7 @@ MM_TgcExtensions::newInstance(MM_GCExtensions *extensions)
 {
 	MM_TgcExtensions * tgcExtensions = (MM_TgcExtensions *) extensions->getForge()->allocate(sizeof(MM_TgcExtensions), MM_AllocationCategory::DIAGNOSTIC, J9_GET_CALLSITE());
 	if (NULL != tgcExtensions) {
-		memset(tgcExtensions, 0, sizeof(MM_TgcExtensions));
+		memset((void *)tgcExtensions, 0, sizeof(MM_TgcExtensions));
 		new(tgcExtensions) MM_TgcExtensions(extensions);
 	}
 	return tgcExtensions;

--- a/runtime/gc_vlhgc/CollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/CollectionSetDelegate.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,7 +69,7 @@ MM_CollectionSetDelegate::initialize(MM_EnvironmentVLHGC *env)
 		if(NULL == _setSelectionDataTable) {
 			goto error_no_memory;
 		}
-		memset(_setSelectionDataTable, 0, tableAllocationSizeInBytes);
+		memset((void *)_setSelectionDataTable, 0, tableAllocationSizeInBytes);
 		for(UDATA index = 0; index < setSelectionEntryCount; index++) {
 			_setSelectionDataTable[index]._compactGroup = index;
 		}

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -421,7 +421,7 @@ MM_CopyForwardScheme::initialize(MM_EnvironmentVLHGC *env)
 		return false;
 	}
 	
-	memset(_reservedRegionList, 0, sizeof(MM_ReservedRegionListHeader) * _compactGroupMaxCount);
+	memset((void *)_reservedRegionList, 0, sizeof(MM_ReservedRegionListHeader) * _compactGroupMaxCount);
 	for(UDATA index = 0; index < _compactGroupMaxCount; index++) {
 		_reservedRegionList[index]._maxSublistCount = 1;
 		_reservedRegionList[index]._sublistCount = 1;

--- a/runtime/gc_vlhgc/CopyScanCacheListVLHGC.cpp
+++ b/runtime/gc_vlhgc/CopyScanCacheListVLHGC.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +57,7 @@ MM_CopyScanCacheListVLHGC::initialize(MM_EnvironmentVLHGC *env)
 		return false;
 	}
 
-	memset(_sublists, 0, sublistBytes);
+	memset((void *)_sublists, 0, sublistBytes);
 	for (UDATA i = 0; i < _sublistCount; i++) {
 		if (!_sublists[i]._cacheLock.initialize(env, &extensions->lnrlOptions, "MM_CopyScanCacheListVLHGC:_sublists[]._cacheLock")) {
 			return false;
@@ -66,7 +65,6 @@ MM_CopyScanCacheListVLHGC::initialize(MM_EnvironmentVLHGC *env)
 	}
 	
 	return true;
-
 }
 
 void

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +72,7 @@ MM_ProjectedSurvivalCollectionSetDelegate::initialize(MM_EnvironmentVLHGC *env)
 		if(NULL == _setSelectionDataTable) {
 			goto error_no_memory;
 		}
-		memset(_setSelectionDataTable, 0, tableAllocationSizeInBytes);
+		memset((void *)_setSelectionDataTable, 0, tableAllocationSizeInBytes);
 		for(UDATA index = 0; index < setSelectionEntryCount; index++) {
 			_setSelectionDataTable[index]._compactGroup = index;
 		}

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -200,7 +200,7 @@ MM_WriteOnceCompactor::initialize(MM_EnvironmentVLHGC *env)
 		_compactGroupDestinations = (MM_CompactGroupDestinations *)j9mem_allocate_memory(sizeof(MM_CompactGroupDestinations) * compactGroups, OMRMEM_CATEGORY_MM);
 		didAllocateTable = (NULL != _compactGroupDestinations);
 		if (didAllocateTable) {
-			memset(_compactGroupDestinations, 0, sizeof(MM_CompactGroupDestinations) * compactGroups);
+			memset((void *)_compactGroupDestinations, 0, sizeof(MM_CompactGroupDestinations) * compactGroups);
 			for (UDATA i = 0; i < compactGroups; i++) {
 				_compactGroupDestinations[i].head = NULL;
 				_compactGroupDestinations[i].tail = NULL;

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -47,8 +47,6 @@ static jint initializeBootClassPathSystemProperty( J9JavaVM *vm);
 static IDATA initializeSystemThreadGroup(J9JavaVM * vm, JNIEnv * env);
 static char * addEndorsedPath(J9PortLibrary *portLib, char *endorsedPath, char *path);
 
-
-
 /* JCL_J2SE */
 #define JCL_J2SE
 
@@ -81,7 +79,6 @@ computeJCLRuntimeFlags( J9JavaVM* vm)
 	flags |= JCL_RTFLAG_OPT_PANAMA;
 #endif
 
-
 #ifdef J9VM_OPT_MODULE
 	if ((J2SE_VERSION(vm) & J2SE_RELEASE_MASK) >= J2SE_19) {
 		flags |= JCL_RTFLAG_OPT_MODULE;
@@ -95,7 +92,8 @@ computeJCLRuntimeFlags( J9JavaVM* vm)
 	return flags;
 }
 
-jint standardInit( J9JavaVM *vm, char* dllName)
+jint
+standardInit( J9JavaVM *vm, char* dllName)
 {
 	jint result;
 	J9VMThread *vmThread = vm->mainThread;
@@ -141,7 +139,7 @@ jint standardInit( J9JavaVM *vm, char* dllName)
 	}
 
 	vmFuncs->internalAcquireVMAccess(vmThread);
-	result = (jint)initializeRequiredClasses(vmThread, dllName );
+	result = (jint)initializeRequiredClasses(vmThread, dllName);
 
 	if (0 == result) {
 		result = vmFuncs->initializeHeapOOMMessage(vmThread);
@@ -166,7 +164,7 @@ jint standardInit( J9JavaVM *vm, char* dllName)
 #endif /* J9VM_OPT_SIDECAR */
 
 	vmFuncs->internalAcquireVMAccess(vmThread);
-	
+
 	if (result == 0) {
 		U_32 runtimeFlags = computeJCLRuntimeFlags(vm);
 		result = initializeKnownClasses(vm, runtimeFlags);
@@ -177,12 +175,10 @@ jint standardInit( J9JavaVM *vm, char* dllName)
 		/* Must do this before initializeAttachedThread */
 		vmFuncs->internalReleaseVMAccess(vmThread);
 
-
 		TRIGGER_J9HOOK_VM_INITIALIZE_REQUIRED_CLASSES_DONE(vm->hookInterface, vmThread, continueInitialization);
 		if (!continueInitialization) {
 			goto _fail;
 		}
-
 
 		result = (jint)initializeSystemThreadGroup(vm, (JNIEnv*)vmThread);
 		if (result != JNI_OK) goto _fail;
@@ -231,7 +227,7 @@ jint standardInit( J9JavaVM *vm, char* dllName)
 		if (!invokeMethod) goto _fail;
 		vm->jlrMethodInvoke = ((J9JNIMethodID *) invokeMethod)->method;
 		(*(JNIEnv*)vmThread)->DeleteLocalRef((JNIEnv*)vmThread, clazz);
-		
+
 		if (J2SE_SHAPE(vm) != J2SE_SHAPE_RAW) {
 			/* JSR 292-related class */
 			clazz = (*(JNIEnv*)vmThread)->FindClass((JNIEnv*)vmThread, "com/ibm/oti/lang/ArgumentHelper");
@@ -288,12 +284,12 @@ _fail:
 	return JNI_ERR;
 }
 
-
 /**
   * Set up any information that might be consumed/modified by other libraries before classes are loaded.
-  *  
+  *
   */
-jint standardPreconfigure( JavaVM *jvm)
+jint
+standardPreconfigure( JavaVM *jvm)
 {
 	J9JavaVM* vm = (J9JavaVM*)jvm;
 
@@ -312,8 +308,8 @@ _fail:
 	return JNI_ERR;
 }
 
-
-static IDATA initializeSystemThreadGroup(J9JavaVM * vm, JNIEnv * env)
+static IDATA
+initializeSystemThreadGroup(J9JavaVM * vm, JNIEnv * env)
 {
 	IDATA result = JNI_ERR;
 	jclass threadClass = NULL;
@@ -361,7 +357,6 @@ done:
 	if (groupNameRef) (*env)->DeleteLocalRef(env, groupNameRef);
 	return result;
 }
-
 
 void
 internalInitializeJavaLangClassLoader(JNIEnv * env)
@@ -433,13 +428,15 @@ exitVM:
 done: ;
 }
 
-
-jint JNICALL JVM_OnUnload(JavaVM* jvm, void* reserved) {
+jint
+JNICALL JVM_OnUnload(JavaVM* jvm, void* reserved)
+{
 	return 0;
 }
 
-
-jint JCL_OnUnload(J9JavaVM* vm, void* reserved) {
+jint
+JCL_OnUnload(J9JavaVM* vm, void* reserved)
+{
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	if (vm->bootstrapClassPath) {
@@ -451,8 +448,8 @@ jint JCL_OnUnload(J9JavaVM* vm, void* reserved) {
 	return 0;
 }
 
-
-IDATA checkJCL(J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Version, UDATA jclVersion)
+IDATA
+checkJCL(J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Version, UDATA jclVersion)
 {
 	J9JavaVM * vm = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -460,7 +457,7 @@ IDATA checkJCL(J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Ver
 	UDATA j9V, jclV;
 
 	/* If jclConfig is NULL or jclVersion is -1, then we didn't find the fields in java.lang.Class. Make sure the dllValue and jclConfig match. */
-	if((jclConfig == NULL) || (jclVersion == (UDATA)-1) || (memcmp( jclConfig, dllValue, 8))) {
+	if ((jclConfig == NULL) || (jclVersion == (UDATA)-1) || (memcmp(jclConfig, dllValue, 8))) {
 		/* Incompatible class library */
 		j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_BEGIN_MULTI_LINE, J9NLS_JCL_INCOMPATIBLE_CL);
 		if (jclConfig != NULL) {
@@ -495,20 +492,17 @@ IDATA checkJCL(J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Ver
 	}
 
 	/* Last, compare the versions */
-	if((jclV = jclVersion & 0xffff) != (j9V = j9Version & 0xffff))
-	{
+	if((jclV = jclVersion & 0xffff) != (j9V = j9Version & 0xffff)) {
 		/* Incompatible class library version: JCL %x, VM %x */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_JCL_INCOMPATIBLE_CL_VERSION, jclV, j9V);
 		return 3;
 	}
-	if((jclV = jclVersion & 0xff0000) < (j9V = j9Version & 0xff0000))
-	{
+	if((jclV = jclVersion & 0xff0000) < (j9V = j9Version & 0xff0000)) {
 		/* Incompatible class library version: expected JCL v%i, found v%i */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_JCL_INCOMPATIBLE_CL_VERSION_JCL, j9V >> 16, jclV >> 16);
 		return 4;
 	}
-	if((jclV = jclVersion & 0xff000000) > (j9V = j9Version & 0xff000000))
-	{
+	if((jclV = jclVersion & 0xff000000) > (j9V = j9Version & 0xff000000)) {
 		/* Incompatible class library version: requires VM v%i, found v%i */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_JCL_INCOMPATIBLE_CL_VERSION_VM, jclV >> 24, j9V >> 24);
 		return 5;
@@ -518,10 +512,10 @@ IDATA checkJCL(J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Ver
 	return 0;
 }
 
-
 #ifdef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
 
-static IDATA initializeBootstrapClassPath(J9JavaVM * vm)
+static IDATA
+initializeBootstrapClassPath(J9JavaVM * vm)
 {
 	VMI_ACCESS_FROM_JAVAVM((JavaVM*)vm);
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
@@ -539,10 +533,10 @@ static IDATA initializeBootstrapClassPath(J9JavaVM * vm)
 	(*VMI)->GetSystemProperty(VMI, BOOT_PATH_SEPARATOR_SYS_PROP, &classpathSeparator);
 
 	/* Fail if the classpath has already been set */
-	if(J9_ARE_ALL_BITS_SET(loader->flags, J9CLASSLOADER_CLASSPATH_SET)){
+	if(J9_ARE_ALL_BITS_SET(loader->flags, J9CLASSLOADER_CLASSPATH_SET)) {
 		return -2;
 	}
-	
+
 #if defined(J9VM_OPT_SHARED_CLASSES)
 	if (J9_ARE_ALL_BITS_SET(loader->flags, J9CLASSLOADER_SHARED_CLASSES_ENABLED)) {
 		/* Warm up the classpath entry so that the Classpath stored in the cache has the correct info.
@@ -559,19 +553,19 @@ static IDATA initializeBootstrapClassPath(J9JavaVM * vm)
 	} else {
 		/* Mark the class path as having been set */
 		loader->flags |= J9CLASSLOADER_CLASSPATH_SET;
-	
+
 		TRIGGER_J9HOOK_VM_CLASS_LOADER_CLASSPATH_ENTRIES_INITIALIZED(vm->hookInterface, vm, loader);
 	}
 
 	return 0;
 }
 
-
-static UDATA isEndorsedBundle(const char *filename)
+static UDATA
+isEndorsedBundle(const char *filename)
 {
 	size_t len = strlen(filename);
 
-	if ( len > 4 ) {
+	if (len > 4) {
 		char suffix[4];
 
 		suffix[0] = j9_ascii_tolower(filename[len-4]);
@@ -579,17 +573,18 @@ static UDATA isEndorsedBundle(const char *filename)
 		suffix[2] = j9_ascii_tolower(filename[len-2]);
 		suffix[3] = j9_ascii_tolower(filename[len-1]);
 
-		if ( strncmp(suffix, ".jar", 4) == 0 ) {
+		if (strncmp(suffix, ".jar", 4) == 0) {
 			return 1;
-		} else if ( strncmp(suffix, ".zip", 4) == 0 ) {
+		} else if (strncmp(suffix, ".zip", 4) == 0) {
 			return 1;
 		}
 	}
+
 	return 0;
 }
 
-
-static char * addEndorsedPath(J9PortLibrary *portLib, char *endorsedPath, char *path)
+static char *
+addEndorsedPath(J9PortLibrary *portLib, char *endorsedPath, char *path)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
@@ -600,7 +595,7 @@ static char * addEndorsedPath(J9PortLibrary *portLib, char *endorsedPath, char *
 	char* endorsedDir = j9mem_allocate_memory(EsMaxPath * 2, J9MEM_CATEGORY_VM_JCL);
 	if (!endorsedDir) return path;
 
-	while ( dirStart  > (char *) 1 ) {
+	while (dirStart > (char *)1) {
 		/* break path into separate directories */
 		dirEnd = strchr(dirEnd, separator);
 
@@ -626,8 +621,8 @@ static char * addEndorsedPath(J9PortLibrary *portLib, char *endorsedPath, char *
 	return path;
 }
 
-
-static char * addEndorsedBundles(J9PortLibrary *portLib, char *endorsedDir, char *path, char *endorsedBundle)
+static char *
+addEndorsedBundles(J9PortLibrary *portLib, char *endorsedDir, char *path, char *endorsedBundle)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
@@ -657,18 +652,18 @@ static char * addEndorsedBundles(J9PortLibrary *portLib, char *endorsedDir, char
 	return path;
 }
 
-
 /**
   * Initialize the BOOT_PATH_SYS_PROP (sun.boot.class.path) system property by scanning the vm args and extracting
   * the value of any -Xbootclasspath: argument.  If no bootpath is explicitly specified then use a default
   * value appropriate for this class library.
-  * 
+  *
   * @return  zero on sucess, non-zero on failure.
   *
   * @note Assumes that the VMI functions are available, and sysprops have been allocated.
-  * @note Requires that the 'java.home' system property be available. 
+  * @note Requires that the 'java.home' system property be available.
   */
-static jint initializeBootClassPathSystemProperty( J9JavaVM *vm)
+static jint
+initializeBootClassPathSystemProperty(J9JavaVM *vm)
 {
 	VMI_ACCESS_FROM_JAVAVM((JavaVM*)vm);
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -683,7 +678,7 @@ static jint initializeBootClassPathSystemProperty( J9JavaVM *vm)
 
 	/* Scan for the explicit bootpath override */
 	for (i = 0; i < args->nOptions; i++) {
-		if (strncmp(args->options[i].optionString, bpOption, bpOptionLength) == 0) { 
+		if (strncmp(args->options[i].optionString, bpOption, bpOptionLength) == 0) {
 			bp = &(args->options[i].optionString[bpOptionLength]);
 
 			/* empty bootclasspath means use default */
@@ -700,7 +695,7 @@ static jint initializeBootClassPathSystemProperty( J9JavaVM *vm)
 		vmiError rcGetProp;
 
 		/* If the bootpath already exists (i.e. it was set using a -D in the startup options), use that one */
-		rcGetProp = (*VMI)->GetSystemProperty(VMI, BOOT_PATH_SYS_PROP,&currentBootpath);
+		rcGetProp = (*VMI)->GetSystemProperty(VMI, BOOT_PATH_SYS_PROP, &currentBootpath);
 		if (rcGetProp != VMI_ERROR_NONE) {
 			return -2;
 		}
@@ -709,30 +704,30 @@ static jint initializeBootClassPathSystemProperty( J9JavaVM *vm)
 		}
 
 		/* Entries are relative to java.home */
-		rcGetProp = (*VMI)->GetSystemProperty(VMI, "java.home",&javaHome);
+		rcGetProp = (*VMI)->GetSystemProperty(VMI, "java.home", &javaHome);
 		if (rcGetProp != VMI_ERROR_NONE) {
 			return -2;
 		}
 
 		/* Add the 'standard' collection of jars */
-		bp = getDefaultBootstrapClassPath( (J9JavaVM*)vm, javaHome);
+		bp = getDefaultBootstrapClassPath((J9JavaVM*)vm, javaHome);
 		if (!bp ) {
 			return -1;
 		}
 
 		/* Remember that the bp must be freed */
-		freeBP = 1; 
-	} 
+		freeBP = 1;
+	}
 
 	/* Set the system property */
 	vmiRC = (*VMI)->SetSystemProperty(VMI, BOOT_PATH_SYS_PROP, bp);
 	if (vmiRC != VMI_ERROR_NONE) {
-		rc = -3;		
+		rc = -3;
 	}
 
 	/* Free the memory if necessary */
 	if (freeBP) {
-		j9mem_free_memory(bp);	
+		j9mem_free_memory(bp);
 	}
 
 	return rc;
@@ -746,7 +741,7 @@ static jint initializeBootClassPathSystemProperty( J9JavaVM *vm)
  *
  * @return 0 On success, non-zero otherwise.
  */
-static IDATA 
+static IDATA
 computeBootstrapClassPathAppend(J9JavaVM *vm)
 {
 	I_32 i = 0;
@@ -829,7 +824,8 @@ _end:
   *
   * @note Requires that the 'java.home' system property has been set in the VMI.
   */
-static IDATA computeFinalBootstrapClassPath(J9JavaVM * vm)
+static IDATA
+computeFinalBootstrapClassPath(J9JavaVM * vm)
 {
 	VMI_ACCESS_FROM_JAVAVM((JavaVM*)vm);
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -843,16 +839,16 @@ static IDATA computeFinalBootstrapClassPath(J9JavaVM * vm)
 #define PRIV_J9_BPA_OPTION_LEN 18  /* strlen() */
 #define PRIV_J9_BPP_OPTION "-Xbootclasspath/p:"
 #define PRIV_J9_BPP_OPTION_LEN 18  /* strlen() */
- 
+
 #define PRIV_J9_IJB_OPTION "-Dibm.jvm.bootclasspath="
 #define PRIV_J9_IJB_OPTION_LEN 24  /* strlen() */
- 
+
 	/* Fetch java.home and cache it in the JavaVM struct */
 	vmiRC = (*VMI)->GetSystemProperty(VMI, "java.home", &javaHome);
 	if (vmiRC != VMI_ERROR_NONE) {
 		return -1;
 	}
-	
+
 	/* Fetch the java.endorsed.dirs path */
 	vmiRC = (*VMI)->GetSystemProperty(VMI, JAVA_ENDORSED_DIRS_PROP, &endorsedPath);
 	if (vmiRC != VMI_ERROR_NONE) {
@@ -876,7 +872,7 @@ static IDATA computeFinalBootstrapClassPath(J9JavaVM * vm)
 	-Xbootclasspath/p: if specified. So scan for -Dibm.jvm.bootclasspath first. */
 #ifdef JCL_J2SE
 	for (i = 0; i < args->nOptions; i++) {
-		if (strncmp(args->options[i].optionString, PRIV_J9_IJB_OPTION, PRIV_J9_IJB_OPTION_LEN) == 0) { 
+		if (strncmp(args->options[i].optionString, PRIV_J9_IJB_OPTION, PRIV_J9_IJB_OPTION_LEN) == 0) {
 			char* oldPath = path;
 			path = catPaths(PORTLIB, &(args->options[i].optionString[PRIV_J9_IJB_OPTION_LEN]), path);
 			j9mem_free_memory(oldPath);
@@ -889,14 +885,14 @@ static IDATA computeFinalBootstrapClassPath(J9JavaVM * vm)
 
 	/* Look for and add the prepend and append bootclasspath options */
 	for (i = 0; i < args->nOptions; i++) {
-		if (strncmp(args->options[i].optionString, PRIV_J9_BPA_OPTION, PRIV_J9_BPA_OPTION_LEN) == 0) { 
+		if (strncmp(args->options[i].optionString, PRIV_J9_BPA_OPTION, PRIV_J9_BPA_OPTION_LEN) == 0) {
 			char* oldPath = path;
 			path = catPaths(PORTLIB, path, &(args->options[i].optionString[PRIV_J9_BPA_OPTION_LEN]));
 			j9mem_free_memory(oldPath);
 			if (path == NULL) {
 				return -5;
 			}
-		} else if (strncmp(args->options[i].optionString, PRIV_J9_BPP_OPTION, PRIV_J9_BPP_OPTION_LEN) == 0) { 
+		} else if (strncmp(args->options[i].optionString, PRIV_J9_BPP_OPTION, PRIV_J9_BPP_OPTION_LEN) == 0) {
 			char* oldPath = path;
 			path = catPaths(PORTLIB, &(args->options[i].optionString[PRIV_J9_BPP_OPTION_LEN]), path);
 			j9mem_free_memory(oldPath);
@@ -920,7 +916,7 @@ static IDATA computeFinalBootstrapClassPath(J9JavaVM * vm)
 	/* Update the VM sysprop */
 	vmiRC = (*VMI)->SetSystemProperty(VMI, BOOT_PATH_SYS_PROP, path);
 	if (vmiRC != VMI_ERROR_NONE) {
-		return -11;		
+		return -11;
 	}
 
 	return 0;

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -633,11 +633,14 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
 	IDATA optionsLength;
 	IDATA rc =  J9VMDLLMAIN_OK;
 
+#define trace_option_helper(option) \
+		splitCommandLineOption(vm, option, LITERAL_STRLEN(option), opts + i)
+
 	/* set up the default options */
-	rc = splitCommandLineOption(vm, UT_MAXIMAL_KEYWORD "=all{level1}", 20, opts);
+	rc = trace_option_helper(UT_MAXIMAL_KEYWORD "=all{level1}");
 	i += 2;
 	if (rc != J9VMDLLMAIN_FAILED) {
-		rc = splitCommandLineOption(vm, UT_EXCEPTION_KEYWORD "=j9mm{gclogger}", 26, opts + i);
+		rc = trace_option_helper(UT_EXCEPTION_KEYWORD "=j9mm{gclogger}");
 		i += 2;
 	}
 
@@ -653,7 +656,7 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
 	 * trace they selected but their selection + level 2.)
 	 */
 	if( xtraceIndex >= 0 && !checkAndSetL2EnabledFlag() ) {
-		rc = splitCommandLineOption(vm, UT_MAXIMAL_KEYWORD "=all{level2}", 20, opts + i);
+		rc = trace_option_helper(UT_MAXIMAL_KEYWORD "=all{level2}");
 		i += 2;
 	}
 	while (xtraceIndex >= 0) {
@@ -675,6 +678,8 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
 	}
 	opts[i++] = NULL;
 	return rc;
+
+#undef trace_option_helper
 }
 
 /*

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -93,7 +93,7 @@ static void javaTraceTerm (void* env, UtModuleInfo *modInfo);
 
 typedef omr_error_t (*traceOptionFunction)(J9JavaVM *vm,const char * value,BOOLEAN atRuntime);
 
-/** 
+/**
  * Structure representing a trace option such as stackdepth
  * or trigger
  */
@@ -109,11 +109,12 @@ struct traceOption {
  * (Set the methods to be traced, set the depth and the compression options
  * for the stacks produced by the jstacktrace trigger action.)
  */
-const struct traceOption TRACE_OPTIONS[] = {
-		/* Name, Can be modified at runtime, option function */
-		{RAS_METHODS_KEYWORD, FALSE, setMethod},
-		{RAS_STACKDEPTH_KEYWORD, TRUE, setStackDepth},
-		{RAS_COMPRESSION_LEVEL_KEYWORD, TRUE, setStackCompressionLevel},
+const struct traceOption TRACE_OPTIONS[] =
+{
+	/* Name, Can be modified at runtime, option function */
+	{RAS_METHODS_KEYWORD, FALSE, setMethod},
+	{RAS_STACKDEPTH_KEYWORD, TRUE, setStackDepth},
+	{RAS_COMPRESSION_LEVEL_KEYWORD, TRUE, setStackCompressionLevel},
 };
 
 #define NUMBER_OF_TRACE_OPTIONS ( sizeof(TRACE_OPTIONS) / sizeof(struct traceOption))
@@ -124,7 +125,8 @@ const struct traceOption TRACE_OPTIONS[] = {
  * trace point hit) can fire Java dependent events (like creating
  * a javacore).
  */
-static struct RasTriggerAction j9vmTriggerActions[] = {
+static struct RasTriggerAction j9vmTriggerActions[] =
+{
 	{ "jstacktrace", AFTER_TRACEPOINT, doTriggerActionJstacktrace},
 	{ "javadump", AFTER_TRACEPOINT, doTriggerActionJavadump},
 	{ "coredump", AFTER_TRACEPOINT, doTriggerActionCoredump},
@@ -144,27 +146,28 @@ static struct RasTriggerAction j9vmTriggerActions[] = {
 
 #define NUM_J9VM_TRIGGER_ACTIONS (sizeof(j9vmTriggerActions) / sizeof(j9vmTriggerActions[0]))
 
-static const struct RasTriggerType methodTriggerType = 	{ "method", processTriggerMethodClause, FALSE };
+static const struct RasTriggerType methodTriggerType = { "method", processTriggerMethodClause, FALSE };
 
 /* Global lock for J9VM trace operations. */
 omrthread_monitor_t j9TraceLock = NULL;
 
 /* Structures for trace interfaces. */
-static J9UtServerInterface	javaUtServerIntfS;
-static UtModuleInterface	javaUtModuleIntfS;
+static J9UtServerInterface  javaUtServerIntfS;
+static UtModuleInterface    javaUtModuleIntfS;
 
-static UtModuleInterface	omrUtModuleIntfS;
+static UtModuleInterface    omrUtModuleIntfS;
 /* Required to look up the current thread if we are passed a null current thread on a trace point.
  * (NoEnv trace points always pass null.)
  */
 J9JavaVM* globalVM;
 
-IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
+IDATA
+J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 {
 	IDATA returnVal = J9VMDLLMAIN_OK;
 	omr_error_t rc = OMR_ERROR_NONE;
 
-	char *ignore[] = {"INITIALIZATION", "METHODS", "WHAT", "STACKDEPTH", "STACKCOMPRESSIONLEVEL", NULL};
+	char *ignore[] = { "INITIALIZATION", "METHODS", "WHAT", "STACKDEPTH", "STACKCOMPRESSIONLEVEL", NULL };
 	char *opts[UT_MAX_OPTS];
 	int i;
 	UtThreadData **tempThr = NULL;
@@ -189,13 +192,13 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 				memset (vm->j9rasGlobalStorage, '\0', sizeof(RasGlobalStorage));
 			}
 		}
-		
+
 		if (vm->j9rasGlobalStorage != NULL) {
 			vm->runtimeFlags |= J9_RUNTIME_EXTENDED_METHOD_BLOCK;
 			RAS_GLOBAL_FROM_JAVAVM(stackdepth,vm) = -1;
 			((RasGlobalStorage *)vm->j9rasGlobalStorage)->configureTraceEngine = (ConfigureTraceFunction)runtimeSetTraceOptions;
 		}
-		
+
 		break;
 	case TRACE_ENGINE_INITIALIZED:
 		if (vm->j9rasGlobalStorage == NULL) {
@@ -304,7 +307,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 		if ((returnVal = initializeTraceOptions(vm, opts)) != J9VMDLLMAIN_OK) {
 			return returnVal;
 		}
-		
+
 
 		for (i = 0; opts[i] != NULL; i += 2) {
 			if (j9_cmdla_stricmp(opts[i], "HELP") == 0) {
@@ -312,7 +315,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 				return J9VMDLLMAIN_SILENT_EXIT_VM;
 			}
 		}
-		
+
 
 		registerj9trc_auxWithTrace( ((RasGlobalStorage *)vm->j9rasGlobalStorage)->utIntf, NULL);
 		if( NULL == j9trc_aux_UtModuleInfo.intf ) {
@@ -353,7 +356,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_TRACE_INIT_FAILED);
 				return J9VMDLLMAIN_FAILED;
 			}
-	
+
 			if (JNI_OK != vm->internalVMFunctions->fillInDgRasInterface( ((RasGlobalStorage *)vm->j9rasGlobalStorage)->jvmriInterface )) {
 				dbg_err_printf(1, PORTLIB, "<UT> Error initializing jvmri interface not available, trace not enabled\n");
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_TRACE_INIT_FAILED);
@@ -407,7 +410,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 				dbg_err_printf(1, PORTLIB, "<UT> Trace engine failed to hook VM Method events, trace not enabled\n");
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_TRACE_INIT_FAILED);
 				return J9VMDLLMAIN_FAILED;
-			} 
+			}
 		}
 
 		 /*
@@ -419,10 +422,10 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 
 		/* initialize tracing in the port library as soon as possible */
 		j9port_control(J9PORT_CTLDATA_TRACE_START, (UDATA) ((RasGlobalStorage *)vm->j9rasGlobalStorage)->utIntf);
-		
+
 		/* initialize tracing in the thread library */
 		omrthread_lib_control(J9THREAD_LIB_CONTROL_TRACE_START, (UDATA) ((RasGlobalStorage *)vm->j9rasGlobalStorage)->utIntf);
-		
+
 		/* Load module for hookable library tracepoints */
 		omrhook_lib_control(J9HOOK_LIB_CONTROL_TRACE_START, (UDATA) ((RasGlobalStorage *)vm->j9rasGlobalStorage)->utIntf);
 
@@ -465,7 +468,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 		break;
 
 	case INTERPRETER_SHUTDOWN:
-	
+
 		thr = vm->internalVMFunctions->currentVMThread(vm);
 
 		/* if command line argument parsing failed we don't want to try to use an uninitialized trace engine */
@@ -481,10 +484,10 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 			reportVMTermination(vm, thr);
 			requestTraceCleanup(vm, thr);
 		}
-		
+
 		{
 			J9VMDllLoadInfo *loadInfo = FIND_DLL_TABLE_ENTRY( J9_RAS_TRACE_DLL_NAME );
-			if ( loadInfo && (IS_STAGE_COMPLETED(loadInfo->completedBits, VM_INITIALIZATION_COMPLETE)) ){
+			if ( loadInfo && (IS_STAGE_COMPLETED(loadInfo->completedBits, VM_INITIALIZATION_COMPLETE)) ) {
 				/* now force the main thread to end */
 				reportTraceEvent(vm, thr, J9RAS_TRACE_ON_THREAD_END);
 			}
@@ -497,7 +500,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 			tempRasGbl = (RasGlobalStorage *)vm->j9rasGlobalStorage;
 			vm->j9rasGlobalStorage = NULL;
 
-			if ( tempRasGbl->jvmriInterface != NULL ){
+			if ( tempRasGbl->jvmriInterface != NULL ) {
 				j9mem_free_memory( tempRasGbl->jvmriInterface );
 			}
 			j9mem_free_memory( tempRasGbl );
@@ -526,14 +529,10 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 	return returnVal;
 }
 
-
-
-
 jint JNICALL JVM_OnLoad(JavaVM *vm, char *options, void *reserved)
 {
 	return JNI_OK;
 }
-
 
 jint JNICALL JVM_OnUnload(JavaVM *vm, void *reserved)
 {
@@ -589,7 +588,7 @@ processTraceOptionString(J9JavaVM *vm, char * opts[], IDATA * optIndex, const ch
 	IDATA rc = J9VMDLLMAIN_OK;
 	const char *optionString = option;
 	IDATA optionsLength = n;
-	
+
 	while (optionsLength > 0 && rc == J9VMDLLMAIN_OK) {
 		IDATA thisOptionLength = parseTraceOptions(vm, optionString, optionsLength);
 		if (thisOptionLength < 0) {
@@ -614,7 +613,7 @@ processTraceOptionString(J9JavaVM *vm, char * opts[], IDATA * optIndex, const ch
 			}
 		}
 	}
-	
+
 	return rc;
 }
 
@@ -625,7 +624,7 @@ processTraceOptionString(J9JavaVM *vm, char * opts[], IDATA * optIndex, const ch
  * Returns them as newly allocated string key/value pairs in the even/odd elements of opts.
  * The strings in opts will need to be freed.
  */
-static IDATA 
+static IDATA
 initializeTraceOptions(J9JavaVM *vm, char* opts[])
 {
 	IDATA xtraceIndex;
@@ -637,7 +636,7 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
 	/* set up the default options */
 	rc = splitCommandLineOption(vm, UT_MAXIMAL_KEYWORD "=all{level1}", 20, opts);
 	i += 2;
-	if (rc != J9VMDLLMAIN_FAILED){
+	if (rc != J9VMDLLMAIN_FAILED) {
 		rc = splitCommandLineOption(vm, UT_EXCEPTION_KEYWORD "=j9mm{gclogger}", 26, opts + i);
 		i += 2;
 	}
@@ -645,7 +644,7 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
 	/*
 	 *  Find all the trace options specified in the command line and pass
 	 *  them to the trace engine. Note that trace args are formatted forwards
-	 *  (left to right) so as to be consistent with dump. 
+	 *  (left to right) so as to be consistent with dump.
 	 */
 	xtraceIndex = FIND_ARG_IN_VMARGS_FORWARD(OPTIONAL_LIST_MATCH, VMOPT_XTRACE, NULL);
 	/* A trace option has been set. We need to check if the level 2 trace points have been
@@ -673,7 +672,7 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
 			}
 		}
 		xtraceIndex = FIND_NEXT_ARG_IN_VMARGS_FORWARD(OPTIONAL_LIST_MATCH, VMOPT_XTRACE, NULL, xtraceIndex);
-	} 
+	}
 	opts[i++] = NULL;
 	return rc;
 }
@@ -683,7 +682,8 @@ initializeTraceOptions(J9JavaVM *vm, char* opts[])
  * the option name in opt[0] and the option value in opt[1]
  * If there is no value to go with the name opt[1] will be null.
  */
-IDATA splitCommandLineOption(J9JavaVM *vm, const char *optionString, IDATA optionLength, char *opt[])
+static IDATA
+splitCommandLineOption(J9JavaVM *vm, const char *optionString, IDATA optionLength, char *opt[])
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	IDATA length;
@@ -694,7 +694,7 @@ IDATA splitCommandLineOption(J9JavaVM *vm, const char *optionString, IDATA optio
 			break;
 		}
 	}
-	
+
 	opt[0] = j9mem_allocate_memory(length + 1, OMRMEM_CATEGORY_TRACE);
 	if (opt[0] == NULL) {
 		return J9VMDLLMAIN_FAILED;
@@ -705,7 +705,7 @@ IDATA splitCommandLineOption(J9JavaVM *vm, const char *optionString, IDATA optio
 			optionString[length + 1] != '\0' &&
 			optionString[length + 1] != ',') {
 		opt[1] = j9mem_allocate_memory(optionLength - length, OMRMEM_CATEGORY_TRACE);
-		if (opt[1] == NULL){
+		if (opt[1] == NULL) {
 			return J9VMDLLMAIN_FAILED;
 		}
 		memcpy(opt[1], optionString + length + 1, optionLength - length - 1);
@@ -713,16 +713,16 @@ IDATA splitCommandLineOption(J9JavaVM *vm, const char *optionString, IDATA optio
 	} else {
 		opt[1] = NULL;
 	}
-	
+
 	return J9VMDLLMAIN_OK;
 }
 
 /*
  * Call back for OMR to set J9VM specific trace options.
  */
-omr_error_t
-setJ9VMTraceOption(const OMR_VM *omr_vm, const char *optName, const char* optValue, BOOLEAN atRuntime) {
-
+static omr_error_t
+setJ9VMTraceOption(const OMR_VM *omr_vm, const char *optName, const char* optValue, BOOLEAN atRuntime)
+{
 	int i = 0;
 	J9JavaVM* vm = (J9JavaVM*) omr_vm->_language_vm;
 	omr_error_t rc = OMR_ERROR_NONE;
@@ -741,15 +741,15 @@ setJ9VMTraceOption(const OMR_VM *omr_vm, const char *optName, const char* optVal
 			} else {
 				rc = TRACE_OPTIONS[i].optionFunction(vm,optValue,atRuntime);
 			}
-			
+
 			break;
 		}
 	}
-	
+
 	return rc;
 }
 
-omr_error_t
+static omr_error_t
 reportTraceEvent(J9JavaVM *vm, J9VMThread *self, UDATA eventFlags)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
@@ -768,7 +768,7 @@ reportTraceEvent(J9JavaVM *vm, J9VMThread *self, UDATA eventFlags)
 	 */
 	tempThr = UT_THREAD_FROM_VM_THREAD(self);
 
-	switch (eventFlags){
+	switch (eventFlags) {
 
 	case J9RAS_TRACE_ON_THREAD_CREATE:
 		/*
@@ -846,7 +846,6 @@ parseTraceOptions(J9JavaVM *vm, const char *optionString, IDATA optionsLength)
 	return inBraces == 0 ? length : -1;
 }
 
-
 static char *
 threadName(OMR_VMThread* vmThread)
 {
@@ -865,11 +864,10 @@ threadName(OMR_VMThread* vmThread)
 	return allocatedName;
 }
 
-
-static void displayTraceHelp(J9JavaVM *vm) 
-{     
+static void displayTraceHelp(J9JavaVM *vm)
+{
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	 
+
 	j9tty_err_printf(PORTLIB, "\nUsage:\n\n");
 	j9tty_err_printf(PORTLIB, "  java -Xtrace[:option,...]\n\n");
 	j9tty_err_printf(PORTLIB, "  Valid options are:\n\n");
@@ -905,8 +903,6 @@ static void displayTraceHelp(J9JavaVM *vm)
 	j9tty_err_printf(PORTLIB, "         \"-Xtrace:methods={java/lang/*,java/util/*},print=mt\"\n\n");
 }
 
-
-
 static void
 hookThreadAboutToStart(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
 {
@@ -914,7 +910,6 @@ hookThreadAboutToStart(J9HookInterface** hook, UDATA eventNum, void* eventData, 
 
 	reportTraceEvent(vmThread->javaVM, vmThread, J9RAS_TRACE_ON_THREAD_CREATE);
 }
-
 
 static void
 hookThreadEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
@@ -929,15 +924,13 @@ hookThreadEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* use
 	}
 }
 
-
-static void 
+static void
 hookVmInitialized(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
 {
 	J9VMThread* vmThread = ((J9VMInitEvent *)eventData)->vmThread;
 
 	vmThread->javaVM->internalVMFunctions->rasStartDeferredThreads(vmThread->javaVM);
 }
-
 
 static void
 reportVMTermination(J9JavaVM* vm, J9VMThread * vmThread)
@@ -947,12 +940,11 @@ reportVMTermination(J9JavaVM* vm, J9VMThread * vmThread)
 	if (traceThread && *traceThread) {
 
 		/* Threads that should be ignored when deciding if all tracing has finished. */
-		char *ignoreThreads[] = {"Finalizer", "Signal dispatcher", "JIT PProfiler thread", "Reference Handler", NULL};
+		char *ignoreThreads[] = { "Finalizer", "Signal dispatcher", "JIT PProfiler thread", "Reference Handler", NULL };
 
 		utTerminateTrace(traceThread, ignoreThreads);
 	}
 }
-
 
 static void
 requestTraceCleanup(J9JavaVM* vm, J9VMThread * vmThread)
@@ -964,10 +956,9 @@ requestTraceCleanup(J9JavaVM* vm, J9VMThread * vmThread)
 	}
 }
 
-
 /*
  * Reconfigure trace at runtime.
- * 
+ *
  * Returns an OMR return code.
  */
 static omr_error_t
@@ -976,7 +967,7 @@ runtimeSetTraceOptions(J9VMThread * thr,const char * traceOptions)
 	PORT_ACCESS_FROM_JAVAVM(thr->javaVM);
 	RasGlobalStorage * j9ras = (RasGlobalStorage *)thr->javaVM->j9rasGlobalStorage;
 	UtInterface * uteInterface = (UtInterface *)(j9ras ? j9ras->utIntf : NULL);
-	
+
 	/* Is trace running? */
 	if ( uteInterface && uteInterface->server ) {
 		char *opts[UT_MAX_OPTS];
@@ -985,7 +976,7 @@ runtimeSetTraceOptions(J9VMThread * thr,const char * traceOptions)
 		omr_error_t rc = OMR_ERROR_NONE;
 		int i = 0;
 		/* Pass option to the trace engine */
-		
+
 		memset(opts,0,sizeof(opts));
 
 		/* A trace option has been set. We need to check if the level 2 trace points have been
@@ -1002,7 +993,7 @@ runtimeSetTraceOptions(J9VMThread * thr,const char * traceOptions)
 		}
 
 		rastraceError = processTraceOptionString(thr->javaVM,opts,&optIndex,traceOptions,strlen(traceOptions));
-		
+
 		if (rastraceError) {
 			/* Clients expect UTE error codes */
 			rc = OMR_ERROR_ILLEGAL_ARGUMENT;
@@ -1030,15 +1021,16 @@ runtimeSetTraceOptions(J9VMThread * thr,const char * traceOptions)
 	}
 }
 
-static omr_error_t 
-populateTraceHeaderInfo(J9JavaVM *vm) {
+static omr_error_t
+populateTraceHeaderInfo(J9JavaVM *vm)
+{
 	JavaVMInitArgs  *vmInitArgs;
 	char *options;
 	char *fullversion;
 	omr_error_t ret = OMR_ERROR_NONE;
 
 	PORT_ACCESS_FROM_JAVAVM( vm );
-	
+
 	/* overwrite the header settings now that we have full vm->j2seVersion info */
 	vmInitArgs = (JavaVMInitArgs  *) vm->vmArgsArray->actualVMArgs;
 	if (vmInitArgs) {
@@ -1163,18 +1155,18 @@ printTraceWhat(J9PortLibrary* portLibrary)
 /**************************************************************************
  * name        - reportJ9VMCommandLineError
  * description - Report an error in a command line option and put the given
- * 			   - string in as detail in an NLS enabled message.
+ *             - string in as detail in an NLS enabled message.
  * parameters  - portLibrary, detailStr, args for formatting into detailStr.
  *************************************************************************/
 static void
-reportJ9VMCommandLineError(J9PortLibrary* portLibrary, const char* detailStr, va_list args) {
+reportJ9VMCommandLineError(J9PortLibrary* portLibrary, const char* detailStr, va_list args)
+{
 	char buffer[1024];
 	PORT_ACCESS_FROM_PORT(portLibrary);
 
 	j9str_vprintf(buffer, sizeof(buffer), detailStr, args);
 
 	j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_TRC_ERROR_DETAIL_STR, buffer);
-
 }
 
 /**************************************************************************
@@ -1184,13 +1176,12 @@ reportJ9VMCommandLineError(J9PortLibrary* portLibrary, const char* detailStr, va
  * parameters  - detailStr, args for formatting into detailStr.
  *************************************************************************/
 void
-vaReportJ9VMCommandLineError(J9PortLibrary* portLibrary, const char* detailStr, ...) {
-
+vaReportJ9VMCommandLineError(J9PortLibrary* portLibrary, const char* detailStr, ...)
+{
 	va_list arg_ptr;
 	va_start(arg_ptr, detailStr);
 	reportJ9VMCommandLineError(portLibrary, detailStr, arg_ptr);
 	va_end(arg_ptr);
-
 }
 
 /**
@@ -1308,7 +1299,7 @@ javaTrace(void *env, UtModuleInfo *modInfo, U_32 traceId, const char *spec, ...)
 
 	va_start(var, spec);
 	/* TODO - Decide whether currentVMThread is fast enough for hot NoEnv trace points. */
-	if( NULL == vmThr ) {	
+	if( NULL == vmThr ) {
 		vmThr = globalVM->internalVMFunctions->currentVMThread(globalVM);
 	}
 	utThr = UT_THREAD_FROM_VM_THREAD(vmThr);
@@ -1319,7 +1310,6 @@ javaTrace(void *env, UtModuleInfo *modInfo, U_32 traceId, const char *spec, ...)
 static void
 javaTraceMem(void *env, UtModuleInfo *modInfo, U_32 traceId, UDATA length, void *memptr)
 {
-
 	/* There's no need to improve this to be cleaner, the function is obsolete and will assert when called. */
 	omrUtModuleIntfS.TraceMem( (env?((J9VMThread*)env)->omrVMThread:NULL), modInfo, traceId, length, memptr);
 }
@@ -1331,7 +1321,6 @@ javaTraceState(void *env, UtModuleInfo *modInfo, U_32 traceId, const char *spec,
 	 * Also since the function just asserts the varargs are never used and we can avoid handling them.
 	 */
 	omrUtModuleIntfS.TraceState( (env?((J9VMThread*)env)->omrVMThread:NULL), modInfo, traceId, spec, NULL);
-
 }
 
 static void
@@ -1351,10 +1340,8 @@ javaTraceInit(void *env, UtModuleInfo *modInfo)
 static void
 javaTraceTerm(void* env, UtModuleInfo *modInfo)
 {
-
 	/* Registering is a one time event, rather than a high performance task,
 	 * call through to the base omr version.
 	 */
 	omrUtModuleIntfS.TraceTerm( (env?((J9VMThread*)env)->omrVMThread:NULL), modInfo);
-
 }

--- a/runtime/shared_common/Manager.cpp
+++ b/runtime/shared_common/Manager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -740,10 +740,8 @@ void
 SH_Manager::getNumItems(J9VMThread* currentThread, UDATA* nonStaleItems, UDATA* staleItems)
 {
 	if (_hashTable && _hashTableGetNumItemsDoFn) {
-		CountData countData;
-		
-		memset(&countData, 0, sizeof(CountData));
-		countData._cache = _cache;
+		CountData countData(_cache);
+
 		/* WARNING - currentThread can be NULL */
 		if (lockHashTable(currentThread, "getNumItems")) {
 			hashTableForEachDo(_hashTable, _hashTableGetNumItemsDoFn, &countData);

--- a/runtime/shared_common/Manager.hpp
+++ b/runtime/shared_common/Manager.hpp
@@ -122,9 +122,14 @@ public:
 	public :
 		UDATA _nonStaleItems;
 		UDATA _staleItems;
-		SH_SharedCache* _cache;
+		SH_SharedCache *_cache;
 
-		CountData() : _nonStaleItems(0), _staleItems(0), _cache(0) {}
+		explicit CountData(SH_SharedCache *cache)
+			: _nonStaleItems(0)
+			, _staleItems(0)
+			, _cache(cache)
+		{
+		}
 	};
 
 #if defined(J9SHR_CACHELET_SUPPORT)

--- a/runtime/tests/shared/CacheDirPerm.cpp
+++ b/runtime/tests/shared/CacheDirPerm.cpp
@@ -20,8 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 #if !defined(WIN32)
-extern "C"
-{
+extern "C" {
 #include "shrinit.h"
 }
 
@@ -37,8 +36,8 @@ extern "C"
 #define J9SH_DEFAULT_CTRL_ROOT "/tmp"
 
 #define USER_PERMISSION_STR "0700"
-#define USER_PERMISSION		0700
-#define NEW_DIR_PERM	0760
+#define USER_PERMISSION      0700
+#define NEW_DIR_PERM         0760
 
 extern "C" IDATA removeTempDir(J9JavaVM *vm, char *dir);
 
@@ -69,25 +68,21 @@ CacheDirPerm::getTempCacheDir(I_32 cacheType, bool useDefaultDir)
 
 	memset(cacheDir, 0, J9SH_MAXPATH);
 	memset(parentDir, 0, J9SH_MAXPATH);
-	if (true == useDefaultDir) {
-		rc = j9shmem_getDir(NULL, TRUE, baseDir, J9SH_MAXPATH);
-	} else {
-		rc = j9shmem_getDir(NULL, FALSE, baseDir, J9SH_MAXPATH);
-	}
+	rc = j9shmem_getDir(NULL, useDefaultDir ? TRUE : FALSE, baseDir, J9SH_MAXPATH);
 	if (-1 == rc) {
 		ERRPRINTF("Failed to get a temporary directory\n");
 		rc = FAIL;
 		goto _end;
 	}
-	if (true == useDefaultDir) {
-		sprintf(cacheDir, "%s", baseDir);
+	if (useDefaultDir) {
+		j9str_printf(PORTLIB, cacheDir, sizeof(cacheDir), "%s", baseDir);
 	} else {
-		sprintf(cacheDir, "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
+		j9str_printf(PORTLIB, cacheDir, sizeof(cacheDir), "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
 			/* for non-persistent cache, actual cache dir is cacheDir/J9SH_BASEDIR. So parent dir is same as cacheDir. */
-			sprintf(parentDir, "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
+			j9str_printf(PORTLIB, parentDir, sizeof(parentDir), "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
 		} else {
-			sprintf(parentDir, "%s%s/", baseDir, TEST_PARENTDIR);
+			j9str_printf(PORTLIB, parentDir, sizeof(parentDir), "%s%s/", baseDir, TEST_PARENTDIR);
 		}
 	}
 _end:
@@ -97,19 +92,19 @@ _end:
 IDATA
 CacheDirPerm::createTempCacheDir(I_32 cacheType, bool useDefaultDir)
 {
-	char actualCacheDir[2*J9SH_MAXPATH];
+	char actualCacheDir[J9SH_MAXPATH];
 	const char *testName = "createTempCacheDir";
 	struct stat statbuf;
 	IDATA rc = PASS;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	if (true == useDefaultDir) {
-		sprintf(actualCacheDir, "%s", cacheDir);
+	if (useDefaultDir) {
+		j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 	} else {
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
-			sprintf(actualCacheDir, "%s/%s", cacheDir, J9SH_BASEDIR);
+			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s/%s", cacheDir, J9SH_BASEDIR);
 		} else {
-			sprintf(actualCacheDir, "%s", cacheDir);
+			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 		}
 	}
 
@@ -132,17 +127,17 @@ IDATA
 CacheDirPerm::getCacheDirPerm(I_32 cacheType, bool isDefaultDir)
 {
 	struct stat statbuf;
-	char actualCacheDir[2*J9SH_MAXPATH];
+	char actualCacheDir[J9SH_MAXPATH];
 	const char *testName = "getCacheDirPerm";
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	if (true == isDefaultDir) {
-		sprintf(actualCacheDir, "%s", cacheDir);
+	if (isDefaultDir) {
+		j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 	} else {
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
-			sprintf(actualCacheDir, "%s/%s", cacheDir, J9SH_BASEDIR);
+			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s/%s", cacheDir, J9SH_BASEDIR);
 		} else {
-			sprintf(actualCacheDir, "%s", cacheDir);
+			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 		}
 	}
 
@@ -195,37 +190,36 @@ removeTempDir(J9JavaVM *vm, char *dir)
 		char resultBuffer[J9SH_MAXPATH];
 		UDATA rc, handle;
 
-        j9str_printf(PORTLIB, baseFilePath, J9SH_MAXPATH, "%s", dir);
-        rc = handle = j9file_findfirst(baseFilePath, resultBuffer);
-        while ((UDATA)-1 != rc) {
-        	char nextEntry[J9SH_MAXPATH];
-        	/* skip current and parent dir */
-        	if (resultBuffer[0] == '.') {
-        		rc = j9file_findnext(handle, resultBuffer);
-        		continue;
-        	}
-        	j9str_printf(PORTLIB, nextEntry, J9SH_MAXPATH, "%s/%s", baseFilePath, resultBuffer);
-        	removeTempDir(vm, nextEntry);
-        	rc = j9file_findnext(handle, resultBuffer);
-        }
-        if (handle != (UDATA)-1) {
-        	j9file_findclose(handle);
-        }
-        rc = j9file_unlinkdir(baseFilePath);
-        if ((UDATA)-1 == rc) {
+		j9str_printf(PORTLIB, baseFilePath, J9SH_MAXPATH, "%s", dir);
+		rc = handle = j9file_findfirst(baseFilePath, resultBuffer);
+		while ((UDATA)-1 != rc) {
+			char nextEntry[J9SH_MAXPATH];
+			/* skip current and parent dir */
+			if (resultBuffer[0] == '.') {
+				rc = j9file_findnext(handle, resultBuffer);
+				continue;
+			}
+			j9str_printf(PORTLIB, nextEntry, J9SH_MAXPATH, "%s/%s", baseFilePath, resultBuffer);
+			removeTempDir(vm, nextEntry);
+			rc = j9file_findnext(handle, resultBuffer);
+		}
+		if (handle != (UDATA)-1) {
+			j9file_findclose(handle);
+		}
+		rc = j9file_unlinkdir(baseFilePath);
+		if ((UDATA)-1 == rc) {
 			ERRPRINTF1("Failed to unlink %s\n", baseFilePath);
 			rc = FAIL;
 			goto _end;
-        }
+		}
 	}
 	rc = PASS;
 _end:
 	return rc;
-
 }
 
 IDATA
-testCacheDirPerm(J9JavaVM* vm)
+testCacheDirPerm(J9JavaVM *vm)
 {
 	IDATA rc = PASS;
 	const char *testName = "testCacheDirPerm";
@@ -517,5 +511,6 @@ _end:
 	return rc;
 }
 
-}
-#endif
+} /* extern "C" */
+
+#endif /* !defined(WIN32) */

--- a/runtime/tests/shared/CacheDirPerm.cpp
+++ b/runtime/tests/shared/CacheDirPerm.cpp
@@ -190,7 +190,7 @@ removeTempDir(J9JavaVM *vm, char *dir)
 		char resultBuffer[J9SH_MAXPATH];
 		UDATA rc, handle;
 
-		j9str_printf(PORTLIB, baseFilePath, J9SH_MAXPATH, "%s", dir);
+		j9str_printf(PORTLIB, baseFilePath, sizeof(baseFilePath), "%s", dir);
 		rc = handle = j9file_findfirst(baseFilePath, resultBuffer);
 		while ((UDATA)-1 != rc) {
 			char nextEntry[J9SH_MAXPATH];
@@ -199,7 +199,7 @@ removeTempDir(J9JavaVM *vm, char *dir)
 				rc = j9file_findnext(handle, resultBuffer);
 				continue;
 			}
-			j9str_printf(PORTLIB, nextEntry, J9SH_MAXPATH, "%s/%s", baseFilePath, resultBuffer);
+			j9str_printf(PORTLIB, nextEntry, sizeof(nextEntry), "%s/%s", baseFilePath, resultBuffer);
 			removeTempDir(vm, nextEntry);
 			rc = j9file_findnext(handle, resultBuffer);
 		}


### PR DESCRIPTION
* avoid possible bounds violations by using j9str_printf instead of sprintf

* Fix 'error=class-memaccess' diagnostics of the form:
```
error: 'void* memset(void*, int, size_t)' clearing an object with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
```

* clean up: add missing 'static' modifiers; fix formatting

* correct lengths of predefined trace options