### PR TITLE
[WIP] Fix linker (ld) cannot find omrsig on ARM

### DIFF
--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -276,7 +276,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</includes>
 		<makefilestubs>
 			<makefilestub data="UMA_EXE_POSTFIX_FLAGS+=-static">
-				<include-if condition="spec.linux_arm.*"/>
+				<include-if condition="spec.linux_arm.* and not spec.flags.J9VM_PORT_OMRSIG_SUPPORT"/>
 			</makefilestub>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 			<makefilestub data="include ddr_cpp_headers.mk"/>

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -33,7 +33,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		</includes>
 		<makefilestubs>
 			<makefilestub data="UMA_EXE_POSTFIX_FLAGS+=-static">
-				<include-if condition="spec.linux_arm.*" />
+				<include-if condition="spec.linux_arm.* and not spec.flags.J9VM_PORT_OMRSIG_SUPPORT" />
 			</makefilestub>
 			<makefilestub data="UMA_TREAT_WARNINGS_AS_ERRORS=1"/>
 		</makefilestubs>


### PR DESCRIPTION
On ARM, `j9ddrgen` and `constgen` are build using the `-static` compiler flag.
`-static` prevents shared libraries to be linked.

When `J9VM_PORT_OMRSIG_SUPPORT` is enabled, `j9ddrgen` and `constgen` need to
link to `omrsig`, which is a shared library.

Now onwards, `-static` compiler flag will not be used for `j9ddrgen` and
`constgen` on ARM if `J9VM_PORT_OMRSIG_SUPPORT` is enabled. This will allow
`j9ddrgen` and `constgen` to link to `omrsig`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>