### PR TITLE
Add checks for the usage of 64 bit registers in long evaluators

### DIFF
--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -2506,7 +2506,7 @@ J9::Z::TreeEvaluator::BCDCHKEvaluatorImpl(TR::Node * node,
       {
       if(isResultLong)
          {
-         if(TR::Compiler->target.is32Bit())
+         if(TR::Compiler->target.is32Bit() && !cg->use64BitRegsOn32Bit())
             {
             TR::RegisterPair* bcdOpPair = bcdOpResultReg->getRegisterPair();
             generateRRInstruction(cg, TR::InstOpCode::LR, node, bcdOpPair->getLowOrder(), callResultReg->getLowOrder());
@@ -2612,7 +2612,7 @@ J9::Z::TreeEvaluator::BCDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
                 * If this is the case, the lcall/icall must have been evaluated.
                 * We can skip the BCDCHK evaluation and return the call result.
                 */
-               TR_ASSERT_FATAL(resultReg != NULL && resultReg->getKind() == TR_GPR,
+               TR_ASSERT_FATAL(resultReg != NULL,
                                "BCDCHKEvaluator: variable precision path encounters an unrecognized and unevaluated long/int call\n");
                }
             }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4077,7 +4077,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_util_concurrent_atomic_AtomicLong_getAndDecrement:
          if (cg->checkFieldAlignmentForAtomicLong() &&
              cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196) &&
-             (TR::Compiler->target.is64Bit() || TR::Compiler->target.isZOS()  ||
+             (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit()  ||
               (cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA))))
             {
             resultReg = inlineAtomicOps(node, cg, 8, methodSymbol);  // LAAG on 31-bit linux must have HPR support
@@ -4093,7 +4093,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::java_util_concurrent_atomic_AtomicLongArray_getAndDecrement:
          if (cg->checkFieldAlignmentForAtomicLong() &&
              cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196) &&
-             (TR::Compiler->target.is64Bit() || TR::Compiler->target.isZOS()  ||
+             (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit()  ||
               (cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA))))
             {
             resultReg = inlineAtomicOps(node, cg, 8, methodSymbol);  // LAAG on 31-bit linux must have HPR support

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -10190,7 +10190,7 @@ extern TR::Register *inlineAtomicOps(
             // 2nd operant needs to be in a register
             deltaChild = node->getSecondChild();
 
-            if (isLong && TR::Compiler->target.is32Bit()) // deal with reg pairs on 31bit platform
+            if (isLong && TR::Compiler->target.is32Bit() && !cg->use64BitRegsOn32Bit()) // deal with reg pairs on 31bit platform
                {
                deltaReg = cg->allocateRegister();
                if (deltaChild->getOpCode().isLoadConst() && !deltaChild->getRegister())
@@ -10265,7 +10265,7 @@ extern TR::Register *inlineAtomicOps(
          cg->stopUsingRegister(valueReg);
 
          TR::Register *resultPairReg;
-         if (isLong && TR::Compiler->target.is32Bit()) // on 31-bit platoform, restore the result back into a register pair
+         if (isLong && TR::Compiler->target.is32Bit() && !cg->use64BitRegsOn32Bit()) // on 31-bit platoform, restore the result back into a register pair
             {
             TR::Register * resultRegLow = cg->allocateRegister();
             resultPairReg = cg->allocateConsecutiveRegisterPair(resultRegLow, resultReg);


### PR DESCRIPTION
Add checks for the usage of 64 bit registers in long evaluators.

Check whether we can use 64 Bit registers on 32 bit JVMs
in BCDCHKEvaluator for z Codegen. Allow inlining direct calls
on 32 bit JVMs and do not shift back into register pairs after
evaluation.

Signed-off-by: Daniel Hong <daniel.hong@live.com>