### PR TITLE
Fix Bug with Condy Primitive Long and Double

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1250,8 +1250,8 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
 
          case J9BCldc:     loadFromCP(TR::NoType, nextByte());   _bcIndex += 2; break;
          case J9BCldcw:    loadFromCP(TR::NoType, next2Bytes()); _bcIndex += 3; break;
-         case J9BCldc2lw:  loadFromCP(TR::Int64,  next2Bytes()); _bcIndex += 3; break;
-         case J9BCldc2dw:  loadFromCP(TR::Double, next2Bytes()); _bcIndex += 3; break;
+         case J9BCldc2lw:  loadFromCP(TR::NoType,  next2Bytes()); _bcIndex += 3; break;
+         case J9BCldc2dw:  loadFromCP(TR::NoType, next2Bytes()); _bcIndex += 3; break;
 
          case J9BCiload0: loadAuto(TR::Int32, 0); _bcIndex += 1; break;
          case J9BCiload1: loadAuto(TR::Int32, 1); _bcIndex += 1; break;


### PR DESCRIPTION
While generating IL for byte code "ldc2lw" and "ldc2dw" we were assuming the constant is long and double type respectively. This is not true in case of Constant Dynamic where these primitives are boxed into corresponding object and we need to take special steps for generating appropriate IL.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>