### PR TITLE
Replace J9VMSTATE_GC_ prefix to OMRVMSTATE_GC_ across OpenJ9

### DIFF
--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -420,7 +420,7 @@ MM_GlobalCollectorDelegate::unloadDeadClassLoaders(MM_EnvironmentBase *env)
 	/* The list of classLoaders to be unloaded by cleanUpClassLoadersEnd is rooted in unloadLink */
 
 	/* set the vmState whilst we're unloading classes */
-	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_CLEANING_METADATA);
+	UDATA vmState = env->pushVMstate(OMRVMSTATE_GC_CLEANING_METADATA);
 
 	/* Count the classes we're unloading and perform class-specific clean up work for each unloading class.
 	 * If we're unloading any classes, perform common class-unloading clean up.

--- a/runtime/gc_modron_standard/ConcurrentSweepGC.hpp
+++ b/runtime/gc_modron_standard/ConcurrentSweepGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ protected:
 	virtual void internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, U_32 gcCode);
 
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_COLLECTOR_CONCURRENTSWEEPGC; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COLLECTOR_CONCURRENTSWEEPGC; };
 	
 	static MM_ConcurrentSweepGC *newInstance(MM_EnvironmentBase *env);
 

--- a/runtime/gc_realtime/RealtimeGC.cpp
+++ b/runtime/gc_realtime/RealtimeGC.cpp
@@ -605,7 +605,7 @@ MM_RealtimeGC::unloadDeadClassLoaders(MM_EnvironmentBase *envModron)
 	J9MemorySegment *reclaimedSegments = NULL;
 
 	/* set the vmState whilst we're unloading classes */
-	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_CLEANING_METADATA);
+	UDATA vmState = env->pushVMstate(OMRVMSTATE_GC_CLEANING_METADATA);
 	
 	lockClassUnloadMonitor(env);
 	

--- a/runtime/gc_realtime/RealtimeGC.hpp
+++ b/runtime/gc_realtime/RealtimeGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -227,7 +227,7 @@ public:
     	return (_extensions->nonDeterministicSweep && !isCollectorSweepingArraylets());
     }
 
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_COLLECTOR_METRONOME; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COLLECTOR_METRONOME; };
 	
 	virtual void kill(MM_EnvironmentBase *env) = 0;
 	bool initialize(MM_EnvironmentBase *env);

--- a/runtime/gc_realtime/RealtimeMarkTask.hpp
+++ b/runtime/gc_realtime/RealtimeMarkTask.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@ private:
 	MM_CycleState *_cycleState;  /**< Collection cycle state active for the task */
 
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_MARK; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_MARK; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_realtime/RealtimeSweepTask.hpp
+++ b/runtime/gc_realtime/RealtimeSweepTask.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ private:
 
 /* Methods */
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_SWEEP; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_SWEEP; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_trace_vlhgc/TgcInterRegionRememberedSetDemographics.cpp
+++ b/runtime/gc_trace_vlhgc/TgcInterRegionRememberedSetDemographics.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ public:
 private:
 protected:
 public:
-	virtual UDATA getVMStateID(void) { return J9VMSTATE_GC_TGC; }
+	virtual UDATA getVMStateID(void) { return OMRVMSTATE_GC_TGC; }
 	virtual void run(MM_EnvironmentBase *env);
 
 	TgcParallelHeapWalkTask(MM_EnvironmentBase *env, MM_Dispatcher *dispatcher)

--- a/runtime/gc_vlhgc/CardListFlushTask.hpp
+++ b/runtime/gc_vlhgc/CardListFlushTask.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ public:
 private:
 protected:
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_MARK; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_MARK; }
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/CopyForwardGMPCardCleaner.hpp
+++ b/runtime/gc_vlhgc/CopyForwardGMPCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_COPY_FORWARD_GMP_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COPY_FORWARD_GMP_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/CopyForwardNoGMPCardCleaner.hpp
+++ b/runtime/gc_vlhgc/CopyForwardNoGMPCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_COPY_FORWARD_NO_GMP_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COPY_FORWARD_NO_GMP_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -134,7 +134,7 @@ private:
 	MM_CycleState *_cycleState;  /**< Collection cycle state active for the task */
 
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_SCAVENGE; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_SCAVENGE; };
 
 	virtual void run(MM_EnvironmentBase *envBase)
 	{

--- a/runtime/gc_vlhgc/GlobalCollectionCardCleaner.hpp
+++ b/runtime/gc_vlhgc/GlobalCollectionCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_GLOBAL_COLLECTION_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_GLOBAL_COLLECTION_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/GlobalCollectionNoScanCardCleaner.hpp
+++ b/runtime/gc_vlhgc/GlobalCollectionNoScanCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,7 +69,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_GLOBAL_COLLECTION_NO_SCAN_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_GLOBAL_COLLECTION_NO_SCAN_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/GlobalMarkCardCleaner.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_GLOBAL_MARK_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_GLOBAL_MARK_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -143,7 +143,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_GLOBAL_MARK_CARD_SCRUBBER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_GLOBAL_MARK_CARD_SCRUBBER; }
 
 public:	
 	
@@ -191,7 +191,7 @@ private:
 	
 public:
 
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_SCRUB_CARD_TABLE; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_SCRUB_CARD_TABLE; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/GlobalMarkNoScanCardCleaner.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkNoScanCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,7 +69,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_GLOBAL_MARK_NO_SCAN_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_GLOBAL_MARK_NO_SCAN_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,7 +83,7 @@ private:
 	MM_CycleState *_cycleState; /**< Current cycle state information */
 	
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_MARK; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_MARK; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);
@@ -143,7 +143,7 @@ protected:
 public:
 	virtual UDATA getVMStateID() 
 	{ 
-		return J9VMSTATE_GC_CONCURRENT_MARK_TRACE;
+		return OMRVMSTATE_GC_CONCURRENT_MARK_TRACE;
 	}
 
 	UDATA getBytesScanned()

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -2483,7 +2483,7 @@ MM_IncrementalGenerationalGC::unloadDeadClassLoaders(MM_EnvironmentVLHGC *env)
 	Assert_MM_true(env->_cycleState->_dynamicClassUnloadingEnabled);
 
 	/* set the vmState whilst we're unloading classes */
-	UDATA vmState = env->pushVMstate(J9VMSTATE_GC_CLEANING_METADATA);
+	UDATA vmState = env->pushVMstate(OMRVMSTATE_GC_CLEANING_METADATA);
 	/* we are going to report that we started unloading, even though we might decide that there is no work to do */
 	reportClassUnloadingStart(env);
 	classUnloadStats->_startTime = j9time_hires_clock();

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -229,7 +229,7 @@ public:
 
 	virtual void kill(MM_EnvironmentBase *env);
 	
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_COLLECTOR_GLOBALGC; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COLLECTOR_GLOBALGC; };
 	
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
 	virtual void collectorShutdown(MM_GCExtensionsBase *extensions);

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -906,7 +906,7 @@ MM_MemorySubSpaceTarok::collectorExpand(MM_EnvironmentBase *env)
 IDATA
 MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
 {
-	UDATA oldVMState = env->pushVMstate(J9VMSTATE_GC_PERFORM_RESIZE);
+	UDATA oldVMState = env->pushVMstate(OMRVMSTATE_GC_PERFORM_RESIZE);
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
 	/* If -Xgc:fvtest=forceTenureResize is specified, then repeat a sequence of 5 expands followed by 5 contracts */	
 	if (extensions->fvtest_forceOldResize) {
@@ -957,7 +957,7 @@ MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescri
 void
 MM_MemorySubSpaceTarok::checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool _systemGC)
 {
-	UDATA oldVMState = env->pushVMstate(J9VMSTATE_GC_CHECK_RESIZE);
+	UDATA oldVMState = env->pushVMstate(OMRVMSTATE_GC_CHECK_RESIZE);
 	if (!timeForHeapContract(env, allocDescription, _systemGC)) {
 		timeForHeapExpand(env, allocDescription);
 	}

--- a/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.hpp
+++ b/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,7 +66,7 @@ protected:
 	MM_CycleState *_cycleState;  /**< Current cycle state used for tasks dispatched */
 
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_SWEEP; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_SWEEP; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/PartialMarkGMPCardCleaner.hpp
+++ b/runtime/gc_vlhgc/PartialMarkGMPCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_PARTIAL_MARK_GMP_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_PARTIAL_MARK_GMP_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/PartialMarkNoGMPCardCleaner.hpp
+++ b/runtime/gc_vlhgc/PartialMarkNoGMPCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_PARTIAL_MARK_NO_GMP_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_PARTIAL_MARK_NO_GMP_CARD_CLEANER; }
 
 public:	
 	

--- a/runtime/gc_vlhgc/PartialMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/PartialMarkingScheme.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ private:
 	MM_CycleState *_cycleState; /**< Current cycle state information */
 	
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_MARK; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_MARK; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,7 +69,7 @@ private:
 	MM_MarkMap *_nextMarkMap;	/**< The next mark map which will be passed to the compactor (it uses it as temporary storage for fixup data) */
 
 public:
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_COMPACT; };
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COMPACT; };
 	
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/WriteOnceFixupCardCleaner.hpp
+++ b/runtime/gc_vlhgc/WriteOnceFixupCardCleaner.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ protected:
 	/**
 	 * @see MM_CardCleaner::getVMStateID()
 	 */
-	virtual UDATA getVMStateID() { return J9VMSTATE_GC_WRITE_ONCE_FIXUP_CARD_CLEANER; }
+	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_WRITE_ONCE_FIXUP_CARD_CLEANER; }
 
 public:
 

--- a/runtime/gcchk/gcchk.cpp
+++ b/runtime/gcchk/gcchk.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -294,7 +294,7 @@ excludeGlobalGc(J9VMThread* vmThread)
 
 	/* If Concurrent Scavenger aborted, do not check before global GC (regardless if J9MODRON_GCCHK_SCAVENGER_BACKOUT is requested or not).
 	 * Since checkEngine->_scavengerBackout is set only if J9MODRON_GCCHK_SCAVENGER_BACKOUT requested, gcExtensions->isScavengerBackOutFlagRaised() is checked instead.  */
-	if (gcExtensions->isConcurrentScavengerEnabled() && gcExtensions->isScavengerBackOutFlagRaised() && (J9VMSTATE_GC_CHECK_BEFORE_GC == vmThread->omrVMThread->vmState)) {
+	if (gcExtensions->isConcurrentScavengerEnabled() && gcExtensions->isScavengerBackOutFlagRaised() && (OMRVMSTATE_GC_CHECK_BEFORE_GC == vmThread->omrVMThread->vmState)) {
 		return true;
 	}
 
@@ -355,7 +355,7 @@ hookGcCycleStart(J9HookInterface** hook, UDATA eventNum, void* eventData, void* 
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
 	UDATA oldVMState = vmThread->omrVMThread->vmState;
-	vmThread->omrVMThread->vmState = J9VMSTATE_GC_CHECK_BEFORE_GC;
+	vmThread->omrVMThread->vmState = OMRVMSTATE_GC_CHECK_BEFORE_GC;
 
 	if (OMR_GC_CYCLE_TYPE_GLOBAL == event->cycleType) {
 		++extensions->globalGcCount;
@@ -419,7 +419,7 @@ hookGcCycleEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 
 	UDATA oldVMState = vmThread->omrVMThread->vmState;
-	vmThread->omrVMThread->vmState = J9VMSTATE_GC_CHECK_AFTER_GC;
+	vmThread->omrVMThread->vmState = OMRVMSTATE_GC_CHECK_AFTER_GC;
 
 	if (OMR_GC_CYCLE_TYPE_GLOBAL == event->cycleType) {
 		if (!excludeGlobalGc(vmThread)) {


### PR DESCRIPTION
Replace prefix for GC related VMState definitions from J9 to OMR as far
as all of them have been moved to OMR. 

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>