### PR TITLE
OpenJ9 fixes for OSX support [Part 2]

### DIFF
--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -252,18 +252,22 @@ void mapLibraryToPlatformName(const char *inPath, char *outPath) {
 char *getPlatformFileEncoding(JNIEnv * env, char *codepageProp, int propSize, int encodingType)
 {
 #if defined(J9ZTPF)
-    return "ISO8859_1";
+	return "ISO8859_1";
 #endif /* defined(J9ZTPF) */
-	PORT_ACCESS_FROM_ENV(env);
-	char *codepage;
-	int i, nameIndex;
+	char *codepage = NULL;
+	int i = 0;
+	int nameIndex = 0;
 #if defined(LINUX)
-    IDATA result;
-    char langProp[24], *ctype;
-#endif
+	IDATA result = 0;
+	char langProp[24] = {0};
+	char *ctype = NULL;
+	PORT_ACCESS_FROM_ENV(env);
+#endif /* defined(LINUX) */
 
 	/* Called with codepageProp == NULL to initialize the locale */
-	if (!codepageProp) return NULL;
+	if (NULL == codepageProp) {
+		return NULL;
+	}
 
 #ifdef LINUX
 	/*[PR 104520] Return EUC_JP when LC_CTYPE is not set, and the LANG environment variable is "ja" */

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -110,9 +110,9 @@ static void abortHandler (int sig);
 static void initRasDumpGlobalStorage(J9JavaVM *vm);
 static void freeRasDumpGlobalStorage(J9JavaVM *vm);
 static void hookVmInitialized PROTOTYPE((J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData));
-#ifdef LINUX
+#if defined(LINUX)
 static void appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName );
-#endif
+#endif /* defined(LINUX) */
 #ifdef J9ZOS390
 static IDATA processZOSDumpOptions(J9JavaVM *vm, J9RASdumpOption* agentOpts, int optIndex);
 static void triggerAbend(void);
@@ -1268,7 +1268,7 @@ initSystemInfo(J9JavaVM *vm)
 		}
 	}
 
-#ifdef LINUX
+#if defined(LINUX)
 	/* On Linux, store the startup value of /proc/sys/kernel/sched_compat_yield if it's set */
 	{
 		char schedCompatYieldValue = j9util_sched_compat_yield_value(vm);
@@ -1287,7 +1287,7 @@ initSystemInfo(J9JavaVM *vm)
 	}
 	appendSystemInfoFromFile(vm, J9RAS_SYSTEMINFO_CORE_PATTERN, J9RAS_CORE_PATTERN_FILE);
 	appendSystemInfoFromFile(vm, J9RAS_SYSTEMINFO_CORE_USES_PID, J9RAS_CORE_USES_PID_FILE);
-#endif
+#endif /* defined(LINUX) */
 }
 
 /**
@@ -1325,7 +1325,7 @@ initDumpDirectory(J9JavaVM *vm)
 	return retVal;
 }
 
-
+#if defined(LINUX)
 /* Adds a J9RASSystemInfo to the end of the system info list using the key
  * specified as the key and the data from the specified file in /proc if
  * it exists.
@@ -1382,7 +1382,7 @@ appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName )
 		j9file_close(fd);
 	}
 }
-
+#endif /* defined(LINUX) */
 
 IDATA
 J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventMethodEntryGrow/emeng001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/eventMethodEntryGrow/emeng001.c
@@ -96,7 +96,7 @@ cbMethodEntry(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread, jmethodID me
 			return;
 		}
 	}
-	(*jvmti_env)->Deallocate(jvmti_env, name_ptr);
+	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)name_ptr);
 
 	return;
 }

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/followReferences/fr003.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/followReferences/fr003.c
@@ -214,7 +214,7 @@ testFollowReferences_heapRefCallback(jvmtiHeapReferenceKind refKind,
 static void *
 getArrayElements(JNIEnv * jni_env, jvmtiPrimitiveType primitiveType, jint primitiveArraySize, jobject array)
 {
-	void * arrayElements;
+	void *arrayElements = NULL;
 
 	switch (primitiveType) {
 		case JVMTI_PRIMITIVE_TYPE_BOOLEAN:
@@ -240,6 +240,9 @@ getArrayElements(JNIEnv * jni_env, jvmtiPrimitiveType primitiveType, jint primit
 	    	break;
 	    case JVMTI_PRIMITIVE_TYPE_DOUBLE:
 	    	arrayElements = (*jni_env)->GetDoubleArrayElements(jni_env, array, NULL);
+	    	break;
+	    default:
+	    	error(_agentEnv, JVMTI_ERROR_INTERNAL, "Unknown array primitive value type [%d]", primitiveType);
 	    	break;
 	}
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/forceEarlyReturn/fer001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/forceEarlyReturn/fer001.c
@@ -85,10 +85,10 @@ testForceEarlyReturn_methodEntry(jvmtiEnv * jvmti_env, JNIEnv * jni_env, jthread
 {
 	jvmtiError err;
 	testForceEarlyReturn_testTrigger *trigger;
-	unsigned char * methName = NULL;
-	unsigned char * threadName = NULL;
-	unsigned char * suspThreadName = NULL;
-	agentEnv * env = _agentEnv;
+	char *methName = NULL;
+	char *threadName = NULL;
+	char *suspThreadName = NULL;
+	agentEnv *env = _agentEnv;
 
 	methName = testForceEarlyReturn_getMethodName(env, method);
 
@@ -288,7 +288,7 @@ testForceEarlyReturn_waitForTestThread(agentEnv * env, jthread thread, jmethodID
 			    !strcmp(thrName, "Thread-Runner")) {
 				unsigned char * suspendedThreadName;
 				*suspendedThread = threads[i];
-				suspendedThreadName = getThreadName(env, thread, *suspendedThread),
+				suspendedThreadName = (unsigned char *)getThreadName(env, thread, *suspendedThread),
 				tprintf(env, 300, 
 					  "\t%-10s state 0x%x thr 0x%x susThr 0x%p i%d is SUSPENDED. returning\n", 
 					  suspendedThreadName, state, thread, threads[i], i);
@@ -375,10 +375,10 @@ testForceEarlyReturn_getMethodName(agentEnv * env, jmethodID method)
 		goto done;                
 	}
 
-	strcpy(name, declaringClassName);
-	strcat(name, ".");
-	strcat(name, methodName);
-	strcat(name, methodSig);
+	strcpy((char *)name, declaringClassName);
+	strcat((char *)name, ".");
+	strcat((char *)name, methodName);
+	strcat((char *)name, methodSig);
 
 done:
 
@@ -392,5 +392,5 @@ done:
 		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *) declaringClassName); 
  
 
-	return name;
+	return (char *)name;
 }

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getAllStackTracesExtended/gaste001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getAllStackTracesExtended/gaste001.c
@@ -167,7 +167,7 @@ static jint testGetAllStackTracesExtended(JavaVM * vm, jvmtiEnv * jvmti_env, jin
 					++num_jitted;       
 			}
         }                     
-        (*jvmti_env)->Deallocate(jvmti_env, (char *)psiExt);                   
+        (*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)psiExt);
 	  
 		if ( high && (num_jitted == 0) ) {
 			rc = JNI_ERR; 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getClassFields/gcf001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getClassFields/gcf001.c
@@ -93,12 +93,12 @@ Java_com_ibm_jvmti_tests_getClassFields_gcf001_checkClassFields(JNIEnv *jni_env,
 			return JNI_FALSE;
 		}
 
-		(*jvmti_env)->Deallocate(jvmti_env, fieldName);
-		(*jvmti_env)->Deallocate(jvmti_env, fieldSignature);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)fieldName);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)fieldSignature);
 		(*jni_env)->ReleaseStringUTFChars(jni_env, expectedNameString, expectedName);
 		(*jni_env)->ReleaseStringUTFChars(jni_env, expectedSignatureString, expectedSignature);
 	}
-	(*jvmti_env)->Deallocate(jvmti_env, (char *)fields);
+	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)fields);
 
 	return JNI_TRUE;
 }

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getMemoryCategories/gmc001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getMemoryCategories/gmc001.c
@@ -53,14 +53,14 @@ gmc001(agentEnv * agent_env, char * args)
 			fprintf(stderr,"gmc001: setting getMemoryCategories extension to %p\n", getMemoryCategories);
 		}
 
-		err = (*jvmti_env)->Deallocate(jvmti_env, extensions[i].id);
+		err = (*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)extensions[i].id);
 
 		if (err != JVMTI_ERROR_NONE) {
 			error(env, JVMTI_ERROR_NOT_FOUND, "gmc001:Couldn't Deallocate extensions[%d].id\n", i);
 			rc = JNI_ERR;
 		}
 
-		err = (*jvmti_env)->Deallocate(jvmti_env, extensions[i].short_description);
+		err = (*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)extensions[i].short_description);
 
 		if (err != JVMTI_ERROR_NONE) {
 			error(env, JVMTI_ERROR_NOT_FOUND, "gmc001:Couldn't Deallocate extensions[%d].short_description\n", i);
@@ -68,7 +68,7 @@ gmc001(agentEnv * agent_env, char * args)
 		}
 
 		for (j = 0; j < extensions[i].param_count; j++) {
-			err = (*jvmti_env)->Deallocate(jvmti_env, extensions[i].params[j].name);
+			err = (*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)extensions[i].params[j].name);
 
 			if (err != JVMTI_ERROR_NONE) {
 				error(env, JVMTI_ERROR_NOT_FOUND, "gmc001:Couldn't Deallocate extensions[%d].params[%d].name\n", i, j);

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getOrSetLocal/gosl001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getOrSetLocal/gosl001.c
@@ -138,8 +138,8 @@ digForStackDepth(jthread thread, char *methodName, char * methodSignature)
 			depth = i;
     		i = count;
     	}
-    	(*jvmti_env)->Deallocate(jvmti_env, name);
-    	(*jvmti_env)->Deallocate(jvmti_env, sig);
+    	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)name);
+    	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)sig);
     }
 
     return depth;
@@ -169,9 +169,9 @@ getVariableSlotNumber(JNIEnv *jni_env, jclass clazz, char * varName, char * meth
 			slotIndex = table[i].slot;
 			/*printf("got slot at i=%d, slot=%d\n", i, slotIndex);*/
 		}
-		(*jvmti_env)->Deallocate(jvmti_env, table[i].name);
-		(*jvmti_env)->Deallocate(jvmti_env, table[i].signature);
-		(*jvmti_env)->Deallocate(jvmti_env, table[i].generic_signature);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)table[i].name);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)table[i].signature);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)table[i].generic_signature);
 	}
 
 	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *) table);

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getThreadGroupChildren/gtgc002.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getThreadGroupChildren/gtgc002.c
@@ -56,7 +56,7 @@ getChildInfo(JNIEnv *jni_env, jthreadGroup *group)
 	}
 
 	if (JNI_OK == (*jvmti_env)->GetThreadGroupInfo(jvmti_env, *group, &groupInfo)) {
-		(*jvmti_env)->Deallocate(jvmti_env, groupInfo.name);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)groupInfo.name);
 	}
 
 	if (JNI_OK == (*jvmti_env)->GetThreadGroupChildren(jvmti_env, *group, &thread_cnt, &threads_p, &group_cnt, &groups_p)) {
@@ -68,7 +68,7 @@ getChildInfo(JNIEnv *jni_env, jthreadGroup *group)
 
 		for (i = 1; i <= thread_cnt; i++) {
 			if (JNI_OK == (*jvmti_env)->GetThreadInfo(jvmti_env, *thread_ptr, &threadInfo)) {
-				(*jvmti_env)->Deallocate(jvmti_env, threadInfo.name);
+				(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)threadInfo.name);
 			}
 		}
 
@@ -76,8 +76,8 @@ getChildInfo(JNIEnv *jni_env, jthreadGroup *group)
 			getChildInfo(jni_env, group_ptr);
 			group_ptr++;
 		}
-		(*jvmti_env)->Deallocate(jvmti_env, (char *) groups_p);
-		(*jvmti_env)->Deallocate(jvmti_env, (char *) threads_p);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)groups_p);
+		(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)threads_p);
 
 	}
 }

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getThreadListStackTracesExtended/gtlste001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getThreadListStackTracesExtended/gtlste001.c
@@ -179,7 +179,7 @@ static jint testGetThreadListStackTracesExtended(JavaVM * vm, jvmtiEnv * jvmti_e
 					++num_jitted;       
 			}
         }                     
-        (*jvmti_env)->Deallocate(jvmti_env, (char *)psiExt);
+        (*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)psiExt);
 		
 		if ( high && (num_jitted == 0) ) {
 			rc = JNI_ERR; 
@@ -188,7 +188,7 @@ static jint testGetThreadListStackTracesExtended(JavaVM * vm, jvmtiEnv * jvmti_e
 			      "getThreadListTracesExtended: Error when high iteration count");
 		}		   
 	}
-	(*jvmti_env)->Deallocate(jvmti_env, (char *)thrds);
+	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char *)thrds);
 	return(rc);
 }
 

--- a/runtime/tests/shared/CompositeCacheTest.cpp
+++ b/runtime/tests/shared/CompositeCacheTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -248,20 +248,20 @@ CompositeCacheTest::allocateAndStats(J9JavaVM* vm, IDATA testCacheSize, SH_Compo
 	cc1->enterWriteMutex(vm->mainThread, false, "allocateAndStats");
 
 	/* Check all is 0'd */
-	if (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1a, cacheBase))) goto _done;
 
 	itemPtr->dataLen = 64;
 	
 	address = cc1->allocateWithSegment(vm->mainThread, itemPtr, 0, &segBuf);
-	if (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, 0, 0, 0, 0, 0, cc1a, cacheBase))) goto _done;
 
 	/* Stats should not be updated until update is committed */
 	cc1->commitUpdate(vm->mainThread, false);
 	runningTotal += itemPtr->dataLen;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1a, cacheBase))) goto _done;
 
 	if (cc1->isAddressInROMClassSegment(address)) {
 		j9tty_printf(PORTLIB, "Address %p should not be in romclass segment\n", address);
@@ -275,12 +275,12 @@ CompositeCacheTest::allocateAndStats(J9JavaVM* vm, IDATA testCacheSize, SH_Compo
 	}
 
 	address = cc1->allocateWithSegment(vm->mainThread, itemPtr, 256, &segBuf);
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 0, 0, 0, 1, cc1a, cacheBase))) goto _done;
 	cc1->commitUpdate(vm->mainThread, false);
 	runningTotal += itemPtr->dataLen;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1a, cacheBase))) goto _done;
 
 	if (cc1->isAddressInROMClassSegment(address)) {
 		j9tty_printf(PORTLIB, "Address %p should not be in romclass segment\n", address);
@@ -296,12 +296,12 @@ CompositeCacheTest::allocateAndStats(J9JavaVM* vm, IDATA testCacheSize, SH_Compo
 	itemPtr->dataLen = 32;
 	
 	address = cc1->allocateWithSegment(vm->mainThread, itemPtr, 8, &segBuf);
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 256, 0, 0, 2, cc1a, cacheBase))) goto _done;
 	cc1->commitUpdate(vm->mainThread, false);
 	runningTotal += itemPtr->dataLen;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1a, cacheBase))) goto _done;
 	if (cc1->isAddressInROMClassSegment(address)) {
 		j9tty_printf(PORTLIB, "Address %p should not be in romclass segment\n", address);
 		result = 10;
@@ -316,12 +316,12 @@ CompositeCacheTest::allocateAndStats(J9JavaVM* vm, IDATA testCacheSize, SH_Compo
 	itemPtr->dataLen = 100;
 
 	address = cc1->allocateBlock(vm->mainThread, itemPtr, SHC_WORDALIGN, 0);
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 3, cc1a, cacheBase))) goto _done;
 	cc1->commitUpdate(vm->mainThread, false);
 	runningTotal += itemPtr->dataLen;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1a, cacheBase))) goto _done;
 	if (cc1->isAddressInROMClassSegment(address)) {
 		j9tty_printf(PORTLIB, "Address %p should not be in romclass segment\n", address);
 		result = 16;
@@ -331,12 +331,12 @@ CompositeCacheTest::allocateAndStats(J9JavaVM* vm, IDATA testCacheSize, SH_Compo
 	itemPtr->dataLen = 128;
 
 	address = cc1->allocateAOT(vm->mainThread, itemPtr, 96);
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 0, 0, 4, cc1a, cacheBase))) goto _done;
 	cc1->commitUpdate(vm->mainThread, false);
 	runningTotal += itemPtr->dataLen - 96;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 96, 0, 5, cc1, cacheBase)) goto _done;
-	if (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 96, 0, 5, cc1a, cacheBase)) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 96, 0, 5, cc1, cacheBase))) goto _done;
+	if (0 != (result |= localTestStats(vm, testCacheSize, runningTotal, 264, 96, 0, 5, cc1a, cacheBase))) goto _done;
 	if (cc1->isAddressInROMClassSegment(address)) {
 		j9tty_printf(PORTLIB, "Address %p should not be in romclass segment\n", address);
 		result = 17;


### PR DESCRIPTION
The changes below should resolve all OpenJ9 related compile errors on OSX where warnings are interpreted as errors:

**1) Use boolean expressions in if statements**

While compiling OpenJ9 with Clang 9.1.0 on OSX, the following compile
error is encountered:

```
CompositeCacheTest.cpp:251:13: error: using the result of an assignment
as a condition without parentheses [-Werror,-Wparentheses]
        if (result |= localTestStats(
            ~~~~~~~^~~~~~~~~~~~~~~~~~~
CompositeCacheTest.cpp:251:13: note: place parentheses around the
assignment to silence this warning
        if (result |= localTestStats(
                   ^
CompositeCacheTest.cpp:251:13: note: use '!=' to turn this compound
assignment into an inequality comparison
        if (result |= localTestStats(
                   ^~
                   !=
```

The above error happens because the output of an assignment is used in
the if statements instead of a boolean expression. Boolean expressions
are used within the if statements to fix the above error.

**2) dmpsup.c::appendSystemInfoFromFile only defined on LINUX**

While compiling OpenJ9 with Clang 9.1.0 on OSX, the following error is
encountered:

```
dmpsup.c:1340:1: error: unused function 'appendSystemInfoFromFile'
[-Werror,-Wunused-function]
appendSystemInfoFromFile(J9JavaVM *vm, U_32 key, const char *fileName )
^
```

`ifdefs` are consistently used for `appendSystemInfoFromFile` in order to
fix the above error.

**3) Fix 'char \*' to 'unsigned char \*' conversion errors**

While compiling OpenJ9 with Clang 9.1.0 on OSX, the following compile
error is seen:

```
com/ibm/jvmti/tests/eventMethodEntryGrow/emeng001.c:99:38: error:
passing 'char *' to parameter of type 'unsigned char *' converts between
pointers to integer types with different sign [-Werror,-Wpointer-sign]
        (*jvmti_env)->Deallocate(jvmti_env, name_ptr);
                                            ^~~~~~~~
```

Type casting is used to fix the above error. At some places, data type
is changed during field declaration in order to fix the above error.
                                          
**4) Add missing default switch case statement**

While compiling OpenJ9 with Clang 9.1.0 on OSX, the following error is
seen:

```
com/ibm/jvmti/tests/followReferences/fr003.c:219:10: error: enumeration
value 'jvmtiPrimitiveTypeEnsureWideEnum' not handled in switch
[-Werror,-Wswitch]
        switch (primitiveType) {
                ^
com/ibm/jvmti/tests/followReferences/fr003.c:219:10: note: add missing
switch cases
        switch (primitiveType) {
                ^
```

The above error is resolved by adding the default switch case statement.

**5) Remove unused privatePortLibrary**

While compiling OpenJ9 with Clang 9.1.0 on OSX, the following error is
seen:

```
../unix/syshelp.c:257:2: error: unused variable 'privatePortLibrary'
[-Werror,-Wunused-variable]
        PORT_ACCESS_FROM_ENV(env);
        ^
../../oti/j9.h:242:53: note: expanded from macro 'PORT_ACCESS_FROM_ENV'
#define PORT_ACCESS_FROM_ENV(jniEnv) J9PortLibrary *privatePortLibrary =
(J9VMTHREAD_FROM_JNIENV(jniEnv))->javaVM->portLibrary
                                                    ^
```
**syshelp.c::getPlatformFileEncoding** requires port access only on Linux. 
The above error is fixed by enabling the call to `PORT_ACCESS_FROM_ENV`
only on Linux.
                                                                                  
Also, fixed variable initialization and code formatting.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>