### PR TITLE
Enable GCC-7.3 toolchain for Linux PPC LE in Jenkins files

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -87,6 +87,10 @@ linux_ppc-64_cmprssptrs_le:
       10: 'hw.arch.ppc64le && sw.os.ubuntu'
       11: 'hw.arch.ppc64le && sw.os.ubuntu'
       next: 'hw.arch.ppc64le && sw.os.ubuntu'
+  build_env:
+    vars:
+      11: 'CC=gcc-7 CXX=g++-7'
+      next: 'CC=gcc-7 CXX=g++-7'
 #========================================#
 # Linux S390 64bits Compressed Pointers
 # Note: boot_jdk 8 must use an Adopt JDK8 build rather than an 


### PR DESCRIPTION
Add build environment variables for gcc-7.3 for JDK11 and Next.

[ci skip]

The build environments table in the doc needs to be updated
https://www.eclipse.org/openj9/docs/openj9_support/#openjdk-10_1
https://github.com/eclipse/openj9-docs/issues/72#issuecomment-420290721

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>