### PR TITLE
Change .i macro annotations to not use @

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -344,11 +344,15 @@ LIBCDEFS := $(word 1,$(wildcard $(foreach d,$(TPF_ROOT),$d/base/lib/libCDEFSFORA
 # We use sed in these scripts to retain only those lines that will be interesting
 # to omr/ddr/tools/getmacros; this reduces the total footprint of all *.i files by
 # over 1GB and reduces the workload of getmacros as it reads them.
+
+DDR_SED_COMMAND := \
+    sed -n -e '/^@/p' -e '/^DDRFILE_BEGIN /,/^DDRFILE_END /s/^/@/p'
+
 %.i : %.c
-	$(CC) $(CFLAGS) -E $< | sed -n -e '/^@/p' > $@
+	$(CC) $(CFLAGS) -E $< | $(DDR_SED_COMMAND) > $@
 
 %.i : %.cpp
-	$(CXX) $(CXXFLAGS) -E $< | sed -n -e '/^@/p' > $@
+	$(CXX) $(CXXFLAGS) -E $< | $(DDR_SED_COMMAND) > $@
 
 # just create empty output files
 %.i : %.asm ; touch $@


### PR DESCRIPTION
Match OMR change (https://github.com/eclipse/omr/pull/2929) to no longer use @ symbols to mark DDR macro annotations.
Use block begin and end markers instead.

In preparation for the OMR change, the sed pattern will match both
versions, with and without the @ symbol markers, since all DDR
annotations are within the DDRFILE_BEGIN and DDRFILE_END lines already.

This should be merged before https://github.com/eclipse/omr/pull/2929

Signed-off-by: mikezhang <mike.h.zhang@ibm.com>