### PR TITLE
Merge archiveArtifact lines

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -290,8 +290,7 @@ def archive() {
                 server.publishBuildInfo buildInfo
               } else {
                 echo "ARTIFACTORY server is not set saving artifacts on jenkins."
-                archiveArtifacts artifacts: "**/${SDK_FILENAME}", fingerprint: true, onlyIfSuccessful: true
-                archiveArtifacts artifacts: "**/${TEST_FILENAME}", fingerprint: true, onlyIfSuccessful: true
+                archiveArtifacts artifacts: "**/${SDK_FILENAME},**/${TEST_FILENAME}", fingerprint: true, onlyIfSuccessful: true
               }
         }
     }


### PR DESCRIPTION
* [skip ci]
* on the single line removes the need to wrap a conditional around
    the native-test-libs.tar.gz as its only created in JDK11+

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>