### PR TITLE
Remove unnecessary synchronization in attach API logging

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Advertisement.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Advertisement.java
@@ -27,6 +27,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import static com.ibm.tools.attach.target.IPC.loggingStatus;
+import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
 
 public final class Advertisement {
 	private static final String KEY_ATTACH_NOTIFICATION_SYNC = "attachNotificationSync"; //$NON-NLS-1$
@@ -209,7 +211,7 @@ public final class Advertisement {
 			}
 			
 			advertOutputStream.write(advertContent.toString().getBytes("ISO8859_1")); //$NON-NLS-1$
-			if (IPC.loggingEnabled ) {
+			if (LOGGING_DISABLED != loggingStatus) {
 				IPC.logMessage("createAdvertisementFile ", advertFile.getAbsolutePath()); //$NON-NLS-1$
 			}
 		}

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/CommonDirectory.java
@@ -22,6 +22,9 @@ package com.ibm.tools.attach.target;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
+import static com.ibm.tools.attach.target.IPC.loggingStatus;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -93,7 +96,7 @@ public abstract class CommonDirectory {
 		String ipcDirProperty = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty(COM_IBM_TOOLS_ATTACH_DIRECTORY, 
 				(new File(systemTmpDir,".com_ibm_tools_attach")).getPath()); //$NON-NLS-1$
 		/*[PR CMVC 165300 restriction on embedded blanks was unnecessary. Also, trailing separators were redundant. ]*/
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("IPC Directory=", ipcDirProperty); //$NON-NLS-1$
 		}
 		File cd = new File(ipcDirProperty);
@@ -107,7 +110,7 @@ public abstract class CommonDirectory {
 	 /*[PR Jazz 30075] createDirectoryAndSemaphore is a misnomer, since it does not create the semaphore. */
 	static void prepareCommonDirectory() throws IOException {
 		File cd = getCommonDirFileObject();
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("createDirectoryAndSemaphore ", cd.getAbsolutePath()); //$NON-NLS-1$
 		}
 		if (cd.exists()) {
@@ -267,7 +270,7 @@ public abstract class CommonDirectory {
 	 * @return 0 on success
 	 */
 	public static int notifyVm(int numberOfTargets) {
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("notifyVm ", numberOfTargets, " targets"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return IPC.notifyVm(getCommonDirFileObject().getAbsolutePath(), MASTER_NOTIFIER, numberOfTargets);
@@ -348,7 +351,7 @@ public abstract class CommonDirectory {
 				continue;
 			}
 			String dirMemberName = dirMember.getName();
-			if (IPC.loggingEnabled ) {
+			if (LOGGING_DISABLED != loggingStatus) {
 				IPC.logMessage("deleteStaleDirectories checking ", dirMemberName); //$NON-NLS-1$
 			}
 			if (dirMember.isFile()) {
@@ -429,14 +432,14 @@ public abstract class CommonDirectory {
 		}
 		pid = advert.getProcessId();
 		long uid = advert.getUid();
-		if (IPC.loggingEnabled) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("getPidFromFile pid = ", (int) pid, dirMember.getName()); //$NON-NLS-1$
 		}
 		/*advertisement is from an older version or is corrupt, or claims to be owned by root.  Get the owner via file stat ]*/
 		if (0 == uid) {
 			uid = CommonDirectory.getFileOwner(dirMember.getAbsolutePath());
 		}
-		if (IPC.loggingEnabled) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("getPidFromFile uid = ", (int) uid); //$NON-NLS-1$
 		}
 		if (((0 != myUid) && (uid != myUid))) {

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/FileLock.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/FileLock.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.TimerTask;
+import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
+import static com.ibm.tools.attach.target.IPC.loggingStatus;
 
 public final class FileLock {
 	long fileDescriptor;
@@ -63,7 +65,7 @@ public final class FileLock {
 	 * @note locking and unlocking must be done by the same thread.
 	 */
 	public boolean lockFile(boolean blocking) throws IOException {
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage(blocking? "locking file ": "non-blocking locking file ", lockFilepath);  //$NON-NLS-1$//$NON-NLS-2$
 		}
 		
@@ -123,7 +125,7 @@ public final class FileLock {
 	 * Release the lock on a file.
 	 */
 	public void unlockFile() {
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("unlocking file ", lockFilepath);  //$NON-NLS-1$
 		}
 		java.nio.channels.FileLock lockObjectCopy = lockObject;

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/TargetDirectory.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/TargetDirectory.java
@@ -24,6 +24,8 @@ package com.ibm.tools.attach.target;
 
 import java.io.File;
 import java.io.IOException;
+import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
+import static com.ibm.tools.attach.target.IPC.loggingStatus;
 
 /**
  * This class represents the advertisement directory representing a potentisal attach API target VM.
@@ -127,10 +129,10 @@ public final class TargetDirectory {
 	 * @return true if the files were successfully deleted
 	 */
 	static boolean deleteMyFiles() {
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("deleting my files"); //$NON-NLS-1$
 		}
-		
+
 		if ((null != advertisementFileObject) && advertisementFileObject.delete()) {
 			advertisementFileObject = null;		
 		} else {
@@ -149,10 +151,9 @@ public final class TargetDirectory {
 	 * @param directoryEmpty set to true if the directory is supposedly empty
 	 */
 	static void deleteMyDirectory(boolean directoryEmpty) {
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("deleting my directory "); //$NON-NLS-1$
-		}
-		
+		}		
 		/* try the fast path for deleting files and directories. try the heavyweight path if something fails */
 		if ((!directoryEmpty && !deleteMyFiles()) || (null == targetDirectoryFileObject) || !targetDirectoryFileObject.delete()) {
 			deleteTargetDirectory(AttachHandler.getVmId());	
@@ -163,21 +164,21 @@ public final class TargetDirectory {
 		if ((null != vmId) && (0 != vmId.length())) { /* skip if the vmid was never set - we didn't create the directory */
 			File tgtDir = new File(getTargetDirectoryPath(vmId));
 			File[] vmFiles = tgtDir.listFiles();
-			if (IPC.loggingEnabled ) {
+			if (LOGGING_DISABLED != loggingStatus) {
 				IPC.logMessage("deleting target directory ", tgtDir.getAbsolutePath()); //$NON-NLS-1$
 			}
 			if (null != vmFiles) {
 				for (File f: vmFiles) {
 					if (!f.delete()) {
 						IPC.logMessage("error deleting directory ", f.getAbsolutePath()); //$NON-NLS-1$
-					} else if (IPC.loggingEnabled ) {
+					} else if (LOGGING_DISABLED != loggingStatus) {
 						IPC.logMessage("deleted file ", f.getAbsolutePath()); //$NON-NLS-1$
 					}
 				}
 			}
 			if (!tgtDir.delete()) {
 				IPC.logMessage("error deleting directory ", tgtDir.getAbsolutePath()); //$NON-NLS-1$
-			} else if (IPC.loggingEnabled ) {
+			} else if (LOGGING_DISABLED != loggingStatus) {
 				IPC.logMessage("deleted directory ", tgtDir.getAbsolutePath()); //$NON-NLS-1$
 			}
 		}

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/WaitLoop.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/WaitLoop.java
@@ -1,7 +1,7 @@
 /*[INCLUDE-IF Sidecar16]*/
 package com.ibm.tools.attach.target;
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,8 @@ package com.ibm.tools.attach.target;
  *******************************************************************************/
 
 import java.io.IOException;
+import static com.ibm.tools.attach.target.IPC.loggingStatus;
+import static com.ibm.tools.attach.target.IPC.LOGGING_DISABLED;
 
 final class WaitLoop extends Thread {
 
@@ -44,7 +46,7 @@ final class WaitLoop extends Thread {
 	private Attachment waitForNotification(boolean retry) throws IOException {
 		Object myIN = AttachHandler.mainHandler.getIgnoreNotification();
 
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("iteration ", AttachHandler.notificationCount," waitForNotification ignoreNotification entering"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
@@ -53,11 +55,11 @@ final class WaitLoop extends Thread {
 		 * We cannot use the file locking trick that the potential target VMs use since this VM holds the file locks.
 		 */
 		synchronized (myIN) {
-			if (IPC.loggingEnabled ) {
+			if (LOGGING_DISABLED != loggingStatus) {
 				IPC.logMessage("iteration ", AttachHandler.notificationCount, " waitForNotification ignoreNotification entered"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("iteration ", AttachHandler.notificationCount, " waitForNotification starting wait"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		
@@ -66,7 +68,7 @@ final class WaitLoop extends Thread {
 			status = CommonDirectory.waitSemaphore(AttachHandler.vmId);
 			AttachHandler.endWaitingForSemaphore();
 		}
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("iteration ", AttachHandler.notificationCount, " waitForNotification ended wait"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
@@ -76,7 +78,7 @@ final class WaitLoop extends Thread {
 			 * to avoid waking other processes.
 			 */
 			if (AttachHandler.getDoCancelNotify()) {
-				if (IPC.loggingEnabled ) {
+				if (LOGGING_DISABLED != loggingStatus) {
 					IPC.logMessage("iteration ", AttachHandler.notificationCount, " waitForNotification cancelNotify"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 				CommonDirectory.cancelNotify(AttachHandler.getNumberOfTargets());
@@ -126,14 +128,14 @@ final class WaitLoop extends Thread {
 			/* cannot create the target directory,so shut down the attach API */
 			AttachHandler.mainHandler.terminate(false); /* no need to notify myself */
 		}
-		if (IPC.loggingEnabled ) {
+		if (LOGGING_DISABLED != loggingStatus) {
 			IPC.logMessage("checkReplyAndCreateAttachment iteration "+ AttachHandler.notificationCount+" waitForNotification obtainLock"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		if (!AttachHandler.mainHandler.syncFileLock.lockFile(true)) { /* the sync file is missing. */
 			TargetDirectory.createMySyncFile();
 			/* don't bother locking this since the attacher will not have locked it. */
 		} else {
-			if (IPC.loggingEnabled ) {
+			if (LOGGING_DISABLED != loggingStatus) {
 				IPC.logMessage("iteration ", AttachHandler.notificationCount," checkReplyAndCreateAttachment releaseLock"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			AttachHandler.mainHandler.syncFileLock.unlockFile();


### PR DESCRIPTION
Avoid synchronization when  the enabled state of logging is known.

- Remove the `volatile` declaration of the logging status variable.
- If the current thread's copy of `loggingStatus` is in a terminal state (enabled or disabled), avoid  synchronizing. 
- In heavily used functions, test `loggingStatus` for the most probable value directly without a method call.
- Clean up and reorganize some logging variables and methods.

Fixes https://github.com/eclipse/openj9/issues/2048

@pshipton would you kindly review this?  Thank you.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>