### PR TITLE
Convert PullRequests to pipeline of jobs

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -27,41 +27,66 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
 ### Triggering Pull Request Builds from Github
 
 - You can request a PR build to do compile or compile & test
-- Current supported test levels are functional sanity and functional extended
-- Current available platforms are 
-    - Linux x86 (xLinux)
-    - Linux x86 largeheap/non-compressed refs (xlinuxlargeheap)
-    - Linux s390x (zLinux)
-    - Linux PPCLE (pLinux)
-    - AIX PPC (aix)
-    - Windows 64 bits (win)
-    - Windows 32 bits (win32) - supported on JDK8 only
+- Current supported test levels are sanity & extended
+- Current supported test groups are functional & system
+- Current available platforms are
+    - Linux on x86-64
+        - Spec: x86-64_linux
+        - Shortname: xlinux
+    - Linux on x86-64 largeheap/non-compressed references
+        - Spec: x86-64_linux_xl
+        - Shortname: xlinuxlargeheap or xlinuxxl
+    - Linux on x86-64 with CMake
+        - Spec: x86-64_linux_cm
+        - Shortname: xlinuxcm or xlinuxcmake
+    - Linux on s390x
+        - Spec: s390x_linux
+        - Shortname: zlinux
+    - Linux on ppc64le
+        - Spec: ppc64le_linux
+        - Shortname: plinux
+    - AIX on ppc64
+        - Spec: ppc64_aix
+        - Shortname: aix
+    - Windows on x86-64
+        - Spec: x86-64_windows
+        - shortname: win
+    - Windows on x86 (32bit, supported on JDK8 only)
+        Spec: x86-32_windows
+        Shortname: win32
+    - OSX on x86-64
+        - Spec: x86-64_mac
+        - Shortname: osx
+    - OSX on x86-64 largeheap/non-compressed references
+        - Spec: x86-64_mac_xl
+        - Shortname: osxlargeheap or osxxl
+
 - OpenJ9 committers can request builds by commenting in a pull request
-    - Format: `Jenkins <build type> <level> <platform>[,<platform>,...,<platform>] jdk<version>[,jdk<version>,...,jdk<version>]`
+    - Format: `Jenkins <build type> <level>.<group> <platform>[,<platform>,...,<platform>] jdk<version>[,jdk<version>,...,jdk<version>]`
     - `<build type>` is compile | test
     - `<level>` is sanity | extended (required only for "test" `<build type>`)
-    - `<platform>` is aix | xlinux | xlinuxlargeheap | zlinux | plinux | win | win32
-    - `<version>` is the number of the supported release, e.g. 8 | 11 | n 
-- Note: You can use keyword `all` for platform
+    - `<group>` is functional | system
+    - `<platform>` is one of the platform shorthands above
+    - `<version>` is the number of the supported release, e.g. 8 | 11 | next
+- Note: You can use keyword `all` for platform but not for test level/type or JDK versions.
+- Note: For backward compatability `<level>.<test type>` equal to `sanity` or `extended` is acceptable and will map to `sanity.functional` and `extended.functional` respectively.
 
 ###### Examples
 - Request a Compile-only build on all platforms and multiple versions by commenting in a PR
     - `Jenkins compile all jdk8,jdk11`
-- Request a Sanity build on zLinux and multiple versions
-    - `Jenkins test sanity zlinux jdk8,jdk11`
-- Request an Extended build on pLinux for a single version
-    - `Jenkins test extended plinux jdk8`
-- Request a Sanity build on z,p Linux for multiple versions
-    - `Jenkins test sanity zlinux,plinux jdk8,jdk9`
-- Request Sanity tests on all platforms and multiple versions
-    - `Jenkins test sanity all jdk8,jdk11`
+- Request a sanity functional build on zLinux and multiple versions
+    - `Jenkins test sanity.functional zlinux jdk8,jdk11`
+- Request an extended functional and system build on pLinux for a single version
+    - `Jenkins test extended.functional,extended.system plinux jdk8`
+- Request a sanity build on z,p Linux for multiple versions
+    - `Jenkins test sanity zlinux,plinux jdk8,jdk11`
+- Request sanity.system test on all platforms and multiple versions
+    - `Jenkins test sanity.system all jdk8,jdk11`
 
-You can also request a Pull Request build from the Eclipse OpenJ9 repository - [openj9](https://github.com/eclipse/openj9) - or the Extensions OpenJDK\* for Eclipse OpenJ9 repositories:
+You can request a Pull Request build from the Eclipse OpenJ9 repository - [openj9](https://github.com/eclipse/openj9) - or the Extensions OpenJDK\* for Eclipse OpenJ9 repositories:
 
 - openj9-openjdk-jdk: https://github.com/ibmruntimes/openj9-openjdk-jdk
 - openj9-openjdk-jdk`<version>`: `https://github.com/ibmruntimes/openj9-openjdk-jdk<version>`
-
-###### Note: When specifying a dependent change in an OpenJDK extensions repo, you can only build the SDK version that matches the repo where the dependent change lives. Eg. You cannot build JDK8 with a PR in openj9-openjdk-jdk9.
 
 ##### Dependent Changes
 
@@ -74,11 +99,13 @@ You can also request a Pull Request build from the Eclipse OpenJ9 repository - [
 - Ex. Dependent change in OpenJ9-OMR Pull Request `#456`
     - `Jenkins test sanity xlinux jdk8 depends eclipse/openj9-omr#456`
 - Ex. Dependent change in OpenJDK Pull Request `#789`
-    - `Jenkins test sanity xlinux jdk8 depends ibmruntimes/openj9-openjdk-jdk9#789`
+    - `Jenkins test sanity xlinux jdk8 depends ibmruntimes/openj9-openjdk-jdk8#789`
 - Ex. Dependent changes in OMR and OpenJDK
-    - `Jenkins test sanity all jdk9 depends eclipse/omr#123 ibmruntimes/openj9-openjdk-jdk9#789`
+    - `Jenkins test sanity all jdk8 depends eclipse/omr#123 ibmruntimes/openj9-openjdk-jdk8#789`
 - Ex. If you have a dependent change and only want one platform, depends comes last
     - `Jenkins test sanity zlinux jdk8 depends eclipse/omr#123`
+
+###### Note: When specifying a dependent change in an OpenJDK extensions repo, you can only build the SDK version that matches the repo where the dependent change lives. Eg. You cannot build JDK8 with a PR in openj9-openjdk-jdk11.
 
 ##### Other Pull Requests builds
 
@@ -91,49 +118,26 @@ You can also request a Pull Request build from the Eclipse OpenJ9 repository - [
 - To trigger a SignedOffBy Check (Only applicable to the Extensions repos)
    - `Jenkins signed off by check`
 
-##### PullRequest Trigger Regexes
-Having a complicated regex in the pull request trigger is what allows us to launch exactly the right combination of builds we need without having to make several trigger comments. The following are examples of what regexes we use in the various jobs.
-
-- Openj9 Repo
-    - Compile
-        - `.*(\n)?\bjenkins\s+compile\b\s*(((all|(([a-z]+(32)?,)*<platform>(,[a-z]+(32)?)*))\s*(jdk[0-9n]+,)*jdk<version>(,jdk[0-9n]+)*)(\s+depends.*)?)(\n)?.*`
-    - Test
-        - `.*(\n)?\bjenkins\s+test\s+<level>\b\s*(((all|(([a-z]+(32)?,)*<platform>(,[a-z]+(32)?)*))\s*(jdk[0-9n]+,)*jdk<version>(,jdk[0-9n]+)*)(\s+depends.*)?)(\n)?.*`
-
-- OpenJDK Extensions repos
-    - Compile
-        - `.*(\n)?\bjenkins\s+compile\b\s*(((all|(([a-z]+(32)?,)*<platform>(,[a-z]+(32)?)*))\s*jdk<version>)(\s+depends.*)?))(\n)?.*`
-    - Test
-        - `.*(\n)?\bjenkins\s+test\s+<level>\b\s*(((all|([a-z]+(32)?,)*<platform>(,[a-z]+(32?))*)\s*jdk<version>)(\s+depends.*)?)(\n)?.*`
-
-
 ### Jenkins Pipelines
 
 In this section:
-- `<platform>` is aix_ppc-64_cmprssptrs | linux_390-64_cmprssptrs | linux_ppc-64_cmprssptrs_le | linux_x86-64 | linux_x86-64_cmprssptrs | win_x86-64_cmprssptrs | win_x86
+- `<platform>` is the full spec name eg. ppc64_aix
 - `<repo>` is the Eclipse OpenJ9 repository or an Extensions OpenJDK\* for Eclipse OpenJ9 repository, e.g. OpenJ9 | OpenJDK`<version>`
 
 #### Pull Requests
 
 Pull Requests for all platforms and versions are available [**here**](https://ci.eclipse.org/openj9/view/Pull%20Requests/).
 
-- PullRequest-Compile-JDK`<version>`-`<platform>`-`<repo>`
-    - Description:
-        - Compile Eclipse OpenJ9 on `<platform>` for Extensions OpenJDK`<version>`
-    - Trigger:
-        - Github PR comment example `Jenkins compile <platform> jdk<version>`
+For Compile & Test PRs, there is a single top level job (for each repository) that connects Jenkins and the Github repo.
+This job will trigger downstream jobs based on what is requested in the pull request trigger comment (ghprbCommentBody)
 
-- PullRequest-Extended-JDK`<version>`-`<platform>`-`<repo>`
+- PullRequest-`<repo>`
     - Description:
-        - Compile Eclipse OpenJ9 on `<platform>` for Extensions OpenJDK`<version>` and run extended tests
+        - Setup job that launches downstream Pipeline job(s)
     - Trigger:
-        - Github PR comment `Jenkins test extended <platform> jdk<version>`
+        - Github PR comment `Jenkins (compile|test).*`
 
-- PullRequest-Sanity-JDK`<version>`-`<platform>`-`<repo>`
-    - Description:
-        - Compile Eclipse OpenJ9 on `<platform>` for Extensions OpenJDK`<version>` and run sanity tests
-    - Trigger:
-        - Github PR comment `Jenkins test sanity <platform> jdk<version>`
+Other PR jobs
 
 - PullRequest-LineEndingsCheck-`<repo>`
     - Description:

--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -109,7 +109,7 @@ def checkout_pullrequest() {
     echo 'Look for Dependent Changes'
 
     def KEYWORD = "depends"
-    def COMMENT = ghprbCommentBody.toLowerCase(Locale.US);
+    def COMMENT = params.ghprbCommentBody.toLowerCase(Locale.US);
     def OPENJDK_PR
     def OMR_PR
     def OPENJ9_PR
@@ -365,11 +365,7 @@ def build_all() {
             add_node_to_description()
             get_source()
             build()
-            // Do not archive in compile only pr jobs
-            // ghprbPullId is the PullRequest ID which only shows up in Pull Requests
-            if (!params.ghprbPullId) {
-                archive()
-            }
+            archive()
         } finally {
             // disableDeferredWipeout also requires deleteDirs. See https://issues.jenkins-ci.org/browse/JENKINS-54225
             cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -165,7 +165,22 @@ def set_build_status(REPO, CONTEXT, SHA, URL, STATE, MESSAGE) {
     ]);
 }
 
-def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SETUP_LABEL, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, CUSTOM_DESCRIPTION) {
+
+def cancel_running_builds(JOB_NAME, BUILD_IDENTIFIER) {
+    echo "Looking to stop running jobs:'${JOB_NAME}' from build:'${BUILD_IDENTIFIER}'"
+    Jenkins.instance.getItemByFullName(JOB_NAME, Job.class)._getRuns().each { number, run ->
+        // get all runs/jobs from the build
+        // Class org.jenkinsci.plugins.workflow.job.WorkflowRun
+        // Only look for running jobs with matching BUILD_IDENTIFIER
+        if ((run.isBuilding()) && (run.getEnvironment().get('BUILD_IDENTIFIER') == "${BUILD_IDENTIFIER}")) {
+            echo "Cancelling Job:'${run}'"
+            run.doStop()
+        }
+    }
+    echo "Done stopping jobs"
+}
+
+def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SETUP_LABEL, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, CUSTOM_DESCRIPTION, ghprbPullId, ghprbCommentBody, ghprbTargetBranch) {
     stage ("${BUILD_JOB_NAME}") {
         return build_with_slack(BUILD_JOB_NAME, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER,
             [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
@@ -188,7 +203,11 @@ def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO
             string(name: 'EXTRA_CONFIGURE_OPTIONS', value: EXTRA_CONFIGURE_OPTIONS),
             string(name: 'EXTRA_MAKE_OPTIONS', value: EXTRA_MAKE_OPTIONS),
             string(name: 'OPENJDK_CLONE_DIR', value: OPENJDK_CLONE_DIR),
-            string(name: 'CUSTOM_DESCRIPTION', value: CUSTOM_DESCRIPTION)])
+            string(name: 'CUSTOM_DESCRIPTION', value: CUSTOM_DESCRIPTION),
+            string(name: 'ghprbPullId', value: ghprbPullId),
+            string(name: 'ghprbGhRepository', value: ghprbGhRepository),
+            string(name: 'ghprbCommentBody', value: ghprbCommentBody),
+            string(name: 'ghprbTargetBranch', value: ghprbTargetBranch)])
     }
 }
 
@@ -275,19 +294,23 @@ def build_with_slack(DOWNSTREAM_JOB_NAME, ghprbGhRepository, ghprbActualCommit, 
         // Get build causes
         build_causes_string = get_causes(currentBuild)
 
-        if (JOB.result == "UNSTABLE") {
-            echo "WARNING: Downstream job ${DOWNSTREAM_JOB_NAME} is unstable after ${DOWNSTREAM_JOB_TIME}. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
-            currentBuild.result = "UNSTABLE"
+        if ((JOB.result == "UNSTABLE") || (JOB.result == "ABORTED")) { // Job unstable (YELLOW) or aborted (GREY)
+            // If the job was ABORTED it either was killed by someone or
+            // killed by cancel_running_builds(). In this case we don't
+            // want to offer the restart option as it is not desired for PR builds.
+            // If the job was UNSTABLE this indicates test(s) failed and we don't want to offer the restart option.
+            echo "WARNING: Downstream job ${DOWNSTREAM_JOB_NAME} is ${JOB.result} after ${DOWNSTREAM_JOB_TIME}. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
+            currentBuild.result = JOB.result
             if (SLACK_CHANNEL) {
-                slackSend channel: SLACK_CHANNEL, color: 'warning', message: "Unstable: ${DOWNSTREAM_JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)\n${build_causes_string}"
+                slackSend channel: SLACK_CHANNEL, color: 'warning', message: "${JOB.result}: ${DOWNSTREAM_JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)\n${build_causes_string}"
             }
             // Set Github Commit Status
             if (ghprbActualCommit) {
                 node('master') {
-                    set_build_status(GITHUB_REPO, DOWNSTREAM_JOB_NAME, ghprbActualCommit, DOWNSTREAM_JOB_URL, 'FAILURE', "Build UNSTABLE")
+                    set_build_status(GITHUB_REPO, DOWNSTREAM_JOB_NAME, ghprbActualCommit, DOWNSTREAM_JOB_URL, 'FAILURE', "Build ${JOB.result}")
                 }
             }
-        } else {
+        } else { // Job faild (RED)
             if (SLACK_CHANNEL) {
                 slackSend channel: SLACK_CHANNEL, color: 'danger', message: "Failure: ${DOWNSTREAM_JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)\n${build_causes_string}\nWould you like to restart the job? (<${RUN_DISPLAY_URL}|Open>)"
             }
@@ -330,7 +353,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
     echo "Repo:${ghprbGhRepository}, Commit:${ghprbActualCommit}, GITHUB_SERVER:${GITHUB_SERVER}"
 
     // compile the source and build the SDK
-    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.BUILD_NODE, SETUP_LABEL, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, CUSTOM_DESCRIPTION)
+    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.BUILD_NODE, SETUP_LABEL, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, CUSTOM_DESCRIPTION, ghprbPullId, ghprbCommentBody, ghprbTargetBranch)
 
     // Determine if Build job archived to Artifactory
     def BUILD_JOB_ENV = jobs["build"].getBuildVariables()
@@ -363,6 +386,11 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
         echo "Using VENDOR_TEST_REPOS = ${VENDOR_TEST_REPOS}, VENDOR_TEST_BRANCHES = ${VENDOR_TEST_BRANCHES}, VENDOR_TEST_SHAS = ${VENDOR_TEST_SHAS}, VENDOR_TEST_DIRS = ${VENDOR_TEST_DIRS}, BUILD_LIST = ${BUILD_LIST}" 
 
+        // For PullRequest Builds, overwrite the OpenJ9 sha for test jobs so they checkout the PR (OpenJ9 PRs only)
+        if (params.ghprbPullId && params.ghprbGhRepository == 'eclipse/openj9') {
+            SHAS['OPENJ9'] = "origin/pr/${params.ghprbPullId}/merge"
+        }
+
         for (name in TARGET_NAMES) {
             // Checking to see if the test should be excluded
             if (EXCLUDED_TESTS.contains(get_target_name(name))){
@@ -373,6 +401,9 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
             def TEST_JOB_NAME = get_test_job_name(get_target_name(name), SPEC, SDK_VERSION, BUILD_IDENTIFIER)
 
             testjobs["${TEST_JOB_NAME}"] = {
+                if (params.ghprbPullId) {
+                    cancel_running_builds(TEST_JOB_NAME, BUILD_IDENTIFIER)
+                }
                 if (ARTIFACTORY_CREDS) {
                     cleanup_artifactory(ARTIFACTORY_MANUAL_CLEANUP, TEST_JOB_NAME, ARTIFACTORY_SERVER, ARTIFACTORY_REPO, ARTIFACTORY_NUM_ARTIFACTS)
                     jobs["${TEST_JOB_NAME}"] = build_with_artifactory(TEST_JOB_NAME, TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST, CUSTOMIZED_SDK_URL, ARTIFACTORY_CREDS, TEST_FLAG, BUILD_IDENTIFIER, ghprbGhRepository, ghprbActualCommit, GITHUB_SERVER, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH)
@@ -553,6 +584,100 @@ def generate_test_jobs(TARGET_NAMES, SPEC, ARTIFACTORY_SERVER, ARTIFACTORY_REPO)
         string(name: 'BUILDS_TO_KEEP', value: DISCARDER_NUM_BUILDS)
     ]
     build job: 'Test_Job_Auto_Gen', parameters: parameters, propagate: false
+}
+
+def setup_pull_request() {
+    // Parse Github trigger comment
+    // Jenkins test sanity <platform>*
+    // Jenkins test extended <platform>*
+    // Jenkins compile <platform>*
+    // Jenkins test <comma_separated_test_target> <platform> *
+    /*
+    * Comment indexes - '+' is an offset of 0/1 if running tests or not
+    * 0 - Jenkins
+    * 1 - test / compile
+    * 1+ - test target
+    * 2+ - platforms
+    * 3+ - jdk versions
+    *
+    * Note: Depends logic is already part of the build/compile job and is located in the checkout_pullrequest() function.
+    */
+    def PARSED_COMMENT = params.ghprbCommentBody.toLowerCase().tokenize(' ')
+    // Don't both checking PARSED_COMMENT[0] since it is hardcoded in the trigger regex of the Jenkins job.
+
+    // Setup TESTS_TARGETS
+    switch ("${PARSED_COMMENT[1]}") {
+        case "compile":
+            if (PARSED_COMMENT.size() < 4) {
+                error("Pull Request trigger comment needs to specify PLATFORM and SDK_VERSION")
+            }
+            TESTS_TARGETS = 'none'
+            OFFSET = 0
+            break
+        case "test":
+            if (PARSED_COMMENT.size() < 5) {
+                error("Pull Request trigger comment needs to specify TESTS_TARGET, PLATFORM and SDK_VERSION")
+            }
+            TESTS_TARGETS = "${PARSED_COMMENT[2]}"
+            if ("${TESTS_TARGETS}" == "all") {
+                error("Test Target 'all' not allowed for Pull Request builds")
+            }
+            OFFSET = 1
+            break
+        default:
+            error("Unable to parse trigger comment. Unknown build option:'${PARSED_COMMENT[1]}'")
+    }
+    echo "TESTS_TARGETS:'${TESTS_TARGETS}'"
+
+    // Setup JDK VERSIONS
+    switch (ghprbGhRepository) {
+        case   ~/.*openj9-openjdk-jdk.*/:
+            TMP_VERSION = ghprbGhRepository.substring(ghprbGhRepository.indexOf('-jdk')+4)
+            if ("${TMP_VERSION}" == "") {
+                TMP_VERSION = 'next'
+            }
+            RELEASES.add(TMP_VERSION)
+            MIN_COMMENT_SIZE = 3
+            break
+        case "eclipse/openj9":
+            TMP_VERSIONS = PARSED_COMMENT[3+OFFSET].tokenize(',')
+            TMP_VERSIONS.each { VERSION ->
+                echo "VERSION:'${VERSION}'"
+                if ("${VERSION}" == "all") {
+                    error("JDK version 'all' not allowed for Pull Request builds\nExpected 'jdkX' where X is one of ${CURRENT_RELEASES}")
+                }
+                if (!("${VERSION}" ==~ /jdk.*/)) {
+                    error("Incorrect syntax for requested JDK version:'${VERSION}'\nExpected 'jdkX' where X is one of ${CURRENT_RELEASES}")
+                }
+                if (CURRENT_RELEASES.contains(VERSION.substring(3))) {
+                    RELEASES.add(VERSION.substring(3))
+                } else {
+                    error("Unsupported JDK version or incorrect syntax:'${VERSION}'\nExpected 'jdkX' where X is one of ${CURRENT_RELEASES}")
+                }
+            }
+            MIN_COMMENT_SIZE = 4
+            break
+        default:
+            error("Unknown source repo:'${ghprbGhRepository}'")
+    }
+
+    echo "RELEASES:'${RELEASES}'"
+
+    if (PARSED_COMMENT.size() < MIN_COMMENT_SIZE) { error("Pull Request trigger comment does not contain enough elements.")}
+
+    // Setup PLATFORMS
+    PARSED_PLATFORMS = PARSED_COMMENT[2+OFFSET].tokenize(',')
+    PARSED_PLATFORMS.each { SHORT ->
+        LONG_PLATFORM = SHORT_NAMES["${SHORT}"]
+        if (LONG_PLATFORM) {
+            PLATFORMS.add(LONG_PLATFORM)
+        } else {
+            error("Unknown PLATFORM short:'${SHORT}'\nExpected one of:${SHORT_NAMES}")
+        }
+    }
+    echo "PLATFORMS:'${PLATFORMS}'"
+
+    PERSONAL_BUILD = 'true'
 }
 
 return this

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -553,6 +553,14 @@ def add_string_params(PARAMETERS_TO_ADD) {
         PARAMETERS.add(string(name: key, defaultValue: value, description: '', trim: true))
     }
 }
+
+def add_pr_to_description() {
+    if (params.ghprbPullId) {
+        def TMP_DESC = (currentBuild.description) ? currentBuild.description + "<br>" : ""
+        currentBuild.description = TMP_DESC + "<a href=https://github.com/${params.ghprbGhRepository}/pull/${params.ghprbPullId}>PR #${params.ghprbPullId}</a>"
+    }
+}
+
 /*
 * Initializes all of the required variables for a Jenkins job by given job type.
 */
@@ -585,6 +593,7 @@ def set_job_variables(job_type) {
             set_build_variables()
             set_sdk_variables()
             set_artifactory_config()
+            add_pr_to_description()
             break
         case "pullRequest":
             // set the node the pull request job would run on
@@ -593,6 +602,7 @@ def set_job_variables(job_type) {
             set_build_variables()
             set_sdk_variables()
             set_test_variables()
+            set_artifactory_config()
             break
         case "pipeline":
             // set variables for a pipeline job
@@ -603,6 +613,7 @@ def set_job_variables(job_type) {
             set_test_targets()
             set_slack_channel()
             set_restart_timeout()
+            add_pr_to_description()
             break
         case "wrapper":
             //set variable for pipeline all/personal
@@ -612,7 +623,7 @@ def set_job_variables(job_type) {
             set_restart_timeout()
             break
         default:
-            error("Unknown Jenkins job type!")
+            error("Unknown Jenkins job type:'${job_type}'")
     }
 }
 
@@ -845,27 +856,31 @@ def get_build_specs_by_release(version, specs) {
  * and test. Returns a map of releases by specs.
  */
 def get_specs(SUPPORTED_SPECS) {
-    def RELEASES = []
-    def PLATFORMS = []
     def SPECS = [:]
 
-    // get releases 
-    params.each { key, value  ->
-        if ((key.indexOf('Java') != -1) && (value == true)) {
-            RELEASES.add(key.substring(4))
+    if (!RELEASES) {
+        // get releases
+        params.each { key, value  ->
+            if ((key.indexOf('Java') != -1) && (value == true)) {
+                RELEASES.add(key.substring(4))
+            }
         }
     }
+    echo "RELEASES:'${RELEASES}'"
 
-    // get specs
-    if (!params.PLATFORMS || (params.PLATFORMS.trim() == 'all')) {
-        // build and test all supported specs
-        PLATFORMS.addAll(SUPPORTED_SPECS.keySet())
-    } else {
-        PLATFORMS.addAll(params.PLATFORMS.split(","))
+    if (!PLATFORMS) {
+        // get specs
+        if (!params.PLATFORMS || (params.PLATFORMS.trim() == 'all')) {
+            // build and test all supported specs
+            PLATFORMS.addAll(SUPPORTED_SPECS.keySet())
+        } else {
+            PLATFORMS.addAll(params.PLATFORMS.split(","))
+        }
     }
-
+    echo "PLATFORMS:'${PLATFORMS}'"
     def RELEASES_STR = RELEASES.join(',')
 
+    // Setup SPEC map
     PLATFORMS.each { SPEC ->
         SPEC = SPEC.trim()
         if (!SUPPORTED_SPECS.keySet().contains(SPEC)) {
@@ -891,7 +906,7 @@ def get_specs(SUPPORTED_SPECS) {
     if (!SPECS) {
         error("Invalid PLATFORMS (${params.PLATFORMS}) and/or Java versions selections(${RELEASES_STR})!")
     }
-
+    echo "SPECS:'${SPECS}'"
     return SPECS
 }
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -75,7 +75,6 @@
  *   OPENJDK<version>_SHA_<platform>: String - the last commit SHA
  */
 
-RELEASES = ['8', '9', '10', '11', '12', 'next']
 CURRENT_RELEASES = ['8', '11', '12', 'next']
 
 SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
@@ -90,14 +89,29 @@ SPECS = ['ppc64_aix'      : CURRENT_RELEASES,
          'x86-32_windows' : ['8'],
          'x86-64_windows' : CURRENT_RELEASES]
 
+// SHORT_NAMES is used for PullRequest triggers
+// TODO Combine SHORT_NAMES and SPECS
+SHORT_NAMES = ['all' : 'all',
+            'aix' : 'ppc64_aix',
+            'zlinux' : 's390x_linux',
+            'plinux' : 'ppc64le_linux',
+            'xlinuxlargeheap' : 'x86-64_linux_xl',
+            'xlinuxxl' : 'x86-64_linux_xl',
+            'xlinux' : 'x86-64_linux',
+            'xlinuxcmake' : 'x86-64_linux_cm',
+            'xlinuxcm' : 'x86-64_linux_cm',
+            'win32' : 'x86-32_windows',
+            'win' : 'x86-64_windows',
+            'osx' : 'x86-64_mac',
+            'osxlargeheap' : 'x86-64_mac_xl',
+            'osxxl' : 'x86-64_mac_xl']
+
 // Initialize all PARAMETERS (params) to Groovy Variables even if they are not passed
 echo "Initialize all PARAMETERS..."
 SETUP_LABEL = (params.SETUP_LABEL) ? params.SETUP_LABEL : "worker"
 echo "Setup SETUP_LABEL:'${SETUP_LABEL}'"
 TESTS_TARGETS = (params.TESTS_TARGETS) ? params.TESTS_TARGETS : ""
 echo "TESTS_TARGETS:'${TESTS_TARGETS}'"
-PLATFORMS = (params.PLATFORMS) ? params.PLATFORMS : ""
-echo "PLATFORMS:'${PLATFORMS}'"
 PERSONAL_BUILD = (params.PERSONAL_BUILD) ? params.PERSONAL_BUILD : ""
 echo "PERSONAL_BUILD:'${PERSONAL_BUILD}'"
 BUILD_NODE_LABELS = (params.BUILD_NODE_LABELS) ? params.BUILD_NODE_LABELS : ""
@@ -121,6 +135,24 @@ echo "TIMEOUT_UNIT: ${TIMEOUT_UNIT}"
 CUSTOM_DESCRIPTION = (params.CUSTOM_DESCRIPTION) ? params.CUSTOM_DESCRIPTION : ""
 echo "CUSTOM_DESCRIPTION:'${CUSTOM_DESCRIPTION}'"
 
+// param PLATFORMS is a string, we convert it to an array later on
+PLATFORMS = []
+echo "PLATFORMS:'${params.PLATFORMS}'"
+
+// Pull Request Builds
+ghprbPullId = (params.ghprbPullId) ? params.ghprbPullId : ""
+echo "ghprbPullId:'${ghprbPullId}'"
+ghprbGhRepository = (params.ghprbGhRepository) ? params.ghprbGhRepository : ""
+echo "ghprbGhRepository:'${ghprbGhRepository}'"
+ghprbCommentBody = (params.ghprbCommentBody) ? params.ghprbCommentBody : ""
+echo "ghprbCommentBody:'${ghprbCommentBody}'"
+ghprbTargetBranch = (params.ghprbTargetBranch) ? params.ghprbTargetBranch : ""
+echo "ghprbTargetBranch:'${ghprbTargetBranch}'"
+ghprbActualCommit = (params.ghprbActualCommit) ? params.ghprbActualCommit : ""
+echo "ghprbActualCommit:'${ghprbActualCommit}'"
+
+RELEASES = []
+
 OPENJDK_REPO = [:]
 OPENJDK_BRANCH = [:]
 OPENJDK_SHA = [:]
@@ -128,7 +160,6 @@ OPENJDK_SHA = [:]
 BUILD_SPECS = [:]
 builds = [:]
 pipelineNames = []
-
 
 try {
     timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNIT) {
@@ -139,19 +170,25 @@ try {
                     variableFile = load 'buildenv/jenkins/common/variables-functions'
                     buildFile = load 'buildenv/jenkins/common/pipeline-functions'
 
+                    // Determine if build is a PullRequest
+                    if (ghprbPullId) {
+                        buildFile.setup_pull_request()
+                    }
+
                     BUILD_SPECS.putAll(variableFile.get_specs(SPECS))
 
                     // parse variables file and initialize variables
                     variableFile.set_job_variables('wrapper')
+
                     SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH)
 
-                    if (params.PERSONAL_BUILD) {
+                    if (PERSONAL_BUILD) {
                         // update build description
-                        currentBuild.description += "<br/>${params.PLATFORMS}"
+                        currentBuild.description += "<br/>${PLATFORMS}"
                     }
 
-                    def BUILD_NODES = get_node_labels(params.BUILD_NODE_LABELS, BUILD_SPECS.keySet())
-                    def TEST_NODES = get_node_labels(params.TEST_NODE_LABELS, BUILD_SPECS.keySet())
+                    def BUILD_NODES = get_node_labels(BUILD_NODE_LABELS, BUILD_SPECS.keySet())
+                    def TEST_NODES = get_node_labels(TEST_NODE_LABELS, BUILD_SPECS.keySet())
 
                     BUILD_SPECS.each { SPEC, SDK_VERSIONS ->
                         if (VARIABLES."${SPEC}") {
@@ -186,7 +223,7 @@ try {
                                 }
 
                                 if (AUTOMATIC_GENERATION != 'false'){
-                                    variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline', buildFile.convert_build_identifier(BUILD_IDENTIFIER))
+                                    variableFile.create_job(job_name, SDK_VERSION, SPEC, 'pipeline', 'Pipeline')
                                 }
 
                                 builds["${job_name}"] = { build(job_name, REPO, BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE, EXTRA_GETSOURCE_OPTIONS, EXTRA_CONFIGURE_OPTIONS, EXTRA_MAKE_OPTIONS, OPENJDK_CLONE_DIR, ADOPTOPENJDK_REPO, ADOPTOPENJDK_BRANCH, AUTOMATIC_GENERATION, CUSTOM_DESCRIPTION) }
@@ -202,7 +239,7 @@ try {
             // launch all pipeline builds
             parallel builds
 
-            if (params.PROMOTE_OMR) {
+            if (PROMOTE_OMR) {
                 stage('Promote') {
                     ghprbGhRepository = OPENJ9_REPO.substring(OPENJ9_REPO.indexOf('.com') +5, OPENJ9_REPO.indexOf('.git'))
                     ghprbActualCommit = SHAS['OPENJ9']
@@ -257,7 +294,12 @@ def build(JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRAN
                     string(name: 'EXTRA_MAKE_OPTIONS', value: EXTRA_MAKE_OPTIONS),
                     string(name: 'OPENJDK_CLONE_DIR', value: OPENJDK_CLONE_DIR),
                     string(name: 'AUTOMATIC_GENERATION', value: AUTOMATIC_GENERATION),
-                    string(name: 'CUSTOM_DESCRIPTION', value: CUSTOM_DESCRIPTION)]
+                    string(name: 'CUSTOM_DESCRIPTION', value: CUSTOM_DESCRIPTION),
+                    string(name: 'ghprbPullId', value: ghprbPullId),
+                    string(name: 'ghprbGhRepository', value: ghprbGhRepository),
+                    string(name: 'ghprbCommentBody', value: ghprbCommentBody),
+                    string(name: 'ghprbTargetBranch', value: ghprbTargetBranch),
+                    string(name: 'ghprbActualCommit', value: ghprbActualCommit)]
         return JOB
     }
 }
@@ -293,7 +335,7 @@ def get_node_labels(NODE_LABELS, SPECS) {
             }
 
             if (!SPECS.contains(ENTRY[0].trim())) {
-                error("Wrong node labels platform: ${ENTRY[0]} in ${ITEM}! It does not match any of your selected platforms: ${params.PLATFORMS}")
+                error("Wrong node labels platform: ${ENTRY[0]} in ${ITEM}! It does not match any of your selected platforms: ${PLATFORMS}")
             }
 
             LABELS.put(ENTRY[0].trim(), ENTRY[1].trim())

--- a/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline_Template.groovy
@@ -29,6 +29,8 @@ if (!binding.hasVariable('VENDOR_CREDENTIALS_ID_DEFAULT')) VENDOR_CREDENTIALS_ID
 if (!binding.hasVariable('DISCARDER_NUM_BUILDS')) DISCARDER_NUM_BUILDS = '1'
 if (!binding.hasVariable('GIT_URI')) GIT_URI = 'https://github.com/eclipse/openj9.git'
 if (!binding.hasVariable('GIT_BRANCH')) GIT_BRANCH = 'refs/heads/master'
+if (!binding.hasVariable('GIT_REFSPEC')) GIT_REFSPEC = ''
+if (!binding.hasVariable('LIGHTWEIGHT_CHECKOUT')) LIGHTWEIGHT_CHECKOUT = true
 
 if (jobType == 'build') {
     pipelineScript = 'buildenv/jenkins/jobs/builds/Build-Test-Any-Platform'
@@ -39,13 +41,14 @@ if (jobType == 'build') {
 }
 
 pipelineJob("$JOB_NAME") {
-    description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><p>This job is defined in Pipeline_Template.groovy in the openj9 repo, if you wish to change it modify that</p>')
+    description('<h3>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h3><p>This job is defined in Pipeline_Template.groovy in the openj9 repo, if you wish to change it modify that</p>')
     definition {
         cpsScm {
             scm {
                 git {
                     remote {
                         url(GIT_URI)
+                        refspec(GIT_REFSPEC)
                     }
                     branch("${GIT_BRANCH}")
                     extensions {
@@ -54,7 +57,7 @@ pipelineJob("$JOB_NAME") {
                 }
             }
             scriptPath(pipelineScript)
-            lightweight(true)
+            lightweight(LIGHTWEIGHT_CHECKOUT)
         }
     }
     logRotator {
@@ -82,6 +85,9 @@ pipelineJob("$JOB_NAME") {
         stringParam('BUILD_IDENTIFIER')
         stringParam('ghprbGhRepository')
         stringParam('ghprbActualCommit')
+        stringParam('ghprbPullId')
+        stringParam('ghprbCommentBody')
+        stringParam('ghprbTargetBranch')
         stringParam('EXTRA_GETSOURCE_OPTIONS')
         stringParam('EXTRA_CONFIGURE_OPTIONS')
         stringParam('EXTRA_MAKE_OPTIONS')

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -84,8 +84,6 @@ build_discarder:
     OMR: 20
     OpenJDK: 20
     Personal: 50
-    # tmp PRs
-    pullRequest: 50
     Pipeline: 100
 restart_timeout:
   time: '5'


### PR DESCRIPTION
- PRs currently run in separate, stand-alone jobs
  and this is not maintenance friendly.
- There are many benefits to switching to the common
  workflow of "pipeline of jobs" used by all other builds.
- This PR adds support for PR builds to use
  Pipeline-Build-Test-All as a top-level job.
- This also adds support in pipeline-functions to accomodate
  various functionality needed by PRs.
- New features:
   - Github commit status updates before and after a Compile or Test job
   - Auto-Cancel Test jobs when new ones are launched from the same PR
   - New Parameter BULD_IDENTIFIER which is useful for determining
     what a build belongs to (Nightly, OMR, PR#123 etc)

Issue #2728
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>