### PR TITLE
Handle interface special cases for MethodHandle

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9116,6 +9116,10 @@ JNIEXPORT jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
 #endif
    }
 
+/* Note this is the underlying implementation of InterfaceHandle.vTableOffset(). Any special cases
+ * (private interface method, methods in Object) have been adapted away by the java code, so this
+ * native only ever deals with iTable interface methods.
+ */
 JNIEXPORT jint JNICALL Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableIndex
   (JNIEnv *env, jclass InterfaceMethodHandle, jlong interfaceArg, jint itableIndex, jlong receiverClassArg)
    {

--- a/test/functional/Java8andUp/src/org/openj9/test/jsr335/interfacePrivateMethod/Test_ReflectionAndMethodHandles.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/jsr335/interfacePrivateMethod/Test_ReflectionAndMethodHandles.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.HashSet;
 import java.lang.invoke.MethodHandles.Lookup;
 
+import org.openj9.test.util.VersionCheck;
+
 /**
  * Test Reflection and MethodHandle lookup for private methods in interfaces.
  */
@@ -448,8 +450,13 @@ public class Test_ReflectionAndMethodHandles {
 		MethodType type = MethodType.methodType(String.class);
 		try {
 			MethodHandle mh = lookup.findVirtual(d, "private_non_static_method", type);
-			Assert.fail("Should have thrown an IllegalAccessException");
+			if (VersionCheck.major() < 11) {
+				Assert.fail("Should have thrown an IllegalAccessException");
+			}
 		} catch (IllegalAccessException e) {
+			if (VersionCheck.major() >= 11) {
+				Assert.fail("private access should be allowed");				
+			}
 			/* Pass */
 		}
 	}
@@ -713,8 +720,13 @@ public class Test_ReflectionAndMethodHandles {
 		MethodHandle mh = lookup.unreflect(method);
 		try {
 			String returnStatement = (String) mh.invoke(instance);
-			Assert.fail("Should have thrown AbstractMethodError!!");
+			if (VersionCheck.major() < 9) {
+				Assert.fail("Should have thrown AbstractMethodError!!");
+			}
 		} catch (AbstractMethodError e) {
+			if (VersionCheck.major() >= 9) {
+				Assert.fail("private access should be allowed");				
+			}
 			/* Pass */
 		} 
 	}

--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -40,6 +40,7 @@
 	<property name="bootstrapSrc_90" location="./bootstrap_src_90"/>
 	<property name="bootstrapBuild" location="./bootstrap_bin"/>
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src"/>
+	<property name="TestUtilities" location="../TestUtilities/src"/> 
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>
@@ -150,6 +151,7 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}"/>
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" /> 
 					<!-- exclude files only for SE90 -->
 					<exclude name="**/MethodHandleAPI_asCollector.java" />
 					<exclude name="**/MethodHandleAPI_asSpreader.java" />
@@ -175,6 +177,7 @@
 					<exclude name="**/indyn/Helper.java" />
 					<exclude name="**/indyn/SimpleIndyGenerator.java" />
 					<exclude name="**/CrossPackageHelper.java"/>
+					<exclude name="**/attachAPI/**" />
 					<classpath>
 						<pathelement location="${bootstrapBuild}"/>
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar" />
@@ -188,12 +191,14 @@
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<src path="${transformerListener}" />
+					<src path="${TestUtilities}" /> 
 					<!-- exclude non test files for indyn test -->
 					<exclude name="**/indyn/BootstrapMethods.java" />
 					<exclude name="**/indyn/ComplexIndyGenerator.java" />
 					<exclude name="**/indyn/Helper.java" />
 					<exclude name="**/indyn/SimpleIndyGenerator.java" />
 					<exclude name="**/CrossPackageHelper.java"/>
+					<exclude name="**/attachAPI/**" />
 					<classpath>
 						<pathelement location="${bootstrapBuild}"/>
 						<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-all.jar" />

--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/InterfaceHandleTest.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/InterfaceHandleTest.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Field;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 
+import org.openj9.test.util.VersionCheck;
+
 /**
  * A class to check if a specific method is correctly compiled by JIT
  */
@@ -114,7 +116,15 @@ public class InterfaceHandleTest {
 		try {
 			mh.invokeExact();
 			Assert.fail("Successfully invoked private implementation of an interface method.");
-		} catch (IllegalAccessError e) { }
+		} catch (IllegalAccessError e) {
+			if (VersionCheck.major() >= 11) {
+				Assert.fail("IllegalAccessError thrown instead of AbstractMethodError");				
+			}
+		} catch (AbstractMethodError e) {
+			if (VersionCheck.major() < 11) {
+				Assert.fail("AbstractMethodError thrown instead of IllegalAccessError");				
+			}
+		}
 	}
 	
 	static class Helper {


### PR DESCRIPTION
- the final (non-virtual Object method) case was not being handled
correctly in adaptInterfaceLookupsOfObjectMethodsIfRequired.

- findVirtual of private interface methods allowed in JDK11 and beyond

- unreflect of private interface methods allowed in JDK9 and beyond

- invoking a private implementation of an interface method results in
AbstractMethodError in JDK11 and beyond, IllegalAccessError before

- fix interpreter to only throw AbstractMethodError for private implementations of interface methods in JDK11

- update tests according to behaviour changes after JDK8

- document that
Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableIndex
does not need to deal with any special case interface invocations

Fixes: #2811 

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>