### PR TITLE
Revert "Fix typo"

### DIFF
--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -2955,7 +2955,7 @@ J9NLS_SHRC_CM_PRINTSTATS_CACHE_CREATED_WITH.system_action=
 J9NLS_SHRC_CM_PRINTSTATS_CACHE_CREATED_WITH.user_response=
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_SHRINIT_FAILURE_COPYING_USERNAME_TOOLONG=The cache name is too long when the user name is included. There are %d bytes left in this buffer, and your user name is %d bytes.
+J9NLS_SHRC_SHRINIT_FAILURE_COPYING_USERNAME_TOOLONG=The cache name is to long when the user name is included. There are %d bytes left in this buffer, and your user name is %d bytes.
 # START NON-TRANSLATABLE
 J9NLS_SHRC_SHRINIT_FAILURE_COPYING_USERNAME_TOOLONG.sample_input_1=23
 J9NLS_SHRC_SHRINIT_FAILURE_COPYING_USERNAME_TOOLONG.sample_input_2=45


### PR DESCRIPTION
Reverts eclipse/openj9#2896

The change was causing a couple of cmdLineTester_SCCommandLineOptionTests to fail. Reverting for now.

```
Testing: nameOption6
Test start time: 2018/09/17 20:55:29 Central Standard Time
Running command: sh nameOption6.sh /bluebird/builds/bld_397152/sdk/xi3290/bin/../bin
Time spent starting: 2 milliseconds
Time spent executing: 252 milliseconds
Test result: FAILED
 [OUT] nameOption6: TEST FAILED. Expected error message
>> Success condition was not found: [Output match: TEST PASSED]
>> Failure condition was found: [Output match: TEST FAILED]
>> Failure condition was not found: [Output match: Error:]
>> Failure condition was not found: [Output match: Unhandled Exception]
>> Failure condition was not found: [Output match: Exception:]

Testing: nameOption18
Test start time: 2018/09/17 20:55:31 Central Standard Time
Running command: perl nameOption18.pl /bluebird/builds/bld_397152/sdk/xi3290/bin/../bin/java 64
Time spent starting: 5 milliseconds
Time spent executing: 40 milliseconds
Test result: FAILED
 [OUT] 
 [OUT]  command to execute :/bluebird/builds/bld_397152/sdk/xi3290/bin/../bin/java -Xshareclasses:name=123456789A123456789B123456789C123456789D123456789E12345678%u HelloWorld    > nameOption18.out 2>&1: 
 [OUT] 
 [OUT]  TEST FAILED : missing error message 
>> Success condition was not found: [Output match: TEST PASSED]
>> Failure condition was found: [Output match: TEST FAILED]
>> Failure condition was not found: [Output match: Error:]
>> Failure condition was not found: [Output match: Unhandled Exception]
>> Failure condition was not found: [Output match: Exception:]
```