### PR TITLE
Improvements for Relocatable Compilations

### DIFF
--- a/doc/compiler/aot/SymbolValidationManager.md
+++ b/doc/compiler/aot/SymbolValidationManager.md
@@ -1,0 +1,173 @@
+<!--
+Copyright (c) 2018, 2018 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# Symbol Validation Manager
+
+In order for the OpenJ9 Compiler to compile Ahead Of Time (AOT),
+or more accurately, Relocatable, code, it needs to be able to store
+information for the AOT load infrastructure to validate all the 
+assumptions made during the compile run, since the AOT load is 
+performed in a different JVM environment than the one the compilation
+was performed in. For these reasons, the Compiler and the Shared Class
+Cache (SCC) has infrastructure to facilate these validations.
+
+Without the Symbol Validation Manager, the validations involves either
+creating a relocation record to validate an Arbitrary Class, a Class
+from a Constant Pool, an Instance Field, or a Static Field. However,
+when getting a Class By Name, the validation stored would be an 
+Arbitrary Class Validation, which is technically incorrect when the
+Name is retrieved from the signature of a method (since the answer
+depends on what the Class of that method "sees"). In order to deal
+with this, the compiler needs to know where the "beholder" Class comes
+from. The Symbol Validation Manager fixes this problem by making the
+answer to the question "where does this _whatever_ come from?" explicit
+and unambigious.
+
+## How it works
+
+The Symbol Validation Manager (SVM) is very much similar to a symbol table
+that a linker might use. The idea is to store information about where
+a particular symbol (eg `J9Class`, `J9Method`, etc.) came from. For example,
+if the compiler got the `J9Class` of `java/lang/String` by name from the
+parameter list of method `C.foo(Ljava/lang/String)V`, then the SVM will
+store a record stating that the compiler got `J9Class` `java/lang/String`
+By Name as seen by `J9Class` `C`. Then in the load run, the load
+infrastructure can validate these answers the compiler got by redoing the
+same queries *in the same order as during the AOT compilation*. In this
+manner, if the AOT load succeeds validations, the compiled body is 100%
+guaranteed to be compatible in the current environment.
+
+However, since `J9Class`es are artifacts of the current environment, how
+does the SVM enable a new environment to validate it? The core idea is to
+associate unique IDs to each new symbol the compiler gets a hold of. Thus,
+when a symbol is acquired by asking a query using a different symbol, the
+validation record that gets generated refers to these two symbols by their
+IDs, which are environment agnostic. In the load run, the AOT load
+infrastructure uses these IDs to build up its table of symbols that are
+valid in _its_ environment.
+
+To give a concrete example:
+
+The compiler decides to compile `A.foo()`. As part of the compilation, it
+gets class `B` from `A`'s constant pool, gets class `C` from `A`'s 
+constant pool, and finally gets `B` by name as seen by `C`. Thus, the 
+validation records that get generated would be:
+
+1. Root Class Record for `A`; `A` gets ID 1
+2. Method From Class Record for `foo`; `foo` gets ID 2
+3. Class From CP of `A` for `B`; `B` gets ID 3
+4. Class From CP of `A` for `C`; `C` gets ID 4
+5. Class By Name as seen by `C`
+
+When writing out the records, the information would be written out in the
+following manner:
+
+1. Root Class Record: ID=1
+2. Method From Class Record: ID=2, classID=1, index=x
+3. Class From CP Record: ID=3, beholderID=1, cpIndex=y
+4. Class From CP Record: ID=4, beholderID=1, cpIndex=z
+5. Class By Name Record: ID=3, beholder=4
+
+Thus the information written in the validation records are entirely
+environment agnostic. In the load run, the AOT infrastructure will
+go through these validations and build up the symbols that are valid
+in _its_ environment:
+
+1. Map ID=1 to the class of the method being compiled
+2. Get the method at index=x from the class associated with ID=1 and
+map it to ID=2
+3. Get the class from cpIndex=y from the class associated with ID=1
+and map it to ID=3
+4. Get the class from cpIndex=z from the class associated with ID=1
+and map it to ID=4
+5. Get the class by name as seen by the class associated with ID=4
+and verify that it is the same class associated with ID=3
+
+If any of the validations fail, the load is aborted. Thus the general 
+approach in the load run is:
+
+1. Find the symbol as specified by the validation record
+2. Map the ID from the validation record to the symbol
+3. If the map already contains a symbol for that ID, validate that
+the symbol in the map is the same as the symbol currently being
+validated; fail otherwise
+
+
+## Subtleties
+
+### Class Chains
+
+Class Chains are a core component of AOT validation; they ensure that
+the shape of a class is the same as that during the compile run. For
+technical details about Class Chains, see 
+[AOT Class Chains](https://github.com/eclipse/openj9/blob/master/doc/compiler/aot/AOTClassChains.md).
+Thus, for every validation record involving classes, a Class Chain
+Validation Record is also created (unless a record for that class
+already exists).
+
+### Array Classes
+
+Array Classes create a problem for validation. Class Chains can only
+exist for non-array classes. However, if the compiler acquired an 
+array class by name or via profiling, in order to use it during an AOT
+compilation, it still needs to ensure that the shape of that class will
+be valid in the load run. Therefore, for every validation record 
+involving classes, what actually happens is the SVM will get the
+leaf component class, store the record as if the compiler acquired the
+leaf component class from the query, and then store as many 
+Array From Component Class Validation Records as there are array
+dimensions. Therefore, on the load run, when performing a validation, 
+the SVM also has ensure to get the leaf component class in order for
+the validation to be consistent with the compile run. The actual array
+class gets validated via the Array From Component Class records.
+
+### Primitive Classes
+
+Primitive Classes create a different problem for validation. As it turns
+out, the ROM Classes for primitive classes aren't stored in the SCC.
+This is an issue when storing Class By Name records, since the name
+portion of the validation is derived from the ROM Class. In order to
+deal with this problem, the Profiled Class and Class By Name 
+Validations also store a char value representing the primitive type;
+if the char value is '\0', then the class being validated isn't
+primitive and the rest of the validation process continues. If the
+char value is not '\0', then class is primitive, and the Profiled 
+Class or Class By Name record returns validaion succeeded, which is
+correct because Primitive Classes are guaranteed to always be the
+same regardless of how they are acquired.
+
+### Guaranteed IDs
+
+Because Primitive Classes (and their associated array classes) are always
+guaranteed to exist, and because the Root Class and method from root class
+have already been validated prior to even attempting to perfom the AOT
+load, these symbols don't need to be validation records stored in 
+the SCC. Therefore, the SVM, in its constructor, initializes the maps
+with these IDs and the associated symbols.
+
+## Benefits
+
+1. Makes explicit the providence of every symbol acquired by the compiler
+2. Enables code paths previously disabled under AOT
+3. Allows relocations of classes/methods associated with cpIndex=-1
+4. Facilitates the enablement of Known Object Table under AOT
+5. Facilitates the enablement of JSR292 under AOT

--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -359,6 +359,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/Runtime.cpp \
     compiler/runtime/RuntimeAssumptions.cpp \
     compiler/runtime/SignalHandler.c \
+    compiler/runtime/SymbolValidationManager.cpp \
     compiler/runtime/Trampoline.cpp \
     compiler/runtime/ValueProfiler.cpp \
     compiler/runtime/codertinit.cpp \

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -27,6 +27,7 @@
 #include "il/DataTypes.hpp"
 #include "env/VMJ9.h"
 #include "codegen/AheadOfTimeCompile.hpp"
+#include "runtime/RelocationRecord.hpp"
 
 extern bool isOrderedPair(uint8_t reloType);
 
@@ -698,6 +699,7 @@ J9::AheadOfTimeCompile::dumpRelocationData()
          case TR_InlinedSpecialMethodWithNopGuard:
          case TR_InlinedVirtualMethodWithNopGuard:
          case TR_InlinedInterfaceMethodWithNopGuard:
+         case TR_InlinedAbstractMethodWithNopGuard:
          case TR_InlinedHCRMethod:
             cursor++;        // unused field
             if (is64BitTarget)
@@ -1079,9 +1081,729 @@ J9::AheadOfTimeCompile::dumpRelocationData()
             traceMsg(self()->comp(), "\n ClassUnloadAssumption \n");
             break;
 
+         case TR_ValidateRootClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateRootClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateRootClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Root Class: classID=%d ", (uint32_t)binaryTemplate->_classID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateRootClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassByName:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassByNameBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassByNameBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class By Name: classID=%d beholderID=%d primitiveType=%c romClassOffsetInSCC=%p ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_primitiveType,
+                        binaryTemplate->_romClassOffsetInSCC);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassByNameBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateProfiledClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateProfiledClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateProfiledClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Profiled Class: classID=%d primitiveType=%c classChainOffsetInSCC=%d classChainOffsetForCLInScc=%p ",
+                        (uint32_t)binaryTemplate->_classID,
+                        binaryTemplate->_primitiveType,
+                        binaryTemplate->_classChainOffsetInSCC,
+                        binaryTemplate->_classChainOffsetForCLInScc);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateProfiledClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class From CP: classID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateDefiningClassFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Defining Class From CP: classID=%d, beholderID=%d, cpIndex=%d, isStatic=%s ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex,
+                        binaryTemplate->_isStatic ? "true" : "false");
+               }
+            cursor += sizeof(TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateStaticClassFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Static Class From CP: classID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassFromMethod:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassFromMethodBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassFromMethodBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class From Method: classID=%d, methodID=%d ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_methodID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateComponentClassFromArrayClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateCompFromArrayBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateCompFromArrayBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Component Class From Array: componentClassID=%d, arrayClassID=%d ",
+                        (uint32_t)binaryTemplate->_componentClassID,
+                        (uint32_t)binaryTemplate->_arrayClassID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateCompFromArrayBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateArrayClassFromComponentClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateArrayFromCompBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateArrayFromCompBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Array Class From Component: arrayClassID=%d, componentClassID=%d ",
+                        (uint32_t)binaryTemplate->_arrayClassID,
+                        (uint32_t)binaryTemplate->_componentClassID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateArrayFromCompBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateSuperClassFromClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Super Class From Class: superClassID=%d, childClassID=%d ",
+                        (uint32_t)binaryTemplate->_superClassID,
+                        (uint32_t)binaryTemplate->_childClassID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassInstanceOfClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class InstanceOf Class: classOneID=%d, classTwoID=%d, objectTypeIsFixed=%s, castTypeIsFixed=%s, isInstanceOf=%s ",
+                        (uint32_t)binaryTemplate->_classOneID,
+                        (uint32_t)binaryTemplate->_classTwoID,
+                        binaryTemplate->_objectTypeIsFixed ? "true" : "false",
+                        binaryTemplate->_castTypeIsFixed ? "true" : "false",
+                        binaryTemplate->_isInstanceOf ? "true" : "false");
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateSystemClassByName:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate System Class By Name: systemClassID=%d romClassOffsetInSCC=%p ",
+                        (uint32_t)binaryTemplate->_systemClassID,
+                        binaryTemplate->_romClassOffsetInSCC);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassFromITableIndexCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class From ITableIndex CP: classID=%d beholderID=%d cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateDeclaringClassFromFieldOrStatic:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Declaring Class From Field Or Static: classID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_classID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class Class: classClassID=%d, objectClassID=%d ",
+                        (uint32_t)binaryTemplate->_classClassID,
+                        (uint32_t)binaryTemplate->_objectClassID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateConcreteSubClassFromClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Concrete SubClass From Class: childClassID=%d, superClassID=%d ",
+                        (uint32_t)binaryTemplate->_childClassID,
+                        (uint32_t)binaryTemplate->_superClassID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassChain:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassChainBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassChainBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class Chain: classID=%d classChainOffsetInSCC=%p ",
+                        (uint32_t)binaryTemplate->_classID,
+                        binaryTemplate->_classChainOffsetInSCC);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassChainBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateRomClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateRomClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateRomClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate RomClass: classID=%d romClassOffsetInSCC=%p ",
+                        (uint32_t)binaryTemplate->_classID,
+                        binaryTemplate->_romClassOffsetInSCC);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateRomClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidatePrimitiveClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidatePrimitiveClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidatePrimitiveClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Primitive Class: classID=%d, primitiveType=%c ",
+                        (uint32_t)binaryTemplate->_classID,
+                        binaryTemplate->_primitiveType);
+               }
+            cursor += sizeof(TR_RelocationRecordValidatePrimitiveClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodFromInlinedSite:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method From Inlined Site: methodID=%d, inlinedSiteIndex=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (int32_t)binaryTemplate->_inlinedSiteIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodByName:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodByNameBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodByNameBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method By Name: methodID=%d, beholderID=%d, romClassOffsetInSCC=%p romMethodOffsetInSCC=%p ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_romClassOffsetInSCC,
+                        binaryTemplate->_romMethodOffsetInSCC);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodByNameBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodFromClass:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodFromClassBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodFromClassBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method By Name: methodID=%d, beholderID=%d, index=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_index);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodFromClassBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateStaticMethodFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Static Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateSpecialMethodFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Special Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateVirtualMethodFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Virtual Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateVirtualMethodFromOffset:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Virtual Method From Offset: methodID=%d, beholderID=%d, virtualCallOffset=%d, ignoreRtResolve=%s ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_virtualCallOffset,
+                        binaryTemplate->_ignoreRtResolve ? "true" : "false");
+               }
+            cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateInterfaceMethodFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Interface Method From CP: methodID=%d, beholderID=%d, lookupID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        (uint32_t)binaryTemplate->_lookupID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateImproperInterfaceMethodFromCP:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Improper Interface Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_cpIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodFromClassAndSig:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method From Class and Sig: methodID=%d, methodClassID=%d, beholderID=%d, romMethodOffsetInSCC=%p ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_methodClassID,
+                        (uint32_t)binaryTemplate->_beholderID,
+                        binaryTemplate->_romMethodOffsetInSCC);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateStackWalkerMaySkipFramesRecord:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Stack Walker May Skip Frames: methodID=%d, methodClassID=%d, beholderID=%d, skipFrames=%s ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_methodClassID,
+                        binaryTemplate->_skipFrames ? "true" : "false");
+               }
+            cursor += sizeof(TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateArrayClassFromJavaVM:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Array Class From JavaVM: arrayClassID=%d, arrayClassIndex=%d ",
+                        (uint32_t)binaryTemplate->_arrayClassID,
+                        binaryTemplate->_arrayClassIndex);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateClassInfoIsInitialized:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Class Info Is Initialized: classID=%d, isInitialized=%s ",
+                        (uint32_t)binaryTemplate->_classID,
+                        binaryTemplate->_isInitialized ? "true" : "false");
+               }
+            cursor += sizeof(TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodFromSingleImplementer:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method From Single Implementor: methodID=%d, thisClassID=%d, cpIndexOrVftSlot=%d, callerMethodID=%d, useGetResolvedInterfaceMethod=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_thisClassID,
+                        binaryTemplate->_cpIndexOrVftSlot,
+                        (uint32_t)binaryTemplate->_callerMethodID,
+                        binaryTemplate->_useGetResolvedInterfaceMethod);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodFromSingleInterfaceImplementer:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method From Single Interface Implementor: methodID=%d, thisClassID=%d, cpIndex=%d, callerMethodID=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_thisClassID,
+                        binaryTemplate->_cpIndex,
+                        (uint32_t)binaryTemplate->_callerMethodID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+         case TR_ValidateMethodFromSingleAbstractImplementer:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Validate Method From Single Interface Implementor: methodID=%d, thisClassID=%d, vftSlot=%d, callerMethodID=%d ",
+                        (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_thisClassID,
+                        binaryTemplate->_vftSlot,
+                        (uint32_t)binaryTemplate->_callerMethodID);
+               }
+            cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
+
+         case TR_SymbolFromManager:
+            {
+            cursor++;
+            if (is64BitTarget)
+               cursor += 4;     // padding
+            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
+            TR_RelocationRecordSymbolFromManagerBinaryTemplate *binaryTemplate =
+                  reinterpret_cast<TR_RelocationRecordSymbolFromManagerBinaryTemplate *>(cursor);
+            if (isVerbose)
+               {
+               traceMsg(self()->comp(), "\n Symbol From Manager: symbolID=%d symbolType=%d ",
+                        (uint32_t)binaryTemplate->_symbolID, (uint32_t)binaryTemplate->_symbolType);
+               }
+            cursor += sizeof(TR_RelocationRecordSymbolFromManagerBinaryTemplate);
+            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
+            }
+            break;
+
          default:
             traceMsg(self()->comp(), "Unknown Relocation type = %d\n", kind);
             TR_ASSERT(false, "should be unreachable");
+            printf("Unknown Relocation type = %d\n", kind);
+            fflush(stdout);
+            exit(0);
+
         break;
          }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -1130,7 +1130,7 @@ J9::CodeGenerator::lowerTreeIfNeeded(
          {
          if (!((methodSymbol && methodSymbol->getResolvedMethodSymbol() &&
                methodSymbol->getResolvedMethodSymbol()->getResolvedMethod() &&
-               methodSymbol->getResolvedMethodSymbol()->getResolvedMethod()->isInterpreted()) ||
+               methodSymbol->getResolvedMethodSymbol()->getResolvedMethod()->isInterpretedForHeuristics()) ||
                methodSymbol->isVMInternalNative()      ||
                methodSymbol->isHelper()                ||
                methodSymbol->isNative()                ||

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2513,6 +2513,10 @@ J9::CodeGenerator::processRelocations()
                type = TR_InlinedInterfaceMethod;
                break;
 
+            case TR_AbstractGuard:
+               type = TR_InlinedAbstractMethodWithNopGuard;
+               break;
+
             case TR_HCRGuard:
                // devinmp: TODO/FIXME this should arrange to create an AOT
                // relocation which, when loaded, creates a
@@ -2569,6 +2573,7 @@ J9::CodeGenerator::processRelocations()
             case TR_InlinedSpecialMethodWithNopGuard:
             case TR_InlinedVirtualMethodWithNopGuard:
             case TR_InlinedInterfaceMethodWithNopGuard:
+            case TR_InlinedAbstractMethodWithNopGuard:
             case TR_InlinedHCRMethod:
             case TR_ProfiledClassGuardRelocation:
             case TR_ProfiledMethodGuardRelocation:
@@ -2610,6 +2615,15 @@ J9::CodeGenerator::processRelocations()
                TR_ASSERT(false, "got a unknown/non-AOT guard at AOT site");
                break;
             }
+         }
+
+      TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
+      for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
+         {
+         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
+                                                                          (uint8_t *)(*it),
+                                                                          (*it)->_kind, self()),
+                                                                          __FILE__, __LINE__, NULL);
          }
 
       TR::list<TR::AOTClassInfo*>* classInfo = self()->comp()->_aotClassInfo;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2617,15 +2617,6 @@ J9::CodeGenerator::processRelocations()
             }
          }
 
-      TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
-      for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
-         {
-         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                          (uint8_t *)(*it),
-                                                                          (*it)->_kind, self()),
-                                                                          __FILE__, __LINE__, NULL);
-         }
-
       TR::list<TR::AOTClassInfo*>* classInfo = self()->comp()->_aotClassInfo;
       if (!classInfo->empty())
          {
@@ -2703,6 +2694,16 @@ J9::CodeGenerator::processRelocations()
                }
             }
          }
+
+      TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
+      for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
+         {
+         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
+                                                                          (uint8_t *)(*it),
+                                                                          (*it)->_kind, self()),
+                                                                          __FILE__, __LINE__, NULL);
+         }
+
 //#endif
       // Now call the platform specific processing of relocations
       self()->getAheadOfTimeCompile()->processRelocations();

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2696,12 +2696,20 @@ J9::CodeGenerator::processRelocations()
          }
 
       TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
-      for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
+      if (!validationRecords.empty() && self()->comp()->getOption(TR_UseSymbolValidationManager))
          {
-         self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                          (uint8_t *)(*it),
-                                                                          (*it)->_kind, self()),
-                                                                          __FILE__, __LINE__, NULL);
+         // Add the flags in TR_AOTMethodHeader on the compile run
+         J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)self()->comp()->getAotMethodDataStart();
+         TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesSymbolValidationManager;
+
+         for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
+            {
+            self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
+                                                                             (uint8_t *)(*it),
+                                                                             (*it)->_kind, self()),
+                                                                             __FILE__, __LINE__, NULL);
+            }
          }
 
 //#endif

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -170,23 +170,7 @@ J9::Compilation::Compilation(
    _profileInfo(NULL),
    _skippedJProfilingBlock(false)
    {
-   _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region());
-   if (compileRelocatableCode() && getOption(TR_UseSymbolValidationManager))
-      {
-      bool validated = false;
-      validated = _symbolValidationManager->addRootClassRecord(compilee->classOfMethod());
-      TR_ASSERT_FATAL(validated, "addRootClassRecord should not fail!\n");
-      validated = _symbolValidationManager->addMethodFromClassRecord(compilee->getNonPersistentIdentifier(), compilee->classOfMethod(), static_cast<uint32_t>(-1));
-      TR_ASSERT_FATAL(validated, "addMethodFromClassRecord should not fail!\n");
-
-      struct J9Class ** arrayClasses = &fej9()->getJ9JITConfig()->javaVM->booleanArrayClass;
-      for (int32_t i = 4; i <= 11; i++)
-         {
-         /* This will first add the primitive, and then an arrayof record */
-         validated = getSymbolValidationManager()->addArrayClassFromJavaVM((TR_OpaqueClassBlock *)arrayClasses[i - 4], i);
-         TR_ASSERT_FATAL(validated, "addArrayClassFromJavaVM should not fail!\n");
-         }
-      }
+   _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
 
    _aotClassClassPointer = NULL;
    _aotClassClassPointerInitialized = false;

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1081,6 +1081,26 @@ J9::Compilation::compilationShouldBeInterrupted(TR_CallingContext callingContext
    return self()->fej9()->compilationShouldBeInterrupted(self(), callingContext);
    }
 
+void
+J9::Compilation::enterHeuristicRegion()
+   {
+   if (self()->getOption(TR_UseSymbolValidationManager)
+       && self()->compileRelocatableCode())
+      {
+      self()->getSymbolValidationManager()->enterHeuristicRegion();
+      }
+   }
+
+void
+J9::Compilation::exitHeuristicRegion()
+   {
+   if (self()->getOption(TR_UseSymbolValidationManager)
+       && self()->compileRelocatableCode())
+      {
+      self()->getSymbolValidationManager()->exitHeuristicRegion();
+      }
+   }
+
 
 void
 J9::Compilation::reportILGeneratorPhase()

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -170,12 +170,15 @@ J9::Compilation::Compilation(
    _profileInfo(NULL),
    _skippedJProfilingBlock(false)
    {
-   _ObjectClassPointer   = fe->getClassFromSignature("Ljava/lang/Object;", 18, compilee);
-   _RunnableClassPointer = fe->getClassFromSignature("Ljava/lang/Runnable;", 20, compilee);
-   _StringClassPointer   = fe->getClassFromSignature("Ljava/lang/String;", 18, compilee);
-   _SystemClassPointer   = fe->getClassFromSignature("Ljava/lang/System;", 18, compilee);
-   _ReferenceClassPointer = fe->getClassFromSignature("Ljava/lang/ref/Reference;", 25, compilee);
-   _JITHelpersClassPointer = fe->getClassFromSignature("Lcom/ibm/jit/JITHelpers;", 24, compilee);
+   _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region());
+   if (compileRelocatableCode() && getOption(TR_UseSymbolValidationManager))
+      {
+      bool validated = false;
+      validated = _symbolValidationManager->addRootClassRecord(compilee->classOfMethod());
+      TR_ASSERT_FATAL(validated, "addRootClassRecord should not fail!\n");
+      validated = _symbolValidationManager->addMethodFromClassRecord(compilee->getNonPersistentIdentifier(), compilee->classOfMethod(), static_cast<uint32_t>(-1));
+      TR_ASSERT_FATAL(validated, "addMethodFromClassRecord should not fail!\n");
+      }
 
    _aotClassClassPointer = NULL;
    _aotClassClassPointerInitialized = false;
@@ -188,6 +191,13 @@ J9::Compilation::Compilation(
       _hiresTimeForPreviousCallingContext = TR::Compiler->vm.getHighResClock(self());
 
    _profileInfo = new (m->trHeapMemory()) TR_AccessedProfileInfo(heapMemoryRegion);
+
+   _ObjectClassPointer   = fe->getClassFromSignature("Ljava/lang/Object;", 18, compilee);
+   _RunnableClassPointer = fe->getClassFromSignature("Ljava/lang/Runnable;", 20, compilee);
+   _StringClassPointer   = fe->getClassFromSignature("Ljava/lang/String;", 18, compilee);
+   _SystemClassPointer   = fe->getClassFromSignature("Ljava/lang/System;", 18, compilee);
+   _ReferenceClassPointer = fe->getClassFromSignature("Ljava/lang/ref/Reference;", 25, compilee);
+   _JITHelpersClassPointer = fe->getClassFromSignature("Lcom/ibm/jit/JITHelpers;", 24, compilee);
    }
 
 J9::Compilation::~Compilation()

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -196,6 +196,20 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    bool compilationShouldBeInterrupted(TR_CallingContext);
 
+   /* Heuristic Region APIs
+    *
+    * Heuristic Regions denotes regions where decisions
+    * within the region do not need to be remembered. In relocatable compiles,
+    * when the compiler requests some information via front end query,
+    * it's possible that the front end might walk a data structure,
+    * looking at several different possible answers before finally deciding
+    * on one. For a relocatable compile, only the final answer is important.
+    * Thus, a heuristic region is used to ignore all of the intermediate
+    * steps in determining the final answer.
+    */
+   void enterHeuristicRegion();
+   void exitHeuristicRegion();
+
    void reportILGeneratorPhase();
    void reportAnalysisPhase(uint8_t id);
    void reportOptimizationPhase(OMR::Optimizations);

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -41,6 +41,7 @@ namespace J9 { typedef J9::Compilation CompilationConnector; }
 #include "env/CompilerEnv.hpp"
 #include "env/OMRMemory.hpp"
 #include "compile/AOTClassInfo.hpp"
+#include "runtime/SymbolValidationManager.hpp"
 
 class TR_AOTGuardSite;
 class TR_FrontEnd;
@@ -287,6 +288,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    //
    bool supportsQuadOptimization();
 
+   TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
+
 private:
 
    J9VMThread *_j9VMThread;
@@ -360,6 +363,8 @@ private:
    TR_AccessedProfileInfo *_profileInfo;
 
    bool _skippedJProfilingBlock;
+
+   TR::SymbolValidationManager *_symbolValidationManager;
    };
 
 }

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -210,6 +210,11 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    void enterHeuristicRegion();
    void exitHeuristicRegion();
 
+   /* Used to ensure that a implementer chosen for inlining is valid under
+    * AOT.
+    */
+   bool validateTargetToBeInlined(TR_ResolvedMethod *implementer);
+
    void reportILGeneratorPhase();
    void reportAnalysisPhase(uint8_t id);
    void reportOptimizationPhase(OMR::Optimizations);

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1928,8 +1928,7 @@ J9::SymbolReferenceTable::checkImmutable(TR::SymbolReference *symRef)
                isClassInitialized = true;
 
             if ((classOfStatic != comp()->getSystemClassPointer()) &&
-                isClassInitialized && TR::Compiler->cls.isClassFinal(comp(), classOfStatic) &&
-                !comp()->getOption(TR_AOT))
+                isClassInitialized && TR::Compiler->cls.isClassFinal(comp(), classOfStatic))
                {
                if (!classInfo->getFieldInfo() &&
                     (comp()->getMethodHotness() >= hot))

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7070,6 +7070,12 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_EnableAnnotations,false);
             }
 
+         if (vm->canUseSymbolValidationManager() && options->getOption(TR_EnableSymbolValidationManager))
+            {
+            options->setOption(TR_UseSymbolValidationManager);
+            options->setOption(TR_DisableKnownObjectTable);
+            }
+
          // Set jitDump specific options
          TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);
          TR::CompilationInfoPerThread *threadCompInfo = compInfo ? compInfo->getCompInfoForThread(vmThread) : NULL;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7414,6 +7414,11 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                   options->setOption(TR_EnableGRACostBenefitModel, false);
                }
 
+            if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP || options->getOptLevel() < warm)
+               {
+               options->setOption(TR_UseSymbolValidationManager, false);
+               }
+
 
             // See if we need to inset GCR trees
             if (!details.supportsInvalidation())

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1794,6 +1794,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotValidateMethodEnterFailure:
             case compilationAotClassChainPersistenceFailure:
             case compilationAotValidateStringCompressionFailure:
+            case compilationSymbolValidationManagerFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;
@@ -10081,6 +10082,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const TR::GCRPatchFailure &e)
       {
       _methodBeingCompiled->_compErrCode = compilationGCRPatchFailure;
+      }
+   catch (const J9::AOTSymbolValidationManagerFailure &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationSymbolValidationManagerFailure;
       }
    catch (const J9::ClassChainPersistenceFailure &e)
       {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2846,6 +2846,8 @@ void TR::CompilationInfo::stopCompilationThreads()
       fprintf(stderr, "numVirtualMethodsValidationSucceeded: %d\n", aotStats->virtualMethods.numSucceededValidations);
       fprintf(stderr, "numInterfaceMethodsValidationFailed: %d\n", aotStats->interfaceMethods.numFailedValidations);
       fprintf(stderr, "numInterfaceMethodsValidationSucceeded: %d\n", aotStats->interfaceMethods.numSucceededValidations);
+      fprintf(stderr, "numAbstractMethodsValidationFailed: %d\n", aotStats->abstractMethods.numFailedValidations);
+      fprintf(stderr, "numAbstractMethodsValidationSucceeded: %d\n", aotStats->abstractMethods.numSucceededValidations);
 
       fprintf(stderr, "-------------------------\n");
       fprintf(stderr, "numProfiledClassGuardsValidationFailed: %d\n", aotStats->profiledClassGuards.numFailedValidations);

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5681,6 +5681,7 @@ static void classLoadPhaseLogic(J9JITConfig * jitConfig, TR::CompilationInfo * c
                 !TR::Options::getCmdLineOptions()->getOption(TR_DisableSelectiveNoOptServer))
                {
                TR::Options::getCmdLineOptions()->setOption(TR_DisableSelectiveNoOptServer); // Turn this feature off
+               TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableSelectiveNoOptServer); // Turn this feature off
                if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
                   TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "t=%u selectiveNoOptServer feature turned off", crtElapsedTime);
                }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1941,6 +1941,10 @@ J9::Options::fePreProcess(void * base)
          }
       }
 
+#if defined(TR_HOST_X86) && defined(TR_TARGET_64BIT)
+   self()->setOption(TR_EnableSymbolValidationManager);
+#endif
+
    return true;
    }
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -195,6 +195,7 @@ char *compilationErrorNames[]={
    "compilationFSDHasInvokeHandle", //47
    "compilationVirtualAddressExhaustion", //48
    "compilationEnforceProfiling", //49
+   "compilationSymbolValidationManagerFailure", //50
    "compilationMaxError"
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -73,6 +73,7 @@ typedef enum {
    compilationFSDHasInvokeHandle                   = 47,
    compilationVirtualAddressExhaustion             = 48,
    compilationEnforceProfiling                     = 49,
+   compilationSymbolValidationManagerFailure       = 50,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -230,7 +230,7 @@ FindSingleJittedImplementer::visitSubclass(TR_PersistentClassInfo *cl)
          }
 
       // check to see if there are any duplicates
-      if (!method->isInterpreted())
+      if (!method->isInterpretedForHeuristics())
          {
          if (_implementer)
             {

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -309,18 +309,29 @@ TR_PersistentCHTable::findClassInfo(TR_OpaqueClassBlock * classId)
  * The class table lock is used to synchronize use of this method
  */
 TR_PersistentClassInfo *
-TR_PersistentCHTable::findClassInfoAfterLocking(
-      TR_OpaqueClassBlock *classId,
+TR_PersistentCHTable::findClassInfoAfterLocking(TR_OpaqueClassBlock *classId,
       TR::Compilation *comp,
       bool returnClassInfoForAOT,
       bool validate)
    {
-   if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE() && !returnClassInfoForAOT) // for AOT do not use the class hierarchy
+   // for AOT do not use the class hierarchy
+   if (comp->compileRelocatableCode() && !returnClassInfoForAOT)
+      {
       return NULL;
+      }
 
    if (comp->getOption(TR_DisableCHOpts))
       return NULL;
-   return findClassInfoAfterLocking(classId, comp->fe(), returnClassInfoForAOT);
+
+   TR_PersistentClassInfo *classInfo = findClassInfoAfterLocking(classId, comp->fe(), returnClassInfoForAOT);
+   if (classInfo &&
+       comp->compileRelocatableCode() &&
+       comp->getOption(TR_UseSymbolValidationManager) &&
+       validate)
+      {
+      comp->getSymbolValidationManager()->addClassInfoIsInitializedRecord(classId, classInfo->isInitialized());
+      }
+   return classInfo;
    }
 
 /**
@@ -408,8 +419,31 @@ TR_ResolvedMethod * TR_PersistentCHTable::findSingleImplementer(
       }
 
    TR_ResolvedMethod *implArray[2]; // collect maximum 2 implemeters if you can
+   comp->enterHeuristicRegion();
    int32_t implCount = TR_ClassQueries::collectImplementorsCapped(classInfo, implArray, 2, cpIndexOrVftSlot, callerMethod, comp, locked, useGetResolvedInterfaceMethod);
-   return (implCount == 1 ? implArray[0] : 0);
+   comp->exitHeuristicRegion();
+
+   TR_ResolvedMethod *implementer = NULL;
+   if (implCount == 1)
+      implementer =implArray[0];
+
+   if (implementer && comp->getOption(TR_UseSymbolValidationManager) && validate)
+      {
+      TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
+
+      bool validated = svm->addMethodFromSingleImplementerRecord(implementer->getPersistentIdentifier(),
+                                                                 thisClass,
+                                                                 cpIndexOrVftSlot,
+                                                                 callerMethod->getPersistentIdentifier(),
+                                                                 useGetResolvedInterfaceMethod);
+      if (validated)
+         validated = svm->addClassFromMethodRecord(implementer->classOfMethod(), implementer->getPersistentIdentifier());
+
+      if (!validated)
+         implementer = NULL;
+      }
+
+   return implementer;
    }
 
 TR_ResolvedMethod *
@@ -436,8 +470,30 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
       }
 
    TR_ResolvedMethod *implArray[2]; // collect maximum 2 implemeters if you can
+   comp->enterHeuristicRegion();
    int32_t implCount = TR_ClassQueries::collectImplementorsCapped(classInfo, implArray, 2, cpIndex, callerMethod, comp, locked);
-   return (implCount == 1 ? implArray[0] : 0);
+   comp->exitHeuristicRegion();
+
+   TR_ResolvedMethod *implementer = NULL;
+   if (implCount == 1)
+      implementer = implArray[0];
+
+   if (implementer && comp->getOption(TR_UseSymbolValidationManager) && validate)
+      {
+      TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
+      bool validated = svm->addMethodFromSingleInterfaceImplementerRecord(implementer->getPersistentIdentifier(),
+                                                                          thisClass,
+                                                                          cpIndex,
+                                                                          callerMethod->getPersistentIdentifier());
+
+      if (validated)
+         validated = svm->addClassFromMethodRecord(implementer->classOfMethod(), implementer->getPersistentIdentifier());
+
+      if (!validated)
+         implementer = NULL;
+      }
+
+   return implementer;
    }
 
 bool
@@ -513,15 +569,38 @@ TR_PersistentCHTable::findSingleAbstractImplementer(
    {
    if (comp->getOption(TR_DisableCHOpts))
       return 0;
-   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp);
+   bool allowForAOT = comp->getOption(TR_UseSymbolValidationManager);
+   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, allowForAOT, validate);
    if (!classInfo) return 0;
 
    if (TR::Compiler->cls.isInterfaceClass(comp, thisClass))
       return 0;
 
    TR_ResolvedMethod *implArray[2]; // collect maximum 2 implemeters if you can
+   comp->enterHeuristicRegion();
    int32_t implCount = TR_ClassQueries::collectImplementorsCapped(classInfo, implArray, 2, vftSlot, callerMethod, comp, locked);
-   return (implCount == 1 ? implArray[0] : 0);
+   comp->exitHeuristicRegion();
+
+   TR_ResolvedMethod *implementer = NULL;
+   if(implCount == 1)
+      implementer = implArray[0];
+
+   if (implementer && comp->getOption(TR_UseSymbolValidationManager) && validate)
+      {
+      TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
+      bool validated = svm->addMethodFromSingleAbstractImplementerRecord(implementer->getPersistentIdentifier(),
+                                                                         thisClass,
+                                                                         vftSlot,
+                                                                         callerMethod->getPersistentIdentifier());
+
+      if (validated)
+         validated = svm->addClassFromMethodRecord(implementer->classOfMethod(), implementer->getPersistentIdentifier());
+
+      if (!validated)
+         implementer = NULL;
+      }
+
+   return implementer;
    }
 
 
@@ -535,7 +614,9 @@ TR_PersistentCHTable::findSingleConcreteSubClass(
    if (comp->getOption(TR_DisableCHOpts))
       return 0;
 
-   TR_PersistentClassInfo *classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(opaqueClass, comp);
+   bool allowForAOT = comp->getOption(TR_UseSymbolValidationManager);
+
+   TR_PersistentClassInfo *classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(opaqueClass, comp, allowForAOT, validate);
    if (classInfo)
       {
       TR_ScratchList<TR_PersistentClassInfo> subClasses(comp->trMemory());
@@ -551,6 +632,12 @@ TR_PersistentCHTable::findSingleConcreteSubClass(
             concreteSubClass = subClass;
             }
          }
+      }
+
+   if (validate && comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (!comp->getSymbolValidationManager()->addConcreteSubClassFromClassRecord(concreteSubClass, opaqueClass))
+         concreteSubClass = NULL;
       }
 
    return concreteSubClass;

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -312,7 +312,8 @@ TR_PersistentClassInfo *
 TR_PersistentCHTable::findClassInfoAfterLocking(
       TR_OpaqueClassBlock *classId,
       TR::Compilation *comp,
-      bool returnClassInfoForAOT)
+      bool returnClassInfoForAOT,
+      bool validate)
    {
    if (comp->fej9()->isAOT_DEPRECATED_DO_NOT_USE() && !returnClassInfoForAOT) // for AOT do not use the class hierarchy
       return NULL;
@@ -387,14 +388,20 @@ TR_PersistentCHTable::isOverriddenInThisHierarchy(
    }
 
 TR_ResolvedMethod * TR_PersistentCHTable::findSingleImplementer(
-   TR_OpaqueClassBlock * thisClass, int32_t cpIndexOrVftSlot, TR_ResolvedMethod * callerMethod, TR::Compilation * comp, bool locked, TR_YesNoMaybe useGetResolvedInterfaceMethod)
+      TR_OpaqueClassBlock * thisClass,
+      int32_t cpIndexOrVftSlot,
+      TR_ResolvedMethod * callerMethod,
+      TR::Compilation * comp,
+      bool locked,
+      TR_YesNoMaybe useGetResolvedInterfaceMethod,
+      bool validate)
    {
    if (comp->getOption(TR_DisableCHOpts))
       return 0;
 
 
 
-   TR_PersistentClassInfo * classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(thisClass, comp, true);
+   TR_PersistentClassInfo * classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(thisClass, comp, true, validate);
    if (!classInfo)
       {
       return 0;
@@ -411,7 +418,8 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
       int32_t cpIndex,
       TR_ResolvedMethod *callerMethod,
       TR::Compilation *comp,
-      bool locked)
+      bool locked,
+      bool validate)
    {
    if (comp->getOption(TR_DisableCHOpts))
       return 0;
@@ -421,7 +429,7 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
       return 0;
       }
 
-   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, true);
+   TR_PersistentClassInfo * classInfo = findClassInfoAfterLocking(thisClass, comp, true, validate);
    if (!classInfo)
       {
       return 0;
@@ -496,7 +504,12 @@ TR_PersistentCHTable::isKnownToHaveMoreThanTwoInterfaceImplementers(
 
 TR_ResolvedMethod *
 TR_PersistentCHTable::findSingleAbstractImplementer(
-   TR_OpaqueClassBlock * thisClass, int32_t vftSlot, TR_ResolvedMethod * callerMethod, TR::Compilation * comp, bool locked)
+   TR_OpaqueClassBlock * thisClass,
+      int32_t vftSlot,
+      TR_ResolvedMethod * callerMethod,
+      TR::Compilation * comp,
+      bool locked,
+      bool validate)
    {
    if (comp->getOption(TR_DisableCHOpts))
       return 0;
@@ -515,7 +528,8 @@ TR_PersistentCHTable::findSingleAbstractImplementer(
 TR_OpaqueClassBlock *
 TR_PersistentCHTable::findSingleConcreteSubClass(
       TR_OpaqueClassBlock *opaqueClass,
-      TR::Compilation *comp)
+      TR::Compilation *comp,
+      bool validate)
    {
    TR_OpaqueClassBlock *concreteSubClass = NULL;
    if (comp->getOption(TR_DisableCHOpts))

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -50,7 +50,7 @@ class TR_PersistentCHTable
 
    TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId);
 
-   TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false);
+   TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false, bool validate = true);
    TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR_FrontEnd *, bool returnClassInfoForAOT = false);
 
    void dumpMethodCounts(TR_FrontEnd *fe, TR_Memory &trMemory);         // A routine to dump initial method compilation counts
@@ -58,15 +58,15 @@ class TR_PersistentCHTable
    void commitSideEffectGuards(TR::Compilation *c);
    bool isOverriddenInThisHierarchy(TR_ResolvedMethod *, TR_OpaqueClassBlock *, int32_t, TR::Compilation *comp, bool locked = false);
 
-   TR_ResolvedMethod * findSingleInterfaceImplementer(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false);
-   TR_ResolvedMethod * findSingleAbstractImplementer(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false);
+   TR_ResolvedMethod * findSingleInterfaceImplementer(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false, bool validate = true);
+   TR_ResolvedMethod * findSingleAbstractImplementer(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false, bool validate = true);
 
    // profiler
    bool isKnownToHaveMoreThanTwoInterfaceImplementers(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false);
 
    // optimizer
-   TR_OpaqueClassBlock *findSingleConcreteSubClass(TR_OpaqueClassBlock *, TR::Compilation *);
-   TR_ResolvedMethod * findSingleImplementer(TR_OpaqueClassBlock * thisClass, int32_t cpIndexOrVftSlot, TR_ResolvedMethod * callerMethod, TR::Compilation * comp, bool locked, TR_YesNoMaybe useGetResolvedInterfaceMethod);
+   TR_OpaqueClassBlock *findSingleConcreteSubClass(TR_OpaqueClassBlock *, TR::Compilation *, bool validate = true);
+   TR_ResolvedMethod * findSingleImplementer(TR_OpaqueClassBlock * thisClass, int32_t cpIndexOrVftSlot, TR_ResolvedMethod * callerMethod, TR::Compilation * comp, bool locked, TR_YesNoMaybe useGetResolvedInterfaceMethod, bool validate = true);
 
    bool hasThreeOrMoreCompiledImplementors(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *, TR::Compilation *, TR_Hotness hotness = warm, bool locked = false);
    int32_t findnInterfaceImplementers(TR_OpaqueClassBlock *, int32_t, TR_ResolvedMethod *implArray[], int32_t, TR_ResolvedMethod *, TR::Compilation *, bool locked = false);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -66,6 +66,7 @@
 #include "runtime/CodeCacheExceptions.hpp"
 #include "exceptions/JITShutDown.hpp"
 #include "exceptions/DataCacheError.hpp"
+#include "exceptions/AOTFailure.hpp"
 #include "env/exports.h"
 #include "env/CompilerEnv.hpp"
 #include "env/CHTable.hpp"
@@ -8551,9 +8552,14 @@ TR_J9SharedCacheVM::isClassVisible(TR_OpaqueClassBlock * sourceClass, TR_OpaqueC
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(sourceClass)) &&
           comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(destClass)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Classes 0x%p and 0x%p should already be validated\n", sourceClass, destClass);
+         {
+         TR_ASSERT(false, "Classes 0x%p and 0x%p should already be validated\n", sourceClass, destClass);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in isClassVisible");
+         }
       }
    else
       {
@@ -8572,9 +8578,10 @@ TR_J9SharedCacheVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_Op
    if (comp && comp->getOption(TR_UseSymbolValidationManager))
       {
       if (!comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames))
-         validated = true;
-      else
-         TR_ASSERT_FATAL(false, "Failed to validate addStackWalkerMaySkipFramesRecord\n");
+         {
+         TR_ASSERT(false, "Failed to validate addStackWalkerMaySkipFramesRecord\n");
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in stackWalkerMaySkipFrames");
+         }
       }
 
    return skipFrames;
@@ -8645,9 +8652,14 @@ TR_J9SharedCacheVM::getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, c
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getInstanceFieldOffset");
+         }
       }
    else
       {
@@ -8720,9 +8732,14 @@ TR_J9SharedCacheVM::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock 
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getResolvedMethods");
+         }
       }
    else
       {
@@ -9003,9 +9020,14 @@ TR_J9SharedCacheVM::isPublicClass(TR_OpaqueClassBlock * classPointer)
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in isPublicClass");
+         }
       }
    else
       {
@@ -9031,9 +9053,14 @@ TR_J9SharedCacheVM::hasFinalizer(TR_OpaqueClassBlock * classPointer)
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in hasFinalizer");
+         }
       }
    else
       {
@@ -9059,9 +9086,14 @@ TR_J9SharedCacheVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointe
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getClassDepthAndFlagsValue");
+         }
       }
    else
       {
@@ -9087,9 +9119,14 @@ TR_J9SharedCacheVM::isPrimitiveClass(TR_OpaqueClassBlock * classPointer)
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in isPrimitiveClass");
+         }
       }
    else
       {
@@ -9115,9 +9152,14 @@ TR_J9SharedCacheVM::getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayC
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(componentClass)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", componentClass);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", componentClass);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getComponentClassFromArrayClass");
+         }
       }
    else
       {
@@ -9168,9 +9210,14 @@ TR_J9SharedCacheVM::getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * ar
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(leafComponent)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", leafComponent);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", leafComponent);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getLeafComponentClassFromArrayClass");
+         }
       }
    else
       {
@@ -9196,9 +9243,14 @@ TR_J9SharedCacheVM::getBaseComponentClass(TR_OpaqueClassBlock * classPointer, in
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(baseComponent)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", baseComponent);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", baseComponent);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getBaseComponentClass");
+         }
       }
    else
       {
@@ -9234,9 +9286,14 @@ TR_J9SharedCacheVM::isPrimitiveArray(TR_OpaqueClassBlock *classPointer)
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in isPrimitiveArray");
+         }
       }
    else
       {
@@ -9262,9 +9319,14 @@ TR_J9SharedCacheVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         {
          validated = true;
+         }
       else
-         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+         {
+         TR_ASSERT(false, "Class 0x%p should already be validated\n", classPointer);
+         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in isReferenceArray");
+         }
       }
    else
       {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6563,6 +6563,14 @@ TR_J9VMBase::getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock * classPo
          memcmp(utf8Data(mSig), signature, sigLength) == 0)
          {
          method = (TR_OpaqueMethodBlock *)(j9Methods + i);
+         if (validate)
+            {
+            TR::Compilation *comp = TR::comp();
+            if (comp && comp->getOption(TR_UseSymbolValidationManager))
+               {
+               comp->getSymbolValidationManager()->addMethodFromClassRecord(method, classPointer, i);
+               }
+            }
          break;
          }
       romMethod = nextROMMethod(romMethod);
@@ -7702,8 +7710,9 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
          // 2      1      0
          {
          //we need to bail out since we create a class pointer const with cpIndex of -1
-         if (isAOT_DEPRECATED_DO_NOT_USE() || ((!(vmThread()->javaVM->extendedRuntimeFlags &  J9_EXTENDED_RUNTIME_ALLOW_GET_CALLER_CLASS)) &&
-             methodID == TR::sun_reflect_Reflection_getCallerClass))
+         if ((isAOT_DEPRECATED_DO_NOT_USE() && !comp->getOption(TR_UseSymbolValidationManager)) ||
+             ((!(vmThread()->javaVM->extendedRuntimeFlags &  J9_EXTENDED_RUNTIME_ALLOW_GET_CALLER_CLASS)) &&
+              methodID == TR::sun_reflect_Reflection_getCallerClass))
             {
             return 0;
             }
@@ -8536,15 +8545,39 @@ TR_J9SharedCacheVM::isClassVisible(TR_OpaqueClassBlock * sourceClass, TR_OpaqueC
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
 
-   return ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) sourceClass) &&
-          ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) destClass) &&
-          TR_J9VMBase::isClassVisible(sourceClass, destClass);
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(sourceClass)) &&
+          comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(destClass)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Classes 0x%p and 0x%p should already be validated\n", sourceClass, destClass);
+      }
+   else
+      {
+      validated = ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) sourceClass) &&
+                  ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) destClass);
+      }
+
+   return (validated ? TR_J9VMBase::isClassVisible(sourceClass, destClass) : false);
    }
 
 bool
 TR_J9SharedCacheVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
    {
-   return false;
+   bool skipFrames = TR_J9VM::stackWalkerMaySkipFrames(method, methodClass);
+   TR::Compilation *comp = TR::comp();
+   if (comp && comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (!comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Failed to validate addStackWalkerMaySkipFramesRecord\n");
+      }
+
+   return skipFrames;
    }
 
 bool
@@ -8607,7 +8640,21 @@ TR_J9SharedCacheVM::getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, c
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
 
-   if (((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)classPointer))
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      validated = ((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)classPointer);
+      }
+
+   if (validated)
       return this->TR_J9VM::getInstanceFieldOffset (classPointer, fieldName, fieldLen, sig, sigLen, options);
 
    return ~0;
@@ -8620,7 +8667,19 @@ TR_J9SharedCacheVM::getClassOfMethod(TR_OpaqueMethodBlock *method)
 
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      validated = comp->getSymbolValidationManager()->addClassFromMethodRecord(classPointer, method);
+      }
+   else
+      {
+      validated = ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer);
+      }
+
+   if (validated)
       return classPointer;
 
    return NULL;
@@ -8631,8 +8690,21 @@ TR_J9SharedCacheVM::getSuperClass(TR_OpaqueClassBlock * classPointer)
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VM::getSuperClass(classPointer);
+
+   bool validated = false;
+   TR_OpaqueClassBlock *superClass = TR_J9VM::getSuperClass(classPointer);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      validated = comp->getSymbolValidationManager()->addSuperClassFromClassRecord(superClass, classPointer);
+      }
+   else
+      {
+      validated = ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer);
+      }
+
+   if (validated)
+      return superClass;
 
    return NULL;
    }
@@ -8642,8 +8714,39 @@ TR_J9SharedCacheVM::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock 
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      validated = ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer);
+      }
+
+   if (validated)
+      {
+      if (comp->getOption(TR_UseSymbolValidationManager))
+         {
+         TR::VMAccessCriticalSection getResolvedMethods(this); // Prevent HCR
+         J9Method * resolvedMethods = (J9Method *) getMethods(classPointer);
+         uint32_t indexIntoArray;
+         uint32_t numMethods = getNumMethods(classPointer);
+         for (indexIntoArray = 0; indexIntoArray < numMethods; indexIntoArray++)
+            {
+            comp->getSymbolValidationManager()->addMethodFromClassRecord((TR_OpaqueMethodBlock *) &(resolvedMethods[indexIntoArray]),
+                                                                         classPointer,
+                                                                         indexIntoArray);
+            }
+         }
+
       TR_J9VM::getResolvedMethods(trMemory, classPointer, resolvedMethodsInClass);
+      }
    }
 
 
@@ -8653,8 +8756,28 @@ TR_J9SharedCacheVM::getResolvedMethodForNameAndSignature(TR_Memory * trMemory, T
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *)comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *)classPointer))
-      return TR_J9VM::getResolvedMethodForNameAndSignature(trMemory, classPointer, methodName, signature);
+
+   bool validated = false;
+   TR_ResolvedMethod *resolvedMethod = TR_J9VM::getResolvedMethodForNameAndSignature(trMemory, classPointer, methodName, signature);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *)((TR_ResolvedJ9Method *)resolvedMethod)->ramMethod();
+      /*
+       * TR_J9VM::getResolvedMethodForNameAndSignature will call getMatchingMethodFromNameAndSignature
+       * which adds a MethodFromClassRecord. Not sure if adding a MethodByNameRecord here will do the
+       * right validation, since the way TR_J9VM::getResolvedMethodForNameAndSignature gets the class
+       * by name and signature is different than TR_J9VM::getMethodFromName...
+       */
+      validated = comp->getSymbolValidationManager()->addClassFromMethodRecord(getClassFromMethodBlock(method), method);
+      }
+   else
+      {
+      validated = ((TR_ResolvedRelocatableJ9Method *)comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *)classPointer);
+      }
+
+   if (validated)
+      return resolvedMethod;
    else
       return NULL;
    }
@@ -8666,12 +8789,29 @@ TR_J9SharedCacheVM::getMethodFromName(char *className, char *methodName, char *s
    TR_OpaqueMethodBlock *omb = this->TR_J9VM::getMethodFromName(className, methodName, signature, callingMethod);
    if (omb)
       {
-      J9Class* methodClass = (J9Class*)getClassFromMethodBlock(omb);
-
       TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
       TR_ASSERT(comp, "Should be called only within a compilation");
-      if (!((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, methodClass))
-         omb = NULL;
+
+      if (comp->getOption(TR_UseSymbolValidationManager))
+         {
+         TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
+         if (!svm->verifySymbolHasBeenValidated(static_cast<void *>(callingMethod)))
+            {
+            TR_ASSERT(false, "callingMethod %p should be valid\n", callingMethod);
+            comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getMethodFromName");
+            }
+         bool validated = svm->addMethodByNameRecord(omb, getClassFromMethodBlock(callingMethod)) &&
+                          svm->addClassFromMethodRecord(getClassFromMethodBlock(omb), omb);
+
+         if (!validated)
+            omb = NULL;
+         }
+      else
+         {
+         J9Class* methodClass = (J9Class*)getClassFromMethodBlock(omb);
+         if (!((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, methodClass))
+            omb = NULL;
+         }
       }
 
    return omb;
@@ -8697,10 +8837,22 @@ TR_J9SharedCacheVM::getMethodFromClass(TR_OpaqueClassBlock * methodClass, char *
       {
       TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
       TR_ASSERT(comp, "Should be called only within a compilation");
-      if (!((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)methodClass))
-         omb = NULL;
-      if (callingClass && !((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)callingClass))
-         omb = NULL;
+
+      if (comp->getOption(TR_UseSymbolValidationManager))
+         {
+         bool validated = callingClass &&
+                          comp->getSymbolValidationManager()->addMethodFromClassAndSignatureRecord(omb, methodClass, callingClass);
+
+         if (!validated)
+            omb = NULL;
+         }
+      else
+         {
+         if (!((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)methodClass))
+            omb = NULL;
+         if (callingClass && !((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)callingClass))
+            omb = NULL;
+         }
       }
 
    return omb;
@@ -8724,51 +8876,91 @@ TR_J9SharedCacheVM::supportAllocationInlining(TR::Compilation *comp, TR::Node *n
 TR_YesNoMaybe
 TR_J9SharedCacheVM::isInstanceOf(TR_OpaqueClassBlock * a, TR_OpaqueClassBlock *b, bool objectTypeIsFixed, bool castTypeIsFixed, bool optimizeForAOT)
    {
-   if (optimizeForAOT)
-      return TR_J9VM::isInstanceOf(a, b, objectTypeIsFixed, castTypeIsFixed, optimizeForAOT);
+   TR::Compilation *comp = TR::comp();
+   TR_YesNoMaybe isAnInstanceOf = TR_J9VM::isInstanceOf(a, b, objectTypeIsFixed, castTypeIsFixed);
+   bool validated = false;
 
-   return TR_maybe;
+   if (comp && comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (isAnInstanceOf != TR_maybe)
+         validated = comp->getSymbolValidationManager()->addClassInstanceOfClassRecord(a, b, objectTypeIsFixed, castTypeIsFixed, (isAnInstanceOf == TR_yes));
+      }
+   else
+      {
+      validated = optimizeForAOT;
+      }
+
+   if (validated)
+      return isAnInstanceOf;
+   else
+      return TR_maybe;
    }
 
 TR_OpaqueClassBlock *
 TR_J9SharedCacheVM::getClassFromSignature(const char * sig, int32_t sigLength, TR_ResolvedMethod * method, bool isVettedForAOT)
    {
-   if (isVettedForAOT)
-      {
-      TR_OpaqueClassBlock* j9class = TR_J9VM::getClassFromSignature(sig, sigLength, method, true);
-      TR::Compilation* comp = TR::comp();
-      if (j9class && ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) j9class))
-         return j9class;
-      }
-
-   return NULL;
+   return getClassFromSignature(sig, sigLength, (TR_OpaqueMethodBlock *)method->getPersistentIdentifier(), isVettedForAOT);
    }
 
 TR_OpaqueClassBlock *
 TR_J9SharedCacheVM::getClassFromSignature(const char * sig, int32_t sigLength, TR_OpaqueMethodBlock * method, bool isVettedForAOT)
    {
-   if (isVettedForAOT)
+   TR_OpaqueClassBlock* j9class = TR_J9VM::getClassFromSignature(sig, sigLength, method, true);
+   bool validated = false;
+   TR::Compilation* comp = TR::comp();
+
+   if (j9class)
       {
-      TR_OpaqueClassBlock* j9class = TR_J9VM::getClassFromSignature(sig, sigLength, method, true);
-      TR::Compilation* comp = TR::comp();
-      if (j9class && ((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) j9class))
-         return j9class;
+      if (comp->getOption(TR_UseSymbolValidationManager))
+         {
+         if (!comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(method)))
+            {
+            TR_ASSERT(false, "method %p should be valid\n", method);
+            comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in getClassFromSignature");
+            }
+
+         validated = comp->getSymbolValidationManager()->addClassByNameRecord(j9class, getClassFromMethodBlock(method));
+         }
+      else
+         {
+         if (isVettedForAOT)
+            {
+            if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) j9class))
+               validated = true;
+            }
+         }
       }
 
-   return NULL;
+   if (validated)
+      return j9class;
+   else
+      return NULL;
    }
 
 TR_OpaqueClassBlock *
 TR_J9SharedCacheVM::getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT)
    {
-   if (isVettedForAOT)
+   TR::Compilation *comp = TR::comp();
+   TR_OpaqueClassBlock *classPointer = TR_J9VM::getSystemClassFromClassName(name, length);
+   bool validated = false;
+
+   if (comp && comp->getOption(TR_UseSymbolValidationManager))
       {
-      TR_OpaqueClassBlock *classPointer = TR_J9VM::getSystemClassFromClassName(name, length);
-      if (((TR_ResolvedRelocatableJ9Method *) TR::comp()->getCurrentMethod())->validateArbitraryClass(TR::comp(), (J9Class *) classPointer))
-         return classPointer;
+      validated = comp->getSymbolValidationManager()->addSystemClassByNameRecord(classPointer);
+      }
+   else
+      {
+      if (isVettedForAOT)
+         {
+         if (((TR_ResolvedRelocatableJ9Method *) TR::comp()->getCurrentMethod())->validateArbitraryClass(TR::comp(), (J9Class *) classPointer))
+            validated = true;
+         }
       }
 
-   return NULL;
+   if (validated)
+      return classPointer;
+   else
+      return NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -8780,9 +8972,23 @@ TR_J9SharedCacheVM::getProfiledClassFromProfiledInfo(TR_ExtraAddressInfo *profil
 
    if (comp->getPersistentInfo()->isObsoleteClass((void *)classPointer, comp->fe()))
       return NULL;
-   if (((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)classPointer))
+
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      validated = comp->getSymbolValidationManager()->addProfiledClassRecord(classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method*) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class*)classPointer))
+         validated = true;
+      }
+
+   if (validated)
       return classPointer;
-   return NULL;
+   else
+      return NULL;
    }
 
 bool
@@ -8790,10 +8996,27 @@ TR_J9SharedCacheVM::isPublicClass(TR_OpaqueClassBlock * classPointer)
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VM::isPublicClass(classPointer);
 
-   return true;
+   bool publicClass = TR_J9VM::isPublicClass(classPointer);
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return publicClass;
+   else
+      return true;
    }
 
 bool
@@ -8801,10 +9024,27 @@ TR_J9SharedCacheVM::hasFinalizer(TR_OpaqueClassBlock * classPointer)
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VM::hasFinalizer(classPointer);
 
-   return true;
+   bool classHasFinalizer = TR_J9VM::hasFinalizer(classPointer);
+   bool validated = false;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return classHasFinalizer;
+   else
+      return true;
    }
 
 uintptrj_t
@@ -8812,10 +9052,27 @@ TR_J9SharedCacheVM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointe
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VM::getClassDepthAndFlagsValue(classPointer);
 
-   return 0;
+   bool validated = false;
+   uintptrj_t classDepthFlags = TR_J9VM::getClassDepthAndFlagsValue(classPointer);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return classDepthFlags;
+   else
+      return 0;
    }
 
 bool
@@ -8823,10 +9080,27 @@ TR_J9SharedCacheVM::isPrimitiveClass(TR_OpaqueClassBlock * classPointer)
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VMBase::isPrimitiveClass(classPointer);
 
-   return false;
+   bool validated = false;
+   bool isPrimClass = TR_J9VMBase::isPrimitiveClass(classPointer);;
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return isPrimClass;
+   else
+      return false;
    }
 
 TR_OpaqueClassBlock *
@@ -8834,10 +9108,27 @@ TR_J9SharedCacheVM::getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayC
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) arrayClass))
-      return TR_J9VM::getComponentClassFromArrayClass(arrayClass);
 
-   return NULL;
+   bool validated = false;
+   TR_OpaqueClassBlock *componentClass = TR_J9VM::getComponentClassFromArrayClass(arrayClass);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(componentClass)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", componentClass);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) arrayClass))
+         validated = true;
+      }
+
+   if (validated)
+      return componentClass;
+   else
+      return NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -8845,10 +9136,24 @@ TR_J9SharedCacheVM::getArrayClassFromComponentClass(TR_OpaqueClassBlock * compon
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) componentClass))
-      return TR_J9VM::getArrayClassFromComponentClass(componentClass);
 
-   return NULL;
+   bool validated = false;
+   TR_OpaqueClassBlock *arrayClass = TR_J9VM::getArrayClassFromComponentClass(componentClass);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      validated = comp->getSymbolValidationManager()->addArrayClassFromComponentClassRecord(arrayClass, componentClass);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) componentClass))
+         validated = true;
+      }
+
+   if (validated)
+      return arrayClass;
+   else
+      return NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -8856,10 +9161,27 @@ TR_J9SharedCacheVM::getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * ar
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) arrayClass))
-      return TR_J9VM::getLeafComponentClassFromArrayClass(arrayClass);
 
-   return NULL;
+   bool validated = false;
+   TR_OpaqueClassBlock *leafComponent = TR_J9VM::getLeafComponentClassFromArrayClass(arrayClass);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(leafComponent)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", leafComponent);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) arrayClass))
+         validated = true;
+      }
+
+   if (validated)
+      return leafComponent;
+   else
+      return NULL;
    }
 
 TR_OpaqueClassBlock *
@@ -8867,15 +9189,35 @@ TR_J9SharedCacheVM::getBaseComponentClass(TR_OpaqueClassBlock * classPointer, in
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VM::getBaseComponentClass(classPointer, numDims);
 
-   return classPointer;  // not sure about this return value, but it's what we used to return before we got "smart"
+   bool validated = false;
+   TR_OpaqueClassBlock *baseComponent = TR_J9VM::getBaseComponentClass(classPointer, numDims);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(baseComponent)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", baseComponent);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return baseComponent;
+   else
+      return classPointer;  // not sure about this return value, but it's what we used to return before we got "smart"
    }
 
 TR_OpaqueClassBlock *
 TR_J9SharedCacheVM::getClassFromNewArrayType(int32_t arrayType)
    {
+   TR::Compilation *comp = TR::comp();
+   if (comp && comp->getOption(TR_UseSymbolValidationManager))
+      return TR_J9VM::getClassFromNewArrayType(arrayType);
    return NULL;
    }
 
@@ -8885,10 +9227,27 @@ TR_J9SharedCacheVM::isPrimitiveArray(TR_OpaqueClassBlock *classPointer)
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VMBase::isPrimitiveArray(classPointer);
 
-   return false;
+   bool validated = false;
+   bool isPrimArray = TR_J9VMBase::isPrimitiveArray(classPointer);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return isPrimArray;
+   else
+      return false;
    }
 
 bool
@@ -8896,16 +9255,39 @@ TR_J9SharedCacheVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
    {
    TR::Compilation* comp = _compInfo->getCompInfoForCompOnAppThread() ? _compInfo->getCompInfoForCompOnAppThread()->getCompilation() : _compInfoPT->getCompilation();
    TR_ASSERT(comp, "Should be called only within a compilation");
-   if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
-      return TR_J9VMBase::isReferenceArray(classPointer);
 
-   return false;
+   bool validated = false;
+   bool isRefArray = TR_J9VMBase::isReferenceArray(classPointer);
+
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(classPointer)))
+         validated = true;
+      else
+         TR_ASSERT_FATAL(false, "Class 0x%p should already be validated\n", classPointer);
+      }
+   else
+      {
+      if (((TR_ResolvedRelocatableJ9Method *) comp->getCurrentMethod())->validateArbitraryClass(comp, (J9Class *) classPointer))
+         validated = true;
+      }
+
+   if (validated)
+      return isRefArray;
+   else
+      return false;
    }
 
 TR_OpaqueClassBlock *
 TR_J9SharedCacheVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    {
    TR_OpaqueClassBlock *ccPointer = TR_J9VM::getClassClassPointer(objectClassPointer);
+   TR::Compilation *comp = TR::comp();
+   if (comp && comp->getOption(TR_UseSymbolValidationManager))
+      {
+      if (!comp->getSymbolValidationManager()->addClassClassRecord(ccPointer, objectClassPointer))
+         ccPointer = NULL;
+      }
    return ccPointer;
    }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -193,7 +193,7 @@ TR_J9VMBase::getCompThreadIDForVMThread(void *vmThread)
 
 
 bool
-TR_J9VMBase::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
+TR_J9VM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
    {
    if(!method)
       return false;
@@ -212,7 +212,7 @@ TR_J9VMBase::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueCla
       }
 
    if ( ( vmThread()->javaVM->jlrAccessibleObject != NULL) &&
-          isInstanceOf( methodClass, (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->jlrAccessibleObject),false) )
+          TR_J9VM::isInstanceOf( methodClass, (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->jlrAccessibleObject),false) )
       {
       return true;
       }
@@ -220,13 +220,13 @@ TR_J9VMBase::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueCla
 
 #if defined(J9VM_OPT_SIDECAR)
    if ( ( vmThread()->javaVM->srMethodAccessor != NULL) &&
-          isInstanceOf(methodClass, (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srMethodAccessor), false) )
+          TR_J9VM::isInstanceOf(methodClass, (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srMethodAccessor), false) )
       {
       return true;
       }
 
    if ( ( vmThread()->javaVM->srConstructorAccessor != NULL) &&
-          isInstanceOf(methodClass, (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srConstructorAccessor), false) )
+          TR_J9VM::isInstanceOf(methodClass, (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srConstructorAccessor), false) )
       {
       return true;
       }
@@ -6534,13 +6534,13 @@ TR_J9VMBase::getResolvedMethods(TR_Memory * trMemory, TR_OpaqueClassBlock * clas
       }
    }
 
-
-TR_ResolvedMethod *
-TR_J9VMBase::getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer,
-                                                  const char* methodName, const char *signature)
+/*
+ * Should be called with VMAccess
+ */
+TR_OpaqueMethodBlock *
+TR_J9VMBase::getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock * classPointer,
+                                                   const char* methodName, const char *signature, bool validate)
    {
-   TR::VMAccessCriticalSection vmCS(this); // Prevent HCR
-   TR_ResolvedMethod *rm = NULL;
    size_t nameLength = strlen(methodName);
    size_t sigLength = strlen(signature);
 
@@ -6549,6 +6549,8 @@ TR_J9VMBase::getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_Opaqu
    uint32_t numMethods = getNumMethods(classPointer);
 
    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
+
+   TR_OpaqueMethodBlock *method = NULL;
 
    // Iterate over all romMethods until the desired one is found
    for (uint32_t i = 0; i < numMethods; i++)
@@ -6560,11 +6562,25 @@ TR_J9VMBase::getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_Opaqu
          memcmp(utf8Data(mName), methodName, nameLength) == 0 &&
          memcmp(utf8Data(mSig), signature, sigLength) == 0)
          {
-         rm = createResolvedMethod(trMemory, (TR_OpaqueMethodBlock *)(j9Methods + i), 0);
+         method = (TR_OpaqueMethodBlock *)(j9Methods + i);
          break;
          }
       romMethod = nextROMMethod(romMethod);
       }
+
+   return method;
+   }
+
+TR_ResolvedMethod *
+TR_J9VMBase::getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer,
+                                                  const char* methodName, const char *signature)
+   {
+   TR::VMAccessCriticalSection vmCS(this); // Prevent HCR
+   TR_ResolvedMethod *rm = NULL;
+
+   TR_OpaqueMethodBlock *method = getMatchingMethodFromNameAndSignature(classPointer, methodName, signature);
+   if (method)
+      rm = createResolvedMethod(trMemory, method, 0);
 
    return rm;
    }
@@ -6792,13 +6808,12 @@ TR_J9VM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer)
 #define LOOKUP_OPTION_NO_THROW 8192
 
 TR_OpaqueMethodBlock *
-TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod)
+TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature, J9ConstantPool *constantPool)
    {
    TR::VMAccessCriticalSection getMethodFromName(this);
    J9Class *methodClass = 0;
-   if (callingMethod)
+   if (constantPool)
       {
-      J9ConstantPool * constantPool = (J9ConstantPool *) (J9_CP_FROM_METHOD((J9Method*)callingMethod));
       methodClass = jitGetClassFromUTF8(vmThread(), constantPool, className, strlen(className));
       }
    if (!methodClass) // try the system class loader
@@ -6808,9 +6823,25 @@ TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature, T
          className, strlen(className));
       }
    TR_OpaqueMethodBlock * result = NULL;
+   /*
+    * Call the TR_J9VM version of getMethodFromClass since at this point,
+    * the methodClass may have never been seen before; if we call the
+    * TR_J9SharedCacheVM version, the validation manager could assert.
+    */
    if (methodClass)
-      result = (TR_OpaqueMethodBlock *)getMethodFromClass((TR_OpaqueClassBlock *)methodClass, methodName, signature);
+      result = (TR_OpaqueMethodBlock *)TR_J9VM::getMethodFromClass((TR_OpaqueClassBlock *)methodClass, methodName, signature);
    return result;
+   }
+
+TR_OpaqueMethodBlock *
+TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod)
+   {
+   J9ConstantPool *cp = NULL;
+
+   if (callingMethod)
+      cp = (J9ConstantPool *) (J9_CP_FROM_METHOD((J9Method*)callingMethod));
+
+   return getMethodFromName(className, methodName, signature, cp);
    }
 
 /** \brief
@@ -7200,8 +7231,14 @@ TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, TR_ResolvedM
 TR_OpaqueClassBlock *
 TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, TR_OpaqueMethodBlock * method, bool isVettedForAOT)
    {
-   TR::VMAccessCriticalSection getClassFromSignature(this);
    J9ConstantPool * constantPool = (J9ConstantPool *) (J9_CP_FROM_METHOD((J9Method*)method));
+   return getClassFromSignature(sig, sigLength, constantPool);
+   }
+
+TR_OpaqueClassBlock *
+TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool)
+   {
+   TR::VMAccessCriticalSection getClassFromSignature(this);
    J9Class * j9class = NULL;
    TR_OpaqueClassBlock * returnValue = NULL;
 
@@ -7710,34 +7747,14 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
                   callerClass = (J9Class*) callerMethodSymbol->getResolvedMethod()->classOfMethod();
                   }
 
-                  {
-                  TR::VMAccessCriticalSection jlrMethodInvoke(this);
+               {
+               TR::VMAccessCriticalSection jlrMethodInvoke(this);
 
-                  if (vmThread()->javaVM->jlrMethodInvoke == NULL)
-                     return 0;
+               if (vmThread()->javaVM->jlrMethodInvoke == NULL)
+                  return 0;
+               }
 
-                  skipFrame = false;
-                  skipFrame = (vmThread()->javaVM->jlrMethodInvoke == callerMethod);
-                  if (!skipFrame)
-                     skipFrame = (vmThread()->javaVM->jlrAccessibleObject != NULL) &&
-                                  isInstanceOf((TR_OpaqueClassBlock*) callerClass,
-                                               (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->jlrAccessibleObject),
-                                               false);
-#if defined(J9VM_OPT_SIDECAR)
-                  if (!skipFrame)
-                     skipFrame = (vmThread()->javaVM->srMethodAccessor != NULL) &&
-                                  isInstanceOf((TR_OpaqueClassBlock*) callerClass,
-                                               (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srMethodAccessor),
-                                               false);
-                  if (!skipFrame)
-                     skipFrame = (vmThread()->javaVM->srConstructorAccessor != NULL) &&
-                                  isInstanceOf((TR_OpaqueClassBlock*) callerClass,
-                                               (TR_OpaqueClassBlock*) J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srConstructorAccessor),
-                                               false);
-#endif // J9VM_OPT_SIDECAR
-
-                  }
-
+               skipFrame = stackWalkerMaySkipFrames((TR_OpaqueMethodBlock *)callerMethod, (TR_OpaqueClassBlock *)callerClass);
 
                if (!skipFrame && inlineDepth == stackDepth)
                   break;
@@ -8525,6 +8542,12 @@ TR_J9SharedCacheVM::isClassVisible(TR_OpaqueClassBlock * sourceClass, TR_OpaqueC
    }
 
 bool
+TR_J9SharedCacheVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
+   {
+   return false;
+   }
+
+bool
 TR_J9SharedCacheVM::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
    {
    // We want to return the same answer as TR_J9VMBase unless we want to force it to allow tracing
@@ -8877,6 +8900,13 @@ TR_J9SharedCacheVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
       return TR_J9VMBase::isReferenceArray(classPointer);
 
    return false;
+   }
+
+TR_OpaqueClassBlock *
+TR_J9SharedCacheVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
+   {
+   TR_OpaqueClassBlock *ccPointer = TR_J9VM::getClassClassPointer(objectClassPointer);
+   return ccPointer;
    }
 
 TR_OpaqueMethodBlock *

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -225,6 +225,7 @@ public:
 
    virtual bool isAOT_DEPRECATED_DO_NOT_USE() { return false; }
    virtual bool supportsMethodEntryPadding() { return true; }
+   virtual bool canUseSymbolValidationManager() { return false; }
 
 #if defined(TR_TARGET_S390)
    virtual void initializeS390zLinuxProcessorFeatures();
@@ -1111,6 +1112,7 @@ public:
    virtual bool               isAOT_DEPRECATED_DO_NOT_USE()                                         { return true; }
 
    // replacing calls to isAOT
+   virtual bool               canUseSymbolValidationManager() { return true; }
    virtual bool               supportsCodeCacheSnippets()                     { return false; }
    virtual bool               canRelocateDirectNativeCalls()                  { return false; }
    virtual bool               needClassAndMethodPointerRelocations()          { return true; }

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -311,7 +311,7 @@ public:
    // Not implemented
    virtual TR_ResolvedMethod * getObjectNewInstanceImplMethod(TR_Memory *) { return 0; }
 
-   bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
+   virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) = 0;
 
    virtual bool supportsEmbeddedHeapBounds()  { return true; }
    virtual bool supportsFastNanoTime();
@@ -322,6 +322,8 @@ public:
    virtual bool forceUnresolvedDispatch() { return false; }
 
    virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, char *, char *, TR_OpaqueClassBlock * = NULL);
+
+   TR_OpaqueMethodBlock * getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature, bool validate = true);
 
    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
    /**
@@ -339,6 +341,8 @@ public:
    virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature);
    virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true);
    virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
+
+   TR_OpaqueMethodBlock *getResolvedInterfaceMethod(J9ConstantPool *ownerCP, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
 
    uintptrj_t getReferenceField(uintptrj_t objectPointer, char *fieldName, char *fieldSignature)
       {
@@ -1043,7 +1047,8 @@ public:
    virtual void               initializeHasFixedFrameC_CallingConvention();
 
    virtual bool               isPublicClass(TR_OpaqueClassBlock *clazz);
-   virtual TR_OpaqueMethodBlock *             getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod=0);
+   TR_OpaqueMethodBlock *     getMethodFromName(char * className, char *methodName, char *signature, J9ConstantPool *constantPool);
+   virtual TR_OpaqueMethodBlock *getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod=0);
    virtual uintptrj_t         getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
 
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
@@ -1057,6 +1062,7 @@ public:
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT=false);
    virtual TR_YesNoMaybe      isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBlock *castClass, bool instanceIsFixed, bool castIsFixed = true, bool optimizeForAOT=false);
 
+   virtual bool               stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
 
    virtual TR_OpaqueClassBlock *             getSuperClass(TR_OpaqueClassBlock *classPointer);
    virtual bool               isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *);
@@ -1086,6 +1092,8 @@ public:
    virtual uint32_t               getPrimitiveArrayOffsetInJavaVM(uint32_t arrayType);
 
    virtual bool isDecimalFormatPattern( TR::Compilation *comp, TR_ResolvedMethod *method);
+
+   TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 
 private:
    void transformJavaLangClassIsArrayOrIsPrimitive( TR::Compilation *, TR::Node * callNode,  TR::TreeTop * treeTop, int32_t andMask);
@@ -1125,6 +1133,8 @@ public:
 
    virtual bool               isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false);
 
+   virtual bool               stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
+
    virtual bool               isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool               isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool               traceableMethodsCanBeInlined();
@@ -1145,6 +1155,8 @@ public:
    virtual int32_t            getJavaLangClassHashCode(TR::Compilation * comp, TR_OpaqueClassBlock * clazzPointer, bool &hashCodeComputed);
    virtual bool               javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, int32_t &result);
    virtual TR_OpaqueClassBlock *             getSuperClass(TR_OpaqueClassBlock *classPointer);
+
+   virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *);
 
    virtual bool               sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *);
    virtual bool               isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1147,6 +1147,10 @@ public:
    virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory * trMemory, TR_OpaqueClassBlock * classPointer, const char* methodName, const char *signature);
    virtual uint32_t           getInstanceFieldOffset(TR_OpaqueClassBlock * classPointer, char * fieldName,
                                                      uint32_t fieldLen, char * sig, uint32_t sigLen, UDATA options);
+
+   virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock * classObject, int32_t cpIndex, bool ignoreReResolve = true);
+   virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
+
 #if defined(TR_TARGET_S390)
    virtual void               initializeS390zLinuxProcessorFeatures();
    virtual void               initializeS390zOSProcessorFeatures();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1199,7 +1199,7 @@ TR_ResolvedJ9MethodBase::isCold(TR::Compilation * comp, bool isIndirectCall, TR:
    // For overridden virtual calls we may decide at some point to traverse all the
    // existing targets to see if they are all interpreted with high counts
    //
-   if (!isInterpreted() || maxBytecodeIndex() <= TRIVIAL_INLINER_MAX_SIZE)
+   if (!isInterpretedForHeuristics() || maxBytecodeIndex() <= TRIVIAL_INLINER_MAX_SIZE)
       return false;
 
    if (isIndirectCall && virtualMethodIsOverridden())
@@ -1490,6 +1490,12 @@ TR_ResolvedRelocatableJ9Method::isInterpreted()
    if (alwaysTreatAsInterpreted)
       return true;
 
+   return TR_ResolvedJ9Method::isInterpreted();
+   }
+
+bool
+TR_ResolvedRelocatableJ9Method::isInterpretedForHeuristics()
+   {
    return TR_ResolvedJ9Method::isInterpreted();
    }
 
@@ -5250,6 +5256,12 @@ TR_ResolvedJ9Method::isInterpreted()
    if (_fe->tossingCode())
       return true;
    return !(TR::CompilationInfo::isCompiled(ramMethod()));
+   }
+
+bool
+TR_ResolvedJ9Method::isInterpretedForHeuristics()
+   {
+   return isInterpreted();
    }
 
 TR_OpaqueMethodBlock *

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -44,6 +44,7 @@
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "exceptions/DataCacheError.hpp"
+#include "exceptions/AOTFailure.hpp"
 #include "il/DataTypes.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -1371,7 +1372,10 @@ TR_ResolvedRelocatableJ9Method::TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBl
          if (comp->getOption(TR_UseSymbolValidationManager))
             {
             if (!comp->getSymbolValidationManager()->verifySymbolHasBeenValidated(static_cast<void *>(aMethod)))
-               TR_ASSERT_FATAL(false, "aMethod 0x%p should already be validated\n", aMethod);
+               {
+               TR_ASSERT(false, "aMethod 0x%p should already be validated\n", aMethod);
+               comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in TR_ResolvedRelocatableJ9Method");
+               }
             comp->getSymbolValidationManager()->addClassFromMethodRecord(containingClass(), aMethod);
             }
          else

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -291,6 +291,7 @@ public:
    virtual bool                  isFinal();
    virtual bool                  isStrictFP();
    virtual bool                  isInterpreted();
+   virtual bool                  isInterpretedForHeuristics();
    virtual bool                  hasBackwardBranches();
    virtual bool                  isObjectConstructor();
    virtual bool                  isNonEmptyObjectConstructor();
@@ -508,6 +509,7 @@ public:
    virtual bool                  isStrictFP();
 
    virtual bool                  isInterpreted();
+   virtual bool                  isInterpretedForHeuristics();
    virtual bool                  hasBackwardBranches();
    virtual bool                  isObjectConstructor();
    virtual bool                  isNonEmptyObjectConstructor();

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -551,6 +551,8 @@ public:
    virtual TR_OpaqueMethodBlock *getNonPersistentIdentifier();
    virtual uint8_t *             allocateException(uint32_t, TR::Compilation*);
 
+   virtual TR_OpaqueClassBlock  *getDeclaringClassFromFieldOrStatic( TR::Compilation *comp, int32_t cpIndex);
+
 private:
    virtual TR_ResolvedMethod *   createResolvedMethodFromJ9Method(TR::Compilation *comp, int32_t cpIndex, uint32_t vTableSlot, J9Method *j9Method, bool * unresolvedInCP, TR_AOTInliningStats *aotStats);
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -318,6 +318,9 @@ public:
 
    virtual TR_OpaqueClassBlock * containingClass();
 
+   static TR_OpaqueClassBlock *  getClassFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, TR::Compilation *comp, uint32_t cpIndex);
+   static TR_OpaqueClassBlock *  getClassOfStaticFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, int32_t cpIndex);
+
    virtual void *                ramConstantPool();
    virtual void *                constantPool();
    virtual TR_OpaqueClassBlock * getClassFromConstantPool( TR::Compilation *, uint32_t cpIndex, bool returnClassForAot=false);
@@ -413,6 +416,9 @@ public:
    virtual uint32_t              vTableSlot(uint32_t);
 
    virtual bool                  isCompilable(TR_Memory *);
+
+   static TR_OpaqueMethodBlock * getVirtualMethod(TR_J9VMBase *fej9, J9ConstantPool *cp, I_32 cpIndex, UDATA *vTableOffset, bool *unresolvedInCP);
+   static TR_OpaqueClassBlock  * getInterfaceITableIndexFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, int32_t cpIndex, uintptrj_t *pITableIndex);
 
    virtual TR_ResolvedMethod *   getResolvedStaticMethod ( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP);
    virtual TR_ResolvedMethod *   getResolvedSpecialMethod( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP);

--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,6 +68,16 @@ class AOTHasInvokeSpecialInInterface : public virtual TR::RecoverableILGenExcept
 class AOTRelocationFailed : public virtual RuntimeFailure
    {
    virtual const char* what() const throw() { return "AOT Relocation Failed"; }
+   };
+
+/**
+ * AOT Symbol Validation Failure exception type.
+ *
+ * Thrown when an AOT validation record that should succeed fails.
+ */
+class AOTSymbolValidationManagerFailure : public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "AOT Symbol Validation Manager Failure"; }
    };
 
 }

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -988,7 +988,8 @@ J9::Node::getTypeSignature(int32_t & len, TR_AllocationKind allocKind, bool parm
    TR::Symbol *sym = symRef->getSymbol();
    if (parmAsAuto && sym->isParm())
       return 0;
-   TR_PersistentClassInfo * classInfo = c->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(c->getCurrentMethod()->containingClass(), c);
+   bool allowForAOT = c->getOption(TR_UseSymbolValidationManager);
+   TR_PersistentClassInfo * classInfo = c->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(c->getCurrentMethod()->containingClass(), c, allowForAOT);
    TR::Node * node = self();
    TR_PersistentFieldInfo * fieldInfo = classInfo && classInfo->getFieldInfo() ? classInfo->getFieldInfo()->findFieldInfo(c, node, false) : 0;
     if (fieldInfo && fieldInfo->isTypeInfoValid() && fieldInfo->getNumChars() > 0)

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -62,8 +62,9 @@ TR_ClassLookahead::perform()
 
     bool isClassInitialized = false;
     bool seenFirstInitializerMethod = false;
+    bool allowForAOT = comp()->getOption(TR_UseSymbolValidationManager);
     TR_PersistentClassInfo * classInfo =
-                           comp()->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(_classPointer, comp());
+                           comp()->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(_classPointer, comp(), allowForAOT);
     if (classInfo && classInfo->isInitialized())
        isClassInitialized = true;
 

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -73,7 +73,8 @@ TR_J9ByteCodeIlGenerator::TR_J9ByteCodeIlGenerator(
          ((comp->getMethodHotness() >= scorching) ||
           (comp->couldBeRecompiled() && (comp->getMethodHotness() >= hot ))))))
       {
-      _classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(method()->containingClass(), comp);
+      bool allowForAOT = comp->getOption(TR_UseSymbolValidationManager);
+      _classInfo = comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(method()->containingClass(), comp, allowForAOT);
       }
    else
       {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -2767,8 +2767,7 @@ TR_J9ByteCodeIlGenerator::loadConstantValueIfPossible(TR::Node *topNode, uintptr
       bool canOptimizeFinalStatic = false;
       if (isResolved && symbol->isFinal() && !symRef->isUnresolved() &&
           classOfStatic != comp()->getSystemClassPointer() &&
-          isClassInitialized &&
-          !comp()->compileRelocatableCode())
+          isClassInitialized)
          {
        //if (symbol->getDataType() == TR::Address)
             {
@@ -6137,8 +6136,7 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
    bool canOptimizeFinalStatic = false;
    if (isResolved && symbol->isFinal() && !symRef->isUnresolved() &&
        classOfStatic != comp()->getSystemClassPointer() &&
-       isClassInitialized &&
-       !comp()->compileRelocatableCode())
+       isClassInitialized)
       {
       //if (type == TR::Address)
          {
@@ -7853,7 +7851,7 @@ void TR_J9ByteCodeIlGenerator::performClassLookahead(TR_PersistentClassInfo *cla
    if (comp()->getOption(TR_EnableHCR))
       return;
 
-   if (comp()->compileRelocatableCode())
+   if (comp()->compileRelocatableCode() && !comp()->getOption(TR_UseSymbolValidationManager))
       return;
 
    _classLookaheadSymRefTab = new (trStackMemory())TR::SymbolReferenceTable(method()->maxBytecodeIndex(), comp());

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6199,7 +6199,7 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
    else
       {
       TR::Node * load;
-      if (cg()->getAccessStaticsIndirectly() && isResolved && type != TR::Address && !comp()->compileRelocatableCode())
+      if (cg()->getAccessStaticsIndirectly() && isResolved && type != TR::Address && (!comp()->compileRelocatableCode() || comp()->getOption(TR_UseSymbolValidationManager)))
          {
          TR::Node * statics = TR::Node::createWithSymRef(TR::loadaddr, 0, symRefTab()->findOrCreateClassStaticsSymbol(_methodSymbol, cpIndex));
          load = TR::Node::createWithSymRef(comp()->il.opCodeForIndirectLoad(type), 1, 1, statics, symRef);
@@ -7367,7 +7367,7 @@ TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
 
       node = TR::Node::createWithSymRef(TR::call, 2, 2, value, statics, volatileLongSymRef);
       }
-   else if (!symRef->isUnresolved() && cg()->getAccessStaticsIndirectly() && type != TR::Address && !comp()->compileRelocatableCode())
+   else if (!symRef->isUnresolved() && cg()->getAccessStaticsIndirectly() && type != TR::Address && (!comp()->compileRelocatableCode() || comp()->getOption(TR_UseSymbolValidationManager)))
       {
       TR::Node * statics = TR::Node::createWithSymRef(TR::loadaddr, 0, symRefTab()->findOrCreateClassStaticsSymbol(_methodSymbol, cpIndex));
       node = TR::Node::createWithSymRef(comp()->il.opCodeForIndirectStore(type), 2, 2, statics, value, symRef);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4218,12 +4218,12 @@ TR_MultipleCallTargetInliner::exceedsSizeThreshold(TR_CallSite *callSite, int by
        && (!trustedInterfaceRegex || !TR::SimpleRegex::match(trustedInterfaceRegex, callSite->_interfaceMethod->signature(trMemory()), false)))
       {
       TR_PersistentJittedBodyInfo *bodyInfo = NULL;
-      if (!calleeResolvedMethod->isInterpreted() && !calleeResolvedMethod->isJITInternalNative())
+      if (!calleeResolvedMethod->isInterpretedForHeuristics() && !calleeResolvedMethod->isJITInternalNative())
          {
          void *startPC = (void *)calleeResolvedMethod->startAddressForInterpreterOfJittedMethod();
          bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(startPC);
          }
-      if (((!bodyInfo && !calleeResolvedMethod->isInterpreted() && !calleeResolvedMethod->isJITInternalNative()) //jitted method without bodyInfo must be scorching 
+      if (((!bodyInfo && !calleeResolvedMethod->isInterpretedForHeuristics() && !calleeResolvedMethod->isJITInternalNative()) //jitted method without bodyInfo must be scorching
          || (bodyInfo && bodyInfo->getHotness() == scorching)
          || comp()->fej9()->isQueuedForVeryHotOrScorching(calleeResolvedMethod, comp()))
          && (comp()->getMethodHotness() == scorching))

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -3492,6 +3492,7 @@ bool TR_MultipleCallTargetInliner::inlineCallTargets(TR::ResolvedMethodSymbol *c
          tracer()->dumpInline(&_callTargets, "inline script");
          }
       }
+
    if (prevCallStack == 0)
       {
       TR_InlinerDelimiter delimiter(tracer(),"inlineTransformation");

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -933,7 +933,6 @@ TR_J9InlinerPolicy::genCodeForUnsafeGetPut(TR::Node* unsafeAddress,
       loadJavaLangClass->getByteCodeInfo().setZeroByteCodeIndex();
       loadJavaLangClass->setIsClassPointerConstant(true);
 
-
       TR::Node *isClassNode = TR::Node::createif(TR::ifacmpeq, vftLoad, loadJavaLangClass, NULL);
       isClassTreeTop = TR::TreeTop::create(comp(), isClassNode, NULL, NULL);
       isClassBlock = TR::Block::createEmptyBlock(vftLoad, comp(), directAccessBlock->getFrequency());

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -302,7 +302,8 @@ List<OMR::RuntimeAssumption> *TR::InterProceduralAnalyzer::analyzeCallGraph(TR::
             }
          }
 
-      TR_PersistentClassInfo *classInfo = comp()->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, comp());
+      bool allowForAOT = comp()->getOption(TR_UseSymbolValidationManager);
+      TR_PersistentClassInfo *classInfo = comp()->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, comp(), allowForAOT);
       if (classInfo)
          {
          TR_ScratchList<TR_PersistentClassInfo> subClasses(trMemory());

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -484,8 +484,9 @@ bool TR_J9VirtualCallSite::findCallSiteForAbstractClass(TR_InlinerBase* inliner)
    TR_PersistentCHTable *chTable = comp()->getPersistentInfo()->getPersistentCHTable();
    TR_ResolvedMethod *implementer;
 
-   if (!comp()->compileRelocatableCode() && TR::Compiler->cls.isAbstractClass(comp(), _receiverClass) &&!comp()->getOption(TR_DisableAbstractInlining) &&
-               (implementer = chTable->findSingleAbstractImplementer(_receiverClass, _vftSlot, _callerResolvedMethod, comp())))
+   bool canInline = (!comp()->compileRelocatableCode() || comp()->getOption(TR_UseSymbolValidationManager));
+   if (canInline && TR::Compiler->cls.isAbstractClass(comp(), _receiverClass) &&!comp()->getOption(TR_DisableAbstractInlining) &&
+       (implementer = chTable->findSingleAbstractImplementer(_receiverClass, _vftSlot, _callerResolvedMethod, comp())))
       {
       heuristicTrace(inliner->tracer(),"Found a single Abstract Implementer %p, signature = %s",implementer,inliner->tracer()->traceSignature(implementer));
       TR_VirtualGuardSelection *guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(TR_AbstractGuard, TR_MethodTest);
@@ -812,6 +813,7 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
       {
       int32_t freq = profiledInfo->_frequency;
       TR_OpaqueClassBlock* tempreceiverClass = (TR_OpaqueClassBlock *) profiledInfo->_value;
+
       float val = (float)freq/(float)valueInfo->getTotalFrequency();        //x87 hardware rounds differently if you leave this division in compare
 
 
@@ -847,7 +849,15 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
          {
          TR_OpaqueClassBlock* callSiteClass = _receiverClass ? _receiverClass : getClassFromMethod();
 
-         if (!callSiteClass || fe()->isInstanceOf (tempreceiverClass, callSiteClass, true, true, true) != TR_yes)
+         bool profiledClassIsNotInstanceOfCallSiteClass = true;
+         if (callSiteClass)
+            {
+            comp()->enterHeuristicRegion();
+            profiledClassIsNotInstanceOfCallSiteClass = (fe()->isInstanceOf(tempreceiverClass, callSiteClass, true, true, true) != TR_yes);
+            comp()->exitHeuristicRegion();
+            }
+
+         if (profiledClassIsNotInstanceOfCallSiteClass)
             {
             inliner->tracer()->insertCounter(Not_Sane,_callNodeTreeTop);
             firstInstanceOfCheckFailed = true;
@@ -858,7 +868,9 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
             continue;
             }
 
+         comp()->enterHeuristicRegion();
          TR_ResolvedMethod* targetMethod = getResolvedMethod (tempreceiverClass);
+         comp()->exitHeuristicRegion();
 
          if (!targetMethod)
             {
@@ -871,6 +883,17 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
          // need to be able to store class chains for these methods
          if (comp()->compileRelocatableCode())
             {
+            if (tempreceiverClass && comp()->getOption(TR_UseSymbolValidationManager))
+               {
+               if (!comp()->getSymbolValidationManager()->addProfiledClassRecord(tempreceiverClass))
+                  continue;
+               /* call getResolvedMethod again to generate the validation records */
+               TR_ResolvedMethod* target_method = getResolvedMethod (tempreceiverClass);
+               if (!comp()->getSymbolValidationManager()->addClassFromMethodRecord(target_method->classOfMethod(), target_method->getPersistentIdentifier()))
+                  continue;
+               }
+
+
             TR_SharedCache *sharedCache = fej9->sharedCache();
             if (!sharedCache->canRememberClass(tempreceiverClass) ||
                 !sharedCache->canRememberClass(callSiteClass))
@@ -947,6 +970,13 @@ void TR_ProfileableCallSite::findSingleProfiledMethod(ListIterator<TR_ExtraAddre
       // need to be able to store class chains for these methods
       if (comp()->compileRelocatableCode())
          {
+         if (clazz && comp()->getOption(TR_UseSymbolValidationManager))
+            if (!comp()->getSymbolValidationManager()->addProfiledClassRecord(clazz))
+               {
+               classValuesAreSane = false;
+               break;
+               }
+
          TR_SharedCache *sharedCache = fej9->sharedCache();
          if (!sharedCache->canRememberClass(clazz) ||
              !sharedCache->canRememberClass(callSiteClass))

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -543,13 +543,16 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                node = TR::Node::recreateWithoutProperties(node, TR::aloadi, 1, arrayComponentClassPointer, comp()->getSymRefTab()->findOrCreateJavaLangClassFromClassSymbolRef());
 
                TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-               TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptrj_t*)(arrayComponentClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
-               addBlockOrGlobalConstraint(node,
-                     TR::VPClass::create(this,
-                        TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),
-                        TR::VPNonNullObject::create(this), NULL, NULL,
-                        TR::VPObjectLocation::create(this, TR::VPObjectLocation::JavaLangClassObject)),
-                     classChildGlobal);
+               if (knot)
+                  {
+                  TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptrj_t*)(arrayComponentClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
+                  addBlockOrGlobalConstraint(node,
+                        TR::VPClass::create(this,
+                           TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),
+                           TR::VPNonNullObject::create(this), NULL, NULL,
+                           TR::VPObjectLocation::create(this, TR::VPObjectLocation::JavaLangClassObject)),
+                        classChildGlobal);
+                  }
 
                invalidateUseDefInfo();
                invalidateValueNumberInfo();
@@ -617,13 +620,16 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                node = TR::Node::recreateWithoutProperties(node, TR::aloadi, 1, superClassPointer, comp()->getSymRefTab()->findOrCreateJavaLangClassFromClassSymbolRef());
 
                TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-               TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptrj_t*)(superClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
-               addBlockOrGlobalConstraint(node,
-                     TR::VPClass::create(this,
-                        TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),
-                        TR::VPNonNullObject::create(this), NULL, NULL,
-                        TR::VPObjectLocation::create(this, TR::VPObjectLocation::JavaLangClassObject)),
-                     classChildGlobal);
+               if (knot)
+                  {
+                  TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptrj_t*)(superClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
+                  addBlockOrGlobalConstraint(node,
+                        TR::VPClass::create(this,
+                           TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),
+                           TR::VPNonNullObject::create(this), NULL, NULL,
+                           TR::VPObjectLocation::create(this, TR::VPObjectLocation::JavaLangClassObject)),
+                        classChildGlobal);
+                  }
 
                invalidateUseDefInfo();
                invalidateValueNumberInfo();

--- a/runtime/compiler/optimizer/StringBuilderTransformer.cpp
+++ b/runtime/compiler/optimizer/StringBuilderTransformer.cpp
@@ -81,7 +81,7 @@ static const char* StringBuilderClassName = "java/lang/StringBuilder";
  */
 int32_t TR_StringBuilderTransformer::perform()
    {
-   if (comp()->getOption(TR_DisableStringBuilderTransformer) || comp()->compileRelocatableCode())
+   if (comp()->getOption(TR_DisableStringBuilderTransformer) || (comp()->compileRelocatableCode() && !comp()->getOption(TR_UseSymbolValidationManager)))
       {
       return 0;
       }

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -229,7 +229,7 @@ int32_t TR_StringPeepholes::perform()
    {
    static char *skipitAtWarm = feGetEnv("TR_noPeepholeAtWarm");
    if (comp()->getOption(TR_DisableStringPeepholes)
-       || !comp()->fej9()->doStringPeepholing()
+       || (!comp()->fej9()->doStringPeepholing() && !comp()->getOption(TR_UseSymbolValidationManager))
        || (skipitAtWarm && comp()->getMethodHotness()==warm))
       return 1;
 

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2451,7 +2451,8 @@ void TR::PPCPrivateLinkage::buildVirtualDispatch(TR::Node                       
                TR_OpaqueClassBlock      *thisClass = refinedThisClass ? refinedThisClass : resolvedMethod->containingClass();
 
                TR_PersistentCHTable     *chTable = comp()->getPersistentInfo()->getPersistentCHTable();
-               if (thisClass && TR::Compiler->cls.isAbstractClass(comp(), thisClass))
+               /* Devirtualization is not currently supported for AOT compilations */
+               if (thisClass && TR::Compiler->cls.isAbstractClass(comp(), thisClass) && !comp()->compileRelocatableCode())
                   {
                   TR_ResolvedMethod *calleeMethod = chTable->findSingleAbstractImplementer(thisClass, methodSymRef->getOffset(), methodSymRef->getOwningMethod(comp()), comp());
                   if (calleeMethod &&

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -49,6 +49,7 @@ j9jit_files(
 	runtime/RuntimeAssumptions.cpp
 	runtime/Runtime.cpp
 	runtime/SignalHandler.c
+	runtime/SymbolValidationManager.cpp
 	runtime/Trampoline.cpp
 	runtime/ValueProfiler.cpp
 )

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -1239,11 +1239,13 @@ J9::PersistentInfo::isUnloadedClass(
 bool
 J9::PersistentInfo::isObsoleteClass(void *v, TR_FrontEnd *fe)
    {
+   TR::Compilation *comp = TR::comp();
+   bool allowForAOT = comp && comp->getOption(TR_UseSymbolValidationManager);
    if (isUnloadedClass(v, true))
       return true;
    else if (!getPersistentCHTable())
       return false; // HCR TODO: Support fixed opt levels
-   else if (!getPersistentCHTable()->findClassInfoAfterLocking((TR_OpaqueClassBlock*)v, fe))
+   else if (!getPersistentCHTable()->findClassInfoAfterLocking((TR_OpaqueClassBlock*)v, fe, allowForAOT))
       return false; // It's not a class, so it can't be a replaced class
    else
       return fe->classHasBeenReplaced((TR_OpaqueClassBlock*)v);

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2380,8 +2380,9 @@ TR_IProfiler::createIProfilingValueInfo (TR_ByteCodeInfo &bcInfo, TR::Compilatio
       // profiling information coming from this caller
       if (comp->getOption(TR_IProfilerPerformTimestampCheck) && method && !_compInfo->isCompiled((J9Method *)method))// method is interpreted
          {
-         TR_PersistentClassInfo *currentPersistentClassInfo = _compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(comp->getCurrentMethod()->containingClass(), comp);
-         TR_PersistentClassInfo *calleePersistentClassInfo = _compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking((TR_OpaqueClassBlock *)J9_CLASS_FROM_METHOD(((J9Method *)method)), comp);
+         bool allowForAOT = comp->getOption(TR_UseSymbolValidationManager);
+         TR_PersistentClassInfo *currentPersistentClassInfo = _compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(comp->getCurrentMethod()->containingClass(), comp, allowForAOT);
+         TR_PersistentClassInfo *calleePersistentClassInfo = _compInfo->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking((TR_OpaqueClassBlock *)J9_CLASS_FROM_METHOD(((J9Method *)method)), comp, allowForAOT);
 
          if (!currentPersistentClassInfo || !calleePersistentClassInfo)
             {

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1808,7 +1808,7 @@ TR_BlockFrequencyInfo::getFrequencyInfo(
             {
             traceMsg(comp, "  found frame for %s with no outter profiling info\n", resolvedMethodSymbol->signature(comp->trMemory()));
             // has this method been compiled so we might have had a chance to profile it?
-            if (!resolvedMethod->isInterpreted()
+            if (!resolvedMethod->isInterpretedForHeuristics()
                 && !resolvedMethod->isNative()
                 && !resolvedMethod->isJNINative())
                {

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -42,6 +42,7 @@
 #include "env/PersistentCHTable.hpp"
 #include "env/jittypes.h"
 #include "env/VMAccessCriticalSection.hpp"
+#include "exceptions/AOTFailure.hpp"
 #include "il/symbol/StaticSymbol.hpp"
 #include "infra/SimpleRegex.hpp"
 #include "runtime/CodeCache.hpp"
@@ -4070,12 +4071,22 @@ TR_RelocationRecordSymbolFromManager::activatePointer(TR_RelocationRuntime *relo
 
    if (needsUnloadAssumptions(symbolType))
       {
-      TR_ASSERT_FATAL(clazz, "clazz must exist!\n");
+      if (!clazz)
+         {
+         TR_ASSERT(false, "clazz must exist to add Unload Assumptions!\n");
+         reloRuntime->comp()->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in activatePointer");
+         }
+
       reloTarget->addPICtoPatchPtrOnClassUnload(clazz, reloLocation);
       }
    if (needsRedefinitionAssumption(reloRuntime, reloLocation, clazz, symbolType))
       {
-      TR_ASSERT_FATAL(clazz, "clazz must exist!\n");
+      if (!clazz)
+         {
+         TR_ASSERT(false, "clazz must exist to add Redefinition Assumptions!\n");
+         reloRuntime->comp()->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in activatePointer");
+         }
+
       createClassRedefinitionPicSite((void *)reloPrivateData->_symbol, (void *) reloLocation, sizeof(uintptrj_t), false, reloRuntime->comp()->getMetadataAssumptionList());
       reloRuntime->comp()->setHasClassRedefinitionAssumptions();
       }

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -51,6 +51,7 @@
 #include "runtime/RelocationRuntime.hpp"
 #include "runtime/RelocationRuntimeLogger.hpp"
 #include "runtime/RelocationTarget.hpp"
+#include  "runtime/SymbolValidationManager.hpp"
 #include "env/VMJ9.h"
 #include "control/rossa.h"
 
@@ -66,169 +67,11 @@ extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAd
 extern "C" void ASM_CALL _patchVirtualGuard(uint8_t*, uint8_t*, uint32_t);
 #endif
 
-
-// These *BinaryTemplate structs describe the shape of the binary relocation records.
-struct TR_RelocationRecordBinaryTemplate
+uint8_t
+TR_RelocationRecordBinaryTemplate::type(TR_RelocationTarget *reloTarget)
    {
-   uint8_t type(TR_RelocationTarget *reloTarget) { return reloTarget->loadUnsigned8b(&_type); }
-
-   uint16_t _size;
-   uint8_t _type;
-   uint8_t _flags;
-
-#if defined(TR_HOST_64BIT)
-   uint32_t _extra;
-#endif
-   };
-
-// Generating 32-bit code on a 64-bit machine or vice-versa won't work because the alignment won't
-// be right.  Relying on inheritance in the structures here means padding is automatically inserted
-// at each inheritance boundary: this inserted padding won't match across 32-bit and 64-bit platforms.
-// Making as many fields as possible UDATA should minimize the differences and gives the most freedom
-// in the hierarchy of binary relocation record structures, but the header definitely has an inheritance
-// boundary at offset 4B.
-
-struct TR_RelocationRecordHelperAddressBinaryTemplate
-   {
-   uint16_t _size;
-   uint8_t _type;
-   uint8_t _flags;
-   uint32_t _helperID;
-   };
-
-struct TR_RelocationRecordPicTrampolineBinaryTemplate
-   {
-   uint16_t _size;
-   uint8_t _type;
-   uint8_t _flags;
-   uint32_t _numTrampolines;
-   };
-
-struct TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate : public TR_RelocationRecordBinaryTemplate
-   {
-   UDATA _inlinedSiteIndex;
-   };
-
-struct TR_RelocationRecordValidateArbitraryClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate //public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
-   {
-   UDATA _loaderClassChainOffset;
-   UDATA _classChainOffsetForClassBeingValidated;
-   };
-
-
-struct TR_RelocationRecordWithOffsetBinaryTemplate : public TR_RelocationRecordBinaryTemplate
-   {
-   UDATA _offset;
-   };
-
-struct TR_RelocationRecordConstantPoolBinaryTemplate : public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
-   {
-   UDATA _constantPool;
-   };
-
-struct TR_RelocationRecordConstantPoolWithIndexBinaryTemplate : public TR_RelocationRecordConstantPoolBinaryTemplate
-   {
-   UDATA _index;
-   };
-
-typedef TR_RelocationRecordConstantPoolWithIndexBinaryTemplate TR_RelocationRecordClassObjectBinaryTemplate;
-
-struct TR_RelocationRecordJ2IVirtualThunkPointerBinaryTemplate : public TR_RelocationRecordConstantPoolBinaryTemplate
-   {
-   IDATA _offsetToJ2IVirtualThunkPointer;
-   };
-
-struct TR_RelocationRecordInlinedAllocationBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
-   {
-   UDATA _branchOffset;
-   };
-
-struct TR_RelocationRecordVerifyClassObjectForAllocBinaryTemplate : public TR_RelocationRecordInlinedAllocationBinaryTemplate
-   {
-   UDATA _allocationSize;
-   };
-
-struct TR_RelocationRecordRomClassFromCPBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
-   {
-   UDATA  _romClassOffsetInSharedCache;
-   };
-
-typedef TR_RelocationRecordRomClassFromCPBinaryTemplate TR_RelocationRecordInlinedMethodBinaryTemplate;
-
-struct TR_RelocationRecordNopGuardBinaryTemplate : public TR_RelocationRecordInlinedMethodBinaryTemplate
-   {
-   UDATA _destinationAddress;
-   };
-
-typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedStaticMethodWithNopGuardBinaryTemplate;
-typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedSpecialMethodWithNopGuardBinaryTemplate;
-typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedVirtualMethodWithNopGuardBinaryTemplate;
-typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedInterfaceMethodWithNopGuardBinaryTemplate;
-
-
-struct TR_RelocationRecordProfiledInlinedMethodBinaryTemplate : TR_RelocationRecordInlinedMethodBinaryTemplate
-   {
-   UDATA _classChainIdentifyingLoaderOffsetInSharedCache;
-   UDATA _classChainForInlinedMethod;
-   UDATA _vTableSlot;
-   };
-
-typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledGuardBinaryTemplate;
-typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledClassGuardBinaryTemplate;
-typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledMethodGuardBinaryTemplate;
-
-
-typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordRamMethodBinaryTemplate;
-
-typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordArrayCopyHelperTemplate;
-
-struct TR_RelocationRecordMethodTracingCheckBinaryTemplate : public TR_RelocationRecordBinaryTemplate
-   {
-   UDATA _destinationAddress;
-   };
-
-struct TR_RelocationRecordValidateClassBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
-   {
-   UDATA _classChainOffsetInSharedCache;
-   };
-
-typedef TR_RelocationRecordRomClassFromCPBinaryTemplate TR_RelocationRecordValidateStaticFieldBinaryTemplate;
-
-struct TR_RelocationRecordDataAddressBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
-   {
-   UDATA _offset;
-   };
-
-struct TR_RelocationRecordPointerBinaryTemplate : TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
-   {
-   UDATA _classChainIdentifyingLoaderOffsetInSharedCache;
-   UDATA _classChainForInlinedMethod;
-   };
-
-typedef TR_RelocationRecordPointerBinaryTemplate TR_RelocationRecordClassPointerBinaryTemplate;
-struct TR_RelocationRecordMethodPointerBinaryTemplate : TR_RelocationRecordPointerBinaryTemplate
-   {
-   UDATA _vTableSlot;
-   };
-struct TR_RelocationRecordEmitClassBinaryTemplate : public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
-   {
-   int32_t _bcIndex;
-#if defined(TR_HOST_64BIT)
-   uint32_t _extra;
-#endif
-   };
-
-struct TR_RelocationRecordDebugCounterBinaryTemplate : public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
-   {
-   UDATA _bcIndex;
-   UDATA _offsetOfNameString;
-   UDATA _delta;
-   UDATA _fidelity;
-   UDATA _staticDelta;
-   };
-
-
-typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordClassUnloadAssumptionBinaryTemplate;
+   return reloTarget->loadUnsigned8b(&_type);
+   }
 
 // TR_RelocationRecordGroup
 
@@ -348,6 +191,9 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
          break;
       case TR_InlinedInterfaceMethod:
          reloRecord = new (storage) TR_RelocationRecordInlinedInterfaceMethod(reloRuntime, record);
+         break;
+      case TR_InlinedAbstractMethodWithNopGuard:
+         reloRecord = new (storage) TR_RelocationRecordInlinedAbstractMethodWithNopGuard(reloRuntime, record);
          break;
       case TR_InlinedHCRMethod:
          reloRecord = new (storage) TR_RelocationRecordInlinedMethod(reloRuntime, record);
@@ -469,6 +315,113 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
          break;
       case TR_ClassUnloadAssumption:
          reloRecord = new (storage) TR_RelocationRecordClassUnloadAssumption(reloRuntime, record);
+      case TR_ValidateRootClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateRootClass(reloRuntime, record);
+         break;
+      case TR_ValidateClassByName:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassByName(reloRuntime, record);
+         break;
+      case TR_ValidateProfiledClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateProfiledClass(reloRuntime, record);
+         break;
+      case TR_ValidateClassFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateDefiningClassFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateDefiningClassFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateStaticClassFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateStaticClassFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateClassFromMethod:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassFromMethod(reloRuntime, record);
+         break;
+      case TR_ValidateComponentClassFromArrayClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateComponentClassFromArrayClass(reloRuntime, record);
+         break;
+      case TR_ValidateArrayClassFromComponentClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateArrayClassFromComponentClass(reloRuntime, record);
+         break;
+      case TR_ValidateSuperClassFromClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateSuperClassFromClass(reloRuntime, record);
+         break;
+      case TR_ValidateClassInstanceOfClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassInstanceOfClass(reloRuntime, record);
+         break;
+      case TR_ValidateSystemClassByName:
+         reloRecord = new (storage) TR_RelocationRecordValidateSystemClassByName(reloRuntime, record);
+         break;
+      case TR_ValidateClassFromITableIndexCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassFromITableIndexCP(reloRuntime, record);
+         break;
+      case TR_ValidateDeclaringClassFromFieldOrStatic:
+         reloRecord = new (storage) TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic(reloRuntime, record);
+         break;
+      case TR_ValidateClassClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassClass(reloRuntime, record);
+         break;
+      case TR_ValidateConcreteSubClassFromClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateConcreteSubClassFromClass(reloRuntime, record);
+         break;
+      case TR_ValidateClassChain:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassChain(reloRuntime, record);
+         break;
+      case TR_ValidateRomClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateRomClass(reloRuntime, record);
+         break;
+      case TR_ValidatePrimitiveClass:
+         reloRecord = new (storage) TR_RelocationRecordValidatePrimitiveClass(reloRuntime, record);
+         break;
+      case TR_ValidateMethodFromInlinedSite:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodFromInlinedSite(reloRuntime, record);
+         break;
+      case TR_ValidateMethodByName:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodByName(reloRuntime, record);
+         break;
+      case TR_ValidateMethodFromClass:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodFromClass(reloRuntime, record);
+         break;
+      case TR_ValidateStaticMethodFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateStaticMethodFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateSpecialMethodFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateSpecialMethodFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateVirtualMethodFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateVirtualMethodFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateVirtualMethodFromOffset:
+         reloRecord = new (storage) TR_RelocationRecordValidateVirtualMethodFromOffset(reloRuntime, record);
+         break;
+      case TR_ValidateInterfaceMethodFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateInterfaceMethodFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateImproperInterfaceMethodFromCP:
+         reloRecord = new (storage) TR_RelocationRecordValidateImproperInterfaceMethodFromCP(reloRuntime, record);
+         break;
+      case TR_ValidateMethodFromClassAndSig:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodFromClassAndSig(reloRuntime, record);
+         break;
+      case TR_ValidateStackWalkerMaySkipFramesRecord:
+         reloRecord = new (storage) TR_RelocationRecordValidateStackWalkerMaySkipFrames(reloRuntime, record);
+         break;
+      case TR_ValidateArrayClassFromJavaVM:
+         reloRecord = new (storage) TR_RelocationRecordValidateArrayClassFromJavaVM(reloRuntime, record);
+         break;
+      case TR_ValidateClassInfoIsInitialized:
+         reloRecord = new (storage) TR_RelocationRecordValidateClassInfoIsInitialized(reloRuntime, record);
+         break;
+      case TR_ValidateMethodFromSingleImplementer:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodFromSingleImpl(reloRuntime, record);
+         break;
+      case TR_ValidateMethodFromSingleInterfaceImplementer:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodFromSingleInterfaceImpl(reloRuntime, record);
+         break;
+      case TR_ValidateMethodFromSingleAbstractImplementer:
+         reloRecord = new (storage) TR_RelocationRecordValidateMethodFromSingleAbstractImpl(reloRuntime, record);
+         break;
+      case TR_SymbolFromManager:
+         reloRecord = new (storage) TR_RelocationRecordSymbolFromManager(reloRuntime, record);
          break;
       default:
          // TODO: error condition
@@ -1205,7 +1158,7 @@ TR_RelocationRecordConstantPoolWithIndex::getInterfaceMethodFromCP(TR_Relocation
       TR_PersistentCHTable * chTable = reloRuntime->getPersistentInfo()->getPersistentCHTable();
       TR_ResolvedMethod *callerResolvedMethod = fe->createResolvedMethod(trMemory, callerMethod, NULL);
 
-      TR_ResolvedMethod *calleeResolvedMethod = chTable->findSingleInterfaceImplementer(interfaceClass, cpIndex, callerResolvedMethod, reloRuntime->comp());
+      TR_ResolvedMethod *calleeResolvedMethod = chTable->findSingleInterfaceImplementer(interfaceClass, cpIndex, callerResolvedMethod, reloRuntime->comp(), false, false);
 
       if (calleeResolvedMethod)
          {
@@ -1218,6 +1171,60 @@ TR_RelocationRecordConstantPoolWithIndex::getInterfaceMethodFromCP(TR_Relocation
 
 
    reloPrivateData->_receiverClass = interfaceClass;
+   return calleeMethod;
+   }
+
+TR_OpaqueMethodBlock *
+TR_RelocationRecordConstantPoolWithIndex::getAbstractMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
+   {
+   TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
+   TR_RelocationRecordInlinedMethodPrivateData *reloPrivateData = &(privateData()->inlinedMethod);
+
+   J9JavaVM *javaVM = reloRuntime->javaVM();
+   TR_J9VMBase *fe = reloRuntime->fej9();
+   TR_Memory *trMemory = reloRuntime->trMemory();
+
+   J9ConstantPool *cp = (J9ConstantPool *) void_cp;
+   J9ROMMethodRef *romMethodRef = (J9ROMMethodRef *)&cp->romConstantPool[cpIndex];
+
+   TR_OpaqueMethodBlock *calleeMethod = NULL;
+   TR_OpaqueClassBlock *abstractClass = NULL;
+   UDATA vTableOffset = (UDATA)-1;
+   J9Method *method = NULL;
+
+      {
+      TR::VMAccessCriticalSection getAbstractlMethodFromCP(reloRuntime->fej9());
+      abstractClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(reloRuntime->currentThread(),
+                                                                                            cp,
+                                                                                            romMethodRef->classRefCPIndex,
+                                                                                            J9_RESOLVE_FLAG_AOT_LOAD_TIME);
+
+      vTableOffset = javaVM->internalVMFunctions->resolveVirtualMethodRefInto(reloRuntime->currentThread(),
+                                                                              cp,
+                                                                              cpIndex,
+                                                                              J9_RESOLVE_FLAG_AOT_LOAD_TIME,
+                                                                              &method,
+                                                                              NULL);
+      }
+
+   if (abstractClass && method)
+      {
+      int32_t vftSlot = (int32_t)(-(vTableOffset - J9JIT_INTERP_VTABLE_OFFSET));
+      TR_PersistentCHTable * chTable = reloRuntime->getPersistentInfo()->getPersistentCHTable();
+      TR_ResolvedMethod *callerResolvedMethod = fe->createResolvedMethod(trMemory, callerMethod, NULL);
+
+      TR_ResolvedMethod *calleeResolvedMethod = chTable->findSingleAbstractImplementer(abstractClass, vftSlot, callerResolvedMethod, reloRuntime->comp(), false, false);
+
+      if (calleeResolvedMethod)
+         {
+         if (!calleeResolvedMethod->virtualMethodIsOverridden())
+            calleeMethod = calleeResolvedMethod->getPersistentIdentifier();
+         else
+            RELO_LOG(reloLogger, 6, "\tgetMethodFromCP: callee method overridden\n");
+         }
+      }
+
+   reloPrivateData->_receiverClass = abstractClass;
    return calleeMethod;
    }
 
@@ -1964,6 +1971,12 @@ TR_RelocationRecordInlinedAllocation::preparePrivateData(TR_RelocationRuntime *r
    TR_J9VMBase *fe = reloRuntime->fej9();
    J9Class *clazz;
 
+   if (reloRuntime->comp()->getOption(TR_UseSymbolValidationManager))
+      {
+      uint16_t classID = (uint16_t)cpIndex(reloTarget);
+      clazz = (J9Class *)reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(classID);
+      }
+   else
       {
       TR::VMAccessCriticalSection preparePrivateData(fe);
       clazz = javaVM->internalVMFunctions->resolveClassRef(javaVM->internalVMFunctions->currentVMThread(javaVM),
@@ -2197,7 +2210,34 @@ TR_RelocationRecordInlinedMethod::validateClassesSame(TR_RelocationRuntime *relo
       {
       J9JavaVM *javaVM = reloRuntime->jitConfig()->javaVM;
       void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache((void *) romClassOffsetInSharedCache(reloTarget));
-      J9Method *currentMethod = (J9Method *) getMethodFromCP(reloRuntime, cp, cpIndex(reloTarget), (TR_OpaqueMethodBlock *) callerMethod);
+      J9Method *currentMethod;
+
+      TR_RelocationRecordInlinedMethodPrivateData *reloPrivateData = &(privateData()->inlinedMethod);
+
+      if (reloRuntime->comp()->getOption(TR_UseSymbolValidationManager))
+         {
+         TR_RelocationRecordInlinedMethodPrivateData *reloPrivateData = &(privateData()->inlinedMethod);
+
+         uintptrj_t data = (uintptrj_t)cpIndex(reloTarget);
+         uint16_t methodID = (uint16_t)(data & 0xFFFF);
+         uint16_t receiverClassID = (uint16_t)((data >> 16) & 0xFFFF);
+
+         currentMethod = (J9Method *)reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(methodID);
+         reloPrivateData->_receiverClass = (TR_OpaqueClassBlock *)reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(receiverClassID);
+
+         if (reloFlags(reloTarget) != inlinedMethodIsStatic && reloFlags(reloTarget) != inlinedMethodIsSpecial)
+            {
+            TR_ResolvedMethod *calleeResolvedMethod = reloRuntime->fej9()->createResolvedMethod(reloRuntime->comp()->trMemory(),
+                                                                                                (TR_OpaqueMethodBlock *)currentMethod,
+                                                                                                NULL);
+            if (calleeResolvedMethod->virtualMethodIsOverridden())
+               currentMethod = NULL;
+            }
+         }
+      else
+         {
+         currentMethod = (J9Method *) getMethodFromCP(reloRuntime, cp, cpIndex(reloTarget), (TR_OpaqueMethodBlock *) callerMethod);
+         }
 
       if (currentMethod != NULL &&
           (reloRuntime->fej9()->isAnyMethodTracingEnabled((TR_OpaqueMethodBlock *) currentMethod) ||
@@ -2522,6 +2562,44 @@ TR_OpaqueMethodBlock *
 TR_RelocationRecordInlinedInterfaceMethod::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
    {
    return getInterfaceMethodFromCP(reloRuntime, void_cp, cpIndex, callerMethod);
+   }
+
+// TR_InlinedAbstractMethodWithNopGuard
+char *
+TR_RelocationRecordInlinedAbstractMethodWithNopGuard::name()
+   {
+   return "TR_InlinedAbstractMethodWithNopGuard";
+   }
+
+TR_OpaqueMethodBlock *
+TR_RelocationRecordInlinedAbstractMethodWithNopGuard::getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod)
+   {
+   return getAbstractMethodFromCP(reloRuntime, void_cp, cpIndex, callerMethod);
+   }
+
+void
+TR_RelocationRecordInlinedAbstractMethodWithNopGuard::createAssumptions(TR_RelocationRuntime *reloRuntime, uint8_t *reloLocation)
+   {
+   TR_RelocationRecordInlinedMethodPrivateData *reloPrivateData = &(privateData()->inlinedMethod);
+   TR_PersistentCHTable *table = reloRuntime->getPersistentInfo()->getPersistentCHTable();
+   List<TR_VirtualGuardSite> sites(reloRuntime->comp()->trMemory());
+   TR_VirtualGuardSite site;
+   site.setLocation(reloLocation);
+   site.setDestination(reloPrivateData->_destination);
+   sites.add(&site);
+   TR_ClassQueries::addAnAssumptionForEachSubClass(table, table->findClassInfo(reloPrivateData->_receiverClass), sites, reloRuntime->comp());
+   }
+
+void
+TR_RelocationRecordInlinedAbstractMethodWithNopGuard::updateFailedStats(TR_AOTStats *aotStats)
+   {
+   aotStats->abstractMethods.numFailedValidations++;
+   }
+
+void
+TR_RelocationRecordInlinedAbstractMethodWithNopGuard::updateSucceededStats(TR_AOTStats *aotStats)
+   {
+   aotStats->abstractMethods.numSucceededValidations++;
    }
 
 // TR_ProfiledInlinedMethod
@@ -3134,6 +3212,873 @@ TR_RelocationRecordValidateArbitraryClass::applyRelocation(TR_RelocationRuntime 
       aotStats->numClassValidationsFailed++;
 
    return compilationAotClassReloFailure;
+   }
+
+
+int32_t
+TR_RelocationRecordValidateRootClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateRootClassBinaryTemplate *)_record)->_classID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateRootClassRecord(classID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassByName::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_classID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_beholderID);
+   char primitiveType = (char)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_primitiveType);
+   void *romClassOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_romClassOffsetInSCC);
+   void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: primitiveType %c\n", primitiveType);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: romClass %p\n", romClass);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassByNameRecord(classID, beholderID, static_cast<J9ROMClass *>(romClass), primitiveType))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateProfiledClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateProfiledClassBinaryTemplate *)_record)->_classID);
+   char primitiveType = (char)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateProfiledClassBinaryTemplate *)_record)->_primitiveType);
+
+   void *classChainForCLOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateProfiledClassBinaryTemplate *)_record)->_classChainOffsetForCLInScc);
+   void *classChainForCL = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainForCLOffset);
+
+   void *classChainOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateProfiledClassBinaryTemplate *)_record)->_classChainOffsetInSCC);
+   void *classChain = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: primitiveType %c\n", primitiveType);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classChainForCL %p\n", classChainForCL);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classChain %p\n", classChain);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateProfiledClassRecord(classID, primitiveType, classChainForCL, classChain))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromCPBinaryTemplate *)_record)->_classID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateClassFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassFromCPRecord(classID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateDefiningClassFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *)_record)->_classID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *)_record)->_cpIndex);
+   bool isStatic = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate *)_record)->_isStatic);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: isStatic %s\n", isStatic ? "true" : "false");
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateDefiningClassFromCPRecord(classID, beholderID, cpIndex, isStatic))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateStaticClassFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *)_record)->_classID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticClassFromCPRecord(classID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassFromMethod::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromMethodBinaryTemplate *)_record)->_classID);
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromMethodBinaryTemplate *)_record)->_methodID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassFromMethodRecord(classID, methodID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateComponentClassFromArrayClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t componentClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateCompFromArrayBinaryTemplate *)_record)->_componentClassID);
+   uint16_t arrayClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateCompFromArrayBinaryTemplate *)_record)->_arrayClassID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: componentClassID %d\n", componentClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: arrayClassID %d\n", arrayClassID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateComponentClassFromArrayClassRecord(componentClassID, arrayClassID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateArrayClassFromComponentClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t arrayClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateArrayFromCompBinaryTemplate *)_record)->_arrayClassID);
+   uint16_t componentClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateArrayFromCompBinaryTemplate *)_record)->_componentClassID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: arrayClassID %d\n", arrayClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: componentClassID %d\n", componentClassID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateArrayClassFromComponentClassRecord(arrayClassID, componentClassID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateSuperClassFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t superClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *)_record)->_superClassID);
+   uint16_t childClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate *)_record)->_childClassID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: superClassID %d\n", superClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: childClassID %d\n", childClassID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateSuperClassFromClassRecord(superClassID, childClassID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassInstanceOfClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classOneID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *)_record)->_classOneID);
+   uint16_t classTwoID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *)_record)->_classTwoID);
+   bool objectTypeIsFixed = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *)_record)->_objectTypeIsFixed);
+   bool castTypeIsFixed = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *)_record)->_castTypeIsFixed);
+   bool isInstanceOf = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate *)_record)->_isInstanceOf);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classOneID %d\n", classOneID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classTwoID %d\n", classTwoID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: objectTypeIsFixed %s\n", objectTypeIsFixed ? "true" : "false'");
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: castTypeIsFixed %s\n", castTypeIsFixed ? "true" : "false'");
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: isInstanceOf %s\n", isInstanceOf ? "true" : "false'");
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassInstanceOfClassRecord(classOneID, classTwoID, objectTypeIsFixed, castTypeIsFixed, isInstanceOf))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateSystemClassByName::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t systemClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *)_record)->_systemClassID);
+   void *romClassOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *)_record)->_romClassOffsetInSCC);
+   void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: systemClassID %d\n", systemClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: romClass %p\n", romClass);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateSystemClassByNameRecord(systemClassID, static_cast<J9ROMClass *>(romClass)))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassFromITableIndexCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *)_record)->_classID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassFromITableIndexCPRecord(classID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *)_record)->_classID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateDeclaringClassFromFieldOrStaticRecord(classID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassClassBinaryTemplate *)_record)->_classClassID);
+   uint16_t objectClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassClassBinaryTemplate *)_record)->_objectClassID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classClassID %d\n", classClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: objectClassID %d\n", objectClassID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassClassRecord(classClassID, objectClassID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateConcreteSubClassFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t childClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *)_record)->_childClassID);
+   uint16_t superClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *)_record)->_superClassID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: childClassID %d\n", childClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: superClassID %d\n", superClassID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateConcreteSubClassFromClassRecord(childClassID, superClassID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassChain::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassChainBinaryTemplate *)_record)->_classID);
+   void *classChainOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateClassChainBinaryTemplate *)_record)->_classChainOffsetInSCC);
+   void *classChain = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classChain %p\n", classChain);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassChainRecord(classID, classChain))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateRomClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateRomClassBinaryTemplate *)_record)->_classID);
+   void *romClassOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateRomClassBinaryTemplate *)_record)->_romClassOffsetInSCC);
+   void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: romClass %p\n", romClass);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateRomClassRecord(classID, static_cast<J9ROMClass *>(romClass)))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidatePrimitiveClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidatePrimitiveClassBinaryTemplate *)_record)->_classID);
+   char primitiveType = (char)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidatePrimitiveClassBinaryTemplate *)_record)->_primitiveType);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: primitiveType %c\n", primitiveType);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validatePrimitiveClassRecord(classID, primitiveType))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodFromInlinedSite::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate *)_record)->_methodID);
+   uint32_t inlinedSiteIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate *)_record)->_inlinedSiteIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: inlinedSiteIndex %d\n", inlinedSiteIndex);
+      }
+
+   TR_InlinedCallSite *inlinedCallSite = (TR_InlinedCallSite *)getInlinedCallSiteArrayElement(reloRuntime->exceptionTable(), inlinedSiteIndex);
+   TR_OpaqueMethodBlock *method = inlinedCallSite->_methodInfo;
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromInlinedSiteRecord(methodID, method))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodByName::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodByNameBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodByNameBinaryTemplate *)_record)->_beholderID);
+
+   void *romClassOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateMethodByNameBinaryTemplate *)_record)->_romClassOffsetInSCC);
+   void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffset);
+
+   void *romMethodOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateMethodByNameBinaryTemplate *)_record)->_romMethodOffsetInSCC);
+   void *romMethod = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romMethodOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: romClass %p\n", romClass);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: romMethod %p\n", romMethod);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodByNameRecord(methodID, beholderID, static_cast<J9ROMClass *>(romClass), static_cast<J9ROMMethod *>(romMethod)))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassBinaryTemplate *)_record)->_beholderID);
+   uint32_t index = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassBinaryTemplate *)_record)->_index);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: index %d\n", index);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassRecord(methodID, beholderID, index))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateStaticMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticMethodFromCPRecord(methodID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateSpecialMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateSpecialMethodFromCPRecord(methodID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateVirtualMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromCPRecord(methodID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateVirtualMethodFromOffset::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_beholderID);
+   uint32_t virtualCallOffset = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_virtualCallOffset);
+   bool ignoreRtResolve = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_ignoreRtResolve);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: virtualCallOffset %d\n", virtualCallOffset);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: ignoreRtResolve %s\n", ignoreRtResolve ? "true" : "false");
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromOffsetRecord(methodID, beholderID, virtualCallOffset, ignoreRtResolve))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateInterfaceMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_beholderID);
+   uint16_t lookupID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_lookupID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: lookupID %d\n", lookupID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateInterfaceMethodFromCPRecord(methodID, beholderID, lookupID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateImproperInterfaceMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_beholderID);
+   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateImproperInterfaceMethodFromCPRecord(methodID, beholderID, cpIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_methodID);
+   uint16_t methodClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_methodClassID);
+   uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_beholderID);
+
+   void *romMethodOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_romMethodOffsetInSCC);
+   void *romMethod = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romMethodOffset);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodClassID %d\n", methodClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: romMethod %p\n", romMethod);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassAndSignatureRecord(methodID, methodClassID, beholderID, static_cast<J9ROMMethod *>(romMethod)))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateStackWalkerMaySkipFrames::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *)_record)->_methodID);
+   uint16_t methodClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *)_record)->_methodClassID);
+   bool skipFrames = reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *)_record)->_skipFrames);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodClassID %d\n", methodClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: skipFrames %s\n", skipFrames ? "true" : "false");
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateStackWalkerMaySkipFramesRecord(methodID, methodClassID, skipFrames))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateArrayClassFromJavaVM::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t arrayClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate *)_record)->_arrayClassID);
+   int32_t arrayClassIndex = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate *)_record)->_arrayClassIndex);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: arrayClassID %d\n", arrayClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: arrayClassIndex %d\n", arrayClassIndex);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateArrayClassFromJavaVM(arrayClassID, arrayClassIndex))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateClassInfoIsInitialized::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *)_record)->_classID);
+   bool wasInitialized = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate *)_record)->_isInitialized);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: wasInitialized %s\n", wasInitialized ? "true" : "false");
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassInfoIsInitializedRecord(classID, wasInitialized))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodFromSingleImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_methodID);
+   uint16_t thisClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_thisClassID);
+   int32_t cpIndexOrVftSlot = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_cpIndexOrVftSlot);
+   uint16_t callerMethodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_callerMethodID);
+   uint16_t useGetResolvedInterfaceMethod = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_useGetResolvedInterfaceMethod);;
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: thisClassID %d\n", thisClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndexOrVftSlot %d\n", cpIndexOrVftSlot);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: callerMethodID %d\n", callerMethodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: useGetResolvedInterfaceMethod %d\n", useGetResolvedInterfaceMethod);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromSingleImplementerRecord(methodID,
+                                                                                                    thisClassID,
+                                                                                                    cpIndexOrVftSlot,
+                                                                                                    callerMethodID,
+                                                                                                    (TR_YesNoMaybe)useGetResolvedInterfaceMethod))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodFromSingleInterfaceImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_methodID);
+   uint16_t thisClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_thisClassID);
+   int32_t cpIndex = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_cpIndex);
+   uint16_t callerMethodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_callerMethodID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: thisClassID %d\n", thisClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: callerMethodID %d\n", callerMethodID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromSingleInterfaceImplementerRecord(methodID,
+                                                                                                             thisClassID,
+                                                                                                             cpIndex,
+                                                                                                             callerMethodID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+int32_t
+TR_RelocationRecordValidateMethodFromSingleAbstractImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_methodID);
+   uint16_t thisClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_thisClassID);
+   int32_t vftSlot = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_vftSlot);
+   uint16_t callerMethodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_callerMethodID);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: thisClassID %d\n", thisClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: vftSlot %d\n", vftSlot);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: callerMethodID %d\n", callerMethodID);
+      }
+
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromSingleAbstractImplementerRecord(methodID,
+                                                                                                            thisClassID,
+                                                                                                            vftSlot,
+                                                                                                            callerMethodID))
+      return 0;
+   else
+      return compilationAotClassReloFailure;
+   }
+
+void
+TR_RelocationRecordSymbolFromManager::preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget)
+   {
+   TR_RelocationSymbolFromManagerPrivateData *reloPrivateData = &(privateData()->symbolFromManager);
+
+   uint16_t symbolID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordSymbolFromManagerBinaryTemplate *)_record)->_symbolID);
+   uint16_t symbolType = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordSymbolFromManagerBinaryTemplate *)_record)->_symbolType);
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tpreparePrivateData: symbolID %d\n", symbolID);
+      reloRuntime->reloLogger()->printf("\tpreparePrivateData: symbolType %d\n", symbolType);
+      }
+
+   reloPrivateData->_symbol = reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(symbolID);
+   reloPrivateData->_symbolType = symbolType;
+   }
+
+int32_t
+TR_RelocationRecordSymbolFromManager::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   TR_RelocationSymbolFromManagerPrivateData *reloPrivateData = &(privateData()->symbolFromManager);
+
+   void *symbol = reloPrivateData->_symbol;
+
+   if (reloRuntime->reloLogger()->logEnabled())
+      {
+      reloRuntime->reloLogger()->printf("%s\n", name());
+      reloRuntime->reloLogger()->printf("\tpreparePrivateData: symbol %p\n", symbol);
+      }
+
+   if (symbol)
+      {
+      reloTarget->storeAddressSequence((uint8_t *)symbol, reloLocation, reloFlags(reloTarget));
+      activatePointer(reloRuntime, reloTarget, reloLocation);
+      }
+   else
+      {
+      return compilationAotClassReloFailure;
+      }
+
+   return 0;
+   }
+
+bool
+TR_RelocationRecordSymbolFromManager::needsUnloadAssumptions(TR::SymbolType symbolType)
+   {
+   bool needsAssumptions = false;
+   switch (symbolType)
+      {
+      case TR::SymbolType::typeClass:
+      case TR::SymbolType::typeMethod:
+         needsAssumptions = true;
+      default:
+         needsAssumptions = false;
+      }
+   return needsAssumptions;
+   }
+
+bool
+TR_RelocationRecordSymbolFromManager::needsRedefinitionAssumption(TR_RelocationRuntime *reloRuntime, uint8_t *reloLocation, TR_OpaqueClassBlock *clazz, TR::SymbolType symbolType)
+   {
+   if (!reloRuntime->options()->getOption(TR_EnableHCR))
+      return false;
+
+   bool needsAssumptions = false;
+   switch (symbolType)
+      {
+      case TR::SymbolType::typeClass:
+         needsAssumptions =  TR::CodeGenerator::wantToPatchClassPointer(reloRuntime->comp(), clazz, reloLocation);
+      case TR::SymbolType::typeMethod:
+         needsAssumptions = true;
+      default:
+         needsAssumptions = false;
+      }
+   return needsAssumptions;
+   }
+
+void
+TR_RelocationRecordSymbolFromManager::activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   TR_RelocationSymbolFromManagerPrivateData *reloPrivateData = &(privateData()->symbolFromManager);
+   TR::SymbolType symbolType = (TR::SymbolType)reloPrivateData->_symbolType;
+
+   TR_OpaqueClassBlock *clazz = NULL;
+   if (symbolType == TR::SymbolType::typeClass)
+      {
+      clazz = (TR_OpaqueClassBlock *)reloPrivateData->_symbol;
+      }
+   else if (symbolType == TR::SymbolType::typeMethod)
+      {
+      clazz = (TR_OpaqueClassBlock *)J9_CLASS_FROM_METHOD((J9Method *)(reloPrivateData->_symbol));
+      }
+
+   if (needsUnloadAssumptions(symbolType))
+      {
+      TR_ASSERT_FATAL(clazz, "clazz must exist!\n");
+      reloTarget->addPICtoPatchPtrOnClassUnload(clazz, reloLocation);
+      }
+   if (needsRedefinitionAssumption(reloRuntime, reloLocation, clazz, symbolType))
+      {
+      TR_ASSERT_FATAL(clazz, "clazz must exist!\n");
+      createClassRedefinitionPicSite((void *)reloPrivateData->_symbol, (void *) reloLocation, sizeof(uintptrj_t), false, reloRuntime->comp()->getMetadataAssumptionList());
+      reloRuntime->comp()->setHasClassRedefinitionAssumptions();
+      }
    }
 
 

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -39,6 +39,392 @@ class TR_RelocationTarget;
 struct TR_RelocationRecordBinaryTemplate;
 typedef TR_ExternalRelocationTargetKind TR_RelocationRecordType;
 
+// These *BinaryTemplate structs describe the shape of the binary relocation records.
+struct TR_RelocationRecordBinaryTemplate
+   {
+   uint8_t type(TR_RelocationTarget *reloTarget);
+
+   uint16_t _size;
+   uint8_t _type;
+   uint8_t _flags;
+
+#if defined(TR_HOST_64BIT)
+   uint32_t _extra;
+#endif
+   };
+
+// Generating 32-bit code on a 64-bit machine or vice-versa won't work because the alignment won't
+// be right.  Relying on inheritance in the structures here means padding is automatically inserted
+// at each inheritance boundary: this inserted padding won't match across 32-bit and 64-bit platforms.
+// Making as many fields as possible UDATA should minimize the differences and gives the most freedom
+// in the hierarchy of binary relocation record structures, but the header definitely has an inheritance
+// boundary at offset 4B.
+
+struct TR_RelocationRecordHelperAddressBinaryTemplate
+   {
+   uint16_t _size;
+   uint8_t _type;
+   uint8_t _flags;
+   uint32_t _helperID;
+   };
+
+struct TR_RelocationRecordPicTrampolineBinaryTemplate
+   {
+   uint16_t _size;
+   uint8_t _type;
+   uint8_t _flags;
+   uint32_t _numTrampolines;
+   };
+
+struct TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   UDATA _inlinedSiteIndex;
+   };
+
+struct TR_RelocationRecordValidateArbitraryClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate //public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
+   {
+   UDATA _loaderClassChainOffset;
+   UDATA _classChainOffsetForClassBeingValidated;
+   };
+
+
+struct TR_RelocationRecordWithOffsetBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   UDATA _offset;
+   };
+
+struct TR_RelocationRecordConstantPoolBinaryTemplate : public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
+   {
+   UDATA _constantPool;
+   };
+
+struct TR_RelocationRecordConstantPoolWithIndexBinaryTemplate : public TR_RelocationRecordConstantPoolBinaryTemplate
+   {
+   UDATA _index;
+   };
+
+typedef TR_RelocationRecordConstantPoolWithIndexBinaryTemplate TR_RelocationRecordClassObjectBinaryTemplate;
+
+struct TR_RelocationRecordJ2IVirtualThunkPointerBinaryTemplate : public TR_RelocationRecordConstantPoolBinaryTemplate
+   {
+   IDATA _offsetToJ2IVirtualThunkPointer;
+   };
+
+struct TR_RelocationRecordInlinedAllocationBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
+   {
+   UDATA _branchOffset;
+   };
+
+struct TR_RelocationRecordVerifyClassObjectForAllocBinaryTemplate : public TR_RelocationRecordInlinedAllocationBinaryTemplate
+   {
+   UDATA _allocationSize;
+   };
+
+struct TR_RelocationRecordRomClassFromCPBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
+   {
+   UDATA  _romClassOffsetInSharedCache;
+   };
+
+typedef TR_RelocationRecordRomClassFromCPBinaryTemplate TR_RelocationRecordInlinedMethodBinaryTemplate;
+
+struct TR_RelocationRecordNopGuardBinaryTemplate : public TR_RelocationRecordInlinedMethodBinaryTemplate
+   {
+   UDATA _destinationAddress;
+   };
+
+typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedStaticMethodWithNopGuardBinaryTemplate;
+typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedSpecialMethodWithNopGuardBinaryTemplate;
+typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedVirtualMethodWithNopGuardBinaryTemplate;
+typedef TR_RelocationRecordNopGuardBinaryTemplate TR_RelocationRecordInlinedInterfaceMethodWithNopGuardBinaryTemplate;
+
+
+struct TR_RelocationRecordProfiledInlinedMethodBinaryTemplate : TR_RelocationRecordInlinedMethodBinaryTemplate
+   {
+   UDATA _classChainIdentifyingLoaderOffsetInSharedCache;
+   UDATA _classChainForInlinedMethod;
+   UDATA _vTableSlot;
+   };
+
+typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledGuardBinaryTemplate;
+typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledClassGuardBinaryTemplate;
+typedef TR_RelocationRecordProfiledInlinedMethodBinaryTemplate TR_RelocationRecordProfiledMethodGuardBinaryTemplate;
+
+
+typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordRamMethodBinaryTemplate;
+
+typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordArrayCopyHelperTemplate;
+
+struct TR_RelocationRecordMethodTracingCheckBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   UDATA _destinationAddress;
+   };
+
+struct TR_RelocationRecordValidateClassBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
+   {
+   UDATA _classChainOffsetInSharedCache;
+   };
+
+typedef TR_RelocationRecordRomClassFromCPBinaryTemplate TR_RelocationRecordValidateStaticFieldBinaryTemplate;
+
+struct TR_RelocationRecordDataAddressBinaryTemplate : public TR_RelocationRecordConstantPoolWithIndexBinaryTemplate
+   {
+   UDATA _offset;
+   };
+
+struct TR_RelocationRecordPointerBinaryTemplate : TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
+   {
+   UDATA _classChainIdentifyingLoaderOffsetInSharedCache;
+   UDATA _classChainForInlinedMethod;
+   };
+
+typedef TR_RelocationRecordPointerBinaryTemplate TR_RelocationRecordClassPointerBinaryTemplate;
+struct TR_RelocationRecordMethodPointerBinaryTemplate : TR_RelocationRecordPointerBinaryTemplate
+   {
+   UDATA _vTableSlot;
+   };
+struct TR_RelocationRecordEmitClassBinaryTemplate : public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
+   {
+   int32_t _bcIndex;
+#if defined(TR_HOST_64BIT)
+   uint32_t _extra;
+#endif
+   };
+
+struct TR_RelocationRecordDebugCounterBinaryTemplate : public TR_RelocationRecordWithInlinedSiteIndexBinaryTemplate
+   {
+   UDATA _bcIndex;
+   UDATA _offsetOfNameString;
+   UDATA _delta;
+   UDATA _fidelity;
+   UDATA _staticDelta;
+   };
+
+typedef TR_RelocationRecordBinaryTemplate TR_RelocationRecordClassUnloadAssumptionBinaryTemplate;
+
+struct TR_RelocationRecordValidateRootClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   };
+
+struct TR_RelocationRecordValidateClassByNameBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   uint16_t _beholderID;
+   char _primitiveType;
+   UDATA _romClassOffsetInSCC;
+   };
+
+struct TR_RelocationRecordValidateProfiledClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   char _primitiveType;
+   UDATA _classChainOffsetInSCC;
+   UDATA _classChainOffsetForCLInScc;
+   };
+
+struct TR_RelocationRecordValidateClassFromCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   uint16_t _beholderID;
+   uint32_t _cpIndex;
+   };
+
+struct TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   bool _isStatic;
+   uint16_t _classID;
+   uint16_t _beholderID;
+   uint32_t _cpIndex;
+   };
+
+typedef TR_RelocationRecordValidateClassFromCPBinaryTemplate TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate;
+
+struct TR_RelocationRecordValidateClassFromMethodBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   uint16_t _methodID;
+   };
+
+struct TR_RelocationRecordValidateCompFromArrayBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _componentClassID;
+   uint16_t _arrayClassID;
+   };
+
+struct TR_RelocationRecordValidateArrayFromCompBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _arrayClassID;
+   uint16_t _componentClassID;
+   };
+
+struct TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _superClassID;
+   uint16_t _childClassID;
+   };
+
+struct TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   bool _objectTypeIsFixed;
+   bool _castTypeIsFixed;
+   bool _isInstanceOf;
+   uint16_t _classOneID;
+   uint16_t _classTwoID;
+   };
+
+struct TR_RelocationRecordValidateSystemClassByNameBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _systemClassID;
+   UDATA _romClassOffsetInSCC;
+   };
+
+struct TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   uint16_t _beholderID;
+   uint32_t _cpIndex;
+   };
+
+typedef TR_RelocationRecordValidateClassFromCPBinaryTemplate TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate;
+
+struct TR_RelocationRecordValidateClassClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classClassID;
+   uint16_t _objectClassID;
+   };
+
+struct TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _childClassID;
+   uint16_t _superClassID;
+   };
+
+struct TR_RelocationRecordValidateClassChainBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   UDATA _classChainOffsetInSCC;
+   };
+
+struct TR_RelocationRecordValidateRomClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   UDATA _romClassOffsetInSCC;
+   };
+
+struct TR_RelocationRecordValidatePrimitiveClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   char _primitiveType;
+   };
+
+struct TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint32_t _inlinedSiteIndex;
+   };
+
+struct TR_RelocationRecordValidateMethodByNameBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _beholderID;
+   UDATA _romClassOffsetInSCC;
+   UDATA _romMethodOffsetInSCC;
+   };
+
+struct TR_RelocationRecordValidateMethodFromClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _beholderID;
+   uint32_t _index;
+   };
+
+struct TR_RelocationRecordValidateMethodFromCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _beholderID;
+   uint32_t _cpIndex;
+   };
+
+typedef TR_RelocationRecordValidateMethodFromCPBinaryTemplate TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate;
+typedef TR_RelocationRecordValidateMethodFromCPBinaryTemplate TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate;
+typedef TR_RelocationRecordValidateMethodFromCPBinaryTemplate TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate;
+typedef TR_RelocationRecordValidateMethodFromCPBinaryTemplate TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate;
+
+struct TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   bool _ignoreRtResolve;
+   uint16_t _methodID;
+   uint16_t _beholderID;
+   uint32_t _virtualCallOffset;
+   };
+
+struct TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _beholderID;
+   uint16_t _lookupID;
+   uint32_t _cpIndex;
+   };
+
+struct TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _methodClassID;
+   uint16_t _beholderID;
+   UDATA _romMethodOffsetInSCC;
+   };
+
+struct TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _thisClassID;
+   int32_t _cpIndexOrVftSlot;
+   uint16_t _callerMethodID;
+   uint16_t _useGetResolvedInterfaceMethod;
+   };
+
+struct TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _thisClassID;
+   int32_t _cpIndex;
+   uint16_t _callerMethodID;
+   };
+
+struct TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _thisClassID;
+   int32_t _vftSlot;
+   uint16_t _callerMethodID;
+   };
+
+struct TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   uint16_t _methodClassID;
+   bool _skipFrames;
+   };
+
+struct TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _arrayClassID;
+   int32_t _arrayClassIndex;
+   };
+
+struct TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _classID;
+   bool _isInitialized;
+   };
+
+struct TR_RelocationRecordSymbolFromManagerBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _symbolID;
+   uint16_t _symbolType;
+   };
+
+
 extern char* AOTcgDiagOn;
 
 class TR_RelocationRecordGroup
@@ -139,6 +525,12 @@ struct TR_RelocationRecordDebugCounterPrivateData
    const char *_name;
    };
 
+struct TR_RelocationSymbolFromManagerPrivateData
+   {
+   uint16_t _symbolType;
+   void *_symbol;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -152,6 +544,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordMethodCallPrivateData methodCall;
    TR_RelocationRecordEmitClassPrivateData emitClass;
    TR_RelocationRecordDebugCounterPrivateData debugCounter;
+   TR_RelocationSymbolFromManagerPrivateData symbolFromManager;
    };
 
 // TR_RelocationRecord is the base class for all relocation records.  It is used for all queries on relocation
@@ -175,6 +568,8 @@ class TR_RelocationRecord
 
       virtual void print(TR_RelocationRuntime *reloRuntime);
       virtual char *name() { return "TR_RelocationRecord"; }
+
+      virtual bool isValidationRecord() { return false; }
 
      
       static TR_RelocationRecord *create(TR_RelocationRecord *storage, TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_RelocationRecordBinaryTemplate *recordPointer);
@@ -386,6 +781,7 @@ class TR_RelocationRecordConstantPoolWithIndex : public TR_RelocationRecordConst
       TR_OpaqueMethodBlock *getStaticMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex);
       TR_OpaqueMethodBlock *getSpecialMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex);
       TR_OpaqueMethodBlock *getInterfaceMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod);
+      TR_OpaqueMethodBlock *getAbstractMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex, TR_OpaqueMethodBlock *callerMethod);
 
       virtual int32_t bytesInHeaderAndPayload();
    };
@@ -814,6 +1210,19 @@ class TR_RelocationRecordInlinedInterfaceMethod: public TR_RelocationRecordInlin
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
    };
 
+class TR_RelocationRecordInlinedAbstractMethodWithNopGuard : public TR_RelocationRecordNopGuard
+   {
+   public:
+      TR_RelocationRecordInlinedAbstractMethodWithNopGuard() {}
+      TR_RelocationRecordInlinedAbstractMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
+      virtual char *name();
+   private:
+      virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
+      virtual void updateFailedStats(TR_AOTStats *aotStats);
+      virtual void updateSucceededStats(TR_AOTStats *aotStats);
+      virtual void createAssumptions(TR_RelocationRuntime *reloRuntime, uint8_t *reloLocation);
+   };
+
 class TR_RelocationRecordProfiledInlinedMethod : public TR_RelocationRecordInlinedMethod
    {
    public:
@@ -1002,6 +1411,442 @@ class TR_RelocationRecordValidateArbitraryClass : public TR_RelocationRecord
       virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };
 
+
+/* SYMBOL VALIDATION MANAGER */
+class TR_RelocationRecordValidateRootClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateRootClass() {}
+      TR_RelocationRecordValidateRootClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateRootClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateRootClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassByName : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassByName() {}
+      TR_RelocationRecordValidateClassByName(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassByName"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassByNameBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateProfiledClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateProfiledClass() {}
+      TR_RelocationRecordValidateProfiledClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateProfiledClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateProfiledClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassFromCP() {}
+      TR_RelocationRecordValidateClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateDefiningClassFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateDefiningClassFromCP() {}
+      TR_RelocationRecordValidateDefiningClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateDefiningClassFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateStaticClassFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateStaticClassFromCP() {}
+      TR_RelocationRecordValidateStaticClassFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateStaticClassFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassFromMethod : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassFromMethod() {}
+      TR_RelocationRecordValidateClassFromMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassFromMethod"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateComponentClassFromArrayClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateComponentClassFromArrayClass() {}
+      TR_RelocationRecordValidateComponentClassFromArrayClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateComponentClassFromArrayClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateCompFromArrayBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateArrayClassFromComponentClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateArrayClassFromComponentClass() {}
+      TR_RelocationRecordValidateArrayClassFromComponentClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateArrayClassFromComponentClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateArrayFromCompBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateSuperClassFromClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateSuperClassFromClass() {}
+      TR_RelocationRecordValidateSuperClassFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateSuperClassFromClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassInstanceOfClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassInstanceOfClass() {}
+      TR_RelocationRecordValidateClassInstanceOfClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassInstanceOfClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateSystemClassByName : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateSystemClassByName() {}
+      TR_RelocationRecordValidateSystemClassByName(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateSystemClassByName"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassFromITableIndexCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassFromITableIndexCP() {}
+      TR_RelocationRecordValidateClassFromITableIndexCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassFromITableIndexCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic() {}
+      TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassClass() {}
+      TR_RelocationRecordValidateClassClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateConcreteSubClassFromClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateConcreteSubClassFromClass() {}
+      TR_RelocationRecordValidateConcreteSubClassFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateConcreteSubClassFromClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassChain : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassChain() {}
+      TR_RelocationRecordValidateClassChain(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassChain"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassChainBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateRomClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateRomClass() {}
+      TR_RelocationRecordValidateRomClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateRomClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateRomClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidatePrimitiveClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidatePrimitiveClass() {}
+      TR_RelocationRecordValidatePrimitiveClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidatePrimitiveClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidatePrimitiveClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodFromInlinedSite : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodFromInlinedSite() {}
+      TR_RelocationRecordValidateMethodFromInlinedSite(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodFromInlinedSite"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodFromInlSiteBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodByName : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodByName() {}
+      TR_RelocationRecordValidateMethodByName(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodByName"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodByNameBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodFromClass : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodFromClass() {}
+      TR_RelocationRecordValidateMethodFromClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodFromClass"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodFromClassBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateStaticMethodFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateStaticMethodFromCP() {}
+      TR_RelocationRecordValidateStaticMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateStaticMethodFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateSpecialMethodFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateSpecialMethodFromCP() {}
+      TR_RelocationRecordValidateSpecialMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateSpecialMethodFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateVirtualMethodFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateVirtualMethodFromCP() {}
+      TR_RelocationRecordValidateVirtualMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateVirtualMethodFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateVirtualMethodFromOffset : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateVirtualMethodFromOffset() {}
+      TR_RelocationRecordValidateVirtualMethodFromOffset(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateVirtualMethodFromOffset"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateInterfaceMethodFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateInterfaceMethodFromCP() {}
+      TR_RelocationRecordValidateInterfaceMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateInterfaceMethodFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateImproperInterfaceMethodFromCP : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateImproperInterfaceMethodFromCP() {}
+      TR_RelocationRecordValidateImproperInterfaceMethodFromCP(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateImproperInterfaceMethodFromCP"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodFromClassAndSig : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodFromClassAndSig() {}
+      TR_RelocationRecordValidateMethodFromClassAndSig(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodFromClassAndSig"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateStackWalkerMaySkipFrames : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateStackWalkerMaySkipFrames() {}
+      TR_RelocationRecordValidateStackWalkerMaySkipFrames(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateStackWalkerMaySkipFrames"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateArrayClassFromJavaVM : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateArrayClassFromJavaVM() {}
+      TR_RelocationRecordValidateArrayClassFromJavaVM(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateArrayClassFromJavaVM"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateArrayClassFromJavaVMBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateClassInfoIsInitialized : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateClassInfoIsInitialized() {}
+      TR_RelocationRecordValidateClassInfoIsInitialized(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateClassInfoIsInitialized"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassInfoIsInitializedBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodFromSingleImpl : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodFromSingleImpl() {}
+      TR_RelocationRecordValidateMethodFromSingleImpl(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleImpl"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodFromSingleInterfaceImpl : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodFromSingleInterfaceImpl() {}
+      TR_RelocationRecordValidateMethodFromSingleInterfaceImpl(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleInterfaceImpl"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordValidateMethodFromSingleAbstractImpl : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateMethodFromSingleAbstractImpl() {}
+      TR_RelocationRecordValidateMethodFromSingleAbstractImpl(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual char *name() { return "TR_RelocationRecordValidateMethodFromSingleAbstractImpl"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordSymbolFromManager : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordSymbolFromManager() {}
+      TR_RelocationRecordSymbolFromManager(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual char *name() { return "TR_RelocationRecordSymbolFromManager"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordSymbolFromManagerBinaryTemplate); }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual void activatePointer(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      bool needsUnloadAssumptions(TR::SymbolType symbolType);
+      bool needsRedefinitionAssumption(TR_RelocationRuntime *reloRuntime, uint8_t *reloLocation, TR_OpaqueClassBlock *clazz, TR::SymbolType symbolType);
+   };
+/* SYMBOL VALIDATION MANAGER */
 
 class TR_RelocationRecordHCR : public TR_RelocationRecordWithOffset
    {

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -234,6 +234,12 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
          }
       }
 
+   // Check the flags related to the symbol validation manager
+   if (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_UsesSymbolValidationManager)
+      {
+      comp->setOption(TR_UseSymbolValidationManager);
+      }
+
    _exceptionTableCacheEntry = (J9JITDataCacheHeader *)((uint8_t *)cacheEntry + _aotMethodHeaderEntry->offsetToExceptionTable);
 
    if (_exceptionTableCacheEntry->type == J9_JIT_DCE_EXCEPTION_INFO)

--- a/runtime/compiler/runtime/Runtime.hpp
+++ b/runtime/compiler/runtime/Runtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -223,6 +223,7 @@ typedef struct TR_AOTStats
    TR_AOTInliningStats specialMethods;
    TR_AOTInliningStats virtualMethods;
    TR_AOTInliningStats interfaceMethods;
+   TR_AOTInliningStats abstractMethods;
 
    TR_AOTInliningStats profiledInlinedMethods;
    TR_AOTInliningStats profiledClassGuards;

--- a/runtime/compiler/runtime/Runtime.hpp
+++ b/runtime/compiler/runtime/Runtime.hpp
@@ -169,6 +169,7 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_IsNotCapableOfMethodExitTracing           0x00000004
 #define TR_AOTMethodHeader_UsesEnableStringCompressionFolding        0x00000008
 #define TR_AOTMethodHeader_StringCompressionEnabled                  0x00000010
+#define TR_AOTMethodHeader_UsesSymbolValidationManager               0x00000020
 
 
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1,0 +1,2006 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <string.h>
+#include "env/VMJ9.h"
+#include "env/ClassLoaderTable.hpp"
+#include "env/PersistentCHTable.hpp"
+#include "env/VMAccessCriticalSection.hpp"
+#include "compile/Compilation.hpp"
+#include "control/CompilationRuntime.hpp"
+#include "control/CompilationThread.hpp"
+#include "runtime/RelocationRuntime.hpp"
+#include "runtime/SymbolValidationManager.hpp"
+
+#include "j9protos.h"
+
+static char getPrimitiveChar(J9UTF8 * primitiveClassName)
+   {
+   const char *name = reinterpret_cast<const char *>(J9UTF8_DATA(primitiveClassName));
+   int32_t length = J9UTF8_LENGTH(primitiveClassName);
+
+   if (0 == strncmp(name,"int", length))
+      return 'I';
+   if (0 == strncmp(name,"boolean", length))
+      return 'Z';
+   if (0 == strncmp(name,"long", length))
+      return 'J';
+   if (0 == strncmp(name,"double", length))
+      return 'D';
+   if (0 == strncmp(name,"float", length))
+      return 'F';
+   if (0 == strncmp(name,"char", length))
+      return 'C';
+   if (0 == strncmp(name,"byte", length))
+      return 'B';
+   if (0 == strncmp(name,"short", length))
+      return 'S';
+
+   return '\0';
+   }
+
+TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region)
+   : _symbolID(FIRST_ID),
+     _region(region),
+     _symbolValidationRecords(_region),
+     _symbolToIdMap((SymbolToIdComparator()), _region),
+     _idToSymbolsMap((IdToSymbolComparator()), _region),
+     _seenSymbolsSet((SeenSymbolsComparator()), _region)
+   {}
+
+void *
+TR::SymbolValidationManager::getSymbolFromID(uint16_t id)
+   {
+   IdToSymbolMap::iterator it = _idToSymbolsMap.find(id);
+   if (it == _idToSymbolsMap.end())
+      return NULL;
+   else
+      return it->second;
+   }
+
+uint16_t
+TR::SymbolValidationManager::getIDFromSymbol(void *symbol)
+   {
+   SymbolToIdMap::iterator it = _symbolToIdMap.find(symbol);
+   if (it == _symbolToIdMap.end())
+      return NO_ID;
+   else
+      return it->second;
+   }
+
+TR_OpaqueClassBlock *
+TR::SymbolValidationManager::getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims)
+   {
+   numDims = 0;
+   if (!clazz)
+      return NULL;
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   while (fej9->isClassArray(clazz))
+      {
+      TR_OpaqueClassBlock * componentClass = fej9->getComponentClassFromArrayClass(clazz);
+      numDims++;
+      clazz = componentClass;
+      }
+
+   return clazz;
+   }
+
+
+void *
+TR::SymbolValidationManager::storeClassChain(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz, bool isStatic)
+   {
+   void *classChain = NULL;
+   bool validated = false;
+
+   classChain = fej9->sharedCache()->rememberClass(clazz);
+   if (classChain)
+      {
+      if (isStatic)
+         validated = addRomClassRecord(clazz);
+      else
+         validated = addClassChainRecord(clazz, classChain);
+      }
+
+   if (validated)
+      return classChain;
+   else
+      return NULL;
+   }
+
+void
+TR::SymbolValidationManager::storeRecord(void *symbol, TR::SymbolValidationRecord *record)
+   {
+   if (!getIDFromSymbol(symbol))
+      {
+      _symbolToIdMap.insert(std::make_pair(symbol, getNewSymbolID()));
+      }
+   _symbolValidationRecords.push_front(record);
+
+   record->printFields();
+   traceMsg(TR::comp(), "\tkind=%d\n", record->_kind);
+   traceMsg(TR::comp(), "\tid=%d\n", (uint32_t)getIDFromSymbol(symbol));
+   traceMsg(TR::comp(), "\n");
+   }
+
+bool
+TR::SymbolValidationManager::storeClassRecord(TR_OpaqueClassBlock *clazz,
+                                              TR::ClassValidationRecord *record,
+                                              int32_t arrayDimsToValidate,
+                                              bool isStatic,
+                                              bool storeCurrentRecord)
+   {
+   bool validated = false;
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_AOTStats *aotStats = ((TR_JitPrivateConfig *)fej9->_jitConfig->privateConfig)->aotStats;
+
+   if (storeCurrentRecord)
+      storeRecord(static_cast<void *>(clazz), record);
+
+   if (fej9->isClassArray(clazz))
+      {
+      validated = true;
+      }
+   else
+      {
+      if (fej9->isPrimitiveClass(clazz))
+         {
+         validated = addPrimitiveClassRecord(clazz);
+         }
+      else
+         {
+         record->_classChain = storeClassChain(fej9, clazz, isStatic);
+         validated = (record->_classChain != NULL);
+         }
+
+      if (validated)
+         {
+         int32_t arrayDims = 0;
+         TR_OpaqueClassBlock *componentClass = clazz;
+         while (validated && componentClass && arrayDims < arrayDimsToValidate)
+            {
+            TR_OpaqueClassBlock *arrayClass = fej9->getArrayClassFromComponentClass(componentClass);
+
+            validated = addArrayClassFromComponentClassRecord(arrayClass, componentClass);
+
+            componentClass = arrayClass;
+            arrayDims++;
+            }
+
+         TR_ASSERT_FATAL((validated && (arrayDims == arrayDimsToValidate)), "Failed to validated clazz 0x%p\n", clazz);
+         }
+      }
+
+   /* If we failed to store the class chain
+    * then it is because we failed to rememberClass;
+    * therefore, the last element in the list
+    * will be the one we added in this method and not
+    * the RomClassRecord or ClassChainRecord
+    */
+   if (!validated)
+      _symbolValidationRecords.pop_front();
+
+   return validated;
+   }
+
+bool
+TR::SymbolValidationManager::storeValidationRecordIfNecessary(void *symbol,
+                                                              TR::SymbolValidationRecord *record,
+                                                              int32_t arrayDimsToValidate,
+                                                              bool isStatic)
+   {
+   bool existsInList = false;
+   bool validated = false;
+
+   for (auto it = _symbolValidationRecords.begin(); it != _symbolValidationRecords.end(); it++)
+      {
+      if ((*it)->_kind == record->_kind && record->isEqual(*it))
+         {
+         existsInList = true;
+         break;
+         }
+      }
+
+   if (!existsInList || arrayDimsToValidate)
+      {
+      if (record->isClassValidationRecord())
+         {
+         validated = storeClassRecord(static_cast<TR_OpaqueClassBlock *>(symbol),
+                                      reinterpret_cast<TR::ClassValidationRecord *>(record),
+                                      arrayDimsToValidate,
+                                      isStatic,
+                                      !existsInList);
+         }
+      else
+         {
+         storeRecord(symbol, record);
+         validated = true;
+         }
+      }
+
+   if (existsInList || !validated)
+      {
+      _region.deallocate(record);
+      }
+
+   return (existsInList || validated);
+   }
+
+bool
+TR::SymbolValidationManager::addRootClassRecord(TR_OpaqueClassBlock *clazz)
+   {
+   if (!clazz)
+      return false;
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   SymbolValidationRecord *record = new (_region) RootClassRecord(clazz);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder)
+   {
+   if (!clazz)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+   char primitiveType = '\0';
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+   if (fej9->isPrimitiveClass(clazz))
+      {
+      J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(clazz));
+      J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+      primitiveType = getPrimitiveChar(className);
+      }
+
+   SymbolValidationRecord *record = new (_region) ClassByNameRecord(clazz, beholder, primitiveType);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addProfiledClassRecord(TR_OpaqueClassBlock *clazz)
+   {
+   if (!clazz)
+      return false;
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+   char primitiveType = '\0';
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+   if (fej9->isPrimitiveClass(clazz))
+      {
+      J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(clazz));
+      J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+      primitiveType = getPrimitiveChar(className);
+      }
+
+   SymbolValidationRecord *record = new (_region) ProfiledClassRecord(clazz, primitiveType);
+   bool validated = storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   return validated;
+   }
+
+bool
+TR::SymbolValidationManager::addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex)
+   {
+   if (!clazz)
+      return false;
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) ClassFromCPRecord(clazz, beholder, cpIndex);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addDefiningClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex, bool isStatic)
+   {
+   if (!clazz)
+      return false;
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) DefiningClassFromCPRecord(clazz, beholder, cpIndex, isStatic);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims, isStatic);
+   }
+
+bool
+TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex)
+   {
+   if (!clazz)
+      return false;
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) StaticClassFromCPRecord(clazz, beholder, cpIndex);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addClassFromMethodRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueMethodBlock *method)
+   {
+   if (!clazz)
+      return false;
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   TR_ASSERT_FATAL(getIDFromSymbol(method) != 0, "method 0x%p should have already been validated\n", method);
+
+   SymbolValidationRecord *record = new (_region) ClassFromMethodRecord(clazz, method);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
+   }
+
+bool
+TR::SymbolValidationManager::addComponentClassFromArrayClassRecord(TR_OpaqueClassBlock *componentClass, TR_OpaqueClassBlock *arrayClass)
+   {
+   if (!componentClass)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(arrayClass) != 0, "arrayClass 0x%p should have already been validated\n", arrayClass);
+
+   SymbolValidationRecord *record = new (_region) ComponentClassFromArrayClassRecord(componentClass, arrayClass);
+   return storeValidationRecordIfNecessary(static_cast<void *>(componentClass), record);
+   }
+
+bool
+TR::SymbolValidationManager::addArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass)
+   {
+   if (!arrayClass)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(componentClass) != 0, "componentClass 0x%p should have already been validated\n", componentClass);
+
+   SymbolValidationRecord *record = new (_region) ArrayClassFromComponentClassRecord(arrayClass, componentClass);
+   return storeValidationRecordIfNecessary(static_cast<void *>(arrayClass), record);
+   }
+
+bool
+TR::SymbolValidationManager::addSuperClassFromClassRecord(TR_OpaqueClassBlock *superClass, TR_OpaqueClassBlock *childClass)
+   {
+   if (!superClass)
+      return false;
+
+   int32_t arrayDims = 0;
+   superClass = getBaseComponentClass(superClass, arrayDims);
+
+   TR_ASSERT_FATAL(getIDFromSymbol(childClass) != 0, "childClass 0x%p should have already been validated\n", childClass);
+
+   SymbolValidationRecord *record = new (_region) SuperClassFromClassRecord(superClass, childClass);
+   return storeValidationRecordIfNecessary(static_cast<void *>(superClass), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addClassInstanceOfClassRecord(TR_OpaqueClassBlock *classOne, TR_OpaqueClassBlock *classTwo, bool objectTypeIsFixed, bool castTypeIsFixed, bool isInstanceOf)
+   {
+   TR_ASSERT_FATAL(getIDFromSymbol(classOne) != 0, "classOne 0x%p should have already been validated\n", classOne);
+   TR_ASSERT_FATAL(getIDFromSymbol(classTwo) != 0, "classTwo 0x%p should have already been validated\n", classTwo);
+
+   SymbolValidationRecord *record = new (_region) ClassInstanceOfClassRecord(classOne, classTwo, objectTypeIsFixed, castTypeIsFixed, isInstanceOf);
+   return storeValidationRecordIfNecessary(static_cast<void *>(classOne), record);
+   }
+
+bool
+TR::SymbolValidationManager::addSystemClassByNameRecord(TR_OpaqueClassBlock *systemClass)
+   {
+   if (!systemClass)
+      return false;
+
+   int32_t arrayDims = 0;
+   systemClass = getBaseComponentClass(systemClass, arrayDims);
+
+   SymbolValidationRecord *record = new (_region) SystemClassByNameRecord(systemClass);
+   return storeValidationRecordIfNecessary(static_cast<void *>(systemClass), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addClassFromITableIndexCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex)
+   {
+   if (!clazz)
+      return false;
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   SymbolValidationRecord *record = new (_region) ClassFromITableIndexCPRecord(clazz, beholder, cpIndex);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex)
+   {
+   if (!clazz)
+      return false;
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   SymbolValidationRecord *record = new (_region) DeclaringClassFromFieldOrStaticRecord(clazz, beholder, cpIndex);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addClassClassRecord(TR_OpaqueClassBlock *classClass, TR_OpaqueClassBlock *objectClass)
+   {
+   if (!classClass)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(objectClass) != 0, "objectClass 0x%p should have already been validated\n", objectClass);
+
+   SymbolValidationRecord *record = new (_region) ClassClassRecord(classClass, objectClass);
+   return storeValidationRecordIfNecessary(static_cast<void *>(classClass), record);
+   }
+
+bool
+TR::SymbolValidationManager::addConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass)
+   {
+   if (!superClass)
+      return false;
+
+   int32_t arrayDims = 0;
+   childClass = getBaseComponentClass(childClass, arrayDims);
+
+   TR_ASSERT_FATAL(getIDFromSymbol(superClass) != 0, "superClass 0x%p should have already been validated\n", superClass);
+
+   SymbolValidationRecord *record = new (_region) ConcreteSubClassFromClassRecord(childClass, superClass);
+   return storeValidationRecordIfNecessary(static_cast<void *>(childClass), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addArrayClassFromJavaVM(TR_OpaqueClassBlock *arrayClass, int32_t arrayClassIndex)
+   {
+   if (!arrayClass)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   int32_t arrayDims = 0;
+   arrayClass = getBaseComponentClass(arrayClass, arrayDims);
+
+   SymbolValidationRecord *record = new (_region) ArrayClassFromJavaVM(arrayClass, arrayClassIndex);
+   return storeValidationRecordIfNecessary(static_cast<void *>(arrayClass), record, arrayDims);
+   }
+
+bool
+TR::SymbolValidationManager::addClassChainRecord(TR_OpaqueClassBlock *clazz, void *classChain)
+   {
+   if (!clazz)
+      return false;
+
+   SymbolValidationRecord *record = new (_region) ClassChainRecord(clazz, classChain);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
+   }
+
+bool
+TR::SymbolValidationManager::addRomClassRecord(TR_OpaqueClassBlock *clazz)
+   {
+   if (!clazz)
+      return false;
+
+   SymbolValidationRecord *record = new (_region) RomClassRecord(clazz);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
+   }
+
+bool
+TR::SymbolValidationManager::addPrimitiveClassRecord(TR_OpaqueClassBlock *clazz)
+   {
+   TR_ASSERT_FATAL(getIDFromSymbol(clazz) != 0, "clazz 0x%p should have already been validated\n", clazz);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(clazz));
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+   char primitiveType =getPrimitiveChar(className);
+
+   TR_ASSERT_FATAL((primitiveType != '\0'), "clazz 0x%p is not primitive\n", clazz);
+
+   SymbolValidationRecord *record = new (_region) PrimitiveClassRecord(clazz, primitiveType);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
+   }
+
+bool
+TR::SymbolValidationManager::addMethodFromInlinedSiteRecord(TR_OpaqueMethodBlock *method,
+                                                            int32_t inlinedSiteIndex)
+   {
+   if (!method)
+      return false;
+
+   SymbolValidationRecord *record = new (_region) MethodFromInlinedSiteRecord(method, inlinedSiteIndex);
+   return storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+   }
+
+bool
+TR::SymbolValidationManager::addMethodByNameRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder)
+   {
+   if (!method)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) MethodByNameRecord(method, beholder);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addMethodFromClassRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, uint32_t index)
+   {
+   if (!method)
+      return false;
+
+   if (index == static_cast<uint32_t>(-1))
+      {
+      TR::Compilation* comp = TR::comp();
+      J9VMThread *vmThread = comp->j9VMThread();
+      TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+      J9Method * resolvedMethods = static_cast<J9Method *>(fej9->getMethods(beholder));
+      uint32_t numMethods = fej9->getNumMethods(beholder);
+      for (index = 0; index < numMethods ; index++)
+         {
+         if ((TR_OpaqueMethodBlock *) &(resolvedMethods[index]) == method)
+            break;
+         }
+
+      if (index == numMethods)
+         {
+         TR_ASSERT_FATAL(false, "Method 0x%p not found in class 0x%p\n", method, beholder);
+         return false;
+         }
+      }
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) MethodFromClassRecord(method, beholder, index);
+   return storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+   }
+
+bool
+TR::SymbolValidationManager::addStaticMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
+   {
+   if (!method)
+      return false;
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) StaticMethodFromCPRecord(method, beholder, cpIndex);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addSpecialMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
+   {
+   if (!method)
+      return false;
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) SpecialMethodFromCPRecord(method, beholder, cpIndex);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addVirtualMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
+   {
+   if (!method)
+      return false;
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) VirtualMethodFromCPRecord(method, beholder, cpIndex);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addVirtualMethodFromOffsetRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, int32_t virtualCallOffset, bool ignoreRtResolve)
+   {
+   if (!method)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) VirtualMethodFromOffsetRecord(method, beholder, virtualCallOffset, ignoreRtResolve);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, TR_OpaqueClassBlock *lookup, int32_t cpIndex)
+   {
+   if (!method)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+   TR_ASSERT_FATAL(getIDFromSymbol(lookup) != 0, "lookup 0x%p should have already been validated\n", lookup);
+
+   SymbolValidationRecord *record = new (_region) InterfaceMethodFromCPRecord(method, beholder, lookup, cpIndex);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addImproperInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
+   {
+   if (!method)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
+
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) ImproperInterfaceMethodFromCPRecord(method, beholder, cpIndex);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addMethodFromClassAndSignatureRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, TR_OpaqueClassBlock *beholder)
+   {
+   if (!method)
+      return false;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(methodClass) != 0, "methodClass 0x%p should have already been validated\n", methodClass);
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   SymbolValidationRecord *record = new (_region) MethodFromClassAndSigRecord(method, methodClass, beholder);
+   return storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+   }
+
+bool
+TR::SymbolValidationManager::addMethodFromSingleImplementerRecord(TR_OpaqueMethodBlock *method,
+                                                                  TR_OpaqueClassBlock *thisClass,
+                                                                  int32_t cpIndexOrVftSlot,
+                                                                  TR_OpaqueMethodBlock *callerMethod,
+                                                                  TR_YesNoMaybe useGetResolvedInterfaceMethod)
+   {
+   if (!method)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(thisClass) != 0, "thisClass 0x%p should have already been validated\n", thisClass);
+   TR_ASSERT_FATAL(getIDFromSymbol(callerMethod) != 0, "callerMethod 0x%p should have already been validated\n", callerMethod);
+
+   SymbolValidationRecord *record = new (_region) MethodFromSingleImplementer(method, thisClass, cpIndexOrVftSlot, callerMethod, useGetResolvedInterfaceMethod);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addMethodFromSingleInterfaceImplementerRecord(TR_OpaqueMethodBlock *method,
+                                                                           TR_OpaqueClassBlock *thisClass,
+                                                                           int32_t cpIndex,
+                                                                           TR_OpaqueMethodBlock *callerMethod)
+   {
+   if (!method)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(thisClass) != 0, "thisClass 0x%p should have already been validated\n", thisClass);
+   TR_ASSERT_FATAL(getIDFromSymbol(callerMethod) != 0, "callerMethod 0x%p should have already been validated\n", callerMethod);
+
+   SymbolValidationRecord *record = new (_region) MethodFromSingleInterfaceImplementer(method, thisClass, cpIndex, callerMethod);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addMethodFromSingleAbstractImplementerRecord(TR_OpaqueMethodBlock *method,
+                                                                          TR_OpaqueClassBlock *thisClass,
+                                                                          int32_t vftSlot,
+                                                                          TR_OpaqueMethodBlock *callerMethod)
+   {
+   if (!method)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(thisClass) != 0, "thisClass 0x%p should have already been validated\n", thisClass);
+   TR_ASSERT_FATAL(getIDFromSymbol(callerMethod) != 0, "callerMethod 0x%p should have already been validated\n", callerMethod);
+
+   SymbolValidationRecord *record = new (_region) MethodFromSingleAbstractImplementer(method, thisClass, vftSlot, callerMethod);
+   bool valid = storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+
+   if (valid)
+      {
+      J9Class *methodClass = J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(method));
+      valid = addClassFromMethodRecord(reinterpret_cast<TR_OpaqueClassBlock *>(methodClass), method);
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames)
+   {
+   if (!method || !methodClass)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(method) != 0, "method 0x%p should have already been validated\n", method);
+   TR_ASSERT_FATAL(getIDFromSymbol(methodClass) != 0, "methodClass 0x%p should have already been validated\n", methodClass);
+
+   SymbolValidationRecord *record = new (_region) StackWalkerMaySkipFramesRecord(method, methodClass, skipFrames);
+   return storeValidationRecordIfNecessary(static_cast<void *>(method), record);
+   }
+
+bool
+TR::SymbolValidationManager::addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized)
+   {
+   if (!clazz)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
+   TR_ASSERT_FATAL(getIDFromSymbol(clazz) != 0, "clazz 0x%p should have already been validated\n", clazz);
+
+   SymbolValidationRecord *record = new (_region) ClassInfoIsInitialized(clazz, isInitialized);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
+   }
+
+
+bool
+TR::SymbolValidationManager::updateMethodFromInlinedSiteRecordWithMethodByNameRecord(TR_OpaqueMethodBlock *method, int32_t inlinedSiteIndex, TR_OpaqueClassBlock *beholder)
+   {
+   TR_ASSERT_FATAL(getIDFromSymbol(method) != 0, "method 0x%p should have already been validated\n", method);
+   TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
+
+   MethodFromInlinedSiteRecord methodFromInlinedSiterecord(method, inlinedSiteIndex);
+   SymbolValidationRecord *record = reinterpret_cast<SymbolValidationRecord *>(&methodFromInlinedSiterecord);
+   SymbolValidationRecord *recordToBeRemoved = NULL;
+
+   auto it = _symbolValidationRecords.begin();
+   for (; it != _symbolValidationRecords.end(); it++)
+      {
+      if ((*it)->_kind == record->_kind && record->isEqual(*it))
+         {
+         recordToBeRemoved = (*it);
+         break;
+         }
+      }
+
+   TR_ASSERT_FATAL(recordToBeRemoved, "Trying to ignore record that does not exist <%p, %d>\n", method, inlinedSiteIndex);
+
+   if (it != _symbolValidationRecords.end())
+      {
+      SymbolValidationRecord *newRecord = new (_region) MethodByNameRecord(method, beholder);
+      (*it) = newRecord;
+      _region.deallocate(recordToBeRemoved);
+      return true;
+      }
+
+   return false;
+   }
+
+
+
+bool
+TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *validSymbol)
+   {
+   bool valid = false;
+   void *symbol = getSymbolFromID(idToBeValidated);
+
+   if (validSymbol)
+      {
+      if (symbol == NULL)
+         {
+         if (_seenSymbolsSet.find(validSymbol) == _seenSymbolsSet.end())
+            {
+            _idToSymbolsMap.insert(std::make_pair(idToBeValidated, validSymbol));
+            _seenSymbolsSet.insert(validSymbol);
+            valid = true;
+            }
+         }
+      else
+         {
+         valid = (symbol == validSymbol);
+         }
+      }
+
+   return valid;
+   }
+
+bool
+TR::SymbolValidationManager::validateRootClassRecord(uint16_t classID)
+   {
+   TR::Compilation *comp = TR::comp();
+   J9Class *rootClass = ((TR_ResolvedJ9Method *)comp->getMethodBeingCompiled())->constantPoolHdr();
+   TR_OpaqueClassBlock *opaqueRootClass = reinterpret_cast<TR_OpaqueClassBlock *>(rootClass);
+
+   int32_t arrayDims = 0;
+   opaqueRootClass = getBaseComponentClass(opaqueRootClass, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(opaqueRootClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_t beholderID, J9ROMClass *romClass, char primitiveType)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+
+   if (primitiveType != '\0')
+      {
+      TR_ASSERT_FATAL(getSymbolFromID(classID) != 0, "primitive classID %u should exist\n", classID);
+      return true;
+      }
+
+   J9UTF8 * classNameData = J9ROMCLASS_CLASSNAME(romClass);
+   char *className = reinterpret_cast<char *>(J9UTF8_DATA(classNameData));
+   uint32_t classNameLength = J9UTF8_LENGTH(classNameData);
+
+   TR_OpaqueClassBlock *classByName = fej9->getClassFromSignature(className, classNameLength, beholderCP);
+
+   if (!classByName)
+      return false;
+
+   int32_t arrayDims = 0;
+   classByName = getBaseComponentClass(classByName, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(classByName));
+   }
+
+bool
+TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, char primitiveType, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated)
+   {
+   TR::Compilation* comp = TR::comp();
+
+   if (primitiveType != '\0')
+      {
+      TR_ASSERT_FATAL(getSymbolFromID(classID) != 0, "primitive classID %u should exist\n", classID);
+      return true;
+      }
+
+   J9ClassLoader *classLoader = (J9ClassLoader *) comp->fej9()->sharedCache()->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
+
+   if (classLoader)
+      {
+      TR_OpaqueClassBlock *clazz = comp->fej9()->sharedCache()->lookupClassFromChainAndLoader(static_cast<uintptrj_t *>(classChainForClassBeingValidated), classLoader);
+
+      if (clazz)
+         {
+         int32_t arrayDims = 0;
+         clazz = getBaseComponentClass(clazz, arrayDims);
+
+         return validateSymbol(classID, static_cast<void *>(clazz));
+         }
+      }
+
+   return false;
+   }
+
+bool
+TR::SymbolValidationManager::validateClassFromCPRecord(uint16_t classID,  uint16_t beholderID, uint32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   TR_OpaqueClassBlock *classFromCP = TR_ResolvedJ9Method::getClassFromCP(fej9, beholderCP, comp, cpIndex);
+
+   int32_t arrayDims = 0;
+   classFromCP = getBaseComponentClass(classFromCP, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(classFromCP));
+   }
+
+bool
+TR::SymbolValidationManager::validateDefiningClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex, bool isStatic)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get(fej9->_jitConfig);
+   TR::CompilationInfoPerThreadBase *compInfoPerThreadBase = compInfo->getCompInfoForCompOnAppThread();
+   TR_RelocationRuntime *reloRuntime;
+   if (compInfoPerThreadBase)
+      reloRuntime = compInfoPerThreadBase->reloRuntime();
+   else
+      reloRuntime = compInfo->getCompInfoForThread(fej9->vmThread())->reloRuntime();
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   TR_OpaqueClassBlock *classFromCP = reloRuntime->getClassFromCP(fej9->vmThread(), fej9->_jitConfig->javaVM, beholderCP, cpIndex, isStatic);
+
+   int32_t arrayDims = 0;
+   classFromCP = getBaseComponentClass(classFromCP, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(classFromCP));
+   }
+
+bool
+TR::SymbolValidationManager::validateStaticClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   TR_OpaqueClassBlock *classFromCP = TR_ResolvedJ9Method::getClassOfStaticFromCP(fej9, beholderCP, cpIndex);
+
+   int32_t arrayDims = 0;
+   classFromCP = getBaseComponentClass(classFromCP, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(classFromCP));
+   }
+
+bool
+TR::SymbolValidationManager::validateClassFromMethodRecord(uint16_t classID, uint16_t methodID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(methodID) != 0, "methodID %u should exist\n", methodID);
+
+   J9Method *method = static_cast<J9Method *>(getSymbolFromID(methodID));
+   TR_OpaqueClassBlock *classFromMethod = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_METHOD(method));
+
+   int32_t arrayDims = 0;
+   classFromMethod = getBaseComponentClass(classFromMethod, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(classFromMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateComponentClassFromArrayClassRecord(uint16_t componentClassID, uint16_t arrayClassID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(arrayClassID) != 0, "arrayClassID %u should exist\n", arrayClassID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *arrayClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(arrayClassID));
+   TR_OpaqueClassBlock *componentClass = fej9->getComponentClassFromArrayClass(arrayClass);
+
+   return validateSymbol(componentClassID, static_cast<void *>(componentClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateArrayClassFromComponentClassRecord(uint16_t arrayClassID, uint16_t componentClassID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(componentClassID) != 0, "componentClassID %u should exist\n", componentClassID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *componentClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(componentClassID));
+   TR_OpaqueClassBlock *arrayClass = fej9->getArrayClassFromComponentClass(componentClass);
+
+   return validateSymbol(arrayClassID, static_cast<void *>(arrayClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateSuperClassFromClassRecord(uint16_t superClassID, uint16_t childClassID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(childClassID) != 0, "childClassID %u should exist\n", childClassID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *childClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(childClassID));
+   TR_OpaqueClassBlock *superClass = fej9->getSuperClass(childClass);
+
+   int32_t arrayDims = 0;
+   superClass = getBaseComponentClass(superClass, arrayDims);
+
+   return validateSymbol(superClassID, static_cast<void *>(superClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateClassInstanceOfClassRecord(uint16_t classOneID, uint16_t classTwoID, bool objectTypeIsFixed, bool castTypeIsFixed, bool wasInstanceOf)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(classOneID) != 0, "classOneID %u should exist\n", classOneID);
+   TR_ASSERT_FATAL(getSymbolFromID(classTwoID) != 0, "classTwoID %u should exist\n", classTwoID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *classOne = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classOneID));
+   TR_OpaqueClassBlock *classTwo = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classTwoID));
+
+   TR_YesNoMaybe isInstanceOf = fej9->isInstanceOf(classOne, classTwo, objectTypeIsFixed, castTypeIsFixed);
+
+   return (wasInstanceOf == isInstanceOf);
+   }
+
+bool
+TR::SymbolValidationManager::validateSystemClassByNameRecord(uint16_t systemClassID, J9ROMClass *romClass)
+   {
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+   TR_OpaqueClassBlock *systemClassByName = fej9->getSystemClassFromClassName(reinterpret_cast<const char *>(J9UTF8_DATA(className)),
+                                                                              J9UTF8_LENGTH(className));
+
+   int32_t arrayDims = 0;
+   systemClassByName = getBaseComponentClass(systemClassByName, arrayDims);
+
+   return validateSymbol(systemClassID, static_cast<void *>(systemClassByName));
+   }
+
+bool
+TR::SymbolValidationManager::validateClassFromITableIndexCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   uintptr_t pITableIndex;
+   TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::getInterfaceITableIndexFromCP(fej9, beholderCP, cpIndex, &pITableIndex);
+
+   int32_t arrayDims = 0;
+   clazz = getBaseComponentClass(clazz, arrayDims);
+
+   return validateSymbol(classID, static_cast<void *>(clazz));
+   }
+
+bool
+TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ROMClass *beholderRomClass = beholder->romClass;
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   J9ROMFieldRef *romCPBase = (J9ROMFieldRef *)((UDATA)beholderRomClass + sizeof(J9ROMClass));
+
+   int32_t classCPIndexOfFieldOrStatic = -1;
+   if (cpIndex != -1)
+      classCPIndexOfFieldOrStatic = ((J9ROMFieldRef *)(&romCPBase[cpIndex]))->classRefCPIndex;
+
+   J9Class *definingClass = NULL;
+   J9Class *cpClass = (J9Class*)TR_ResolvedJ9Method::getClassFromCP(fej9, beholderCP, comp, classCPIndexOfFieldOrStatic);
+
+   if (cpClass)
+      {
+      TR::VMAccessCriticalSection getDeclaringClassFromFieldOrStatic(fej9);
+
+      int32_t fieldLen;
+      char *field = cpIndex >= 0 ? utf8Data(J9ROMNAMEANDSIGNATURE_NAME(J9ROMFIELDREF_NAMEANDSIGNATURE(&romCPBase[cpIndex])), fieldLen) : 0;
+
+      int32_t sigLen;
+      char *sig = cpIndex >= 0 ? utf8Data(J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMFIELDREF_NAMEANDSIGNATURE(&romCPBase[cpIndex])), sigLen) : 0;
+
+      vmThread->javaVM->internalVMFunctions->instanceFieldOffset(vmThread,
+                                                                 cpClass,
+                                                                 (U_8*)field,
+                                                                 fieldLen,
+                                                                 (U_8*)sig,
+                                                                 sigLen,
+                                                                 &definingClass,
+                                                                 NULL,
+                                                                 J9_LOOK_NO_JAVA);
+      }
+   else
+      {
+      return false;
+      }
+
+   TR_OpaqueClassBlock *opaqueDefiningClass = reinterpret_cast<TR_OpaqueClassBlock*>(definingClass);
+   int32_t arrayDims = 0;
+   opaqueDefiningClass = getBaseComponentClass(opaqueDefiningClass, arrayDims);
+
+   return validateSymbol(definingClassID, static_cast<void *>(opaqueDefiningClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateClassClassRecord(uint16_t classClassID, uint16_t objectClassID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(objectClassID) != 0, "objectClassID %u should exist\n", objectClassID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *objectClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(objectClassID));
+   TR_OpaqueClassBlock *classClass = fej9->getClassClassPointer(objectClass);
+
+   return validateSymbol(classClassID, static_cast<void *>(classClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateConcreteSubClassFromClassRecord(uint16_t childClassID, uint16_t superClassID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(superClassID) != 0, "superClassID %u should exist\n", superClassID);
+
+   TR_OpaqueClassBlock *superClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(superClassID));
+
+   TR_PersistentCHTable * chTable = comp()->getPersistentInfo()->getPersistentCHTable();
+   TR_OpaqueClassBlock *childClass = chTable->findSingleConcreteSubClass(superClass, TR::comp(), false);
+
+   int32_t arrayDims = 0;
+   childClass = getBaseComponentClass(childClass, arrayDims);
+
+   return validateSymbol(childClassID, static_cast<void *>(childClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateArrayClassFromJavaVM(uint16_t arrayClassID, int32_t arrayClassIndex)
+   {
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   struct J9Class ** arrayClasses = &fej9->getJ9JITConfig()->javaVM->booleanArrayClass;
+   TR_OpaqueClassBlock *arrayClass = reinterpret_cast<TR_OpaqueClassBlock *>(arrayClasses[arrayClassIndex - 4]);
+
+   int32_t arrayDims = 0;
+   arrayClass = getBaseComponentClass(arrayClass, arrayDims);
+
+   return validateSymbol(arrayClassID, static_cast<void *>(arrayClass));
+   }
+
+bool
+TR::SymbolValidationManager::validateClassChainRecord(uint16_t classID, void *classChain)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(classID) != 0, "classID %u should exist\n", classID);
+
+   TR::Compilation* comp = TR::comp();
+   TR_OpaqueClassBlock *definingClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classID));
+
+   return comp->fej9()->sharedCache()->classMatchesCachedVersion(definingClass, (uintptrj_t *) classChain);
+   }
+
+bool
+TR::SymbolValidationManager::validateRomClassRecord(uint16_t classID, J9ROMClass *romClass)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(classID) != 0, "classID %u should exist\n", classID);
+
+   J9Class *definingClass = static_cast<J9Class *>(getSymbolFromID(classID));
+
+   return (definingClass->romClass == romClass);
+   }
+
+bool
+TR::SymbolValidationManager::validatePrimitiveClassRecord(uint16_t classID, char primitiveType)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(classID) != 0, "classID %u should exist\n", classID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *primitiveClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classID));
+
+   J9ROMClass *romClass = reinterpret_cast<J9ROMClass *>(fej9->getPersistentClassPointerFromClassPointer(primitiveClass));
+   J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+
+   return (primitiveType == getPrimitiveChar(className));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodFromInlinedSiteRecord(uint16_t methodID, TR_OpaqueMethodBlock *method)
+   {
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodByNameRecord(uint16_t methodID, uint16_t beholderID, J9ROMClass *romClass, J9ROMMethod *romMethod)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VM *fej9 = reinterpret_cast<TR_J9VM *>(TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread));
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+
+   J9UTF8 *methodNameData = J9ROMMETHOD_NAME(romMethod);
+   char *methodName = (char *)alloca(J9UTF8_LENGTH(methodNameData)+1);
+   strncpy(methodName, reinterpret_cast<const char *>(J9UTF8_DATA(methodNameData)), J9UTF8_LENGTH(methodNameData));
+   methodName[J9UTF8_LENGTH(methodNameData)] = '\0';
+
+   J9UTF8 *methodSigData = J9ROMMETHOD_SIGNATURE(romMethod);
+   char *methodSig = (char *)alloca(J9UTF8_LENGTH(methodSigData)+1);
+   strncpy(methodSig, reinterpret_cast<const char *>(J9UTF8_DATA(methodSigData)), J9UTF8_LENGTH(methodSigData));
+   methodSig[J9UTF8_LENGTH(methodSigData)] = '\0';
+
+   J9UTF8 * classNameData = J9ROMCLASS_CLASSNAME(romClass);
+   char *className = (char *)alloca(J9UTF8_LENGTH(classNameData)+1);
+   strncpy(className, reinterpret_cast<const char *>(J9UTF8_DATA(classNameData)), J9UTF8_LENGTH(classNameData));
+   className[J9UTF8_LENGTH(classNameData)] = '\0';
+
+   TR_OpaqueMethodBlock *method = fej9->getMethodFromName(className, methodName, methodSig, beholderCP);
+
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodFromClassRecord(uint16_t methodID, uint16_t beholderID, uint32_t index)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *beholder = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(beholderID));
+   J9Method *method;
+
+      {
+      TR::VMAccessCriticalSection getResolvedMethods(fej9); // Prevent HCR
+      J9Method *methods = static_cast<J9Method *>(fej9->getMethods(beholder));
+      uint32_t numMethods = fej9->getNumMethods(beholder);
+      TR_ASSERT_FATAL(numMethods > index, "Index is not within the bounds of the ramMethods array\n");
+
+      method = &(methods[index]);
+      }
+
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateStaticMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   J9Method *ramMethod;
+
+      {
+      TR::VMAccessCriticalSection getResolvedStaticMethod(fej9);
+      ramMethod = jitResolveStaticMethodRef(vmThread, beholderCP, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
+      }
+
+   return validateSymbol(methodID, static_cast<void *>(ramMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateSpecialMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   J9Method *ramMethod;
+
+      {
+      TR::VMAccessCriticalSection resolveSpecialMethodRef(fej9);
+      ramMethod = jitResolveSpecialMethodRef(vmThread, beholderCP, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
+      }
+
+   return validateSymbol(methodID, static_cast<void *>(ramMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateVirtualMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+
+   UDATA vTableOffset;
+   bool unresolvedInCP;
+   TR_OpaqueMethodBlock * ramMethod = TR_ResolvedJ9Method::getVirtualMethod(fej9, beholderCP, cpIndex, &vTableOffset, &unresolvedInCP);
+
+   return validateSymbol(methodID, static_cast<void *>(ramMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateVirtualMethodFromOffsetRecord(uint16_t methodID, uint16_t beholderID, int32_t virtualCallOffset, bool ignoreRtResolve)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *beholder = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(beholderID));
+
+   TR_OpaqueMethodBlock *ramMethod = fej9->getResolvedVirtualMethod(beholder, virtualCallOffset, ignoreRtResolve);
+
+   return validateSymbol(methodID, static_cast<void *>(ramMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, uint16_t lookupID, int32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+   TR_ASSERT_FATAL(getSymbolFromID(lookupID) != 0, "lookupID %u should exist\n", lookupID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *lookup = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(lookupID));
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+
+   TR_OpaqueMethodBlock *ramMethod = fej9->getResolvedInterfaceMethod(beholderCP, lookup, cpIndex);
+
+   return validateSymbol(methodID, static_cast<void *>(ramMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateImproperInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   J9Class *beholder = static_cast<J9Class *>(getSymbolFromID(beholderID));
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+   J9Method *ramMethod;
+
+      {
+      TR::VMAccessCriticalSection resolveImproperMethodRef(fej9);
+      ramMethod = jitGetImproperInterfaceMethodFromCP(vmThread, beholderCP, cpIndex);
+      }
+
+   return validateSymbol(methodID, static_cast<void *>(ramMethod));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodFromClassAndSignatureRecord(uint16_t methodID, uint16_t methodClassID, uint16_t beholderID, J9ROMMethod *romMethod)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(methodClassID) != 0, "methodClassID %u should exist\n", methodClassID);
+   TR_ASSERT_FATAL(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueClassBlock *methodClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(methodClassID));
+   TR_OpaqueClassBlock *beholder = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(beholderID));
+
+   J9UTF8 *methodNameData = J9ROMMETHOD_NAME(romMethod);
+   char *methodName = (char *)alloca(J9UTF8_LENGTH(methodNameData)+1);
+   strncpy(methodName, reinterpret_cast<const char *>(J9UTF8_DATA(methodNameData)), J9UTF8_LENGTH(methodNameData));
+   methodName[J9UTF8_LENGTH(methodNameData)] = '\0';
+
+   J9UTF8 *methodSigData = J9ROMMETHOD_SIGNATURE(romMethod);
+   char *methodSig = (char *)alloca(J9UTF8_LENGTH(methodSigData)+1);
+   strncpy(methodSig, reinterpret_cast<const char *>(J9UTF8_DATA(methodSigData)), J9UTF8_LENGTH(methodSigData));
+   methodSig[J9UTF8_LENGTH(methodSigData)] = '\0';
+
+   TR_OpaqueMethodBlock *method = fej9->getMethodFromClass(methodClass, methodName, methodSig, beholder);
+
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodFromSingleImplementerRecord(uint16_t methodID,
+                                                                       uint16_t thisClassID,
+                                                                       int32_t cpIndexOrVftSlot,
+                                                                       uint16_t callerMethodID,
+                                                                       TR_YesNoMaybe useGetResolvedInterfaceMethod)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(thisClassID) != 0, "thisClassID %u should exist\n", thisClassID);
+   TR_ASSERT_FATAL(getSymbolFromID(callerMethodID) != 0, "callerMethodID %u should exist\n", callerMethodID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+   TR_Memory *trMemory = comp->trMemory();
+   TR_PersistentCHTable * chTable = comp->getPersistentInfo()->getPersistentCHTable();
+
+   TR_OpaqueClassBlock *thisClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(thisClassID));
+   TR_OpaqueMethodBlock *callerMethod = static_cast<TR_OpaqueMethodBlock *>(getSymbolFromID(callerMethodID));
+
+   TR_ResolvedMethod *callerResolvedMethod = fej9->createResolvedMethod(trMemory, callerMethod, NULL);
+   TR_ResolvedMethod *calleeResolvedMethod = chTable->findSingleImplementer(thisClass, cpIndexOrVftSlot, callerResolvedMethod, comp, false, useGetResolvedInterfaceMethod, false);
+
+   if (!calleeResolvedMethod)
+      return false;
+
+   TR_OpaqueMethodBlock *method = calleeResolvedMethod->getPersistentIdentifier();
+
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodFromSingleInterfaceImplementerRecord(uint16_t methodID,
+                                                                                uint16_t thisClassID,
+                                                                                int32_t cpIndex,
+                                                                                uint16_t callerMethodID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(thisClassID) != 0, "thisClassID %u should exist\n", thisClassID);
+   TR_ASSERT_FATAL(getSymbolFromID(callerMethodID) != 0, "callerMethodID %u should exist\n", callerMethodID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+   TR_Memory *trMemory = comp->trMemory();
+   TR_PersistentCHTable * chTable = comp->getPersistentInfo()->getPersistentCHTable();
+
+   TR_OpaqueClassBlock *thisClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(thisClassID));
+   TR_OpaqueMethodBlock *callerMethod = static_cast<TR_OpaqueMethodBlock *>(getSymbolFromID(callerMethodID));
+
+   TR_ResolvedMethod *callerResolvedMethod = fej9->createResolvedMethod(trMemory, callerMethod, NULL);
+   TR_ResolvedMethod *calleeResolvedMethod = chTable->findSingleInterfaceImplementer(thisClass, cpIndex, callerResolvedMethod, comp, false, false);
+
+   if (!calleeResolvedMethod)
+      return false;
+
+   TR_OpaqueMethodBlock *method = calleeResolvedMethod->getPersistentIdentifier();
+
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateMethodFromSingleAbstractImplementerRecord(uint16_t methodID,
+                                                                               uint16_t thisClassID,
+                                                                               int32_t vftSlot,
+                                                                               uint16_t callerMethodID)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(thisClassID) != 0, "thisClassID %u should exist\n", thisClassID);
+   TR_ASSERT_FATAL(getSymbolFromID(callerMethodID) != 0, "callerMethodID %u should exist\n", callerMethodID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+   TR_Memory *trMemory = comp->trMemory();
+   TR_PersistentCHTable * chTable = comp->getPersistentInfo()->getPersistentCHTable();
+
+   TR_OpaqueClassBlock *thisClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(thisClassID));
+   TR_OpaqueMethodBlock *callerMethod = static_cast<TR_OpaqueMethodBlock *>(getSymbolFromID(callerMethodID));
+
+   TR_ResolvedMethod *callerResolvedMethod = fej9->createResolvedMethod(trMemory, callerMethod, NULL);
+   TR_ResolvedMethod *calleeResolvedMethod = chTable->findSingleAbstractImplementer(thisClass, vftSlot, callerResolvedMethod, comp, false, false);
+
+   if (!calleeResolvedMethod)
+      return false;
+
+   TR_OpaqueMethodBlock *method = calleeResolvedMethod->getPersistentIdentifier();
+
+   return validateSymbol(methodID, static_cast<void *>(method));
+   }
+
+bool
+TR::SymbolValidationManager::validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(methodID) != 0, "methodID %u should exist\n", methodID);
+   TR_ASSERT_FATAL(getSymbolFromID(methodClassID) != 0, "methodClassID %u should exist\n", methodClassID);
+
+   TR::Compilation* comp = TR::comp();
+   J9VMThread *vmThread = comp->j9VMThread();
+   TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
+
+   TR_OpaqueMethodBlock *method = static_cast<TR_OpaqueMethodBlock *>(getSymbolFromID(methodID));
+   TR_OpaqueClassBlock *methodClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(methodClassID));
+
+   bool canSkipFrames = fej9->stackWalkerMaySkipFrames(method, methodClass);
+
+   return (canSkipFrames == couldSkipFrames);
+   }
+
+bool
+TR::SymbolValidationManager::validateClassInfoIsInitializedRecord(uint16_t classID, bool wasInitialized)
+   {
+   TR_ASSERT_FATAL(getSymbolFromID(classID) != 0, "classID %u should exist\n", classID);
+
+   TR::Compilation* comp = TR::comp();
+   TR_OpaqueClassBlock *clazz = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classID));
+
+   bool initialized = false;
+
+   TR_PersistentClassInfo * classInfo =
+                          comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, comp);
+
+   if (classInfo)
+      initialized = classInfo->isInitialized();
+
+   bool valid = (!wasInitialized || initialized);
+   return valid;
+   }
+
+
+static void printClass(TR_OpaqueClassBlock *clazz)
+   {
+   J9UTF8 *className = J9ROMCLASS_CLASSNAME(((J9Class *)clazz)->romClass);
+   traceMsg(TR::comp(), "\tclassName=%.*s\n", J9UTF8_LENGTH(className), J9UTF8_DATA(className));
+   }
+
+void TR::ClassValidationRecord::printFields()
+   {
+   traceMsg(TR::comp(), "\t_classChain=0x%p\n", _classChain);
+   }
+
+void TR::RootClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "RootClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   }
+
+void TR::ClassByNameRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassByNameRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_primitiveType=%c\n", _primitiveType);
+   }
+
+void TR::ProfiledClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ProfiledClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_primitiveType=%c\n", _primitiveType);
+   }
+
+void TR::ClassFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassFromCPRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::DefiningClassFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "DefiningClassFromCPRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   traceMsg(TR::comp(), "\t_isStatic=%s\n", (_isStatic ? "true" : "false"));
+   }
+
+void TR::StaticClassFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "StaticClassFromCPRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::ClassFromMethodRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassFromMethodRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   }
+
+void TR::ComponentClassFromArrayClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ComponentClassFromArrayClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_componentClass=0x%p\n", _componentClass);
+   printClass(_componentClass);
+   traceMsg(TR::comp(), "\t_arrayClass=0x%p\n", _arrayClass);
+   printClass(_arrayClass);
+   }
+
+void TR::ArrayClassFromComponentClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ArrayClassFromComponentClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_arrayClass=0x%p\n", _arrayClass);
+   printClass(_arrayClass);
+   traceMsg(TR::comp(), "\t_componentClass=0x%p\n", _componentClass);
+   printClass(_componentClass);
+   }
+
+void TR::SuperClassFromClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "SuperClassFromClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_superClass=0x%p\n", _superClass);
+   printClass(_superClass);
+   traceMsg(TR::comp(), "\t_childClass=0x%p\n", _childClass);
+   printClass(_childClass);
+   }
+
+void TR::ClassInstanceOfClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassInstanceOfClassRecord\n");
+   traceMsg(TR::comp(), "\t_classOne=0x%p\n", _classOne);
+   printClass(_classOne);
+   traceMsg(TR::comp(), "\t_classTwo=0x%p\n", _classTwo);
+   printClass(_classTwo);
+   traceMsg(TR::comp(), "\t_objectTypeIsFixed=%s\n", _objectTypeIsFixed ? "true" : "false");
+   traceMsg(TR::comp(), "\t_castTypeIsFixed=%s\n", _castTypeIsFixed ? "true" : "false");
+   traceMsg(TR::comp(), "\t_isInstanceOf=%s\n", _isInstanceOf ? "true" : "false");
+   }
+
+void TR::SystemClassByNameRecord::printFields()
+   {
+   traceMsg(TR::comp(), "SystemClassByNameRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_systemClass=0x%p\n", _systemClass);
+   printClass(_systemClass);
+   }
+
+void TR::ClassFromITableIndexCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassFromITableIndexCPRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::DeclaringClassFromFieldOrStaticRecord::printFields()
+   {
+   traceMsg(TR::comp(), "DeclaringClassFromFieldOrStaticRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::ClassClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_classClass=0x%p\n", _classClass);
+   printClass(_classClass);
+   traceMsg(TR::comp(), "\t_objectClass=0x%p\n", _objectClass);
+   printClass(_objectClass);
+   }
+
+void TR::ConcreteSubClassFromClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ConcreteSubClassFromClassRecord\n");
+   TR::ClassValidationRecord::printFields();
+   traceMsg(TR::comp(), "\t_childClass=0x%p\n", _childClass);
+   traceMsg(TR::comp(), "\t_superClass=0x%p\n", _superClass);
+   }
+
+void TR::ClassChainRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ClassChainRecord\n");
+   traceMsg(TR::comp(), "\t_classChain=0x%p\n", _classChain);
+   }
+
+void TR::RomClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "RomClassRecord\n");
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   }
+
+void TR::PrimitiveClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "PrimitiveClassRecord\n");
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   }
+
+void TR::MethodFromInlinedSiteRecord::printFields()
+   {
+   traceMsg(TR::comp(), "MethodFromInlinedSiteRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_inlinedSiteIndex=%d\n", _inlinedSiteIndex);
+   }
+
+void TR::MethodByNameRecord::printFields()
+   {
+   traceMsg(TR::comp(), "MethodByNameRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   }
+
+void TR::MethodFromClassRecord::printFields()
+   {
+   traceMsg(TR::comp(), "MethodFromClassRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_index=%u\n", _index);
+   }
+
+void TR::StaticMethodFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "StaticMethodFromCPRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::SpecialMethodFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "SpecialMethodFromCPRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::VirtualMethodFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "VirtualMethodFromCPRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::VirtualMethodFromOffsetRecord::printFields()
+   {
+   traceMsg(TR::comp(), "VirtualMethodFromOffsetRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_virtualCallOffset=%d\n", _virtualCallOffset);
+   traceMsg(TR::comp(), "\t_ignoreRtResolve=%s\n", _ignoreRtResolve ? "true" : "false");
+   }
+
+void TR::InterfaceMethodFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "InterfaceMethodFromCPRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_lookup=0x%p\n", _lookup);
+   printClass(_lookup);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }
+
+void TR::MethodFromClassAndSigRecord::printFields()
+   {
+   traceMsg(TR::comp(), "MethodFromClassAndSigRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_methodClass=0x%p\n", _methodClass);
+   printClass(_methodClass);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   }
+
+void TR::StackWalkerMaySkipFramesRecord::printFields()
+   {
+   traceMsg(TR::comp(), "StackWalkerMaySkipFramesRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_methodClass=0x%p\n", _methodClass);
+   printClass(_methodClass);
+   traceMsg(TR::comp(), "\t_skipFrames=%sp\n", _skipFrames ? "true" : "false");
+   }
+
+void TR::ArrayClassFromJavaVM::printFields()
+   {
+   traceMsg(TR::comp(), "ArrayClassFromJavaVM\n");
+   traceMsg(TR::comp(), "\t_arrayClass=0x%p\n", _arrayClass);
+   printClass(_arrayClass);
+   traceMsg(TR::comp(), "\t_arrayClassIndex=%d\n", _arrayClassIndex);
+   }
+
+void TR::ClassInfoIsInitialized::printFields()
+   {
+   traceMsg(TR::comp(), "ClassInfoIsInitialized\n");
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_isInitialized=%sp\n", _isInitialized ? "true" : "false");
+   }
+
+void TR::MethodFromSingleImplementer::printFields()
+   {
+   traceMsg(TR::comp(), "MethodFromSingleImplementer\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_thisClass=0x%p\n", _thisClass);
+   printClass(_thisClass);
+   traceMsg(TR::comp(), "\t_cpIndexOrVftSlot=%d\n", _cpIndexOrVftSlot);
+   traceMsg(TR::comp(), "\t_callerMethod=0x%p\n", _callerMethod);
+   traceMsg(TR::comp(), "\t_useGetResolvedInterfaceMethod=%d\n", _useGetResolvedInterfaceMethod);
+   }
+
+void TR::MethodFromSingleInterfaceImplementer::printFields()
+   {
+   traceMsg(TR::comp(), "MethodFromSingleInterfaceImplementer\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_thisClass=0x%p\n", _thisClass);
+   printClass(_thisClass);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   traceMsg(TR::comp(), "\t_callerMethod=0x%p\n", _callerMethod);
+   }
+
+void TR::MethodFromSingleAbstractImplementer::printFields()
+   {
+   traceMsg(TR::comp(), "MethodFromSingleAbstractImplementer\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_thisClass=0x%p\n", _thisClass);
+   printClass(_thisClass);
+   traceMsg(TR::comp(), "\t_vftSlot=%d\n", _vftSlot);
+   traceMsg(TR::comp(), "\t_callerMethod=0x%p\n", _callerMethod);
+   }
+
+void TR::ImproperInterfaceMethodFromCPRecord::printFields()
+   {
+   traceMsg(TR::comp(), "ImproperInterfaceMethodFromCPRecord\n");
+   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
+   traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
+   printClass(_beholder);
+   traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
+   }

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1718,7 +1718,7 @@ TR::SymbolValidationManager::validateClassInfoIsInitializedRecord(uint16_t class
    bool initialized = false;
 
    TR_PersistentClassInfo * classInfo =
-                          comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, comp);
+                          comp->getPersistentInfo()->getPersistentCHTable()->findClassInfoAfterLocking(clazz, comp, true);
 
    if (classInfo)
       initialized = classInfo->isInitialized();

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -60,6 +60,7 @@ static char getPrimitiveChar(J9UTF8 * primitiveClassName)
 
 TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region)
    : _symbolID(FIRST_ID),
+     _heuristicRegion(0),
      _region(region),
      _symbolValidationRecords(_region),
      _symbolToIdMap((SymbolToIdComparator()), _region),
@@ -257,6 +258,8 @@ TR::SymbolValidationManager::addRootClassRecord(TR_OpaqueClassBlock *clazz)
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    clazz = getBaseComponentClass(clazz, arrayDims);
@@ -270,6 +273,8 @@ TR::SymbolValidationManager::addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
 
@@ -296,6 +301,8 @@ TR::SymbolValidationManager::addProfiledClassRecord(TR_OpaqueClassBlock *clazz)
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    clazz = getBaseComponentClass(clazz, arrayDims);
@@ -321,6 +328,8 @@ TR::SymbolValidationManager::addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    clazz = getBaseComponentClass(clazz, arrayDims);
@@ -338,6 +347,8 @@ TR::SymbolValidationManager::addDefiningClassFromCPRecord(TR_OpaqueClassBlock *c
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    clazz = getBaseComponentClass(clazz, arrayDims);
@@ -355,6 +366,8 @@ TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *cla
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    clazz = getBaseComponentClass(clazz, arrayDims);
@@ -372,6 +385,8 @@ TR::SymbolValidationManager::addClassFromMethodRecord(TR_OpaqueClassBlock *clazz
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    clazz = getBaseComponentClass(clazz, arrayDims);
@@ -387,6 +402,8 @@ TR::SymbolValidationManager::addComponentClassFromArrayClassRecord(TR_OpaqueClas
    {
    if (!componentClass)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(arrayClass) != 0, "arrayClass 0x%p should have already been validated\n", arrayClass);
 
@@ -399,6 +416,8 @@ TR::SymbolValidationManager::addArrayClassFromComponentClassRecord(TR_OpaqueClas
    {
    if (!arrayClass)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(componentClass) != 0, "componentClass 0x%p should have already been validated\n", componentClass);
 
@@ -411,6 +430,8 @@ TR::SymbolValidationManager::addSuperClassFromClassRecord(TR_OpaqueClassBlock *s
    {
    if (!superClass)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    superClass = getBaseComponentClass(superClass, arrayDims);
@@ -424,6 +445,9 @@ TR::SymbolValidationManager::addSuperClassFromClassRecord(TR_OpaqueClassBlock *s
 bool
 TR::SymbolValidationManager::addClassInstanceOfClassRecord(TR_OpaqueClassBlock *classOne, TR_OpaqueClassBlock *classTwo, bool objectTypeIsFixed, bool castTypeIsFixed, bool isInstanceOf)
    {
+   if (inHeuristicRegion())
+      return true;
+
    TR_ASSERT_FATAL(getIDFromSymbol(classOne) != 0, "classOne 0x%p should have already been validated\n", classOne);
    TR_ASSERT_FATAL(getIDFromSymbol(classTwo) != 0, "classTwo 0x%p should have already been validated\n", classTwo);
 
@@ -436,6 +460,8 @@ TR::SymbolValidationManager::addSystemClassByNameRecord(TR_OpaqueClassBlock *sys
    {
    if (!systemClass)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    systemClass = getBaseComponentClass(systemClass, arrayDims);
@@ -449,6 +475,8 @@ TR::SymbolValidationManager::addClassFromITableIndexCPRecord(TR_OpaqueClassBlock
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
 
@@ -466,6 +494,8 @@ TR::SymbolValidationManager::addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueC
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
 
@@ -483,6 +513,8 @@ TR::SymbolValidationManager::addClassClassRecord(TR_OpaqueClassBlock *classClass
    {
    if (!classClass)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(objectClass) != 0, "objectClass 0x%p should have already been validated\n", objectClass);
 
@@ -495,6 +527,8 @@ TR::SymbolValidationManager::addConcreteSubClassFromClassRecord(TR_OpaqueClassBl
    {
    if (!superClass)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    int32_t arrayDims = 0;
    childClass = getBaseComponentClass(childClass, arrayDims);
@@ -525,6 +559,8 @@ TR::SymbolValidationManager::addClassChainRecord(TR_OpaqueClassBlock *clazz, voi
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    SymbolValidationRecord *record = new (_region) ClassChainRecord(clazz, classChain);
    return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
@@ -535,6 +571,8 @@ TR::SymbolValidationManager::addRomClassRecord(TR_OpaqueClassBlock *clazz)
    {
    if (!clazz)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    SymbolValidationRecord *record = new (_region) RomClassRecord(clazz);
    return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record);
@@ -543,6 +581,11 @@ TR::SymbolValidationManager::addRomClassRecord(TR_OpaqueClassBlock *clazz)
 bool
 TR::SymbolValidationManager::addPrimitiveClassRecord(TR_OpaqueClassBlock *clazz)
    {
+   if (!clazz)
+      return false;
+   if (inHeuristicRegion())
+      return true;
+
    TR_ASSERT_FATAL(getIDFromSymbol(clazz) != 0, "clazz 0x%p should have already been validated\n", clazz);
 
    TR::Compilation* comp = TR::comp();
@@ -565,6 +608,8 @@ TR::SymbolValidationManager::addMethodFromInlinedSiteRecord(TR_OpaqueMethodBlock
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    SymbolValidationRecord *record = new (_region) MethodFromInlinedSiteRecord(method, inlinedSiteIndex);
    return storeValidationRecordIfNecessary(static_cast<void *>(method), record);
@@ -575,6 +620,8 @@ TR::SymbolValidationManager::addMethodByNameRecord(TR_OpaqueMethodBlock *method,
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
 
@@ -595,6 +642,8 @@ TR::SymbolValidationManager::addMethodFromClassRecord(TR_OpaqueMethodBlock *meth
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    if (index == static_cast<uint32_t>(-1))
       {
@@ -628,6 +677,8 @@ TR::SymbolValidationManager::addStaticMethodFromCPRecord(TR_OpaqueMethodBlock *m
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
 
@@ -650,6 +701,8 @@ TR::SymbolValidationManager::addSpecialMethodFromCPRecord(TR_OpaqueMethodBlock *
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
 
@@ -672,6 +725,8 @@ TR::SymbolValidationManager::addVirtualMethodFromCPRecord(TR_OpaqueMethodBlock *
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(cp));
 
@@ -694,6 +749,8 @@ TR::SymbolValidationManager::addVirtualMethodFromOffsetRecord(TR_OpaqueMethodBlo
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
 
@@ -714,6 +771,8 @@ TR::SymbolValidationManager::addInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);
    TR_ASSERT_FATAL(getIDFromSymbol(lookup) != 0, "lookup 0x%p should have already been validated\n", lookup);
@@ -759,6 +818,8 @@ TR::SymbolValidationManager::addMethodFromClassAndSignatureRecord(TR_OpaqueMetho
    {
    if (!method)
       return false;
+   if (inHeuristicRegion())
+      return true;
 
    TR_ASSERT_FATAL(getIDFromSymbol(methodClass) != 0, "methodClass 0x%p should have already been validated\n", methodClass);
    TR_ASSERT_FATAL(getIDFromSymbol(beholder) != 0, "beholder 0x%p should have already been validated\n", beholder);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1,0 +1,1337 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef SYMBOL_VALIDATION_MANAGER_INCL
+#define SYMBOL_VALIDATION_MANAGER_INCL
+
+#include <algorithm>                       // for std::max, etc
+#include <map>
+#include <set>
+#include <stddef.h>                        // for NULL
+#include <stdint.h>                        // for int32_t, uint8_t, etc
+#include "env/jittypes.h"                  // for uintptrj_t
+#include "j9.h"
+#include "j9nonbuilder.h"
+#include "infra/TRlist.hpp"
+#include "env/TRMemory.hpp"
+#include "env/VMJ9.h"
+#include "runtime/Runtime.hpp"
+
+namespace TR {
+
+struct SymbolValidationRecord
+   {
+   SymbolValidationRecord(TR_ExternalRelocationTargetKind kind)
+      : _kind(kind)
+      {}
+
+   virtual bool isEqual(SymbolValidationRecord *other) = 0;
+   virtual void printFields() = 0;
+
+   virtual bool isClassValidationRecord() { return false; }
+
+   TR_ExternalRelocationTargetKind _kind;
+   };
+
+struct ClassValidationRecord : public SymbolValidationRecord
+   {
+   ClassValidationRecord(TR_ExternalRelocationTargetKind kind)
+      : SymbolValidationRecord(kind),
+        _classChain(NULL)
+      {}
+
+   virtual bool isEqual(SymbolValidationRecord *other) = 0;
+   virtual void printFields();
+
+   virtual bool isClassValidationRecord() { return true; }
+
+   void * _classChain;
+   };
+
+struct RootClassRecord : public ClassValidationRecord
+   {
+   RootClassRecord(TR_OpaqueClassBlock *clazz)
+      : ClassValidationRecord(TR_ValidateRootClass),
+        _class(clazz)
+      {}
+
+   bool operator ==(const RootClassRecord &rhs)
+      {
+      if (_class == rhs._class)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<RootClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   };
+
+
+struct ClassByNameRecord : public ClassValidationRecord
+   {
+   ClassByNameRecord(TR_OpaqueClassBlock *clazz,
+                     TR_OpaqueClassBlock *beholder,
+                     char primitiveType)
+      : ClassValidationRecord(TR_ValidateClassByName),
+        _class(clazz),
+        _beholder(beholder),
+        _primitiveType(primitiveType)
+      {}
+
+   bool operator ==(const ClassByNameRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _beholder == rhs._beholder &&
+          _primitiveType == rhs._primitiveType)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassByNameRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   char _primitiveType;
+   };
+
+struct ProfiledClassRecord : public ClassValidationRecord
+   {
+   ProfiledClassRecord(TR_OpaqueClassBlock *clazz,
+                       char primitiveType)
+      : ClassValidationRecord(TR_ValidateProfiledClass),
+        _class(clazz),
+        _primitiveType(primitiveType)
+      {}
+
+   bool operator ==(const ProfiledClassRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _primitiveType == rhs._primitiveType)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ProfiledClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   char _primitiveType;
+   };
+
+struct ClassFromCPRecord : public ClassValidationRecord
+   {
+   ClassFromCPRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder, uint32_t cpIndex)
+      : ClassValidationRecord(TR_ValidateClassFromCP),
+        _class(clazz),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==(const ClassFromCPRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   uint32_t  _cpIndex;
+   };
+
+struct DefiningClassFromCPRecord : public ClassValidationRecord
+   {
+   DefiningClassFromCPRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder, uint32_t cpIndex, bool isStatic)
+      : ClassValidationRecord(TR_ValidateDefiningClassFromCP),
+        _class(clazz),
+        _beholder(beholder),
+        _cpIndex(cpIndex),
+        _isStatic(isStatic)
+      {}
+
+   bool operator ==(const DefiningClassFromCPRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex &&
+          _isStatic == rhs._isStatic)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<DefiningClassFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   uint32_t  _cpIndex;
+   bool      _isStatic;
+   };
+
+struct StaticClassFromCPRecord : public ClassValidationRecord
+   {
+   StaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder, uint32_t cpIndex)
+      : ClassValidationRecord(TR_ValidateStaticClassFromCP),
+        _class(clazz),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==(const StaticClassFromCPRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<StaticClassFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   uint32_t  _cpIndex;
+   };
+
+struct ClassFromMethodRecord : public ClassValidationRecord
+   {
+   ClassFromMethodRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueMethodBlock *method)
+      : ClassValidationRecord(TR_ValidateClassFromMethod),
+        _class(clazz),
+        _method(method)
+      {}
+
+   bool operator ==(const ClassFromMethodRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _method == rhs._method)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassFromMethodRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueMethodBlock *_method;
+   };
+
+struct ComponentClassFromArrayClassRecord : public ClassValidationRecord
+   {
+   ComponentClassFromArrayClassRecord(TR_OpaqueClassBlock *componentClass, TR_OpaqueClassBlock *arrayClass)
+      : ClassValidationRecord(TR_ValidateComponentClassFromArrayClass),
+        _componentClass(componentClass),
+        _arrayClass(arrayClass)
+      {}
+
+   bool operator ==(const ComponentClassFromArrayClassRecord &rhs)
+      {
+      if (_componentClass == rhs._componentClass &&
+          _arrayClass == rhs._arrayClass)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ComponentClassFromArrayClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _componentClass;
+   TR_OpaqueClassBlock * _arrayClass;
+   };
+
+struct ArrayClassFromComponentClassRecord : public ClassValidationRecord
+   {
+   ArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass)
+      : ClassValidationRecord(TR_ValidateArrayClassFromComponentClass),
+        _arrayClass(arrayClass),
+        _componentClass(componentClass)
+      {}
+
+   bool operator ==(const ArrayClassFromComponentClassRecord &rhs)
+      {
+      if (_arrayClass == rhs._arrayClass &&
+          _componentClass == rhs._componentClass)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ArrayClassFromComponentClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _arrayClass;
+   TR_OpaqueClassBlock * _componentClass;
+   };
+
+struct SuperClassFromClassRecord : public ClassValidationRecord
+   {
+   SuperClassFromClassRecord(TR_OpaqueClassBlock *superClass, TR_OpaqueClassBlock *childClass)
+      : ClassValidationRecord(TR_ValidateSuperClassFromClass),
+        _superClass(superClass),
+        _childClass(childClass)
+      {}
+
+   bool operator ==(const SuperClassFromClassRecord &rhs)
+      {
+      if (_superClass == rhs._superClass &&
+          _childClass == rhs._childClass)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<SuperClassFromClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_superClass;
+   TR_OpaqueClassBlock *_childClass;
+   };
+
+struct ClassInstanceOfClassRecord : public SymbolValidationRecord
+   {
+   ClassInstanceOfClassRecord(TR_OpaqueClassBlock *classOne, TR_OpaqueClassBlock *classTwo, bool objectTypeIsFixed, bool castTypeIsFixed, bool isInstanceOf)
+      : SymbolValidationRecord(TR_ValidateClassInstanceOfClass),
+        _classOne(classOne),
+        _classTwo(classTwo),
+        _objectTypeIsFixed(objectTypeIsFixed),
+        _castTypeIsFixed(castTypeIsFixed),
+        _isInstanceOf(isInstanceOf)
+      {}
+
+   bool operator ==(const ClassInstanceOfClassRecord &rhs)
+      {
+      if (_classOne == rhs._classOne &&
+          _classTwo == rhs._classTwo &&
+          _objectTypeIsFixed == rhs._objectTypeIsFixed &&
+          _castTypeIsFixed == rhs._castTypeIsFixed &&
+          _isInstanceOf == rhs._isInstanceOf)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassInstanceOfClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_classOne;
+   TR_OpaqueClassBlock *_classTwo;
+   bool _objectTypeIsFixed;
+   bool _castTypeIsFixed;
+   bool _isInstanceOf;
+   };
+
+struct SystemClassByNameRecord : public ClassValidationRecord
+   {
+   SystemClassByNameRecord(TR_OpaqueClassBlock *systemClass)
+      : ClassValidationRecord(TR_ValidateSystemClassByName),
+        _systemClass(systemClass)
+      {}
+
+   bool operator ==(const SystemClassByNameRecord &rhs)
+      {
+      if (_systemClass == rhs._systemClass)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<SystemClassByNameRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_systemClass;
+   };
+
+struct ClassFromITableIndexCPRecord : public ClassValidationRecord
+   {
+   ClassFromITableIndexCPRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder, uint32_t cpIndex)
+      : ClassValidationRecord(TR_ValidateClassFromITableIndexCP),
+        _class(clazz),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==(const ClassFromITableIndexCPRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassFromITableIndexCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   int32_t _cpIndex;
+
+   };
+
+struct DeclaringClassFromFieldOrStaticRecord : public ClassValidationRecord
+   {
+   DeclaringClassFromFieldOrStaticRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder, uint32_t cpIndex)
+      : ClassValidationRecord(TR_ValidateDeclaringClassFromFieldOrStatic),
+        _class(clazz),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==(const DeclaringClassFromFieldOrStaticRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<DeclaringClassFromFieldOrStaticRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   TR_OpaqueClassBlock * _beholder;
+   uint32_t  _cpIndex;
+   };
+
+struct ClassClassRecord : public ClassValidationRecord
+   {
+   ClassClassRecord(TR_OpaqueClassBlock *classClass, TR_OpaqueClassBlock *objectClass)
+      : ClassValidationRecord(TR_ValidateClassClass),
+        _classClass(classClass),
+        _objectClass(objectClass)
+      {}
+
+   bool operator ==(const ClassClassRecord &rhs)
+      {
+      if (_classClass == rhs._classClass &&
+          _objectClass == rhs._objectClass)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_classClass;
+   TR_OpaqueClassBlock *_objectClass;
+   };
+
+struct ConcreteSubClassFromClassRecord : public ClassValidationRecord
+   {
+   ConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass)
+      : ClassValidationRecord(TR_ValidateConcreteSubClassFromClass),
+        _childClass(childClass),
+        _superClass(superClass)
+      {}
+
+   bool operator ==(const ConcreteSubClassFromClassRecord &rhs)
+      {
+      if (_childClass == rhs._childClass &&
+          _superClass == rhs._superClass)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ConcreteSubClassFromClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_childClass;
+   TR_OpaqueClassBlock *_superClass;
+   };
+
+struct ClassChainRecord : public SymbolValidationRecord
+   {
+   ClassChainRecord(TR_OpaqueClassBlock *clazz, void *classChain)
+      : SymbolValidationRecord(TR_ValidateClassChain),
+        _class(clazz),
+        _classChain(classChain)
+      {}
+
+   bool operator ==(const ClassChainRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _classChain == rhs._classChain)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassChainRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_class;
+   void *_classChain;
+   };
+
+struct RomClassRecord : public SymbolValidationRecord
+   {
+   RomClassRecord(TR_OpaqueClassBlock *clazz)
+      : SymbolValidationRecord(TR_ValidateRomClass),
+        _class(clazz)
+      {}
+
+   bool operator ==(const RomClassRecord &rhs)
+      {
+      if (_class == rhs._class)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<RomClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_class;
+   };
+
+struct PrimitiveClassRecord : public SymbolValidationRecord
+   {
+   PrimitiveClassRecord(TR_OpaqueClassBlock *clazz, char primitiveType)
+      : SymbolValidationRecord(TR_ValidatePrimitiveClass),
+        _class(clazz),
+        _primitiveType(primitiveType)
+      {}
+
+   bool operator ==(const PrimitiveClassRecord &rhs)
+      {
+      if (_class == rhs._class &&
+          _primitiveType == rhs._primitiveType)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<PrimitiveClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_class;
+   char _primitiveType;
+   };
+
+struct MethodFromInlinedSiteRecord : public SymbolValidationRecord
+   {
+   MethodFromInlinedSiteRecord(TR_OpaqueMethodBlock *method,
+                               int32_t inlinedSiteIndex)
+      : SymbolValidationRecord(TR_ValidateMethodFromInlinedSite),
+        _method(method),
+        _inlinedSiteIndex(inlinedSiteIndex)
+      {}
+
+   bool operator ==( const MethodFromInlinedSiteRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _inlinedSiteIndex == rhs._inlinedSiteIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodFromInlinedSiteRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   int32_t _inlinedSiteIndex;
+   };
+
+struct MethodByNameRecord : public SymbolValidationRecord
+   {
+   MethodByNameRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder)
+      : SymbolValidationRecord(TR_ValidateMethodByName),
+        _method(method),
+        _beholder(beholder)
+      {}
+
+   bool operator ==( const MethodByNameRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodByNameRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   };
+
+struct MethodFromClassRecord : public SymbolValidationRecord
+   {
+   MethodFromClassRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, uint32_t index)
+      : SymbolValidationRecord(TR_ValidateMethodFromClass),
+        _method(method),
+        _beholder(beholder),
+        _index(index)
+      {}
+
+   bool operator ==( const MethodFromClassRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _index == rhs._index)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodFromClassRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   uint32_t _index;
+   };
+
+struct StaticMethodFromCPRecord : public SymbolValidationRecord
+   {
+   StaticMethodFromCPRecord(TR_OpaqueMethodBlock *method,
+                               TR_OpaqueClassBlock *beholder,
+                               int32_t cpIndex)
+      : SymbolValidationRecord(TR_ValidateStaticMethodFromCP),
+        _method(method),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==( const StaticMethodFromCPRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<StaticMethodFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _cpIndex;
+   };
+
+struct SpecialMethodFromCPRecord : public SymbolValidationRecord
+   {
+   SpecialMethodFromCPRecord(TR_OpaqueMethodBlock *method,
+                             TR_OpaqueClassBlock *beholder,
+                             int32_t cpIndex)
+      : SymbolValidationRecord(TR_ValidateSpecialMethodFromCP),
+        _method(method),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==( const SpecialMethodFromCPRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<SpecialMethodFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _cpIndex;
+   };
+
+struct VirtualMethodFromCPRecord : public SymbolValidationRecord
+   {
+   VirtualMethodFromCPRecord(TR_OpaqueMethodBlock *method,
+                             TR_OpaqueClassBlock *beholder,
+                             int32_t cpIndex)
+      : SymbolValidationRecord(TR_ValidateVirtualMethodFromCP),
+        _method(method),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==( const VirtualMethodFromCPRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<VirtualMethodFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _cpIndex;
+   };
+
+struct VirtualMethodFromOffsetRecord : public SymbolValidationRecord
+   {
+   VirtualMethodFromOffsetRecord(TR_OpaqueMethodBlock *method,
+                                 TR_OpaqueClassBlock *beholder,
+                                 int32_t virtualCallOffset,
+                                 bool ignoreRtResolve)
+      : SymbolValidationRecord(TR_ValidateVirtualMethodFromOffset),
+        _method(method),
+        _beholder(beholder),
+        _virtualCallOffset(virtualCallOffset),
+        _ignoreRtResolve(ignoreRtResolve)
+      {}
+
+   bool operator ==( const VirtualMethodFromOffsetRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _virtualCallOffset == rhs._virtualCallOffset &&
+          _ignoreRtResolve == rhs._ignoreRtResolve)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<VirtualMethodFromOffsetRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _virtualCallOffset;
+   bool _ignoreRtResolve;
+   };
+
+struct InterfaceMethodFromCPRecord : public SymbolValidationRecord
+   {
+   InterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method,
+                               TR_OpaqueClassBlock *beholder,
+                               TR_OpaqueClassBlock *lookup,
+                               int32_t cpIndex)
+      : SymbolValidationRecord(TR_ValidateInterfaceMethodFromCP),
+        _method(method),
+        _beholder(beholder),
+        _lookup(lookup),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==( const InterfaceMethodFromCPRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _lookup == rhs._lookup &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<InterfaceMethodFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   TR_OpaqueClassBlock *_lookup;
+   int32_t _cpIndex;
+   };
+
+struct MethodFromClassAndSigRecord : public SymbolValidationRecord
+   {
+   MethodFromClassAndSigRecord(TR_OpaqueMethodBlock *method,
+                               TR_OpaqueClassBlock *beholder,
+                               TR_OpaqueClassBlock *methodClass)
+      : SymbolValidationRecord(TR_ValidateMethodFromClassAndSig),
+        _method(method),
+        _methodClass(methodClass),
+        _beholder(beholder)
+      {}
+
+   bool operator ==( const MethodFromClassAndSigRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _methodClass == rhs._methodClass &&
+          _beholder == rhs._beholder)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodFromClassAndSigRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_methodClass;
+   TR_OpaqueClassBlock *_beholder;
+   };
+
+struct StackWalkerMaySkipFramesRecord : public SymbolValidationRecord
+   {
+   StackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method,
+                                  TR_OpaqueClassBlock *methodClass,
+                                  bool skipFrames)
+      : SymbolValidationRecord(TR_ValidateStackWalkerMaySkipFramesRecord),
+        _method(method),
+        _methodClass(methodClass),
+        _skipFrames(skipFrames)
+      {}
+
+   bool operator ==( const StackWalkerMaySkipFramesRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _methodClass == rhs._methodClass &&
+          _skipFrames == rhs._skipFrames)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<StackWalkerMaySkipFramesRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_methodClass;
+   bool _skipFrames;
+   };
+
+struct ArrayClassFromJavaVM : public ClassValidationRecord
+   {
+   ArrayClassFromJavaVM(TR_OpaqueClassBlock *arrayClass, int32_t arrayClassIndex)
+      : ClassValidationRecord(TR_ValidateArrayClassFromJavaVM),
+        _arrayClass(arrayClass),
+        _arrayClassIndex(arrayClassIndex)
+      {}
+
+   bool operator ==(const ArrayClassFromJavaVM &rhs)
+      {
+      if (_arrayClass == rhs._arrayClass &&
+          _arrayClassIndex == rhs._arrayClassIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ArrayClassFromJavaVM *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_arrayClass;
+   int32_t _arrayClassIndex;
+   };
+
+struct ClassInfoIsInitialized : public SymbolValidationRecord
+   {
+   ClassInfoIsInitialized(TR_OpaqueClassBlock *clazz, bool isInitialized)
+      : SymbolValidationRecord(TR_ValidateClassInfoIsInitialized),
+        _class(clazz),
+        _isInitialized(isInitialized)
+      {}
+
+   bool operator ==(const ClassInfoIsInitialized &rhs)
+      {
+      if (_class == rhs._class &&
+          _isInitialized == rhs._isInitialized)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ClassInfoIsInitialized *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_class;
+   bool _isInitialized;
+   };
+
+struct MethodFromSingleImplementer : public SymbolValidationRecord
+   {
+   MethodFromSingleImplementer(TR_OpaqueMethodBlock *method,
+                               TR_OpaqueClassBlock *thisClass,
+                               int32_t cpIndexOrVftSlot,
+                               TR_OpaqueMethodBlock *callerMethod,
+                               TR_YesNoMaybe useGetResolvedInterfaceMethod)
+      : SymbolValidationRecord(TR_ValidateMethodFromSingleImplementer),
+        _method(method),
+        _thisClass(thisClass),
+        _cpIndexOrVftSlot(cpIndexOrVftSlot),
+        _callerMethod(callerMethod),
+        _useGetResolvedInterfaceMethod(useGetResolvedInterfaceMethod)
+      {}
+
+   bool operator ==( const MethodFromSingleImplementer &rhs)
+      {
+      if (_method == rhs._method &&
+          _thisClass == rhs._thisClass &&
+          _cpIndexOrVftSlot == rhs._cpIndexOrVftSlot &&
+          _callerMethod == rhs._callerMethod &&
+          _useGetResolvedInterfaceMethod == rhs._useGetResolvedInterfaceMethod)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodFromSingleImplementer *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_thisClass;
+   int32_t _cpIndexOrVftSlot;
+   TR_OpaqueMethodBlock *_callerMethod;
+   TR_YesNoMaybe _useGetResolvedInterfaceMethod;
+   };
+
+struct MethodFromSingleInterfaceImplementer : public SymbolValidationRecord
+   {
+   MethodFromSingleInterfaceImplementer(TR_OpaqueMethodBlock *method,
+                                        TR_OpaqueClassBlock *thisClass,
+                                        int32_t cpIndex,
+                                        TR_OpaqueMethodBlock *callerMethod)
+      : SymbolValidationRecord(TR_ValidateMethodFromSingleInterfaceImplementer),
+        _method(method),
+        _thisClass(thisClass),
+        _cpIndex(cpIndex),
+        _callerMethod(callerMethod)
+      {}
+
+   bool operator ==( const MethodFromSingleInterfaceImplementer &rhs)
+      {
+      if (_method == rhs._method &&
+          _thisClass == rhs._thisClass &&
+          _cpIndex == rhs._cpIndex &&
+          _callerMethod == rhs._callerMethod)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodFromSingleInterfaceImplementer *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_thisClass;
+   int32_t _cpIndex;
+   TR_OpaqueMethodBlock *_callerMethod;
+   };
+
+struct MethodFromSingleAbstractImplementer : public SymbolValidationRecord
+   {
+   MethodFromSingleAbstractImplementer(TR_OpaqueMethodBlock *method,
+                                       TR_OpaqueClassBlock *thisClass,
+                                       int32_t vftSlot,
+                                       TR_OpaqueMethodBlock *callerMethod)
+      : SymbolValidationRecord(TR_ValidateMethodFromSingleAbstractImplementer),
+        _method(method),
+        _thisClass(thisClass),
+        _vftSlot(vftSlot),
+        _callerMethod(callerMethod)
+      {}
+
+   bool operator ==( const MethodFromSingleAbstractImplementer &rhs)
+      {
+      if (_method == rhs._method &&
+          _thisClass == rhs._thisClass &&
+          _vftSlot == rhs._vftSlot &&
+          _callerMethod == rhs._callerMethod)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<MethodFromSingleAbstractImplementer *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_thisClass;
+   int32_t _vftSlot;
+   TR_OpaqueMethodBlock *_callerMethod;
+   };
+
+struct ImproperInterfaceMethodFromCPRecord : public SymbolValidationRecord
+   {
+   ImproperInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method,
+                               TR_OpaqueClassBlock *beholder,
+                               int32_t cpIndex)
+      : SymbolValidationRecord(TR_ValidateImproperInterfaceMethodFromCP),
+        _method(method),
+        _beholder(beholder),
+        _cpIndex(cpIndex)
+      {}
+
+   bool operator ==( const ImproperInterfaceMethodFromCPRecord &rhs)
+      {
+      if (_method == rhs._method &&
+          _beholder == rhs._beholder &&
+          _cpIndex == rhs._cpIndex)
+         return true;
+      else
+         return false;
+      }
+
+   virtual bool isEqual(SymbolValidationRecord *other)
+      {
+      return (*this == *static_cast<ImproperInterfaceMethodFromCPRecord *>(other));
+      }
+
+   virtual void printFields();
+
+   TR_OpaqueMethodBlock *_method;
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _cpIndex;
+   };
+
+class SymbolValidationManager
+   {
+public:
+   TR_ALLOC(TR_MemoryBase::SymbolValidationManager);
+
+   SymbolValidationManager(TR::Region &region);
+
+   void* getSymbolFromID(uint16_t id);
+   uint16_t getIDFromSymbol(void *symbol);
+
+   bool isAlreadyValidated(void *symbol) { return (getIDFromSymbol(symbol) != 0); }
+
+   bool addRootClassRecord(TR_OpaqueClassBlock *clazz);
+   bool addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder);
+   bool addProfiledClassRecord(TR_OpaqueClassBlock *clazz);
+   bool addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
+   bool addDefiningClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex, bool isStatic = false);
+   bool addStaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
+   bool addClassFromMethodRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueMethodBlock *method);
+   bool addComponentClassFromArrayClassRecord(TR_OpaqueClassBlock *componentClass, TR_OpaqueClassBlock *arrayClass);
+   bool addArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass);
+   bool addSuperClassFromClassRecord(TR_OpaqueClassBlock *superClass, TR_OpaqueClassBlock *childClass);
+   bool addClassInstanceOfClassRecord(TR_OpaqueClassBlock *classOne, TR_OpaqueClassBlock *classTwo, bool objectTypeIsFixed, bool castTypeIsFixed, bool isInstanceOf);
+   bool addSystemClassByNameRecord(TR_OpaqueClassBlock *systemClass);
+   bool addClassFromITableIndexCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex);
+   bool addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex);
+   bool addClassClassRecord(TR_OpaqueClassBlock *classClass, TR_OpaqueClassBlock *objectClass);
+   bool addConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass);
+   bool addArrayClassFromJavaVM(TR_OpaqueClassBlock *arrayClass, int32_t arrayClassIndex);
+
+   bool addClassChainRecord(TR_OpaqueClassBlock *clazz, void *classChain);
+   bool addRomClassRecord(TR_OpaqueClassBlock *clazz);
+   bool addPrimitiveClassRecord(TR_OpaqueClassBlock *clazz);
+
+   bool addMethodFromInlinedSiteRecord(TR_OpaqueMethodBlock *method, int32_t inlinedSiteIndex);
+   bool addMethodByNameRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder);
+   bool addMethodFromClassRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, uint32_t index);
+   bool addStaticMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex);
+   bool addSpecialMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex);
+   bool addVirtualMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex);
+   bool addVirtualMethodFromOffsetRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, int32_t virtualCallOffset, bool ignoreRtResolve);
+   bool addInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, TR_OpaqueClassBlock *lookup, int32_t cpIndex);
+   bool addImproperInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex);
+   bool addMethodFromClassAndSignatureRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, TR_OpaqueClassBlock *beholder);
+   bool addMethodFromSingleImplementerRecord(TR_OpaqueMethodBlock *method,
+                                             TR_OpaqueClassBlock *thisClass,
+                                             int32_t cpIndexOrVftSlot,
+                                             TR_OpaqueMethodBlock *callerMethod,
+                                             TR_YesNoMaybe useGetResolvedInterfaceMethod);
+   bool addMethodFromSingleInterfaceImplementerRecord(TR_OpaqueMethodBlock *method,
+                                           TR_OpaqueClassBlock *thisClass,
+                                           int32_t cpIndex,
+                                           TR_OpaqueMethodBlock *callerMethod);
+   bool addMethodFromSingleAbstractImplementerRecord(TR_OpaqueMethodBlock *method,
+                                          TR_OpaqueClassBlock *thisClass,
+                                          int32_t vftSlot,
+                                          TR_OpaqueMethodBlock *callerMethod);
+
+   bool addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames);
+   bool addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized);
+
+
+   bool updateMethodFromInlinedSiteRecordWithMethodByNameRecord(TR_OpaqueMethodBlock *method, int32_t inlinedSiteIndex, TR_OpaqueClassBlock *beholder);
+
+
+   bool validateRootClassRecord(uint16_t classID);
+   bool validateClassByNameRecord(uint16_t classID, uint16_t beholderID, J9ROMClass *romClass, char primitiveType);
+   bool validateProfiledClassRecord(uint16_t classID, char primitiveType, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated);
+   bool validateClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
+   bool validateDefiningClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex, bool isStatic);
+   bool validateStaticClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
+   bool validateClassFromMethodRecord(uint16_t classID, uint16_t methodID);
+   bool validateComponentClassFromArrayClassRecord(uint16_t componentClassID, uint16_t arrayClassID);
+   bool validateArrayClassFromComponentClassRecord(uint16_t arrayClassID, uint16_t componentClassID);
+   bool validateSuperClassFromClassRecord(uint16_t superClassID, uint16_t childClassID);
+   bool validateClassInstanceOfClassRecord(uint16_t classOneID, uint16_t classTwoID, bool objectTypeIsFixed, bool castTypeIsFixed, bool wasInstanceOf);
+   bool validateSystemClassByNameRecord(uint16_t systemClassID, J9ROMClass *romClass);
+   bool validateClassFromITableIndexCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
+   bool validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
+   bool validateClassClassRecord(uint16_t classClassID, uint16_t objectClassID);
+   bool validateConcreteSubClassFromClassRecord(uint16_t childClassID, uint16_t superClassID);
+   bool validateArrayClassFromJavaVM(uint16_t arrayClassID, int32_t arrayClassIndex);
+
+   bool validateClassChainRecord(uint16_t classID, void *classChain);
+   bool validateRomClassRecord(uint16_t classID, J9ROMClass *romClass);
+   bool validatePrimitiveClassRecord(uint16_t classID, char primitiveType);
+
+   bool validateMethodFromInlinedSiteRecord(uint16_t methodID, TR_OpaqueMethodBlock *method);
+   bool validateMethodByNameRecord(uint16_t methodID, uint16_t beholderID, J9ROMClass *romClass, J9ROMMethod *romMethod);
+   bool validateMethodFromClassRecord(uint16_t methodID, uint16_t beholderID, uint32_t index);
+   bool validateStaticMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
+   bool validateSpecialMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
+   bool validateVirtualMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
+   bool validateVirtualMethodFromOffsetRecord(uint16_t methodID, uint16_t beholderID, int32_t virtualCallOffset, bool ignoreRtResolve);
+   bool validateInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, uint16_t lookupID, int32_t cpIndex);
+   bool validateImproperInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
+   bool validateMethodFromClassAndSignatureRecord(uint16_t methodID, uint16_t methodClassID, uint16_t beholderID, J9ROMMethod *romMethod);
+   bool validateMethodFromSingleImplementerRecord(uint16_t methodID,
+                                                  uint16_t thisClassID,
+                                                  int32_t cpIndexOrVftSlot,
+                                                  uint16_t callerMethodID,
+                                                  TR_YesNoMaybe useGetResolvedInterfaceMethod);
+   bool validateMethodFromSingleInterfaceImplementerRecord(uint16_t methodID,
+                                                uint16_t thisClassID,
+                                                int32_t cpIndex,
+                                                uint16_t callerMethodID);
+   bool validateMethodFromSingleAbstractImplementerRecord(uint16_t methodID,
+                                               uint16_t thisClassID,
+                                               int32_t vftSlot,
+                                               uint16_t callerMethodID);
+
+   bool validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames);
+   bool validateClassInfoIsInitializedRecord(uint16_t classID, bool wasInitialized);
+
+
+   static TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t & numDims);
+
+   typedef TR::list<SymbolValidationRecord *, TR::Region&> SymbolValidationRecordList;
+
+   SymbolValidationRecordList& getValidationRecordList() { return _symbolValidationRecords; }
+
+private:
+
+   static const uint16_t NO_ID = 0;
+   static const uint16_t FIRST_ID = 1;
+
+   uint16_t getNewSymbolID()
+      {
+      if (_symbolID == 0xFFFF)
+         {
+         TR_ASSERT_FATAL(false, "_symbolID overflow\n");
+         }
+         return _symbolID++;
+      }
+
+   void storeRecord(void *symbol, SymbolValidationRecord *record);
+   bool storeClassRecord(TR_OpaqueClassBlock *clazz,
+                         ClassValidationRecord *record,
+                         int32_t arrayDimsToValidate,
+                         bool isStatic,
+                         bool storeCurrentRecord);
+   bool storeValidationRecordIfNecessary(void *symbol, SymbolValidationRecord *record, int32_t arrayDimsToValidate = 0, bool isStatic = false);
+   void *storeClassChain(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz, bool isStatic);
+
+   bool validateSymbol(uint16_t idToBeValidated, void *validSymbol);
+
+
+   /* Monotonically increasing IDs */
+   uint16_t _symbolID;
+
+   TR::Region &_region;
+
+   /* List of validation records to be written to the AOT buffer */
+   SymbolValidationRecordList _symbolValidationRecords;
+
+   typedef TR::typed_allocator<std::pair<void* const, uint16_t>, TR::Region&> SymbolToIdAllocator;
+   typedef std::less<void*> SymbolToIdComparator;
+   typedef std::map<void*, uint16_t, SymbolToIdComparator, SymbolToIdAllocator> SymbolToIdMap;
+
+   typedef TR::typed_allocator<std::pair<uint16_t const, void*>, TR::Region&> IdToSymbolAllocator;
+   typedef std::less<uint16_t> IdToSymbolComparator;
+   typedef std::map<uint16_t, void*, IdToSymbolComparator, IdToSymbolAllocator> IdToSymbolMap;
+
+   typedef TR::typed_allocator<void*, TR::Region&> SeenSymbolsAlloc;
+   typedef std::less<void*> SeenSymbolsComparator;
+   typedef std::set<void*, SeenSymbolsComparator, SeenSymbolsAlloc> SeenSymbolsSet;
+
+   /* Used for AOT Compile */
+   SymbolToIdMap _symbolToIdMap;
+
+   /* Used for AOT Load */
+   IdToSymbolMap _idToSymbolsMap;
+
+   SeenSymbolsSet _seenSymbolsSet;
+   };
+
+}
+
+#endif //SYMBOL_VALIDATION_MANAGER_INCL

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1164,7 +1164,7 @@ class SymbolValidationManager
 public:
    TR_ALLOC(TR_MemoryBase::SymbolValidationManager);
 
-   SymbolValidationManager(TR::Region &region);
+   SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee);
 
    void* getSymbolFromID(uint16_t id);
    uint16_t getIDFromSymbol(void *symbol);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -36,6 +36,9 @@
 #include "env/VMJ9.h"
 #include "runtime/Runtime.hpp"
 
+#define SVM_ASSERT(manager, condition, format, ...) \
+   do { (manager->inHeuristicRegion() && condition) ? (void)0 : TR::fatal_assertion(__FILE__, __LINE__, #condition, format, ##__VA_ARGS__); } while(0)
+
 namespace TR {
 
 struct SymbolValidationRecord
@@ -1277,6 +1280,10 @@ public:
 
    SymbolValidationRecordList& getValidationRecordList() { return _symbolValidationRecords; }
 
+   void enterHeuristicRegion() { _heuristicRegion++; }
+   void exitHeuristicRegion() { _heuristicRegion--; }
+   bool inHeuristicRegion() { return (_heuristicRegion > 0); }
+
 private:
 
    static const uint16_t NO_ID = 0;
@@ -1305,6 +1312,8 @@ private:
 
    /* Monotonically increasing IDs */
    uint16_t _symbolID;
+
+   uint32_t _heuristicRegion;
 
    TR::Region &_region;
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1221,8 +1221,6 @@ public:
    bool addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized);
 
 
-   bool updateMethodFromInlinedSiteRecordWithMethodByNameRecord(TR_OpaqueMethodBlock *method, int32_t inlinedSiteIndex, TR_OpaqueClassBlock *beholder);
-
 
    bool validateRootClassRecord(uint16_t classID);
    bool validateClassByNameRecord(uint16_t classID, uint16_t beholderID, J9ROMClass *romClass, char primitiveType);
@@ -1297,14 +1295,7 @@ private:
    static const uint16_t NO_ID = 0;
    static const uint16_t FIRST_ID = 1;
 
-   uint16_t getNewSymbolID()
-      {
-      if (_symbolID == 0xFFFF)
-         {
-         TR_ASSERT_FATAL(false, "_symbolID overflow\n");
-         }
-         return _symbolID++;
-      }
+   uint16_t getNewSymbolID();
 
    void storeRecord(void *symbol, SymbolValidationRecord *record);
    bool storeClassRecord(TR_OpaqueClassBlock *clazz,

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1284,6 +1284,14 @@ public:
    void exitHeuristicRegion() { _heuristicRegion--; }
    bool inHeuristicRegion() { return (_heuristicRegion > 0); }
 
+   bool verifySymbolHasBeenValidated(void *symbol)
+      {
+      if (inHeuristicRegion())
+         return true;
+      else
+         return (getIDFromSymbol(symbol) != 0);
+      }
+
 private:
 
    static const uint16_t NO_ID = 0;

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -206,7 +206,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
          }
       else
          {
-         TR_ASSERT(0, "Can't handle resolved IPICs here yet!");
+         TR_ASSERT_FATAL(0, "Can't handle resolved IPICs here yet!");
          }
 
       // Reserve space for resolved interface class and itable offset.
@@ -319,7 +319,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
          }
       else
          {
-         TR_ASSERT(0, "Can't handle resolved VPICs here yet!");
+         TR_ASSERT_FATAL(0, "Can't handle resolved VPICs here yet!");
          }
 
       _dispatchSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86populateVPicVTableDispatch, false, false, false);
@@ -435,6 +435,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86PicDataSnippet *snippet)
    if (pOutFile == NULL)
       return;
 
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(_cg->fe());
+
    uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
    // Account for VPic data appearing before the actual entry label.
@@ -480,7 +482,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86PicDataSnippet *snippet)
       printLabelInstruction(pOutFile, "jmp", snippet->getDoneLabel());
       bufferPos += 5;
 
-      if (methodSymRef->isUnresolved())
+      if (methodSymRef->isUnresolved() || fej9->forceUnresolvedDispatch())
          {
          const char *op = (sizeof(uintptrj_t) == 4) ? "DD" : "DQ";
 
@@ -851,7 +853,11 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
          }
       }
 
-   if (methodSymRef->isUnresolved() || fej9->forceUnresolvedDispatch())
+   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      forceUnresolvedDispatch = false;
+
+   if (methodSymRef->isUnresolved() || forceUnresolvedDispatch)
       {
       // Unresolved interpreted dispatch snippet shape:
       //
@@ -875,7 +881,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       // (4)   dd    cpIndex
       //
 
-      TR_ASSERT(!isJitInduceOSRCall || !fej9->forceUnresolvedDispatch(), "calling jitInduceOSR is not supported yet under AOT\n");
+      TR_ASSERT(!isJitInduceOSRCall || !forceUnresolvedDispatch, "calling jitInduceOSR is not supported yet under AOT\n");
       cursor = alignCursorForCodePatching(cursor, TR::Compiler->target.is64Bit());
 
       if (comp->getOption(TR_EnableHCR))
@@ -888,7 +894,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
          getSnippetLabel()->setCodeLocation(cursor);
          }
 
-      TR_ASSERT((methodSymbol->isStatic() || methodSymbol->isSpecial() || fej9->forceUnresolvedDispatch()), "Unexpected unresolved dispatch");
+      TR_ASSERT((methodSymbol->isStatic() || methodSymbol->isSpecial() || forceUnresolvedDispatch), "Unexpected unresolved dispatch");
 
       // CALL interpreterUnresolved{Static|Special}Glue
       //
@@ -1011,6 +1017,16 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
          *(intptrj_t *)cursor = ramMethod;
 
+         if (comp->getOption(TR_UseSymbolValidationManager))
+            {
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                  (uint8_t *)ramMethod,
+                                                                  (uint8_t *)TR::SymbolType::typeMethod,
+                                                                  TR_SymbolFromManager,
+                                                                  cg()),  __FILE__, __LINE__, getNode());
+            }
+
+
          // HCR in TR::X86CallSnippet::emitSnippetBody register the method address
          //
          if (comp->getOption(TR_EnableHCR))
@@ -1064,7 +1080,12 @@ uint32_t TR::X86CallSnippet::getLength(int32_t estimatedSnippetStart)
       length += codeSize;
       }
 
-   if (methodSymRef->isUnresolved() || fej9->forceUnresolvedDispatch())
+   TR::Compilation *comp = cg()->comp();
+   bool forceUnresolvedDispatch = fej9->forceUnresolvedDispatch();
+   if (comp->getOption(TR_UseSymbolValidationManager))
+      forceUnresolvedDispatch = false;
+
+   if (methodSymRef->isUnresolved() || forceUnresolvedDispatch)
       {
       // +7 accounts for maximum length alignment padding.
       //

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -455,7 +455,6 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
             {
             TR_OpaqueClassBlock *classOfMethod = (TR_OpaqueClassBlock *)recordInfo->data5;
             uintptrj_t classID = (uintptrj_t)symValManager->getIDFromSymbol(static_cast<void *>(classOfMethod));
-            TR_ASSERT_FATAL(classID, "classID should exist!\n");
             *(uintptrj_t *)cursor = classID;
             }
          else
@@ -490,7 +489,6 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
             {
             TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock *)recordInfo->data5;
             uintptrj_t classID = (uintptrj_t)symValManager->getIDFromSymbol(static_cast<void *>(clazz));
-            TR_ASSERT_FATAL(classID, "classID should exist!\n");
             *(uintptrj_t *)cursor = classID;
             }
          else
@@ -639,8 +637,6 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          else
             {
             void *classChainForClassToValidate = record->_classChain;
-
-            TR_ASSERT_FATAL(classChainForClassToValidate, "Class Chain shouldn't be NULL, classToValidate=%p\n", classToValidate);
 
             //store the classchain's offset for the classloader for the class
             void *loaderForClazzToValidate = fej9->getClassLoader(classToValidate);
@@ -1239,8 +1235,6 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          uint16_t symbolID = comp->getSymbolValidationManager()->getIDFromSymbol(static_cast<void *>(symbol));
 
          uint16_t symbolType = (uint16_t)(uintptrj_t)relocation->getTargetAddress2();
-
-         TR_ASSERT_FATAL(symbolID, "symbolID should exist!\n");
 
          cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -3630,7 +3630,9 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node* node, TR_
    {
    TR_ASSERT(clazz && TR::Compiler->cls.isInterfaceClass(cg->comp(), clazz), "Not a compile-time known Interface.");
 
-   auto use64BitClasses = TR::Compiler->target.is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
+   auto use64BitClasses = TR::Compiler->target.is64Bit() &&
+                             (!TR::Compiler->om.generateCompressedObjectHeaders() ||
+                              (cg->comp()->compileRelocatableCode() && cg->comp()->getOption(TR_UseSymbolValidationManager)));
 
    auto j9class = cg->allocateRegister();
    auto tmp     = use64BitClasses ? cg->allocateRegister() : NULL;
@@ -3679,6 +3681,11 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node* node, TR_
          guessClass = (uintptrj_t)guessClassArray[i];
          }
       }
+
+   if (cg->comp()->compileRelocatableCode() && cg->comp()->getOption(TR_UseSymbolValidationManager))
+      if (!cg->comp()->getSymbolValidationManager()->addProfiledClassRecord((TR_OpaqueClassBlock *)guessClass))
+         guessClass = NULL;
+
    // Call site cache
    auto cache = sizeof(J9Class*) == 4 ? cg->create4ByteData(node, (uint32_t)guessClass) : cg->create8ByteData(node, (uint64_t)guessClass);
    cache->setClassAddress(true);
@@ -3767,7 +3774,9 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node* node, TR_
 inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node* node, TR_OpaqueClassBlock* clazz, TR::CodeGenerator* cg, bool isCheckCast)
    {
    auto fej9 = (TR_J9VMBase*)(cg->fe());
-   auto use64BitClasses = TR::Compiler->target.is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
+   auto use64BitClasses = TR::Compiler->target.is64Bit() &&
+                             (!TR::Compiler->om.generateCompressedObjectHeaders() ||
+                              (cg->comp()->compileRelocatableCode() && cg->comp()->getOption(TR_UseSymbolValidationManager)));
 
    auto clazzData = use64BitClasses ? cg->create8ByteData(node, (uint64_t)(uintptr_t)clazz) : NULL;
    if (clazzData)
@@ -3928,7 +3937,7 @@ TR::Register *J9::X86::TreeEvaluator::checkcastinstanceofEvaluator(TR::Node *nod
    auto clazz = TR::TreeEvaluator::getCastClassAddress(node->getChild(1));
    if (clazz &&
        !TR::Compiler->cls.isClassArray(cg->comp(), clazz) && // not yet optimized
-       !cg->comp()->compileRelocatableCode() && // TODO subsequent PR will support AOT
+       (!cg->comp()->compileRelocatableCode() || cg->comp()->getOption(TR_UseSymbolValidationManager)) &&
        !cg->comp()->getOption(TR_DisableInlineCheckCast)  &&
        !cg->comp()->getOption(TR_DisableInlineInstanceOf))
       {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -7749,7 +7749,7 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
 
       if (comp->getOption(TR_UseSymbolValidationManager))
          {
-         TR_ASSERT_FATAL(classToValidate, "classToValidate should not be NULL, clazz=%p\n", clazz);
+         TR_ASSERT(classToValidate, "classToValidate should not be NULL, clazz=%p\n", clazz);
          recordInfo->data5 = (uintptr_t)classToValidate;
          }
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -7707,12 +7707,15 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
                                                         node->getOpCodeValue() == TR::anewarray) )
       {
       startInstr = startInstr->getNext();
+      TR_OpaqueClassBlock *classToValidate = clazz;
+
       TR_RelocationRecordInformation *recordInfo =
          (TR_RelocationRecordInformation *) comp->trMemory()->allocateMemory(sizeof(TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = allocationSize;
       recordInfo->data2 = node->getInlinedSiteIndex();
       recordInfo->data3 = (uintptr_t) failLabel;
       recordInfo->data4 = (uintptr_t) startInstr;
+
       TR::SymbolReference * classSymRef;
       TR_ExternalRelocationTargetKind reloKind;
 
@@ -7725,6 +7728,15 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
          {
          classSymRef = node->getSecondChild()->getSymbolReference();
          reloKind = TR_VerifyRefArrayForAlloc;
+
+         if (comp->getOption(TR_UseSymbolValidationManager))
+            classToValidate = comp->fej9()->getComponentClassFromArrayClass(classToValidate);
+         }
+
+      if (comp->getOption(TR_UseSymbolValidationManager))
+         {
+         TR_ASSERT_FATAL(classToValidate, "classToValidate should not be NULL, clazz=%p\n", clazz);
+         recordInfo->data5 = (uintptr_t)classToValidate;
          }
 
       cg->addExternalRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(startInstr,

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1329,7 +1329,8 @@ void TR::X86CallSite::setupVirtualGuardInfo()
 
             TR::SymbolReference *methodSymRef = getSymbolReference();
             TR_PersistentCHTable * chTable = comp()->getPersistentInfo()->getPersistentCHTable();
-            if (thisClass && TR::Compiler->cls.isAbstractClass(comp(), thisClass))
+            /* Devirtualization is not currently supported for AOT compilations */
+            if (thisClass && TR::Compiler->cls.isAbstractClass(comp(), thisClass) && !comp()->compileRelocatableCode())
                {
                TR_ResolvedMethod * method = chTable->findSingleAbstractImplementer(thisClass, methodSymRef->getOffset(), methodSymRef->getOwningMethod(comp()), comp());
                if (method &&

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -2026,7 +2026,8 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
                      }
 
                   TR_PersistentCHTable * chTable = comp()->getPersistentInfo()->getPersistentCHTable();
-                  if (thisClass && TR::Compiler->cls.isAbstractClass(comp(), thisClass))
+                  /* Devirtualization is not currently supported for AOT compilations */
+                  if (thisClass && TR::Compiler->cls.isAbstractClass(comp(), thisClass) && !comp()->compileRelocatableCode())
                      {
                      TR_ResolvedMethod * method = chTable->findSingleAbstractImplementer(thisClass, methodSymRef->getOffset(),
                                                                 methodSymRef->getOwningMethod(comp()), comp());


### PR DESCRIPTION
Depends on https://github.com/eclipse/omr/pull/2978

This PR introduces changes in OpenJ9 required to enable optimizations that are currently implicitly disabled for relocatable compilations. It does so by introducing the Symbol Validation Manager infrastructure. The fundamental idea for the Symbol Validation Manager was thought up by @jdmpapin ; the current implementation is a collaboration between myself and @jdmpapin .

Issue tracking all the PRs: #2921