### PR TITLE
Add OS checks for Vector PD and Facility Enhancement

### DIFF
--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -521,6 +521,11 @@ typedef struct J9ProcessorDesc {
 
 /*  Linux on Z features
  *  Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on Z.
+ *  Obtained from: https://github.com/torvalds/linux/blob/050cdc6c9501abcd64720b8cc3e7941efee9547d/arch/s390/include/asm/elf.h#L94-L109.
+ *  If new facility support is required, then it must be defined there (and here), before we can check for it consistently.
+ *
+ *  The linux kernel will use the defines in the above link to set HWCAP features. This is done inside "setup_hwcaps(void)" routine found
+ *  in arch/s390/kernel/setup.c in the linux kernel source tree.
  */
 #define J9PORT_HWCAP_S390_ESAN3     0x1
 #define J9PORT_HWCAP_S390_ZARCH     0x2

--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -1100,7 +1100,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if defined(J9ZOS390)
+		/* Vector packed decimal requires hardware and OS support (for OS, checking for VEF is sufficient) */
+		if (getS390zOS_supportsVectorExtensionFacility())
+#elif (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS_BCD))
 #endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
@@ -1112,7 +1115,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if defined(J9ZOS390)
+		/* Vector facility enhancement 1 requires hardware and OS support (for OS, checking for VEF is sufficient) */
+		if (getS390zOS_supportsVectorExtensionFacility())
+#elif (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS_EXT))
 #endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */


### PR DESCRIPTION
zOS checks for Vector Packed Decimal and Vector Facility Enhancement 1 are missing inside the port library. This commit adds both of those checks. Additionally, a comment is added inside j9port.h explaining where the J9PORT_HWCAP_S390 defines are derived from for future reference and maintainability.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>