### PR TITLE
Fix issues with extensible class member functions and static member function calls

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1204,7 +1204,7 @@ void
 J9::Compilation::addClassForStaticFinalFieldModification(TR_OpaqueClassBlock *clazz)
    {
    // Class redefinition can also modify static final fields
-   addClassForOSRRedefinition(clazz);
+   self()->addClassForOSRRedefinition(clazz);
 
    for (uint32_t i = 0; i < _classForStaticFinalFieldModification.size(); ++i)
       if (_classForStaticFinalFieldModification[i] == clazz)

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -670,7 +670,7 @@ J9::TransformUtil::transformIndirectLoad(TR::Compilation *comp, TR::Node *node)
          int32_t len;
          char * name = fej9->getClassNameChars((TR_OpaqueClassBlock*)fieldClass, len);
          if (sym->getRecognizedField() != TR::Symbol::assertionsDisabled
-             && !foldFinalFieldsIn((TR_OpaqueClassBlock *)fieldClass, name, len, sym->isStaticField(), comp))
+          && !J9::TransformUtil::foldFinalFieldsIn((TR_OpaqueClassBlock *)fieldClass, name, len, sym->isStaticField(), comp))
             return NULL;
 
          // Note that the load type can differ from the type of the symbol, eg.
@@ -1042,7 +1042,7 @@ J9::TransformUtil::transformDirectLoad(TR::Compilation *comp, TR::Node *node)
       //
       if (comp->getOption(TR_RestrictStaticFieldFolding)
           && sym->getRecognizedField() != TR::Symbol::assertionsDisabled
-          && !foldFinalFieldsIn((TR_OpaqueClassBlock*)fieldClass, name, len, true, comp))
+         && !J9::TransformUtil::foldFinalFieldsIn((TR_OpaqueClassBlock*)fieldClass, name, len, true, comp))
          return false;
 
       // Static initializer can produce different values in different runs


### PR DESCRIPTION
This minor PR contains some fixes to issues detected when locally running the OMRChecker Clang plugin on J9 JIT's code. This is needed to allow the enabling of OMRChecker linting tool to detect issues with the implementation of extensible classes. See: #941 

Signed-off-by: Nazim Uddin Bhuiyan <nazim.uddin.bhuiyan@ibm.com>