### PR TITLE
Improve interface method resolution

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1541,10 +1541,9 @@ retry:
 	J9ConstantPool *ramConstantPool = ((J9ConstantPool**)indexAndLiteralsEA)[0];
 	UDATA cpIndex = indexAndLiteralsEA[1];
 	J9RAMInterfaceMethodRef *ramMethodRef = (J9RAMInterfaceMethodRef*)ramConstantPool + cpIndex;
-	J9Class* volatile interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
-	VM_AtomicSupport::readBarrier();
-	UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
-	if (NULL == interfaceClass) {
+	J9Class* const interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
+	UDATA const methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
+	if (!J9RAMINTERFACEMETHODREF_RESOLVED(interfaceClass, methodIndexAndArgCount)) {
 		buildJITResolveFrameWithPC(currentThread, J9_SSF_JIT_RESOLVE_INTERFACE_METHOD, parmCount, true, 0, jitEIP);
 		currentThread->javaVM->internalVMFunctions->resolveInterfaceMethodRef(currentThread, ramConstantPool, cpIndex, J9_RESOLVE_FLAG_RUNTIME_RESOLVE);
 		addr = restoreJITResolveFrame(currentThread, jitEIP);

--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -66,13 +66,11 @@ J9Method*
 jitGetImproperInterfaceMethodFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex)
 {
 	J9RAMInterfaceMethodRef *ramMethodRef = (J9RAMInterfaceMethodRef*)constantPool + cpIndex;
-	/* interfaceClass is used to indicate 'resolved'. Make sure to read it first */
-	J9Class* volatile interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
-	VM_AtomicSupport::readBarrier();
-	UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
+	J9Class* interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
+	UDATA methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
 	J9Method *improperMethod = NULL;
 	/* If the ref is resolved, do not call the resolve helper, as it will currently fail if the interface class is not initialized */
-	if (NULL == interfaceClass) {
+	if (!J9RAMINTERFACEMETHODREF_RESOLVED(interfaceClass, methodIndexAndArgCount)) {
 		J9RAMInterfaceMethodRef localEntry;
 		if (NULL == currentThread->javaVM->internalVMFunctions->resolveInterfaceMethodRefInto(currentThread, constantPool, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, &localEntry)) {
 			goto done;
@@ -112,12 +110,10 @@ J9Class*
 jitGetInterfaceITableIndexFromCP(J9VMThread *currentThread, J9ConstantPool *constantPool, UDATA cpIndex, UDATA* pITableIndex)
 {
 	J9RAMInterfaceMethodRef *ramMethodRef = (J9RAMInterfaceMethodRef*)constantPool + cpIndex;
-	/* interfaceClass is used to indicate 'resolved'. Make sure to read it first */
-	J9Class* volatile interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
-	VM_AtomicSupport::readBarrier();
-	UDATA volatile methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
+	J9Class* interfaceClass = (J9Class*)ramMethodRef->interfaceClass;
+	UDATA methodIndexAndArgCount = ramMethodRef->methodIndexAndArgCount;
 	/* If the ref is resolved, do not call the resolve helper, as it will currently fail if the interface class is not initialized */
-	if (NULL == interfaceClass) {
+	if (!J9RAMINTERFACEMETHODREF_RESOLVED(interfaceClass, methodIndexAndArgCount)) {
 		J9RAMInterfaceMethodRef localEntry;
 		if (NULL == currentThread->javaVM->internalVMFunctions->resolveInterfaceMethodRefInto(currentThread, constantPool, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, &localEntry)) {
 			goto done;

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -316,4 +316,8 @@ static const struct { \
 /* Skip Interpreter VTable header */
 #define JIT_VTABLE_START_ADDRESS(clazz) ((UDATA *)(clazz) - (sizeof(J9VTableHeader) / sizeof(UDATA)))
 
+/* Check if J9RAMInterfaceMethodRef is resolved */
+#define J9RAMINTERFACEMETHODREF_RESOLVED(interfaceClass, methodIndexAndArgCount) \
+	((NULL != (interfaceClass)) && ((J9_ITABLE_INDEX_UNRESOLVED != ((methodIndexAndArgCount) & ~255))))
+
 #endif /* J9_H */

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -834,11 +834,17 @@ extern "C" {
  *
  * Non-vTable methods in Object will have J9_ITABLE_INDEX_OBJECT and J9_ITABLE_INDEX_METHOD_INDEX set,
  * indicating that the underlying index is a method index in Object.
+ *
+ * J9_ITABLE_INDEX_UNRESOLVED represents an impossible value to represent an unresolved
+ * CP entry (an unaligned vTable offset). J9_ITABLE_INDEX_UNRESOLVED_VALUE is the index value
+ * after the CP value has been downshifted.
  */
 #define J9_ITABLE_INDEX_SHIFT 10
 #define J9_ITABLE_INDEX_METHOD_INDEX ((UDATA)1 << 8)
 #define J9_ITABLE_INDEX_OBJECT ((UDATA)1 << 9)
 #define J9_ITABLE_INDEX_TAG_BITS (J9_ITABLE_INDEX_METHOD_INDEX | J9_ITABLE_INDEX_OBJECT)
+#define J9_ITABLE_INDEX_UNRESOLVED_VALUE ((UDATA)1)
+#define J9_ITABLE_INDEX_UNRESOLVED ((J9_ITABLE_INDEX_UNRESOLVED_VALUE << J9_ITABLE_INDEX_SHIFT) | J9_ITABLE_INDEX_OBJECT)
 
 /* Tag bits for iTableOffset field in JIT interface snippet data:
  *

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1632,7 +1632,7 @@ reresolveHotSwappedConstantPool(J9ConstantPool * ramConstantPool, J9VMThread * c
 						romMethodRef = ((J9ROMMethodRef *) romConstantPool) + i;
 						nas = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
 						((J9RAMInterfaceMethodRef *) ramConstantPool)[i].interfaceClass = 0;
-						((J9RAMInterfaceMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
+						((J9RAMInterfaceMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = J9_ITABLE_INDEX_UNRESOLVED | getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
 					} else {
 						vmFuncs->resolveInterfaceMethodRef(currentThread, ramConstantPool, i,
 																			resolveFlagsBase | J9_RESOLVE_FLAG_NO_THROW_ON_FAIL);

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -367,7 +367,7 @@ internalRunPreInitInstructions(J9Class * ramClass, J9VMThread * vmThread)
 				case J9CPTYPE_INTERFACE_METHOD:
 					romMethodRef = ((J9ROMMethodRef *) romConstantPool) + i;
 					nas = J9ROMMETHODREF_NAMEANDSIGNATURE(romMethodRef);
-					((J9RAMInterfaceMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
+					((J9RAMInterfaceMethodRef *) ramConstantPool)[i].methodIndexAndArgCount = J9_ITABLE_INDEX_UNRESOLVED | getSendSlotsFromSignature(J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(nas)));
 					break;
 
 				case J9CPTYPE_METHOD_TYPE:

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1094,8 +1094,6 @@ resolveInterfaceMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA
 			methodIndex <<= J9_ITABLE_INDEX_SHIFT;
 			methodIndex = methodIndex | tagBits | oldArgCount;
 			ramCPEntry->methodIndexAndArgCount = methodIndex;
-			/* interfaceClass is used to indicate resolved. Make sure to write it last */
-			issueWriteBarrier();
 			ramCPEntry->interfaceClass = (UDATA)interfaceClass;
 		}
 		/* indicate success */


### PR DESCRIPTION
Remove the need for memory barriers in interface method resolution
checks by adding a special initial value for the methodIndex. The new
resolution check is that the interfaceClass is not NULL and the
methodIndex is not the special value. The special value represents a bit
pattern which can not occur in a resolved entry.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>