### PR TITLE
Add TR_J2IVirtualThunkPointer relocation kind

### DIFF
--- a/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/arm/codegen/J9AheadOfTimeCompile.cpp
@@ -273,6 +273,22 @@ uint8_t *J9::ARM::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          cursor += SIZEPOINTER;
          break;
          }
+
+      case TR_J2IVirtualThunkPointer:
+         {
+         auto info = (TR_RelocationRecordInformation*)relocation->getTargetAddress();
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data2; // inlined site index
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data1; // constantPool
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data3; // offset to J2I virtual thunk pointer
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       case TR_CheckMethodEnter:
       case TR_CheckMethodExit:
          {
@@ -742,6 +758,7 @@ uint32_t J9::ARM::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    16,                                       // TR_ArbitraryClassAddress               = 58,
    28,                                        // TR_DebugCounter                        = 59
    4,                                        // TR_ClassUnloadAssumption               = 60
+   16,                                       // TR_J2IVirtualThunkPointer              = 61
    };
 
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -539,6 +539,24 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   }
                }
             break;
+         case TR_J2IVirtualThunkPointer:
+            cursor++;        // unused field
+            cursor += is64BitTarget ? 4 : 0;
+            ep1 = cursor;
+            ep2 = cursor + sizeof(uintptrj_t);
+            ep3 = cursor + 2 * sizeof(uintptrj_t);
+            cursor += 3 * sizeof(uintptrj_t);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            if (isVerbose)
+               {
+               traceMsg(
+                  self()->comp(),
+                  "\nInlined site index %lld, constant pool 0x%llx, offset to j2i thunk pointer 0x%llx",
+                  (int64_t)*(uintptrj_t*)ep1,
+                  (uint64_t)*(uintptrj_t*)ep2,
+                  (uint64_t)*(uintptrj_t*)ep3);
+               }
+            break;
          case TR_Trampolines:
             // constant pool address is placed as the last word of the header
             //traceMsg(self()->comp(), "\nConstant pool %x\n", *(uint32_t *)++cursor);

--- a/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/p/codegen/J9AheadOfTimeCompile.cpp
@@ -423,6 +423,21 @@ uint8_t *J9::Power::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterat
          }
          break;
 
+      case TR_J2IVirtualThunkPointer:
+         {
+         auto info = (TR_RelocationRecordInformation*)relocation->getTargetAddress();
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data2; // inlined site index
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data1; // constantPool
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data3; // offset to J2I virtual thunk pointer
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       case TR_CheckMethodEnter:
       case TR_CheckMethodExit:
          {
@@ -891,6 +906,7 @@ uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_
    32,                                       // TR_ArbitraryClassAddress               = 58,
    56,                                       // TR_DebugCounter                        = 59
    8,                                        // TR_ClassUnloadAssumption               = 60
+   32,                                       // TR_J2IVirtualThunkPointer              = 61
    };
 #else
 uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumExternalRelocationKinds] =
@@ -956,6 +972,7 @@ uint32_t J9::Power::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_
    16,                                       // TR_ArbitraryClassAddress               = 58,
    28,                                        // TR_DebugCounter                        = 59
    4,                                        // TR_ClassUnloadAssumption               = 60
+   16,                                       // TR_J2IVirtualThunkPointer              = 61
    };
 
 #endif

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -582,9 +582,30 @@ class TR_RelocationRecordThunks : public TR_RelocationRecordConstantPool
       virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
 
    protected:
-      virtual int32_t relocateAndRegisterThunk(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uintptrj_t cp, uintptr_t cpIndex);
+      int32_t relocateAndRegisterThunk(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uintptrj_t cp, uintptr_t cpIndex, uint8_t *reloLocation);
+
+      /** Relocate the J2I virtual thunk pointer, if applicable */
+      virtual void relocateJ2IVirtualThunkPointer(TR_RelocationTarget *reloTarget, uint8_t *reloLocation, void *thunk)
+         {
+         // nothing to relocate
+         }
    };
 
+class TR_RelocationRecordJ2IVirtualThunkPointer : public TR_RelocationRecordThunks
+   {
+   public:
+      TR_RelocationRecordJ2IVirtualThunkPointer() {}
+
+      TR_RelocationRecordJ2IVirtualThunkPointer(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record)
+         : TR_RelocationRecordThunks(reloRuntime, record) {}
+
+      virtual char *name();
+      virtual int32_t bytesInHeaderAndPayload();
+
+   protected:
+      virtual void relocateJ2IVirtualThunkPointer(TR_RelocationTarget *reloTarget, uint8_t *reloLocation, void *thunk);
+      uintptrj_t offsetToJ2IVirtualThunkPointer(TR_RelocationTarget *reloTarget);
+   };
 
 class TR_RelocationRecordTrampolines : public TR_RelocationRecordConstantPool
    {

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -484,6 +484,22 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          }
          break;
 
+      case TR_J2IVirtualThunkPointer:
+         {
+         // Note: thunk relos should only be created for 64 bit
+         auto info = (TR_RelocationRecordInformation*)relocation->getTargetAddress();
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data2; // inlined site index
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data1; // constantPool
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data3; // offset to J2I virtual thunk pointer
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       case TR_PicTrampolines:
          {
          TR_ASSERT(TR::Compiler->target.is64Bit(), "TR_PicTrampolines not supported on 32-bit");
@@ -687,6 +703,7 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    32,                                              // TR_ArbitraryClassAddress               = 58,
    56,                                              // TR_DebugCounter                        = 59
    8,                                               // TR_ClassUnloadAssumption               = 60
+   32,                                              // TR_J2IVirtualThunkPointer              = 61,
 #else
 
    12,                                              // TR_ConstantPool                        = 0
@@ -750,6 +767,7 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    16,                                              // TR_ArbitraryClassAddress               = 58,
    28,                                               // TR_DebugCounter                        = 59
    4,                                               // TR_ClassUnloadAssumption               = 60
+   16,                                              // TR_J2IVirtualThunkPointer              = 61,
 #endif
    };
 

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -356,6 +356,21 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          }
          break;
 
+      case TR_J2IVirtualThunkPointer:
+         {
+         auto info = (TR_RelocationRecordInformation*)relocation->getTargetAddress();
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data2; // inlined site index
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data1; // constantPool
+         cursor += SIZEPOINTER;
+
+         *(uintptrj_t *)cursor = (uintptrj_t)info->data3; // offset to J2I virtual thunk pointer
+         cursor += SIZEPOINTER;
+         }
+         break;
+
       case TR_CheckMethodEnter:
       case TR_CheckMethodExit:
          {
@@ -1009,6 +1024,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    32,                                        // TR_ArbitraryClassAddress               = 58,
    56,                                        // TR_DebugCounter                        = 59
    8,                                         // TR_ClassUnloadAssumption               = 60
+   32,                                        // TR_J2IVirtualThunkPointer              = 61
    };
 
 #else
@@ -1076,6 +1092,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    16,                                        // TR_ArbitraryClassAddress               = 58,
    28,                                         // TR_DebugCounter                        = 59
    4,                                         // TR_ClassUnloadAssumption               = 60
+   16,                                        // TR_J2IVirtualThunkPointer              = 61
    };
 
 #endif


### PR DESCRIPTION
This relocates a J2I (JIT to interpreter) virtual thunk pointer along
with a nearby constant pool address and index. The relocation is
necessary because with nestmates, the data consumed by PicBuilder now
contains a J2I thunk pointer, which is used for direct dispatch in case
the callee has not yet been compiled.

No such relocations are created yet. That will be done in each code
generator's call snippet code.