### PR TITLE
Nestmates invokevirtual and invokeinterface work for Power

### DIFF
--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -525,8 +525,17 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    TR::Node       *callNode = getNode();
    TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCvirtualUnresolvedHelper, false, false, false);
-   intptrj_t  distance = (intptrj_t)glueRef->getMethodAddress() - (intptrj_t)cursor;
+   intptrj_t  distance;
+   void* thunk = fej9->getJ2IThunk(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->getMethod(), comp);
 
+   // We want the data in the snippet to be naturally aligned
+   if (TR::Compiler->target.is64Bit() && (((uint64_t)cursor % TR::Compiler->om.sizeofReferenceAddress()) == 4))
+      {
+      *(int32_t *)cursor = 0xdeadc0de;
+      cursor += 4;
+      }
+
+   distance = (intptrj_t)glueRef->getMethodAddress() - (intptrj_t)cursor;
    getSnippetLabel()->setCodeLocation(cursor);
 
    if (!(distance>=BRANCH_BACKWARD_LIMIT && distance<=BRANCH_FORWARD_LIMIT))
@@ -540,6 +549,18 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    *(int32_t *)cursor = 0x48000001 | (distance & 0x03fffffc);
    cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,(uint8_t *)glueRef,TR_HelperAddress, cg()),
       __FILE__, __LINE__, callNode);
+   cursor += 4;
+
+   /*
+    * Place a 'b' back to the main line code after the 'bl'.
+    * This is used to have 'blr's return to their corresponding 'bl's when handling private nestmate calls.
+    * Ideally, 'blr's return to their corresponding 'bl's in other cases as well but currently that does not happen.
+    */
+   distance = (intptrj_t)getReturnLabel()->getCodeLocation() - (intptrj_t)cursor;
+   *(int32_t *)cursor = 0x48000000 | (distance & 0x03fffffc);
+
+   TR_ASSERT(gcMap().isGCSafePoint() && gcMap().getStackMap(), "Virtual call snippets must have GC maps when preserving the link stack");
+   gcMap().registerStackMap(cursor - 4, cg());
    cursor += 4;
 
    // Store the code cache RA
@@ -564,14 +585,42 @@ uint8_t *TR::PPCVirtualUnresolvedSnippet::emitSnippetBody()
    *(uintptrj_t *)cursor = callNode->getSymbolReference()->getCPIndexForVM();
    cursor += TR::Compiler->om.sizeofReferenceAddress();
 
+   /*
+    * Reserved spot to hold J9Method pointer of the callee.
+    * This is used for private nestmate calls.
+    */
+   *(intptrj_t *)cursor = (intptrj_t)0;
+   cursor += sizeof(intptrj_t);
+
+   /*
+    * J2I thunk address.
+    * This is used for private nestmate calls.
+    */
+   *(intptrj_t*)cursor = (intptrj_t)thunk;
+   //TODO: Handle relocation here for the thunk. Currently not supported by AOT.
+   cursor += sizeof(intptrj_t);
+
    *(int32_t *)cursor = 0;        // Lock word
-   return(cursor + 4);
+   cursor += sizeof(int32_t);
+
+   return cursor;
    }
 
 uint32_t TR::PPCVirtualUnresolvedSnippet::getLength(int32_t estimatedSnippetStart)
    {
+   /*
+    * 4 = Code alignment may add 4 to the length. To be conservative it is always part of the estimate.
+    * 8 = Two instructions. One bl and one b instruction.
+    * 5 address fields:
+    *   - Call Site RA
+    *   - Constant Pool Pointer
+    *   - Constant Pool Index
+    *   - Private J9Method pointer
+    *   - J2I thunk address
+    * 4 = Lockword
+    */
    TR::Compilation* comp = cg()->comp();
-   return(8 + 3*TR::Compiler->om.sizeofReferenceAddress());
+   return(4 + 8 + (5 * TR::Compiler->om.sizeofReferenceAddress()) + 4);
    }
 
 uint8_t *TR::PPCInterfaceCallSnippet::emitSnippetBody()
@@ -1388,6 +1437,12 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCVirtualUnresolvedSnippet * snippet)
    trfprintf(pOutFile, "bl \t" POINTER_PRINTF_FORMAT "\t\t;%s", (intptrj_t)cursor + distance, info);
    cursor += 4;
 
+   printPrefix(pOutFile, NULL, cursor, 4);
+   distance = *((int32_t *) cursor) & 0x03fffffc;
+   distance = (distance << 6) >> 6;   // sign extend
+   trfprintf(pOutFile, "b \t" POINTER_PRINTF_FORMAT "\t\t; Back to program code", (intptrj_t)cursor + distance);
+   cursor += 4;
+
    printPrefix(pOutFile, NULL, cursor, sizeof(intptrj_t));
    trfprintf(pOutFile, ".long \t" POINTER_PRINTF_FORMAT "\t\t; Call Site RA", (intptrj_t)snippet->getReturnLabel()->getCodeLocation());
    cursor += sizeof(intptrj_t);
@@ -1398,6 +1453,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCVirtualUnresolvedSnippet * snippet)
 
    printPrefix(pOutFile, NULL, cursor, sizeof(intptrj_t));
    trfprintf(pOutFile, ".long \t" POINTER_PRINTF_FORMAT "\t\t; Constant Pool Index", callNode->getSymbolReference()->getCPIndexForVM());
+   cursor += sizeof(intptrj_t);
+
+   printPrefix(pOutFile, NULL, cursor, sizeof(intptrj_t));
+   trfprintf(pOutFile, ".long \t" POINTER_PRINTF_FORMAT "\t\t; Private J9Method pointer", *(intptrj_t *)cursor);
+   cursor += sizeof(intptrj_t);
+
+   printPrefix(pOutFile, NULL, cursor, sizeof(intptrj_t));
+   trfprintf(pOutFile, ".long \t" POINTER_PRINTF_FORMAT "\t\t; J2I thunk address for private", *(intptrj_t *)cursor);
    cursor += sizeof(intptrj_t);
 
    printPrefix(pOutFile, NULL, cursor, 4);

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2421,6 +2421,7 @@ void TR::PPCPrivateLinkage::buildVirtualDispatch(TR::Node                       
          generateDepLabelInstruction(cg(), TR::InstOpCode::label, callNode, doneLabel, dependencies);
 
          gcPoint->PPCNeedsGCMap(regMapForGC);
+         snippet->gcMap().setGCRegisterMask(regMapForGC);
          return;
          }
 

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -434,6 +434,7 @@
 	.extern   jitLookupInterfaceMethod
 	.extern   jitAddPicToPatchOnClassUnload
 	.extern   jitCallCFunction
+	.extern   jitInstanceOf
 	.extern   mcc_reservationAdjustment_unwrapper
 	.extern   mcc_callPointPatching_unwrapper
 	.extern   mcc_lookupHelperTrampoline_unwrapper
@@ -2666,6 +2667,13 @@ _interfaceCallHelper:
 	cmpi	cr0, CmpAddr, r5, -1
 	isync							! Make sure none -1 is seen
 	bc	BO_IF_NOT, CR0_EQ, .L.continueLookup
+	laddr	r5, 4*ALen(r11)					! Load ITable Index
+	andi.	r5, r5, J9TR_J9_ITABLE_OFFSET_DIRECT		! Check if J9TR_J9_ITABLE_OFFSET_DIRECT flag is set
+	bc	BO_IF, CR0_EQ, .L.callResolve			! If not set, need to call jitResolveInterfaceMethod
+	laddr	r5, 3*ALen(r11)					! Load Interface Class Pointer
+	or.	r5, r5, r5					! Check if Interface Class Pointer is null
+	bc	BO_IF_NOT, CR0_EQ, .L.typeCheckAndDirectDispatch	! If not null, this is a known private interface call
+.L.callResolve:
 	addi	r3, r11, ALen
 	mr	r4, r11						! Load code cache RA
 #ifdef AIXPPC
@@ -2682,6 +2690,67 @@ _interfaceCallHelper:
 	mtspr	CTR, r5						! Prepare for long jump
 	bcctrl	BO_ALWAYS, CR0_LT					! Call for resolution
 	sync
+	laddr	r5, 4*ALen(r11)					! Load ITable Index
+	andi.	r5, r5, J9TR_J9_ITABLE_OFFSET_DIRECT		! Check if J9TR_J9_ITABLE_OFFSET_DIRECT flag is set
+	bc	BO_IF, CR0_EQ, .L.callInterface			! If not set, this does not need a direct dispatch
+.L.typeCheckAndDirectDispatch:
+#ifdef AIXPPC
+	laddr	r5, TOCjitInstanceOf(RTOC)
+	laddr	r5, 0(r5)					! Load target address
+#elif defined(LINUXPPC64)
+	laddr	r5, TOCjitInstanceOf@toc(RTOC)
+#if !defined(__LITTLE_ENDIAN__)
+	laddr	r5, 0(r5)					! Load target address
+#endif
+#else
+	laddr	r5, jitInstanceOf@got(RTOC)			! Load the callee address
+#endif
+	laddr	r3, 3*ALen(r11)					! Load Interface Class Pointer
+	laddr	r4, 7*ALen(J9SP)				! Load this pointer
+	mtspr	CTR, r5
+	bcctrl	BO_ALWAYS, CR0_LT				! Branch to jitInstanceOf
+	or.	r3, r3, r3					! Check if jitInstanceOf returned null
+	bc	BO_IF_NOT, CR0_EQ, .L.directDispatchInterface	! If not null, continue on to direct dispatch
+#ifdef AIXPPC
+	laddr	r5, TOCjitLookupInterfaceMethod(RTOC)
+	laddr	r5, 0(r5)					! Load target address
+#elif defined(LINUXPPC64)
+	laddr	r5, TOCjitLookupInterfaceMethod@toc(RTOC)
+#if !defined(__LITTLE_ENDIAN__)
+	laddr	r5, 0(r5)					! Load target address
+#endif
+#else
+	laddr	r5, jitLookupInterfaceMethod@got(RTOC)		! Load the callee address
+#endif
+	mtspr	CTR, r5						! Prepare for long jump
+#ifdef J9VM_INTERP_COMPRESSED_OBJECT_HEADER
+	lwz	r3, J9TR_J9Object_class(r4)				! Load the class offset
+#else
+	laddr	r3, J9TR_J9Object_class(r4)				! Load the class
+#endif
+	maskVFT(r3)
+	addi	r4, r11, 3*ALen					! Address of interface table&slot number
+	mr	r5, r11						! Load original RA for use inside jitLookupInterfaceMethod
+	bcctr	BO_ALWAYS, CR0_LT				! Branch to jitLookupInterfaceMethod to trigger exception
+								! The code will not return here after the branch.
+.L.directDispatchInterface:
+	laddr	r5, 4*ALen(r11)					! Load ITable Index. This is actually a J9Method.
+	xori	r5, r5, J9TR_J9_ITABLE_OFFSET_DIRECT		! Clear J9TR_J9_ITABLE_OFFSET_DIRECT flag.
+	laddr	r6, J9TR_MethodPCStartOffset(r5)		! load startPC/extra field
+	andi.	r7, r6, J9TR_MethodNotCompiledBit		! Check to see if the method has already been compiled
+	bc	BO_IF_NOT, CR0_EQ, .L.interpretedDispatch	! If not compiled, handle interpreted case
+	lwz	r7, -4(r6)					! Load offset of jit --> jit
+	rlwinm	r7, r7, 16, 0x0000FFFF				! shift right to get the bits we want
+	add	r7, r7, r6					! Addr of jit --> jit in r7 to jump to
+	b	.L.setupCTRforCallout
+.L.interpretedDispatch:
+	ori	r12, r5, J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG	! put tagged J9Method into r12
+	laddr	r7, 9*ALen(r11)					! put thunk into r7 to jump to
+.L.setupCTRforCallout:
+	laddr	r3, 7*ALen(J9SP)				! Restore object ptr: this
+	mtspr	CTR, r7						! move r7 to ctr to jump to later
+	b	.L.calloutInterface
+.L.callInterface:
 	li	r3, 5*ALen
 	li	r5, 0
 .L.loopToSetZero:
@@ -2789,7 +2858,6 @@ _interfaceCallHelper:
 	neg	r4, r3
 	addi	r12, r4,J9TR_InterpVTableOffset			! Must set it up in r12
 	laddr	r3, 7*ALen(J9SP)					! Restore "this"
-	mr	r7, r11						! Load code cache RA
 #ifdef J9VM_INTERP_COMPRESSED_OBJECT_HEADER
 	lwz	r5, J9TR_J9Object_class(r3)				! class offset
         ! may need to convert class offset to J9Class pointer
@@ -2797,9 +2865,10 @@ _interfaceCallHelper:
 	laddr	r5, J9TR_J9Object_class(r3)				! class pointer
 #endif
 	maskVFT(r5)
-	mtspr	LR, r7						! Set up to return
 	laddrx	r4, r5, r12
 	mtspr	CTR, r4						! set up callee addr
+.L.calloutInterface:
+	mtspr	LR, r11						! Set up to return
 	laddr	r4, 6*ALen(J9SP)					! Restore r4 -- r10
 	laddr	r5, 5*ALen(J9SP)
 	laddr	r6, 4*ALen(J9SP)
@@ -3122,6 +3191,8 @@ TOC_jitAddPicToPatchOnClassUnload:
 	.tc       jitAddPicToPatchOnClassUnload[TC],jitAddPicToPatchOnClassUnload
 TOCjitCallCFunction:
 	.tc       jitCallCFunction[TC],jitCallCFunction
+TOCjitInstanceOf:
+	.tc       jitInstanceOf[TC],jitInstanceOf
 TOCmcc_callPointPatching_unwrapper:
 	.tc       mcc_callPointPatching_unwrapper[TC],mcc_callPointPatching_unwrapper
 TOCmcc_reservationAdjustment_unwrapper:
@@ -3469,6 +3540,8 @@ TOC_jitAddPicToPatchOnClassUnload:
 	.tc       jitAddPicToPatchOnClassUnload[TC],jitAddPicToPatchOnClassUnload
 TOCjitCallCFunction:
 	.tc       jitCallCFunction[TC],jitCallCFunction
+TOCjitInstanceOf:
+	.tc       jitInstanceOf[TC],jitInstanceOf
 TOCmcc_callPointPatching_unwrapper:
 	.tc       mcc_callPointPatching_unwrapper[TC],mcc_callPointPatching_unwrapper
 TOCmcc_reservationAdjustment_unwrapper:

--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -2476,6 +2476,21 @@ __refreshHelper:
 	blr
 	endproc.__refreshHelper:
 
+#ifdef TR_TARGET_64BIT
+#define VirtualRAOffset       1*ALen-4
+#define VirtualCPPOffset      2*ALen-4
+#define VirtualJ9MethodOffset 4*ALen-4
+#define VirtualJ2IThunkOffset 5*ALen-4
+#define VirtualLockwordOffset 6*ALen-4
+#else
+#define VirtualRAOffset       1*ALen
+#define VirtualCPPOffset      2*ALen
+#define VirtualJ9MethodOffset 4*ALen
+#define VirtualJ2IThunkOffset 5*ALen
+#define VirtualLockwordOffset 6*ALen
+#endif
+
+
 #ifdef AIXPPC
 ._virtualUnresolvedHelper:
 	.function ._virtualUnresolvedHelper,startproc._virtualUnresolvedHelper,16,0,(endproc._virtualUnresolvedHelper-startproc._virtualUnresolvedHelper)
@@ -2495,6 +2510,9 @@ _virtualUnresolvedHelper:
         staddr  r5, 5*ALen(J9SP)
         staddr  r4, 6*ALen(J9SP)
         staddr  r3, 7*ALen(J9SP)
+        laddr   r9, VirtualJ9MethodOffset(r11)                          ! Load the J9Method
+        or.     r9, r9, r9                                              ! Check if J9Method is null
+        bc      BO_IF_NOT, CR0_EQ, .L.callPrivate                       ! If not null, this is a prevously resolved private method
 #ifdef AIXPPC
 	laddr	RTOC, J9TR_VMThreadRTOCOffset(J9VM_STRUCT)		! Restore TOC register
 	laddr	r5, TOCjitResolveVirtualMethod(RTOC)
@@ -2511,15 +2529,36 @@ _virtualUnresolvedHelper:
 	laddr	RTOC, J9TR_VMThreadRTOCOffset(J9VM_STRUCT)		! Restore TOC register
 	laddr	r0, jitResolveVirtualMethod@got(RTOC)			! Load the callee address
 #endif
-	addi	r3, r11, ALen						! Load address of [idx:CP] pair
-	laddr	r4, 0(r11)						! Load code cache RA
+	addi	r3, r11, VirtualCPPOffset				! Load address of [CPP:idx] pair
+	laddr	r4, VirtualRAOffset(r11)				! Load code cache RA
 	mtspr   CTR, r0							! Set up to jump
 	bcctrl  BO_ALWAYS, CR0_LT					! Call to resolution, return
 									!   vtable offset in gr3
 	or.	r3, r3, r3						! If 0, means exception
 	bc      BO_IF, CR0_EQ, .L.commonMethodLookupException
 									! Require: J9SP-96, RTOC, r11
-	addi    r10, r11, 3*ALen					! Lock word addr in gr10
+        andi.   r9, r3, J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG         ! Check if result is tagged with J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG
+        bc      BO_IF, CR0_EQ, .L.callVirtual                           ! If it is not, go to the original path
+        xor     r9, r3, r9                                              ! r9 currently equals 0x1 so this will clear the direct method flag bit
+        staddr  r9, VirtualJ9MethodOffset(r11)                          ! stores the J9Method for future calls to this helper
+.L.callPrivate:
+        laddr   r8, J9TR_MethodPCStartOffset(r9)                        ! load startPC/extra field
+        andi.   r10, r8, J9TR_MethodNotCompiledBit                      ! Check to see if the method has already been compiled
+        bc      BO_IF_NOT, CR0_EQ, .L.interpretedPrivate                ! If not compiled, handle interpreted case
+        lwz     r10, -4(r8)                                             ! Load offset of jit --> jit
+        rlwinm  r10, r10, 16, 0x0000FFFF                                ! shift right to get the bits we want
+        add     r10, r10, r8                                            ! Addr of jit --> jit in r10 to jump to
+        b       .L.setupForCallout
+.L.interpretedPrivate:
+        ori     r12, r9, J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG        ! put tagged J9Method into r12
+        laddr   r10, VirtualJ2IThunkOffset(r11)                         ! put thunk into r10 to jump to
+.L.setupForCallout:
+        laddr   r3, 7*ALen(J9SP)                                        ! Restore object ptr: this
+        mtspr   CTR, r10                                                ! move r10 to ctr to jump to later
+        mtspr   LR, r11                                                 ! Set up the return addr to the b instruction inside the snippet
+        b       .L.callout
+.L.callVirtual:
+	addi    r10, r11, VirtualLockwordOffset				! Lock word addr in gr10
 	addi	r9, 0, LOCKED_VALUE					! Lock value
 	bl      .__common_lock_check					! Try to lock
 	or.     r8, r8, r8						! Grab the lock successfully?
@@ -2529,7 +2568,7 @@ _virtualUnresolvedHelper:
 	srawi   r6, r5, 16						! gr5{0:15} in gr6
 	add     r6, r6, r3						! upper half in gr6
 	rlwinm  r6, r6, 0, 0x0000ffff					! Mask off any overflow bits
-	laddr	r3, 0(r11)						! Load code cache RA
+	laddr	r3, VirtualRAOffset(r11)				! Load code cache RA
 #ifdef TR_HOST_64BIT
 	lis	r7, 0xffffffffffffe98c					! Binary: ld gr12, 0(gr12)
 #else
@@ -2560,7 +2599,7 @@ _virtualUnresolvedHelper:
 	bl      .__spin_for_update
 .L.directDispatch:							! J9SP-96,r5(offset),r11,RTOC
 	laddr	r3, 7*ALen(J9SP)					! Restore object ptr: this
-	laddr	r0, 0(r11)						! Load code cache RA
+	laddr	r0, VirtualRAOffset(r11)				! Load code cache RA
 #ifdef J9VM_INTERP_COMPRESSED_OBJECT_HEADER
         lwz     r6, J9TR_J9Object_class(r3)                                               ! Load class offset
         ! may need to convert class offset to J9Class
@@ -2571,6 +2610,7 @@ _virtualUnresolvedHelper:
 	mtspr   LR, r0							! Set up the return addr
 	laddrx	r8, r6, r5						! Load the vtable entry
 	mtspr   CTR, r8							! Set up the jump target
+.L.callout:
 	laddr   r4, 6*ALen(J9SP)					! Restore r4 -- r10
 	laddr   r5, 5*ALen(J9SP)
 	laddr   r6, 4*ALen(J9SP)
@@ -2595,7 +2635,7 @@ _virtualUnresolvedHelper:
 #else
 	laddr	r0, jitThrowException@got(RTOC)				! Load the callee address
 #endif
-	laddr	r5, 0(r11)						! Load code cache RA
+	laddr	r5, VirtualRAOffset(r11)				! Load code cache RA
 	mtspr   LR, r5							! As if called from code cache
 	laddr	r3, J9TR_VMThreadCurrentException(J9VM_STRUCT)
 	mtspr   CTR, r0


### PR DESCRIPTION
I'm implementing this on Power:
https://github.com/eclipse/openj9/issues/2673

Changes were made to support private resolved interface and virtual calls.

For invokeinterface the J2I thunk was added to the PPCInterfaceCallSnippet snipper. The interfaceCallHelper assembly is now able to recognize tagged J9Methods returned from jitResolveInterfaceMethod and new code was added to handle this case.

Similar changes were made for invokevirtual. The J2I thunk and a location to store the J9Method were added to the PPCVirtualUnresolvedSnippet snippet. Furthermore a branch back to the mainline code was added after the bl to the helper. virtualUnresolvedHelper is also now able to recognize and handle tagged J9Methods returned from jitResolveVirtualMethod. A small complication was added to how the value stored to the lr. Under the new private virtual method path, the lr is given a return address back to the new b instruction in the snippet. Under the older, original path, the lr is a return address back to the mainline code. The code tries to jump back to the new b instruction if possible since that is the instruction right after the bl to the helper and there can be a performance hit from not doing this. The original path requires the lr to hold a return address back to mainline code so that was not changed.