### PR TITLE
Change .i macro annotations to not use @, pt. 2

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -346,7 +346,7 @@ LIBCDEFS := $(word 1,$(wildcard $(foreach d,$(TPF_ROOT),$d/base/lib/libCDEFSFORA
 # over 1GB and reduces the workload of getmacros as it reads them.
 
 DDR_SED_COMMAND := \
-    sed -n -e '/^@/p' -e '/^DDRFILE_BEGIN /,/^DDRFILE_END /s/^/@/p'
+    sed -n -e '/^DDRFILE_BEGIN /,/^DDRFILE_END /s/^/@/p'
 
 %.i : %.c
 	$(CC) $(CFLAGS) -E $< | $(DDR_SED_COMMAND) > $@


### PR DESCRIPTION
With https://github.com/eclipse/omr/pull/2929, the change to ddrgen to not annotate source files with the @ symbol merged, we can now simplify the sed command to only match the new pattern.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>