### PR TITLE
Remove unused function set_job_names

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -444,15 +444,6 @@ def set_artifactory_config() {
     }
 }
 
-/*
-* Sets the names of the downstream build & test jobs
-*/
-def set_job_names() {
-    BUILD_JOB_NAME = VARIABLES.build_job_prefix + "${SDK_VERSION}-${SPEC}"
-    SANITY_JOB_NAME = VARIABLES.sanity_job_prefix + "${SDK_VERSION}-${SPEC}"
-    EXTENDED_JOB_NAME = VARIABLES.extended_job_prefix + "${SDK_VERSION}-${SPEC}"
-}
-
 def set_job_properties(JOB_TYPE) {
     /*************************
     * Setup Jenkins Properties
@@ -668,7 +659,6 @@ def set_job_variables(job_type) {
             set_sdk_variables()
             set_test_targets()
             set_slack_channel()
-            set_job_names()
             break
         case "wrapper":
             //set variable for pipeline all/personal

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -47,9 +47,6 @@ credentials:
   github: 'b6987280-6402-458f-bdd6-7affc2e360d4'
 test_dependencies_job_name: 'test.getDependency'
 slack_channel: '#jenkins'
-build_job_prefix: 'Build-JDK-'
-sanity_job_prefix: 'Sanity-JDK-'
-extended_job_prefix: 'Extended-JDK-'
 build_discarder:
   logs:
     build: 20


### PR DESCRIPTION
- This function was added but has never been used.
- We set the job names directly in the workflow function.
- Cleanup to avoid confusion.

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>