### PR TITLE
Handle string conversion errors in attach API

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
@@ -52,7 +52,7 @@ public abstract class CommonDirectory {
 	/**
 	 * default name of directories where VMs place their advertisements
 	 */
-	private static String systemTmpDir = IPC.getTmpDir();
+	private static final String systemTmpDir = IPC.getTmpDir();
 	/**
 	 * Indicates the control file is newer than the semaphore
 	 */

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/IPC.java
@@ -51,6 +51,7 @@ import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
  */
 public class IPC {
 
+	private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
 	/**
 	 * Successful return code from natives.
 	 */
@@ -261,7 +262,8 @@ public class IPC {
 	static String getTmpDir() {
 		String tmpDir = getTempDirImpl();
 		if (null == tmpDir) {
-			tmpDir = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty("java.io.tmpdir"); //$NON-NLS-1$
+			IPC.logMessage("Could not get system temporary directory. Trying "+JAVA_IO_TMPDIR); //$NON-NLS-1$
+			tmpDir = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty(JAVA_IO_TMPDIR); //$NON-NLS-1$
 		}
 		return tmpDir;
 	}

--- a/runtime/jcl/common/attach.c
+++ b/runtime/jcl/common/attach.c
@@ -91,6 +91,9 @@ Java_com_ibm_tools_attach_target_IPC_getTempDirImpl(JNIEnv *env, jclass clazz)
 			} else {
 				conversionBuffer = NULL; /* string is bogus */
 			}
+		} else if (conversionResult < 0) {
+			Trc_JCL_stringConversionFailed(env, charResult, conversionResult);
+			conversionBuffer = NULL; /* string conversion failed */
 		}
 		if (NULL != conversionBuffer) {
 			result =  (*env)->NewStringUTF(env, (char*)conversionBuffer);

--- a/runtime/jcl/j9jcl.tdf
+++ b/runtime/jcl/j9jcl.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2017 IBM Corp. and others
+// Copyright (c) 2006, 2018 IBM Corp. and others
 //	
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -623,3 +623,5 @@ TraceExit=Trc_JCL_com_ibm_oti_shared_SharedClassStatistics_maxJitDataBytesImpl_E
 
 TraceEvent=Trc_JCL_getMethodImpl_result Overhead=1 Level=10 Template="Java_java_lang_Class_getMethodImpl %.*s(%.*s) = %p"
 TraceExit=Trc_JCL_com_ibm_oti_shared_getCpeTypeForProtocol_ExitJIMAGE Noenv Overhead=1 Level=3 Template="JCL: com.ibm.oti.shared getCpeTypeForProtocol: Exiting with JIMAGE"
+
+TraceException=Trc_JCL_stringConversionFailed Overhead=1 Level=1 Template="JCL: string conversion of %s failed with error %d"


### PR DESCRIPTION
If the name of the temporary directory cannot be converted to UTF-16, use the
Java system property.

Fixes https://github.com/eclipse/openj9/issues/2781

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>