### PR TITLE
Add constant dynamic unit tests

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -70,6 +70,11 @@ my %asm_all = (
 	fname => 'asm-all.jar',
 	sha1 => '535f141f6c8fc65986a3469839a852a3266d1025'
 );
+my %asm_7_0 = (
+	url => 'https://repository.ow2.org/nexus/content/repositories/snapshots/org/ow2/asm/asm/7.0-beta-SNAPSHOT/asm-7.0-beta-20180911.182645-11.jar',
+	fname => 'asm-7.0.jar',
+	sha1 => 'a5cd898ac5f15b99bc6b76167556a19fcea5c757'
+);
 my %commons_cli = (
 	url => 'http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar',
 	fname => 'commons-cli.jar',
@@ -115,6 +120,7 @@ my %jaxb_api = (
 # Put all dependent jars hash to array to prepare dowloading
 my @jars_info = (
 	\%asm_all,
+	\%asm_7_0,
 	\%commons_cli,
 	\%commons_exec,
 	\%javassist,

--- a/test/functional/Java11andUp/build.xml
+++ b/test/functional/Java11andUp/build.xml
@@ -41,8 +41,48 @@
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build}"/>
 	</target>
+
+	<target name="compile_generator" depends="init" description="Compile CondyGenerator">
+		<echo>Compiling CondyTest helpers</echo>
+		<echo>Ant version is ${ant.version}"</echo>
+		<property name="compiler.javac" value="${JAVA_BIN}/javac" />
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:		${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:			${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}"/>
+			<include name="**/condy/BootstrapMethods.java" />
+			<include name="**/condy/CondyGenerator.java" />
+			<classpath>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar" />
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="generate_condy" depends="compile_generator" description="Run Condugenerator to generate bytecode" >
+		<property name="javaexecutable.java" value="${JAVA_BIN}/java" />
+		<echo>Running CondyGenerator</echo>
+		<java classname="org.openj9.test.condy.CondyGenerator" fork="true" failonerror="true" logError="true" jvm="${javaexecutable.java}">
+			<jvmarg value="-Xverify:none" />
+			<classpath>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar" />
+				<pathelement location="${build}" />
+			</classpath>
+		</java>
+		<copy file="PrimitiveCondyMethods.class" todir="${build}/org/openj9/test/condy" overwrite="true" />
+		<delete failonerror="true" verbose="true">
+			<fileset dir=".">
+				<include name="PrimitiveCondyMethods.class"/>
+			</fileset>
+		</delete>
+	</target>
+   
+      
+      
 	
-	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source " >
+	<target name="compile" depends="generate_condy" description="Using ${JAVA_VERSION} java compile the source " >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:				yes</echo>
@@ -57,6 +97,8 @@
 			<classpath>
 				<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar"/>
 				<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar"/>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/asm-7.0.jar" />
+				<pathelement location="${build}" />
 			</classpath>
 		</javac>
 	</target>

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -98,6 +98,44 @@
 		<subsets>
 			<subset>SE110</subset>
 		</subsets>
+   </test>
+
+
+	<!--
+		Following test covers scenario for both type of constant dynamics (Object and Primitives)
+		Variation 1:
+			This variation runs tests in default mode.
+		Variation 2:
+			This variation runs test under -Xjit:count=1 option which makes sure that ConstantDynamic is resoleved before we compile a method
+			to test JIT's handling of resolved constant dynamic
+		Variation 3:
+			This variation runs test under -Xjit:count=0 option means JIT faces unresolved constant dynamic and it needs to resolve them before
+			using it.
+		-->
+	<test>
+		<testCaseName>CondyPrimitive</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>'-Xjit:count=1,disableAsyncCompilation,rtResolve'</variation>
+			<variation>'-Xjit:count=0,disableAsyncCompilation'</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames PrimitiveCondyTest \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE110</subset>
+		</subsets>
 	</test>
-	
+
 </playlist>

--- a/test/functional/Java11andUp/src/org/openj9/test/condy/BootstrapMethods.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/condy/BootstrapMethods.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.condy;
+
+import java.lang.invoke.*;
+public class BootstrapMethods {
+
+	public static Object bootstrap_constant_string(MethodHandles.Lookup l, String name, Class<?> c, String s) {
+		return s;
+	}
+
+	public static int bootstrap_constant_int(MethodHandles.Lookup l, String name, Class<?> c, int v) {
+		return v;
+	}
+
+	public static float bootstrap_constant_float(MethodHandles.Lookup l, String name, Class<?> c, float v) {
+		return v;
+	}
+
+	public static double bootstrap_constant_double(MethodHandles.Lookup l, String name, Class<?> c, double v) {
+		return v;
+	}
+
+	public static long bootstrap_constant_long(MethodHandles.Lookup l, String name, Class<?> c, long v) {
+		return v;
+	}
+}

--- a/test/functional/Java11andUp/src/org/openj9/test/condy/CondyGenerator.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/condy/CondyGenerator.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.condy;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.H_INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.H_INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.IRETURN;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.LRETURN;
+import static org.objectweb.asm.Opcodes.FRETURN;
+import static org.objectweb.asm.Opcodes.DRETURN;
+
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.*;
+
+import java.util.*;
+import java.io.*;
+
+public class CondyGenerator extends ClassLoader{
+   
+	public static byte[] gen() {
+		ClassWriter cw = new ClassWriter( ClassWriter.COMPUTE_FRAMES );
+		cw.visit( 55, ACC_PUBLIC | ACC_SUPER, "org/openj9/test/condy/PrimitiveCondyMethods", null, "java/lang/Object", null );
+
+		MethodVisitor mv;
+		{
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "condy_return_string", "()Ljava/lang/String;", null, null );
+			mv.visitCode();
+			mv.visitLdcInsn( 
+				new ConstantDynamic( "constant_string", "Ljava/lang/String;",
+					new Handle(
+							H_INVOKESTATIC, 
+							"org/openj9/test/condy/BootstrapMethods", 
+							"bootstrap_constant_string",
+							Type.getType(
+									"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Object;"
+									).getDescriptor() ),
+									"world"
+					)
+				);
+			mv.visitInsn( ARETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+		}
+
+		{
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "condy_return_int", "()I", null, null );
+			mv.visitCode();
+			mv.visitLdcInsn( 
+				new ConstantDynamic( "constant_int", "I",
+					new Handle(
+							H_INVOKESTATIC, 
+							"org/openj9/test/condy/BootstrapMethods", 
+							"bootstrap_constant_int",
+							Type.getType(
+									"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;I)I"
+									).getDescriptor() ),
+									123432
+					)
+				);
+			mv.visitInsn( IRETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+		}
+
+		{
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "condy_return_float", "()F", null, null );
+			mv.visitCode();
+			mv.visitLdcInsn( 
+				new ConstantDynamic( "constant_float", "F",
+					new Handle(
+							H_INVOKESTATIC, 
+							"org/openj9/test/condy/BootstrapMethods", 
+							"bootstrap_constant_float",
+							Type.getType(
+									"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;F)F"
+									).getDescriptor() ),
+									10.12F
+					)
+				);
+			mv.visitInsn( FRETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+		}
+
+      {
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "condy_return_long", "()J", null, null );
+			mv.visitCode();
+			mv.visitLdcInsn( 
+				new ConstantDynamic( "constant_long", "J",
+					new Handle(
+							H_INVOKESTATIC, 
+							"org/openj9/test/condy/BootstrapMethods", 
+							"bootstrap_constant_long",
+							Type.getType(
+									"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;J)J"
+									).getDescriptor() ),
+									100000000000L
+					)
+				);
+			mv.visitInsn( LRETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+      }
+
+      {
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "condy_return_double", "()D", null, null );
+			mv.visitCode();
+			mv.visitLdcInsn( 
+				new ConstantDynamic( "constant_double", "D",
+					new Handle(
+							H_INVOKESTATIC, 
+							"org/openj9/test/condy/BootstrapMethods", 
+							"bootstrap_constant_double",
+							Type.getType(
+									"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;D)D"
+									).getDescriptor() ),
+									1111111.12D
+					)
+				);
+			mv.visitInsn( DRETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+      }
+
+		{
+			mv = cw.visitMethod( ACC_PUBLIC | ACC_STATIC, "condy_return_null", "()Ljava/lang/Object;", null, null );
+			mv.visitCode();
+			mv.visitLdcInsn( 
+				new ConstantDynamic( "constant_NULL", "Ljava/lang/Object;",
+					new Handle(
+						H_INVOKESTATIC, 
+						"java/lang/invoke/ConstantBootstraps", 
+						"nullConstant",
+						Type.getType( "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;").getDescriptor() 
+					)
+				)
+			);
+			mv.visitInsn( ARETURN );
+			mv.visitMaxs( 0, 0 );
+			mv.visitEnd();
+		}
+
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+	public static void main(String[] args) throws Throwable {
+		FileOutputStream fos = new FileOutputStream( "PrimitiveCondyMethods.class" );
+		fos.write(gen());
+		fos.flush();
+		fos.close();
+	}
+}

--- a/test/functional/Java11andUp/src/org/openj9/test/condy/PrimitiveCondyTest.java
+++ b/test/functional/Java11andUp/src/org/openj9/test/condy/PrimitiveCondyTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.condy;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+public class PrimitiveCondyTest {
+	/**
+	 * In all of the following test methods, methods from PrimitiveCondyMethods are called 3 times
+	 * That helps testing following JIT scenarios.
+	 * 1. Constant Dynamic is resolved
+	 * 	With variation "-Xjit:count=1,disableAsyncCompilation,reResolve" , we make sure that method is
+	 * 	atleast ran one time in interpreted mode so that Dynamic Constants are resolved and next method invocations
+	 * 	tests JIT generated body with resolved Constant Dynamic seen by JIT compiler.
+	 * 2. Constant Dynamic is unresolved
+	 * 	With variation "-Xjit:count=0,disableAsyncCompilation", we make sure while compiling methods,
+	 * 	JIT sees unresolved ConstantDynamic and it generates appropriate JIT body that resolves Constant
+	 * 	Dynamic by calling JIT helper which calls appropriate Bootstrap methods. 
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testCondyNull() {
+		Assert.assertNull(PrimitiveCondyMethods.condy_return_null());
+		Assert.assertNull(PrimitiveCondyMethods.condy_return_null());
+		Assert.assertNull(PrimitiveCondyMethods.condy_return_null());
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testCondyInt() {
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_int(), 123432);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_int(), 123432);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_int(), 123432);
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testCondyFloat() {
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_float(), 10.12F);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_float(), 10.12F);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_float(), 10.12F);
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testCondyLong() {
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_long(), 100000000000L);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_long(), 100000000000L);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_long(), 100000000000L);
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testCondyDouble() {
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_double(), 1111111.12D);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_double(), 1111111.12D);
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_double(), 1111111.12D);
+	}
+
+	@Test(groups = { "level.sanity" })
+	public void testCondyString() {
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_string(), "world");
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_string(), "world");
+		Assert.assertEquals(PrimitiveCondyMethods.condy_return_string(), "world");
+	}
+}

--- a/test/functional/Java11andUp/testng.xml
+++ b/test/functional/Java11andUp/testng.xml
@@ -38,4 +38,10 @@
 			<class name="org.openj9.test.nestmate.NestmateTest" />
 		</classes>
 	</test>
+
+	<test name="PrimitiveCondyTest">
+		<classes>
+			<class name="org.openj9.test.condy.PrimitiveCondyTest" />
+		</classes>
+	</test>
 </suite>


### PR DESCRIPTION
Add Java 11 tests for Constant Dynamic mainly involves String object, NULL object and Primitive data types objects. Variation covers running this test in interpreted mode as well as specific JIT compilation modes which checks out JIT's handling of resolved and unresolved Constant Dynamic cases.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>