### PR TITLE
Support 128-bit register values in javacore files

### DIFF
--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/platform/PlatformSectionParser.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/javacore/parser/j9/section/platform/PlatformSectionParser.java
@@ -22,6 +22,7 @@
  *******************************************************************************/
 package com.ibm.dtfj.javacore.parser.j9.section.platform;
 
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.LinkedHashMap;
@@ -173,23 +174,29 @@ public class PlatformSectionParser extends SectionParser implements IPlatformTyp
 	 * @throws ParserException
 	 */
 	private void registerInfo() throws ParserException {
-		IAttributeValueMap results;
-		
 		// T_1XHREGISTERS line if present indicates registers
 		if (processTagLineOptional(T_1XHREGISTERS) != null) {
-			Map m = new LinkedHashMap();
-			while((results = processTagLineOptional(T_2XHREGISTER)) != null) {
+			Map<String, Number> m = new LinkedHashMap<>();
+			IAttributeValueMap results;
+			while ((results = processTagLineOptional(T_2XHREGISTER)) != null) {
 				String name = results.getTokenValue(PL_REGISTER_NAME);
-				String val = results.getTokenValue(PL_REGISTER_VALUE);
-				Number n;
-				if (val == null) {
-					n = null;
-				} else if (val.startsWith("0x") && val.length() <= 2+4) {
-					n = Short.valueOf((short)results.getIntValue(PL_REGISTER_VALUE));
-				} else if (val.startsWith("0x") && val.length() <= 2+8) {
-					n = Integer.valueOf((int)results.getLongValue(PL_REGISTER_VALUE));
-				} else {
-					n = Long.valueOf(results.getLongValue(PL_REGISTER_VALUE));
+				String value = results.getTokenValue(PL_REGISTER_VALUE);
+				Number n = null;
+				if (value != null) {
+					// normally there's no '0x' prefix, but remove it if present
+					String digits = value.regionMatches(true, 0, "0x", 0, 2) ? value.substring(2) : value;
+					// register values are always in hex
+					BigInteger bigN = new BigInteger(digits, 16);
+					int bits = bigN.bitLength();
+					if (bits <= 16) {
+						n = Short.valueOf((short) bigN.intValue());
+					} else if (bits <= 32) {
+						n = Integer.valueOf(bigN.intValue());
+					} else if (bits <= 64) {
+						n = Long.valueOf(bigN.longValue());
+					} else {
+						n = bigN;
+					}
 				}
 				m.put(name, n);
 			}


### PR DESCRIPTION
On z/OS, vr0 through vr31 are 128-bit registers. A javacore file created for a GPF event expressed their values as 32 digit hexadecimal strings:
```
2XHREGISTER      vr0: 40100000000000000000000000000000
```
With this change, those large registers can be properly parsed.