### PR TITLE
Replace `aotMethodCodeStart` with `relocatableMethodCodeStart`

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -110,7 +110,7 @@ uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
    TR_ResolvedMethod *resolvedMethod;
 
    uint8_t *cursor = relocation->getRelocationData();
-   uint8_t * aotMethodCodeStart = (uint8_t *) comp->getAotMethodCodeStart();
+   uint8_t * aotMethodCodeStart = (uint8_t *) comp->getRelocatableMethodCodeStart();
 
    // size of relocation goes first in all types
    *(uint16_t *)cursor = relocation->getSizeOfRelocationData();

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -111,7 +111,7 @@ uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
    TR_ResolvedMethod *resolvedMethod;
 
    uint8_t *cursor = relocation->getRelocationData();
-   uint8_t * aotMethodCodeStart = (uint8_t *) comp->getAotMethodCodeStart();
+   uint8_t * aotMethodCodeStart = (uint8_t *) comp->getRelocatableMethodCodeStart();
    // size of relocation goes first in all types
    *(uint16_t *) cursor = relocation->getSizeOfRelocationData();
 

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1547,9 +1547,9 @@ createMethodMetaData(
          aotMethodHeaderEntry->offsetToRelocationDataItems = 0;
          }
 
-      aotMethodHeaderEntry->compileMethodCodeStartPC = (UDATA)comp->getAotMethodCodeStart();
+      aotMethodHeaderEntry->compileMethodCodeStartPC = (UDATA)comp->getRelocatableMethodCodeStart();
       aotMethodHeaderEntry->compileMethodDataStartPC = (UDATA)comp->getAotMethodDataStart();
-      aotMethodHeaderEntry->compileMethodCodeSize = (UDATA)codeCache->getWarmCodeAlloc() - (UDATA)comp->getAotMethodCodeStart();
+      aotMethodHeaderEntry->compileMethodCodeSize = (UDATA)codeCache->getWarmCodeAlloc() - (UDATA)comp->getRelocatableMethodCodeStart();
 
       // For AOT we should have a reserved dataCache
       //


### PR DESCRIPTION
Fixes the build break introduced when importing OMR and unblocks (at least one of) the OMR acceptance build failures.
Related to eclipse/omr#2913 & eclipse/omr#2960

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>