### PR TITLE
Add access barrier API to copy valueTypes

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -177,6 +177,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_getArrayObjectDataAddress,
 	j9gc_objaccess_getLockwordAddress,
 	j9gc_objaccess_cloneObject,
+	j9gc_objaccess_copyObjectFields,
 	j9gc_objaccess_cloneIndexableObject,
 	j9gc_objaccess_asConstantPoolObject,
 #if defined(J9VM_GC_REALTIME)

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -227,6 +227,7 @@ public:
 	virtual U_8 *getArrayObjectDataAddress(J9VMThread *vmThread, J9IndexableObject *arrayObject);
 	virtual j9objectmonitor_t *getLockwordAddress(J9VMThread *vmThread, J9Object *object);
 	virtual void cloneObject(J9VMThread *vmThread, J9Object *srcObject, J9Object *destObject);
+	virtual void copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset);
 	virtual void cloneIndexableObject(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject);
 	virtual J9Object* asConstantPoolObject(J9VMThread *vmThread, J9Object* toConvert, UDATA allocationFlags);
 	virtual void storeObjectToInternalVMSlot(J9VMThread *vmThread, J9Object** destSlot, J9Object *value);

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -609,6 +609,16 @@ j9gc_objaccess_cloneObject(J9VMThread *vmThread, J9Object *srcObject, J9Object *
 }
 
 /**
+ * Called by certain specs to copy objects
+ */
+void
+j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset)
+{
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->copyObjectFields(vmThread, valueClass, srcObject, srcOffset, destObject, destOffset);
+}
+
+/**
  * Called by certain specs to clone objects. See J9VMObjectAccessBarrier#cloneArray:into:sizeInElements:class:
  */
 void

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -97,6 +97,7 @@ extern J9_CFUNC UDATA j9gc_software_read_barrier_enabled(J9JavaVM *javaVM);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreAddress(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_cloneObject(J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject);
+extern J9_CFUNC void j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset);
 extern J9_CFUNC j9object_t j9gc_objaccess_asConstantPoolObject(J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags);
 extern J9_CFUNC jvmtiIterationControl j9mm_iterate_heaps(J9JavaVM *vm, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl(*func)(J9JavaVM *vm, struct J9MM_IterateHeapDescriptor *heapDesc, void *userData), void *userData);
 extern J9_CFUNC int gcStartupHeapManagement(J9JavaVM * vm);

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -304,8 +304,12 @@ public:
 	VMINLINE j9objectmonitor_t *
 	getLockwordAddress(J9Object *object)
 	{
+		J9Class *clazz = TMP_J9OBJECT_CLAZZ(object);
+		if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+			return NULL;
+		}
 #if defined(J9VM_THR_LOCK_NURSERY)
-		UDATA lockOffset = TMP_J9OBJECT_CLAZZ(object)->lockOffset;
+		UDATA lockOffset = clazz->lockOffset;
 		if ((IDATA) lockOffset < 0) {
 			return NULL;
 		}
@@ -357,41 +361,68 @@ public:
 	}
 
 	VMINLINE UDATA
-	mixedObjectGetDataSize(J9Class *objectClass, j9object_t object)
+	mixedObjectGetDataSize(J9Class *objectClass, bool dontIncludeLockword)
 	{
-		return objectClass->totalInstanceSize;
+		UDATA size = objectClass->totalInstanceSize;
+		if (dontIncludeLockword) {
+			if ((0 <= (IDATA)objectClass->lockOffset)) {
+				size -= sizeof(j9objectmonitor_t);
+			}
+		}
+
+		return size;
 	}
 
 	VMINLINE void
 	cloneObject(J9VMThread *currentThread, j9object_t original, j9object_t copy, J9Class *objectClass)
 	{
-#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) 
-		currentThread->javaVM->memoryManagerFunctions->j9gc_objaccess_cloneObject(currentThread, original, copy);
+		copyObjectFields(currentThread, objectClass, original, mixedObjectGetHeaderSize(), copy, mixedObjectGetHeaderSize());
+	}
+
+
+	/**
+	 * Copy valueType from sourceObject to destObject
+	 * See MM_ObjectAccessBarrier::copyObjectFields for detailed description
+	 *
+	 * @param vmThread vmthread token
+	 * @param valueClass The valueType class
+	 * @param srcObject The object being used.
+	 * @param srcOffset The offset of the field.
+	 * @param destObject The object being used.
+	 * @param destOffset The offset of the field.
+	 */
+	VMINLINE void
+	copyObjectFields(J9VMThread *vmThread, J9Class *objectClass, j9object_t srcObject, UDATA srcOffset, j9object_t destObject, UDATA destOffset)
+	{
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFields(vmThread, objectClass, srcObject, srcOffset, destObject, destOffset);
 #else /* defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
 		/* TODO implement HW barriers */
 		if (j9gc_modron_readbar_none != _readBarrierType) {	
 			if (j9gc_modron_readbar_evacuate == _readBarrierType) {
-				currentThread->javaVM->memoryManagerFunctions->j9gc_objaccess_cloneObject(currentThread, original, copy);
+				vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFields(vmThread, objectClass, srcObject, srcOffset, destObject, destOffset);
 			} else if (j9gc_modron_readbar_always == _readBarrierType) {
-				currentThread->javaVM->memoryManagerFunctions->j9gc_objaccess_cloneObject(currentThread, original, copy);
+				vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFields(vmThread, objectClass, srcObject, srcOffset, destObject, destOffset);
 			}
 		} else {
-			UDATA offset = mixedObjectGetHeaderSize();
-			UDATA limit = offset + mixedObjectGetDataSize(objectClass, original);
+			UDATA offset = 0;
+			bool isValueType = J9_IS_J9CLASS_VALUETYPE(objectClass);
+			UDATA limit = mixedObjectGetDataSize(objectClass, isValueType);
+			
 			while (offset < limit) {
-				/* No need for pre-store barrier as we are always overwriting 0's in the new object */
-				*(fj9object_t *)((UDATA)copy + offset) = *(fj9object_t *)((UDATA)original + offset);
+				*(fj9object_t *)((UDATA)destObject + offset + destOffset) = *(fj9object_t *)((UDATA)srcObject + offset + srcOffset);
 				offset += sizeof(fj9object_t);
 			}
 		
 #if defined(J9VM_THR_LOCK_NURSERY)
 			/* zero lockword, if present */
-			j9objectmonitor_t *lockwordAddress = getLockwordAddress(copy);
+			j9objectmonitor_t *lockwordAddress = getLockwordAddress(destObject);
 			if (NULL != lockwordAddress) {
 				*lockwordAddress = 0;
 			}
 #endif /* J9VM_THR_LOCK_NURSERY */
-			postBatchStoreObject(currentThread, copy);
+
+			postBatchStoreObject(vmThread, destObject);
 		}
 #endif /* defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
 	}

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -320,4 +320,11 @@ static const struct { \
 #define J9RAMINTERFACEMETHODREF_RESOLVED(interfaceClass, methodIndexAndArgCount) \
 	((NULL != (interfaceClass)) && ((J9_ITABLE_INDEX_UNRESOLVED != ((methodIndexAndArgCount) & ~255))))
 
+/* Macros for ValueTypes */
+/* TODO this will have to be updated to look at the ramClass instead when further support is added */
+#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
+#define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET(clazz->romClass->modifiers, J9AccValueType)
+#else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+#define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #endif /* J9_H */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4389,6 +4389,7 @@ typedef struct J9MemoryManagerFunctions {
 	U_8*  ( *j9gc_objaccess_getArrayObjectDataAddress)(struct J9VMThread *vmThread, J9IndexableObject *arrayObject) ;
 	j9objectmonitor_t*  ( *j9gc_objaccess_getLockwordAddress)(struct J9VMThread *vmThread, j9object_t object) ;
 	void  ( *j9gc_objaccess_cloneObject)(struct J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject) ;
+	void ( *j9gc_objaccess_copyObjectFields)(struct J9VMThread *vmThread, J9Class* valueClass, j9object_t srcObject, UDATA srcOffset, j9object_t destObject, UDATA destOffset) ;
 	void  ( *j9gc_objaccess_cloneIndexableObject)(struct J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject) ;
 	j9object_t  ( *j9gc_objaccess_asConstantPoolObject)(struct J9VMThread *vmThread, j9object_t toConvert, UDATA allocationFlags) ;
 #if defined(J9VM_GC_REALTIME)


### PR DESCRIPTION
Add access barrier API to copy valueTypes

Add access barrier API to copy valueTypes to copy valueTypes
given a src/dest object and src/dest offset. 

This PR is based on Eric's work in
https://github.com/eclipse/openj9/pull/1770

Signed-off-by: tajila <atobia@ca.ibm.com>