### PR TITLE
Store generated test natives generated at openj9 compile

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -261,7 +261,12 @@ def build() {
 def archive() {
     stage('Archive') {
         timestamps {
-              sh "tar -C build/${RELEASE}/images/ -zcvf ${SDK_FILENAME} ${JDK_FOLDER}"
+              def buildDir = "build/${RELEASE}/images/"
+              def testDir = "test/openj9"
+
+              sh "tar -C ${buildDir} -zcvf ${SDK_FILENAME} ${JDK_FOLDER}"
+              // test if the test natives directory is present, only in JDK11+
+              sh "if test -d ${buildDir}${testDir}; then tar -C ${buildDir} -zcvf ${TEST_FILENAME} ${testDir} --transform 's,${testDir},native-test-libs,'; fi"
               if (ARTIFACTORY_SERVER) {
                 def server = Artifactory.server ARTIFACTORY_SERVER
                 // if the archive location is modified the definition of CUSTOMIZED_SDK_URL will also need to be updated
@@ -269,6 +274,10 @@ def archive() {
                   "files":[
                     {
                       "pattern": "${env.WORKSPACE}/${SDK_FILENAME}",
+                      "target": "${ARTIFACTORY_REPO}/${env.JOB_NAME}/${env.BUILD_ID}/"
+                    },
+                    {
+                      "pattern": "${env.WORKSPACE}/${TEST_FILENAME}",
                       "target": "${ARTIFACTORY_REPO}/${env.JOB_NAME}/${env.BUILD_ID}/"
                     }
                   ]
@@ -282,6 +291,7 @@ def archive() {
               } else {
                 echo "ARTIFACTORY server is not set saving artifacts on jenkins."
                 archiveArtifacts artifacts: "**/${SDK_FILENAME}", fingerprint: true, onlyIfSuccessful: true
+                archiveArtifacts artifacts: "**/${TEST_FILENAME}", fingerprint: true, onlyIfSuccessful: true
               }
         }
     }

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -135,7 +135,7 @@ def get_date() {
     ).trim()
 }
 
-def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SDK_FILENAME) {
+def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SDK_FILENAME, TEST_FILENAME) {
     stage ("${BUILD_JOB_NAME}") {
         return build_with_slack(BUILD_JOB_NAME,
             [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
@@ -152,7 +152,8 @@ def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO
             string(name: 'VENDOR_BRANCH', value: VENDOR_BRANCH),
             string(name: 'VENDOR_CREDENTIALS_ID', value: VENDOR_CREDENTIALS_ID),
             string(name: 'NODE', value: NODE),
-            string(name: 'SDK_FILENAME', value: SDK_FILENAME)])
+            string(name: 'SDK_FILENAME', value: SDK_FILENAME),
+            string(name: 'TEST_FILENAME', value: TEST_FILENAME)])
     }
 }
 
@@ -239,7 +240,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
     // compile the source and build the SDK
     def BUILD_JOB_NAME = "Build-JDK${SDK_VERSION}-${SPEC}"
-    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.BUILD_NODE, SDK_FILENAME)
+    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.BUILD_NODE, SDK_FILENAME, TEST_FILENAME)
     echo "JOB: ${BUILD_JOB_NAME} PASSED in: ${jobs['build'].getDurationString()}"
 
     if (TESTS_TARGETS.trim() != "none") {
@@ -277,7 +278,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
             testjobs["${TEST_JOB_NAME}"] = {
                 // run tests against the SDK build in the upstream job: Build-JDK${SDK_VERSION}-${SPEC}
                      if (ARTIFACTORY_SERVER) {
-                          def CUSTOMIZED_SDK_URL = "${ARTIFACTORY_BASE_URL}/${BUILD_JOB_NAME}/${jobs["build"].getNumber()}/${SDK_FILENAME}"
+                          def CUSTOMIZED_SDK_URL = "${ARTIFACTORY_BASE_URL}/${BUILD_JOB_NAME}/${jobs["build"].getNumber()}/${SDK_FILENAME} ${ARTIFACTORY_BASE_URL}/${BUILD_JOB_NAME}/${jobs["build"].getNumber()}/${TEST_FILENAME}"
                           echo "Using CUSTOMIZED_SDK_URL = ${CUSTOMIZED_SDK_URL}, ARTIFACTORY_CREDS = ${ARTIFACTORY_CREDS}"
                           jobs["${TEST_JOB_NAME}"] = build_with_artifactory(TEST_JOB_NAME, params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST, CUSTOMIZED_SDK_URL, ARTIFACTORY_CREDS)
                      } else {

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -379,6 +379,7 @@ def set_build_variables() {
 
 def set_sdk_variables() {
     SDK_FILENAME = params.SDK_FILENAME
+    TEST_FILENAME = params.TEST_FILENAME
     if (!SDK_FILENAME) {
         DATESTAMP = sh (
             script: 'date +%Y%d%m%H%M',
@@ -386,6 +387,9 @@ def set_sdk_variables() {
             ).trim()
         SDK_FILENAME = "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}.tar.gz"
         echo "Using SDK_FILENAME = ${SDK_FILENAME}"
+    }
+    if (!TEST_FILENAME) {
+        TEST_FILENAME = "native-test-libs.tar.gz"
     }
 }
 


### PR DESCRIPTION
* [skip ci]
* add check if test native are present compress and attach to artifactory
    or jenkins archive as required

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>