### PR TITLE
Fix Nestmates to throw correct exception type

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -352,7 +352,8 @@ tryAgain:
 	{
 		IDATA checkResult = checkVisibility(vmStruct, J9_CLASS_FROM_CP(ramCP), accessClass, accessModifiers, resolveFlags);
 		if (checkResult < J9_VISIBILITY_ALLOWED) {
-			if (canRunJavaCode) {
+			/* Check for pending exception for (ie. Nesthost class loading/verify), do not overwrite these exceptions */
+			if (canRunJavaCode && (!VM_VMHelpers::exceptionPending(vmStruct))) {
 				char *errorMsg = NULL;
 				PORT_ACCESS_FROM_VMC(vmStruct);
 				if (J9_VISIBILITY_NON_MODULE_ACCESS_ERROR == checkResult) {


### PR DESCRIPTION
- Check for Nesthost exception before throwing illegalAccessException

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>