### PR TITLE
Change default shared cache size to 300MB on OpenJ9 Java 8

### DIFF
--- a/runtime/oti/j9cfg_builder.h
+++ b/runtime/oti/j9cfg_builder.h
@@ -61,17 +61,17 @@
 #define J9_INVARIANT_INTERN_TABLE_NODE_COUNT 2345
 #define J9_SHARED_CLASS_CACHE_MIN_SIZE (4 * 1024)
 #define J9_SHARED_CLASS_CACHE_MAX_SIZE I_32_MAX
-/* Default shared class cache size for Java 9 (and up) on 64-bit platforms (if OS allows)
+/* Default shared class cache size on 64-bit platforms (if OS allows)
  * Otherwise,
  * 1. For non-persistent cache, if SHMMAX < J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM (300MB), default cache size is set to SHMMAX
  * 2. For persistent cache, if free disk space is < SHRINIT_LOW_FREE_DISK_SIZE (6GB), default cache size is set to J9_SHARED_CLASS_CACHE_DEFAULT_SOFTMAX_SIZE_64BIT_PLATFORM (64MB)
  */
 #define J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM (300 * 1024 * 1024)
-/* Default shared class soft max size for Java 9 (and up) on 64-bit platforms. This value is only set if the OS allows default cache size to be greater than J9_SHARED_CLASS_CACHE_MIN_DEFAULT_CACHE_SIZE_FOR_SOFTMAX */
+/* Default shared class soft max size on 64-bit platforms. This value is only set if the OS allows default cache size to be greater than J9_SHARED_CLASS_CACHE_MIN_DEFAULT_CACHE_SIZE_FOR_SOFTMAX */
 #define J9_SHARED_CLASS_CACHE_DEFAULT_SOFTMAX_SIZE_64BIT_PLATFORM (64 * 1024 * 1024)
-/* The minimum default shared class cache size to set a default soft max. Java 9 (and up) on 64-bit platforms only. */
+/* The minimum default shared class cache size to set a default soft max, on 64-bit platforms only. */
 #define J9_SHARED_CLASS_CACHE_MIN_DEFAULT_CACHE_SIZE_FOR_SOFTMAX (80 * 1024 *1024)
-/* Default shared class cache size for Java 8 on all platforms, Java 9 (and up) on 32-bit platforms */
+/* Default shared class cache size on 32-bit platforms */
 #define J9_SHARED_CLASS_CACHE_DEFAULT_SIZE (16 * 1024 * 1024)
 
 #define J9_FIXED_SPACE_SIZE_NUMERATOR 0

--- a/runtime/shared_common/OSCachemmap.cpp
+++ b/runtime/shared_common/OSCachemmap.cpp
@@ -163,12 +163,16 @@ SH_OSCachemmap::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	struct J9FileStat statBuf;
 	IDATA errorCode = J9SH_OSCACHE_FAILURE;
 	LastErrorInfo lastErrorInfo;
-
 	UDATA defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
+
 #if defined(J9VM_ENV_DATA64)
+#if defined(OPENJ9_BUILD)
+	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+#else /* OPENJ9_BUILD */
 	if (J2SE_VERSION(vm) >= J2SE_19) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
+#endif /* OPENJ9_BUILD */
 #endif /* J9VM_ENV_DATA64 */
 	
 	PORT_ACCESS_FROM_PORT(_portLibrary);

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -150,10 +150,15 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 	IDATA semLength = 0;
 	LastErrorInfo lastErrorInfo;
 	UDATA defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
+
 #if defined(J9VM_ENV_DATA64)
+#if defined(OPENJ9_BUILD)
+	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+#else /* OPENJ9_BUILD */
 	if (J2SE_VERSION(vm) >= J2SE_19) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
+#endif /* OPENJ9_BUILD */
 #endif /* J9VM_ENV_DATA64 */
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -2708,9 +2708,13 @@ ensureCorrectCacheSizes(J9JavaVM *vm, J9PortLibrary* portlib, U_64 runtimeFlags,
 	bool is64BitPlatDefaultSize = false;
 
 #if defined(J9VM_ENV_DATA64)
+#if defined(OPENJ9_BUILD)
+	defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+#else /* OPENJ9_BUILD */
 	if (J2SE_VERSION(vm) >= J2SE_19) {
 		defaultCacheSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 	}
+#endif /* OPENJ9_BUILD */
 #endif /* J9VM_ENV_DATA64 */
 
 	if (*cacheSize == 0) {

--- a/runtime/tests/shared/OSCacheTestSysv.cpp
+++ b/runtime/tests/shared/OSCacheTestSysv.cpp
@@ -839,9 +839,13 @@ SH_OSCacheTestSysv::testSize(J9PortLibrary* portLibrary, J9JavaVM *vm)
 		if(osc->getError() < 0) {
 			UDATA defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE;
 #if defined(J9VM_ENV_DATA64)
+#if defined(OPENJ9_BUILD)
+			defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
+#else /* OPENJ9_BUILD */
 			if (J2SE_VERSION(vm) >= J2SE_19) {
 				defaultSize = J9_SHARED_CLASS_CACHE_DEFAULT_SIZE_64BIT_PLATFORM;
 			}
+#endif /* OPENJ9_BUILD */
 #endif /* J9VM_ENV_DATA64 */
 			if ((i == 0) && (defaultSize > 1024) && (defaultSize < shmmax)) {
 				/*CMVC 153490: if we fail alloc ulimit the lets retry tests with the default size*/

--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -44,7 +44,7 @@
 	<if>
 		<equals arg1="${OS}" arg2="os.zos"/>
 		<then>
-			<property name="DUMP_OPTION" value="-Xdump:system:events=vmstop,label=%uid.${dump.name},request=exclusive+compact+prepwalk -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M -version" />
+			<property name="DUMP_OPTION" value="-Xdump:system:events=vmstop,label=%uid.${dump.name},request=exclusive+compact+prepwalk -Xscmx16m -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M -version" />
 				<if>
 				<equals arg1="${BITS}" arg2="bits.64"/>
 				<then>
@@ -56,7 +56,7 @@
 			</if>
 		</then>
 		<else>
-			<property name="DUMP_OPTION" value="-Xdump:system:events=vmstop,label=${system.dump},request=exclusive+compact+prepwalk -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M -version" />
+			<property name="DUMP_OPTION" value="-Xdump:system:events=vmstop,label=${system.dump},request=exclusive+compact+prepwalk -Xscmx16m -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M -version" />
 		</else>
 	</if>
 

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -590,7 +590,7 @@
 
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Class debug area size[\s]*= 0</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Class debug area used bytes[\s]*= 0</output>
-		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">Class debug area % used[\s]*= 0%</output>
+		<!-- do not check if Class debug area % used is 0%. When Class debug area used bytes is too small (< 1%) compared to Class debug area size, Class debug area % used will show up as 0% -->
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
@@ -982,12 +982,29 @@
 		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
 	</test>
 	
-	<test id="Test 55 Check default cache size on Java 8" timeout="600" runPath=".">
+	<test id="Test 55 Check default cache size on non-OpenJ9 Java 8" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ -verbose:sizes $currentMode$ -Xtrace:print={j9shr.369,j9shr.734} -version</command>
 		<output type="success" caseSensitive="yes" regex="no" showMatch="yes">SH_OSCachemmap::startup: Successfully set cache length to 16777216</output>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes">OSCache startup.*length=16777216 create=1</output>
 		<output type="required" caseSensitive="yes" regex="no" showMatch="yes">XX:SharedCacheHardLimit=16M</output>
 
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 55 Check default cache size on OpenJ9 Java 8" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -verbose:sizes $currentMode$ -Xtrace:print={j9shr.369,j9shr.734} -version</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$NON_64BIT_PLATFORMS$">SH_OSCachemmap::startup: Successfully set cache length to 16777216</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$NON_64BIT_PLATFORMS$">OSCache startup.*length=16777216 create=1</output>
+		<output type="required" caseSensitive="yes" regex="no" showMatch="yes" platforms="NON_64BIT_PLATFORMS">XX:SharedCacheHardLimit=16M</output>
+
+		<output type="success" caseSensitive="yes" regex="no" showMatch="yes" platforms="$64BIT_PLATFORMS$">SH_OSCachemmap::startup: Successfully set cache length to 314572800</output>
+		<output type="success" caseSensitive="yes" regex="no" showMatch="yes" platforms="$64BIT_PLATFORMS$">SH_OSCachemmap::startup: Successfully set cache length to 67108864</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$64BIT_PLATFORMS$">OSCache startup.*length=314572800 create=1</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$64BIT_PLATFORMS$">(XX:SharedCacheHardLimit=300M(.)*[\n\r](.)*Xscmx64M|XX:SharedCacheHardLimit=64M)</output>
+		
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude_openj9.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/exclude_openj9.xml
@@ -26,6 +26,8 @@
 <?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
 <suite id="CommandLineOption Excluded Test Case List">
 
+	<!-- Use this file to exclude tests when testing OpenJ9 -->
+
 	<platform id="none"/>
 	<platform id="all"/>
 	
@@ -204,17 +206,17 @@
 	<exclude id="Test 182-d: Verify that Intermediate Class Data is present" platform="latest">
 		<reason>This test doesn't work for openj9</reason>
 	</exclude>
-	<exclude id="Test 27: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" platform="SE[^8]\d+">
-		<reason>The default non-persistent cache size is not 16MB on Java 9 and up</reason>
+	<exclude id="Test 27: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" platform="all">
+		<reason>Exclude this test on OpenJ9, as the default nonpersistent cache is usually greater than SHMMAX, we do not know the value of SHMMAX on the testing machines</reason>
 	</exclude>
-	<exclude id="Test 29: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" platform="SE[^8]\d+">
-		<reason>The default non-persistent cache size is not 16MB on Java 9 and up</reason>
+	<exclude id="Test 29: CMVC 168131 : Ensure Java 8 cache size is default (16 MB)" platform="all">
+		<reason>Exclude this test on OpenJ9, as the default nonpersistent cache is usually greater than SHMMAX, we do not know the value of SHMMAX on the testing machines</reason>
 	</exclude>
-	<exclude id="Test 55 Check default cache size on non-OpenJ9 Java 8" platform="SE[^8]\d+">
+	<exclude id="Test 55 Check default cache size on non-OpenJ9 Java 8" platform="all">
+		<reason>This test should not be run on OpenJ9</reason>
+	</exclude>
+	<exclude id="Test 55 Check default cache size on OpenJ9 Java 8" platform="SE[^8]\d+">
 		<reason>This test should not be run on Java 9 and up</reason>
-	</exclude>
-	<exclude id="Test 55 Check default cache size on OpenJ9 Java 8" platform="all">
-		<reason>This test should be run on OpenJ9 Java 8 only</reason>
 	</exclude>
 	<exclude id="Test 55 Check default cache size on Java 9 and up" platform="SE80">
 		<reason>This test should not be run on Java 8</reason>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -49,6 +49,45 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>ibm</impl>
+		</impls>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>testSCCMLTests1_openj9</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+	$(CD) $(REPORTDIR); \
+	cp $(Q)$(TEST_RESROOT)$(D)..$(D)URLHelperTests$(D)URLHelperTests.jar$(Q) .; \
+	true URLHelperTests.jar ;\
+	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf URLHelperTests.jar; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DPATHSEP=$(Q)$(D)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DPROPS_DIR=$(PROPS_DIR) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) \
+	-DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DJAVA_HOME='$(JDK_HOME)' -DSCMODE=204 -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLTests-1.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION),$(JAVA_IMPL) -plats all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION)_$(BITS) -xlist $(Q)$(TEST_RESROOT)$(D)exclude_openj9.xml$(Q) \
+	-nonZeroExitWhenError \
+	-outputLimit 300; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
 		<subsets>
 			<subset>SE80</subset>
 			<subset>SE90</subset>


### PR DESCRIPTION
1. Increase default shared cache size of OpenJ9 Java 8 to 300MB on
64-bit platforms.
2. Split testSCCMLTests1 into two targets and add exclude_openj9.xml

Fixes #1938
Depends on doc issue https://github.com/eclipse/openj9-docs/issues/80

Signed-off-by: hangshao <hangshao@ca.ibm.com>