### PR TITLE
Implement constant dynamic support in Power codegen

### DIFF
--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -108,6 +108,10 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
       {
       glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_interpreterUnresolvedMethodTypeTableEntryGlue, false, false, false);
       }
+   else if (getDataSymbol()->isConstantDynamic())
+      {
+      glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedConstantDynamicGlue, false, false, false);
+      }
    else // must be static data
       {
       if (isUnresolvedStore())
@@ -187,7 +191,7 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
    else
       {
       *(int32_t *)cursor = getMemoryReference()->getOffset(*(comp)); // offset
-      if (getDataSymbol()->isConstObjectRef())
+      if (getDataSymbol()->isConstObjectRef() || getDataSymbol()->isConstantDynamic())
          {
          cg()->addProjectSpecializedRelocation(cursor, *(uint8_t **)(cursor-4),
                getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
@@ -294,6 +298,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::UnresolvedDataSnippet * snippet)
    else if (snippet->getDataSymbol()->isMethodTypeTableEntry())
       {
       glueRef = _cg->getSymRef(TR_interpreterUnresolvedMethodTypeTableEntryGlue);
+      }
+   else if (snippet->getDataSymbol()->isConstantDynamic())
+      {
+      glueRef = _cg->getSymRef(TR_PPCinterpreterUnresolvedConstantDynamicGlue);
       }
    else // must be static data
       {

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -194,6 +194,8 @@
 	.globl    _interpreterUnresolvedClassGlue2{DS}
 	.globl    ._interpreterUnresolvedStringGlue
 	.globl    _interpreterUnresolvedStringGlue{DS}
+	.globl    ._interpreterUnresolvedConstantDynamicGlue{DS}
+	.globl    _interpreterUnresolvedConstantDynamicGlue
 	.globl    ._interpreterUnresolvedMethodTypeGlue
 	.globl    _interpreterUnresolvedMethodTypeGlue{DS}
 	.globl    ._interpreterUnresolvedMethodHandleGlue
@@ -332,6 +334,8 @@
 	.type  FUNC_LABEL(_interpreterUnresolvedStaticGlue),@function
 	.globl FUNC_LABEL(_interpreterUnresolvedStringGlue)
 	.type  FUNC_LABEL(_interpreterUnresolvedStringGlue),@function
+	.globl FUNC_LABEL(_interpreterUnresolvedConstantDynamicGlue)
+	.type  FUNC_LABEL(_interpreterUnresolvedConstantDynamicGlue),@function
 	.globl FUNC_LABEL(_interpreterUnresolvedMethodTypeGlue)
 	.type  FUNC_LABEL(_interpreterUnresolvedMethodTypeGlue),@function
 	.globl FUNC_LABEL(_interpreterUnresolvedMethodHandleGlue)
@@ -387,6 +391,7 @@
 	.globl _interpreterUnresolvedStaticDataStoreGlue
 	.globl _interpreterUnresolvedStaticGlue
 	.globl _interpreterUnresolvedStringGlue
+	.globl _interpreterUnresolvedConstantDynamicGlue
 	.globl _interpreterUnresolvedMethodTypeGlue
 	.globl _interpreterUnresolvedMethodHandleGlue
 	.globl _interpreterUnresolvedCallSiteTableEntryGlue
@@ -406,6 +411,7 @@
 	.extern   jitResolveClass
 	.extern   jitResolveClassFromStaticField
 	.extern   jitResolveString
+	.extern   jitResolveConstantDynamic
 	.extern   jitResolveMethodType
 	.extern   jitResolveMethodHandle
 	.extern   jitResolveInvokeDynamic
@@ -1016,6 +1022,70 @@ _interpreterUnresolvedStringGlue:
 	lwz	r8, 2*ALen+8(r7)				! Load the template instruction
 	b	.L_patch_dword_load
 	endproc._interpreterUnresolvedStringGlue:
+
+#ifdef AIXPPC
+._interpreterUnresolvedConstantDynamicGlue:
+   .function ._interpreterUnresolvedConstantDynamicGlue,startproc._interpreterUnresolvedConstantDynamicGlue,16,0,(endproc._interpreterUnresolvedConstantDynamicGlue-startproc._interpreterUnresolvedConstantDynamicGlue)
+#elif defined(LINUXPPC64)
+FUNC_LABEL(_interpreterUnresolvedConstantDynamicGlue):
+#else
+_interpreterUnresolvedConstantDynamicGlue:
+._interpreterUnresolvedConstantDynamicGlue:
+#endif
+        startproc._interpreterUnresolvedConstantDynamicGlue:
+#include "p/runtime/SaveGPRs.inc"
+        mfcr    r0
+        stw     r0,-4(J9SP)                                     ! Save CR also
+        addi    J9SP,J9SP,-(33*ALen)
+        mfspr   r7, LR                                          ! Get the RA in snippet
+        laddr   RTOC, J9TR_VMThreadRTOCOffset(J9VM_STRUCT)      ! Restore RTOC
+#ifdef AIXPPC
+        laddr   r8, TOCjitResolveConstantDynamic(RTOC)          ! Load descriptor pointer
+        laddr   r8, 0(r8)                                       ! Load the callee address
+#elif defined(LINUXPPC64)
+        laddr   r8, TOCjitResolveConstantDynamic@toc(RTOC)      ! Load descriptor pointer
+#if !defined(__LITTLE_ENDIAN__)
+        laddr   r8, 0(r8)                                       ! Load the callee address
+#endif
+#else
+        laddr   r8, jitResolveConstantDynamic@got(RTOC)         ! Load the callee address
+#endif
+        laddr   r3, 1*ALen+4(r7)                                ! Load constant pool literal
+        lwz     r4, 1*ALen(r7)                                  ! Load cp index for this field
+        laddr   r5, 0(r7)                                       ! Load code cache RA
+        rlwinm  r4, r4, 0, 5, 31                                ! Masking off the flag bits
+        addi    r5, r5, 1                                       ! Increament for EX search
+        mtspr   CTR, r8                                         ! Move callee address to CTR
+        bcctrl  BO_ALWAYS, CR0_LT                               ! Call to resolve: RTOC, r7
+        laddr   r6, 0(r7)                                       ! Load code cache RA
+        rlwinm  r17, r3, 0, 31, 31                              ! keep in r17 if r3 last bit is set: <clinit> is being executed
+#ifdef TR_HOST_64BIT
+        clrrdi r3, r3, 1                                        ! <clinit> clear up the last bit, which must be zero
+#else
+        rlwinm  r3, r3, 0, 0xfffffffe                           ! <clinit> clear up the last bit, which must be zero
+#endif
+        cmpi    cr0, 0, r17, in_clinit                          ! <clinit> is being executed
+        bc      BO_IF, CR0_EQ, .L_condy_update                  ! If in <clinit>
+        addi    r10, r7, 2*ALen+12                              ! Calculate lock address
+        addi    r9, 0, LOCKED_VALUE
+        bl      .__common_lock_check                            ! Try to lock
+        or.     r8, r8, r8                                      ! Result in r8
+        bc      BO_IF,CR0_EQ,.L_condy_update                    ! Grab the lock successfully?
+        bl      .__spin_for_update                              ! r10 containing lock address
+        b       .L_restore_and_return
+.L_condy_update:
+        lwz     r4, 1*ALen(r7)                                  ! Load cp index
+        andis.  r4, r4, 0x8000                                  ! Test the pTOC bit
+        lwz     r4, 2*ALen+4(r7)                                ! Load offset to be merged
+#ifdef TR_HOST_64BIT
+        extsw   r4, r4
+#endif
+        bc      BO_IF_NOT, CR0_EQ, .L_pTOC_update               ! Is pTOC case?
+        or      r3, r4, r4                                      ! Not pTOC case -- 32bit
+        lwz     r9, 4(r6)                                       ! Load the second instr
+        lwz     r8, 2*ALen+8(r7)                                ! Load the template instruction
+        b       .L_patch_dword_load
+        endproc._interpreterUnresolvedConstantDynamicGlue:
 
 #ifdef AIXPPC
 ._interpreterUnresolvedMethodTypeGlue:
@@ -3018,6 +3088,8 @@ TOCjitResolveClassFromStaticField:
 	.tc       jitResolveClass[TC],jitResolveClassFromStaticField
 TOCjitResolveString:
 	.tc       jitResolveString[TC],jitResolveString
+TOCjitResolveConstantDynamic:
+	.tc       jitResolveConstantDynamic[TC],jitResolveConstantDynamic
 TOCjitResolveMethodType:
 	.tc       jitResolveMethodType[TC],jitResolveMethodType
 TOCjitResolveMethodHandle:
@@ -3138,6 +3210,12 @@ __staticGlueTable:
 	ADDR      TOC{TC0}
 	ADDR      0x00000000
 ! End   csect     _interpreterUnresolvedStringGlue{DS}
+
+	.csect    _interpreterUnresolvedConstantDynamicGlue{DS}
+	ADDR      ._interpreterUnresolvedConstantDynamicGlue
+	ADDR      TOC{TC0}
+	ADDR      0x00000000
+! End   csect     _interpreterUnresolvedConstantDynamicGlue{DS}
 
 	.csect    _interpreterUnresolvedMethodTypeGlue{DS}
 	ADDR      ._interpreterUnresolvedMethodTypeGlue
@@ -3365,6 +3443,8 @@ TOCjitResolveClassFromStaticField:
 	.tc       jitResolveClass[TC],jitResolveClassFromStaticField
 TOCjitResolveString:
 	.tc       jitResolveString[TC],jitResolveString
+TOCjitResolveConstantDynamic:
+	.tc       jitResolveConstantDynamic[TC],jitResolveConstantDynamic
 TOCjitResolveMethodType:
 	.tc       jitResolveMethodType[TC],jitResolveMethodType
 TOCjitResolveMethodHandle:
@@ -3499,6 +3579,14 @@ _interpreterUnresolvedClassGlue2:
 	.size     _interpreterUnresolvedStringGlue,24
 _interpreterUnresolvedStringGlue:
 	.quad     ._interpreterUnresolvedStringGlue
+	.quad     .TOC.@tocbase
+	.long     0x00000000
+	.long     0x00000000
+
+	.globl    _interpreterUnresolvedConstantDynamicGlue
+	.size     _interpreterUnresolvedConstantDynamicGlue,24
+_interpreterUnresolvedConstantDynamicGlue:
+	.quad     ._interpreterUnresolvedConstantDynamicGlue
 	.quad     .TOC.@tocbase
 	.long     0x00000000
 	.long     0x00000000

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -412,6 +412,7 @@ JIT_HELPER(_interpreterUnresolvedDirectVirtualGlue);
 JIT_HELPER(_interpreterUnresolvedClassGlue);
 JIT_HELPER(_interpreterUnresolvedClassGlue2);
 JIT_HELPER(_interpreterUnresolvedStringGlue);
+JIT_HELPER(_interpreterUnresolvedConstantDynamicGlue);
 JIT_HELPER(_interpreterUnresolvedMethodTypeGlue);
 JIT_HELPER(_interpreterUnresolvedMethodHandleGlue);
 JIT_HELPER(_interpreterUnresolvedCallSiteTableEntryGlue);
@@ -1281,6 +1282,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_PPCinterpreterUnresolvedClassGlue,              (void *) _interpreterUnresolvedClassGlue,               TR_Helper);
    SET(TR_PPCinterpreterUnresolvedClassGlue2,             (void *) _interpreterUnresolvedClassGlue2,              TR_Helper);
    SET(TR_PPCinterpreterUnresolvedStringGlue,             (void *) _interpreterUnresolvedStringGlue,              TR_Helper);
+   SET(TR_PPCinterpreterUnresolvedConstantDynamicGlue,    (void *) _interpreterUnresolvedConstantDynamicGlue,     TR_Helper);
    SET(TR_interpreterUnresolvedMethodTypeGlue,            (void *)_interpreterUnresolvedMethodTypeGlue,           TR_Helper);
    SET(TR_interpreterUnresolvedMethodHandleGlue,          (void *)_interpreterUnresolvedMethodHandleGlue,         TR_Helper);
    SET(TR_interpreterUnresolvedCallSiteTableEntryGlue,    (void *)_interpreterUnresolvedCallSiteTableEntryGlue,   TR_Helper);


### PR DESCRIPTION
This commit adds the necessary code to the Power code generator to
support resolving unresolved constant dynamic constant pool entries in
JITted code.

Signed-off-by: Ben Thomas <ben@benthomas.ca>

This PR depends on eclipse/omr#2946.