### PR TITLE
Support for native test libs

### DIFF
--- a/test/docs/OpenJ9TestUserGuide.md
+++ b/test/docs/OpenJ9TestUserGuide.md
@@ -50,6 +50,7 @@ tools should be installed on your test machine to run tests.
     JAVA_VERSION=[SE80|SE90|SE100|SE110|Panama|Valhalla] (SE90 default value)
     JAVA_IMPL=[openj9|ibm|hotspot|sap] (openj9 default value)
     BUILD_LIST=<comma separated projects to be compiled and executed> (default to all projects)
+    NATIVE_TEST_LIBS=<path to native test libraries> (default to native-test-libs folder at same level as JDK_HOME)
     ```
 
 Please refer *.spec files in [buildspecs](https://github.com/eclipse/openj9/tree/master/buildspecs)

--- a/test/functional/cmdLineTests/lazyClassLoadingTest/playlist.xml
+++ b/test/functional/cmdLineTests/lazyClassLoadingTest/playlist.xml
@@ -25,7 +25,8 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>cmdLineTester_LazyClassLoading</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)lazyClassLoadingTest.jar$(Q) \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DJ9JAR=$(Q)$(TEST_RESROOT)$(D)lazyClassLoadingTest.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -Xint -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)lazyClassLoading.xml$(Q) \
 	-nonZeroExitWhenError; \

--- a/test/functional/cmdLineTests/vmRuntimeState/playlist.xml
+++ b/test/functional/cmdLineTests/vmRuntimeState/playlist.xml
@@ -28,7 +28,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)vmruntimestate.jar$(Q) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)vmruntimestate.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+		$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump -DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' -DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)vmruntimestate.jar$(Q) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)vmruntimestate.xml$(Q) -explainExcludes -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>^arch.arm</platformRequirements>
 		<levels>


### PR DESCRIPTION
- update LIBPATH, LD_LIBRARY_PATH or PATH to point to new native
 test libs location based on the platform
- add $(ADD_JVM_LIB_DIR_TO_LIBPATH) for cmdLineTester_LazyClassLoading
and cmdLineTester_vmRuntimeState test
- readme update

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>