### PR TITLE
Update API/field names for aotMethodCode

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2297,7 +2297,7 @@ TR_J9VMBase::allocateCodeMemory(TR::Compilation * comp, uint32_t warmCodeSize, u
       fprintf(stderr, "comp %p ID=%d switched cache to %p\n", comp, comp->getCompThreadID(), codeCache);
 #endif
       TR_ASSERT(!codeCache || codeCache->isReserved(), "Substitute code cache isn't marked as reserved");  // Either we didn't get a code cache, or the one we should get is
-      comp->setAotMethodCodeStart(warmCode);
+      comp->setRelocatableMethodCodeStart(warmCode);
       switchCodeCache(comp, comp->getCurrentCodeCache(), codeCache);
       }
 
@@ -8958,7 +8958,7 @@ TR_J9SharedCacheVM::getDesignatedCodeCache(TR::Compilation *comp)
       codeCache->alignWarmCodeAlloc(_jitConfig->codeCacheAlignment - 1);
 
       // For AOT we must install the beginning of the code cache
-      comp->setAotMethodCodeStart((uint32_t *)codeCache->getWarmCodeAlloc());
+      comp->setRelocatableMethodCodeStart((uint32_t *)codeCache->getWarmCodeAlloc());
       }
    else
       {

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -2588,7 +2588,7 @@ TR_DebugExt::dxPrintCompilation()
 
    _dbgPrintf("\tTR_CHTable * _transientCHTable = !trprint chtable 0x%p\n",localCompiler->_transientCHTable);
    _dbgPrintf("\tvoid * _aotMethodDataStart = %p\n",localCompiler->_aotMethodDataStart);
-   _dbgPrintf("\tvoid * _aotMethodCodeStart = %p\n",localCompiler->_aotMethodCodeStart);
+   _dbgPrintf("\tvoid * _relocatableMethodCodeStart = %p\n",localCompiler->_relocatableMethodCodeStart);
    _dbgPrintf("\tint32_t _compThreadID = %d\n",localCompiler->_compThreadID);
    _dbgPrintf("\tbool _failCHtableCommitFlag = %s\n",localCompiler->_failCHtableCommitFlag?"TRUE":"FALSE");
    _dbgPrintf("\tsize_t _scratchSpaceLimit = %llu\n", static_cast<unsigned long long>(localCompiler->_scratchSpaceLimit));


### PR DESCRIPTION
OMR's aotMethodCodeStart query is about to be changed to relocatableMethodCodeStart,
this query called in OpenJ9 will need to be renamed as well.
Depends on https://github.com/eclipse/omr/pull/2913

Signed-off-by: Harry Yu <harryyu1994@gmail.com>