### PR TITLE
[WIP] [OSX and Linux on x86] Initial PR for migrating JIT assembly files to NASM 

### DIFF
--- a/runtime/compiler/build/files/host/amd64.mk
+++ b/runtime/compiler/build/files/host/amd64.mk
@@ -18,6 +18,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
-JIT_PRODUCT_SOURCE_FILES+=\
+ifeq ($(USE_NASM),yes)
+    JIT_PRODUCT_SOURCE_FILES+=\
+    compiler/x/amd64/runtime/AMD64CompressString.nasm \
+    compiler/x/amd64/runtime/AMD64Recompilation.nasm
+else
+    JIT_PRODUCT_SOURCE_FILES+=\
     compiler/x/amd64/runtime/AMD64CompressString.asm \
     compiler/x/amd64/runtime/AMD64Recompilation.asm
+
+endif

--- a/runtime/compiler/build/files/host/x.mk
+++ b/runtime/compiler/build/files/host/x.mk
@@ -21,6 +21,20 @@
 JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/x/runtime/VirtualGuardRuntime.cpp
 
+ifeq ($(USE_NASM),yes)
+    JIT_PRODUCT_SOURCE_FILES+=\
+    compiler/x/runtime/Recomp.cpp \
+    compiler/x/runtime/X86ArrayTranslate.nasm \
+    compiler/x/runtime/X86Codert.nasm \
+    compiler/x/runtime/X86EncodeUTF16.nasm \
+    compiler/x/runtime/X86LockReservation.nasm \
+    compiler/x/runtime/X86PicBuilder.pnasm \
+    compiler/x/runtime/X86PicBuilderC.cpp \
+    compiler/x/runtime/X86RelocationTarget.cpp \
+    compiler/x/runtime/X86Unresolveds.pnasm
+
+else
+
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/x/runtime/Recomp.cpp \
     compiler/x/runtime/X86ArrayTranslate.asm \
@@ -31,5 +45,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/x/runtime/X86PicBuilderC.cpp \
     compiler/x/runtime/X86RelocationTarget.cpp \
     compiler/x/runtime/X86Unresolveds.pasm
+
+endif # USE_NASM
 
 include $(JIT_MAKE_DIR)/files/host/$(HOST_SUBARCH).mk

--- a/runtime/compiler/build/rules/gnu/filetypes.mk
+++ b/runtime/compiler/build/rules/gnu/filetypes.mk
@@ -126,6 +126,59 @@ endef # DEF_RULE.pasm
 
 RULE.pasm=$(eval $(DEF_RULE.pasm))
 
+### NASM-specific rules
+
+ifeq ($(OS),linux)
+	ifeq ($(HOST_BITS),32)
+		OBJ_FORMAT=-felf32
+	else
+		OBJ_FORMAT=-felf64
+	endif
+endif #(OS = linux)
+
+ifeq ($(OS),osx)
+	OBJ_FORMAT=-fmacho64
+endif #(OS = osx)
+
+#
+# Compile .nasm file into .o file
+#
+define DEF_RULE.nasm
+$(1): $(2) | jit_createdirs
+	nasm $(OBJ_FORMAT) $$(patsubst %,-D%=1,$$(S_DEFINES)) $$(patsubst %,-I'%/',$$(S_INCLUDES)) -o $$@ $$< #$$(S_CMD) $$(S_FLAGS) $$(patsubst %,--defsym %=1,$$(S_DEFINES)) $$(patsubst %,-I'%',$$(S_INCLUDES)) -o $$@ $$<
+
+JIT_DIR_LIST+=$(dir $(1))
+
+jit_cleanobjs::
+	rm -f $(1)
+
+endef # DEF_RULE.nasm
+
+RULE.nasm=$(eval $(DEF_RULE.nasm))
+
+
+#
+# Preprocess pnasm into nasm and then assemble into .o
+# 
+
+#
+# Compile .pasm file into .o file
+#
+define DEF_RULE.pnasm
+$(1).nasm: $(2) | jit_createdirs
+	$$(PASM_CMD) $$(PASM_FLAGS) $$(patsubst %,-I'%',$$(PASM_INCLUDES)) -o $$@ -x assembler-with-cpp -E -P $$<
+
+JIT_DIR_LIST+=$(dir $(1))
+
+jit_cleanobjs::
+	rm -f $(1).nasm
+
+$(call RULE.nasm,$(1),$(1).nasm)
+endef # DEF_RULE.pnasm
+
+RULE.pnasm=$(eval $(DEF_RULE.pnasm))
+
+
 endif # ($(HOST_ARCH),x)
 ##### END X SPECIFIC RULES #####
 

--- a/runtime/compiler/x/amd64/runtime/AMD64CompressString.nasm
+++ b/runtime/compiler/x/amd64/runtime/AMD64CompressString.nasm
@@ -1,0 +1,38 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 or Apache-2.0 or GPL-2.0 WITH Classpath-exception-2.0 or LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%ifdef TR_HOST_64BIT
+%include "jilconsts_nasm.inc"
+
+%include "x/amd64/runtime/AMD64CompressString_nasm.inc"
+
+
+
+J9TR_ObjectColorBlack equ 03h
+
+    segment .text
+
+%else ; not TR_HOST_64BIT
+
+segment .data
+IA32ArrayCopy:
+        db      00h            
+
+%endif ; TR_HOST_64BIT

--- a/runtime/compiler/x/amd64/runtime/AMD64CompressString_nasm.inc
+++ b/runtime/compiler/x/amd64/runtime/AMD64CompressString_nasm.inc
@@ -1,0 +1,239 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+    segment .text
+
+                global  _compressString
+                global  _compressStringJ
+                global  _compressStringNoCheck
+		global  _compressStringNoCheckJ
+		global  _andORString
+
+                align 16
+
+
+_compressString: ; PROC 
+		shr  rcx, 4
+		add  rsi, rax
+		add  rsi, rax
+		mov  rdx, 0
+eightchars:
+		mov  rax, QWORD  [rsi]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rdx, rax				;
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+2], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+		mov  rax, QWORD  [rsi+8]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rdx, rax				;
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi+4], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+6], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+		mov  rax, QWORD  [rsi+16]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rdx, rax				;
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi+8], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+10], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+
+		mov  rax, QWORD  [rsi+24]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rdx, rax				;
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi+12], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+14], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+		add  rdi, 16
+		add  rsi, 32		
+		loop eightchars
+                mov  rax, rdx
+                shl  rdx, 32
+                or   rax, rdx
+                ;loop eightchars
+		shr  rax, 32
+                ret
+;_compressString endp
+;
+
+
+; A c-style memmove with no assumptions on the element size
+; or copy direction required.
+; ecx has length of copy in bytes
+; esi has source address
+; edi has destination address
+_compressStringJ: ; PROC
+		shr  rcx, 4
+		add  rsi, rax
+		add  rsi, rax
+		mov  rdx, 0
+eightcharsJ:
+		mov  rax, QWORD  [rsi]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, QWORD  [rsi+8]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rdx, rax				;
+		or   rdx, rbx
+		shl  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  QWORD  [rdi], rax			; write the low 2 bytes of the 4 byte value in the destination
+
+		mov  rax, QWORD  [rsi+16]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, QWORD  [rsi+24]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rdx, rax				;
+		or   rdx, rbx
+		shl  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  QWORD  [rdi+8], rax			; write the low 2 bytes of the 4 byte value in the destination
+
+		add  rdi, 16
+		add  rsi, 32		
+		loop eightcharsJ
+                mov  rax, rdx
+                shl  rdx, 32
+                or   rax, rdx
+		shr  rax, 32
+                ret
+;_compressStringJ endp
+;
+
+_andORString: ;    PROC
+		shr  rcx, 4
+		add  rsi, rax
+		add  rsi, rax
+		mov  rbx, 0
+		mov  rdx, 0ffffffffffffffffh
+eightchars2:
+		mov  rax, QWORD  [rsi]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rbx, rax
+		and  rdx, rax
+		mov  rax, QWORD  [rsi+8]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rbx, rax
+		and  rdx, rax
+		mov  rax, QWORD  [rsi+16]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rbx, rax
+		and  rdx, rax
+		mov  rax, QWORD  [rsi+24]  		; load 4 bytes from the source array into EAX (2 chars)
+		or   rbx, rax
+		and  rdx, rax
+		add  rsi, 32		
+		loop eightchars2
+
+		mov  rax, rbx                           ; building the or
+		mov  rcx, rdx                           ; building the and
+		shr  rbx, 32                            ; building the or
+		shr  rdx, 32                            ; building the and
+		or   ebx, eax				; building the or
+		and  edx, ecx				; building the and
+		mov  eax, ebx				; building the or
+		mov  ecx, edx				; building the and
+		shr  ebx, 16				; building the or
+		shl  edx, 16				; building the and
+		or   bx, ax				; building the or
+		and  edx, ecx				; building the and
+
+		mov  dx, bx
+                ret
+;_andORString endp
+;
+
+
+_compressStringNoCheckJ: ;    PROC
+		shr  rcx, 4
+		add  rsi, rax
+		add  rsi, rax
+eightcharsNoCheckJ:
+		mov  rax, QWORD  [rsi]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, QWORD  [rsi+8]  		; load 4 bytes from the source array into EAX (2 chars)
+		shl  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  QWORD  [rdi], rax			; write the low 2 bytes of the 4 byte value in the destination
+
+		mov  rax, QWORD  [rsi+16]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, QWORD  [rsi+24]  		; load 4 bytes from the source array into EAX (2 chars)
+		shl  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  QWORD  [rdi+8], rax			; write the low 2 bytes of the 4 byte value in the destination
+
+		add  rdi, 16
+		add  rsi, 32		
+		loop eightcharsNoCheckJ
+                ret
+;_compressStringNoCheckJ endp
+;
+
+
+_compressStringNoCheck: ; PROC 
+		shr  rcx, 4
+		add  rsi, rax
+		add  rsi, rax
+eightcharsNoCheck:
+		mov  rax, QWORD  [rsi]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+2], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+		mov  rax, QWORD  [rsi+8]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi+4], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+6], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+		mov  rax, QWORD  [rsi+16]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi+8], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+10], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+
+		mov  rax, QWORD  [rsi+24]  		; load 4 bytes from the source array into EAX (2 chars)
+		mov  rbx, rax					; copy the loaded value
+		shr  rbx, 8					; shift right by 8
+		or   rax, rbx					; or the 2 values
+		mov  WORD  [rdi+12], ax			; write the low 2 bytes of the 4 byte value in the destination
+		shr  rax, 32
+		mov  WORD  [rdi+14], ax			; write the low 2 bytes of the 4 byte value in the destination
+
+		add  rdi, 16
+		add  rsi, 32		
+		loop eightcharsNoCheck
+                ret
+;_compressStringNoCheck endp
+;
+
+
+;_TEXT           ends
+

--- a/runtime/compiler/x/amd64/runtime/AMD64Recompilation.nasm
+++ b/runtime/compiler/x/amd64/runtime/AMD64Recompilation.nasm
@@ -1,0 +1,467 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+	
+%ifdef TR_HOST_64BIT
+
+%include "jilconsts_nasm.inc"
+
+                ;OPTION NOSCOPED
+
+                extern jitRetranslateMethod
+                extern jitCallCFunction
+                extern induceRecompilation_unwrapper
+                extern mcc_AMD64callPointPatching_unwrapper
+                extern initialInvokeExactThunk_unwrapper
+                extern methodHandleJ2I_unwrapper
+
+                global _countingRecompileMethod
+                global _samplingRecompileMethod
+                global _countingPatchCallSite
+                global _samplingPatchCallSite
+                global _induceRecompilation
+                global _initialInvokeExactThunkGlue
+                global methodHandleJ2IGlue
+
+segment .text ;_TEXT   segment para 'CODE'
+
+; Offsets for sampling
+eq_stack_samplingBodyInfo            equ  0
+eq_retAddr_startPC                   equ  12
+
+; Offsets for counting
+eq_stack_countingJitEntryToPrologue  equ  19
+eq_countingSnippet_startPCOffset     equ  0
+
+; Offsets for induceRecompilationSnippet
+eq_induceSnippet_startPCOffset       equ  5
+
+; Common offsets
+eq_startPC_BodyInfo                  equ -12
+eq_startPC_JitEntryOffset            equ -2
+eq_startPC_LinkageInfo               equ -4
+eq_startPC_OriginalFirstTwoBytes     equ -19
+eq_BodyInfo_MethodInfo               equ  8
+eq_MethodInfo_J9Method               equ  0
+eq_MethodInfo_Flags                  equ 8
+eq_MethodInfo_HasBeenReplaced        equ 0100000h
+eq_stack_senderPC                    equ  96
+eq_HasFailedRecompilation            equ  80h ; Flag bit, defined in codert.dev/Runtime.hpp
+
+%macro saveRegs 0
+                ; XMMs
+                sub     rsp, 64 ; Reserve space for XMMs
+                ; Do the writes in-order so we don't defeat the cache
+                movsd   qword  [rsp+0],  xmm8
+                movsd   qword  [rsp+8],  xmm9
+                movsd   qword  [rsp+16], xmm10
+                movsd   qword  [rsp+24], xmm11
+                movsd   qword  [rsp+32], xmm12
+                movsd   qword  [rsp+40], xmm13
+                movsd   qword  [rsp+48], xmm14
+                movsd   qword  [rsp+56], xmm15
+                ; GPRs
+                push    rax     ; arg0
+                push    rsi     ; arg1
+                push    rdx     ; arg2
+                push    rcx     ; arg3
+%endmacro
+
+exitRecompileMethod: ; PROC
+                ; GPRs
+                pop     rcx     ; arg3
+                pop     rdx     ; arg2
+                pop     rsi     ; arg1
+                pop     rax     ; arg0
+                ; XMMs
+                ; Do the reads in-order so we don't defeat the cache
+                movsd   xmm8,  qword  [rsp+0]
+                movsd   xmm9,  qword  [rsp+8]
+                movsd   xmm10, qword  [rsp+16]
+                movsd   xmm11, qword  [rsp+24]
+                movsd   xmm12, qword  [rsp+32]
+                movsd   xmm13, qword  [rsp+40]
+                movsd   xmm14, qword  [rsp+48]
+                movsd   xmm15, qword  [rsp+56]
+                add     rsp,   64
+                ; Branch to desired target
+                jmp     rdi
+ret ;exitRecompileMethod endp
+
+;
+                align 16
+;
+_countingRecompileMethod: ; PROC
+;
+                pop     rdi ; Return address in snippet
+                saveRegs
+
+                ; senderPC (= call site)
+                mov     rdx, qword [rsp+eq_stack_senderPC]
+
+                ; old startPC
+                movsxd  rsi, dword [rdi+eq_countingSnippet_startPCOffset]
+                add     rsi, rdi
+
+                ; J9Method
+                mov     rax, qword [rsi+eq_startPC_BodyInfo]
+		mov	rax, qword [rax+eq_BodyInfo_MethodInfo]
+                mov     rax, qword [rax+eq_MethodInfo_J9Method]
+
+                CallHelperUseReg jitRetranslateMethod,rax
+                test    rax, rax
+                jnz     countingGotStartAddress
+
+                ; If the compilation hasn't been done yet, skip the counting
+                ; code at the start of the method and continue with the rest of
+                ; the method body
+                movsxd  rax, dword [rdi+eq_countingSnippet_startPCOffset]
+                add     rdi, rax
+                movsx   rax, word  [rdi+eq_startPC_JitEntryOffset]
+                add     rdi, rax
+                add     rdi, eq_stack_countingJitEntryToPrologue        ; skip the sub/jl (or cmp/jl)
+                jmp     exitRecompileMethod
+
+countingGotStartAddress:
+
+                ; Now the new startPC is in rax.
+                movsx   rdi, word  [rax+eq_startPC_JitEntryOffset]
+                add     rdi, rax
+                jmp     exitRecompileMethod
+;
+ret ;_countingRecompileMethod ENDP
+;
+;
+
+
+
+;
+                align 16
+;
+_samplingRecompileMethod: ; PROC
+;
+                pop     rdi ; Return address in preprologue
+                saveRegs
+
+                ; senderPC (= call site)
+                mov     rdx, qword [rsp+eq_stack_senderPC]
+
+                ; old startPC
+                lea     rsi, [rdi+eq_retAddr_startPC]
+
+                ; J9Method
+                mov     rax, qword [rdi+eq_stack_samplingBodyInfo]
+		mov	rax, qword [rax+eq_BodyInfo_MethodInfo]
+                mov     rax, qword [rax+eq_MethodInfo_J9Method]
+
+                CallHelperUseReg jitRetranslateMethod,rax
+
+                ; If the compilation has not been done yet, restart this method.
+                ; It should now execute normally
+                test    rax, rax
+                jnz     samplingGotStartAddress
+                movsx   rdi, word  [rsi+eq_startPC_JitEntryOffset]
+                add     rdi, rsi
+                jmp     exitRecompileMethod
+
+samplingGotStartAddress:
+
+                ; Now the new startPC is in rax.
+                movsx   rdi, word  [rax+eq_startPC_JitEntryOffset]
+                add     rdi, rax
+                jmp     exitRecompileMethod
+;
+;
+ret ;_samplingRecompileMethod ENDP
+;
+
+
+                align 16
+;
+_induceRecompilation: ; PROC
+;
+                xchg    rdi, [rsp] ; Return address in snippet
+                push    rsi        ; Preserve
+                push    rax        ; Preserve
+
+                ; old startPC
+                movsxd  rsi, dword [rdi+eq_induceSnippet_startPCOffset]
+                add     rsi, rdi
+
+                ; set up args to induceRecompilation_unwrapper
+                push    rbp        ; parm: vmThread
+                push    rsi        ; parm: startPC
+
+                ; set up args to jitCallCFunction
+                MoveHelper rax, induceRecompilation_unwrapper  ; parm: C function to call
+                mov     rsi, rsp                               ; parm: args array
+                                                               ; parm: result pointer; don't care
+                CallHelper jitCallCFunction
+                add     rsp, 16
+
+                ; restore regs and return to snippet
+                pop     rax
+                pop     rsi
+                xchg    rdi, [rsp]
+                ret
+
+;
+;
+;_induceRecompilation ENDP
+;
+
+                align 16
+;
+_countingPatchCallSite: ; PROC
+;
+                xchg    qword [rsp], rdi
+                push    rdx
+                push    rax
+
+                ; Compute the old startPC
+                mov     rax, rdi
+                movsx   rdx, word [rdi]
+                sub     rax, rdx
+
+                ; Assume:
+                ;    rax == old startPC
+                ;    rdi == return address in preprologue
+                ;    old rdi, rdx, rax on stack
+                ;    no return address on stack
+
+		push    rdi ; HCR: We may need this
+                ; rdi = new jit entry point
+                mov     rdi, qword [rax+eq_startPC_BodyInfo]
+		mov	rdi, qword [rdi+eq_BodyInfo_MethodInfo]
+                mov     rdi, qword [rdi+eq_MethodInfo_J9Method]
+                mov     rdi, qword [rdi+J9TR_MethodPCStartOffset]   ; rdi = new startPC
+
+                test    rdi, 1h ; HCR: Has method been replaced by one that's not jitted yet?
+                jne     countingPatchToRecompile ;
+                add     rsp, 8 ; Turns out we don't need the preprologue return address after all
+
+
+
+patchCallSite:
+                movsx   rdx, word  [rdi+eq_startPC_JitEntryOffset]  ; rdx = jitEntryOffset
+                add     rdi, rdx                                       ; rdi = new jit entry point
+
+                ; rdx = call site return address
+                mov     rdx, qword [rsp+24]
+
+                ; Check if it's a call immediate
+                cmp     byte [rdx-5], 0e8h
+                jne     finishedPatchCallSite
+
+
+                ; Call MCC service to do the call site patching. Argument layout:
+                ; rsp+24    extraArg
+                ; rsp+16    newPC
+                ; rsp+8     callSite
+                ; rsp       j9method
+                ;
+                push    rsi                                          ; preserve rsi
+                xor     rsi, rsi
+                push    rsi                                          ; extraArg
+                push    rax                                          ; pass old startPC to mcc_AMD64callPointPatching_unwrapper
+                mov     rsi, qword [rax+eq_startPC_BodyInfo]
+		mov     rsi, qword [rsi+eq_BodyInfo_MethodInfo]
+                mov     rax, qword [rsi+eq_MethodInfo_J9Method]   ; rax = j9method
+                mov     rsi, qword [rax+J9TR_MethodPCStartOffset] ; rsi = new startPC
+                sub     rdx, 5                                       ; call instruction
+                push    rbp                                          ; vmThread
+                push    rsi                                          ; new startPC
+                push    rdx                                          ; call instruction
+                push    rax                                          ; j9method
+                MoveHelper rax, mcc_AMD64callPointPatching_unwrapper
+                lea     rsi, [rsp]
+                lea     rdx, [rsp]
+                call    jitCallCFunction
+                add     rsp, 48
+                pop     rsi
+                
+finishedPatchCallSite:
+                ; Assume:
+                ;    rdi == new jit entry
+                ;    old rdi, rdx, rax on stack
+                ;    no return address on stack
+
+                ; Restore regs, "return" to the new jit entry
+                pop     rax
+                pop     rdx
+                xchg    qword [rsp], rdi
+                ret
+
+countingPatchToRecompile:
+		; HCR: we've got our hands on a new j9method that hasn't been compiled yet,
+		; so there's no way to patch the call site without first compiling the new method
+		;
+		; edi points to the DB here:
+		;   CALL  patchCallSite          (5 bytes)
+		;   DB    ??                     (8 bytes of junk)
+		;   JL    recompilationSnippet   (always 6 bytes)
+		;
+		; Restore registers and stack the way they looked originally, then jump to the recompilationSnippet
+		pop     rdi
+		pop     rax
+		add     rdi, 8+6               ; end of JL instruction
+		movsxd  rdx, dword  [rdi-4] ; offset to recompilationSnippet
+		add     rdi, rdx               ; start of recompilationSnippet
+		pop     rdx
+		xchg    qword [rsp], rdi    ; restore edi
+		ret                            ; jump to recompilationSnippet while minimizing damage to return address branch prediction
+		
+;
+;
+;_countingPatchCallSite ENDP
+;
+
+
+                align 16
+;
+_samplingPatchCallSite: ; PROC
+;
+                xchg    qword [rsp], rdi
+                push    rdx
+                push    rax
+
+                ; Compute the old startPC
+                lea     rax, [rdi+eq_retAddr_startPC]
+
+
+                ; Assume:
+                ;    rax == old startPC
+                ;    rdi == return address in preprologue
+                ;    old rdi, rdx, rax on stack
+                ;    no return address on stack
+
+		push    rdi ; HCR: We may need this
+                ; rdi = new jit entry point
+                mov     rdi, qword [rax+eq_startPC_BodyInfo]
+		mov	rdi, qword [rdi+eq_BodyInfo_MethodInfo]
+                mov     rdi, qword [rdi+eq_MethodInfo_J9Method]
+                mov     rdi, qword [rdi+J9TR_MethodPCStartOffset]   ; rdi = new startPC
+
+                test    rdi, 1h ; HCR: Has method been replaced by one that's not jitted yet?
+                jne     samplingPatchToRecompile ;
+                add     rsp, 8 ; Turns out we don't need the preprologue return address after all
+
+
+                jmp     patchCallSite
+
+samplingPatchToRecompile:
+                ; HCR: we've got our hands on a new j9method that hasn't been compiled yet,
+                ; so there's no way to patch the call site without first compiling the new method
+                ;
+                ; Make the world look the way it should for a call to _samplingRecompileMethod
+		pop     rdi
+                pop     rax
+                pop     rdx
+                xchg    qword [rsp], rdi
+                jmp     _samplingRecompileMethod
+;
+;
+ret ;_samplingPatchCallSite ENDP
+;
+
+                align 16
+;
+_initialInvokeExactThunkGlue: ; PROC
+;
+                ; preserve all non-scratch regs
+                push    rax
+                push    rsi
+                push    rdx
+
+                ; set up args to initialInvokeExactThunk_unwrapper
+                push    rbp     ; parm: vmThread
+                push    rax     ; parm: receiver MethodHandle; also, result goes here
+
+                ; set up args to jitCallCFunction
+                MoveHelper rax, initialInvokeExactThunk_unwrapper       ; parm: C function to call
+                mov     rsi, rsp                                        ; parm: args array
+                mov     rdx, rsp                                        ; parm: result pointer
+                CallHelper jitCallCFunction
+                pop     rax      ; result jitted entry point
+		pop     rbp
+
+                ; restore regs
+                pop     rdx
+                pop     rsi
+
+                ; Restore rax and jump to address returned by initialInvokeExactThunk
+		; Sadly, this probably kills return address stack branch prediction
+		; TODO:JSR292: check for null and call vm helper to interpret instead
+		xchg    rax, [rsp]
+                ret
+;
+;
+;_initialInvokeExactThunkGlue ENDP
+;
+
+                align 16
+;
+methodHandleJ2IGlue: ; PROC
+;
+                ; Note: this glue is not called, it is jumped to.  There is no
+                ; return address on the stack.
+
+                ; preserve all non-scratch regs
+                push    rax
+                push    rsi
+                push    rdx
+
+                ; set up args to initialInvokeExactThunk_unwrapper
+                push    rbp     ; parm: vmThread
+                lea     rsi, [rsp+40]
+                push    rsi     ; parm: stack pointer before the call to the j2i thunk
+                push    rax     ; parm: receiver MethodHandle; also, result goes here
+
+                ; set up args to jitCallCFunction
+                MoveHelper rax, methodHandleJ2I_unwrapper               ; parm: C function to call
+                mov     rsi, rsp                                        ; parm: args array
+                mov     rdx, rsp                                        ; parm: result pointer
+                CallHelper jitCallCFunction
+                pop     rax      ; result (currently unused)
+                pop     rsi
+                pop     rbp
+
+                ; restore regs
+                pop     rdx
+                pop     rsi
+                pop     rax
+
+                ; continue J2I
+                jmp     rdi
+;
+;
+ret ;methodHandleJ2IGlue ENDP
+;
+
+        ;_TEXT ends
+%else ;not defined TR_HOST_64BIT
+                CPU P2 ; .686p
+                ;assume cs:flat,ds:flat,ss:flat
+segment .data ;_DATA           segment para use32 public 'DATA'
+AMD64PicBuilder:
+                db      00h
+;_DATA           ends
+%endif ;TR_HOST_64BIT
+        
+;end

--- a/runtime/compiler/x/runtime/X86ArrayTranslate.nasm
+++ b/runtime/compiler/x/runtime/X86ArrayTranslate.nasm
@@ -1,0 +1,251 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%include "jilconsts_nasm.inc"
+
+; %include x/runtime/X86RegisterMap.inc : TODO: needed for 32bit support
+
+segment .text
+
+   global  _arrayTranslateTRTO
+   global  _arrayTranslateTROTNoBreak
+   global  _arrayTranslateTROT
+   align 16
+
+   ; pseudocode:
+   ; int i;
+   ; for (i = 0; i < N; i++)
+   ;   if (chararray[i] && DX != 0) break; //DX is the register
+   ;   else bytearray[i] = (byte) chararray[i])
+   ; return i
+   _arrayTranslateTRTO:                      ;TO stands for Two bytes to One byte
+   %ifdef TR_HOST_64BIT
+      mov ecx, ecx
+   %endif
+      xor  rax, rax
+      cmp  rcx, 8
+      jl   byteresidualTO
+      movd xmm1, edx
+      pshufd xmm1, xmm1, 0
+      cmp  rcx, 16
+      jl   eightcharsTO
+   sixteencharsTO:
+      movdqu xmm2, [rsi+2*rax]
+      ptest xmm2, xmm1          ; SSE4.1 instruction
+      jnz  failedloopTO
+      movdqu xmm3, [rsi+2*rax+16]
+      ptest xmm3, xmm1          ; SSE4.1 instruction
+      jnz  eightcharsTO
+      packuswb xmm2, xmm3
+      movdqu oword [rdi+rax], xmm2
+      sub  rcx, 16
+      add  rax, 16
+      cmp  rcx, 16
+      jge  sixteencharsTO
+      cmp  rcx, 8
+      jl   byteresidualTO
+   eightcharsTO:
+      movdqu xmm2, [rsi+2*rax]
+      ptest xmm2, xmm1          ; SSE4.1 instruction
+      jnz  failedloopTO
+      packuswb xmm2, xmm1       ; only the first 8 bytes of xmm2 are meaningful
+      movq qword [rdi+rax], xmm2
+      sub  rcx, 8
+      add  rax, 8
+   byteresidualTO:
+      and rcx, rcx
+      je  doneTO
+   failedloopTO:
+      mov  bx, word [rsi+2*rax]
+      test bx, dx
+      jnz  doneTO
+      mov  byte [rdi+rax], bl
+      inc  rax
+      dec  rcx
+      jnz  failedloopTO
+   doneTO:   ;EAX is result register
+      ret
+
+   ; _arrayTranslateTRTO endp
+
+   ; pseudocode:
+   ; int i;
+   ; for (i = 0; i < N; i++)
+   ;   chararray[i] = (char) bytearray[i];
+   _arrayTranslateTROTNoBreak:               ;OT stands for One byte to Two bytes
+   %ifdef TR_HOST_64BIT
+      mov ecx, ecx
+   %endif
+      xor    rax, rax
+      xorps  xmm3, xmm3
+      cmp    rcx, 16
+      jl     qwordResidualOTNoBreak
+
+   sixteencharsOTNoBreak:
+      movdqu  xmm1, [rsi+rax]
+      movdqu  xmm2, xmm1
+      punpcklbw xmm1, xmm3
+      punpckhbw xmm2, xmm3
+      movdqu [rdi+rax*2], xmm1
+      movdqu [rdi+rax*2+16], xmm2
+      sub rcx, 16
+      add rax, 16
+      cmp rcx, 16
+      jge sixteencharsOTNoBreak
+
+   slideWindowResidualOTNoBreak:
+      test rcx, rcx
+      jz doneOTNoBreak
+      sub rax, 16
+      add rax, rcx
+      mov rcx, 16
+      jmp sixteencharsOTNoBreak
+
+   doneOTNoBreak:
+      ret
+
+   qwordResidualOTNoBreak:
+      bt rcx, 3
+      jnc dwordResidualOTNoBreak
+      movq xmm1, qword [rsi+rax]
+      punpcklbw xmm1, xmm3
+      movdqu [rdi+rax*2], xmm1
+      add rax, 8
+      sub rcx, 8
+
+   dwordResidualOTNoBreak:
+      bt rcx, 2
+      jnc byteResidualOTNoBreak
+      movd xmm1, dword [rsi+rax]
+      punpcklbw xmm1, xmm3
+      movq qword [rdi+rax*2], xmm1
+      add rax, 4
+      sub rcx, 4
+
+   byteResidualOTNoBreak:
+      test rcx, rcx
+      jz doneOTNoBreak
+      xor  bx, bx
+
+   failedloopOTNoBreak:
+      mov  bl, [rsi+rax]
+      mov  [rdi+rax*2], bx
+      inc  rax
+      dec  rcx
+      jnz  failedloopOTNoBreak
+      jmp  doneOTNoBreak
+
+   ;_arrayTranslateTROTNoBreak endp
+
+
+   ; pseudocode:
+   ; int i;
+   ; for (i = 0; i < N; i++)
+   ;   if (bytearray[i] < 0) break;
+   ;   else chararray[i] = (char) bytearray[i];
+   ; return i;
+   _arrayTranslateTROT:                      ;OT stands for One byte to Two bytes
+   %ifdef TR_HOST_64BIT
+      mov ecx, ecx
+   %endif
+      xor    rax, rax
+      xorps  xmm3, xmm3
+      cmp    rcx, 16
+      jl     qwordResidualOT
+
+   sixteencharsOT:
+      movdqu  xmm1, [rsi+rax]
+      pmovmskb ebx, xmm1
+      test ebx, ebx
+      jnz    computeNewLengthOT
+      movdqu  xmm2, xmm1
+      punpcklbw xmm1, xmm3
+      punpckhbw xmm2, xmm3
+      movdqu [rdi+rax*2], xmm1
+      movdqu [rdi+rax*2+16], xmm2
+      sub rcx, 16
+      add rax, 16
+      cmp rcx, 16
+      jge sixteencharsOT
+
+   slideWindowResidualOT:
+      test rcx, rcx
+      jz doneOT
+      sub rax, 16
+      add rax, rcx
+      mov rcx, 16
+      jmp sixteencharsOT
+
+   doneOT:
+      ret
+
+   computeNewLengthOT:
+      bsf ebx, ebx
+   %ifdef TR_HOST_64BIT
+      mov ebx, ebx
+   %endif
+      mov rcx, rbx
+      cmp rax, 16
+      jge slideWindowResidualOT
+
+   qwordResidualOT:
+      bt rcx, 3
+      jnc dwordResidualOT
+      movq xmm1, qword [rsi+rax]
+      pmovmskb ebx, xmm1
+      test ebx, ebx
+      jnz computeNewLengthOT
+      punpcklbw xmm1, xmm3
+      movdqu [rdi+rax*2], xmm1
+      add rax, 8
+      sub rcx, 8
+
+   dwordResidualOT:
+      bt rcx, 2
+      jnc byteResidualOT
+      movd xmm1, dword [rsi+rax]
+      pmovmskb ebx, xmm1
+      test ebx, ebx
+      jnz computeNewLengthOT
+      punpcklbw xmm1, xmm3
+      movq qword [rdi+rax*2], xmm1
+      add rax, 4
+      sub rcx, 4
+
+   byteResidualOT:
+      test rcx, rcx
+      jz doneOT
+      xor  bx, bx
+
+   failedloopOT:
+      mov  bl, [rsi+rax]
+      test bl, 80h
+      jnz  doneOT
+      mov  [rdi+rax*2], bx
+      inc  rax
+      dec  rcx
+      jnz  failedloopOT
+      jmp doneOT
+
+   ;_arrayTranslateTROT endp
+
+;_TEXT ends
+
+ret ;end

--- a/runtime/compiler/x/runtime/X86Codert.nasm
+++ b/runtime/compiler/x/runtime/X86Codert.nasm
@@ -1,0 +1,1211 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%include "jilconsts_nasm.inc"
+
+; %include x/runtime/X86RegisterMap.inc : TODO: needed for 32bit
+
+%ifdef TR_HOST_64BIT
+        ; 64-bit
+eq_floats_Offset              equ 128
+eq_gprs_Offset                equ 0
+
+eq_gpr_size                   equ 8
+%ifdef ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER
+   eq_vft_pointer_size        equ 4
+%else
+   eq_vft_pointer_size        equ 8
+%endif
+
+   ;OPTION NOSCOPED
+
+   ; Hack marker:
+%ifdef WINDOWS
+   NO_X87_UNDER_WIN64 textequ <true>
+%endif
+%else
+        ; 32-bit
+        CPU P2 ;.686p
+        ;assume cs:flat,ds:flat,ss:flat
+        ;option NoOldMacros
+        ;.xmm
+
+eq_gpr_size                   equ 4
+eq_vft_pointer_size           equ 4
+
+%endif
+
+
+eq_MaxInteger               equ 07fffffffh
+eq_MinInteger               equ 080000000h
+
+eq_singleSignMask           equ 080000000h
+eq_singleExponentMask       equ 07f800000h
+eq_singleMantissaMask       equ 0007fffffh
+eq_singleNanMask            equ 07fc00000h
+
+eq_IndefiniteInteger        equ 080000000h
+eq_singleDelta              equ 00a800000h
+eq_doubleDelta              equ 003200000h
+eq_mxcsr_rounding_mask      equ 0ffff9fffh
+eq_mxcsr_round_truncate     equ 000006000h
+
+eq_ObjectClassMask          equ -J9TR_RequiredClassAlignment
+
+%ifdef TR_HOST_64BIT
+
+eq_MaxLong                    equ 07fffffffffffffffh
+eq_MinLong                    equ 08000000000000000h
+
+; doubles are inspected after a left rotation to get the interesting bits into
+; the lower half of the register, where we can use CMP, TEST, etc. on them.
+eq_doubleLeftRotation         equ 12
+eq_doubleSignMaskRotated      equ 0800h
+eq_doubleExponentMaskRotated  equ 07ffh
+;eq_doubleMantissaMaskRotated  equ 0fffffffffffff000h
+eq_doubleMantissaMaskRotated  equ -01000h
+
+%else
+
+eq_MaxLongLow               equ 0ffffffffh
+eq_MaxLongHigh              equ eq_MaxInteger
+eq_MinLongHigh              equ eq_MinInteger
+
+eq_doubleSignMaskHigh       equ 080000000h
+eq_doubleExponentMaskHigh   equ 07ff00000h
+eq_doubleMantissaMaskHigh   equ 0000fffffh
+eq_doubleNanMaskHigh        equ 07ff80000h
+
+%endif
+
+
+segment .data
+
+        align 16
+ABSMASK:
+   dq 7fffffffffffffffh
+   dq 7fffffffffffffffh
+QNaN:
+   dq 7ff8000000000000h
+   dq 7ff8000000000000h
+POS_INFINITY:
+   dq 7ff0000000000000h
+   dq 7ff0000000000000h
+INF_NULL_MASK:
+   dq 7ff0000000000000h
+   dq 0000000000000000h
+NULL_INF_MASK:
+   dq 0000000000000000h
+   dq 7ff0000000000000h
+MAGIC_NUM1:
+        dq 7fde42d130773b76h
+        dq 7fde42d130773b76h
+H32_NOSIGN_MASK:
+        dq 7fffffff00000000h
+        dq 7fffffff00000000h
+SCALEUP_NUM:
+        dq 4350000000000000h
+        dq 4350000000000000h
+SCALEDOWN_NUM:
+        dq 3c90000000000000h
+        dq 3c90000000000000h
+ONEHALF:
+        dq 3fe0000000000000h
+        dq 3fe0000000000000h
+;_DATA ends
+
+segment .text
+
+%ifdef TR_HOST_32BIT
+        global _doubleToLong
+        global _doubleToInt
+        global _floatToLong
+        global _floatToInt
+%endif
+        global _X87floatRemainder
+        global _X87doubleRemainder
+
+        global _SSEfloatRemainder
+        global _SSEdoubleRemainder
+        global _SSEfloatRemainderIA32Thunk
+        global _SSEdoubleRemainderIA32Thunk
+%ifdef TR_HOST_32BIT
+        global _SSEdouble2LongIA32
+%endif
+        global jitFPHelpersBegin
+        global jitFPHelpersEnd
+
+        align 16
+jitFPHelpersBegin:
+
+%ifdef TR_HOST_32BIT
+
+; _doubleToInt
+;
+; Convert doubles to ints when it has already been determined that the
+; double cannot be represented in an int OR if it appears that the
+; double is MIN_INT.
+;
+; Parameters:
+;
+;   [esp+4] - double to convert
+;
+; Returns:
+;
+;   eax - equivalent integer: either 0, MAX_INT, or MIN_INT
+;
+        align       16
+_doubleToInt:
+        push        edx
+        mov         eax, dword  [esp + 12]      ; binary representation of high dword of double
+        mov         edx, eax
+        and         edx, eq_doubleExponentMaskHigh
+        cmp         edx, eq_doubleExponentMaskHigh
+        jz short    d2i_NaNorInfinity
+
+d2i_MinOrMaxInt:
+        test        eax, eq_doubleSignMaskHigh    ; MAX_INT if +ve, MIN_INT if -ve
+        mov         eax, eq_MinInteger
+        jnz short   d2i_done
+        mov         eax, eq_MaxInteger
+        jmp short   d2i_done
+
+d2i_NaNorInfinity:
+        test        eax, eq_doubleMantissaMaskHigh
+        jnz short   d2i_isNaN
+        mov         edx, dword [esp + 8]
+        test        edx, edx
+        jz short    d2i_MinOrMaxInt               ; double is +INF or -INF
+
+d2i_isNaN:
+        xor         eax, eax                      ; double is a NaN
+
+d2i_done:
+        pop         edx
+        retn
+;_doubleToInt endp
+
+
+; _doubleToLong
+;
+; Convert doubles to longs when it has already been determined that the
+; double cannot be represented in a long OR if it appears that the
+; double is MIN_LONG.
+;
+; Parameters:
+;
+;   ST0 - double to convert
+;
+; Returns:
+;
+;   eax,edx - equivalent low/high dword of long: either 0, MAX_LONG, or MIN_LONG
+;   ST0     - unchanged
+;
+        align       16
+_doubleToLong:
+        push        ecx
+        sub         esp, 8
+        fst         qword  [esp]
+        mov         eax, dword  [esp +4]        ; binary representation of high dword of double
+        mov         ecx, eax
+        and         ecx, eq_doubleExponentMaskHigh
+        cmp         ecx, eq_doubleExponentMaskHigh
+        jz short    d2l_NaNorInfinity
+
+d2l_MinOrMaxInt:
+        test        eax, eq_doubleSignMaskHigh    ; MAX_LONG if +ve, MIN_LONG if -ve
+        mov         eax, eq_MaxLongLow
+        mov         edx, eq_MaxLongHigh
+        jz short    d2l_done
+        xor         eax, eax
+        mov         edx, eq_MinLongHigh
+        jmp short   d2l_done
+
+d2l_NaNorInfinity:
+        test        eax, eq_doubleMantissaMaskHigh
+        jnz short   d2l_isNaN
+        mov         ecx, dword  [esp]
+        test        ecx, ecx
+        jz short    d2l_MinOrMaxInt               ; double is +INF or -INF
+
+d2l_isNaN:
+        xor         eax, eax                      ; double is a NaN
+        xor         edx, edx
+
+d2l_done:
+        add         esp, 8
+        pop         ecx
+        retn
+;_doubleToLong endp
+
+
+; _floatToInt
+;
+; Convert floats to ints when it has already been determined that the
+; float cannot be represented in an int OR if it appears that the float
+; is MIN_INT.
+;
+; Parameters:
+;
+;   [esp+4] - float to convert
+;
+; Returns:
+;
+;   eax - equivalent integer: either 0, MAX_INT, or MIN_INT
+;
+        align       16
+_floatToInt:
+        push        edx
+        mov         eax, dword [esp+8]         ; binary representation of float
+        mov         edx, eax
+        and         edx, eq_singleExponentMask
+        cmp         edx, eq_singleExponentMask
+        jnz short   f2i_MinOrMaxInt
+        test        eax, eq_singleMantissaMask
+        jz short    f2i_MinOrMaxInt               ; float is +INF or -INF
+        xor         eax, eax                      ; float is a NaN
+        jmp short   f2i_done
+
+f2i_MinOrMaxInt:
+        test        eax, eq_singleSignMask        ; MAX_INT if +ve, MIN_INT if -ve
+        mov         eax, eq_MaxInteger
+        jz short    f2i_done
+        mov         eax, eq_MinInteger
+
+f2i_done:
+        pop         edx
+        retn
+;_floatToInt endp
+
+
+; _floatToLong
+;
+; Convert floats to longs when it has already been determined that the
+; float cannot be represented in a long OR if it appears that the
+; float is MIN_LONG.
+;
+; Parameters:
+;
+;   ST0 - float to convert
+;
+; Returns:
+;
+;   eax,edx - equivalent low/high dword of long: either 0, MAX_LONG, or MIN_LONG
+;   ST0     - unchanged
+;
+        align       16
+_floatToLong:; proc near
+        push        ecx
+        sub         esp, 4
+        fst         dword [esp]
+        mov         eax, dword [esp]           ; binary representation of float
+        mov         ecx, eax
+        and         ecx, eq_singleExponentMask
+        cmp         ecx, eq_singleExponentMask
+        jz short    f2l_NaNorInfinity
+
+f2l_MinOrMaxInt:
+        test        eax, eq_singleSignMask        ; MAX_LONG if +ve, MIN_LONG if -ve
+        mov         eax, eq_MaxLongLow
+        mov         edx, eq_MaxLongHigh
+        jz short    f2l_done
+        xor         eax, eax
+        mov         edx, eq_MinLongHigh
+        jmp short   f2l_done
+
+f2l_NaNorInfinity:
+        test        eax, eq_singleMantissaMask
+        jz short    f2l_MinOrMaxInt               ; float is +INF or -INF
+        xor         eax, eax                      ; float is a NaN
+        xor         edx, edx
+
+f2l_done:
+        add         esp, 4
+        pop         ecx
+        retn
+;_floatToLong endp
+
+%endif
+
+
+; _X87floatRemainder, _X87doubleRemainder
+;
+; Compute the remainder from the division of two floats, or two doubles,
+; respectively, using the Intel floating-point partial remainder instruction
+; (FPREM) in an iterative algorithm.
+;
+; Parameters:
+;
+;   (float)                      (double)
+;   [esp+8] - divisor            [esp+12] - divisor
+;   [esp+4] - dividend           [esp+4]  - dividend
+;
+; Returns:
+;
+;   ST0 - dividend % divisor
+;
+        align       16
+
+_X87floatRemainder:
+
+%ifdef NO_X87_UNDER_WIN64
+   int 3
+%else
+        push        rax
+        fld         dword [rsp+12]  ; load divisor (ST1)
+        fld         dword [rsp+8]   ; load dividend (ST0)
+fremloop:
+        fprem
+        fstsw       ax
+        test        ax, 0400h
+        jnz short   fremloop
+        fstp        st1
+        pop         rax
+        ret         8
+%endif
+        ret
+
+        align 16
+%ifdef TR_HOST_64BIT
+_X87doubleRemainder:
+%else
+_X87doubleRemainder:near
+%endif
+%ifdef NO_X87_UNDER_WIN64
+   int 3
+%else
+        push        rax
+        fld         qword [rsp+16]  ; load divisor (ST1)
+        fld         qword [rsp+8]   ; load dividend (ST0)
+dremloop:
+        fprem
+        fstsw       ax
+        test        ax, 0400h
+        jnz short   dremloop
+        fstp        st1
+        pop         rax
+        ret         16
+%endif
+        ret
+
+
+; The assumption is that this thunk method would be called from a 32-bit runtime only.
+; Otherwise, the stack offsets will have to change to accomodate the correct size of return
+; address.
+;
+        align 16
+_SSEfloatRemainderIA32Thunk:
+        sub         rsp, 8
+        movq        qword [rsp], xmm1
+        cvtss2sd    xmm1, dword [rsp +16]    ; dividend
+        cvtss2sd    xmm0, dword [rsp +12]     ; divisor
+        call        doSSEdoubleRemainder
+        cvtsd2ss    xmm0, xmm0
+        movq        xmm1, qword [rsp]
+        add         rsp, 8
+        ret         8
+;_SSEfloatRemainderIA32Thunk endp
+
+
+; The assumption is that this thunk method would be called from a 32-bit runtime only.
+; Otherwise, the stack offsets will have to change to accomodate the correct size of return
+; address.
+;
+        align 16
+_SSEdoubleRemainderIA32Thunk:
+        sub         rsp, 8
+        movq        qword [rsp], xmm1
+        movq        xmm1, qword [rsp +20]   ; dividend
+        movq        xmm0, qword [rsp +12]   ; divisor
+        call        doSSEdoubleRemainder
+        movq        xmm1, qword [rsp]
+        add         rsp, 8
+        ret         16
+;_SSEdoubleRemainderIA32Thunk endp
+
+
+        align 16
+;%ifdef TR_HOST_64BIT
+;_SSEfloatRemainder proc
+;%else
+;_SSEfloatRemainder proc near
+;%endif
+_SSEfloatRemainder:
+        cvtss2sd    xmm0, xmm0
+        cvtss2sd    xmm1, xmm1
+        call        doSSEdoubleRemainder
+        cvtsd2ss    xmm0, xmm0
+        ret
+;_SSEfloatRemainder endp
+
+        align 16
+_SSEdoubleRemainder:
+
+doSSEdoubleRemainder:
+%ifdef ASM_J9VM_USE_GOT
+        push        rdx
+        LoadGOTInto rdx
+%endif
+        ucomisd xmm0, xmm1      ; unordered compare, is either operand NaN
+        jp short RETURN_NAN     ; either dividend or divisor was a NaN
+
+        sub     rsp, 8
+        movq    qword [rsp], xmm2
+
+        ; TODO: current helper linkage expects the dividend and divisor to be
+        ; the opposite order of how this code is written
+        ; swap xmm0 and xmm1 until this is fixed
+
+        movq xmm2, xmm0
+        movq xmm0, xmm1
+        movq xmm1, xmm2
+
+        punpcklqdq xmm1, xmm0   ; xmm1 = {a, b}
+        ; note, the sign of the divisor has no affect on the final result
+%ifndef ASM_J9VM_USE_GOT
+        andpd xmm1, oword  [rel + ABSMASK]           ; xmm1 = {|a|, |b|}
+        movapd xmm2, [rel NULL_INF_MASK];QWORD  [rel NULL_INF_MASK]    ; xmm2 = {+inf, 0.0}
+%else ;todo
+        andpd xmm1, QWORD  ABSMASK@GOTOFF[rdx]           ; xmm1 = {|a|, |b|}
+        movapd xmm2, QWORD  NULL_INF_MASK@GOTOFF[rdx]    ; xmm2 = {+inf, 0.0}
+%endif
+        cmppd xmm2, xmm1, 4     ; compare xmm2 != xmm1, leave mask in xmm1
+
+        ; xmm1 = {(|a| != +inf ? |a| : 0, |b| != 0.0 ? |b| : 0}
+        andpd xmm1, xmm2
+
+        ; xmm2 = {|a| != +inf ? 0 : QNaN, |b| != 0.0 ? 0 : QNaN}
+%ifndef ASM_J9VM_USE_GOT
+        andnpd xmm2, [rel  QNaN] ;qword
+%else
+        andnpd xmm2, QWORD  QNaN@GOTOFF[rdx]
+%endif
+        ; xmm1 = {|a| != +inf ? |a| : QNaN, |b| != 0.0 ? |b| : QNaN}
+        orpd xmm1, xmm2
+        movapd xmm2, xmm1       ; xmm2 = xmm1
+        shufpd xmm2, xmm2, 1    ; swap elems in xmm2 so |a| (or QNaN) in xmm2
+
+        add     rsp, 8
+        ucomisd xmm2, xmm1
+        movq    xmm2, qword [rsp -8]  ; for scheduling reasons updating of the SP was done 2 intrs above
+%ifndef ASM_J9VM_USE_GOT
+        jae short _dblRemain    ; Do normal algorithm
+%else
+        jae short JMP_DBLREMAIN ; Do normal algorithm
+%endif
+        jnp short RETURN_DIVIDEND
+
+RETURN_NAN:
+%ifndef ASM_J9VM_USE_GOT
+        movapd xmm0, [rel QNaN];QWORD  [rel QNaN]     ; xmm0 = QNaN
+%else
+        movapd xmm0, QWORD  QNaN@GOTOFF[rdx]     ; xmm0 = QNaN
+%endif
+RETURN_DIVIDEND:                               ; dividend already in xmm0
+%ifdef ASM_J9VM_USE_GOT
+        pop     rdx
+%endif
+        nop
+        ret
+
+%ifdef ASM_J9VM_USE_GOT
+JMP_DBLREMAIN:
+        pop     rdx
+        jmp short _dblRemain    ; Do normal algorithm
+%endif
+
+        ret
+;_SSEdoubleRemainder endp
+
+        align 16
+;%ifdef TR_HOST_64BIT
+;_dblRemain proc
+;%else
+;_dblRemain proc near
+;%endif
+_dblRemain:
+        ; Prolog Start
+        push rax
+        push rbx
+        push rcx
+%ifdef ASM_J9VM_USE_GOT
+        push rdx
+        LoadGOTInto rdx
+%endif
+        sub rsp, 48                            ; rsp = rsp - 48(bytes)
+        movq QWORD  [rsp+16], xmm2      ; preserve xmm2
+        ; Prolog End
+%ifndef ASM_J9VM_USE_GOT
+        andpd xmm1, [rel ABSMASK];QWORD  [rel ABSMASK]   ; xmm1 = |divisor|
+%else
+        andpd xmm1, QWORD  ABSMASK@GOTOFF[rdx]   ; xmm1 = |divisor|
+%endif
+        movq QWORD  [rsp], xmm0 ; store dividend on stack
+        movq QWORD  [rsp+8], xmm1       ; store |divisor| on stack
+        mov eax, DWORD  [rsp+12]    ; eax = high 32 bits of |divisor|
+        and eax, 7ff00000h              ; eax = exponent of |divisor|
+        shr eax, 20
+        cmp eax, 2                      ; ppc uses 0x0001 and does bgt L144
+        jb SMALL_NUMS             ; we do < 2 and jb SMALL_NUMS
+L144:                                   ; and fall through to the normal case
+
+        ; Anything greater than MAGIC_NUM1 is considered "large"
+        ; compare |dividend| to MAGIC_NUM1
+%ifndef ASM_J9VM_USE_GOT
+        ucomisd xmm1, [rel MAGIC_NUM1] ;QWORD
+%else
+        ucomisd xmm1, QWORD  MAGIC_NUM1@GOTOFF[rdx]
+%endif
+        jae LARGE_NUMS            ; if xmm1 >= 0x7fde42d13077b76
+
+L184:
+        movq  xmm2, xmm1             ; xmm2 = xmm1
+        addsd xmm2, xmm1                ; xmm2 = xmm1 + xmm1 (2 * |divisor|)
+        movq  QWORD  [rsp+32], xmm2  ; store xmm2 on the stack
+        mov eax, DWORD  [rsp+4]     ; eax = high 32 bits of dividend
+
+        movq  xmm4, xmm0             ; xmm4 = xmm0 (dividend)
+%ifndef ASM_J9VM_USE_GOT
+        andpd xmm4, [rel ABSMASK] ;QWORD xmm4 = |dividend|
+%else
+        andpd xmm4, QWORD  ABSMASK@GOTOFF[rdx] ; xmm4 = |dividend|
+%endif
+        movq QWORD  [rsp], xmm4 ; store xmm4 on the stack
+        mov ebx, eax                    ; ebx = eba
+        and ebx, 80000000h              ; ebx = sign bit of dividend
+
+        ucomisd xmm4, xmm2              ; compare xmm4 with xmm2
+        jna L234                  ; if xmm4 <= xmm2 goto L234
+
+        movq QWORD  [rsp+40], xmm2  ; store xmm2 on the stack
+        mov ecx, DWORD  [rsp+36]    ; ms 32bits of |dividend| (was xmm4)
+        sub eax, ecx                    ; eax = eax - ecx
+        and eax, 7ff00000h               ; get exponent (rlwinm r0,r0,0,1,11)
+        mov ecx, DWORD  [rsp+44]
+        movq xmm2, QWORD  [rsp]         ; save xmm2 to stack
+        add ecx, eax                            ; ecx += eax
+        mov eax, ecx                            ; eax = ecx (2 results)
+        add eax, 0fff00000h                     ; addis r0,r4,-16
+        mov DWORD  [rsp+44], ecx            ; save ecx to stack
+        movq xmm0, QWORD  [rsp+40]      ; store xmm0 to stack
+L1d8:
+        ucomisd xmm2, xmm0              ; moved this instruction down from ppc
+        jae short L1e8                  ; if xmm2 >= xmm0 goto L1e8
+        mov DWORD  [rsp+44], eax
+        movq  xmm2, QWORD  [rsp]
+        movq  xmm0, QWORD  [rsp+40]
+L1e8:
+        movq  xmm4, xmm2                     ; xmm4 = xmm2
+        subsd xmm4, xmm0                        ; xmm4 = xmm4 - xmm0
+        movq  QWORD  [rsp], xmm4         ; save xmm4
+        movq  xmm2, QWORD  [rsp+32]      ; load xmm2 from stack
+        ucomisd xmm4, xmm2                      ; compare xmm4 with xmm2
+        jna short L230                          ; if xmm4 <= xmm2 goto L230
+        mov eax, DWORD  [rsp+4]     ; eax = ms 32bits of dividend stack area
+        mov ecx, DWORD  [rsp+36]
+        movq QWORD  [rsp+40], xmm2      ; store xmm2 on stack
+   sub eax, ecx               ;  (subf r0,r4,r0)
+        mov ecx, DWORD  [rsp+44]
+        and eax, 7ff00000h              ; eax = exponent of |divisor|
+        add ecx, eax                    ; ecx += eax
+        mov eax, ecx
+        add eax, 0fff00000h             ; addis r0,r4,-16
+        mov DWORD  [rsp+44], ecx    ; save ecx to stack
+        movq xmm2, QWORD  [rsp]
+        movq xmm0, QWORD  [rsp+40]
+        jmp short L1d8
+
+L230:
+        movq    xmm1, QWORD  [rsp+8]
+L234:
+        ucomisd xmm4, xmm1
+        xorpd   xmm2, xmm2      ; xmm2 = {0.0, 0.0} (only need scalar part)
+        jb short L258
+        subsd xmm4, xmm1
+        ucomisd xmm4, xmm1
+        movq    QWORD  [rsp], xmm4
+        jb L258
+        subsd xmm4, xmm1
+        movq  QWORD  [rsp], xmm4
+
+L258:
+        ucomisd xmm2, xmm4
+        mov eax, DWORD  [rsp+4]     ; ms 32bits of dividend
+        jne short L280
+        or eax, ebx                     ; restore sign of result
+        mov DWORD  [rsp+4], eax     ; put result back on stack
+        movq xmm0, QWORD  [rsp] ; load result into xmm0
+
+        ; Epilog Start
+        movq xmm2, QWORD  [rsp+16]      ; restore xmm2
+        add rsp, 48
+%ifdef ASM_J9VM_USE_GOT
+        pop rdx
+%endif
+        pop rcx
+        pop rbx
+        pop rax
+        ret                                     ; Epilog End
+L280:
+        xor eax, ebx
+        mov DWORD  [rsp+4], eax
+        movq xmm0, QWORD  [rsp]         ; load result into xmm0
+
+        ; Epilog Start
+        movq xmm2, QWORD  [rsp+16]      ; restore xmm2
+        add rsp, 48
+%ifdef ASM_J9VM_USE_GOT
+        pop rdx
+%endif
+        pop rcx
+        pop rbx
+        pop rax
+        ret                                     ; Epilog End
+
+SMALL_NUMS:
+%ifndef ASM_J9VM_USE_GOT
+        mulsd xmm1,  [rel SCALEUP_NUM] ; xmm1 = |divisor| * 2^54
+%else
+        mulsd xmm1, QWORD  SCALEUP_NUM@GOTOFF[rdx] ; xmm1 = |divisor| * 2^54
+%endif
+        movq  QWORD  [rsp+8], xmm1       ; store xmm1 on the stack
+        call _dblRemain
+
+%ifndef ASM_J9VM_USE_GOT
+        mulsd xmm0,  [rel SCALEUP_NUM]       ; xmm0 = dividend * 2^54
+%else
+        mulsd xmm0, QWORD  SCALEUP_NUM@GOTOFF[rdx]       ; xmm0 = dividend * 2^54
+%endif
+        movq  xmm1, QWORD  [rsp+8]       ; load divisor from the stack
+        movq  QWORD  [rsp], xmm0         ; store dividend on the stack
+        call _dblRemain
+
+%ifndef ASM_J9VM_USE_GOT
+        mulsd xmm0,  [rel SCALEDOWN_NUM]     ; dividend * 1/2^54
+%else
+        mulsd xmm0, QWORD  SCALEDOWN_NUM@GOTOFF[rdx]     ; dividend * 1/2^54
+%endif
+
+        ; Epilog Start
+        movq xmm2, QWORD  [rsp+16]              ; restore xmm2
+        add rsp, 48
+%ifdef ASM_J9VM_USE_GOT
+        pop rdx
+%endif
+        pop rcx
+        pop rbx
+        pop rax
+        ret                                             ; Epilog End
+
+LARGE_NUMS:
+%ifndef ASM_J9VM_USE_GOT
+        mulsd xmm1,  [rel ONEHALF]   ; xmm1 *= 0.5 (scaledown)
+%else
+        mulsd xmm1, QWORD  ONEHALF@GOTOFF[rdx]   ; xmm1 *= 0.5 (scaledown)
+%endif
+        ; store xmm1 in divisor slot on stack
+        movq  QWORD  [rsp+8], xmm1
+%ifndef ASM_J9VM_USE_GOT
+        mulsd xmm0,  [rel ONEHALF]   ; xmm2 *= 0.5 (scaledown)
+%else
+        mulsd xmm0, QWORD  ONEHALF@GOTOFF[rdx]   ; xmm2 *= 0.5 (scaledown)
+%endif
+        movq     QWORD  [rsp], xmm0 ; store xmm0 in dividend slot on stack
+        call _dblRemain
+
+        addsd xmm0, xmm0                        ; xmm0 *= 2 (scaleup)
+
+        ; Epilog Start
+        movq     xmm2, QWORD  [rsp+16]  ; restore xmm2
+        add rsp, 48
+%ifdef ASM_J9VM_USE_GOT
+        pop rdx
+%endif
+        pop rcx
+        pop rbx
+        pop rax
+        ret                             ; Epilog End
+
+;_dblRemain endp
+
+%ifndef TR_HOST_64BIT
+; in:   32-bit slot on stack - double to convert
+; out:  edx, eax - resulting long
+; uses: eax, ebx, ecx, edx, esi
+;
+; Note that the double is assumed to have an exponent >= 32.
+
+        align 16
+;%ifdef TR_HOST_64BIT
+;_SSEdouble2LongIA32 proc
+;%else
+;_SSEdouble2LongIA32 proc near
+;%endif
+_SSEdouble2LongIA32:
+        mov edx, dword [rsp+8]      ; load the double into edx:eax
+        mov eax, dword [rsp+4]
+
+   push esi       ; save esi as private linkage
+   push ecx       ; save ecx as private linkage
+   push ebx       ; save ebx as private linkage
+
+        mov ecx, edx                    ; extract the biased exponent E of the double into cx
+        shr ecx, 20
+        and cx, 07ffh
+
+        mov esi, edx                    ; set esi if the double is negative
+        shr esi, 31
+
+        and edx, 000fffffh              ; clear out the sign bit and the 11-bit exponent field of the double number
+        or edx, 00100000h               ; add the implicit leading 1 to the mantissa of the double
+
+        cmp cx, 1075
+        jae SSEd2l_convertLarge         ; if exponent is >= 52, we need to scale up the mantissa
+
+; if E < 1075 (i.e. the unbiased exponent is >= 32 and < 52),
+; then 1 or more low bits of the 52-bit mantissa must be truncated,
+; since those bits represent the fraction
+
+        neg cx                          ; cl = cx = 52 - exponent
+        add cx, 1075
+
+        mov ebx, edx                    ; shift the mantissa (edx:eax) right by cl; this removes the fraction from the double
+        shr edx, cl
+        shr eax, cl
+
+        neg cl                          ; cl = 32 - cl
+        add cl, 32
+        shl ebx, cl                     ; shift the lower bits of edx into the upper end of eax
+        or eax, ebx
+
+        jmp SSEd2l_doneConversion       ; done
+
+SSEd2l_convertLarge:
+        cmp cx, 1086
+        jae SSEd2l_convertSpecial       ; if exponent is >= 63, the value is too large for a long
+
+; if E < 1086 (i.e. the unbiased exponent is >= 52 and < 63),
+; then the long can be computed by shifting the mantissa to the left
+; by (exponent - 52).
+
+        sub cx, 1075                    ; cl = cx = exponent - 52
+        je  SSEd2l_doneConversion       ; if exponent == 52, no shifting is needed
+
+        mov ebx, eax                    ; shift the mantissa (edx:eax) left by cl; the result is the desired long
+        shl edx, cl
+        shl eax, cl
+
+        neg cl                          ; cl = 32 - cl
+        add cl, 32
+        shr ebx, cl                     ; shift the upper bits eax into the lower end of edx
+        or edx, ebx
+
+SSEd2l_doneConversion:
+        test esi, esi
+        jne SSEd2l_negateLong
+   pop ebx           ; restore ebx as private linkage
+   pop ecx           ; restore ecx as private linkage
+   pop esi           ; restore esi as private linkage
+        ret 8
+
+SSEd2l_negateLong:
+        not edx
+        neg eax
+        sbb edx, -1
+   pop ebx           ; restore ebx as private linkage
+   pop ecx           ; restore ecx as private linkage
+   pop esi           ; restore esi as private linkage
+        ret 8
+
+SSEd2l_convertSpecial:                  ; perform conversions for special numbers (very large values, infinities, NaNs)
+        cmp cx, 7ffh                    ; if the exponent is all 1's then the double is either an infinity or a NaN
+        je SSEd2l_NaNOrInfinity
+
+SSEd2l_maxLong:                         ; if double is simply a very large number (exponent >= 63 and < 1023)
+        test esi, esi                   ; if the number is positive then return (2^63 - 1), else return -(2^63)
+        jne SSEd2l_minLong
+        or eax, -1
+        mov edx, 7fffffffh
+   pop ebx           ; restore ebx as private linkage
+   pop ecx           ; restore ecx as private linkage
+   pop esi           ; restore esi as private linkage
+        ret 8
+
+SSEd2l_minLong:
+        xor eax, eax
+        mov edx, 80000000h
+   pop ebx           ; restore ebx as private linkage
+   pop ecx           ; restore ecx as private linkage
+   pop esi           ; restore esi as private linkage
+        ret 8
+
+SSEd2l_NaNOrInfinity:                   ; if the double is either an infinity or Nan
+        test eax, eax                   ; if the mantissa is 0, the double is an infinity; return a max or min long
+        jne SSEd2l_NaN
+        cmp edx, 00100000h              ; mantissa is 0, but don't forget we added a leading 1, hence 00100000h
+        jne SSEd2l_NaN
+        jmp SSEd2l_maxLong
+
+SSEd2l_NaN:                             ; if the number is a NaN, return 0 (note: no exception flags are set if it is a QNaN)
+        xor edx, edx
+        xor eax, eax
+   pop ebx           ; restore ebx as private linkage
+   pop ecx           ; restore ecx as private linkage
+   pop esi           ; restore esi as private linkage
+        ret 8
+;_SSEdouble2LongIA32 endp
+%endif
+
+jitFPHelpersEnd:
+
+
+eq_J9VMThread_heapAlloc      equ J9TR_VMThread_heapAlloc
+eq_J9VMThread_heapTop        equ J9TR_VMThread_heapTop
+eq_J9VMThread_PrefetchCursor equ J9TR_VMThread_tlhPrefetchFTA
+
+      global prefetchTLH
+      global newPrefetchTLH
+
+%ifdef ASM_J9VM_GC_TLH_PREFETCH_FTA
+
+      align 16
+;%ifdef TR_HOST_64BIT
+;prefetchTLH proc
+;%else
+;prefetchTLH proc near
+;%endif
+prefetchTLH:
+      push  rcx
+
+%ifdef TR_HOST_64BIT
+      mov   rcx, qword [rbp + eq_J9VMThread_heapAlloc]
+%else
+      mov   rcx, dword [rbp + eq_J9VMThread_heapAlloc]
+%endif
+      prefetchnta byte [rcx+256]
+      prefetchnta byte [rcx+320]
+      prefetchnta byte [rcx+384]
+      prefetchnta byte [rcx+448]
+      prefetchnta byte [rcx+512]
+      prefetchnta byte [rcx+576]
+      prefetchnta byte [rcx+640]
+      prefetchnta byte [rcx+704]
+      prefetchnta byte [rcx+768]
+
+%ifdef TR_HOST_64BIT
+      mov   qword [rbp + eq_J9VMThread_PrefetchCursor], 384
+%else
+      mov   dword [rbp + eq_J9VMThread_PrefetchCursor], 384
+%endif
+prefetch_done:
+      pop   rcx
+      ret
+;prefetchTLH endp
+
+
+
+; Linkage:
+;
+; rax = start of object just allocated
+;
+; Variable definitions:
+;
+; O = TLH allocation pointer before the current object was allocated
+; S = size of current object + padding
+; A = allocation pointer (A = O+S)
+; B = current prefetch trigger boundary
+
+eq_initialPrefetchWindow    equ 64*10
+eq_prefetchWindow           equ 64*4
+eq_prefetchTriggerDistance  equ 64*8
+
+      align 16
+;%ifdef TR_HOST_64BIT
+;newPrefetchTLH proc
+;%else
+;newPrefetchTLH proc near
+;%endif
+newPrefetchTLH:
+;      int 3
+
+      push        rcx                                         ; preserve
+      push        rdx                                         ; preserve
+      push        rsi                                         ; preserve
+
+%ifdef TR_HOST_64BIT
+      mov         rdx, qword [rbp + eq_J9VMThread_heapAlloc]      ; rdx = O+S
+      mov         ecx, dword [rbp + eq_J9VMThread_PrefetchCursor]  ; rcx = current trigger boundary (B)
+%else
+      mov         rdx, dword [rbp + eq_J9VMThread_heapAlloc]      ; rdx = O+S
+      mov         rcx, dword [rbp + eq_J9VMThread_PrefetchCursor] ; rcx = current trigger boundary (B)
+%endif
+
+      ; A zero value for the trigger boundary indicates that this is a new TLH
+      ; that we haven't prefetched from yet.
+      ;
+      test        rcx, rcx
+      jz prefetchFromNewTLH
+
+      lea         rcx, [rcx + eq_prefetchTriggerDistance]    ; rcx = derive prefetch frontier (F)
+                                                               ;    where F = B + prefetchTriggerDistance
+      lea         rsi, [rcx +64]                             ; rsi = prefetch frontier (F) + 1 cache line
+                                                               ;    +1 = start at the next cache line after the frontier
+
+      ; Push the new frontier out even further if we're allocating a large object that
+      ; exceeds the current frontier.
+      ;
+      cmp         rcx, rdx
+      cmovl       rcx, rdx                                   ; rcx = max(F, O+S)
+      add         rcx, eq_prefetchWindow                      ; rcx = F' = F+eq_prefetchWindow = new prefetch frontier (F')
+
+%ifdef TR_HOST_64BIT
+      mov         rdx, qword [rbp + eq_J9VMThread_heapTop]
+%else
+      mov         rdx, dword [rbp + eq_J9VMThread_heapTop]
+%endif
+
+      cmp         rcx, rdx                                   ; F' >= heapTop?
+      jae prefetchFinalFrontier
+
+mergePrefetchTLHRoundDown:
+      and         rcx, -64                                    ; round down to cache line
+
+mergePrefetchTLH:
+      ; Prefetch all lines between the last prefetch frontier (F) and the new one (F').
+      ; Prefetch forward to give the data a greater chance of being there when we need it.
+      ;
+      ; rsi = last frontier (F)
+      ; rcx = next frontier (F')
+
+      ; Since interpreter allocations do not advance the prefetch frontier the last frontier
+      ; might be behind the allocation pointer, in which case we want to move it forward so
+      ; that we don't prefetch data that has already been allocated.
+      ;
+      cmp         rsi, rax
+      cmovl       rsi, rax                                   ; rsi = max(F+64, O)
+
+      sub         rsi, rcx
+doPrefetch:
+      prefetchnta [rcx+rsi]
+      add         rsi, 64
+      jle short doPrefetch
+
+      sub         rcx, eq_prefetchTriggerDistance             ; rcx = new trigger boundary (B)
+
+%ifdef TR_HOST_64BIT
+      mov         dword [rbp + eq_J9VMThread_PrefetchCursor], ecx
+%else
+      mov         dword [rbp + eq_J9VMThread_PrefetchCursor], rcx
+%endif
+      pop         rsi
+      pop         rdx
+      pop         rcx
+      ret
+
+prefetchFinalFrontier:
+      mov         rcx, rdx
+      jmp mergePrefetchTLH
+
+
+prefetchFromNewTLH:
+      ; We have a new TLH that has not been prefetched.  Assume that the object
+      ; just allocated will have already been pulled into the cache.  Begin
+      ;
+      ; Prefetch from O through O+initialPrefetchWindow
+      ; if (O+i <= O+s) prefetch to
+      ;
+      mov         rsi, rdx                                   ; rsi = A
+      lea         rcx, [rdx + eq_initialPrefetchWindow]      ; rcx = A + Wi
+
+%ifdef TR_HOST_64BIT
+      mov         rdx, qword [rbp + eq_J9VMThread_heapTop]
+%else
+      mov         rdx, dword [rbp + eq_J9VMThread_heapTop]
+%endif
+      cmp         rcx, rdx
+      jae mergePrefetchTLH
+
+;;      cmovg    rcx, rdx                                    ; rcx = F' = min(F', heapTop)
+
+      jmp mergePrefetchTLHRoundDown
+
+ret ;newPrefetchTLH endp
+
+
+%else  ; ASM_J9VM_GC_TLH_PREFETCH_FTA
+
+      align 16
+;%ifdef TR_HOST_64BIT
+;prefetchTLH proc
+;%else
+;prefetchTLH proc near
+;%endif
+prefetchTLH:
+         ret
+;prefetchTLH endp
+
+      align 16
+;%ifdef TR_HOST_64BIT
+;newPrefetchTLH proc
+;%else
+;newPrefetchTLH proc near
+;%endif
+newPrefetchTLH:
+         ret
+;newPrefetchTLH endp
+
+%endif  ; REALTIME
+
+      global   jitReleaseVMAccess
+
+%ifndef TR_HOST_64BIT
+
+; --------------------------------------------------------------------------------
+;
+;                                    32-BIT
+;
+; --------------------------------------------------------------------------------
+
+      global   clearFPStack
+
+jitReleaseVMAccess:; PROC NEAR
+                pusha
+                push       ebp
+                mov        eax, [ebp+J9TR_VMThread_javaVM]
+                mov        eax, [eax+J9TR_JavaVMInternalFunctionTable]
+%ifdef ASM_J9VM_INTERP_ATOMIC_FREE_JNI
+                call       [eax+J9TR_InternalFunctionTableExitVMToJNI]
+%else
+                call       [eax+J9TR_InternalFunctionTableReleaseVMAccess]
+%endif
+                add        esp,4
+                popa
+                retn
+;jitReleaseVMAccess ENDP
+
+	; Wipe the entire FP stack without raising any exceptions.
+	;
+		align 16
+clearFPStack:; proc near
+		ffree     st0
+		ffree     st1
+		ffree     st2
+		ffree     st3
+		ffree     st4
+		ffree     st5
+		ffree     st6
+		ffree     st7
+		retn
+;clearFPStack endp
+
+%else
+
+; --------------------------------------------------------------------------------
+;
+;                                    64-BIT
+;
+; --------------------------------------------------------------------------------
+
+jitReleaseVMAccess:; proc
+        ; Save system-linkage volatile regs
+        ; GPRs
+        push    r11     ; Lin Win
+        push    r10     ; Lin Win
+        push    r9      ; Lin Win
+        push    r8      ; Lin Win
+        push    rsi     ; Lin
+        push    rdi     ; Lin
+        push    rdx     ; Lin Win
+        push    rcx     ; Lin Win
+        push    rax     ; Lin Win
+        ; XMMs
+        ; TODO: We don't need to save them all on Windows
+        sub     rsp, 128 ; Reserve space for XMMs
+        ; Do the writes in-order so we don't defeat the cache
+        movq    qword  [rsp+0],   xmm0
+        movq    qword  [rsp+8],   xmm1
+        movq    qword  [rsp+16],  xmm2
+        movq    qword  [rsp+24],  xmm3
+        movq    qword  [rsp+32],  xmm4
+        movq    qword  [rsp+40],  xmm5
+        movq    qword  [rsp+48],  xmm6
+        movq    qword  [rsp+56],  xmm7
+        movq    qword  [rsp+64],  xmm8
+        movq    qword  [rsp+72],  xmm9
+        movq    qword  [rsp+80],  xmm10
+        movq    qword  [rsp+88],  xmm11
+        movq    qword  [rsp+96],  xmm12
+        movq    qword  [rsp+104], xmm13
+        movq    qword  [rsp+112], xmm14
+        movq    qword  [rsp+120], xmm15
+
+        ; Call vmThread->internalFunctionTable->releaseVMAccess(rbp)
+%ifdef WINDOWS
+        mov     rcx, rbp
+%else
+        mov     rdi, rbp
+%endif
+        mov     rax, qword [rbp+J9TR_VMThread_javaVM]
+        mov     rax, qword [rax+J9TR_JavaVMInternalFunctionTable]
+%ifdef ASM_J9VM_INTERP_ATOMIC_FREE_JNI
+        call    qword  [rax+J9TR_InternalFunctionTableExitVMToJNI]
+%else
+        call    qword  [rax+J9TR_InternalFunctionTableReleaseVMAccess]
+%endif
+
+        ; Restore registers
+        ; XMMs
+        movq    xmm0,  qword  [rsp+0]
+        movq    xmm1,  qword  [rsp+8]
+        movq    xmm2,  qword  [rsp+16]
+        movq    xmm3,  qword  [rsp+24]
+        movq    xmm4,  qword  [rsp+32]
+        movq    xmm5,  qword  [rsp+40]
+        movq    xmm6,  qword  [rsp+48]
+        movq    xmm7,  qword  [rsp+56]
+        movq    xmm8,  qword  [rsp+64]
+        movq    xmm9,  qword  [rsp+72]
+        movq    xmm10, qword  [rsp+80]
+        movq    xmm11, qword  [rsp+88]
+        movq    xmm12, qword  [rsp+96]
+        movq    xmm13, qword  [rsp+104]
+        movq    xmm14, qword  [rsp+112]
+        movq    xmm15, qword  [rsp+120]
+        add     rsp, 128
+        ; GPRs
+        pop     rax
+        pop     rcx
+        pop     rdx
+        pop     rdi
+        pop     rsi
+        pop     r8
+        pop     r9
+        pop     r10
+        pop     r11
+        ret
+;jitReleaseVMAccess endp
+
+
+%endif ; 64-bit
+
+
+;_TEXT ends
+
+;end

--- a/runtime/compiler/x/runtime/X86EncodeUTF16.nasm
+++ b/runtime/compiler/x/runtime/X86EncodeUTF16.nasm
@@ -1,0 +1,190 @@
+; Copyright (c) 2014, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+                SURROGATE_MASK      equ 0f800h
+                SURROGATE_MASK32    equ 0f800f800h
+                SURROGATE_BITS      equ 0d800h
+                SURROGATE_BITS32    equ 0d800d800h
+                SSE_MIN_CHARS       equ 32
+
+                ;include x/runtime/X86RegisterMap.inc TODO: needed for 32 bit compatibility
+
+segment .text
+
+                global _encodeUTF16Big
+                global _encodeUTF16Little
+
+                align 16
+_encodeUTF16Big_shufmask:
+                dq 0607040502030001h
+                dq 0e0f0c0d0a0b0809h
+
+%macro DefineUTF16EncodeHelper 2 ; args: helperName, bigEndian
+; UTF16 encoding for BMP characters
+; pseudocode(uint8_t *dest, uint16_t *src, int n):
+;    {
+;    for (int i = 0; i < n; i++)
+;       {
+;       uint16_t c = src[i];
+;       if ((c & SURROGATE_MASK) == SURROGATE_BITS) break;
+; #if bigEndian
+;       *dest++ = (uint8_t)(c >> 8);
+;       *dest++ = (uint8_t)(c & 0xff);
+; #else
+;       *dest++ = (uint8_t)(c & 0xff);
+;       *dest++ = (uint8_t)(c >> 8);
+; #endif
+;       }
+;    return i;
+;    }
+
+; NB. c is a surrogate code unit
+; iff SURROGATE_MIN = 0xd800 <= c <= 0xdfff = SURROGATE_MAX
+; iff (c & SURROGATE_MASK) == SURROGATE_BITS,
+; where SURROGATE_MASK = 0xf800, SURROGATE_BITS = 0xd800
+
+; registers:
+;    _rdi    dest ptr (into byte array)
+;    _rsi    src  ptr (into char array)
+;    _rdx    n
+;    [_r]cx  c (one-at-a-time); tmp when using SSE
+;    bx      c & SURROGATE_MASK (one-at-a-time)
+;    _rax    original n / return value
+;    xmm0    constant SURROGATE_MASK vector (0xf800..f800)
+;    xmm1    constant SURROGATE_BITS vector (0xd800..d800)
+;    xmm2    current 8 characters (8-at-a-time)
+;    xmm3    surrogate bitmask
+;    xmm4    byte shuffle mask (big-endian only)
+
+                align 16
+%1: ;helperName
+                ; Remember original count -
+                ; will subtract at return to compute number converted
+                mov rax, rdx
+                cmp rdx, 0
+                je Lend_%1 ;helpername
+                sub rdi, rsi  ; relative to _rsi, only advance _rsi
+                cmp rdx, SSE_MIN_CHARS
+                jl Lresidue_loop_%1 ;helperName
+
+Lprealign_%1: ;helperName
+                test rsi, 0fh
+                jz Laligned16_%1 ;&helperName
+
+                mov cx, word [rsi]
+
+                ; return if surrogate
+                mov bx, cx
+                and bx, SURROGATE_MASK
+                cmp bx, SURROGATE_BITS
+                je Lend_%1 ;helperName
+
+                ; not surrogate
+%if %2 ;bigEndian
+                xchg cl, ch
+%endif
+                mov word [rsi + rdi], cx
+                add rsi, 2
+                dec rdx
+                jg Lprealign_%1 ;&helperName
+                jmp Lend_%1 ;&helperName
+
+Laligned16_%1: ;helperName:
+                sub rdx, 8
+                jl Lresidue_%1 ;&helperName
+
+                ; initialize constant vectors:
+                ; SURROGATE_MASK
+                mov ecx, SURROGATE_MASK32
+                movd xmm0, ecx
+                pshufd xmm0, xmm0, 0
+
+                ; SURROGATE_BITS
+                mov ecx, SURROGATE_BITS32
+                movd xmm1, ecx
+                pshufd xmm1, xmm1, 0
+
+%if %2 ;&bigEndian
+                ; shuffle mask for PSHUFB
+                movdqa xmm4, oword [rel _encodeUTF16Big_shufmask]
+%endif
+
+L8_at_a_time_%1: ;&helperName:
+                ; read 8 chars
+                ; should this use movdqu, start once 8-byte aligned?
+                movdqa xmm2, oword [rsi]
+
+                ; jump to residue loop if any are surrogate
+                movdqa xmm3, xmm2
+                pand xmm3, xmm0
+                pcmpeqw xmm3, xmm1
+                ptest xmm3, xmm3    ; SSE4.1
+                jnz Lresidue_%1 ;&helperName
+
+                ; no surrogates
+%if %2 ;&bigEndian
+                pshufb xmm2, xmm4   ; SSSE3
+%endif
+
+                ; write 8 chars
+                movdqu oword [rsi + rdi], xmm2
+
+                add rsi, 16
+                sub rdx, 8
+                jge L8_at_a_time_%1 ;&helperName
+
+Lresidue_%1: ;&helperName:
+                add rdx, 8
+                cmp rdx, 0
+                je Lend_%1 ;&helperName
+
+Lresidue_loop_%1: ;&helperName:
+                mov cx, word [rsi]
+
+                ; return if surrogate
+                mov bx, cx
+                and bx, SURROGATE_MASK
+                cmp bx, SURROGATE_BITS
+                je Lend_%1 ;&helperName
+
+                ; not surrogate
+%if %2 ;&bigEndian
+                xchg cl, ch
+%endif
+                mov word [rsi + rdi], cx
+                add rsi, 2
+                dec rdx
+                jg Lresidue_loop_%1 ;&helperName
+
+Lend_%1: ;&helperName:
+                sub rax, rdx
+                ret
+
+;&helperName endp
+%endmacro
+
+; Expand out the two helpers
+
+DefineUTF16EncodeHelper _encodeUTF16Big, 1
+DefineUTF16EncodeHelper _encodeUTF16Little, 0
+
+;_TEXT           ends
+
+;                end

--- a/runtime/compiler/x/runtime/X86LockReservation.nasm
+++ b/runtime/compiler/x/runtime/X86LockReservation.nasm
@@ -1,0 +1,333 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%include "jilconsts_nasm.inc"
+
+
+; %include x/runtime/X86RegisterMap.inc : TODO: not including this makes this code work only on 64bit
+
+    global jitMonitorEnterReserved
+    global jitMonitorEnterReservedPrimitive
+    global jitMonitorEnterPreservingReservation
+    global jitMethodMonitorEnterReserved
+    global jitMethodMonitorEnterReservedPrimitive
+    global jitMethodMonitorEnterPreservingReservation
+    global jitMonitorExitReserved
+    global jitMonitorExitReservedPrimitive
+    global jitMonitorExitPreservingReservation
+    global jitMethodMonitorExitPreservingReservation
+    global jitMethodMonitorExitReserved
+    global jitMethodMonitorExitReservedPrimitive
+
+%ifdef WINDOWS
+    UseFastCall equ 1
+%else
+    %ifdef TR_HOST_32BIT
+        UseFastCall equ 1
+    %endif
+%endif
+
+eq_ObjectClassMask            equ -J9TR_RequiredClassAlignment
+eq_J9Monitor_IncDecValue      equ 08h
+eq_J9Monitor_INFBit           equ 01h
+eq_J9Monitor_RESBit           equ 04h
+eq_J9Monitor_RESINCBits       equ 0Ch
+eq_J9Monitor_FLCINFBits       equ 03h
+eq_J9Monitor_RecCountMask     equ 0F8h
+
+
+%ifndef TR_HOST_64BIT
+
+eq_J9Monitor_LockWord         equ 04h
+eq_J9Monitor_CountsClearMask  equ 0FFFFFF07h
+eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFF05h
+
+%else ; ndef  64bit
+; this stupidness is required because masm2gas can't handle
+; ifdef on definitions
+
+%ifdef ASM_J9VM_INTERP_SMALL_MONITOR_SLOT
+eq_J9Monitor_LockWord         equ 04h
+%else
+eq_J9Monitor_LockWord         equ 08h
+%endif
+
+eq_J9Monitor_CountsClearMask  equ 0FFFFFFFFFFFFFF07h
+eq_J9Monitor_CNTFLCClearMask  equ 0FFFFFFFFFFFFFF05h
+
+%endif ;64bit
+
+; object <= ObjAddr
+; lockword address => _rcx
+; lockword value   => _rax
+; args: ObjAddr
+%macro ObtainLockWordHelper 1 
+    %ifdef ASM_J9VM_THR_LOCK_NURSERY
+        %ifdef ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER
+            mov  eax, [%1 + J9TR_J9Object_class] ; receiver class
+        %else
+            mov rax, [%1 + J9TR_J9Object_class] ; receiver class
+        %endif
+        and rax, eq_ObjectClassMask
+        mov rax, [rax + J9TR_J9Class_lockOffset]     ; offset of lock word in receiver class
+        lea rcx, [%1 + rax]                    ; load the address of object lock word
+    %else
+        lea rcx, [%1 + eq_J9Monitor_LockWord]   ; load the address of object lock word
+    %endif
+    %ifdef ASM_J9VM_INTERP_SMALL_MONITOR_SLOT
+        mov  eax, [rcx]
+    %else
+        mov rax, [rcx]
+    %endif
+%endmacro
+
+%macro ObtainLockWord 0
+    %ifdef UseFastCall
+        ObtainLockWordHelper rdx
+    %else
+        ObtainLockWordHelper rsi
+    %endif
+%endmacro
+
+; try to obtain the lock
+; lockword address <= _rcx
+; vmthread         <= _rbp
+%macro TryLock 0
+    push bp
+    lea  rbp, [rbp + eq_J9Monitor_RESINCBits] ; make thread ID + RES + INC_DEC value
+
+    ; Set _rax to the lock word value that allows a monitor to be reserved (the
+    ; reservation bit by default, or 0 for -XlockReservation). This value is
+    ; provided to the reserving monent helper as the third argument. Calling
+    ; conventions differ...
+%ifdef TR_HOST_32BIT
+        ; 32-bit always uses fastcall. This is the only argument on the stack.
+        ; Stack offsets: +0 saved ebp, +4 return address, +8 argument
+        mov eax, dword [esp+8]
+%else
+%ifdef UseFastCall
+            mov rax, r8
+%else
+            mov rax, rdx
+%endif
+%endif
+
+%ifdef ASM_J9VM_INTERP_SMALL_MONITOR_SLOT
+        lock cmpxchg [rcx],  ebp               ; try taking the lock
+%else
+        lock cmpxchg [rcx], rbp               ; try taking the lock
+%endif
+    pop  rbp
+%endmacro
+
+; We reach the reserved monitor enter code here if the monitor isn't reserved, it's reserved
+; by another thread or the reservation count has reached it's maximum value.
+; In this helper we first check if the reservation count is about to overflow
+; then we try taking the lock and if we succeed we increment the reservation count and we
+; are back to mainline code.
+%macro MonitorEnterReserved 0
+    ;local fallback,trylock
+    ObtainLockWord
+    push rax
+    and  rax, eq_J9Monitor_RecCountMask            ; check if the recursive count has
+    xor  rax, eq_J9Monitor_RecCountMask            ; reached the max value
+    pop  rax
+    jz    .fallback                                   ; and call VM helper to resolve it
+    xor  rax, rbp                                 ; mask thread ID
+    xor  rax, eq_J9Monitor_RESBit                  ; mask RES bit
+    and  rax, eq_J9Monitor_CountsClearMask         ; clear the count bits
+    jnz   .trylock                                    ; if any bit is set we don't have it reserved by the same thread, or not reserved at all
+    add  dword [rcx], eq_J9Monitor_IncDecValue ; add 1 to the reservation count
+    %ifdef TR_HOST_32BIT
+        ret 4
+    %else
+        ret
+    %endif
+   .trylock:
+    TryLock
+    jne  .fallback                                   ; call out to VM if we couldn't take the lock, which means it's not reserved for us
+    %ifdef TR_HOST_32BIT
+        ret 4
+    %else
+        ret
+    %endif
+  .fallback:
+%endmacro
+
+; This code is called when we need to exit reserved montior with couple of possible
+; scenarios:
+;   - more than one level of recursion
+;   - FLC or INF are set
+;   - we have illegal monitor state
+%macro MonitorExitReserved 0
+    ;local fallback
+    ObtainLockWord
+    test rax, eq_J9Monitor_RESBit
+    jz   .fallback
+    test rax, eq_J9Monitor_FLCINFBits
+    jnz  .fallback
+    test rax, eq_J9Monitor_RecCountMask
+    jz   .fallback
+    sub  dword [rcx], eq_J9Monitor_IncDecValue
+    ret
+  .fallback:
+%endmacro
+
+; We reach the reserved monitor enter code here if the monitor isn't reserved, it's reserved
+; by another thread. We try to reserve it for ourselves and if we succeed we just go into
+; main line code.
+%macro MonitorEnterReservedPrimitive 0
+    ;local fallback,trylock
+    ObtainLockWord
+    xor  rax, rbp                         ; mask thread ID
+    xor  rax, eq_J9Monitor_RESBit          ; mask RES bit
+    and  rax, eq_J9Monitor_CNTFLCClearMask ; clear the count bits
+    jnz  .trylock                            ; if any bit is set we don't have it reserved by the same thread, or not reserved at all
+    %ifdef TR_HOST_32BIT
+        ret 4
+    %else
+        ret
+    %endif
+  .trylock:
+    TryLock
+    jne  .fallback                           ; call out to VM if we couldn't take the lock, which means it's not reserved for us
+    %ifdef TR_HOST_32BIT
+        ret 4
+    %else
+        ret
+    %endif
+  .fallback:
+%endmacro
+
+; This code is reachable from reserved primitive exit code and it is
+; supposed to make sure we call out to monitor exit but with recursive count
+; set to 1 if reservation is on. Namely, primitive reserving monitors don't
+; increment and decrement reserving counts because the execution cannot be
+; stopped inside them. We can get stopped at the exit in which we have to
+; make sure we have count set to at least 1, that is pretend we increment/decrement.
+; The state of count=0, RES=1, FLC=1 is invalid and illegal monitor state exception is thrown.
+%macro MonitorExitReservedPrimitive 0
+    ;local fallback
+    ObtainLockWord
+    test rax, eq_J9Monitor_INFBit                   ; check to see if we have inflated monitor
+    jnz  .fallback                                    ; monitor inflated call the VM helper
+    test rax, eq_J9Monitor_RESBit                   ; check to see if we have reservation ON
+    jz   .fallback                                    ; no reserved bit set - go on, call the helper to exit
+    test rax, eq_J9Monitor_RecCountMask             ; check to see if we have any recursive bits on
+    jnz  .fallback                                    ; yes some recursive count, go back to main line code
+    sub  dword [rcx], eq_J9Monitor_IncDecValue
+    ret
+  .fallback:
+%endmacro
+
+; We reach this out of line code when we fail to enter monitor with
+; flat lock, where the monitor is supposed to preserve existing reservation.
+; This enter procedure is different compared to the regular monitor enter
+; sequence only that it checks for reservation and enters in reserved manner
+; if possible.
+%macro MonitorEnterPreservingReservation 0
+    ;local fallback
+    ObtainLockWord
+    push rax
+    and  rax, eq_J9Monitor_RecCountMask            ; check if the recursive count has
+    xor  rax, eq_J9Monitor_RecCountMask            ; reached the max value
+    pop  rax
+    jz   .fallback                                   ; and call VM helper to resolve it
+    xor  rax, rbp                                 ; mask thread ID
+    xor  rax, eq_J9Monitor_RESBit                  ; mask RES bit
+    and  rax, eq_J9Monitor_CountsClearMask         ; clear the count bits
+    jnz  .fallback                                   ; if any bit is set we don't have it reserved by the same thread, or not reserved at all
+    add  dword [rcx], eq_J9Monitor_IncDecValue ; add 1 to the reservation count
+    ret
+  .fallback:
+%endmacro
+
+; We reach this code when we are in regular monitor and we want to make sure we
+; preserve reservation for any monitor that has reserved bit set and we are the
+; same thread.
+%macro MonitorExitPreservingReservation 0
+    ;local fallback
+    ObtainLockWord
+    test rax, eq_J9Monitor_RecCountMask            ; check if the recursive count is greater than 1
+    jz   .fallback                                   ; branch to VM if 0, weird thing has happened
+    xor  rax, rbp                                 ; mask thread ID
+    xor  rax, eq_J9Monitor_RESBit                  ; mask RES bit
+    and  rax, eq_J9Monitor_CountsClearMask         ; clear the count bits
+    jnz  .fallback                                   ; if any bit is set we don't have it reserved by the same thread, or not reserved at all
+    sub  dword [rcx], eq_J9Monitor_IncDecValue
+    ret
+  .fallback:
+%endmacro
+
+
+; template for exported functions args: Name, Fallback, Template
+%macro MonitorReservationFunction 3
+    align 16
+    %1: ; name
+    %3 ; template
+    %ifdef UseFastCall
+        mov  rcx, rbp ; restore the first param - vmthread
+    %endif
+    jmp %2;call %2 wrt ..plt ;fallback
+%endmacro
+
+; %ifdef TR_HOST_64BIT
+SECTION .text
+; %else
+;SECTION .text
+;%endif
+
+extern jitMonitorEntry
+extern jitMethodMonitorEntry
+extern jitMonitorExit
+extern jitMethodMonitorExit
+
+%ifdef TR_HOST_64BIT
+    entryFallback equ jitMonitorEntry
+    methodEntryFallback equ jitMethodMonitorEntry
+%else
+    entryFallback:
+        ; jitMonitorEntry won't clean up the extra argument
+        pop eax
+        mov dword [esp], eax
+        jmp jitMonitorEntry
+        retn
+
+    methodEntryFallback:
+        ; jitMethodMonitorEntry won't clean up the extra argument
+        pop eax
+        mov dword [esp], eax
+        jmp jitMethodMonitorEntry
+        retn
+%endif
+
+MonitorReservationFunction jitMonitorEnterReserved,                    entryFallback,         MonitorEnterReserved
+MonitorReservationFunction jitMethodMonitorEnterReserved,              methodEntryFallback,   MonitorEnterReserved
+MonitorReservationFunction jitMonitorEnterReservedPrimitive,           entryFallback,         MonitorEnterReservedPrimitive
+MonitorReservationFunction jitMethodMonitorEnterReservedPrimitive,     methodEntryFallback,   MonitorEnterReservedPrimitive
+MonitorReservationFunction jitMonitorEnterPreservingReservation,       jitMonitorEntry,       MonitorEnterPreservingReservation
+MonitorReservationFunction jitMethodMonitorEnterPreservingReservation, jitMethodMonitorEntry, MonitorEnterPreservingReservation
+
+MonitorReservationFunction jitMonitorExitReserved,                    jitMonitorExit,       MonitorExitReserved
+MonitorReservationFunction jitMethodMonitorExitReserved,              jitMethodMonitorExit, MonitorExitReserved
+MonitorReservationFunction jitMonitorExitReservedPrimitive,           jitMonitorExit,       MonitorExitReservedPrimitive
+MonitorReservationFunction jitMethodMonitorExitReservedPrimitive,     jitMethodMonitorExit, MonitorExitReservedPrimitive
+MonitorReservationFunction jitMonitorExitPreservingReservation,       jitMonitorExit,       MonitorExitPreservingReservation
+MonitorReservationFunction jitMethodMonitorExitPreservingReservation, jitMethodMonitorExit, MonitorExitPreservingReservation

--- a/runtime/compiler/x/runtime/X86PicBuilder.pnasm
+++ b/runtime/compiler/x/runtime/X86PicBuilder.pnasm
@@ -1,0 +1,2296 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+
+#include "j9cfg.h"
+%ifndef TR_HOST_64BIT
+
+; --------------------------------------------------------------------------------
+;
+;                                    32-BIT
+;
+; --------------------------------------------------------------------------------
+
+      CPU PPRO
+
+      %include jilconsts_nasm.inc
+      %include x/runtime/X86PicBuilder_nasm.inc
+
+      segment .text
+
+      extern jitLookupInterfaceMethod
+      extern jitResolveInterfaceMethod
+      extern jitResolveVirtualMethod
+      extern jitCallJitAddPicToPatchOnClassUnload
+
+      global resolveIPicClass
+      global populateIPicSlotClass
+      global populateIPicSlotCall
+      global dispatchInterpretedFromIPicSlot
+      global IPicLookupDispatch
+
+      global resolveVPicClass
+      global populateVPicSlotClass
+      global populateVPicSlotCall
+      global dispatchInterpretedFromVPicSlot
+      global populateVPicVTableDispatch
+      global resolveAndPopulateVTableDispatch
+      global memoryFence
+
+
+; Perform a memory fence. The capabilities of the target architecture must be inspected at runtime
+; to determine the appropriate fence instruction to use.
+;
+      align 16
+memoryFence: ;proc near
+
+      push ecx ; preserve
+      mov ecx, J9TR_VMThread_javaVM[ebp]
+      mov ecx, J9TR_JavaVMJitConfig[ecx]
+      mov ecx, J9TR_JitConfig_runtimeFlags[ecx]
+      test ecx, J9TR_runtimeFlags_PatchingFenceType
+      jz short doLockOrEsp
+
+      MEMORY_FENCE
+      jmp doneMemoryFence
+
+doLockOrEsp:
+      db          0F0h
+      db          083h
+      db          00Ch
+      db          024h
+      db          000h
+
+doneMemoryFence:
+      pop         ecx                                          ; restore
+      retn
+
+;memoryFence endp
+
+
+; Resolve the interface method and update the IPIC data area with the interface J9Class
+; and the itable index.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the resolution helper.
+;
+      align 16
+resolveIPicClass: ; proc near
+      push edx                                                 ; preserve
+      push edi                                                 ; preserve
+      mov edi, dword [esp+8]                                   ; RA in code cache
+
+      cmp byte [edi+1], 075h                                   ; is it a short branch?
+      jnz resolveIPicClassLongBranch ; no
+
+      lea edi, [edi+9] ; EA of disp8 in JMP
+                                                               ; 9 = 1 + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      movzx edx, byte [edi] ; disp8 to end of IPic
+      lea edx, [edi+edx-11] ; edx = EA of disp32 of JNE
+                                                               ; -11 = 1 (instr. after JMP) -12 (EA of disp32 of JNE)
+      add edx, dword [edx] ; EA of lookup dispatch snippet
+      lea edx, [edx+14] ; EA of IPic data block
+
+mergeFindDataBlockForResolveIPicClass:
+      push eax ; push receiver
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+      push edi ; p) jit valid EIP
+      push edx ; p) push the address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveInterfaceMethod,eax ; returns interpreter vtable index
+
+      call memoryFence ; Ensure IPIC data area drains to memory before proceeding.
+
+      push ebx ; preserve
+      push ecx ; preserve
+
+      ; Stack shape:
+      ;
+      ; +24 last parameter
+      ; +20 RA in code cache (call to helper)
+      ; +16 saved edx
+      ; +12 saved edi
+      ; +8 saved eax (receiver)
+      ; +4 saved ebx
+      ; +0 saved ecx
+      ;
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper eax, resolveIPicClass
+      MoveHelper ebx, populateIPicSlotClass
+      mov edi, dword [esp+20] ; edi = RA in mainline (call to helper)
+      mov edx, dword [edi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      sub eax, edi ; Expected disp32 for call to helper
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the byte sequence in ecx:ebx to re-route the call
+      ; to populateIPicSlotClass.
+      ;
+      sub ebx, edi ; disp32 to populate snippet
+      mov ecx, edx
+      rol ebx, 8
+      mov cl, bl ; Form high byte of calculated disp32
+      mov bl, 0e8h ; add CALL opcode
+
+      ; Attempt to patch the code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword [edi-5] ; EA of CMP instruction in mainline
+%else
+      lock cmpxchg8b [edi-5] ; EA of CMP instruction in mainline
+%endif
+
+      pop ecx ; restore
+      pop ebx ; restore
+      pop eax
+      pop edi
+      pop edx
+
+      sub dword [esp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+resolveIPicClassLongBranch:
+      mov edx, dword [edi+3] ; disp32 for branch to snippet
+      lea edx, [edi+edx+17] ; EA of IPic data block
+                                                               ; 17 = 7 (offset to instr after branch) + 5 (CALL) + 5 (JMP)
+      jmp mergeFindDataBlockForResolveIPicClass
+
+ret ;resolveIPicClass endp
+
+
+; Look up a resolved interface method and attempt to occupy the PIC slot
+; that routed control to this helper.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateIPicSlotClass: ; proc near
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword [esp+8] ; RA in code cache
+
+      cmp byte [edi+1], 075h ; is it a short branch?
+      jnz populateIPicClassLongBranch ; no
+
+      lea edi, [edi+9] ; EA of disp8 in JMP
+                                                               ; 9 = 1 + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      movzx edx, byte  [edi] ; disp8 to end of IPic
+      lea edx, [edi+edx-11] ; edx = EA of disp32 of JNE
+                                                               ; -11 = 1 (instr. after JMP) -12 (EA of disp32 of JNE)
+      add edx, dword  [edx] ; EA of lookup dispatch snippet
+
+      lea edx, [edx+14] ; EA of constant pool and cpIndex
+                                                               ; 14 = 4 + 10 (CALL+JMP)
+mergePopulateIPicClass:
+      push eax ; push receiver
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+
+
+
+#ifdef J9VM_OPT_TEMP_NEW_INTERFACE_INVOCATION
+      push        edx                                          ; p) push the address of the constant pool and cpIndex
+#endif
+      lea edx, [edx+8] ; EA of IClass in data block
+                                                               ; = 4 + 10 (CALL+JMP) + 8 (cpaddr,cpIndex)
+                                                               ;
+                                                               ; Or if jmp to mergePopulateIPicClass taken
+                                                               ; = 7 (offset to instr after branch) + 5 (CALL) +
+                                                               ; 5 (JMP) + 8 (cpaddr,cpIndex)
+
+      push edi ; p) jit EIP
+      push edx ; p) EA of resolved interface class
+      LoadClassPointerFromObjectHeader eax, eax, eax
+      push eax ; p) receiver class
+      CallHelperUseReg jitLookupInterfaceMethod,eax ; returns interpreter vtable offset
+
+      ; Lookup succeeded--attempt to grab the PIC slot for this receivers class.
+      ;
+      push ebx ; preserve
+      push ecx ; preserve
+      push esi ; preserve
+
+      ; Stack shape:
+      ;
+      ; +28 last parameter
+      ; +24 RA in code cache (call to helper)
+      ; +20 saved edx
+      ; +16 saved edi
+      ; +12 saved eax (receiver)
+      ; +8 saved ebx
+      ; +4 saved ecx
+      ; +0 saved esi
+      ;
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      mov esi, edx ; esi = EA of IClass in data block
+
+      MoveHelper eax, populateIPicSlotClass
+      mov edi, dword  [esp+24] ; edi = RA in mainline (call to helper)
+      mov edx, dword  [edi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      sub eax, edi ; Expected disp32 for call to snippet
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the CMP instruction in ecx:ebx to devirtualize the interface
+      ; method for this receivers class.
+      ;
+      mov cx, word  [edi+1] ; 2 bytes of jump to next slot
+      rol ecx, 16
+      mov ebx, dword  [esp+12] ; receiver
+      LoadClassPointerFromObjectHeader ebx, ebx, ebx ; receiver class
+      rol ebx, 16
+      mov cx, bx
+      mov bl, 081h ; CMP opcode
+      mov bh, byte  [esi+8] ; ModRM byte in data area (offset from IClass)
+
+      ; Attempt to patch in the CMP instruction.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [edi-5] ; EA of CMP instruction in mainline
+%else
+      lock cmpxchg8b [edi-5] ; EA of CMP instruction in mainline
+%endif
+
+
+%ifdef ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING
+      jnz short IPicClassSlotUpdateFailed
+
+      ; Register the address of the immediate field in the CMP instruction
+      ; for dynamic class unloading iff the interface class and the
+      ; receiver class have been loaded by different class loaders.
+      ;
+      mov eax, dword  [esp+12] ; grab the receiver before its restored
+      LoadClassPointerFromObjectHeader eax, edx, edx ; receiver class
+      mov eax, dword  [edx+J9TR_J9Class_classLoader] ; receivers class loader
+
+      mov ebx, dword  [esi] ; ebx == IClass from IPic data area
+      cmp eax, dword  [ebx+J9TR_J9Class_classLoader] ; compare class loaders
+      jz short IPicClassSlotUpdateFailed ; class loaders are the same--do nothing
+
+      lea edi, [edi-3] ; EA of immediate
+      push edi ; p) address to patch
+      push edx ; p) receivers class
+      CallHelper jitCallJitAddPicToPatchOnClassUnload
+IPicClassSlotUpdateFailed:
+%endif
+
+      pop esi ; restore
+      pop ecx ; restore
+      pop ebx ; restore
+      pop eax ; restore receiver
+      pop edi
+      pop edx
+
+      sub dword [esp], 5 ; fix RA to re-run the CMP
+      ret ; branch will mispredict so single-byte RET is ok
+
+populateIPicClassLongBranch:
+      mov edx, dword  [edi+3] ; disp32 for branch to snippet
+      lea edx, [edi+edx+17] ; EA of constant pool and cpIndex
+                                                               ; 17 = 7 (offset to instr after branch) + 5 (CALL) +
+                                                               ; 5 (JMP)
+      jmp mergePopulateIPicClass
+ret ;populateIPicSlotClass endp
+
+
+; Look up a resolved interface method and update the call to the method
+; that routed control to this helper.
+;
+; STACK SHAPE: must maintain stack shape expected by call to
+; getJitVirtualMethodResolvePushes() across the call to the lookup helper.
+;
+      align 16
+populateIPicSlotCall: ; proc near
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      cmp byte  [edi-13], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or a CMP opcode.
+                                                               ; -13 = -5 (CALL) -3 (NOP) -5 (CMP or JNE)
+      jz populateLastIPicSlot
+      movzx edx, byte  [edi+1] ; JMP displacement to end of IPic
+      lea edx, [edi+edx-6] ; edx = EA of NOP instruction after JNE in last slot
+                                                               ; -6 = +2 (skip JMP disp8) - 5 (call in last slot) - 3 (NOP)
+
+mergeIPicSlotCall:
+      add edx, dword  [edx-4] ; EA of lookup dispatch snippet
+      lea edx, [edx+10] ; EA of constant pool and cpIndex
+                                                               ; 10 = 5 (CALL) + 5 (JMP)
+
+      push eax ; push receiver
+      LoadClassPointerFromObjectHeader eax, eax, eax ; receiver class
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+
+
+
+#ifdef J9VM_OPT_TEMP_NEW_INTERFACE_INVOCATION
+      push        edx                                          ; p) push the address of the constant pool and cpIndex
+#endif
+      lea edx, [edx+8] ; EA of IClass in data block
+                                                               ; 18 = 5 (CALL) + 5 (JMP) + 8 (cpAddr,cpIndex)
+
+      push edi ; p) jit EIP
+      push edx ; p) EA of resolved interface class
+      push eax ; p) receiver class
+      CallHelperUseReg jitLookupInterfaceMethod,eax ; returns interpreter vtable offset
+      mov edx, eax
+      pop eax ; restore receiver
+      push ecx ; preserve
+
+      LoadClassPointerFromObjectHeader eax, ecx, ecx ; receiver class
+      mov ecx, dword  [ecx+edx] ; J9Method from interpreter vtable
+      test byte  [ecx + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jnz short IPicSlotMethodInterpreted
+
+mergeUpdateIPicSlotCallWithCompiledMethod:
+      mov ecx, dword  [ecx+J9TR_MethodPCStartOffset]
+
+mergeUpdateIPicSlotCall:
+      mov edi, dword  [esp+12] ; RA in code cache
+      sub ecx, edi ; compute new disp32
+      mov dword  [edi-4], ecx ; patch disp32 in call instruction
+
+      pop ecx ; restore
+      add esp, 8 ; edx and edi do not need to be restored because they
+                                                               ; are killed by the linkage
+      sub edi, 5 ; set up RA to re-run patched call instruction
+      mov dword  [esp], edi
+      ret ; re-run the call instruction
+
+populateLastIPicSlot:
+      lea edx, [edi-8] ; 8 = 5 (CALL) + 3 (NOP)
+      jmp mergeIPicSlotCall
+
+IPicSlotMethodInterpreted:
+      MoveHelper ecx, dispatchInterpretedFromIPicSlot
+      jmp short mergeUpdateIPicSlotCall
+
+ret ;populateIPicSlotCall endp
+
+
+; Call an interpreted method from an IPic slot.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+dispatchInterpretedFromIPicSlot: ; proc near
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      cmp byte  [edi-13], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or a CMP opcode.
+                                                               ; -13 = -5 (CALL) -3 (NOP) -5 (CMP or JNE)
+      jz interpretedLastIPicSlot
+      movzx edx, byte  [edi+1] ; JMP displacement to end of IPic
+      lea edx, [edi+edx-6] ; edx = EA of NOP instruction after JNE in last slot
+                                                               ; -6 = +2 (skip JMP disp8) - 5 (call in last slot) - 3 (NOP)
+mergeIPicInterpretedDispatch:
+      add edx, dword  [edx-4] ; EA of lookup dispatch snippet
+      lea edx, [edx+10] ; EA of constant pool and cpIndex
+                                                               ; 10 = 5 (CALL) + 5 (JMP)
+
+      push eax ; push receiver
+      LoadClassPointerFromObjectHeader eax, eax, eax ; receiver class
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+
+#ifdef J9VM_OPT_TEMP_NEW_INTERFACE_INVOCATION
+      push        edx                                          ; p) push the address of the constant pool and cpIndex
+#endif
+
+      lea edx, [edx+8] ; EA of IClass in data block
+                                                               ; 18 = 5 (CALL) + 5 (JMP) + 8 (cpAddr,cpIndex)
+
+      push edi ; p) jit EIP
+      push edx ; p) EA of resolved interface class
+      push eax ; p) receiver class
+      CallHelperUseReg jitLookupInterfaceMethod,eax ; returns interpreter vtable offset
+      mov edx, eax
+      pop eax ; restore receiver
+      push ecx ; preserve
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved ecx
+      ;
+      LoadClassPointerFromObjectHeader eax, ecx, ecx ; receiver class
+      mov ecx, dword  [ecx+edx] ; J9Method from interpreter vtable
+      test byte  [ecx + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jz mergeUpdateIPicSlotCallWithCompiledMethod
+
+      ; Target method is still interpreted--dispatch it.
+      ;
+      sub edx, J9TR_InterpVTableOffset
+      neg edx ; JIT vtable offset
+      LoadClassPointerFromObjectHeader eax, ecx, ecx ; receiver class
+      mov edi, [ecx+edx] ; target in JIT side vtable
+      pop ecx ; restore
+      add esp, 8 ; edx and edi do not need to be restored because they
+                                                               ; are killed by the linkage.
+      jmp edi
+
+interpretedLastIPicSlot:
+      lea edx, [edi-8] ; 8 = 5 (CALL) + 3 (NOP)
+      jmp mergeIPicInterpretedDispatch
+
+ret ;dispatchInterpretedFromIPicSlot endp
+
+
+; Look up an implemented interface method in this receivers class and
+; dispatch it.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+IPicLookupDispatch:  ;proc near
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      lea edi, [edi+5] ; EA of constant pool and cpIndex
+                                                               ; 5 = 5 (JMP)
+
+      push eax ; push receiver
+      LoadClassPointerFromObjectHeader eax, edx, edx ; receiver class
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+
+#ifdef J9VM_OPT_TEMP_NEW_INTERFACE_INVOCATION
+      push        edi                                          ; p) push the address of the constant pool and cpIndex
+#endif
+
+      lea edi, [edi+8] ; EA of IClass in data block
+                                                               ; 13 = 5 (JMP) + 8 (cpAddr,cpIndex)
+
+      push edi ; p) jit EIP
+      push edi ; p) EA of resolved interface class in IPic
+      push edx ; p) receiver class
+      CallHelperUseReg jitLookupInterfaceMethod,eax ; returns interpreter vtable offset
+      sub eax, J9TR_InterpVTableOffset
+      neg eax ; JIT vtable offset
+      mov edi, [edx+eax] ; target in JIT side vtable
+
+      ; j2iVirtual expects edx to contain the JIT vtable offset
+      ;
+      mov edx, eax
+      pop eax ; restore receiver
+      add esp, 8 ; edx and edi do not need to be restored because they
+                                                               ; are killed by the linkage
+      jmp edi
+ret ;IPicLookupDispatch endp
+
+
+; Resolve the virtual method and throw an exception if the resolution was not successful.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the resolution helper.
+;
+      align 16
+resolveVPicClass:  ;proc near
+; int 3
+
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      cmp byte  [edi+1], 075h ; is it a short branch?
+      jnz resolveVPicClassLongBranch ; no
+
+      lea edi, [edi+9] ; EA of disp8 in JMP
+                                                               ; 9 = 1 + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      movzx edx, byte  [edi] ; disp8 to end of VPic
+      lea edx, [edi+edx-11] ; edx = EA of disp32 of JNE
+                                                               ; -11 = 1 (instr. after JMP) -12 (EA of disp32 of JNE)
+      add edx, dword  [edx] ; EA of vtable dispatch snippet
+      lea edx, [edx-9] ; EA of VPic data block
+
+mergeFindDataBlockForResolveVPicClass:
+      push eax ; push receiver
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+      push edi ; p) jit valid EIP
+      push edx ; p) push the address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveVirtualMethod,eax ; returns compiler vtable index
+
+      push ebx ; preserve
+      push ecx ; preserve
+
+      ; Stack shape:
+      ;
+      ; +24 last parameter
+      ; +20 RA in code cache (call to helper)
+      ; +16 saved edx
+      ; +12 saved edi
+      ; +8 saved eax (receiver)
+      ; +4 saved ebx
+      ; +0 saved ecx
+      ;
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper eax, resolveVPicClass
+      MoveHelper ebx, populateVPicSlotClass
+      mov edi, dword  [esp+20] ; edi = RA in mainline (call to helper)
+      mov edx, dword  [edi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      sub eax, edi ; Expected disp32 for call to helper
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the byte sequence in ecx:ebx to re-route the call
+      ; to populateVPicSlotClass.
+      ;
+      sub ebx, edi ; disp32 to populate snippet
+      mov ecx, edx
+      rol ebx, 8
+      mov cl, bl ; Form high byte of calculated disp32
+      mov bl, 0e8h ; add CALL opcode
+
+      ; Attempt to patch the code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [edi-5] ; EA of CMP instruction in mainline
+%else
+      lock cmpxchg8b [edi-5] ; EA of CMP instruction in mainline
+%endif
+
+      pop ecx ; restore
+      pop ebx ; restore
+      pop eax ; restore
+      pop edi ; restore
+      pop edx ; restore
+
+      sub dword [esp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+resolveVPicClassLongBranch:
+      mov edx, dword  [edi+3] ; disp32 for branch to snippet
+      lea edx, [edi+edx-2] ; EA of VPic data block
+                                                               ; -2 = 7 (offset to instr after branch) -9 (DB+cpIndex+cpAddr)
+      jmp mergeFindDataBlockForResolveVPicClass
+
+ret ;resolveVPicClass endp
+
+
+; Populate a PIC slot with the class of the receiver.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateVPicSlotClass:  ;proc near
+; int 3
+
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      cmp byte  [edi+1], 075h ; is it a short branch?
+      jnz populateVPicClassLongBranch ; no
+
+      lea edi, [edi+9] ; EA of disp8 in JMP
+                                                               ; 9 = 1 + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      movzx edx, byte  [edi] ; disp8 to end of VPic
+      lea edx, [edi+edx-11] ; edx = EA of disp32 of JNE
+                                                               ; -11 = 1 (instr. after JMP) -12 (EA of disp32 of JNE)
+      add edx, dword  [edx] ; EA of vtable dispatch snippet
+      lea edx, [edx-5] ; EA of VPic data block
+                                                               ; -5 = 4 - 9 (DB + cpAddr,cpIndex)
+mergePopulateVPicClass:
+      push eax ; push receiver
+      push ebx ; preserve
+      push ecx ; preserve
+      push esi ; preserve
+
+      ; Stack shape:
+      ;
+      ; +28 last parameter
+      ; +24 RA in code cache (call to helper)
+      ; +20 saved edx
+      ; +16 saved edi
+      ; +12 saved eax (receiver)
+      ; +8 saved ebx
+      ; +4 saved ecx
+      ; +0 saved esi
+      ;
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      mov esi, edx ; esi = EA of VPic data block
+
+      MoveHelper eax, populateVPicSlotClass
+      mov edi, dword  [esp+24] ; edi = RA in mainline (call to helper)
+      mov edx, dword  [edi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      sub eax, edi ; Expected disp32 for call to snippet
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the CMP instruction in ecx:ebx to devirtualize the virtual
+      ; method for this receivers class.
+      ;
+      mov cx, word  [edi+1] ; 2 bytes of jump to next slot
+      rol ecx, 16
+      mov ebx, dword  [esp+12] ; receiver
+      LoadClassPointerFromObjectHeader ebx, ebx, ebx ; receiver class
+      rol ebx, 16
+      mov cx, bx
+      mov bl, 081h ; CMP opcode
+      mov bh, byte  [esi+8] ; ModRM byte in VPic data area
+
+      ; Attempt to patch in the CMP instruction.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [edi-5] ; EA of CMP instruction in mainline
+%else
+      lock cmpxchg8b [edi-5] ; EA of CMP instruction in mainline
+%endif
+
+
+%ifdef ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING
+      jnz short VPicClassSlotUpdateFailed
+
+      ; Register the address of the immediate field in the CMP instruction.
+      ;
+      mov eax, dword  [esp+12] ; grab the receiver before its restored
+      LoadClassPointerFromObjectHeader eax, edx, edx ; receiver class
+
+      lea edi, [edi-3] ; EA of immediate
+      push edi ; p) address to patch
+      push edx ; p) receivers class
+      CallHelper jitCallJitAddPicToPatchOnClassUnload
+VPicClassSlotUpdateFailed:
+%endif
+
+      pop esi ; restore
+      pop ecx ; restore
+      pop ebx ; restore
+      pop eax ; restore receiver
+      pop edi ; restore
+      pop edx ; restore
+      sub dword [esp], 5 ; fix RA to re-run the CMP
+      ret ; branch will mispredict so single-byte RET is ok
+
+populateVPicClassLongBranch:
+      mov edx, dword  [edi+3] ; disp32 for branch to snippet
+      lea edx, [edi+edx-2] ; EA of VPic data block
+                                                               ; -2 = 7 (offset to instr after branch) - 9 (DB,cpIndex,cpAddr)
+      jmp mergePopulateVPicClass
+ret ;populateVPicSlotClass endp
+
+
+; Populate a PIC slot with the devirtualized method from this receivers class.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateVPicSlotCall:  ;proc near
+; int 3
+
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      cmp byte  [edi-13], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or a CMP opcode.
+                                                               ; -13 = -5 (CALL) -3 (NOP) -5 (CMP or JNE)
+      jz populateLastVPicSlot
+      movzx edx, byte  [edi+1] ; JMP displacement to end of VPic
+      lea edx, [edi+edx-6] ; edx = EA of NOP instruction after JNE in last slot
+                                                               ; -6 = +2 (skip JMP disp8) - 5 (call in last slot) - 3 (NOP)
+mergeVPicSlotCall:
+      add edx, dword  [edx-4] ; EA of vtable dispatch snippet
+      lea edx, [edx-9] ; EA of VPic data block
+                                                               ; -9 = (DB,cpIndex,cpAddr)
+      push eax ; push receiver
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+      push edi ; p) jit valid EIP
+      push edx ; p) push the address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveVirtualMethod,eax ; returns compiler vtable index
+
+      mov edx, dword [esp] ; edx = receiver
+
+      ; Stack shape:
+      ;
+      ; +12 last parameter
+      ; +8 RA in code cache (call to helper)
+      ; +4 saved edx
+      ; +0 saved edi
+      ;
+      LoadClassPointerFromObjectHeader edx, edx, edx ; receiver class
+
+      ; Check the RAM method to see if the target is compiled.
+      ;
+      neg eax ; negate to turn it into an interpreter offset
+      mov eax, dword [edx + eax + J9TR_InterpVTableOffset] ; eax = RAM method from interpreter vtable
+      test byte  [eax + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jnz short VPicSlotMethodInterpreted
+
+mergeUpdateVPicSlotCallWithCompiledMethod:
+      mov edx, dword  [eax+J9TR_MethodPCStartOffset] ; edx = compiled method entry point
+
+mergeUpdateVPicSlotCall:
+      pop eax ; restore receiver
+      sub edx, edi ; compute new disp32
+      mov dword  [edi-4], edx ; patch disp32 in call instruction
+      lea edi, [edi-5] ; set up RA to re-run patched call instruction
+      mov dword  [esp+8], edi ; re-run the call instruction
+      pop edi
+      pop edx
+      ret
+
+populateLastVPicSlot:
+      lea edx, [edi-8] ; 8 = 5 (CALL) + 3 (NOP)
+      jmp mergeVPicSlotCall
+
+VPicSlotMethodInterpreted:
+      MoveHelper edx, dispatchInterpretedFromVPicSlot
+      jmp short mergeUpdateVPicSlotCall
+
+ret ;populateVPicSlotCall endp
+
+
+; Dispatch an interpreted devirtualized target. If the target is compiled then patch the PIC slot
+; with the compiled target and dispatch through that. Otherwise, route control through the vtable
+; dispatch path.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+dispatchInterpretedFromVPicSlot:  ;proc near
+; int 3
+
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+
+      cmp byte  [edi-13], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or a CMP opcode.
+                                                               ; -13 = -5 (CALL) -3 (NOP) -5 (CMP or JNE)
+      jz interpretedLastVPicSlot
+      movzx edx, byte  [edi+1] ; JMP displacement to end of VPic
+      lea edx, [edi+edx-6] ; edx = EA of NOP instruction after JNE in last slot
+                                                               ; -6 = +2 (skip JMP disp8) - 5 (call in last slot) - 3 (NOP)
+mergeVPicInterpretedDispatch:
+      add edx, dword  [edx-4] ; edx = EA of vtable dispatch snippet
+      push eax ; push receiver
+      LoadClassPointerFromObjectHeader eax, edi, edi ; receiver class
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+
+      ; If the call through vtable has already been patched then grab the
+      ; compiler vtable offset from the disp32 of that instruction.
+      ;
+      cmp byte  [edx], 0e8h ; still a direct CALL instruction?
+      je vtableCallNotPatched ; yes
+      mov eax, dword [edx+2] ; eax = compiler vtable offset
+
+mergeCheckIfMethodCompiled:
+
+      ; Check the RAM method to see if the target is compiled.
+      ;
+      neg eax ; negate to turn it into an interpreter offset
+      mov eax, dword [edi + eax + J9TR_InterpVTableOffset] ; eax = RAM method from interpreter vtable
+      test byte  [eax + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+
+      mov edi, dword [esp+12] ; restore edi for merge branch
+      jz mergeUpdateVPicSlotCallWithCompiledMethod
+
+      ; Re-route the caller to dispatch through the vtable code in the snippet.
+      ;
+      mov dword  [esp+12], edx ; redirect return to vtable dispatch snippet
+      pop eax ; restore receiver
+      pop edi ; restore
+      pop edx ; restore
+      ret
+
+interpretedLastVPicSlot:
+      lea edx, [edi-8] ; 8 = 5 (CALL) + 3 (NOP)
+      jmp mergeVPicInterpretedDispatch
+
+vtableCallNotPatched:
+      lea edx, [edx-9] ; edx = EA of VPic data
+                                                               ; -9 = (DB + cpAddr,cpIndex)
+      push dword  [esp+12] ; p) jit valid EIP
+      push edx ; p) push the address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveVirtualMethod,eax ; eax = compiler vtable index
+      lea edx, [edx+9] ; restore edx = EA of vtable dispatch
+      jmp short mergeCheckIfMethodCompiled
+
+ret ;dispatchInterpretedFromVPicSlot endp
+
+
+; Patch the code to dispatch through the compiled vtable slot now that the vtable
+; slot is known.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the resolution helper.
+;
+      align 16
+populateVPicVTableDispatch:  ;proc near
+; int 3
+
+      push edx ; preserve
+      push edi ; preserve
+      mov edi, dword  [esp+8] ; RA in code cache
+      lea edx, [edi-14] ; EA of VPic data block
+                                                               ; -14 = -5 (CALL) -9 (DB,cpIndex,cpAddr)
+      push eax ; push receiver
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to helper)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+      push edi ; p) jit valid EIP
+      push edx ; p) push the address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveVirtualMethod,eax ; returns compiler vtable index
+
+      push ebx ; preserve
+      push ecx ; preserve
+      push esi ; preserve
+
+      ; Stack shape:
+      ;
+      ; +28 last parameter
+      ; +24 RA in code cache (call to helper)
+      ; +20 saved edx
+      ; +16 saved edi
+      ; +12 saved eax (receiver)
+      ; +8 saved ebx
+      ; +4 saved ecx
+      ; +0 saved esi
+      ;
+
+      mov ecx, eax ; ecx = compiler vtable index
+
+      ; An atomic CMPXCHG8B is not strictly necessary to patch this instruction.
+      ; However, it simplifies the code to have only a single path through here rather
+      ; than several based on the atomic 64-bit store capabilities on various
+      ; supported processors.
+      ;
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper eax, populateVPicVTableDispatch
+      mov edx, dword  [edi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      mov esi, edx ; copy to preserve 3 bytes
+      sub eax, edi ; Expected disp32 for call to helper
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the byte sequence in ecx:ebx to dispatch through vtable.
+      ;
+      rol ecx, 16
+      mov ebx, ecx
+      and esi, 0ffff0000h ; mask off 2 bytes following CMP instruction
+      and ecx, 0ffffh ; mask off high 2 bytes of vtable disp32
+      or ecx, esi
+
+      and ebx, 0ffff0000h ; mask off low 2 bytes of vtable disp32
+      mov bh, byte  [edi-6] ; ModRM of CMP instruction
+      sub bh, 068h ; convert to ModRM for CALL instruction
+      mov bl, 0ffh ; add CALL opcode
+
+      lea edi, [edi-5]
+
+      ; Attempt to patch the code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [edi] ; EA of vtable dispatch
+%else
+      lock cmpxchg8b [edi] ; EA of vtable dispatch
+%endif
+
+      mov dword  [esp+24], edi ; fix RA to run the vtable call
+      pop esi ; restore
+      pop ecx ; restore
+      pop ebx ; restore
+      pop eax ; restore receiver
+      pop edi ; restore
+      pop edx ; restore
+      ret ; branch will mispredict so single-byte RET is ok
+
+ret ;populateVPicVTableDispatch endp
+
+
+; Resolve and populate a vtable dispatch call at runtime.
+;
+; The invocation of this function is expected to occur in the following context:
+;
+; ...
+; call vtableDispatchSnippet --> call [classPtr + vtable slot]
+; ...
+;
+; vtableDispatchSnippet:
+; push edx
+; call resolveAndPopulateVtableDispatch
+; dd cpAddr
+; dd cpIndex
+; dw CALL opcode + modRM
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the resolution helper.
+;
+      align 16
+
+resolveAndPopulateVTableDispatch:  ;proc near
+; int 3
+
+      ; edx was preserved prior to the call and is available as a scratch register
+      ;
+      pop edx ; edx = RA in snippet = EA of resolution data block
+      push edi ; preserve
+      push eax ; push receiver
+
+      ; Stack shape:
+      ;
+      ; +16 last parameter
+      ; +12 RA in code cache (call to snippet)
+      ; +8 saved edx
+      ; +4 saved edi
+      ; +0 saved eax (receiver)
+      ;
+      push edx ; p) jit valid EIP
+      push edx ; p) push the address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveVirtualMethod,eax ; returns compiler vtable index
+
+      push ebx ; preserve
+      push ecx ; preserve
+      push esi ; preserve
+      push edx ; preserve
+
+      ; Stack shape:
+      ;
+      ; +32 last parameter
+      ; +28 RA in code cache (call to snippet)
+      ; +24 saved edx
+      ; +20 saved edi
+      ; +16 saved eax (receiver)
+      ; +12 saved ebx
+      ; +8 saved ecx
+      ; +4 saved esi
+      ; +0 saved edx
+      ;
+      mov ecx, eax ; ecx = compiler vtable index
+
+      ; An atomic CMPXCHG8B is not strictly necessary to patch this instruction.
+      ; However, it simplifies the code to have only a single path through here rather
+      ; than several based on the atomic 64-bit store capabilities on various
+      ; supported processors.
+      ;
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this snippet + the following 3 bytes.
+      ;
+      lea eax, [edx-6] ; eax = snippet entry point
+                                                               ; -6 = -5 (CALL) -1 (PUSH edx)
+      mov edi, dword  [esp+28] ; edi = RA in mainline
+      mov edx, dword  [edi-1] ; edx = 3 bytes after the call to snippet + high byte of disp32
+      mov esi, edx ; copy to preserve 3 bytes
+      sub eax, edi ; Expected disp32 for call to snippet
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the byte sequence in ecx:ebx to dispatch through vtable.
+      ;
+      rol ecx, 16
+      mov ebx, ecx
+      and esi, 0ffff0000h ; mask off 2 bytes following CALL instruction
+      and ecx, 0ffffh ; mask off high 2 bytes of vtable disp32
+      or ecx, esi
+
+      and ebx, 0ffff0000h ; mask off low 2 bytes of vtable disp32
+      pop esi ; esi = RA in snippet
+      mov bx, word  [esi+8] ; add in CALL + modRM byte
+                                                               ; +8 = 4 (cpAddr) + 4 (cpIndex)
+      lea edi, [edi-5]
+
+      ; Attempt to patch the code. No need to check for failure as we will always
+      ; back up and re-run the instruction in the mainline code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [edi] ; EA of vtable dispatch
+%else
+      lock cmpxchg8b [edi] ; EA of vtable dispatch
+%endif
+
+      mov dword  [esp+24], edi ; fix RA to run the vtable call
+      pop esi ; restore
+      pop ecx ; restore
+      pop ebx ; restore
+      pop eax ; restore receiver
+      pop edi ; restore
+      pop edx ; restore
+      ret ; branch will mispredict so single-byte RET is ok
+
+ret ;resolveAndPopulateVTableDispatch endp
+
+;_TEXT ends
+
+%else
+
+; --------------------------------------------------------------------------------
+;
+;                                    64-BIT
+;
+; --------------------------------------------------------------------------------
+
+%include "jilconsts_nasm.inc"
+%include "x/runtime/X86PicBuilder_nasm.inc"
+
+;OPTION NOSCOPED
+
+;_TEXT segment para 'CODE'
+segment .text
+
+      global resolveIPicClass
+      global populateIPicSlotClass
+      global populateIPicSlotCall
+      global dispatchInterpretedFromIPicSlot
+      global IPicLookupDispatch
+
+      global resolveVPicClass
+      global populateVPicSlotClass
+      global populateVPicSlotCall
+      global dispatchInterpretedFromVPicSlot
+      global populateVPicVTableDispatch
+
+      extern jitResolveInterfaceMethod
+      extern jitLookupInterfaceMethod
+      extern jitResolveVirtualMethod
+      extern jitCallCFunction
+      extern jitCallJitAddPicToPatchOnClassUnload
+      extern jitMethodIsNative
+
+      extern resolveIPicClassHelperIndex
+      extern populateIPicSlotClassHelperIndex
+      extern dispatchInterpretedFromIPicSlotHelperIndex
+      extern resolveVPicClassHelperIndex
+      extern populateVPicSlotClassHelperIndex
+      extern dispatchInterpretedFromVPicSlotHelperIndex
+      extern populateVPicVTableDispatchHelperIndex
+
+      extern mcc_lookupHelperTrampoline_unwrapper
+      extern mcc_reservationInterfaceCache_unwrapper
+      extern mcc_callPointPatching_unwrapper
+
+
+
+; Given a code cache address following a branch to a helper, return the disp32
+; to either the helper itself or its reachable trampoline.
+;
+; p1 [rax] : helper address
+; p2 [rsi] : helper index
+; p3 [rdx] : RA in code cache after branch to helper
+;
+; All registers preserved except rax.
+;
+      align 16
+selectHelperOrTrampolineDisp32:  ;proc
+      push rcx ; preserve
+      push rdx ; preserve
+      push rsi ; preserve
+
+      ; Determine if the call to the helper is within range.
+      ;
+      mov rcx, rax
+      sub rcx, rdx
+      sar rcx, 31
+      jz helperIsReachable
+      cmp rcx, -1
+      jz helperIsReachable
+
+      ; Helper is not in range--find the trampoline for this helper.
+      ;
+      ; Create and populate TLS area for trampoline lookup call.
+      ;
+      ; rsp+32 return value
+      ; rsp+24 padding
+      ; rsp+16 padding
+      ; rsp+8 helper index
+      ; rsp call site
+
+      mov rcx, rdx ; preserve RA in code cache
+      sub rsp, 24 ; 24 = 8 (RV) + 16 (padding)
+      push rsi ; helper index
+      push rdx ; RA after call site
+
+      ; Call MCC service
+      ;
+      ;lea rax, [rel mcc_lookupHelperTrampoline_unwrapper]
+      MoveHelper rax, mcc_lookupHelperTrampoline_unwrapper ; p1) helper address
+      lea rsi, [rsp] ; p2) EA parms in TLS area
+      lea rdx, [rsp+32] ; p3) EA of return value in TLS area
+      call jitCallCFunction
+      add rsp, 32
+      pop rax ; trampoline address from return area
+      mov rdx, rcx ; restore RA in code cache
+
+helperIsReachable:
+      sub rax, rdx ; calculate disp32
+      mov eax, eax ; ensure upper 32-bits are zero
+      pop rsi ; restore
+      pop rdx ; restore
+      pop rcx ; restore
+      ret
+ret ;selectHelperOrTrampolineDisp32 endp
+
+%if 0
+(10) mov rdi, 0x0000ffffffffffff call resolveIPicClass -> populateIPicSlotClass
+(3) cmp rdx, rdi
+(2) jne checkNextSlot
+(5) call devirtualizedTarget call populateIPicSlotCall
+(2) jmp done
+
+(2) .align 8
+
+         .align 8
+checkLastSlot:
+(10) mov rdi, 0x0000ffffffffffff call populateIPicSlotClass
+(3) cmp rdx, rdi
+(6) jne lookupDispatchSnippet
+(5) call devirtualizedTarget call populateIPicSlotCall
+
+      0: ret addr to picbuilder
+      1: arg3
+      2: arg2
+      3: arg1
+      4: arg0
+      5: saved RDI <==== unwindSP points here
+      6: code cache return address
+      7: last arg <==== unwindSP should point here
+%endif
+
+
+; Resolve the interface method and update the IPIC data area with the interface J9Class
+; and the itable index.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the resolution helper.
+;
+         align 16
+resolveIPicClass:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+      mov rdi, qword  [rsp+40] ; RA in code cache
+
+      cmp byte  [rdi+8], 075h ; is it a short branch?
+      jnz resolveIPicClassLongBranch ; no
+      movzx rsi, byte  [rdi+16] ; disp8 to end of IPic
+                                                               ; 16 = 5 + 3 (CMP) + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      lea rdx, [rdi+rsi+8] ; rdx = EA of disp32 of JNE
+                                                               ; 8 = 1 (instr. after JMP) -9 (EA of disp32 of JNE) + 16 (offset to disp8 EA)
+      movsxd rsi, dword  [rdx]
+      lea rdx, [rsi+rdx+14] ; EA of IPic data block
+                                                               ; 14 = +4 (EA after JNE) + 5 (CALL) + 5 (JMP)
+mergeResolveIPicClass:
+
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      mov rsi, rdi ; p2) jit valid EIP
+      mov rax, rdx ; p1) address of the constant pool and cpIndex
+      CallHelperUseReg jitResolveInterfaceMethod,rax ; returns interpreter vtable index
+
+      mfence ; Ensure IPIC data area drains to memory before proceeding.
+
+      ; Construct the call instruction in rax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper rax, populateIPicSlotClass ; p1) rax = helper address
+      LoadHelperIndex esi, populateIPicSlotClassHelperIndex ; p2) rsi = helper index
+      mov rdx, rdi ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      mov rcx, rax
+      shl rcx, 8
+      mov cl, 0e8h
+
+      MoveHelper rax, resolveIPicClass ; p1) rax = helper address
+      LoadHelperIndex esi, resolveIPicClassHelperIndex ; p2) rsi = helper index
+                                                               ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      shl rax, 8
+      mov al, 0e8h
+
+      lock cmpxchg qword  [rdx-5], rcx ; patch attempt
+
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword [rsp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+resolveIPicClassLongBranch:
+      movsxd rdx, dword  [rdi+10] ; disp32 for branch to snippet
+                                                               ; 10 = 5 + 3 (CMP) + 2 (JNE)
+      lea rdx, [rdi+rdx+24] ; EA of IPic data block
+                                                               ; 24 = 14 (offset to instr after branch) + 5 (CALL) + 5 (JMP)
+      jmp mergeResolveIPicClass
+ret ;resolveIPicClass endp
+
+; Look up a resolved interface method and attempt to occupy the PIC slot
+; that routed control to this helper.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateIPicSlotClass:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      cmp byte  [rdx+8], 075h ; is it a short branch?
+      jnz populateIPicClassLongBranch ; no
+      movzx rcx, byte  [rdx+16] ; disp8 to end of IPic
+                                                               ; 16 = 5 + 3 (CMP) + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      lea rsi, [rdx+rcx+8] ; rsi = EA of disp32 of JNE
+                                                               ; 8 = 1 (instr. after JMP) -9 (EA of disp32 of JNE) + 16 (offset to disp8 EA)
+      movsxd rdi, dword  [rsi]
+      lea rcx, [rsi+rdi+14] ; EA of constant pool and cpIndex
+                                                               ; 14 = 4 + 10 (CALL+JMP)
+      lea rsi, [rsi+rdi+30] ; EA of IPic data block
+                                                               ; 30 = 4 + 10 (CALL+JMP) + 16 (cpAddr,cpIndex)
+mergePopulateIPicClass:
+
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      LoadClassPointerFromObjectHeader rax, rax, eax ; p1) receiver class
+                                                               ; p2) rsi = resolved interface class EA
+                                                               ; p3) rdx = jit RIP
+                                                               ; p4) rcx = address of constant pool and cpIndex
+      CallHelperUseReg jitLookupInterfaceMethod,rax ; returns interpreter vtable offset
+
+      mov rdi, rsi ; resolved IClass EA
+
+      ; Lookup succeeded--attempt to grab the PIC slot for this receivers class.
+      ;
+      ; Construct the call instruction in rax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper rax, populateIPicSlotClass ; p1) rax = helper address
+      LoadHelperIndex esi, populateIPicSlotClassHelperIndex ; p2) rsi = helper index
+                                                               ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      shl rax, 8
+      mov al, 0e8h
+
+      ; Construct the MOV instruction in rcx to load the cached class address.
+      ;
+      mov rcx, qword [rsp+24] ; receiver
+      LoadClassPointerFromObjectHeader rcx, rcx, ecx ; receiver class
+      mov rsi, rcx ; receiver class
+      rol rcx, 16
+      mov cx, word [rdi+16] ; REX+MOV
+
+      lock cmpxchg qword  [rdx-5], rcx ; patch attempt
+
+%ifdef ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING
+      jnz short IPicClassSlotUpdateFailed
+
+      ; Register the address of the immediate field in the MOV instruction
+      ; for dynamic class unloading iff the interface class and the
+      ; receiver class have been loaded by different class loaders.
+      ;
+      mov rax, rsi ; receivers class
+      mov rsi, qword  [rsi+J9TR_J9Class_classLoader] ; receivers class loader
+
+      mov rcx, qword  [rdi] ; rcx == IClass from IPic data area
+      cmp rsi, qword  [rcx+J9TR_J9Class_classLoader] ; compare class loaders
+      jz short IPicClassSlotUpdateFailed ; class loaders are the same--do nothing
+
+                                                               ; p1) rax = receivers class
+      lea rsi, [rdx-3] ; p2) rsi = EA of Imm64 to patch
+      CallHelper jitCallJitAddPicToPatchOnClassUnload
+IPicClassSlotUpdateFailed:
+%endif
+
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword [rsp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+populateIPicClassLongBranch:
+      movsxd rsi, dword  [rdx+10] ; disp32 for branch to snippet
+                                                               ; 10 = 5 + 3 (CMP) + 2 (JNE)
+      lea rcx, [rdx+rsi+24] ; EA of constant pool and cpIndex
+                                                               ; 24 = 14 (offset to instr after branch) + 5 (CALL) + 5 (JMP)
+      lea rsi, [rdx+rsi+40] ; EA of IPic data block
+                                                               ; 40 = 14 (offset to instr after branch) + 5 (CALL) + 5 (JMP)
+                                                               ; + 16 (cpAddr,cpIndex)
+      jmp mergePopulateIPicClass
+ret ;populateIPicSlotClass endp
+
+
+; Look up a resolved interface method and update the call to the method
+; that routed control to this helper.
+;
+; STACK SHAPE: must maintain stack shape expected by call to
+; getJitVirtualMethodResolvePushes() across the call to the lookup helper.
+;
+         align 16
+populateIPicSlotCall:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      cmp byte  [rdx-10], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or the REX prefix of a CMP opcode.
+                                                               ; -10 = -5 (CALL) -5 (CMP or JNE)
+      jz populateLastIPicSlot
+      movzx rdi, byte  [rdx+1] ; JMP displacement to end of IPic
+      lea rdi, [rdi+rdx-3] ; rdi = EA after JNE in last slot
+                                                               ; -3 = +2 (skip JMP disp8) - 5 (call in last slot)
+mergeIPicSlotCall:
+      movsxd rsi, dword  [rdi-4]
+
+      lea rcx, [rsi+rdi+10] ; EA of constant pool and cpIndex
+                                                               ; 10 = 10 (CALL+JMP)
+
+      lea rsi, [rsi+rdi+26] ; EA of IPic data block
+                                                               ; 26 = 10 (CALL+JMP) + 16 (cpAddr,cpIndex)
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      LoadClassPointerFromObjectHeader rax, rax, eax ; p1) receiver class
+      mov rdi, rax
+                                                               ; p2) rsi = resolved interface class EA
+                                                               ; p3) rdx = jit RIP
+                                                               ; p4) rcx = address of constant pool and cpIndex
+      CallHelperUseReg jitLookupInterfaceMethod,rax ; returns interpreter vtable offset
+
+      mov rax, qword  [rdi+rax] ; rax = J9Method from interpreter vtable
+      test byte  [rax + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jnz short IPicSlotMethodInterpreted
+
+      ; We have a compiled method. Claim the trampoline reservation for this
+      ; target method if one doesnt exist for it yet reclaim the trampoline
+      ; space if it already does.
+      ;
+mergeUpdateIPicSlotCallWithCompiledMethod:
+      push rax ; build descriptor : J9Method
+      push rdx ; build descriptor : call site
+      MoveHelper rax, mcc_reservationInterfaceCache_unwrapper ; p1) helper
+      lea rsi, [rsp] ; p2) pointer to args
+      lea rdx, [rsp] ; p3) pointer to return
+      call jitCallCFunction
+      pop rdx ; tear down descriptor
+      pop rax ; tear down descriptor
+
+      mov rcx, qword  [rax+J9TR_MethodPCStartOffset] ; compiled method interpreter entry point from J9Method
+      mov edi, dword  [rcx-4] ; fetch preprologue info word
+      shr edi, 16 ; isolate interpreter argument flush area size
+      add rcx, rdi ; rcx = JIT entry point
+
+      ; Check if a branch through a trampoline is currently required at this callsite.
+      ; If not, defer creating one until its actually required at runtime.
+      ;
+      sub rcx, rdx
+      mov rdi, rcx
+      sar rdi, 31
+      jz mergeUpdateIPicSlotCall
+      cmp rdi, -1
+      jnz populateIPicSlotCallWithTrampoline
+
+mergeUpdateIPicSlotCall:
+      mov dword  [rdx-4], ecx ; patch disp32 in call instruction
+
+populateIPicSlotCallExit:
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword [rsp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+IPicSlotMethodInterpreted:
+      MoveHelper rax, dispatchInterpretedFromIPicSlot ; p1) rax = helper address
+      LoadHelperIndex esi, dispatchInterpretedFromIPicSlotHelperIndex ; p2) rsi = helper index
+                                                                ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      mov ecx, eax ; 32-bit copy because disp32
+      jmp short mergeUpdateIPicSlotCall
+
+populateLastIPicSlot:
+      lea rdi, [rdx-5] ; -5 = -5 (CALL)
+      jmp mergeIPicSlotCall
+
+populateIPicSlotCallWithTrampoline:
+      push 0 ; argsPtr[3] : extra arg
+      mov rsi, qword [rax+J9TR_MethodPCStartOffset]
+      push rsi ; argsPtr[2] : compiled method interpreter entry point
+      lea rsi, [rdx-5]
+      push rsi ; argsPtr[1] : call site (EA of CALL instruction)
+      push rax ; argsPtr[0] : J9Method
+
+      MoveHelper rax, mcc_callPointPatching_unwrapper ; p1) rax = helper address
+      lea rsi, [rsp] ; p2) rsi = descriptor EA (args)
+      lea rdx, [rsp] ; p3) rdx = return value (meaningless because call is void)
+      call jitCallCFunction
+      add rsp, 32
+      jmp populateIPicSlotCallExit
+
+ret ;populateIPicSlotCall endp
+
+
+; Call an interpreted method from an IPic slot.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+dispatchInterpretedFromIPicSlot:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      cmp byte  [rdx-10], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or the REX prefix of a CMP opcode.
+                                                               ; -10 = -5 (CALL) -5 (CMP or JNE)
+      jz interpretedLastIPicSlot
+
+      movzx rdi, byte  [rdx+1] ; JMP displacement to end of IPic
+      lea rdi, [rdi+rdx-3] ; rdi = EA after JNE in last slot
+                                                               ; -3 = +2 (skip JMP disp8) - 5 (call in last slot)
+
+mergeIPicInterpretedDispatch:
+      movsxd rsi, dword  [rdi-4]
+
+      lea rcx, [rsi+rdi+10] ; EA of constant pool and cpIndex
+                                                               ; 10 = 10 (CALL+JMP)
+
+      lea rsi, [rsi+rdi+26] ; EA of IPic data block
+                                                               ; 26 = 10 (CALL+JMP) + 16 (cpAddr,cpIndex)
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      LoadClassPointerFromObjectHeader rax, rax, eax ; p1) receiver class
+      mov rdi, rax
+                                                               ; p2) rsi = resolved interface class EA
+                                                               ; p3) rdx = jit RIP
+                                                               ; p4) rcx = address of constant pool and cpIndex
+      CallHelperUseReg jitLookupInterfaceMethod,rax ; returns interpreter vtable offset
+
+      mov r8, rax
+      mov rax, qword  [rdi+rax] ; rax = J9Method from interpreter vtable
+      test byte  [rax + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jz mergeUpdateIPicSlotCallWithCompiledMethod
+
+      ; Target method is still interpreted--dispatch it through JIT vtable.
+      ;
+      jmp mergeIPicLookupDispatch
+
+interpretedLastIPicSlot:
+      lea rdi, [rdx-5] ; -5 = -5 (CALL)
+      jmp mergeIPicInterpretedDispatch
+
+ret ;dispatchInterpretedFromIPicSlot endp
+
+
+; Look up an implemented interface method in this receivers class and
+; dispatch it.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+IPicLookupDispatch:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      lea rcx, [rdx+5] ; EA of constant pool and cpIndex
+                                                               ; 5 = 5 (JMP)
+
+      lea rsi, [rdx+21] ; EA of IPic data block
+                                                               ; 21 = 5 (JMP) + 16 (cpAddr,cpIndex)
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      LoadClassPointerFromObjectHeader rax, rax, eax ; p1) receiver class
+      mov rdi, rax
+                                                               ; p2) rsi = resolved interface class EA
+                                                               ; p3) rdx = jit RIP
+                                                               ; p4) rcx = address of constant pool and cpIndex
+      CallHelperUseReg jitLookupInterfaceMethod,rax ; returns interpreter vtable offset
+      mov r8, rax
+
+mergeIPicLookupDispatch:
+      sub r8, J9TR_InterpVTableOffset
+      neg r8 ; r8 = JIT vtable offset
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      add rsp, 8 ; skip rdi
+
+      ; j2iVirtual expects r8 to contain the JIT vtable offset
+      ;
+      mov rdi, qword [rdi + r8]
+      jmp rdi
+
+ret ;IPicLookupDispatch endp
+
+
+; Resolve the virtual method and throw an exception if the resolution was not successful.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the resolution helper.
+;
+      align 16
+resolveVPicClass:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+      mov rdi, qword  [rsp+40] ; RA in code cache
+
+      cmp byte  [rdi+8], 075h ; is it a short branch?
+      jnz resolveVPicClassLongBranch ; no
+      movzx rsi, byte  [rdi+16] ; disp8 to end of VPic
+                                                               ; 16 = 5 + 3 (CMP) + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      lea rdx, [rdi+rsi+8] ; rdx = EA of disp32 of JNE
+                                                               ; 8 = 1 (instr. after JMP) -9 (EA of disp32 of JNE) + 16 (offset to disp8 EA)
+      movsxd rsi, dword  [rdx]
+      lea rdx, [rsi+rdx-16] ; EA of VPic data block
+                                                               ; -16 = +4 (EA after JNE) -4 (instr data) -16 (cpA,cpI)
+mergeResolveVPicClass:
+
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      mov rax, rdx ; p1) address of the constant pool and cpIndex
+      mov rsi, rdi ; p2) jit valid EIP
+      CallHelperUseReg jitResolveVirtualMethod,rax ; returns compiler vtable index
+
+      ; Construct the call instruction in rax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper rax, populateVPicSlotClass ; p1) rax = helper address
+      LoadHelperIndex esi, populateVPicSlotClassHelperIndex ; p2) rsi = helper index
+      mov rdx, rdi ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      mov rcx, rax
+      shl rcx, 8
+      mov cl, 0e8h
+
+      MoveHelper rax, resolveVPicClass ; p1) rax = helper address
+      LoadHelperIndex esi, resolveVPicClassHelperIndex ; p2) rsi = helper index
+                                                               ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      shl rax, 8
+      mov al, 0e8h
+
+      lock cmpxchg qword  [rdx-5], rcx ; patch attempt
+
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword [rsp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+resolveVPicClassLongBranch:
+      movsxd rdx, dword  [rdi+10] ; disp32 for branch to snippet
+                                                               ; 10 = 5 + 3 (CMP) + 2 (JNE)
+      lea rdx, [rdi+rdx-6] ; EA of VPic data block
+                                                               ; -6 = 14 (offset to instr after branch) -4 (instr data) -16 (cpA,cpI)
+      jmp mergeResolveVPicClass
+
+ret ;resolveVPicClass endp
+
+
+; Populate a PIC slot with the class of the receiver.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateVPicSlotClass:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      cmp byte  [rdx+8], 075h ; is it a short branch?
+      jnz populateVPicClassLongBranch ; no
+      movzx rcx, byte  [rdx+16] ; disp8 to end of VPic
+                                                               ; 16 = 5 + 3 (CMP) + 2 (JNE) + 5 (CALL) + 1 (JMP)
+      lea rsi, [rdx+rcx+8] ; rsi = EA of disp32 of JNE
+                                                               ; 8 = 1 (instr. after JMP) -9 (EA of disp32 of JNE) + 16 (offset to disp8 EA)
+      movsxd rdi, dword  [rsi]
+      lea rsi, [rsi+rdi-16] ; EA of VPic data block
+                                                               ; -16 = 4 (EA after JNE) - 4 (instr data) -16 (cpA+cpI)
+mergePopulateVPicClass:
+
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+      mov rdi, rsi ; EA of VPic data block
+
+      ; Construct the call instruction in rax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper rax, populateVPicSlotClass ; p1) rax = helper address
+      LoadHelperIndex esi, populateVPicSlotClassHelperIndex ; p2) rsi = helper index
+                                                               ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      shl rax, 8
+      mov al, 0e8h
+
+      ; Construct the MOV instruction in rcx to load the cached class address.
+      ;
+      mov rcx, qword [rsp+24] ; receiver
+      LoadClassPointerFromObjectHeader rcx, rcx, ecx ; receiver class
+      mov rsi, rcx ; receiver class
+      rol rcx, 16
+      mov cx, word [rdi+16] ; REX+MOV
+
+      lock cmpxchg qword  [rdx-5], rcx ; patch attempt
+
+%ifdef ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING
+      jnz short VPicClassSlotUpdateFailed
+
+      ; Register the address of the immediate field in the MOV instruction
+      ; for dynamic class unloading.
+      ;
+      mov rax, rsi ; p1) rax = receivers class
+      lea rsi, [rdx-3] ; p2) rsi = EA of Imm64 to patch
+      CallHelper jitCallJitAddPicToPatchOnClassUnload
+VPicClassSlotUpdateFailed:
+%endif
+
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword [rsp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+populateVPicClassLongBranch:
+      movsxd rsi, dword  [rdx+10] ; disp32 for branch to snippet
+                                                               ; 10 = 5 + 3 (CMP) + 2 (JNE)
+      lea rsi, [rdx+rsi-6] ; EA of VPic data block
+                                                               ; -6 = 14 (offset to instr after branch) - 4 (instr data) - 16 (cpA+cpI)
+      jmp mergePopulateVPicClass
+
+ret ;populateVPicSlotClass endp
+
+
+; Populate a PIC slot with the devirtualized method from this receivers class.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateVPicSlotCall:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      cmp byte  [rdx-10], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or the REX prefix of a CMP opcode.
+                                                               ; -10 = -5 (CALL) -5 (CMP or JNE)
+      jz populateLastVPicSlot
+      movzx rdi, byte  [rdx+1] ; JMP displacement to end of VPic
+      lea rdi, [rdi+rdx-3] ; rdi = EA after JNE in last slot
+                                                               ; -3 = +2 (skip JMP disp8) - 5 (call in last slot)
+mergeVPicSlotCall:
+      movsxd rsi, dword  [rdi-4]
+      LoadClassPointerFromObjectHeader rax, rcx, ecx
+      lea rax, [rsi+rdi-20] ; EA of VPic data block
+                                                               ; -20 = -4 (instr data) - 16 (cpAddr+cpIndex)
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+
+      ; Get vtable offset again by resolving.
+      ;
+                                                               ; p1) rax = address of constant pool and cpIndex
+      mov rsi, rdx ; p2) rsi = jit valid EIP
+      CallHelperUseReg jitResolveVirtualMethod,rax ; returns compiler vtable index
+
+      ; Check the RAM method to see if the target is compiled.
+      ;
+      neg rax ; negate to turn it into an interpreter offset
+      mov rax, qword [rcx + rax + J9TR_InterpVTableOffset] ; load RAM method from interpreter vtable
+      test byte  [rax + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jnz short VPicSlotMethodInterpreted
+
+      ; Now check if the target is a native because they need special handling.
+      ;
+      mov rcx, rax ; rcx = RAM method
+      CallHelperUseReg jitMethodIsNative,rax
+      test rax, rax
+      mov rax, rcx ; restore rax
+      jnz short VPicSlotMethodIsNative
+
+      ; We have a compiled method. Claim the trampoline reservation for this
+      ; target method if one doesnt exist for it yet reclaim the trampoline
+      ; space if it already does.
+      ;
+mergeUpdateVPicSlotCallWithCompiledMethod:
+      push rax ; build descriptor : J9Method
+      push rdx ; build descriptor : call site
+      MoveHelper rax, mcc_reservationInterfaceCache_unwrapper ; p1) helper
+      lea rsi, [rsp] ; p2) pointer to args
+      lea rdx, [rsp] ; p3) pointer to return
+      call jitCallCFunction
+      pop rdx ; tear down descriptor
+      pop rax ; tear down descriptor
+
+      mov rcx, qword  [rax+J9TR_MethodPCStartOffset] ; compiled method interpreter entry point from J9Method
+      mov edi, dword  [rcx-4] ; fetch preprologue info word
+      shr edi, 16 ; isolate interpreter argument flush area size
+      add rcx, rdi ; rcx = JIT entry point
+
+      ; Check if a branch through a trampoline is currently required at this callsite.
+      ; If not, defer creating one until its actually required at runtime.
+      ;
+      sub rcx, rdx
+      mov rdi, rcx
+      sar rdi, 31
+      jz mergeUpdateVPicSlotCall
+      cmp rdi, -1
+      jnz populateVPicSlotCallWithTrampoline
+
+mergeUpdateVPicSlotCall:
+      mov dword  [rdx-4], ecx ; patch disp32 in call instruction
+
+populateVPicSlotCallExit:
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword [rsp], 5 ; fix RA to re-run the call
+      ret ; branch will mispredict so single-byte RET is ok
+
+VPicSlotMethodInterpreted:
+      MoveHelper rax, dispatchInterpretedFromVPicSlot ; p1) rax = helper address
+      LoadHelperIndex esi, dispatchInterpretedFromVPicSlotHelperIndex ; p2) rsi = helper index
+                                                                ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      mov ecx, eax ; 32-bit copy because disp32
+      jmp short mergeUpdateVPicSlotCall
+
+VPicSlotMethodIsNative:
+      ; Check if the target is a compiled JNI native.
+      ;
+      test qword  [rax+8], 1 ; check low-bit of constant pool for JNI native
+      jnz mergeUpdateVPicSlotCallWithCompiledMethod
+
+      ; This is a JIT callable native for which trampolines are not created.
+      ; Check if the target is reachable without and if so then branch to
+      ; it directly. Otherwise, the longer dispatch sequence through glue
+      ; code needs to be taken.
+      ;
+      ; TODO: figure out why trampolines are not created. I do not see why they
+      ; shouldnt be...
+      ;
+      mov rcx, qword  [rax+J9TR_MethodPCStartOffset] ; compiled native entry point
+      mov edi, dword  [rcx-4] ; fetch preprologue info word
+      shr edi, 16 ; isolate interpreter argument flush area size
+      add rcx, rdi ; rcx = JIT entry point
+
+      ; Check if a branch through a trampoline is currently required at this callsite.
+      ; If not, defer creating one until its actually required at runtime.
+      ;
+      sub rcx, rdx
+      mov rdi, rcx
+      sar rdi, 31
+      jz mergeUpdateVPicSlotCall
+      cmp rdi, -1
+      jz mergeUpdateVPicSlotCall
+      jmp VPicSlotMethodInterpreted
+
+populateLastVPicSlot:
+      lea rdi, [rdx-5] ; -5 = -5 (CALL)
+      jmp mergeVPicSlotCall
+
+populateVPicSlotCallWithTrampoline:
+      push 0 ; argsPtr[3] : extra arg
+      mov rsi, qword [rax+J9TR_MethodPCStartOffset]
+      push rsi ; argsPtr[2] : compiled method interpreter entry point
+      lea rsi, [rdx-5]
+      push rsi ; argsPtr[1] : call site (EA of CALL instruction)
+      push rax ; argsPtr[0] : J9Method
+
+      MoveHelper rax, mcc_callPointPatching_unwrapper ; p1) rax = helper address
+      lea rsi, [rsp] ; p2) rsi = descriptor EA (args)
+      lea rdx, [rsp] ; p3) rdx = return value (meaningless because call is void)
+      call jitCallCFunction
+      add rsp, 32
+      jmp populateVPicSlotCallExit
+
+ret ;populateVPicSlotCall endp
+
+
+; Dispatch an interpreted devirtualized target. If the target is compiled then patch the PIC slot
+; with the compiled target and dispatch through that. Otherwise, route control through the vtable
+; dispatch path.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+dispatchInterpretedFromVPicSlot:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      cmp byte  [rdx-10], 085h ; is this the last slot?
+                                                               ; The branch in the last slot will be a long branch.
+                                                               ; This byte will either be a long JNE opcode (last
+                                                               ; slot) or the REX prefix of a CMP opcode.
+                                                               ; -10 = -5 (CALL) -5 (CMP or JNE)
+      jz interpretedLastVPicSlot
+      movzx rdi, byte  [rdx+1] ; JMP displacement to end of VPic
+      lea rdi, [rdi+rdx-3] ; rdi = EA after JNE in last slot
+                                                               ; -3 = +2 (skip JMP disp8) - 5 (call in last slot)
+mergeVPicInterpretedDispatch:
+      movsxd rsi, dword  [rdi-4]
+      LoadClassPointerFromObjectHeader rax, rcx, ecx
+      lea rax, [rsi+rdi] ; EA of CALLMem instruction in snippet
+
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+
+      ; If the call through vtable has already been patched then grab the
+      ; compiler vtable offset from the disp32 of that instruction.
+      ;
+      cmp byte  [rax], 0e8h ; still a direct CALL instruction?
+      je vtableCallNotPatched ; yes
+
+      ; If theres a SIB byte then the displacement has been shifted by one byte.
+      ;
+      cmp byte  [rax+2], 094h ; if ModRM==0x94 then a SIB is necessary for r12+disp32 form
+      jne short noSIB
+      lea rax, [rax+1]
+noSIB:
+      movsxd rax, dword  [rax+3]
+
+mergeCheckIfMethodCompiled:
+
+      ; Check the RAM method to see if the target is compiled.
+      ;
+      neg rax ; negate to turn it into an interpreter offset
+      mov rax, qword [rcx + rax + J9TR_InterpVTableOffset] ; load RAM method from interpreter vtable
+      test byte  [rax + J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit ; method compiled?
+      jnz dispatchThroughVTable ; branch if interpreted
+
+      ; The target is JIT callable, but check if the target is a native because
+      ; they may need special handling.
+      ;
+      mov rcx, rax ; rcx = RAM method
+      CallHelperUseReg jitMethodIsNative,rax
+      test rax, rax
+      mov rax, rcx ; restore rax
+      jz mergeUpdateVPicSlotCallWithCompiledMethod ; branch if not native
+
+      ; Check if the target is a compiled JNI native.
+      ;
+      test qword  [rax+8], 1 ; check low-bit of constant pool for JNI native
+      jnz mergeUpdateVPicSlotCallWithCompiledMethod
+
+      ; This is a JIT callable native for which trampolines are not created.
+      ; Check if the target is reachable without and if so then branch to
+      ; it directly. Otherwise, the longer dispatch sequence through glue
+      ; code needs to be taken.
+      ;
+      mov rcx, qword  [rax+J9TR_MethodPCStartOffset] ; compiled native entry point
+      mov esi, dword  [rcx-4] ; fetch preprologue info word
+      shr esi, 16 ; isolate interpreter argument flush area size
+      add rcx, rsi ; rcx = JIT entry point
+
+      ; Check if a branch through a trampoline is currently required at this callsite.
+      ; If not, defer creating one until its actually required at runtime.
+      ;
+      sub rcx, rdx
+      mov rsi, rcx
+      sar rsi, 31
+      jz mergeUpdateVPicSlotCall
+      cmp rsi, -1
+      jz mergeUpdateVPicSlotCall
+
+dispatchThroughVTable:
+
+      ; Re-route the caller to dispatch through the vtable code in the snippet.
+      ;
+      movsxd rsi, dword  [rdi-4]
+      lea rdi, [rsi+rdi] ; EA of vtable dispatch instruction
+
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+
+      mov qword [rsp+8], rdi
+      pop rdi ; restore
+
+      ret ; branch will mispredict so single-byte RET is ok
+
+interpretedLastVPicSlot:
+      lea rdi, [rdx-5] ; -5 = -5 (CALL)
+      jmp mergeVPicInterpretedDispatch
+
+vtableCallNotPatched:
+      ; Get vtable offset again by resolving.
+      ;
+      lea rax, [rax-20] ; p1) rax = address of constant pool and cpIndex
+                                                               ; -20 = -4 (instr data) - 16 (cpAddr,cpIndex)
+      mov rsi, rdx ; p2) rsi = jit valid EIP
+      CallHelperUseReg jitResolveVirtualMethod,rax ; returns compiler vtable index
+      jmp mergeCheckIfMethodCompiled
+
+ret ;dispatchInterpretedFromVPicSlot endp
+
+
+; Patch the code to dispatch through the compiled vtable slot now that the vtable
+; slot is known.
+;
+; STACK SHAPE: must maintain stack shape expected by call to getJitVirtualMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+populateVPicVTableDispatch:  ;proc
+
+%ifdef ENABLE_PIC_INT3
+      int 3
+%endif
+      push rdi ; preserve
+      push rax ; preserve GP arg0 (the receiver)
+      push rsi ; preserve GP arg1
+      push rdx ; preserve GP arg2
+      push rcx ; preserve GP arg3
+
+      mov rdx, qword [rsp+40] ; RA in code cache
+
+      LoadClassPointerFromObjectHeader rax, rcx, ecx
+      lea rax, [rdx-25] ; EA of VPic data block
+                                                               ; -25 = -5 (CALL) -4 (instr data) - 16 (cpAddr,cpIndex)
+      ; Stack shape:
+      ;
+      ; +40 RA in code cache (call to helper)
+      ; +32 saved rdi
+      ; +24 saved rax (receiver)
+      ; +16 saved rsi
+      ; +8 saved rdx
+      ; +0 saved rcx
+      ;
+
+      ; Get vtable offset again by resolving.
+      ;
+      mov rdi, rax
+                                                               ; p1) rax = address of constant pool and cpIndex
+      mov rsi, rdx ; p2) rsi = jit valid EIP
+      CallHelperUseReg jitResolveVirtualMethod,rax ; returns compiler vtable index
+
+      ; Construct the indirect call instruction in rcx plus the first
+      ; byte of the direct long jump.
+      ;
+      mov ecx, eax ; copy and whack the high 32-bits
+      rol rcx, 32
+
+      cmp byte [rdi+19], 094h ; SIB byte needed?
+      je short callNeedsSIB ; yes
+
+      or rcx, 0ff00e9h ; JMP4 + CALLMem opcodes
+      mov ch, byte [rdi+18] ; REX from snippet
+      ror rcx, 24
+      mov cl, byte [rdi+19] ; ModRM from snippet
+      rol rcx, 16
+      mov rdi, 0e9000000000000e8h
+
+mergePopulateVPicVTableDispatch:
+
+      ; Construct the call instruction in rax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      MoveHelper rax, populateVPicVTableDispatch ; p1) rax = helper address
+      LoadHelperIndex esi, populateVPicVTableDispatchHelperIndex ; p2) rsi = helper index
+                                                               ; p3) rdx = JIT RA
+      call selectHelperOrTrampolineDisp32
+      shl rax, 8
+      or rax, rdi ; add JMP and CALL bytes
+
+      lock cmpxchg qword  [rdx-5], rcx ; patch attempt
+
+      pop rcx ; restore
+      pop rdx ; restore
+      pop rsi ; restore
+      pop rax ; restore
+      pop rdi ; restore
+
+      sub qword  [rsp], 5 ; re-run the patched call instruction
+      ret ; branch will mispredict so single-byte RET is ok
+
+callNeedsSIB:
+      or rcx, 02494ff49h ; REX + CALL op + ModRM + SIB for CALL [r12+disp32]
+      mov edi, 0e8h
+      jmp short mergePopulateVPicVTableDispatch
+
+ret ;populateVPicVTableDispatch endp
+
+
+
+;_TEXT ends
+
+;; !TR_HOST_64BIT
+%endif
+
+      ;end

--- a/runtime/compiler/x/runtime/X86PicBuilder_nasm.inc
+++ b/runtime/compiler/x/runtime/X86PicBuilder_nasm.inc
@@ -1,0 +1,103 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+
+; --------------------------------------------------------------------------------
+;                                    COMMON
+; --------------------------------------------------------------------------------
+
+; Binary encoding of the MFENCE instruction.  Not all assemblers can handle the mnemonic.
+;
+%macro tr_mfence 0
+      db          00Fh
+      db          0AEh
+      db          0F0h
+%endmacro
+
+%macro MEMORY_FENCE 0
+      tr_mfence
+%endmacro
+
+eq_WideCPIndexPush                equ 000800000h
+eq_ResolveWithoutPatchingMainline equ 000400000h
+eq_ResolveWithoutPatchingSnippet  equ 000200000h
+eq_ResolveStatic                  equ 020000000h
+eq_Patch8ByteResolution           equ 040000000h
+eq_CPIndexMask                    equ 00001ffffh
+eq_VolatilityCheck                equ 000080000h
+eq_UpperLongCheck                 equ 000020000h
+eq_LowerLongCheck                 equ 000040000h
+eq_MemFenceRAOffset32             equ 09ch
+eq_MemFenceCallLength32           equ 005h
+eq_MemFenceLCXHG                  equ 0ff0h
+eq_HighWordOfLongPair             equ 040000000h
+eq_ExtremeStaticMemBarPos         equ 080000000h
+eq_LORBinaryWord                  equ 083f0h
+eq_IsFloatOp                      equ 000040000h
+eq_CompressedPointer              equ 040000000h
+eq_isOwningObjectNeeded           equ 000040000h
+eq_ObjectClassMask                equ -256 ;hack!! this is supposed to be read from jilconsts.inc: J9TR_RequiredClassAlignment
+
+; --------------------------------------------------------------------------------
+;                                    32-BIT
+; --------------------------------------------------------------------------------
+
+%ifndef TR_HOST_64BIT
+
+J9PreservedFPRStackSize    equ   80
+
+%macro LoadClassPointerFromObjectHeader 3 ;ObjectReg, ClassPtrReg64, ClassPtrReg32
+        mov     %3, dword [%1+J9TR_J9Object_class]
+        and     %3, eq_ObjectClassMask
+%endmacro
+
+%else
+
+; --------------------------------------------------------------------------------
+;                                    64-BIT
+; --------------------------------------------------------------------------------
+
+
+
+
+%macro LoadHelperIndex 2 ; targetReg,helperIndexSym
+%ifdef WINDOWS
+        mov     %1, dword [%2] ;&targetReg, dword ptr[&helperIndexSym]
+%else
+        mov     %1, dword [rel %2] ;&targetReg, dword ptr[rip+&helperIndexSym]
+%endif
+%endmacro
+
+
+; Reads the class pointer from an object (the first 4 or 8 bytes)
+; ObjectReg and ClassPtrReg may be the same register
+; ClassPtrReg32 must be the lower part of ClassPtrReg64
+;
+%macro LoadClassPointerFromObjectHeader 3 ;ObjectReg, ClassPtrReg64, ClassPtrReg32
+%ifdef ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER
+        mov     %3, dword [%1+J9TR_J9Object_class] ;&ClassPtrReg32, dword ptr[&ObjectReg+J9TR_J9Object_class]  ; read only 32 bits and zero extend
+        and     %3, eq_ObjectClassMask ;&ClassPtrReg32, eq_ObjectClassMask
+%else
+        mov     %2, qword [%1 + J9TR_J9Object_class] ;&ClassPtrReg64, qword ptr[&ObjectReg+J9TR_J9Object_class]
+        and     %3, eq_ObjectClassMask ;&ClassPtrReg64, eq_ObjectClassMask
+%endif
+%endmacro
+
+%endif

--- a/runtime/compiler/x/runtime/X86Unresolveds.pnasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.pnasm
@@ -1,0 +1,2067 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https:
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https:
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%include "x/runtime/X86PicBuilder_nasm.inc"
+
+#include "j9cfg.h"
+
+%ifndef TR_HOST_64BIT
+
+; --------------------------------------------------------------------------------
+;
+; 32-BIT
+;
+; --------------------------------------------------------------------------------
+
+      CPU P2 ; 686 = P2 = PPRO
+      CPU P4 ; P4 = WILLAMETTE
+
+      eq_offsetof_J9Object_clazz equ 8 ; offset of class pointer in a J9Object
+
+      %include "jilconsts_nasm.inc"
+
+      segment .text
+
+      global interpreterUnresolvedStaticGlue
+      global interpreterUnresolvedSpecialGlue
+      global updateInterpreterDispatchGlueSite
+      global interpreterVoidStaticGlue
+      global interpreterSyncVoidStaticGlue
+      global interpreterEAXStaticGlue
+      global interpreterSyncEAXStaticGlue
+      global interpreterEDXEAXStaticGlue
+      global interpreterSyncEDXEAXStaticGlue
+      global interpreterST0FStaticGlue
+      global interpreterSyncST0FStaticGlue
+      global interpreterST0DStaticGlue
+      global interpreterSyncST0DStaticGlue
+
+      global interpreterUnresolvedStringGlue
+      global interpreterUnresolvedMethodTypeGlue
+      global interpreterUnresolvedMethodHandleGlue
+      global interpreterUnresolvedCallSiteTableEntryGlue
+      global interpreterUnresolvedMethodTypeTableEntryGlue
+      global interpreterUnresolvedClassGlue
+      global interpreterUnresolvedClassFromStaticFieldGlue
+      global interpreterUnresolvedStaticFieldGlue
+      global interpreterUnresolvedStaticFieldSetterGlue
+      global interpreterUnresolvedFieldGlue
+      global interpreterUnresolvedFieldSetterGlue
+
+      global MTUnresolvedInt32Load
+      global MTUnresolvedInt64Load
+      global MTUnresolvedFloatLoad
+      global MTUnresolvedDoubleLoad
+      global MTUnresolvedAddressLoad
+
+      global MTUnresolvedInt32Store
+      global MTUnresolvedInt64Store
+      global MTUnresolvedFloatStore
+      global MTUnresolvedDoubleStore
+      global MTUnresolvedAddressStore
+
+      extern jitResolveStaticMethod
+      extern jitResolveSpecialMethod
+      extern jitCallCFunction
+      extern jitResolveString
+      extern jitResolveMethodType
+      extern jitResolveMethodHandle
+      extern jitResolveInvokeDynamic
+      extern jitResolveHandleMethod
+      extern jitResolveClass
+      extern jitResolveClassFromStaticField
+      extern jitResolveStaticField
+      extern jitResolveStaticFieldSetter
+      extern jitResolveField
+      extern jitResolveFieldSetter
+      ;1179
+      extern jitResolvedFieldIsVolatile
+
+      extern icallVMprJavaSendStatic0
+      extern icallVMprJavaSendStatic1
+      extern icallVMprJavaSendStaticJ
+      extern icallVMprJavaSendStaticF
+      extern icallVMprJavaSendStaticD
+      extern icallVMprJavaSendStaticSync0
+      extern icallVMprJavaSendStaticSync1
+      extern icallVMprJavaSendStaticSyncJ
+      extern icallVMprJavaSendStaticSyncF
+      extern icallVMprJavaSendStaticSyncD
+      extern interpretedDispatchGlueDisp32_unwrapper
+
+%ifdef WINDOWS
+      extern j9thread_self
+      extern j9thread_tls_get
+      extern vmThreadTLSKey:dword
+%endif
+
+      extern memoryFence
+
+
+%macro CheckIfMethodCompiledAndPatch 1 ;macro helperName
+      test byte [edi+J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit
+      jnz %1
+      jmp mergedStaticGlueCallFixer2
+%endmacro
+
+; mergedStaticGlueCallFixer
+;
+; This function is a back-patching routine for interpreter calls to static
+; methods that have recently been compiled. It patches the call site (in the
+; code cache) of an interpreter call snippet, so that future executions will
+; invoke the compiled method instead.
+;
+; NOTES:
+;
+; [1] The RAM method is in EDI on entry. It was loaded by the preceding instruction.
+;
+; [2] This function must appear here so as to require a non-short jump on NTO
+;
+  align 16
+mergedStaticGlueCallFixer2: ;proc near
+      mov edi, dword  [edi+J9TR_MethodPCStartOffset]
+      mov edx, dword  [esp]
+      sub edi, edx
+      mov dword  [edx-4], edi
+      add edi, edx
+      jmp edi
+retn ;mergedStaticGlueCallFixer2 endp
+
+
+
+; interpreterUnresolved{Static|Special}Glue
+;
+; Resolve a static or special method. The call instruction routing control here is
+; updated to load the RAM method into EDI.
+;
+; The unresolved {Static|Special} interpreted dispatch snippet look like:
+; align 8
+; (5) call interpreterUnresolved{Static|Special}Glue ; replaced with "mov edi, 0xaabbccdd"
+; (3) NOP
+; ---
+; (5) call updateInterpreterDispatchGlueSite ; replaced with "JMP disp32"
+; (2) dw 2-byte glue method helper index
+; (4) dd cpAddr
+; (4) dd cpIndex
+;
+; NOTES:
+;
+; [1] A POP is not strictly necessary to shapen the stack. The RA could be left on the
+; stack and the new stack shape updated in getJitStaticMethodResolvePushes(). It
+; was left this way because we have to dork with the RA anyways to get back from
+; this function which will already cause a return mispredict. Leaving it as is
+; changes less code.
+;
+; [2] STACK SHAPE: must maintain stack shape expected by call to getJitStaticMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+interpreterUnresolvedStaticGlue: ;proc near
+      pop edi ; RA in snippet (see [1] above)
+
+      push dword  [edi+14] ; p3) cpIndex
+                                                               ; 14 = 3 (NOP) + 5 (CALL) + 2 (DW) + 4 (cpAddr)
+      push dword  [edi+10] ; p2) cpAddr
+                                                               ; 10 = 3 (NOP) + 5 (CALL) + 2 (DW)
+      push dword  [esp+8] ; p1) RA in mainline code
+      CallHelperUseReg jitResolveStaticMethod,eax
+
+      ; The interpreter may low-tag the result to avoid populating the constant pool--whack it.
+      ;
+      and eax, -2
+
+      push ebx ; preserve
+      push ecx ; preserve
+
+      ; Patch the call that brought us here into a load of the resolved RAM method into EDI.
+      ;
+      mov ebx, eax
+      MoveHelper eax, interpreterUnresolvedStaticGlue
+
+mergeInterpreterUnresolvedDispatch:
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      mov edx, dword  [edi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      mov ecx, edx
+      sub eax, edi ; Expected disp32 for call to helper
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the byte sequence in ecx:ebx to load the RAM method into edi
+      ;
+      rol ebx, 8
+      mov cl, bl
+      mov bl, 0bfh
+
+      lea edi, [edi-5]
+
+      ; Attempt to patch the code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [edi]
+%else
+      lock cmpxchg8b [edi]
+%endif
+
+      pop ecx ; restore
+      pop ebx ; restore
+
+      ; Adjust the return address to re-run the patched instruction.
+      ; The RET will mispredict anyway so we can get away with pushing
+      ; the adjusted RA back on the stack.
+      ;
+      push edi
+      ret
+
+;interpreterUnresolvedStaticGlue endp
+
+
+      align 16
+interpreterUnresolvedSpecialGlue: ;proc near
+      pop edi ; RA in snippet (see [1] above)
+
+      push dword  [edi+14] ; p3) cpIndex
+                                                               ; 14 = 3 (NOP) + 5 (CALL) + 2 (DW) + 4 (cpAddr)
+      push dword  [edi+10] ; p2) cpAddr
+                                                               ; 10 = 3 (NOP) + 5 (CALL) + 2 (DW)
+      push dword  [esp+8] ; p1) RA in mainline code
+      CallHelperUseReg jitResolveSpecialMethod,eax
+
+      push ebx ; preserve
+      push ecx ; preserve
+
+      mov ebx, eax
+      MoveHelper eax, interpreterUnresolvedSpecialGlue
+
+      jmp mergeInterpreterUnresolvedDispatch
+
+retn ;interpreterUnresolvedSpecialGlue endp
+
+
+; updateInterpreterDispatchGlueSite
+;
+; Now that a resolved RAM method is available, determine the appropriate interpreter
+; dispatch glue code to call and then patch the snippet to jump to it directly.
+;
+; NOTES:
+;
+; [1] The RAM method is in EDI on entry. It was loaded by the preceding instruction.
+;
+      align 16
+updateInterpreterDispatchGlueSite: ;proc near
+
+      mov edx, dword [esp] ; edx = snippet RA
+
+      sub esp, 4 ; descriptor+8 : return value
+      push edx ; descriptor+4 : snippet RA
+      push edi ; descriptor+0 : RAM method
+      lea edx, [esp+8]
+      push edx ; p3) EA of return value in TLS area
+      lea edx, [esp+4]
+      push edx ; p2) EA parms in TLS area
+      MoveHelper edx, interpretedDispatchGlueDisp32_unwrapper
+      push edx ; p1) helper address
+      call jitCallCFunction
+      add esp, 8 ; tear down descriptor
+      pop eax ; eax = return value (disp32 to dispatch glue)
+
+      ; Patch the call that brought us here into a JMP to the dispatch glue code.
+      ;
+      push ebx ; preserve
+      push ecx ; preserve
+      push esi ; preserve
+
+      ; Stack shape:
+      ;
+      ; esp+16 : main line code RA
+      ; esp+12 : snippet RA
+      ; esp+8 : ebx
+      ; esp+4 : ecx
+      ; esp+0 : esi
+      ;
+      mov ebx, eax
+      MoveHelper eax, updateInterpreterDispatchGlueSite
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this helper + the following 3 bytes.
+      ;
+      mov esi, dword  [esp+12] ; snippet RA
+
+      mov edx, dword  [esi-1] ; edx = 3 bytes after the call to helper + high byte of disp32
+      mov ecx, edx
+      sub eax, esi ; Expected disp32 for call to helper
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      ; Construct the byte sequence in ecx:ebx to jump to the dispatch glue.
+      ;
+      rol ebx, 8
+      mov cl, bl
+      mov bl, 0e9h
+
+      lea esi, [esi-5]
+
+      ; Attempt to patch the code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [esi]
+%else
+      lock cmpxchg8b [esi]
+%endif
+
+      mov dword  [esp+12], esi ; update return address to re-run
+
+      pop esi ; restore
+      pop ecx ; restore
+      pop ebx ; restore
+      ret
+
+;updateInterpreterDispatchGlueSite endp
+
+         align 16
+;1179
+checkReferenceVolatility: ;proc near
+
+      ; preserve register states
+      ;
+      push ebp
+      push ebx ; Low dword of patch instruction in snippet
+      push ecx ; High dword of patch instruction in snippet
+      push eax ; The call instruction (edx:eax) that should have brought
+      push edx ; us to this snippet + the following 3 bytes.
+      push esi ; The RA in mainline code
+
+      ; jitResolvedFieldIsVolatile requires us to restore ebp before calling it
+      ;
+      mov ebp, dword  [esp + 28] ; [esp + 4 + 24]
+
+      ; determine if the field is volatile.
+      ;
+      mov ecx, dword  [esp + 152] ; load the cpIndex [esp + 124 + 24 + 4]
+      mov ebx, ecx
+      mov edx, ecx
+      and ebx, eq_ResolveStatic ; get the static flag bit
+      and ecx, eq_CPIndexMask
+
+      ; push the parameters for the volatile check
+      ;
+      push ebx ; push isStatic
+      push ecx ; push cpIndex
+      push dword  [esp + eq_MemFenceRAOffset32] ; push cpAddr
+
+      ; call the volatile check
+      ;
+      xor eax, eax
+      CallHelperUseReg jitResolvedFieldIsVolatile, eax
+
+      ;clear ebp which will be used as to tell if we need to patch over a barrier in the mainline code.
+      ;
+      xor ebp, ebp
+
+      ; if this field is not volatile, patch the mfence with a nop
+      ;
+      test eax, eax
+      jnz patchMainlineInstructionFromCache
+
+      ; check to see if we are patching the lower or upper half of a long store.
+      ;
+      test edx, eq_UpperLongCheck
+      jnz patchUpperLong
+
+      test edx, eq_LowerLongCheck
+      jnz patchLowerLong
+
+      ; check to see if we are patching the lock cmpxchng8b of a long store.
+      ;
+      mov esi, dword  [esp + 144] ; find the instruction in the snippet cache.
+      mov dx, word  [esi + 1]
+      cmp dx, eq_MemFenceLCXHG ; check if the opcode is for a lock cmpxchng
+      je patchCmpxchgForLongStore ; lock cmpxchng should appear ONLY for a long store
+
+
+      ; we need to patch an mfence in the mainline code, set the flag
+      ;
+      or ebp, 001h
+
+      jmp patchMainlineInstructionFromCache
+
+patchBarrierWithNop:
+
+      mov esi, dword  [esp + eq_MemFenceRAOffset32] ; esp + 128 = RA of mainline code (mfence instruction or nop)
+
+      ; patch the mfence following a non-long store.
+      ; get the instruction descriptor and find the length of the store instruction
+      ;
+      mov edx, dword  [esp + 144] ; get instruction descriptor address [esp + 116 + 24 + 4]
+      mov bl, byte  [edx] ; get instruction length from instruciton descriptor
+      and ebx, 0f0h ; mask size of instruction
+      shr ebx, 4 ; shift size to last nibble of byte
+      lea ebx, dword  [ebx - eq_MemFenceCallLength32] ; get the delta between the RA in the mainline code and
+                                                                ; the end of the store instruction
+      lea esi, dword  [esi + ebx] ; find the end of the store instruction
+
+      ; determine what kind of fence we are dealing with: mfence or LOCK OR [ESP] (on legacy systems)
+      ;
+      mov edx, dword  [esp + 28]
+      mov edx, J9TR_VMThread_javaVM[edx]
+      mov edx, J9TR_JavaVMJitConfig[edx]
+      mov edx, J9TR_JitConfig_runtimeFlags[edx]
+      test edx, J9TR_runtimeFlags_PatchingFenceType
+      jz short doLOCKORESP
+
+      ; 3 byte memory fence
+      ;
+      lea esi, dword  [esi + 3] ; find the 4 byte aligned address
+      and esi, 0fffffffch ; should now have a 4 byte aligned instruction of the memfence
+
+      ;make sure we are patching over an mfence (avoids potential race condition with lock cmpxchg patching)
+      ;
+      cmp word  [esi], 0ae0fh
+      jne restoreRegs;
+
+      mov ecx, 001f0f00h ; load the 3 byte nop instruction plus padding
+      mov cl, byte  [esi + 3] ; get the byte following the memory fence
+      ror ecx, 8 ; realign and copied byte
+      mov dword  [esi], ecx ; write the nop
+      jmp restoreRegs
+
+      ; 5 byte lock or esp
+      ;
+doLOCKORESP:
+
+      ; ecx:ebx nop instruction
+      ; edx:eax original instruction
+      ;
+      mov esi, dword  [esp + eq_MemFenceRAOffset32] ; esp + 128 = RA of mainline code (mfence instruction or nop)
+      lea esi, dword  [esi + ebx] ; find the end of the store instruction
+      lea esi, dword  [esi + 7] ; find the 8 byte aligned address of the lock or [esp]
+      and esi, 0fffffff8h
+      mov eax, dword  [esi] ; construct the edx:eax pair (original instruction)
+      mov edx, dword  [esi + 4]
+      mov ebx, 00441f0fh ; construct the ecx:ebx pair (nop and trailing bytes)
+      mov ecx, edx
+      mov cl, 00h
+
+%ifdef WINDOWS ; write the nop
+      lock cmpxchg8b qword  [esi]
+%else
+      lock cmpxchg8b [esi]
+%endif
+      jmp restoreRegs
+
+
+
+      ; Loading a long in 32 bit is done with a lock cmpxchng by default.
+      ; We need to swtitch the op bits of the instructions that performs loads for the lock cmpxchng setup
+      ; to stores. We also need to patch over the lock cmpxchg with nops.
+      ;
+patchLowerLong:
+
+      mov esi, dword  [esp + 144]
+      mov ebx, dword  [esi + 1]
+      and ebx, 0fffffffdh ; change the mov reg mem opcode (8b) into a mov mem reg opcode (89)
+      or ebx, 000001800h ; change EAX to EBX
+      mov ecx, dword  [esp + 12]
+      jmp patchMainlineInstruction
+
+
+patchUpperLong:
+
+      mov esi, dword  [esp + 144]
+      mov ebx, dword  [esi + 1]
+      and ebx, 0ffffeffdh ; change the mov reg mem opcode (8b) into a mov mem reg opcode (89)
+      or ebx, 000000800h ; change EDX to ECX
+      mov ecx, dword  [esp + 12]
+      jmp patchMainlineInstruction
+
+
+patchCmpxchgForLongStore:
+
+      mov ebx, 090666666h ; setup the ecx:ebx pair (nop instruction)
+      mov ecx, 090666666h
+      jmp patchMainlineInstruction
+
+
+patchMainlineInstructionFromCache:
+
+      mov ecx, dword  [esp + 12] ; Load low dword of patch instruction in snippet BEFORE volatile resolution
+      mov ebx, dword  [esp + 16] ; Load high dword of patch instruction in snippet BEFORE volatile resoluion
+
+
+patchMainlineInstruction:
+
+
+      mov esi, dword  [esp] ; Restor RA in mainline code.
+      mov edx, dword  [esp + 4] ; Restore the call instruction (edx:eax) that should have brought
+      mov eax, dword  [esp + 8] ; us to this snippet + the following 3 bytes.
+
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [esi - 5]
+%else
+      lock cmpxchg8b [esi - 5]
+%endif
+
+      test ebp, ebp
+      jnz patchBarrierWithNop
+
+restoreRegs:
+
+      pop esi
+      pop edx
+      pop eax
+      pop ecx
+      pop ebx
+      pop ebp
+      ret
+
+;checkReferenceVolatility endp
+;1179
+
+         align 16
+interpreterVoidStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStatic0
+retn ;interpreterVoidStaticGlue endp
+
+         align 16
+interpreterSyncVoidStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSync0
+retn ; interpreterSyncVoidStaticGlue endp
+
+         align 16
+interpreterEAXStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStatic1
+retn ;interpreterEAXStaticGlue endp
+
+         align 16
+interpreterSyncEAXStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSync1
+retn ;interpreterSyncEAXStaticGlue endp
+
+         align 16
+interpreterEDXEAXStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticJ
+retn ;interpreterEDXEAXStaticGlue endp
+
+         align 16
+interpreterSyncEDXEAXStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSyncJ
+retn ;interpreterSyncEDXEAXStaticGlue endp
+
+         align 16
+interpreterST0FStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticF
+retn ;interpreterST0FStaticGlue endp
+
+         align 16
+interpreterSyncST0FStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSyncF
+retn ;interpreterSyncST0FStaticGlue endp
+
+         align 16
+interpreterST0DStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticD
+retn ;interpreterST0DStaticGlue endp
+
+         align 16
+interpreterSyncST0DStaticGlue: ;proc near
+         CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSyncD
+retn ;interpreterSyncST0DStaticGlue endp
+
+
+; --------------------------------------------------------------------------------
+;
+; 32-BIT DATA RESOLUTION
+;
+; --------------------------------------------------------------------------------
+
+
+%macro DataResolvePrologue
+      ;local doneFPRpreservation, preserveX87loop
+
+      pushfd ; save flags , addr=esp+28
+      push ebp ; save register, addr=esp+24
+      push esi ; save register, addr=esp+20
+      push edi ; save register, addr=esp+16
+      push edx ; save register, addr=esp+12
+      push ecx ; save register, addr=esp+8
+      push ebx ; save register, addr=esp+4
+      push eax ; save register, addr=esp+0
+
+%ifdef WINDOWS
+      ; Restore the VMThread into ebp
+      ;
+      call j9thread_self
+      push [vmThreadTLSKey]
+      push eax
+      call j9thread_tls_get
+      add esp, 8
+      mov ebp, dword  [eax+8] ; get J9JavaVM from OMR_VMThread in tls
+%endif
+
+      mov esi, dword  [esp+32] ; esi = return address in snippet
+      mov eax, dword  [esp+36] ; eax = cpAddr
+      mov ecx, dword  [esp+40] ; ecx = cpIndex
+      mov edx, ecx ; edx = cpIndex
+
+      sub esp, J9PreservedFPRStackSize ; reserve stack space for all possible FPRs
+      shr edx, 24
+      and edx, 01fh ; isolate number of live FPRs across this resolution
+      jz short .doneFPRpreservation ; none, so were done
+
+      test edx, 010h ; test SSE bit
+      jz short .preserveX87loop
+      movq qword  [esp], xmm0
+      movq qword  [esp+8], xmm1
+      movq qword  [esp+16], xmm2
+      movq qword  [esp+24], xmm3
+      movq qword  [esp+32], xmm4
+      movq qword  [esp+40], xmm5
+      movq qword  [esp+48], xmm6
+      movq qword  [esp+56], xmm7
+      jmp short .doneFPRpreservation
+
+.preserveX87loop:
+      dec edx
+      lea edi, [edx+edx*4]
+      fstp tword  [esp+edi*2] ; store and pop from the FP stack
+      jnz short .preserveX87loop
+.doneFPRpreservation:
+
+%endmacro
+
+
+%macro DispatchUnresolvedDataHelper 1 ; MACRO helper
+      and ecx, 1ffffh ; isolate the cpIndex
+      push dword  [esp+124] ; p) RA in mainline code
+      push ecx ; p) cpIndex
+      push eax ; p) cpAddr
+      CallHelperUseReg %1,eax ;helper
+%endmacro
+
+
+%macro FPRDataResolveEpilogue 3 ;MACRO cpScratchReg, scratchReg, scratchReg2
+      ;local restoreX87stack, restoreX87loop, doneFPRrestoration
+
+      movzx %1, byte [esp+123] ; &cpScratchReg ; load number of FPRs live across this resolution
+      and %1, 01fh ; isolate number of live FPRs across this resolution
+      test %1, %1
+      jz short .doneFPRrestoration ; none, so leave
+
+      test %1, 010h ; test SSE bit
+      jz short .restoreX87stack
+      movq xmm0, qword  [esp]
+      movq xmm1, qword  [esp +8]
+      movq xmm2, qword  [esp +16]
+      movq xmm3, qword  [esp +24]
+      movq xmm4, qword  [esp +32]
+      movq xmm5, qword  [esp +40]
+      movq xmm6, qword  [esp +48]
+      movq xmm7, qword  [esp +56]
+      jmp short .doneFPRrestoration
+
+.restoreX87stack:
+      lea %2, [%1 + %1 * 4] ;&scratchReg, [&cpScratchReg+&cpScratchReg*4]
+      lea %3, [esp + %2*2 - 10] ;&scratchReg2, [esp+&scratchReg*2-10] ; first FPR preserved
+      neg %1 ;&cpScratchReg
+.restoreX87loop:
+      inc %1 ;&cpScratchReg
+      lea %2, [%1 + %1 * 4] ;&scratchReg, [&cpScratchReg+&cpScratchReg*4]
+      fld tword [%3 + %2 * 2] ;tbyte [&scratchReg2+&scratchReg*2] ; restore FP stack register
+      jnz short .restoreX87loop
+.doneFPRrestoration:
+      add esp, J9PreservedFPRStackSize
+%endmacro
+
+
+
+; interpreterUnresolved{*}Glue
+;
+; Generic code to perform runtime resolution of a data reference. These functions
+; are called from a snippet that has the following general shape:
+;
+; push cpIndex
+; push cpAddr
+; call interpreterUnresolved{*}Glue
+; db high nibble (L) : length of instruction in snippet (must be 1-15)
+; low nibble (O) : offset to disp32 in patched instruction (must be 1-4)
+; dq 8 bytes of instruction to patch (includes bytes from following instruction if necessary)
+; db N remaining N bytes of instruction for static resolves
+; db 0xc3 RET instruction for unpatched static resolves
+; db if static and L<8 then this is the byte over which the RET instruction
+; is written.
+;
+; Spare bits in the cpIndex passed in are used to specify behaviour based on the
+; kind of resolution. The anatomy of a cpIndex:
+;
+; byte 3 byte 2 byte 1 byte 0
+;
+; 3 222 2 222 1 1 0 0 0
+; 10987654 32109876 54321098 76543210
+; |||||__| ||| ||||_________________|
+; |||| | ||| ||| |
+; |||| | ||| ||| +---------------- cpIndex (0-16)
+; |||| | ||| ||+-------------------------- upper long dword resolution (17)
+; |||| | ||| |+--------------------------- lower long dword resolution (18)
+; |||| | ||| +---------------------------- check volatility (19)
+; |||| | ||+------------------------------ resolve, but do not patch snippet template (21)
+; |||| | |+------------------------------- resolve, but do not patch mainline code (22)
+; |||| | +-------------------------------- long push instruction (23)
+; |||| +------------------------------------ number of live X87 registers across this resolution (24-27)
+; |||+-------------------------------------- has live XMM registers (28)
+; ||+--------------------------------------- static resolution (29)
+; |+---------------------------------------- 64-bit: resolved value is 8 bytes (30)
+; | 32-bit: resolved value is high word of long pair (30)
+; +----------------------------------------- 64 bit: extreme static memory barrier position (31)
+;
+; NOTES:
+;
+; [1] STACK SHAPE: must maintain stack shape expected by call to getJitDataResolvePushes()
+; across the resolution helper.
+;
+; [2] On 32-bit we will never patch more than 8 bytes in the mainline code. Hence, the
+; resolved data must always reside within the first 8 bytes of the instruction and we
+; only need to write the first 8 bytes cached in the snippet back over the mainline
+; code.
+;
+      align 16
+interpreterUnresolvedStringGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveString
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedStringGlue endp
+
+
+      align 16
+interpreterUnresolvedMethodTypeGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveMethodType
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedMethodTypeGlue endp
+
+
+      align 16
+interpreterUnresolvedMethodHandleGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveMethodHandle
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedMethodHandleGlue endp
+
+
+      align 16
+interpreterUnresolvedCallSiteTableEntryGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveInvokeDynamic
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedCallSiteTableEntryGlue endp
+
+
+      align 16
+interpreterUnresolvedMethodTypeTableEntryGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveHandleMethod
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedMethodTypeTableEntryGlue endp
+
+
+      align 16
+interpreterUnresolvedClassGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveClass
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedClassGlue endp
+
+
+      align 16
+interpreterUnresolvedClassFromStaticFieldGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveClassFromStaticField
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedClassFromStaticFieldGlue endp
+
+
+      align 16
+interpreterUnresolvedStaticFieldGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveStaticField
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedStaticFieldGlue endp
+
+
+      align 16
+interpreterUnresolvedStaticFieldSetterGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveStaticFieldSetter
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedStaticFieldSetterGlue endp
+
+      align 16
+interpreterUnresolvedFieldGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveField
+; int 3
+      jmp commonUnresolvedCode
+retn ;interpreterUnresolvedFieldGlue endp
+
+
+      align 16
+interpreterUnresolvedFieldSetterGlue: ;proc near
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveFieldSetter
+; int 3
+
+commonUnresolvedCode:
+
+      ; STACK SHAPE:
+      ;
+      ; esp+128 : RA in mainline code
+      ; esp+124 : cp index
+      ; esp+120 : cp address
+      ; esp+116 : RA in snippet
+      ; -------
+      ; esp+112 : eflags
+      ; esp+108 : ebp
+      ; esp+104 : esi
+      ; esp+100 : edi
+      ; esp+96 : edx
+      ; esp+92 : ecx
+      ; esp+88 : ebx
+      ; esp+84 : eax
+      ;
+      ; |
+      ; +-------+--------+
+      ; | |
+      ;
+      ; ----- XMM ---- ---- X87 ----
+      ; esp+60 : xmm7 esp+74 : ST0
+      ; esp+52 : xmm6 esp+64 : ST1
+      ; esp+44 : xmm5 esp+54 : ST2
+      ; esp+36 : xmm4 esp+44 : ST3
+      ; esp+28 : xmm3 esp+34 : ST4
+      ; esp+20 : xmm2 esp+24 : ST5
+      ; esp+12 : xmm1 esp+14 : ST6
+      ; esp+4 : xmm0 esp+4 : ST7
+      ;
+      ; | |
+      ; +-------+--------+
+      ; |
+      ;
+      ; esp+0 : vmThread address
+
+      push ebp ; keep the address of the vmThread at the top of the stack
+      mov ecx, dword  [esp+124] ; ecx = full cpIndex dword
+
+      ; Check for the special case of a data resolution without code patching.
+      ; This happens when you have an explicit NULLCHK guarding a data resolution and
+      ; we need to ensure the exceptions are thrown in the correct order if they occur.
+      ; In this case any resolution exceptions are required to be thrown before any NPEs.
+      ;
+      test ecx, eq_ResolveWithoutPatchingMainline
+      jnz doneDataResolution
+
+      ; Check if the snippet instruction must be patched. This is not necessary, for
+      ; example, for unresolved strings because the snippet instruction is already
+      ; correct since it contains the address of the constant pool entry from which
+      ; the java/lang/Strings address can now be loaded.
+      ;
+      test ecx, eq_ResolveWithoutPatchingSnippet
+      jnz disp32AlreadyPatched
+
+      mov edx, dword  [esp+116] ; edx = EA of header byte in snippet
+
+      ; Patch the cached instruction bytes in the snippet. The disp32 field must lie within
+      ; the first 8 bytes of the instruction. Valid default values for the disp32 field
+      ; are 0, 4, or an address.
+      ;
+      ; Multiple threads can be executing this code, but all threads must be patching the
+      ; same value.
+      ;
+      movzx edx, byte  [edx] ; header byte
+      and edx, 0fh ; isolate disp32 offset in first nibble
+      mov edi, eax ; edi = resolve result
+      and edi, 0fffffffeh ; whack any low tagging of resolve result
+      test ecx, eq_HighWordOfLongPair ; is this the high word of a long pair?
+      jz short patchDisp32
+      add edi, 4 ; yes, offset address by 4 bytes
+
+patchDisp32:
+      mov dword  [esi+edx+1], edi ; patch the disp32 field in the snippet
+      call memoryFence ; make sure all stores crossing a line are issued
+
+disp32AlreadyPatched:
+
+      ; For static resolves if the address from the resolution helper is low tagged then
+      ; this means that class initialization has not completed yet and we should not
+      ; be patching the mainline code (in case the remaining initialization were to fail).
+      ;
+      ; We could probably get away with just testing whether the resolve result was low-tagged
+      ; in order to do this.
+      ;
+      mov ebp, dword  [esp+116] ; ebp = EA of header byte in snippet
+      test ecx, eq_ResolveStatic ; static resolve?
+      jz short patchMainlineCode
+      test eax, 1 ; low-tagged resolution result (clinit not finished)?
+      jnz executeSnippetCode
+
+patchMainlineCode:
+
+      ; Construct the call instruction in edx:eax that should have brought
+      ; us to this snippet + the following 3 bytes.
+      ;
+      lea eax, [ebp-12] ; assume short cpIndex push
+      test ecx, eq_WideCPIndexPush
+      jz short shortCPIndexPush
+      lea eax, [eax-3] ; account for wide cpIndex push
+
+shortCPIndexPush:
+      mov esi, dword  [esp+128] ; edx = RA in mainline
+      mov edx, dword  [esi-1] ; edx = 3 bytes after the call to snippet + high byte of disp32
+      sub eax, esi ; calculate disp32
+      rol eax, 8
+      mov dl, al ; Copy high byte of calculated disp32 to expected word
+      mov al, 0e8h ; add CALL opcode
+
+      test ecx, eq_ResolveStatic ; static resolve?
+      jnz patchUnresolvedStatic
+
+loadTargetInstruction:
+
+      ; Load the patched data reference instruction in ecx:ebx.
+      ;
+      mov ebx, dword  [ebp+1] ; low dword of patch instruction in snippet
+      mov ecx, dword  [ebp+5] ; high dword of patch instruction in snippet
+
+mergePatchUnresolvedDataReference:
+
+; determine if nop patching might be necessary
+; if a volatile check is necessary, code patching will occur within the check.
+;
+      test dword  [esp+124], eq_VolatilityCheck ; get the cpIndex
+      jz short noVolatileCheck
+
+      call checkReferenceVolatility
+      jmp doneDataResolution
+
+noVolatileCheck:
+
+      ; Attempt to patch the code.
+      ;
+%ifdef WINDOWS
+      lock cmpxchg8b qword  [esi-5]
+%else
+      lock cmpxchg8b [esi-5]
+%endif
+
+doneDataResolution:
+
+      pop eax ; remove the vmThread address from the top of the stack
+      FPRDataResolveEpilogue ecx, edi, edx
+
+      pop eax ; restore
+      pop ebx ; restore
+      pop ecx ; restore
+      pop edx ; restore
+      pop edi ; restore
+      pop esi ; restore
+      pop ebp ; restore
+      add dword  [esp+16], -5 ; re-run patched instruction
+      popfd ; restore
+      lea esp, [esp+12] ; skip over cpAddr, cpIndex, RA in snippet
+      ret
+
+doneDataResolutionAndNoRerun:
+      pop eax ; remove the vmThread address from the top of the stack
+      FPRDataResolveEpilogue ecx, edi, edx
+
+      pop eax ; restore
+      pop ebx ; restore
+      pop ecx ; restore
+      pop edx ; restore
+      pop edi ; restore
+      pop esi ; restore
+      pop ebp ; restore
+      popfd ; restore
+      lea esp, [esp+12] ; skip over cpAddr, cpIndex, RA in snippet
+      ret
+
+patchUnresolvedStatic:
+
+      ; For unresolved statics the RET instruction may need to be overwritten
+      ; if the static instruction length < 8.
+      ;
+      movzx ecx, byte  [ebp] ; header byte
+      cmp ecx, 080h ; length < 8?
+      jge loadTargetInstruction
+
+      ; The RET instruction must be inserted at least 4 bytes past the start
+      ; of the unresolved static instruction. This is guaranteed because the
+      ; unresolved static will have a disp32 field. Since this is true, then
+      ; only the instruction data in ECX needs to be patched.
+      ;
+      and ecx, 030h ; isolate dword offset
+      shr ecx, 1 ; number of bits to rotate by
+
+      mov ebx, dword  [ebp+5] ; high dword of patch instruction in snippet
+      ror ebx, cl
+      mov bl, byte  [ebp+9] ; replace RET instruction by cached original value
+      rol ebx, cl
+
+      mov ecx, dword  [ebp+1] ; low dword of patch instruction in snippet
+      xchg ebx, ecx
+      jmp mergePatchUnresolvedDataReference
+
+executeSnippetCode:
+      ; Execute the patched instruction in the snippet. The instruction is followed
+      ; by a 1-byte RET to route control to after the data reference instruction in the
+      ; mainline code.
+      ;
+      pop eax ; remove the vmThread address from the top of the stack
+      FPRDataResolveEpilogue ecx, edi, edx
+
+      movzx ecx, byte  [ebp] ; header byte in snippet
+      and ecx, 0f0h ; mask off static instruction length
+      shr ecx, 4
+      sub ecx, 5 ; account for length of CALL instruction
+      add dword  [esp+44], ecx ; adjust RA in mainline code to point to the
+                                                               ; instruction following the patched instruction
+
+      pop eax ; restore
+      pop ebx ; restore
+      pop ecx ; restore
+      pop edx ; restore
+      pop edi ; restore
+      pop esi ; restore
+      pop ebp ; restore
+      add dword  [esp+4], 1 ; adjust RA in snippet to patched instruction in snippet
+      popfd ; restore
+      ret 8 ; execute patched instruction in snippet
+
+retn ;interpreterUnresolvedFieldSetterGlue endp
+
+
+
+MTUnresolvedInt32Load: ;proc near
+retn ;MTUnresolvedInt32Load endp
+
+MTUnresolvedInt64Load: ;proc near
+retn ;MTUnresolvedInt64Load endp
+
+MTUnresolvedFloatLoad: ;proc near
+retn ;MTUnresolvedFloatLoad endp
+
+MTUnresolvedDoubleLoad: ;proc near
+retn ;MTUnresolvedDoubleLoad endp
+
+MTUnresolvedAddressLoad: ;proc near
+retn ;MTUnresolvedAddressLoad endp
+
+MTUnresolvedInt32Store: ;proc near
+retn ;MTUnresolvedInt32Store endp
+
+MTUnresolvedInt64Store: ;proc near
+retn ;MTUnresolvedInt64Store endp
+
+MTUnresolvedFloatStore: ;proc near
+retn ;MTUnresolvedFloatStore endp
+
+MTUnresolvedDoubleStore: ;proc near
+retn ;MTUnresolvedDoubleStore endp
+
+MTUnresolvedAddressStore: ;proc near
+retn ;MTUnresolvedAddressStore endp
+
+;_TEXT ends
+
+%else
+
+; --------------------------------------------------------------------------------
+;
+; 64-BIT
+;
+; --------------------------------------------------------------------------------
+
+
+
+
+#ifdef J9VM_INTERP_COMPRESSED_OBJECT_HEADER
+eq_offsetof_J9Object_clazz equ   8     ; offset of class pointer in a J9Object
+#else
+eq_offsetof_J9Object_clazz equ   16     ; offset of class pointer in a J9Object
+#endif
+
+%include "jilconsts_nasm.inc"
+
+segment .text
+
+      global interpreterUnresolvedStaticGlue
+      global interpreterUnresolvedSpecialGlue
+      global updateInterpreterDispatchGlueSite
+      global interpreterVoidStaticGlue
+      global interpreterEAXStaticGlue
+      global interpreterRAXStaticGlue
+      global interpreterXMM0FStaticGlue
+      global interpreterXMM0DStaticGlue
+      global interpreterSyncVoidStaticGlue
+      global interpreterSyncEAXStaticGlue
+      global interpreterSyncRAXStaticGlue
+      global interpreterSyncXMM0FStaticGlue
+      global interpreterSyncXMM0DStaticGlue
+
+      global interpreterUnresolvedStringGlue
+      global interpreterUnresolvedMethodTypeGlue
+      global interpreterUnresolvedMethodHandleGlue
+      global interpreterUnresolvedCallSiteTableEntryGlue
+      global interpreterUnresolvedMethodTypeTableEntryGlue
+      global interpreterUnresolvedClassGlue
+      global interpreterUnresolvedClassFromStaticFieldGlue
+      global interpreterUnresolvedStaticFieldGlue
+      global interpreterUnresolvedStaticFieldSetterGlue
+      global interpreterUnresolvedFieldGlue
+      global interpreterUnresolvedFieldSetterGlue
+
+      global MTUnresolvedInt32Load
+      global MTUnresolvedInt64Load
+      global MTUnresolvedFloatLoad
+      global MTUnresolvedDoubleLoad
+      global MTUnresolvedAddressLoad
+
+      global MTUnresolvedInt32Store
+      global MTUnresolvedInt64Store
+      global MTUnresolvedFloatStore
+      global MTUnresolvedDoubleStore
+      global MTUnresolvedAddressStore
+
+      extern jitResolveStaticMethod
+      extern jitResolveSpecialMethod
+      extern jitCallCFunction
+      extern jitResolveString
+      extern jitResolveMethodType
+      extern jitResolveMethodHandle
+      extern jitResolveInvokeDynamic
+      extern jitResolveHandleMethod
+      extern jitResolveClass
+      extern jitResolveClassFromStaticField
+      extern jitResolveStaticField
+      extern jitResolveStaticFieldSetter
+      extern jitResolveField
+      extern jitResolveFieldSetter
+      ;1179
+      extern jitResolvedFieldIsVolatile
+
+      extern icallVMprJavaSendStatic0
+      extern icallVMprJavaSendStatic1
+      extern icallVMprJavaSendStaticJ
+      extern icallVMprJavaSendStaticF
+      extern icallVMprJavaSendStaticD
+      extern icallVMprJavaSendStaticSync0
+      extern icallVMprJavaSendStaticSync1
+      extern icallVMprJavaSendStaticSyncJ
+      extern icallVMprJavaSendStaticSyncF
+      extern icallVMprJavaSendStaticSyncD
+
+      extern adjustTrampolineInterpretedDispatchGlueDisp32_unwrapper
+      extern mcc_callPointPatching_unwrapper
+
+
+%macro CheckIfMethodCompiledAndPatch 1 ; helperName
+      test byte [rdi+J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit
+      jnz %1
+      jmp mergedStaticGlueCallFixer2
+%endmacro
+
+
+; interpreterUnresolved{Static|Special}Glue
+;
+; Resolve a static or special method. The call instruction routing control here is
+; updated to load the RAM method into RDI.
+;
+; The unresolved {Static|Special} interpreted dispatch snippet look like:
+; align 8
+; (10) call interpreterUnresolved{Static|Special}Glue ; replaced with "mov rdi, 0x0000aabbccddeeff"
+; (5) call updateInterpreterDispatchGlueSite ; replaced with "JMP disp32"
+; (2) dw 2-byte glue method helper index
+; (8) dq cpAddr
+; (4) dd cpIndex
+;
+; NOTES:
+;
+; [1] This runtime code uses the JIT linkage registers as volatile registers and hence
+; does not preserve them. This is because the eventual dispatch path will be through
+; the interpreter which reads the parameters from the stack. The backspilling has
+; already occured at this point.
+;
+; [2] A POP is not strictly necessary to shapen the stack. The RA could be left on the
+; stack and the new stack shape updated in getJitStaticMethodResolvePushes(). It
+; was left this way because we have to dork with the RA anyways to get back from
+; this function which will already cause a return mispredict. Leaving it as is
+; changes less code.
+;
+; [3] STACK SHAPE: must maintain stack shape expected by call to getJitStaticMethodResolvePushes()
+; across the call to the lookup helper.
+;
+      align 16
+interpreterUnresolvedStaticGlue: ;proc
+      pop rdi ; RA in snippet (see [2] above)
+
+      ; Attempt to resolve static method.
+      ;
+      mov rax, qword [rsp] ; p1) rax = RA in mainline code
+      mov rsi, qword [rdi+12] ; p2) rsi = cpAddr
+                                                               ; 12 = 5 + 5 (call update) + 2 (DW)
+      mov edx, dword [rdi+20] ; p3) rdx = cpIndex
+                                                               ; 20 = 5 + 5 (call update) + 2 (DW) + 8 (cpAddr)
+      CallHelperUseReg jitResolveStaticMethod,rax
+
+      ; The interpreter may low-tag the result to avoid populating the constant pool--whack it.
+      ;
+      and rax, -2
+
+mergeInterpreterUnresolvedDispatch:
+
+      ; Patch the call that brought us here into a load of the resolved RAM method into RDI.
+      ;
+      lea rdi, [rdi-5] ; Adjust the return address to re-run the patched
+      push rdi ; instruction. The RET will mispredict anyway so we
+                                                               ; can get away with pushing the adjusted RA back on
+                                                               ; the stack.
+      rol rax, 16
+      mov ax, 0bf48h ; REX+MOV bytes
+
+      mov qword [rdi], rax
+      ret
+
+ret ;interpreterUnresolvedStaticGlue endp
+
+
+      align 16
+interpreterUnresolvedSpecialGlue: ;proc
+      pop rdi ; RA in snippet
+
+      ; Attempt to resolve special method.
+      ;
+      mov rax, qword [rsp] ; p1) rax = RA in mainline code
+      mov rsi, qword [rdi+12] ; p2) rsi = cpAddr
+                                                               ; 12 = 5 + 5 (call update) + 2 (DW)
+      mov edx, dword [rdi+20] ; p3) rdx = cpIndex
+                                                               ; 20 = 5 + 5 (call update) + 2 (DW) + 8 (cpAddr)
+      CallHelperUseReg jitResolveSpecialMethod,rax
+      jmp mergeInterpreterUnresolvedDispatch
+
+ret ;interpreterUnresolvedSpecialGlue endp
+
+
+; updateInterpreterDispatchGlueSite
+;
+; Now that a resolved RAM method is available, determine the appropriate interpreter
+; dispatch glue code to call and then patch the snippet to jump to it directly (or
+; to its trampoline).
+;
+; NOTES:
+;
+; [1] The RAM method is in RDI on entry. It was loaded by the preceding instruction.
+;
+; [2] This runtime code uses the JIT linkage registers as volatile registers and hence
+; does not preserve them. This is because the eventual dispatch path will be through
+; the interpreter which reads the parameters from the stack. The backspilling has
+; already occured at this point.
+;
+      align 16
+updateInterpreterDispatchGlueSite: ;proc
+      mov rcx, qword [rsp] ; rcx = snippet RA
+
+      sub rsp, 8 ; descriptor+32: return value
+      push rcx ; descriptor+24: snippet RA
+      mov edx, dword  [rcx+10] ; 10 = 2 (DW index) + 8 (cpAddr)
+      push rdx ; descriptor+16: cpIndex
+      mov rdx, qword  [rcx+2] ; 2 = (DW index)
+      push rdx ; descriptor+8: cpAddr
+      push rdi ; descriptor+0: RAM method
+      MoveHelper rax, adjustTrampolineInterpretedDispatchGlueDisp32_unwrapper ; p1) helper address
+      lea rsi, [rsp] ; p2) EA parms in TLS area
+      lea rdx, [rsp+32] ; p3) EA of return value in TLS area
+      call jitCallCFunction
+      add rsp, 32 ; tear down descriptor
+      pop rax ; rax = return value (disp32)
+
+      ; Patch the call instruction with a direct jump to the glue code.
+      ; An atomic CMPXCHG is not required to patch this in because all threads
+      ; should be patching the same value and should either see a call to this
+      ; PicBuilder function or a jump to the interpreter dispatch glue.
+      ;
+      lea rcx, [rcx-5]
+
+      mov eax, eax ; whack any upper bit sign extension
+      shl rax, 8
+      mov al, 0e9h ; add JMP opcode
+
+      mov rdx, qword [rcx] ; load up existing 8-bytes
+      shr rdx, 40
+      shl rdx, 40 ; isolate upper 24-bits
+      or rdx, rax ; merge instructions
+
+      mov qword [rcx], rdx ; patch the call instruction
+
+      MEMORY_FENCE
+
+      sub qword [rsp], 5 ; re-run the calling instruction
+      ret
+
+ret ;updateInterpreterDispatchGlueSite endp
+
+
+; mergedStaticGlueCallFixer
+;
+; This function is a back-patching routine for interpreter calls to static
+; methods that have recently been compiled. It patches the call site (in the
+; code cache) of an interpreter call snippet, so that future executions will
+; invoke the compiled method instead.
+;
+; NOTES:
+;
+; [1] The RAM method is in RDI on entry. It was loaded by the preceding instruction.
+;
+; [2] This runtime code uses the JIT linkage registers as volatile registers and hence
+; does not preserve them. This is because the eventual dispatch path will be through
+; the interpreter which reads the parameters from the stack. The backspilling has
+; already occured at this point.
+;
+      align 16
+mergedStaticGlueCallFixer2: ;proc
+      mov rcx, qword [rdi + J9TR_MethodPCStartOffset] ; rcx = interpreter entry point of the compiled method
+      mov rsi, qword [rsp] ; rsi = RA in mainline code
+      sub rsi, 5
+      push 0 ; descriptor+24: 0
+      push rcx ; descriptor+16: compiled method PC
+      push rsi ; descriptor+8: call site
+      push rdi ; descriptor+0: RAM method
+      MoveHelper rax, mcc_callPointPatching_unwrapper ; p1) rax = helper
+      lea rsi, [rsp] ; p2) rsi = EA of descriptor
+      lea rdx, [rsp] ; p3) rdx = EA of return value
+      call jitCallCFunction
+      add rsp, 32 ; tear down descriptor
+      jmp rcx ; Dispatch compiled method through the interpreted entry
+                                                               ; point. This is because the linkage registers may not be
+                                                               ; set up any longer.
+ret ;mergedStaticGlueCallFixer2 endp
+
+
+; interpreter[Sync]{Void,EAX,RAX,XMM0F,XMM0D}StaticGlue
+;
+; This function checks if the given RAM method in rdi has already been
+; compiled, and if it has not, jumps to the VM helper that interprets
+; methods of the matching return type. If the given method has
+; already been compiled, this function jumps to mergedStaticGlueCallFixer,
+; which patches the call site so that future invocations will call the
+; compiled method directly.
+;
+      align 16
+interpreterVoidStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStatic0
+ret ;interpreterVoidStaticGlue endp
+
+      align 16
+interpreterSyncVoidStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSync0
+ret ;interpreterSyncVoidStaticGlue endp
+
+      align 16
+interpreterEAXStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStatic1
+ret ;interpreterEAXStaticGlue endp
+
+      align 16
+interpreterSyncEAXStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSync1
+ret ;interpreterSyncEAXStaticGlue endp
+
+      align 16
+interpreterRAXStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticJ
+ret ;interpreterRAXStaticGlue endp
+
+      align 16
+interpreterSyncRAXStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSyncJ
+ret ;interpreterSyncRAXStaticGlue endp
+
+      align 16
+interpreterXMM0FStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticF
+ret ;interpreterXMM0FStaticGlue endp
+
+      align 16
+interpreterSyncXMM0FStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSyncF
+ret ;interpreterSyncXMM0FStaticGlue endp
+
+      align 16
+interpreterXMM0DStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticD
+ret ;interpreterXMM0DStaticGlue endp
+
+      align 16
+interpreterSyncXMM0DStaticGlue: ;proc
+      CheckIfMethodCompiledAndPatch icallVMprJavaSendStaticSyncD
+ret ;interpreterSyncXMM0DStaticGlue endp
+
+
+; --------------------------------------------------------------------------------
+;
+; 64-BIT DATA RESOLUTION
+;
+; --------------------------------------------------------------------------------
+
+%macro DataResolvePrologue 0
+      pushfq ; rsp+256 = flags
+      push r15 ; rsp+248
+      push r14 ; rsp+240
+      push r13 ; rsp+232
+      push r12 ; rsp+224
+      push r11 ; rsp+216
+      push r10 ; rsp+208
+      push r9 ; rsp+200
+      push r8 ; rsp+192
+      push rsp ; rsp+184 -- Ugh
+      push rbp ; rsp+176
+      push rsi ; rsp+168
+      push rdi ; rsp+160
+      push rdx ; rsp+152
+      push rcx ; rsp+144
+      push rbx ; rsp+136
+      push rax ; rsp+128
+      sub rsp, 128
+      movsd qword  [rsp+0], xmm0
+      movsd qword  [rsp+8], xmm1
+      movsd qword  [rsp+16], xmm2
+      movsd qword  [rsp+24], xmm3
+      movsd qword  [rsp+32], xmm4
+      movsd qword  [rsp+40], xmm5
+      movsd qword  [rsp+48], xmm6
+      movsd qword  [rsp+56], xmm7
+      movsd qword  [rsp+64], xmm8
+      movsd qword  [rsp+72], xmm9
+      movsd qword  [rsp+80], xmm10
+      movsd qword  [rsp+88], xmm11
+      movsd qword  [rsp+96], xmm12
+      movsd qword  [rsp+104], xmm13
+      movsd qword  [rsp+112], xmm14
+      movsd qword  [rsp+120], xmm15
+%endmacro
+
+
+%macro DispatchUnresolvedDataHelper 1; helper
+      mov rdi, qword [rsp+264] ; RA in snippet (see stack shape below)
+      mov rax, qword [rdi] ; p1) rax = cpAddr
+      mov esi, dword [rdi+8] ; p2) rsi = cpIndex
+      and esi, 1ffffh ; isolate the cpIndex
+      mov rdx, qword [rsp+272] ; p3) rdx = RA in mainline code
+                                                               ; (see stack shape below)
+      CallHelperUseReg %1, rax ;&helper,rax
+%endmacro
+
+
+%macro DataResolveEpilogue 0
+      movsd xmm0, qword  [rsp+0]
+      movsd xmm1, qword  [rsp+8]
+      movsd xmm2, qword  [rsp+16]
+      movsd xmm3, qword  [rsp+24]
+      movsd xmm4, qword  [rsp+32]
+      movsd xmm5, qword  [rsp+40]
+      movsd xmm6, qword  [rsp+48]
+      movsd xmm7, qword  [rsp+56]
+      movsd xmm8, qword  [rsp+64]
+      movsd xmm9, qword  [rsp+72]
+      movsd xmm10, qword  [rsp+80]
+      movsd xmm11, qword  [rsp+88]
+      movsd xmm12, qword  [rsp+96]
+      movsd xmm13, qword  [rsp+104]
+      movsd xmm14, qword  [rsp+112]
+      movsd xmm15, qword  [rsp+120]
+      add rsp, 128
+      pop rax
+      pop rbx
+      pop rcx
+      pop rdx
+      pop rdi
+      pop rsi
+
+      ; Do not pop the old RSP value as the stack may have moved during the
+      ; resolution. RBP is already restored by the VM.
+      ;
+      add rsp, 16
+
+      pop r8
+      pop r9
+      pop r10
+      pop r11
+      pop r12
+      pop r13
+      pop r14
+      pop r15
+%endmacro
+
+
+         align 16
+;1179
+checkReferenceVolatility: ; proc
+
+      ; preserve register states
+      ;
+      push rbp
+      push rax
+      push rcx
+      push rdx
+      push rsi
+      push rbx
+      push r9
+
+      ; jitResolvedFieldIsVolatile requires us to restore ebp before calling it
+      ;
+      mov rbp, qword  [rsp + 240] ; [rsp + 176 + 8 + 56]
+                                                                ; [rsp + rbp stack slot + proc RA + local reg preservation]
+
+      ; determine if the field is volatile.
+      ;
+      mov rbx, qword  [rsp + 328] ; load the snippet RA [rsp + 264 + 8 + 56]
+      mov edx, dword  [rbx + 8] ; load the cpIndex [snippet RA + size of cpAddr]
+      mov esi, edx
+      and edx, eq_ResolveStatic ; get the static flag bit
+      and esi, eq_CPIndexMask ; mask with the CPIndexMask
+      mov rax, qword  [rbx] ; load the cpAddr [snippet RA]
+
+      ; call the volatile check
+      ;
+      CallHelperUseReg jitResolvedFieldIsVolatile,rax
+
+      ; if this field is not volatile, patch the barrier with a nop
+      ;
+      test eax, eax
+      jnz restoreRegs
+
+
+      ; determine what kind of fence we are dealing with: LOCK OR [ESP] (or mfence using appropriate command line option)
+      ;
+      mov rsi, [J9TR_VMThread_javaVM + rbp] ;[rbp]
+      mov rsi, [J9TR_JavaVMJitConfig + rsi] ;[rsi]
+      mov rsi, [J9TR_JitConfig_runtimeFlags + rsi] ;[rsi]
+
+      ; get the RA in the mainline code
+      ;
+      mov r9, qword  [rsp + 336]
+
+      ; determine if we are looking at a store to a static field
+      ;
+      cmp edx, eq_ResolveStatic
+      je patchStatic
+
+      ; get the instruction descriptor and find the length of the patched instruction
+      ;
+
+      mov bl, byte  [rbx + 12] ; get the first byte of the instruction descriptor (+ 8 (length of cpAddr) + 4 (length of cpIndex))
+      and rbx, 0f0h ; find the length of the instruction stored in the upper nibble
+      shr rbx, 4
+      lea rbx,   [rbx - 5]
+      lea rax,   [r9 + rbx]
+
+      ; select the patching path based on the type of barrier being used
+      ;
+
+      test esi, J9TR_runtimeFlags_PatchingFenceType
+      jnz short patchOverMfence
+      jmp patchOverLockOrESP
+
+patchStatic:
+
+
+      ; select the patching path based on the type of barrier being used
+      ;
+      sub r9, 5
+      test esi, J9TR_runtimeFlags_PatchingFenceType
+      jz short patchOverLockOrESPStatic
+
+
+patchOverMfenceStatic:
+     ; find the address of the LOR instruction. It is either 16 or 24 bytes from the start of the resolved instruction.
+     ;
+
+     test edx, eq_ExtremeStaticMemBarPos
+     jnz barrierAt20Offset
+
+     lea rax, [r9 + 16]
+     jmp patchWith3ByteNOP
+
+barrierAt20Offset:
+
+     lea rax, [r9 + 20]
+     jmp patchWith3ByteNOP
+
+patchOverMfence:
+
+      ; patch over 3 byte mfence
+      ;
+      lea rax, [rax + 3]
+      mov rcx, 0fffffffffffffffch
+      and rax, rcx ; should now have the 4 byte aligned instruction of the memfence
+
+patchWith3ByteNOP:
+
+      mov ecx, dword  [rax] ; load existing double word containg mfence
+      and ecx, 0ff000000h ; insert trailing byte of 3 word nop
+      or ecx, 000001f0fh ; load the the first 2 bytes of the 3 word nop
+      mov dword  [rax], ecx ; write the nop
+
+      pop r9
+      pop rbx
+      pop rsi
+      pop rdx
+      pop rcx
+      pop rax
+      pop rbp
+
+      ret
+
+patchOverLockOrESPStatic:
+
+     ; find the address of the LOR instruction. It is either 16 or 24 bytes from the start of the resolved instruction.
+     ;
+     mov edx, dword  [rbx + 8] ; get unchanged CPindex
+
+     test edx, eq_ExtremeStaticMemBarPos
+     jnz barrierAt24Offset
+
+     lea rax, [r9 + 16]
+     jmp patchWith5ByteNOP
+
+barrierAt24Offset:
+
+     lea rax, [r9 + 24]
+     jmp patchWith5ByteNOP
+
+
+patchOverLockOrESP:
+
+      mov rbx, qword  [rsp + 328] ; load the cpIndex [rsp + 272 + 8 + 56 + 8]
+      mov edx, dword  [rbx + 8] ; get unchanged CPindex
+
+      ; patch over 5 byte lock or esp
+      ;
+      lea rax, [rax + 7]
+
+      ; if this is a float, we need to add an extra 8 bytes to account for the LEA.
+      ;
+      test edx, eq_IsFloatOp
+      jz findOffset
+
+      lea rax, [rax + 8]
+
+findOffset:
+
+      mov rcx, 0fffffffffffffff8h ; find the 8 byte aligned LOR instruction
+      and rax, rcx
+
+patchWith5ByteNOP:
+      ;cmp word ptr[rax], eq_LORBinaryWord ; make sure we are pathcing over a lock or [esp] ;TEMP
+      ;je restoreRegs
+
+      mov ecx, dword  [rax + 4] ; load the existing dword with the last byte of the lock and the following 3 bytes
+      and ecx, 0ffffff00h ; insert the last byte if the 5 byte nop
+      rol rcx, 32
+      or rcx, 00441f0fh ; insert the first 4 bytes of the 5 byte nop
+      mov qword  [rax], rcx ; write the nop
+
+restoreRegs:
+
+      pop r9
+      pop rbx
+      pop rsi
+      pop rdx
+      pop rcx
+      pop rax
+      pop rbp
+
+      ret
+
+ret ;checkReferenceVolatility endp
+;1179
+
+
+; interpreterUnresolved{*}Glue
+;
+; Generic code to perform runtime resolution of a data reference. These functions
+; are called from a snippet that has the following general shape:
+;
+; call interpreterUnresolved{*}Glue
+; dq cpAddr
+; dd cpIndex
+; [db] header byte -- ONLY PRESENT FOR disp32 PATCHING
+; high nibble : length of instruction in snippet (must be 8-15)
+; low nibble : offset to disp32 in patched instruction
+; dq 8 bytes of instruction to patch (includes bytes from following instruction if necessary)
+; db remaining bytes of instruction for static resolves
+; ret return for unpatched static resolves
+;
+; Spare bits in the cpIndex passed in are used to specify behaviour based on the
+; kind of resolution. The anatomy of a cpIndex:
+;
+; Spare bits in the cpIndex passed in are used to specify behaviour based on the
+; kind of resolution. The anatomy of a cpIndex:
+;
+; byte 3 byte 2 byte 1 byte 0
+;
+; 3 222 2 222 1 1 0 0 0
+; 10987654 32109876 54321098 76543210
+; |||||__| ||| ||||_________________|
+; |||| | ||| ||| |
+; |||| | ||| ||| +---------------- cpIndex (0-16)
+; |||| | ||| ||+-------------------------- upper long dword resolution (17)
+; |||| | ||| |+--------------------------- lower long dword resolution (18)
+; |||| | ||| +---------------------------- check volatility (19)
+; |||| | ||+------------------------------ resolve, but do not patch snippet template (21)
+; |||| | |+------------------------------- resolve, but do not patch mainline code (22)
+; |||| | +-------------------------------- long push instruction (23)
+; |||| +------------------------------------ number of live X87 registers across this resolution (24-27)
+; |||+-------------------------------------- has live XMM registers (28)
+; ||+--------------------------------------- static resolution (29)
+; |+---------------------------------------- 64-bit: resolved value is 8 bytes (30)
+; | 32-bit: resolved value is high word of long pair (30)
+; +----------------------------------------- 64 bit: extreme static memory barrier position (31)
+;
+;
+; NOTES:
+;
+; [1] STACK SHAPE: must maintain stack shape expected by call to getJitDataResolvePushes()
+; across the resolution helper.
+
+      align 16
+interpreterUnresolvedStringGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveString
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedStringGlue endp
+
+
+      align 16
+interpreterUnresolvedMethodTypeGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveMethodType
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedMethodTypeGlue endp
+
+
+      align 16
+interpreterUnresolvedMethodHandleGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveMethodHandle
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedMethodHandleGlue endp
+
+
+      align 16
+interpreterUnresolvedCallSiteTableEntryGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveInvokeDynamic
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedCallSiteTableEntryGlue endp
+
+
+      align 16
+interpreterUnresolvedMethodTypeTableEntryGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveHandleMethod
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedMethodTypeTableEntryGlue endp
+
+
+      align 16
+interpreterUnresolvedClassGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveClass
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedClassGlue endp
+
+
+      align 16
+interpreterUnresolvedClassFromStaticFieldGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveClassFromStaticField
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedClassFromStaticFieldGlue endp
+
+
+      align 16
+interpreterUnresolvedStaticFieldGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveStaticField
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedStaticFieldGlue endp
+
+
+      align 16
+interpreterUnresolvedStaticFieldSetterGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveStaticFieldSetter
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedStaticFieldSetterGlue endp
+
+      align 16
+interpreterUnresolvedFieldGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveField
+; int 3
+      jmp commonUnresolvedCode
+ret ;interpreterUnresolvedFieldGlue endp
+
+      align 16
+interpreterUnresolvedFieldSetterGlue: ;proc
+      DataResolvePrologue
+      DispatchUnresolvedDataHelper jitResolveFieldSetter
+; int 3
+
+commonUnresolvedCode:
+
+      ; STACK SHAPE:
+      ;
+      ; rsp+272 : RA in mainline
+      ; rsp+264 : RA in snippet
+      ; rsp+256 : RFlags
+      ; rsp+248 : r15
+      ; rsp+240 : r14
+      ; rsp+232 : r13
+      ; rsp+224 : r12
+      ; rsp+216 : r11
+      ; rsp+208 : r10
+      ; rsp+200 : r9
+      ; rsp+192 : r8
+      ; rsp+184 : rsp
+      ; rsp+176 : rbp
+      ; rsp+168 : rsi
+      ; rsp+160 : rdi
+      ; rsp+152 : rdx
+      ; rsp+144 : rcx
+      ; rsp+136 : rbx
+      ; rsp+128 : rax
+      ; rsp+120 : xmm15
+      ; rsp+112 : xmm14
+      ; rsp+104 : xmm13
+      ; rsp+96 : xmm12
+      ; rsp+88 : xmm11
+      ; rsp+80 : xmm10
+      ; rsp+72 : xmm9
+      ; rsp+64 : xmm8
+      ; rsp+56 : xmm7
+      ; rsp+48 : xmm6
+      ; rsp+40 : xmm5
+      ; rsp+32 : xmm4
+      ; rsp+24 : xmm3
+      ; rsp+16 : xmm2
+      ; rsp+8 : xmm1
+      ; rsp+0 : xmm0
+      ;
+      ; rax = result from resolve helper
+      ; rdi = return address in snippet
+
+      mov esi, dword [rdi+8] ; full cpIndex word
+
+      ; Check for the special case of a data resolution without code patching.
+      ; This happens when you have an explicit NULLCHK guarding a data resolution and
+      ; we need to ensure the exceptions are thrown in the correct order if they occur.
+      ; In this case any resolution exceptions are required to be thrown before any NPEs.
+      ;
+      test esi, eq_ResolveWithoutPatchingMainline
+      jnz doneDataResolution
+
+      test esi, eq_Patch8ByteResolution
+      jz patch4ByteResolution
+
+      ; Resolved value is 8-bytes. The target instruction must be a 'MOV R,Imm64' instruction.
+      ; Synthesize the first 8 bytes of this instruction with the REX+op from the snippet and
+      ; the 48-bit virtual address returned from the resolution and patch the snippet.
+      ;
+      ; Multiple threads can be executing this code, but all threads must be patching the
+      ; same value.
+      ;
+      test esi, eq_ResolveStatic
+      jnz patchStaticResolution
+
+mergePatch8ByteResolution:
+      movzx edx, word  [rdi+12] ; rdx = REX + OpCode
+      mov rbx, rax ; rbx = resolve result
+      and rbx, -2 ; whack any low tagging of resolve result
+      shl rbx, 16
+      or rdx, rbx ; synthesize patched instruction bytes
+
+      mov rbx, qword  [rsp+272] ; rbx = RA in mainline
+      mov qword  [rbx-5], rdx ; patch mainline
+
+; determine if nop patching might be necessary
+;
+
+     test dword  [rdi + 8], eq_VolatilityCheck ; test for the volatility check flag
+     jz short noVolatileCheck8Byte
+
+     call checkReferenceVolatility
+
+
+noVolatileCheck8Byte:
+
+      DataResolveEpilogue
+
+      add qword  [rsp+16], -5 ; re-run patched instruction
+      popfq ; restore
+      lea rsp, [rsp+8] ; skip over RA in snippet--mispredict
+      ret
+
+patchStaticResolution:
+      test rax, 1 ; low-tagged resolution result (clinit not finished)?
+      jz mergePatch8ByteResolution
+
+      ; Static resolves have the entire unresolved address load instruction
+      ; embedded in the snippet plus a RET instruction. The snippet must
+      ; be patched and executed.
+      ;
+      movzx edx, word  [rdi+12] ; rdx = REX + OpCode
+      mov rbx, rax ; rbx = resolve result
+      and rbx, -2 ; whack any low tagging of resolve result
+      shl rbx, 16
+      or rdx, rbx ; synthesize patched instruction bytes
+
+      mov qword  [rdi+12], rdx ; patch snippet
+      mfence ; make sure memory stores are seen
+
+doneDataResolution:
+      DataResolveEpilogue
+
+      add qword  [rsp+16], 5 ; patch the RA in the mainline code to skip
+                                                               ; over the remaining 5 bytes of what would
+                                                               ; have been the 10-byte MOV R,Imm64 instruction
+                                                               ; that did not get patched.
+
+      add qword  [rsp+8], 12 ; patch RA in snippet such that the instruction
+                                                               ; patched in the snippet is re-run.
+                                                               ; +12 = +8 (cpAddr) + 4 (cpIndex)
+      popfq
+      ret
+
+doneDataResolutionAndNoRerun:
+      DataResolveEpilogue
+
+      popfq
+      lea rsp, [rsp+8]
+      ret
+
+patch4ByteResolution:
+
+      ; Patch the cached instruction bytes in the snippet. The disp32 field must lie within
+      ; the first 8 bytes of the instruction.
+      ;
+      ; Multiple threads can be executing this code, but all threads must be patching the
+      ; same value.
+      ;
+      movzx ecx, byte  [rdi+12] ; rcx = header byte
+      and ecx, 0fh ; isolate disp32 offset in first nibble
+
+      mov rdx, qword  [rdi+13] ; rdx = cached instruction bytes
+                                                               ; +13 = +8 (cpAddr) + 4 (cpIndex) + 1 (header)
+      shl ecx, 3
+      ror rdx, cl ; rotate disp32 into lower dword
+
+      ; The dword field from the snippet is assumed to be 0.
+      ;
+      or rdx, rax ; patch the disp32 field
+      rol rdx, cl
+
+      mov rbx, qword  [rsp+272] ; rbx = RA in mainline
+      mov qword  [rbx-5], rdx ; patch mainline
+
+; determine if nop patching might be necessary
+;
+      test dword  [rdi + 8], eq_VolatilityCheck ; test for the check volatility flag
+      jz short noVolatileCheck4Byte
+
+      call checkReferenceVolatility
+
+noVolatileCheck4Byte:
+
+      DataResolveEpilogue
+
+      add qword  [rsp+16], -5 ; re-run patched instruction
+      popfq ; restore
+      lea rsp, [rsp+8] ; skip over RA in snippet--mispredict
+      ret
+
+ret ;interpreterUnresolvedFieldSetterGlue endp
+
+
+MTUnresolvedInt32Load: ;proc
+ret ;MTUnresolvedInt32Load endp
+
+MTUnresolvedInt64Load: ;proc
+ret ;MTUnresolvedInt64Load endp
+
+MTUnresolvedFloatLoad: ;proc
+ret ;MTUnresolvedFloatLoad endp
+
+MTUnresolvedDoubleLoad: ;proc
+ret ;MTUnresolvedDoubleLoad endp
+
+MTUnresolvedAddressLoad: ;proc
+ret ;MTUnresolvedAddressLoad endp
+
+MTUnresolvedInt32Store: ;proc
+ret ;MTUnresolvedInt32Store endp
+
+MTUnresolvedInt64Store: ;proc
+ret ;MTUnresolvedInt64Store endp
+
+MTUnresolvedFloatStore: ;proc
+ret ;MTUnresolvedFloatStore endp
+
+MTUnresolvedDoubleStore: ;proc
+ret ;MTUnresolvedDoubleStore endp
+
+MTUnresolvedAddressStore: ;proc
+ret ;MTUnresolvedAddressStore endp
+;_TEXT ends
+
+;; !TR_HOST_64BIT
+%endif
+
+ ;     end

--- a/runtime/oti/jilconsts_nasm.inc
+++ b/runtime/oti/jilconsts_nasm.inc
@@ -1,0 +1,194 @@
+; Copyright (c) 2000, 2018 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+; temporary workaround!!!
+
+; this is only temporarily placed here to have the nasm files being able to include a replacement for "jilconsts.inc"
+; Currently, the jilconsts.inc is in masm format, so until that is addressed, this is a temporary placeholder
+
+
+%assign ASM_J9VM_JIT_NEW_DUAL_HELPERS 1
+%assign ASM_J9VM_ENV_LITTLE_ENDIAN 1
+%assign ASM_J9VM_ENV_DATA64 1
+%assign ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER 1
+%assign ASM_J9VM_THR_LOCK_NURSERY 1
+%assign ASM_J9VM_INTERP_SMALL_MONITOR_SLOT 1
+%assign ASM_J9VM_GC_TLH_PREFETCH_FTA 1
+%assign ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING 1
+%assign J9TR_cframe_sizeof 280
+%assign J9TR_cframe_vmStruct 0
+%assign J9TR_cframe_machineBP 8
+%assign J9TR_cframe_jitGPRs 16
+%assign J9TR_cframe_jitFPRs 144
+%assign J9TR_cframe_rax 16
+%assign J9TR_cframe_rbx 24
+%assign J9TR_cframe_rcx 32
+%assign J9TR_cframe_rdx 40
+%assign J9TR_cframe_rdi 48
+%assign J9TR_cframe_rsi 56
+%assign J9TR_cframe_rbp 64
+%assign J9TR_cframe_rsp 72
+%assign J9TR_cframe_r8 80
+%assign J9TR_cframe_r9 88
+%assign J9TR_cframe_r10 96
+%assign J9TR_cframe_r11 104
+%assign J9TR_cframe_r12 112
+%assign J9TR_cframe_r13 120
+%assign J9TR_cframe_r14 128
+%assign J9TR_cframe_r15 136
+%assign J9TR_runtimeFlags_PatchingFenceRequired 67108864
+%assign J9TR_runtimeFlags_PatchingFenceType 134217728
+%assign J9TR_VMThread_machineSP 2392
+%assign J9TR_machineSP_machineBP 8
+%assign J9TR_machineSP_vmStruct 0
+%assign J9TR_VMThreadCurrentException 72
+%assign J9TR_VMThread_floatTemp1 264
+%assign J9TR_VMThread_floatTemp2 272
+%assign J9TR_VMThread_floatTemp3 280
+%assign J9TR_VMThread_floatTemp4 288
+%assign J9TR_VMThread_stackOverflowMark 80
+%assign J9TR_VMThread_heapAlloc 96
+%assign J9TR_VMThread_heapTop 104
+%assign J9TR_VMThread_tlhPrefetchFTA 112
+%assign J9TR_VMThread_publicFlags 152
+%assign J9TR_VMThread_privateFlags 424
+%assign J9TR_VMThread_privateFlags2 2336
+%assign J9TR_VMThreadJavaVM 8
+%assign J9TR_VMThread_javaVM 8
+%assign J9TR_VMThread_sp 32
+%assign J9TR_VMThread_pc 40
+%assign J9TR_VMThread_literals 48
+%assign J9TR_VMThread_arg0EA 16
+%assign J9TR_VMThread_codertTOC 344
+%assign J9TR_VMThread_debugEventData1 496
+%assign J9TR_VMThread_debugEventData2 504
+%assign J9TR_VMThread_debugEventData3 512
+%assign J9TR_VMThread_debugEventData4 520
+%assign J9TR_VMThread_debugEventData5 528
+%assign J9TR_VMThread_debugEventData6 536
+%assign J9TR_VMThread_debugEventData7 544
+%assign J9TR_VMThread_debugEventData8 552
+%assign J9TR_VMThread_tempSlot 248
+%assign J9TR_VMThread_jitReturnAddress 256
+%assign J9TR_VMThread_returnValue 296
+%assign J9TR_VMThread_returnValue2 304
+%assign J9TR_VMThread_entryLocalStorage 616
+%assign J9TR_VMThread_stackWalkState 608
+%assign J9TR_J9StackWalkState_restartPoint 224
+%assign J9TR_JavaVMJitConfig 6384
+%assign J9TR_JavaVM_runtimeFlags 224
+%assign J9TR_JavaVM_cInterpreter 184
+%assign J9TR_JavaVM_bytecodeLoop 192
+%assign J9TR_JavaVM_extendedRuntimeFlags 228
+%assign J9TR_JavaVMInternalFunctionTable 0
+%assign J9TR_ELS_jitGlobalStorageBase 8
+%assign J9TR_ELS_jitFPRegisterStorageBase 48
+%assign J9TR_ELS_machineSPSaveSlot 88
+%assign J9TR_J9VMJITRegisterState_jit_fpr0 128
+%assign J9TR_J9Class_classLoader 40
+%assign J9TR_J9Class_lastITable 96
+%assign J9TR_J9Class_lockOffset 200
+%assign J9TR_ArrayClass_componentType 88
+%assign J9TR_ITableOffset 24
+%assign J9TR_J9ITable_interfaceClass 0
+%assign J9TR_MethodFlagsOffset 8
+%assign J9TR_MethodPCStartOffset 24
+%assign J9TR_JitConfig_runtimeFlags 1088
+%assign J9TR_JitConfig_loadPreservedAndBranch 2960
+%assign J9TR_JitConfig_pseudoTOC 1984
+%assign J9TR_InternalFunctionTableReleaseVMAccess 312
+%assign J9TR_J9Object_class 0
+%assign J9TR_ObjectHeader_class 0
+%assign J9TR_IndexableObjectContiguous_objectData 8
+%assign J9TR_J9SFJNICallInFrame_exitAddress 0
+%assign J9TR_bcloop_execute_bytecode 0
+%assign J9TR_bcloop_handle_pop_frames 10
+%assign J9TR_bcloop_i2j_transition 16
+%assign J9TR_bcloop_j2i_invoke_exact 12
+%assign J9TR_bcloop_j2i_transition 11
+%assign J9TR_bcloop_j2i_virtual 13
+%assign J9TR_bcloop_jump_bytecode_prototype 2
+%assign J9TR_bcloop_load_preserved_and_branch 14
+%assign J9TR_bcloop_return_from_jit 17
+%assign J9TR_bcloop_return_from_jit_ctor 18
+%assign J9TR_bcloop_run_exception_handler 4
+%assign J9TR_bcloop_run_jni_native 5
+%assign J9TR_bcloop_run_method 1
+%assign J9TR_bcloop_run_method_compiled 3
+%assign J9TR_bcloop_run_method_handle 7
+%assign J9TR_bcloop_run_method_handle_compiled 8
+%assign J9TR_bcloop_run_method_interpreted 9
+%assign J9TR_bcloop_stack_overflow 6
+%assign J9TR_bcloop_throw_current_exception 15
+%assign J9TR_bcloop_enter_method_monitor 19
+%assign J9TR_bcloop_report_method_enter 20
+%assign J9TR_bcloop_exit_interpreter 22
+%assign J9TR_MethodNotCompiledBit 1
+%assign J9TR_InterpVTableOffset 328
+%assign J9TR_RequiredClassAlignment 256
+%assign J9TR_RequiredClassAlignmentInBits 8
+%assign J9TR_pointerSize 8
+%assign J9TR_ELSSize 96
+%assign J9TR_J9_EXTENDED_RUNTIME_DEBUG_MODE 16384
+%assign J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS 1
+%assign J9TR_J9_INLINE_JNI_MAX_ARG_COUNT 32
+
+%macro MoveHelper 2 ; register, helperName
+		lea %1,[rel + %2]
+%endmacro
+
+%macro CompareHelperUseReg 3 ; source, helperName, register
+	   	lea %3,[rel + %2]
+	   	cmp %1, %3
+%endmacro
+
+%macro CallHelper 1 ; helperName
+	   	call %1
+%endmacro
+
+%macro CallHelperUseReg 2 ; helperName, register
+	   	call %1
+%endmacro
+
+%macro JumpTableHelper 3 ; temp, index, table
+		lea %1,[rel + %3]
+		jmp qword [%1 + %2 * 8]
+%endmacro
+
+%macro JumpTableStart 1 ;table
+align 16
+%1:
+%endmacro
+
+
+%macro JumpTableEnd 1 ; table
+; NASM does not use ENDS or equivalent
+%endmacro
+
+
+%macro ExternHelper 1 ; helperName
+extern _%1:near
+%endmacro
+
+%macro GlueHelper 1 ;helperName
+		test    byte [rdi+J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit
+	   	jnz     %1
+	   	jmp     mergedStaticGlueCallFixer
+%endmacro


### PR DESCRIPTION
### Background

Currently, x86 JIT assembly files are handled differently on the 2 supported OSes, neither of which could be easily adapted for Mac OSX. In order to support OpenJ9 on Mac OSX (see #36 ) , it was time we reworked how we handled the x86 assembly files in the JIT. Windows builds consume the MASM files directly, whereas Linux on x86 builds first convert the MASM files to GNU-assembly format using the masm2gas script, and then build them. Some of the assembly files first go through the C preprocessor before being consumed by the masm2gas script, adding to the difficulty with connecting errors to the MASM source line. This rewrite of the X86 JIT assembly files aims to simplify the handling of the assembly files across x86, while making it possible to build the OpenJ9 JIT on OSX. More discussions regarding this occurred in issue #2418 

### How to build them

This PR does not contain CMake-specific changes, so you will have to use autotools. In order to allow Linux builds to make use of the original assembly files, the newly introduced files do not get built by default. In order to build the nasm files, you will have to set the following environment variable:
```sh
export USE_NASM=yes 
```

I've only used NASM versions 2.13.03 and 2.11.08.

### WIP because...
* While building and linking succeeds on Linux (along with `java -version`), there are a number of linker errors on Mac OSX that I am currently working on
* Incomplete 32-bit host support. This was low on the priority list due to being irrelevant to Mac OSX. Currently working on a solution for using the correct register names on 32bit hosts. This was originally handled through the use of x86RegisterMap.inc
* Currently working on auto-generating jilconsts.inc in NASM format. Currently, it is output in MASM format. A replacement exists in this PR, but that is definitely only temporary.
* Currently working on a solution to remove the need for using the C Preprocessor (for .pnasm files)
* Currently working on examining the disassembled code obtained from ELF objects generated by GNU-as and NASM to verify equivalence
* Need to run tests to verify functionality
