### PR TITLE
Download asmtools from the stable build

### DIFF
--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -106,7 +106,7 @@ my %jcommander = (
 	sha1 => 'bfcb96281ea3b59d626704f74bc6d625ff51cbce'
 );
 my %asmtools = (
-	url => 'https://ci.adoptopenjdk.net/view/Dependencies/job/asmtools/lastSuccessfulBuild/artifact/asmtools.jar',
+	url => 'https://ci.adoptopenjdk.net/view/Dependencies/job/asmtools/107/artifact/asmtools.jar',
 	fname => 'asmtools.jar',
 	sha1 => '04cf07c584121c2e5a3d1dad2839fc8ab4828b6d'
 );


### PR DESCRIPTION
The SHA changes when there is new available one, which we need to update
the SHA and test if the jar works.

Issue #2932 

[ci skip]

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>