### PR TITLE
Dispatch direct (private) calls in x86 PicBuilder

### DIFF
--- a/runtime/compiler/x/codegen/CallSnippet.hpp
+++ b/runtime/compiler/x/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,7 @@ class X86PicDataSnippet : public TR::Snippet
    uint8_t            *_thunkAddress;
    int32_t             _numberOfSlots;
    bool                _isInterface;
+   bool                _hasJ2IThunkInPicData;
 
    public:
 
@@ -65,24 +66,40 @@ class X86PicDataSnippet : public TR::Snippet
          _slotPatchInstruction(slotPatchInstruction),
          _isInterface(isInterface),
          _dispatchSymRef(NULL),
-         _thunkAddress(thunkAddress)
+         _thunkAddress(thunkAddress),
+         _hasJ2IThunkInPicData(shouldEmitJ2IThunkPointer())
       {}
 
    bool isInterface()         {return _isInterface;}
    int32_t getNumberOfSlots() {return _numberOfSlots;}
+   bool hasJ2IThunkInPicData() {return _hasJ2IThunkInPicData;}
 
    TR::SymbolReference *getDispatchSymRef() {return _dispatchSymRef;}
    TR::SymbolReference *getMethodSymRef() {return _methodSymRef;}
 
    TR::LabelSymbol *getDoneLabel() {return _doneLabel;}
 
+   bool forceUnresolvedDispatch()
+      {
+      return ((TR_J9VMBase*)(cg()->fe()))->forceUnresolvedDispatch();
+      }
+
+   bool unresolvedDispatch()
+      {
+      return _methodSymRef->isUnresolved() || forceUnresolvedDispatch();
+      }
+
    uint8_t *encodeConstantPoolInfo(uint8_t *cursor);
+   uint8_t *encodeJ2IThunkPointer(uint8_t *cursor);
 
    virtual Kind getKind() { return (_isInterface ? IsIPicData : IsVPicData); }
 
    virtual uint8_t *emitSnippetBody();
 
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+   private:
+   bool shouldEmitJ2IThunkPointer();
    };
 
 

--- a/runtime/compiler/x/runtime/X86PicBuilder.inc
+++ b/runtime/compiler/x/runtime/X86PicBuilder.inc
@@ -1,4 +1,4 @@
-; Copyright (c) 2000, 2017 IBM Corp. and others
+; Copyright (c) 2000, 2018 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,19 @@ eq_ObjectClassMask                equ -J9TR_RequiredClassAlignment
 
 ifndef TR_HOST_64BIT
 
+eq_VPicData_cpAddr             equ 00h
+eq_VPicData_cpIndex            equ 04h
+eq_VPicData_directMethod       equ 08h
+eq_VPicData_cmpRegImm4ModRM    equ 0ch
+eq_VPicData_size               equ 0dh
+
+eq_IPicData_cpAddr             equ 00h
+eq_IPicData_cpIndex            equ 04h
+eq_IPicData_interfaceClass     equ 08h
+eq_IPicData_itableOffset       equ 0ch
+eq_IPicData_cmpRegImm4ModRM    equ 10h
+; IPIC data size is omitted here since it would be unused anyway.
+
 J9PreservedFPRStackSize    equ   80
 
 LoadClassPointerFromObjectHeader macro ObjectReg, ClassPtrReg64, ClassPtrReg32
@@ -73,8 +86,23 @@ else
 ;                                    64-BIT
 ; --------------------------------------------------------------------------------
 
+eq_VPicData_cpAddr             equ 00h
+eq_VPicData_cpIndex            equ 08h
+eq_VPicData_directMethod       equ 10h
+eq_VPicData_j2iThunk           equ 18h
+eq_VPicData_movabsRexAndOpcode equ 20h
+eq_VPicData_callMemRex         equ 22h
+eq_VPicData_callMemModRM       equ 23h
+eq_VPicData_size               equ 24h
 
-
+eq_IPicData_cpAddr             equ 00h
+eq_IPicData_cpIndex            equ 08h
+eq_IPicData_interfaceClass     equ 10h
+eq_IPicData_itableOffset       equ 18h
+eq_IPicData_movabsRexAndOpcode equ 20h
+eq_IPicData_j2iThunk           equ 22h    ; only present if direct invoke is possible
+; IPIC data size is either 22h or 2ah, due to the optional j2iThunk.
+; It's omitted here since it would be unused anyway.
 
 LoadHelperIndex macro targetReg,helperIndexSym
 ifdef WINDOWS


### PR DESCRIPTION
In x86 PicBuilder, handle J9TR_J9_VTABLE_INDEX_DIRECT_METHOD_FLAG for
virtual calls and J9TR_J9_ITABLE_OFFSET_DIRECT for interface calls as
required for nestmates unresolved private invoke (#2673).