### PR TITLE
Remove .dbg target using aspp from targets.mk.ftl

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -429,9 +429,6 @@ UMA_PASM_INCLUDES:=$(addprefix -I ,$(UMA_INCLUDES))
 
 </#if>
 <#if uma.spec.type.aix>
-# compilation rule for .dbg files
-%$(UMA_DOT_O): %.dbg
-	aspp $(UMA_ASPP_DEBUG) $< $
 
 # compilation rule for .spp files - translate ! to newline
 %$(UMA_DOT_O): %.spp


### PR DESCRIPTION
We no longer even have aspp on AIX, and this conflicts with the .dbg
extension used by DDR.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes a acceptance build issue with https://github.com/eclipse/omr/pull/2719 on AIX.

@keithc-ca can you please review.