### PR TITLE
Add method waitForReferenceProcessing() in Reference.java

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -88,6 +88,12 @@ public abstract class Reference<T> extends Object {
 			  }
 			});
 	}
+	
+	/* The method waitForReferenceProcessing() is not used directly, just adapt for openjdk regression tests for TLS 1.3 */
+    private static boolean waitForReferenceProcessing() throws InterruptedException {
+    		return waitForReferenceProcessingImpl();
+    }
+
 	/*[ELSE]
 	static {
 		SharedSecrets.setJavaLangRefAccess(new JavaLangRefAccess() {


### PR DESCRIPTION
        - Add private static method waitForReferenceProcessing() in
	java.lang.ref.Reference.java to adapt for openjdk TLS 1.3 
	regression tests.
	
Fixes: eclipse/openj9#2909

Signed-off-by: Lin Hu <linhu@ca.ibm.com>