### PR TITLE
Include CodeGenerator_inlines.hpp in InlinerTempForJ9.cpp

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -44,6 +44,7 @@
 #include "optimizer/PreExistence.hpp"
 #include "optimizer/Structure.hpp"
 #include "codegen/CodeGenerator.hpp"                      // for CodeGenerator
+#include "codegen/CodeGenerator_inlines.hpp"
 #include "il/ILOpCodes.hpp"
 #include "il/ILOps.hpp"                                   // for ILOpCode, etc
 #include "ilgen/IlGenRequest.hpp"


### PR DESCRIPTION
InlinerTempForJ9.cpp uses CodeGenerator which may need methods from CodeGenerator_inlines.hpp

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>