### PR TITLE
Fold static final fields of type VarHandle under Xaggressive

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1353,12 +1353,34 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
       TR::VMAccessCriticalSection getObjectReferenceLocation(comp());
       if (*((uintptrj_t*)dataAddress) != NULL)
          {
+         TR_J9VMBase *fej9 = comp()->fej9();
          TR_OpaqueClassBlock *declaringClass = owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
-         if (declaringClass)
+         if (declaringClass && fej9->isClassInitialized(declaringClass))
             {
+            static const char *foldVarHandle = feGetEnv("TR_FoldVarHandle");
             int32_t clazzNameLength = 0;
-            char *clazzName = comp()->fej9()->getClassNameChars(declaringClass, clazzNameLength);
+            char *clazzName = fej9->getClassNameChars(declaringClass, clazzNameLength);
+            bool createKnownObject = false;
+
             if (J9::TransformUtil::foldFinalFieldsIn(declaringClass, clazzName, clazzNameLength, true, comp()))
+               {
+               createKnownObject = true;
+               }
+            else if ((foldVarHandle || comp()->getOption(TR_AggressiveOpts))
+                     && (clazzNameLength != 16 || strncmp(clazzName, "java/lang/System", 16)))
+               {
+               TR_OpaqueClassBlock *varHandleClass =  fej9->getSystemClassFromClassName("java/lang/invoke/VarHandle", 26);
+               TR_OpaqueClassBlock *objectClass = TR::Compiler->cls.objectClass(comp(), *((uintptrj_t*)dataAddress));
+
+               if (varHandleClass != NULL
+                   && objectClass != NULL
+                   && fej9->isInstanceOf(objectClass, varHandleClass, true, true))
+                  {
+                  createKnownObject = true;
+                  }
+               }
+
+            if (createKnownObject)
                {
                TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
                if (knot)


### PR DESCRIPTION
Create known object index for static final fields that are instances of
VarHandle in ILGen under Xaggressive such that VarHandle calls can
be targeted inlined.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>