### PR TITLE
Fix Nesthost constant pool entry type

### DIFF
--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -980,7 +980,7 @@ ClassFileWriter::writeAttributes()
 		}
 	} else if (NULL != nestHost) {
 		writeAttributeHeader((J9UTF8 *) &NEST_HOST, 2);
-		writeU16(indexForUTF8(nestHost));
+		writeU16(indexForClass(nestHost));
 	}
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
 


### PR DESCRIPTION
- Use CFR_CONSTANT_Class instead of CFR_CONSTANT_UTF8

Close: #2708 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>