### PR TITLE
Private methods do not override interface methods

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1449,19 +1449,24 @@ obj:;
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_sendMethod);
 		if (romMethod->modifiers & J9AccAbstract) {
 			exception = J9VMCONSTANTPOOL_JAVALANGABSTRACTMETHODERROR;
-			/* If the method class is an interface, do the special checks to throw the correct error */
-			J9Class *methodClass = J9_CLASS_FROM_METHOD(_sendMethod);
-			if (J9ROMCLASS_IS_INTERFACE(methodClass->romClass)) {
-				J9Method *method = (J9Method*)javaLookupMethod(
-						_currentThread,
-						J9OBJECT_CLAZZ(_currentThread, *(j9object_t*)_arg0EA),
-						&romMethod->nameAndSignature,
-						NULL,
-						J9_LOOK_VIRTUAL | J9_LOOK_NO_THROW);
-				if (NULL != method) {
-					if (0 == (J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccPublic)) {
-						exception = J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSERROR;
-						_sendMethod = method;
+			/* Starting with JDK11, private methods expressly do not override any methods from
+			 * superclass/superinterfaces, so AbstractMethodError is the correct error to throw.
+			 */
+			if (J2SE_VERSION(_vm) < J2SE_V11) {
+				/* If the method class is an interface, do the special checks to throw the correct error */
+				J9Class *methodClass = J9_CLASS_FROM_METHOD(_sendMethod);
+				if (J9ROMCLASS_IS_INTERFACE(methodClass->romClass)) {
+					J9Method *method = (J9Method*)javaLookupMethod(
+							_currentThread,
+							J9OBJECT_CLAZZ(_currentThread, *(j9object_t*)_arg0EA),
+							&romMethod->nameAndSignature,
+							NULL,
+							J9_LOOK_VIRTUAL | J9_LOOK_NO_THROW);
+					if (NULL != method) {
+						if (0 == (J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccPublic)) {
+							exception = J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSERROR;
+							_sendMethod = method;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
As of JDK11, private methods expressly do not override methods
inherited from the superclass or superinterfaces, so the correct error
to throw in this case is AbstractMethodError, not IllegalAccessError
that's thrown by older JDK levels.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>