### PR TITLE
OpenJ9 fixes for OSX support [Part 1]

### DIFF
--- a/runtime/gc_realtime/BarrierSynchronization.hpp
+++ b/runtime/gc_realtime/BarrierSynchronization.hpp
@@ -1,6 +1,5 @@
- 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,7 +44,6 @@ private:
 	J9JavaVM *_vm;                                 /**< Retained to access VM functions. */
 	UDATA _vmResponsesRequiredForExclusiveVMAccess;  /**< Used to support the (request/wait)ExclusiveVMAccess methods. */
 	UDATA _jniResponsesRequiredForExclusiveVMAccess;  /**< Used to support the (request/wait)ExclusiveVMAccess methods. */
-	U_32 _tokenCount;                              /**< A counter for which ragged barrier we are currently on. */
 
 /* Methods */
 public:
@@ -59,8 +57,7 @@ public:
 	MM_BarrierSynchronization(MM_EnvironmentBase *env) :
 		_vm((J9JavaVM *)env->getOmrVM()->_language_vm),
 		_vmResponsesRequiredForExclusiveVMAccess(0),
-		_jniResponsesRequiredForExclusiveVMAccess(0),
-		_tokenCount(0)
+		_jniResponsesRequiredForExclusiveVMAccess(0)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_realtime/MetronomeAlarm.cpp
+++ b/runtime/gc_realtime/MetronomeAlarm.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -246,13 +245,13 @@ MM_ITAlarm::initialize(MM_EnvironmentBase *env, MM_MetronomeAlarmThread* alarmTh
 void
 MM_RTCAlarm::sleep()
 {
-#if defined(LINUX)
+#if defined(LINUX) && !defined(J9ZTPF)
 	UDATA data;
 	ssize_t readAmount = read(RTCfd, &data, sizeof(data));
 	if (readAmount == -1) {
 		perror("blocking read failed");
 	}
-#endif
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
 }
 
 void

--- a/runtime/gc_realtime/MetronomeAlarm.hpp
+++ b/runtime/gc_realtime/MetronomeAlarm.hpp
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,8 +98,10 @@ public:
 
 class MM_RTCAlarm : public MM_Alarm
 {
-private:	
+private:
+#if defined(LINUX) && !defined(J9ZTPF)
 	IDATA RTCfd;
+#endif /* defined(LINUX) && !defined(J9ZTPF) */
 
 public:
 	static MM_RTCAlarm * newInstance(MM_EnvironmentBase *env, MM_OSInterface* osInterface);

--- a/runtime/util/cpplink.c
+++ b/runtime/util/cpplink.c
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +24,7 @@
 #include <stdlib.h>
 #include "j9user.h"
 
-#if defined(LINUX)
+#if defined(LINUX) || defined(OSX)
 /* Hack - to satisfy the runtime linker we need a definition of this function, should never be called */
 void __pure_virtual();
 void __cxa_pure_virtual();
@@ -41,4 +40,4 @@ void __cxa_pure_virtual()
         __pure_virtual();
 }
 
-#endif /* defined(LINUX) */
+#endif /* defined(LINUX) || defined(OSX) */

--- a/runtime/vm/statistics.c
+++ b/runtime/vm/statistics.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,26 +25,24 @@
 
 
 void *
-addStatistic (J9JavaVM* javaVM, U_8 * name, U_8 dataType)
+addStatistic(J9JavaVM *javaVM, U_8 *name, U_8 dataType)
 {
+	J9Statistic *statistic = NULL;
+
+	/* J9Statistic->name[1] accounts +1 for the null character. */
+	IDATA size = sizeof(*statistic) + (sizeof(char) * strlen((char *)name));
+
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
-
-	IDATA stringSize = strlen((char*)name) + 1;
-	IDATA size = stringSize;
-	J9Statistic * statistic;
-
-	/* Adjust for the default size in the struct array of 4 */
-	size += offsetof(J9Statistic, name);
 
 	/* Allocate and fill the structure */
 	statistic = j9mem_allocate_memory(size, OMRMEM_CATEGORY_VM);
-	if (statistic != NULL) {
+	if (NULL != statistic) {
 		statistic->dataSlot = 0;
 		statistic->dataType = (U_32) dataType;
-		strcpy((char*)&(statistic->name), (char*)name);
+		strcpy((char *)statistic->name, (char *)name);
 
 		/* Grab the monitor - if initialized (some statistics set prior to vmthinit.c) */
-		if (javaVM->statisticsMutex) {
+		if (NULL != javaVM->statisticsMutex) {
 			omrthread_monitor_enter(javaVM->statisticsMutex);
 		}
 
@@ -53,65 +51,65 @@ addStatistic (J9JavaVM* javaVM, U_8 * name, U_8 dataType)
 		javaVM->nextStatistic = statistic;
 
 		/* Release the monitor */
-		if (javaVM->statisticsMutex) {
+		if (NULL != javaVM->statisticsMutex) {
 			omrthread_monitor_exit(javaVM->statisticsMutex);
 		}
 	}
 
-	return (void *) statistic;
+	return (void *)statistic;
 }
 
 
 void
-deleteStatistics (J9JavaVM* javaVM)
+deleteStatistics(J9JavaVM *javaVM)
 {
+	J9Statistic *statistic = NULL;
+
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
-	J9Statistic * statistic;
-
-	if (javaVM->statisticsMutex) {
+	if (NULL != javaVM->statisticsMutex) {
 		omrthread_monitor_enter(javaVM->statisticsMutex);
 	}
 
 	statistic = javaVM->nextStatistic;
 
 	/* Delete the linked list */
-	while (statistic != NULL) {
-		J9Statistic * nextStatistic = statistic->nextStatistic;
+	while (NULL != statistic) {
+		J9Statistic *nextStatistic = statistic->nextStatistic;
 		j9mem_free_memory(statistic);
 		statistic = nextStatistic;
 	}
 	javaVM->nextStatistic = NULL;
 
-	if (javaVM->statisticsMutex) {
+	if (NULL != javaVM->statisticsMutex) {
 		omrthread_monitor_exit(javaVM->statisticsMutex);
 	}
 }
 
 
 void *
-getStatistic (J9JavaVM* javaVM, U_8 * name)
+getStatistic(J9JavaVM *javaVM, U_8 *name)
 {
-	J9Statistic * statistic;
+	J9Statistic *statistic = NULL;
 	
-	if (javaVM->statisticsMutex) {
+	if (NULL != javaVM->statisticsMutex) {
 		omrthread_monitor_enter(javaVM->statisticsMutex);
 	}
 	
 	statistic = javaVM->nextStatistic;
 
 	/* Walk the linked list */
-	while (statistic != NULL) {
-		if (strcmp((char*)name, (char*)&(statistic->name)) == 0) {
+	while (NULL != statistic) {
+		if (strcmp((char *)name, (char *)statistic->name) == 0) {
 			break;
 		}
 		statistic = statistic->nextStatistic;
 	}
 
-	if (javaVM->statisticsMutex) {
+	if (NULL != javaVM->statisticsMutex) {
 		omrthread_monitor_exit(javaVM->statisticsMutex);
 	}
 
-	return (void *) statistic;
+	return (void *)statistic;
 }
 


### PR DESCRIPTION
**1) Satisfy runtime linker on OSX for `__cxa_pure_virtual's` definition**

On OSX, linker fails to find the definition of `__cxa_pure_virtual`. Existing stub for `__cxa_pure_virtual` is enabled on OSX to satisfy the runtime linker. The stub for `__cxa_pure_virtual` should never be called. 

**2) Fix "Abort trap: 6" on OSX**

On OSX, **Abort trap: 6** happens while copying a name into `J9Statistic->name` using strcpy. Reworked memory allocation of `J9Statistic` in order to prevent **Abort trap: 6**.

**3) private field `_tokenCount` unused in BarrierSynchronization**

While compiling OpenJ9 with Clang 9.1.0 on OSX, the following error is seen:

`./BarrierSynchronization.hpp:48:7: error: private field '_tokenCount' is not used [-Werror,-Wunused-private-field]`

private field `_tokenCount` is removed since it is unused.

**4) Real-time clock is not supported on OSX**

In MetronomeAlarm.hpp, private field `RTCfd` is used to store real-time clock related information.

On OSX, real-time clock is not supported. So, private field `RTCfd` is unused. While compiling OpenJ9 with Clang 9.1.0 on OSX, the following error is seen:

`./MetronomeAlarm.hpp:103:8: error: private field 'RTCfd' is not used
[-Werror,-Wunused-private-field]`

The declaration of private field `RTCfd` is surrounded by `#if defined(LINUX) && !defined(J9ZTPF)`. This resolves the compiler error on OSX.

Also, fixed ifdefs related to `RTCfd` in `MM_RTCAlarm::sleep()`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>
