### PR TITLE
Fold VarHandle held in static final fields with fear

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -169,7 +169,8 @@ J9::Compilation::Compilation(int32_t id,
    _classForStaticFinalFieldModification(m),
    _profileInfo(NULL),
    _skippedJProfilingBlock(false),
-   _reloRuntime(reloRuntime)
+   _reloRuntime(reloRuntime),
+   _osrProhibitedOverRangeOfTrees(false)
    {
    _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -315,6 +315,10 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
 
+   // Flag to record if any optimization has prohibited OSR over a range of trees
+   void setOSRProhibitedOverRangeOfTrees() { _osrProhibitedOverRangeOfTrees = true; }
+   bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
+
 private:
    enum CachedClassPointerId
       {
@@ -399,6 +403,7 @@ private:
    TR_RelocationRuntime *_reloRuntime;
 
    TR::SymbolValidationManager *_symbolValidationManager;
+   bool _osrProhibitedOverRangeOfTrees;
    };
 
 }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1068,8 +1068,6 @@ J9::Options::fePreProcess(void * base)
    #if defined(J9ZOS390)
       self()->setOption(TR_DisableTraps);
    #endif
-
-   self()->setOption(TR_DisableGuardedStaticFinalFieldFolding);
 
    if (self()->getOption(TR_AggressiveOpts))
       self()->setOption(TR_DontDowngradeToCold, true);

--- a/runtime/compiler/optimizer/FearPointAnalysis.hpp
+++ b/runtime/compiler/optimizer/FearPointAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,6 @@ class TR_FearPointAnalysis : public TR_BackwardUnionSingleBitContainerAnalysis
    virtual void analyzeTreeTopsInBlockStructure(TR_BlockStructure *);
    virtual bool postInitializationProcessing();
    TR_SingleBitContainer *generatedFear(TR::Node *node);
-   bool shouldSkipBlock(TR::Block *block);
 
    static bool virtualGuardsKillFear();
 

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,7 @@
 #include "env/VMAccessCriticalSection.hpp"      // for VMAccessCriticalSection
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/J9JitMemory.hpp"
+#include "optimizer/HCRGuardAnalysis.hpp"
 
 #define OPT_DETAILS "O^O VALUE PROPAGATION: "
 
@@ -1174,4 +1175,236 @@ J9::ValuePropagation::getParmValues()
       }
 
    TR_ASSERT(parmIterator->atEnd() && parmIndex == numParms, "Bad signature for owning method");
+   }
+
+static bool isTakenSideOfAVirtualGuard(TR::Compilation* comp, TR::Block* block)
+   {
+   // First block can never be taken side
+   if (block == comp->getMethodSymbol()->getFirstTreeTop()->getEnclosingBlock())
+      return false;
+
+   for (auto edge = block->getPredecessors().begin(); edge != block->getPredecessors().end(); ++edge)
+      {
+      TR::Block *pred = toBlock((*edge)->getFrom());
+      TR::Node* predLastRealNode = pred->getLastRealTreeTop()->getNode();
+
+      if (predLastRealNode
+          && predLastRealNode->isTheVirtualGuardForAGuardedInlinedCall()
+          && predLastRealNode->getBranchDestination()->getEnclosingBlock() == block)
+         return true;
+
+      }
+
+   return false;
+   }
+
+static bool skipFinalFieldFoldingInBlock(TR::Compilation* comp, TR::Block* block)
+   {
+   if (block->isCold()
+       || block->isOSRCatchBlock()
+       || block->isOSRCodeBlock()
+       || isTakenSideOfAVirtualGuard(comp, block))
+      return true;
+
+   return false;
+   }
+
+static bool isStaticFinalFieldWorthFolding(TR::Compilation* comp, TR_OpaqueClassBlock* declaringClass, char* fieldSignature, int32_t fieldSigLength)
+   {
+   if (comp->getMethodSymbol()->hasMethodHandleInvokes()
+       && !TR::Compiler->cls.classHasIllegalStaticFinalFieldModification(declaringClass))
+      {
+      if (fieldSigLength == 28 && !strncmp(fieldSignature, "Ljava/lang/invoke/VarHandle;", 28))
+         return true;
+      }
+
+   return false;
+   }
+
+
+// Do not add fear point in a frame that doesn't support OSR
+static bool cannotAttemptOSRDuring(TR::Compilation* comp, int32_t callerIndex)
+   {
+   TR::ResolvedMethodSymbol *method = callerIndex == -1 ?
+      comp->getJittedMethodSymbol() : comp->getInlinedResolvedMethodSymbol(callerIndex);
+
+   return method->cannotAttemptOSRDuring(callerIndex, comp, false);
+   }
+
+bool J9::ValuePropagation::transformDirectLoad(TR::Node* node)
+   {
+   // Allow OMR to fold reliable static final field first
+   if (OMR::ValuePropagation::transformDirectLoad(node))
+      return true;
+
+   if (node->isLoadOfStaticFinalField() &&
+       tryFoldStaticFinalFieldAt(_curTree, node))
+      {
+      return true;
+      }
+
+   return false;
+   }
+
+
+static TR_HCRGuardAnalysis* runHCRGuardAnalysisIfPossible()
+   {
+   return NULL;
+   }
+
+TR_YesNoMaybe J9::ValuePropagation::safeToAddFearPointAt(TR::TreeTop* tt)
+   {
+   if (trace())
+      {
+      traceMsg(comp(), "Checking if it is safe to add fear point at n%dn\n", tt->getNode()->getGlobalIndex());
+      }
+
+   int32_t callerIndex = tt->getNode()->getByteCodeInfo().getCallerIndex();
+   if (!cannotAttemptOSRDuring(comp(), callerIndex) && !comp()->isOSRProhibitedOverRangeOfTrees())
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Safe to add fear point because there is no OSR prohibition\n");
+         }
+      return TR_yes;
+      }
+
+   // Look for an OSR point dominating tt in block
+   TR::Block* block = tt->getEnclosingBlock();
+   TR::TreeTop* firstTT = block->getEntry();
+   while (tt != firstTT)
+      {
+      if (comp()->isPotentialOSRPoint(tt->getNode()))
+         {
+         TR_YesNoMaybe result = comp()->isPotentialOSRPointWithSupport(tt) ? TR_yes : TR_no;
+         if (trace())
+            {
+            traceMsg(comp(), "Found %s potential OSR point n%dn, %s to add fear point\n",
+                     result == TR_yes ? "supported" : "unsupported",
+                     tt->getNode()->getGlobalIndex(),
+                     result == TR_yes ? "Safe" : "Not safe");
+            }
+
+         return result;
+         }
+      tt = tt->getPrevTreeTop();
+      }
+
+   TR_HCRGuardAnalysis* guardAnalysis = runHCRGuardAnalysisIfPossible();
+   if (guardAnalysis)
+      {
+      TR_YesNoMaybe result = guardAnalysis->_blockAnalysisInfo[block->getNumber()]->isEmpty() ? TR_yes : TR_no;
+      if (trace())
+         {
+         traceMsg(comp(), "%s to add fear point based on HCRGuardAnalysis\n", result == TR_yes ? "Safe" : "Not safe");
+         }
+
+      return result;
+      }
+
+   if (trace())
+      {
+      traceMsg(comp(), "Cannot determine if it is safe\n");
+      }
+   return TR_maybe;
+   }
+
+/** \brief
+ *     Try to fold static final field
+ *
+ *  \param tree
+ *     The tree with the load of static final field.
+ *
+ *  \param fieldNode
+ *     The node which is a load of a static final field.
+ */
+bool J9::ValuePropagation::tryFoldStaticFinalFieldAt(TR::TreeTop* tree, TR::Node* fieldNode)
+   {
+   TR_ASSERT(fieldNode->isLoadOfStaticFinalField(), "Node n%dn %p has to be a load of a static final field", fieldNode->getGlobalIndex(), fieldNode);
+
+   if (comp()->getOption(TR_DisableGuardedStaticFinalFieldFolding))
+      {
+      return false;
+      }
+
+   if (!comp()->supportsInduceOSR()
+       || !comp()->isOSRTransitionTarget(TR::postExecutionOSR)
+       || comp()->getOSRMode() != TR::voluntaryOSR)
+      {
+      return false;
+      }
+
+   if (skipFinalFieldFoldingInBlock(comp(), tree->getEnclosingBlock())
+       || safeToAddFearPointAt(tree) != TR_yes
+       || TR::TransformUtil::canFoldStaticFinalField(comp(), fieldNode) != TR_maybe)
+      {
+      return false;
+      }
+
+   TR::SymbolReference* symRef = fieldNode->getSymbolReference();
+   if (symRef->hasKnownObjectIndex())
+      {
+      return false;
+      }
+
+   int32_t cpIndex = symRef->getCPIndex();
+   TR_OpaqueClassBlock* declaringClass = symRef->getOwningMethod(comp())->getClassFromFieldOrStatic(comp(), cpIndex);
+   int32_t fieldNameLen;
+   char* fieldName = symRef->getOwningMethod(comp())->fieldName(cpIndex, fieldNameLen, comp()->trMemory(), stackAlloc);
+   int32_t fieldSigLength;
+   char* fieldSignature = symRef->getOwningMethod(comp())->staticSignatureChars(cpIndex, fieldSigLength);
+
+   if (trace())
+      {
+      traceMsg(comp(),
+              "Looking at static final field n%dn %.*s declared in class %p\n",
+              fieldNode->getGlobalIndex(), fieldNameLen, fieldName, declaringClass);
+      }
+
+   if (isStaticFinalFieldWorthFolding(comp(), declaringClass, fieldSignature, fieldSigLength))
+      {
+      if (TR::TransformUtil::foldStaticFinalFieldAssumingProtection(comp(), fieldNode))
+         {
+         // Add class to assumption table
+         comp()->addClassForStaticFinalFieldModification(declaringClass);
+         // Insert osrFearPointHelper call
+         TR::TreeTop* helperTree = TR::TreeTop::create(comp(),
+                                                       TR::Node::create(fieldNode,
+                                                                        TR::treetop,
+                                                                        1,
+                                                                        TR::Node::createOSRFearPointHelperCall(fieldNode)));
+         tree->insertBefore(helperTree);
+
+         if (trace())
+            {
+            traceMsg(comp(),
+                    "Static final field n%dn is folded with OSRFearPointHelper call tree n%dn  helper tree n%dn\n",
+                    fieldNode->getGlobalIndex(), tree->getNode()->getGlobalIndex(), helperTree->getNode()->getGlobalIndex());
+            }
+
+         TR::DebugCounter::prependDebugCounter(comp(),
+                                               TR::DebugCounter::debugCounterName(comp(),
+                                                                                  "staticFinalFieldFolding/success/(field %.*s)/(%s %s)",
+                                                                                  fieldNameLen,
+                                                                                  fieldName,
+                                                                                  comp()->signature(),
+                                                                                  comp()->getHotnessName(comp()->getMethodHotness())),
+                                                                                  tree->getNextTreeTop());
+
+         return true;
+         }
+      }
+   else
+      {
+      TR::DebugCounter::prependDebugCounter(comp(),
+                                            TR::DebugCounter::debugCounterName(comp(),
+                                                                               "staticFinalFieldFolding/notWorthFolding/(field %.*s)/(%s %s)",
+                                                                               fieldNameLen,
+                                                                               fieldName,
+                                                                               comp()->signature(),
+                                                                               comp()->getHotnessName(comp()->getMethodHotness())),
+                                                                               tree->getNextTreeTop());
+      }
+
+   return false;
    }

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,6 +49,8 @@ class ValuePropagation : public OMR::ValuePropagation
  #endif
 
    virtual void constrainRecognizedMethod(TR::Node *node);
+   virtual bool transformDirectLoad(TR::Node *node);
+   bool tryFoldStaticFinalFieldAt(TR::TreeTop* tree, TR::Node* fieldNode);
    virtual void doDelayedTransformations();
    void transformCallToIconstWithHCRGuard(TR::TreeTop *callTree, int32_t result);
    void transformCallToIconstInPlaceOrInDelayedTransformations(TR::TreeTop *callTree, int32_t result, bool isGlobal, bool inPlace = true);
@@ -59,6 +61,8 @@ class ValuePropagation : public OMR::ValuePropagation
    virtual void getParmValues();
 
    private:
+
+   TR_YesNoMaybe safeToAddFearPointAt(TR::TreeTop* tt);
 
    struct TreeIntResultPair {
       TR_ALLOC(TR_Memory::ValuePropagation)

--- a/runtime/compiler/optimizer/OSRGuardInsertion.hpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,5 +53,7 @@ class TR_OSRGuardInsertion : public TR::Optimization
    int32_t insertOSRGuards(TR_BitVector &fearGeneratingNodes);
    void performRemat(TR::TreeTop *osrPoint, TR::TreeTop *osrGuard, TR::TreeTop *rematDest);
    void generateTriggeringRecompilationTrees(TR::TreeTop *osrGuard, TR_PersistentMethodInfo::InfoBits reason);
+   void collectFearFromOSRFearPointHelperCalls(TR_BitVector &fearGeneratingNodes, TR_HCRGuardAnalysis* guardAnalysis);
+   void cleanUpOSRFearPoints();
    };
 #endif

--- a/runtime/compiler/optimizer/StringPeepholes.hpp
+++ b/runtime/compiler/optimizer/StringPeepholes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,6 +104,7 @@ class TR_StringPeepholes : public TR::Optimization
    bool skipNodeUnderOSR(TR::Node *node);
    bool invalidNodeUnderOSR(TR::Node *node);
    void removePendingPushOfResult(TR::TreeTop *callTreeTop);
+   void postProcessTreesForOSR(TR::TreeTop *startTree, TR::TreeTop *endTree);
 
    bool _stringClassesRedefined;
    bool classesRedefined();


### PR DESCRIPTION
Fold static final fields that hold VarHandle object with OSR guard. The
folding occurs in VP and when OSR infrastructure is still available.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>