### PR TITLE
Disable testDDRExt_General_win on ibm windows

### DIFF
--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -93,7 +93,6 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
-			<impl>ibm</impl>
 		</impls>
 		<subsets>
 			<subset>SE80</subset>


### PR DESCRIPTION
- Remove ibm impl for testDDRExt_General_win

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>