### PR TITLE
Implement direct-call field resolve helpers

### DIFF
--- a/runtime/codert_vm/armnathelp.m4
+++ b/runtime/codert_vm/armnathelp.m4
@@ -317,6 +317,13 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveConstantDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveHandleMethod,3)
 
+dnl Direct call field resolve helpers
+
+SLOW_PATH_ONLY_HELPER(jitResolveFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveFieldSetterDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetterDirect,2)
+
 dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)

--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -362,6 +362,13 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveConstantDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveHandleMethod,3)
 
+dnl Direct call field resolve helpers
+
+SLOW_PATH_ONLY_HELPER(jitResolveFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveFieldSetterDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetterDirect,2)
+
 dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -416,6 +416,13 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveConstantDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveHandleMethod,3)
 
+dnl Direct call field resolve helpers
+
+SLOW_PATH_ONLY_HELPER(jitResolveFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveFieldSetterDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetterDirect,2)
+
 dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)

--- a/runtime/codert_vm/znathelp.m4
+++ b/runtime/codert_vm/znathelp.m4
@@ -362,6 +362,13 @@ PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveInvokeDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveConstantDynamic,3)
 PICBUILDER_SLOW_PATH_ONLY_HELPER(jitResolveHandleMethod,3)
 
+dnl Direct call field resolve helpers
+
+SLOW_PATH_ONLY_HELPER(jitResolveFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveFieldSetterDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldDirect,2)
+SLOW_PATH_ONLY_HELPER(jitResolveStaticFieldSetterDirect,2)
+
 dnl Recompilation helpers
 
 SLOW_PATH_ONLY_HELPER(jitRetranslateCaller,2)

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -97,6 +97,8 @@ JIT_HELPER(jitResolveClassFromStaticField);  // asm calling-convention helper
 JIT_HELPER(jitResolvedFieldIsVolatile);  // asm calling-convention helper
 JIT_HELPER(jitResolveField);  // asm calling-convention helper
 JIT_HELPER(jitResolveFieldSetter);  // asm calling-convention helper
+JIT_HELPER(jitResolveFieldDirect);  // asm calling-convention helper
+JIT_HELPER(jitResolveFieldSetterDirect);  // asm calling-convention helper
 JIT_HELPER(jitResolveHandleMethod);  // asm calling-convention helper
 JIT_HELPER(jitResolveInterfaceMethod);  // asm calling-convention helper
 JIT_HELPER(jitResolveInvokeDynamic);  // asm calling-convention helper
@@ -106,6 +108,8 @@ JIT_HELPER(jitResolveMethodType);  // asm calling-convention helper
 JIT_HELPER(jitResolveSpecialMethod);  // asm calling-convention helper
 JIT_HELPER(jitResolveStaticField);  // asm calling-convention helper
 JIT_HELPER(jitResolveStaticFieldSetter);  // asm calling-convention helper
+JIT_HELPER(jitResolveStaticFieldDirect);  // asm calling-convention helper
+JIT_HELPER(jitResolveStaticFieldSetterDirect);  // asm calling-convention helper
 JIT_HELPER(jitResolveStaticMethod);  // asm calling-convention helper
 JIT_HELPER(jitResolveString);  // asm calling-convention helper
 JIT_HELPER(jitResolveVirtualMethod);  // asm calling-convention helper

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -613,8 +613,12 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_fast_jitResolvedFieldIsVolatile", offsetof(J9JITConfig, old_fast_jitResolvedFieldIsVolatile)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveField", offsetof(J9JITConfig, old_slow_jitResolveField)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveFieldSetter", offsetof(J9JITConfig, old_slow_jitResolveFieldSetter)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveFieldDirect", offsetof(J9JITConfig, old_slow_jitResolveFieldDirect)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveFieldSetterDirect", offsetof(J9JITConfig, old_slow_jitResolveFieldSetterDirect)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveStaticField", offsetof(J9JITConfig, old_slow_jitResolveStaticField)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveStaticFieldSetter", offsetof(J9JITConfig, old_slow_jitResolveStaticFieldSetter)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveStaticFieldDirect", offsetof(J9JITConfig, old_slow_jitResolveStaticFieldDirect)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveStaticFieldSetterDirect", offsetof(J9JITConfig, old_slow_jitResolveStaticFieldSetterDirect)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveInterfaceMethod", offsetof(J9JITConfig, old_slow_jitResolveInterfaceMethod)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveSpecialMethod", offsetof(J9JITConfig, old_slow_jitResolveSpecialMethod)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JitConfig_old_slow_jitResolveStaticMethod", offsetof(J9JITConfig, old_slow_jitResolveStaticMethod)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3471,8 +3471,12 @@ typedef struct J9JITConfig {
 	void *old_fast_jitResolvedFieldIsVolatile;
 	void *old_slow_jitResolveField;
 	void *old_slow_jitResolveFieldSetter;
+	void *old_slow_jitResolveFieldDirect;
+	void *old_slow_jitResolveFieldSetterDirect;
 	void *old_slow_jitResolveStaticField;
 	void *old_slow_jitResolveStaticFieldSetter;
+	void *old_slow_jitResolveStaticFieldDirect;
+	void *old_slow_jitResolveStaticFieldSetterDirect;
 	void *old_slow_jitResolveInterfaceMethod;
 	void *old_slow_jitResolveSpecialMethod;
 	void *old_slow_jitResolveStaticMethod;
@@ -3832,8 +3836,12 @@ typedef struct J9AOTConfig {
 	void *old_fast_jitResolvedFieldIsVolatile;
 	void *old_slow_jitResolveField;
 	void *old_slow_jitResolveFieldSetter;
+	void *old_slow_jitResolveFieldDirect;
+	void *old_slow_jitResolveFieldSetterDirect;
 	void *old_slow_jitResolveStaticField;
 	void *old_slow_jitResolveStaticFieldSetter;
+	void *old_slow_jitResolveStaticFieldDirect;
+	void *old_slow_jitResolveStaticFieldSetterDirect;
 	void *old_slow_jitResolveInterfaceMethod;
 	void *old_slow_jitResolveSpecialMethod;
 	void *old_slow_jitResolveStaticMethod;


### PR DESCRIPTION
The unresolved path in the new inline field watch compilations needs to
call field resolve helpers directly from the code cache. Add direct
versions of the 4 helpers, with the same first 2 arguments and return
value (the 3rd argument is omitted as it can be inferred from the return
address like other runtime helpers).

jitResolveFieldDirect
jitResolveFieldSetterDirect
jitResolveStaticFieldDirect
jitResolveStaticFieldSetterDirect

Also modified the static field reporting helpers to block if another
thread is initializing the field class.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>