### PR TITLE
Remove duplicate definitions for J9VMSTATE_GC states from OpenJ9

### DIFF
--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -23,7 +23,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
-#include "j9modron.h"
+#include "omrmodroncore.h"
 #include "thrdsup.h"
 #include "thrtypes.h"
 #include "codegen/CodeGenerator.hpp"

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -27,7 +27,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
-#include "j9modron.h"
+#include "omrmodroncore.h"
 #include "thrdsup.h"
 #include "thrtypes.h"
 #include "codegen/AheadOfTimeCompile.hpp"           // for AheadOfTimeCompile

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -35,7 +35,7 @@
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
-#include "j9modron.h"
+#include "omrmodroncore.h"
 #include "thrdsup.h"
 #include "thrtypes.h"
 #include "codegen/AheadOfTimeCompile.hpp"

--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -420,7 +420,7 @@ MM_GlobalCollectorDelegate::unloadDeadClassLoaders(MM_EnvironmentBase *env)
 	/* The list of classLoaders to be unloaded by cleanUpClassLoadersEnd is rooted in unloadLink */
 
 	/* set the vmState whilst we're unloading classes */
-	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_UNLOADING_DEAD_CLASSLOADERS);
+	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_CLEANING_METADATA);
 
 	/* Count the classes we're unloading and perform class-specific clean up work for each unloading class.
 	 * If we're unloading any classes, perform common class-unloading clean up.

--- a/runtime/gc_include/j9modron.h
+++ b/runtime/gc_include/j9modron.h
@@ -100,37 +100,9 @@ typedef enum {
 
 
 /**
- * Card state definitions
- * @note CARD_DIRTY 0x01 has been hardcoded in builder see J9VMObjectAccessBarrier>>#dirtyCard
- * @ingroup GC_Include
- * @{
- */
-
-/* means that this card requires no special handling in the next collection as a result of previous collection or mutator activity */
-#define CARD_CLEAN 0x00
-/* means that this card has been changed by the mutator since the collector last processed it */
-#define CARD_DIRTY 0x01
-/* means that a PGC has viewed the card but the next GMP increment (or SYS/OOM fall-back) must also process the card (since it could have hidden objects) */
-#define CARD_GMP_MUST_SCAN 0x02
-/* means that a GMP has viewed the card but the next PGC increment must also process the card (since it might have unseen inter-region references - the GMP has a smaller live set so it wouldn't see them nor does it update the RSLists) */
-#define CARD_PGC_MUST_SCAN 0x03
-/* largely equivalent to CARD_PGC_MUST_SCAN but can only exist between RSCL flushing and the end of PGC mark and has the special connotation that the only objects, in this card, which refer to other regions have their remembered bit set */
-#define CARD_REMEMBERED 0x04
-/* largely equivalent to CARD_DIRTY but can only exist between RSCL flushing and the end of PGC mark and has the special connotation that the only objects, in this card, which refer to other regions have their remembered bit set */
-#define CARD_REMEMBERED_AND_GMP_SCAN 0x05
-/* used to state that this card contains objects which refer to other regions but all of those who do have their remembered bit set and are not yet in the region's RSCL - the compact treats this much like PGC_MUST_SCAN in that it may promote it to GMP_MUST_SCAN if a GMP is active */
-#define CARD_MARK_COMPACT_TRANSITION 0x06
-/* used when a value must be passed which is considered uninitialized or otherwise invalid */
-#define CARD_INVALID 0xFF
-	
-/**
  * Signature for the callback function passed to <code>MM_ReferenceChainWalker</code>
  */
 typedef jvmtiIterationControl J9MODRON_REFERENCE_CHAIN_WALKER_CALLBACK(J9Object **slotPtr, J9Object *sourcePtr, void *userData, IDATA type, IDATA index, IDATA wasReportedBefore);
-
-/**
- * @}
- */
 
 #define J9GC_ROOT_TYPE_UNKNOWN 1 /**< root that fell through a default state in an iterator, or called via non abstracted doSlot() */
 #define J9GC_ROOT_TYPE_CLASS 2
@@ -169,64 +141,6 @@ typedef jvmtiIterationControl J9MODRON_REFERENCE_CHAIN_WALKER_CALLBACK(J9Object 
 #define J9GC_REFERENCE_TYPE_CLASS_ARRAY_CLASS -12 /**< reference to an array class' component type class */
 #define J9GC_REFERENCE_TYPE_CLASS_NAME_STRING -13 /**< reference to a class' name string */
 #define J9GC_REFERENCE_TYPE_CALL_SITE -14 /**< call site reference to an object */
-
-/**
- * #defines representing the vmState that should be set during various GC activities
- * @note J9VMSTATE_GC is the "major mask" representing a "GC" activity - we OR in a minor mask
- * representing the specific activity.
- * @ingroup GC_Include
- * @{
- */
-#define J9VMSTATE_GC_GLOBALGC (J9VMSTATE_GC | 0x0001)
-#define J9VMSTATE_GC_MARK (J9VMSTATE_GC | 0x0002)
-#define J9VMSTATE_GC_SWEEP (J9VMSTATE_GC | 0x0003)
-#define J9VMSTATE_GC_COMPACT (J9VMSTATE_GC | 0x0004)
-#define J9VMSTATE_GC_CONCURRENT_MARK_PREPARE_CARD_TABLE (J9VMSTATE_GC | 0x0006)
-#define J9VMSTATE_GC_COMPACT_FIX_HEAP_FOR_WALK (J9VMSTATE_GC | 0x0007)
-#define J9VMSTATE_GC_CONCURRENT_MARK_CLEAR_NEW_MARKBITS (J9VMSTATE_GC | 0x0008)
-#define J9VMSTATE_GC_CONCURRENT_MARK_SCAN_REMEMBERED_SET (J9VMSTATE_GC | 0x0009)
-#define J9VMSTATE_GC_CONCURRENT_MARK_FINAL_CLEAN_CARDS (J9VMSTATE_GC | 0x000A)
-#define J9VMSTATE_GC_CONCURRENT_SWEEP_COMPLETE_SWEEP (J9VMSTATE_GC | 0x000B)
-#define J9VMSTATE_GC_CONCURRENT_SWEEP_FIND_MINIMUM_SIZE_FREE (J9VMSTATE_GC | 0x000C)
-#define J9VMSTATE_GC_PARALLEL_OBJECT_DO (J9VMSTATE_GC | 0x000D)
-#define J9VMSTATE_GC_PARALLEL_VMSLOTS_DO (J9VMSTATE_GC | 0x000E)
-#define J9VMSTATE_GC_SCAVENGE (J9VMSTATE_GC | 0x000F)
-#define J9VMSTATE_GC_SCRUB_CARD_TABLE (J9VMSTATE_GC | 0x0010)
-#define J9VMSTATE_GC_UNLOADING_DEAD_CLASSLOADERS (J9VMSTATE_GC | 0x0011)
-#define J9VMSTATE_GC_COLLECTOR_CONCURRENTGC (J9VMSTATE_GC | 0x0012)
-#define J9VMSTATE_GC_COLLECTOR_CONCURRENTSWEEPGC (J9VMSTATE_GC | 0x0013)
-#define J9VMSTATE_GC_COLLECTOR_GLOBALGC (J9VMSTATE_GC | 0x0014)
-#define J9VMSTATE_GC_COLLECTOR_SCAVENGER (J9VMSTATE_GC | 0x0015)
-#define J9VMSTATE_GC_CONCURRENT_MARK_TRACE (J9VMSTATE_GC | 0x0016)
-#define J9VMSTATE_GC_CONCURRENT_SWEEP (J9VMSTATE_GC | 0x0017)
-#define J9VMSTATE_GC_COLLECTOR_METRONOME (J9VMSTATE_GC | 0x0018)
-#define J9VMSTATE_GC_ALLOCATE_OBJECT (J9VMSTATE_GC | 0x0019)
-#define J9VMSTATE_GC_ALLOCATE_INDEXABLE_OBJECT (J9VMSTATE_GC | 0x001A)
-#define J9VMSTATE_GC_TLH_ALLOCATE (J9VMSTATE_GC | 0x001B)
-#define J9VMSTATE_GC_TLH_FLUSH (J9VMSTATE_GC | 0x001C)
-#define J9VMSTATE_GC_TLH_RESET (J9VMSTATE_GC | 0x001D)
-#define J9VMSTATE_GC_CONCURRENT_MARK_COMPLETE_TRACING (J9VMSTATE_GC | 0x001E)
-#define J9VMSTATE_GC_CHECK_RESIZE (J9VMSTATE_GC | 0x0020)
-#define J9VMSTATE_GC_PERFORM_RESIZE (J9VMSTATE_GC | 0x0021)
-#define J9VMSTATE_GC_CHECK_BEFORE_GC (J9VMSTATE_GC | 0x0022)
-#define J9VMSTATE_GC_CHECK_AFTER_GC (J9VMSTATE_GC | 0x0023)
-#define J9VMSTATE_GC_TGC (J9VMSTATE_GC | 0x0024)
-#define J9VMSTATE_GC_DISPATCHER_IDLE (J9VMSTATE_GC | 0x0025)
-#define J9VMSTATE_GC_CONCURRENT_SCAVENGER (J9VMSTATE_GC | 0x0026)
-
-#define J9VMSTATE_GC_COPY_FORWARD_GMP_CARD_CLEANER (J9VMSTATE_GC | 0x0102)
-#define J9VMSTATE_GC_COPY_FORWARD_NO_GMP_CARD_CLEANER (J9VMSTATE_GC | 0x0103)
-#define J9VMSTATE_GC_GLOBAL_COLLECTION_CARD_CLEANER (J9VMSTATE_GC | 0x0104)
-#define J9VMSTATE_GC_GLOBAL_COLLECTION_NO_SCAN_CARD_CLEANER (J9VMSTATE_GC | 0x0105)
-#define J9VMSTATE_GC_GLOBAL_MARK_CARD_CLEANER (J9VMSTATE_GC | 0x0106)
-#define J9VMSTATE_GC_GLOBAL_MARK_CARD_SCRUBBER (J9VMSTATE_GC | 0x0107)
-#define J9VMSTATE_GC_GLOBAL_MARK_NO_SCAN_CARD_CLEANER (J9VMSTATE_GC | 0x0108)
-#define J9VMSTATE_GC_PARTIAL_MARK_GMP_CARD_CLEANER (J9VMSTATE_GC | 0x0109)
-#define J9VMSTATE_GC_PARTIAL_MARK_NO_GMP_CARD_CLEANER (J9VMSTATE_GC | 0x010A)
-#define J9VMSTATE_GC_WRITE_ONCE_FIXUP_CARD_CLEANER (J9VMSTATE_GC | 0x010B)
-/**
- * @}
- */
 
 /**
  * #defines representing the results from j9gc_ext_check_is_valid_heap_object.

--- a/runtime/gc_realtime/RealtimeGC.cpp
+++ b/runtime/gc_realtime/RealtimeGC.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -605,7 +605,7 @@ MM_RealtimeGC::unloadDeadClassLoaders(MM_EnvironmentBase *envModron)
 	J9MemorySegment *reclaimedSegments = NULL;
 
 	/* set the vmState whilst we're unloading classes */
-	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_UNLOADING_DEAD_CLASSLOADERS);
+	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_CLEANING_METADATA);
 	
 	lockClassUnloadMonitor(env);
 	

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -2483,7 +2483,7 @@ MM_IncrementalGenerationalGC::unloadDeadClassLoaders(MM_EnvironmentVLHGC *env)
 	Assert_MM_true(env->_cycleState->_dynamicClassUnloadingEnabled);
 
 	/* set the vmState whilst we're unloading classes */
-	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_UNLOADING_DEAD_CLASSLOADERS);
+	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_CLEANING_METADATA);
 	/* we are going to report that we started unloading, even though we might decide that there is no work to do */
 	reportClassUnloadingStart(env);
 	classUnloadStats->_startTime = j9time_hires_clock();


### PR DESCRIPTION
All J9VMSTATE_GC state definitions have been moved to OMR, so remove
duplicate definitions from OpenJ9. Also rename
J9VMSTATE_GC_UNLOADING_DEAD_CLASSLOADERS to
J9VMSTATE_GC_CLEANING_METADATA
 
Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>