### PR TITLE
Fix condy constantpool iterator code

### DIFF
--- a/runtime/gc_structs/ConstantPoolObjectSlotIterator.cpp
+++ b/runtime/gc_structs/ConstantPoolObjectSlotIterator.cpp
@@ -70,7 +70,6 @@ GC_ConstantPoolObjectSlotIterator::nextSlot() {
 			/* Determine if the slot is constant dynamic */
 			if (slotType == J9CPTYPE_CONSTANT_DYNAMIC) {
 				result = scanCondySlot(slotPtr, &nextSlot);
-				break;
 			}
 		} else {
 			/* Determine if the slot should be processed */


### PR DESCRIPTION
Fix condy constantpool iterator code

In cases where we are only iterating condy slots, the constant
pool iterator breaks out of the loop which causes us to not 
update the iteration variables. As a result the iterator cycles 
indefinitely.

Signed-off-by: tajila <atobia@ca.ibm.com>