### PR TITLE
Improve condy PicBuilder sequence

### DIFF
--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1820,8 +1820,7 @@ ZZ into the Literal Pool
     L_GPR r14,eq_codeRA_inDataSnippet(,r14) # Get mainline RA
 
 ZZ Branch instruction in mainline will be patched here with NOP
-    LHI r1,HEX(04)
-    STCY r1,-5(r14)
+    MVIY -5(r14),HEX(04)
     BR r14 # Return
     END_FUNC(_jitResolveConstantDynamic,jRCD,6)
 


### PR DESCRIPTION
As suggested in [1] we can use a better instruction sequence in our
condy resolution function.

[1] https://github.com/eclipse/openj9/pull/2806#issuecomment-421013666

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>