### PR TITLE
Fix typo in Power's PicBuilder.spp

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -194,8 +194,8 @@
 	.globl    _interpreterUnresolvedClassGlue2{DS}
 	.globl    ._interpreterUnresolvedStringGlue
 	.globl    _interpreterUnresolvedStringGlue{DS}
-	.globl    ._interpreterUnresolvedConstantDynamicGlue{DS}
-	.globl    _interpreterUnresolvedConstantDynamicGlue
+	.globl    ._interpreterUnresolvedConstantDynamicGlue
+	.globl    _interpreterUnresolvedConstantDynamicGlue{DS}
 	.globl    ._interpreterUnresolvedMethodTypeGlue
 	.globl    _interpreterUnresolvedMethodTypeGlue{DS}
 	.globl    ._interpreterUnresolvedMethodHandleGlue


### PR DESCRIPTION
A typo in an AIX-specific part of PicBuilder.spp was causing a build
failure on AIX machines. This typo has been corrected, so AIX builds
should work once again.

Signed-off-by: Ben Thomas <ben@benthomas.ca>