### PR TITLE
Remove deprecated X86ScratchArgHelperCallSnippet

### DIFF
--- a/runtime/compiler/build/files/target/x.mk
+++ b/runtime/compiler/build/files/target/x.mk
@@ -73,7 +73,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/x/codegen/JNIPauseSnippet.cpp \
     compiler/x/codegen/PassJNINullSnippet.cpp \
     compiler/x/codegen/RecompilationSnippet.cpp \
-    compiler/x/codegen/ScratchArgHelperCallSnippet.cpp \
+    compiler/x/codegen/StackOverflowCheckSnippet.cpp \
     compiler/x/codegen/WriteBarrierSnippet.cpp \
     compiler/x/codegen/X86HelperLinkage.cpp \
     compiler/x/codegen/X86PrivateLinkage.cpp \

--- a/runtime/compiler/x/codegen/CMakeLists.txt
+++ b/runtime/compiler/x/codegen/CMakeLists.txt
@@ -38,7 +38,7 @@ j9jit_files(
 	x/codegen/JNIPauseSnippet.cpp
 	x/codegen/PassJNINullSnippet.cpp
 	x/codegen/RecompilationSnippet.cpp
-	x/codegen/ScratchArgHelperCallSnippet.cpp
+	x/codegen/StackOverflowCheckSnippet.cpp
 	x/codegen/WriteBarrierSnippet.cpp
 	x/codegen/X86HelperLinkage.cpp
 	x/codegen/X86PrivateLinkage.cpp

--- a/runtime/compiler/x/codegen/StackOverflowCheckSnippet.hpp
+++ b/runtime/compiler/x/codegen/StackOverflowCheckSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef SCRATCHARGHELPERCALLSNIPPET_INCL
-#define SCRATCHARGHELPERCALLSNIPPET_INCL
+#ifndef STACKOVERFLOWCHECKSNIPPET_INCL
+#define STACKOVERFLOWCHECKSNIPPET_INCL
 
 #include "x/codegen/HelperCallSnippet.hpp"
 
@@ -35,49 +35,27 @@ namespace TR { class SymbolReference; }
 
 namespace TR {
 
-class X86ScratchArgHelperCallSnippet : public TR::X86HelperCallSnippet
+class X86StackOverflowCheckSnippet : public TR::X86HelperCallSnippet
    {
    uintptrj_t _scratchArg;
 
    public:
 
-   X86ScratchArgHelperCallSnippet(TR::CodeGenerator   *cg,
-                                     TR::Node            *node,
-                                     TR::LabelSymbol      *restartlab,
-                                     TR::LabelSymbol      *snippetlab,
-                                     TR::SymbolReference *helper,
-                                     uintptrj_t          scratchArg,
-                                     int32_t             stackPointerAdjustment=0)
+   X86StackOverflowCheckSnippet(TR::CodeGenerator   *cg,
+                                TR::Node            *node,
+                                TR::LabelSymbol      *restartlab,
+                                TR::LabelSymbol      *snippetlab,
+                                TR::SymbolReference *helper,
+                                uintptrj_t          scratchArg,
+                                int32_t             stackPointerAdjustment=0)
       :_scratchArg(scratchArg), TR::X86HelperCallSnippet(cg, node, restartlab, snippetlab, helper, stackPointerAdjustment){}
-
-   virtual Kind getKind() { return IsScratchArgHelperCall; }
 
    uintptrj_t getScratchArg(){ return _scratchArg; }
 
    virtual uint8_t *genHelperCall(uint8_t *buffer);
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
-
+   virtual void print(TR::FILE* pOutFile, TR_Debug* debug);
    };
-
-class X86StackOverflowCheckSnippet : public TR::X86ScratchArgHelperCallSnippet
-   {
-   public:
-
-   X86StackOverflowCheckSnippet(
-      TR::Node            *node,
-      TR::LabelSymbol      *restartLabel,
-      TR::LabelSymbol      *snippetLabel,
-      TR::SymbolReference *helper,
-      uintptrj_t          scratchArg,
-      int32_t             stackPointerAdjustment,
-      TR::CodeGenerator   *cg) :
-         TR::X86ScratchArgHelperCallSnippet(cg, node, restartLabel, snippetLabel, helper, scratchArg, stackPointerAdjustment)
-      {
-      }
-
-   virtual uint8_t *genHelperCall(uint8_t *buffer);
-   };
-
 }
 
 #endif

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -51,7 +51,7 @@
 #include "x/codegen/CallSnippet.hpp"
 #include "x/codegen/FPTreeEvaluator.hpp"
 #include "x/codegen/CheckFailureSnippet.hpp"
-#include "x/codegen/ScratchArgHelperCallSnippet.hpp"
+#include "x/codegen/StackOverflowCheckSnippet.hpp"
 #include "runtime/J9Profiler.hpp"
 #include "runtime/J9ValueProfiler.hpp"
 
@@ -133,13 +133,13 @@ TR::X86PrivateLinkage::createStackOverflowCheck(
 
    TR::X86HelperCallSnippet  *snippet =
       new (trHeapMemory()) TR::X86StackOverflowCheckSnippet(
+         cg(),
          cursor->getNode(),
          reStartLabel,
          snippetLabel,
          helper,
          stackSpaceAllocated,
-         stackPointerAdjustment,
-         cg());
+         stackPointerAdjustment);
 
    cg()->addSnippet(snippet);
    cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, LABEL, reStartLabel, cg());


### PR DESCRIPTION
X86ScratchArgHelperCallSnippet has been long deprecated, removing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>