### PR TITLE
Fix incorrect pass/fail criteria

### DIFF
--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -40,6 +40,7 @@
 	<property name="bootstrapSrc_90" location="./bootstrap_src_90"/>
 	<property name="bootstrapBuild" location="./bootstrap_bin"/>
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/> 
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>
@@ -150,6 +151,7 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}"/>
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" /> 
 					<!-- exclude files only for SE90 -->
 					<exclude name="**/MethodHandleAPI_asCollector.java" />
 					<exclude name="**/MethodHandleAPI_asSpreader.java" />
@@ -188,6 +190,7 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" /> 
 					<!-- exclude non test files for indyn test -->
 					<exclude name="**/indyn/BootstrapMethods.java" />
 					<exclude name="**/indyn/ComplexIndyGenerator.java" />

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/InterfaceHandleTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/InterfaceHandleTest.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Field;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 
+import org.openj9.test.util.VersionCheck;
+
 /**
  * A class to check if a specific method is correctly compiled by JIT
  */
@@ -82,7 +84,15 @@ public class InterfaceHandleTest {
 		try {
 			mh.invokeExact();
 			Assert.fail("Successfully invoked protected implementation of an interface method.");
-		} catch (IllegalAccessError e) { }
+		} catch (IllegalAccessError e) {
+			if (VersionCheck.major() >= 9) {
+				Assert.fail("IllegalAccessError thrown instead of AbstractMethodError");				
+			}
+		} catch (AbstractMethodError e) {
+			if (VersionCheck.major() < 9) {
+				Assert.fail("AbstractMethodError thrown instead of IllegalAccessError");				
+			}
+		}
 	}
 	
 	/**
@@ -98,7 +108,15 @@ public class InterfaceHandleTest {
 		try {
 			mh.invokeExact();
 			Assert.fail("Successfully invoked package private implementation of an interface method.");
-		} catch (IllegalAccessError e) { }
+		} catch (IllegalAccessError e) {
+			if (VersionCheck.major() >= 9) {
+				Assert.fail("IllegalAccessError thrown instead of AbstractMethodError");				
+			}
+		} catch (AbstractMethodError e) {
+			if (VersionCheck.major() < 9) {
+				Assert.fail("AbstractMethodError thrown instead of IllegalAccessError");				
+			}
+		}
 	}
 	
 	/**
@@ -114,7 +132,15 @@ public class InterfaceHandleTest {
 		try {
 			mh.invokeExact();
 			Assert.fail("Successfully invoked private implementation of an interface method.");
-		} catch (IllegalAccessError e) { }
+		} catch (IllegalAccessError e) {
+			if (VersionCheck.major() >= 9) {
+				Assert.fail("IllegalAccessError thrown instead of AbstractMethodError");				
+			}
+		} catch (AbstractMethodError e) {
+			if (VersionCheck.major() < 9) {
+				Assert.fail("AbstractMethodError thrown instead of IllegalAccessError");				
+			}
+		}
 	}
 	
 	static class Helper {


### PR DESCRIPTION
As of JDK9, AbstractMethodError is thrown instead of IllegalAccessError
for an invalid implementation of an interface method in the concrete
class (i.e. the bad method does not override the interface one).

Fixes: #2811

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>