### PR TITLE
Adjust use of internal methods in String.lines()

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE configurationreg SYSTEM "http://home.ottawa.ibm.com/teams/bluebird/web/eclipse_site/jpp.dtd">
-
 <!--
 /*******************************************************************************
  * Copyright (c) 2002, 2018 IBM Corp. and others
@@ -24,7 +23,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
  -->
-
 <configurationreg version="3.0">
 	<!-- AUTOMATED TEST METADATA -->
 	<automatedtests project="J9 JCL Automated Tests v2">
@@ -263,7 +261,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava11.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava12.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="com.ibm.oti.vm.library.version=29"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1,6 +1,4 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
-package java.lang;
-
 /*******************************************************************************
  * Copyright (c) 1998, 2018 IBM Corp. and others
  *
@@ -22,6 +20,7 @@ package java.lang;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+package java.lang;
 
 import java.io.Serializable;
 
@@ -54,7 +53,6 @@ import java.util.stream.Stream;
  *
  * @see StringBuffer
  */
-
 public final class String implements Serializable, Comparable<String>, CharSequence {
 	
 	/*
@@ -2606,9 +2604,17 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 */
 	public Stream<String> lines() {
 		if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
+			/*[IF Java12]*/
+			return StringLatin1.lines(value, 0, 0);
+			/*[ELSE]*/
 			return StringLatin1.lines(value);
+			/*[ENDIF] Java12*/
 		} else {
+			/*[IF Java12]*/
+			return StringUTF16.lines(value, 0, 0);
+			/*[ELSE]*/
 			return StringUTF16.lines(value);
+			/*[ENDIF] Java12*/
 		}
 	}
 /*[ENDIF] Java11*/


### PR DESCRIPTION
In the head stream of openjdk, the support methods in `StringLatin1` and `StringUTF16` used by `String.lines()` require two more arguments.

Fixes #2886