### PR TITLE
Consolidate implementations of RegisterIterators in OMR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,11 @@ com.ibm.jvmti.tests
 
 # Root level .project should be ignored as Eclipse automatically creates this file when new repositories are added as Projects for C/C++ indexing
 /.project
+/.cproject
 
 # Visual Studio
 /.vs
 
 # Default test directory (BUILD_ROOT)
 /jvmtest/
+/build/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ com.ibm.jvmti.tests
 # Visual Studio
 /.vs
 
+# IntelliJ CLion
+/.idea
+
 # Default test directory (BUILD_ROOT)
 /jvmtest/
 /build/

--- a/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMJNILinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -164,7 +164,7 @@ printf("JNI: offset %d\n", offset); fflush(stdout);
 #endif
    const TR::ARMLinkageProperties &jniLinkageProperties = getProperties();
    int32_t                spOffset = offset + jniLinkageProperties.getOffsetToFirstParm();
-   TR::RealRegister    *sp       = cg()->machine()->getARMRealRegister(jniLinkageProperties.getStackPointerRegister());
+   TR::RealRegister    *sp       = cg()->machine()->getRealRegister(jniLinkageProperties.getStackPointerRegister());
    TR::MemoryReference *result   = new (trHeapMemory()) TR::MemoryReference(sp, spOffset, cg());
    memArg.argRegister = argReg;
    memArg.argMemory   = result;
@@ -362,7 +362,7 @@ int32_t TR::ARMJNILinkage::buildJNIArgs(TR::Node *callNode,
 #ifdef DEBUG_ARM_LINKAGE
 printf("subtracting %d slots from SP\n", numStackParmSlots); fflush(stdout);
 #endif
-      TR::RealRegister *sp = codeGen->machine()->getARMRealRegister(jniLinkageProperties.getStackPointerRegister());
+      TR::RealRegister *sp = codeGen->machine()->getRealRegister(jniLinkageProperties.getStackPointerRegister());
       uint32_t base, rotate;
       if (constantIsImmed8r(numStackParmSlots, &base, &rotate))
          {
@@ -843,9 +843,9 @@ TR::Register *TR::ARMJNILinkage::buildDirectDispatch(TR::Node *callNode)
 
    TR::Machine      *machine  = codeGen->machine();
    TR::RealRegister *metaReg  = codeGen->getMethodMetaDataRegister();
-   TR::RealRegister *stackPtr = machine->getARMRealRegister(privateLinkageProperties.getStackPointerRegister());//JavaSP
-   TR::RealRegister *instrPtr = machine->getARMRealRegister(TR::RealRegister::gr15);
-   TR::RealRegister *gr13Reg  = machine->getARMRealRegister(TR::RealRegister::gr13);
+   TR::RealRegister *stackPtr = machine->getRealRegister(privateLinkageProperties.getStackPointerRegister());//JavaSP
+   TR::RealRegister *instrPtr = machine->getRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr13Reg  = machine->getRealRegister(TR::RealRegister::gr13);
    TR::Register        *gr4Reg   = deps->searchPreConditionRegister(TR::RealRegister::gr4);
    TR::Register        *gr5Reg   = deps->searchPreConditionRegister(TR::RealRegister::gr5);
 
@@ -987,7 +987,7 @@ TR::Register *TR::ARMJNILinkage::buildDirectDispatch(TR::Node *callNode)
          {
          case TR::Float:
             {
-            TR::RealRegister *fpReg   = machine->getARMRealRegister(jniLinkageProperties.getFloatReturnRegister());
+            TR::RealRegister *fpReg   = machine->getRealRegister(jniLinkageProperties.getFloatReturnRegister());
             fpReg->setAssignedRegister(fpReg);
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp1Offset(), codeGen);
             generateMemSrc1Instruction(codeGen, ARMOp_fsts, callNode, tempMR, fpReg);
@@ -996,7 +996,7 @@ TR::Register *TR::ARMJNILinkage::buildDirectDispatch(TR::Node *callNode)
             }
          case TR::Double:
             {
-            TR::RealRegister *fdReg   = machine->getARMRealRegister(jniLinkageProperties.getDoubleReturnRegister());
+            TR::RealRegister *fdReg   = machine->getRealRegister(jniLinkageProperties.getDoubleReturnRegister());
             fdReg->setAssignedRegister(fdReg);
             TR_ASSERT(fej9->thisThreadGetFloatTemp2Offset() - fej9->thisThreadGetFloatTemp1Offset() == 4,"floatTemp1 and floatTemp2 not contiguous");
             tempMR = new (trHeapMemory()) TR::MemoryReference(metaReg, fej9->thisThreadGetFloatTemp1Offset(), codeGen);
@@ -1013,7 +1013,7 @@ TR::Register *TR::ARMJNILinkage::buildDirectDispatch(TR::Node *callNode)
    // restore the system stack pointer (r13)
    if (spSize > 0)
       {
-      TR::RealRegister *sp = machine->getARMRealRegister(jniLinkageProperties.getStackPointerRegister());
+      TR::RealRegister *sp = machine->getRealRegister(jniLinkageProperties.getStackPointerRegister());
       uint32_t base, rotate;
       if (constantIsImmed8r(spSize, &base, &rotate))
          {

--- a/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
+++ b/runtime/compiler/arm/codegen/ARMPrivateLinkage.cpp
@@ -179,33 +179,33 @@ void TR::ARMPrivateLinkage::initARMRealRegisterLinkage()
 
    for (icount = TR::RealRegister::FirstGPR; icount <= TR::RealRegister::gr5; icount++)
       {
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
       }
 
    // mark all magic registers as locked and having a physical
    // register associated so the register assigner stays happy
    lockRegister(codeGen->getMethodMetaDataRegister());
    lockRegister(codeGen->getFrameRegister());
-   lockRegister(codeGen->machine()->getARMRealRegister(properties.getStackPointerRegister()));
-   lockRegister(machine->getARMRealRegister(TR::RealRegister::gr12)); // r12 is OS reserved
-   lockRegister(machine->getARMRealRegister(TR::RealRegister::gr13)); // r13 is OS SP
+   lockRegister(codeGen->machine()->getRealRegister(properties.getStackPointerRegister()));
+   lockRegister(machine->getRealRegister(TR::RealRegister::gr12)); // r12 is OS reserved
+   lockRegister(machine->getRealRegister(TR::RealRegister::gr13)); // r13 is OS SP
 #ifdef LOCK_R14
-   lockRegister(machine->getARMRealRegister(TR::RealRegister::gr14)); // r14 is LR
+   lockRegister(machine->getRealRegister(TR::RealRegister::gr14)); // r14 is LR
 #endif
-   lockRegister(machine->getARMRealRegister(TR::RealRegister::gr15)); // r15 is IP
+   lockRegister(machine->getRealRegister(TR::RealRegister::gr15)); // r15 is IP
 
    for (icount=TR::RealRegister::LastGPR; icount>=TR::RealRegister::gr6; icount--)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
 
 #if defined(__VFP_FP__) && !defined(__SOFTFP__)
    for (icount=TR::RealRegister::FirstFPR; icount<=TR::RealRegister::LastFPR; icount++)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
 #else
    for (icount=TR::RealRegister::FirstFPR; icount<=TR::RealRegister::fp3; icount++)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
 
    for (icount=TR::RealRegister::LastFPR; icount>=TR::RealRegister::fp4; icount--)
-      machine->getARMRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
 #endif
    }
 
@@ -368,7 +368,7 @@ uint16_t getAssignedRegisterList(TR::Machine *machine, const TR::ARMLinkagePrope
       assignedRegisters <<= 1;
       if(linkage->getPreserved((TR::RealRegister::RegNum)i))
          {
-         assignedRegisters |= machine->getARMRealRegister((TR::RealRegister::RegNum)i)->getHasBeenAssignedInMethod();
+         assignedRegisters |= machine->getRealRegister((TR::RealRegister::RegNum)i)->getHasBeenAssignedInMethod();
          }
       }
 
@@ -383,7 +383,7 @@ uint16_t getAssignedRegisterCount(TR::Machine *machine, const TR::ARMLinkageProp
       {
       if (linkage->getPreserved((TR::RealRegister::RegNum)i))
          {
-         assignedRegisters += machine->getARMRealRegister((TR::RealRegister::RegNum)i)->getHasBeenAssignedInMethod() ? 1 : 0;
+         assignedRegisters += machine->getRealRegister((TR::RealRegister::RegNum)i)->getHasBeenAssignedInMethod() ? 1 : 0;
          }
       }
 
@@ -394,7 +394,7 @@ TR::RealRegister::RegNum getSingleAssignedRegister(TR::Machine *machine, const T
    {
    for (int i = TR::RealRegister::LastGPR; i; i--)
       if (linkage->getPreserved((TR::RealRegister::RegNum)i) &&
-          machine->getARMRealRegister((TR::RealRegister::RegNum)i)->getHasBeenAssignedInMethod())
+          machine->getRealRegister((TR::RealRegister::RegNum)i)->getHasBeenAssignedInMethod())
          return (TR::RealRegister::RegNum) i;
    return (TR::RealRegister::RegNum) -1;
    }
@@ -419,7 +419,7 @@ void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
    TR::CodeGenerator   *codeGen    = cg();
    TR::Machine         *machine    = codeGen->machine();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
-   TR::RealRegister    *stackPtr   = machine->getARMRealRegister(properties.getStackPointerRegister());
+   TR::RealRegister    *stackPtr   = machine->getRealRegister(properties.getStackPointerRegister());
    TR::RealRegister    *metaBase   = codeGen->getMethodMetaDataRegister();
    TR::Node               *firstNode  = comp()->getStartTree()->getNode();
    int i;
@@ -432,7 +432,7 @@ void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
 
    TR::RealRegister::RegNum lastSavedFPR = TR::RealRegister::LastFPR;
    while (lastSavedFPR >= TR::RealRegister::fp8 &&
-          !machine->getARMRealRegister(lastSavedFPR)->getHasBeenAssignedInMethod())
+          !machine->getRealRegister(lastSavedFPR)->getHasBeenAssignedInMethod())
       {
       lastSavedFPR = (TR::RealRegister::RegNum)((uint32_t)lastSavedFPR - 1);
       }
@@ -472,10 +472,10 @@ void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
    //
    cursor = saveArguments(cursor);
 
-   TR::RealRegister    *gr4    = machine->getARMRealRegister(TR::RealRegister::gr4);
-   TR::RealRegister    *gr5    = machine->getARMRealRegister(TR::RealRegister::gr5);
-   TR::RealRegister    *gr11   = machine->getARMRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister    *gr14   = machine->getARMRealRegister(TR::RealRegister::gr14);
+   TR::RealRegister    *gr4    = machine->getRealRegister(TR::RealRegister::gr4);
+   TR::RealRegister    *gr5    = machine->getRealRegister(TR::RealRegister::gr5);
+   TR::RealRegister    *gr11   = machine->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister    *gr14   = machine->getRealRegister(TR::RealRegister::gr14);
    TR::MemoryReference *tempMR = NULL;
    uint32_t base, rotate;
 
@@ -524,7 +524,7 @@ void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
       {
       if (1 == intRegistersSaved)
          {
-         TR::Register *reg = machine->getARMRealRegister(getSingleAssignedRegister(machine, &linkage));
+         TR::Register *reg = machine->getRealRegister(getSingleAssignedRegister(machine, &linkage));
          tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
          cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, tempMR, reg, cursor);
          }
@@ -543,7 +543,7 @@ void TR::ARMPrivateLinkage::createPrologue(TR::Instruction *cursor)
       {
       if (1 == fpRegistersSaved)
          {
-         TR::Register *reg = machine->getARMRealRegister(lastSavedFPR);
+         TR::Register *reg = machine->getRealRegister(lastSavedFPR);
          if (constantIsImmed10(outgoingArgSize))
             {
             tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
@@ -718,7 +718,7 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
    TR::CodeGenerator   *codeGen    = cg();
    TR::Machine         *machine    = codeGen->machine();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
-   TR::RealRegister    *stackPtr   = machine->getARMRealRegister(properties.getStackPointerRegister());
+   TR::RealRegister    *stackPtr   = machine->getRealRegister(properties.getStackPointerRegister());
    TR::Node               *lastNode   = cursor->getNode();
 
    const TR::ARMLinkageProperties &linkage = getProperties();
@@ -728,7 +728,7 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
 
    TR::RealRegister::RegNum lastSavedFPR = TR::RealRegister::LastFPR;
    while (lastSavedFPR >= TR::RealRegister::fp8 &&
-          !machine->getARMRealRegister(lastSavedFPR)->getHasBeenAssignedInMethod())
+          !machine->getRealRegister(lastSavedFPR)->getHasBeenAssignedInMethod())
       {
       lastSavedFPR = (TR::RealRegister::RegNum)((uint32_t)lastSavedFPR - 1);
       }
@@ -752,13 +752,13 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
       {
       if (1 == intRegistersSaved)
          {
-         TR::RealRegister *reg = machine->getARMRealRegister(getSingleAssignedRegister(machine, &linkage));
+         TR::RealRegister *reg = machine->getRealRegister(getSingleAssignedRegister(machine, &linkage));
          tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
          cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, lastNode, reg, tempMR, cursor);
          }
       else
          {
-         TR::RealRegister *gr4 = machine->getARMRealRegister(TR::RealRegister::gr4);
+         TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
          constantIsImmed8r(outgoingArgSize, &base, &rotate);
          cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, lastNode, gr4, stackPtr, base, rotate, cursor);
          cursor = new (trHeapMemory()) TR::ARMMultipleMoveInstruction(cursor, ARMOp_ldm, lastNode, gr4, getAssignedRegisterList(machine, &linkage), codeGen);
@@ -768,10 +768,10 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
    outgoingArgSize += intRegistersSaved * 4;
    if (fpRegistersSaved > 0)
       {
-      TR::RealRegister *gr4 = machine->getARMRealRegister(TR::RealRegister::gr4);
+      TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
       if (1 == fpRegistersSaved)
          {
-         TR::Register *reg = machine->getARMRealRegister(lastSavedFPR);
+         TR::Register *reg = machine->getRealRegister(lastSavedFPR);
          if (constantIsImmed10(outgoingArgSize))
             {
             tempMR = new (trHeapMemory()) TR::MemoryReference(stackPtr, outgoingArgSize, codeGen);
@@ -803,8 +803,8 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // Reload return address.
-   TR::RealRegister *gr14 = machine->getARMRealRegister(TR::RealRegister::gr14);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr14 = machine->getRealRegister(TR::RealRegister::gr14);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
 
    if (codeGen->getSnippetList().size() > 1 ||
        (comp()->isDLT() && !codeGen->getSnippetList().empty()) ||
@@ -822,7 +822,7 @@ void TR::ARMPrivateLinkage::createEpilogue(TR::Instruction *cursor)
       }
    else
       {
-      TR::RealRegister *gr4 = machine->getARMRealRegister(TR::RealRegister::gr4);
+      TR::RealRegister *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
       cursor = armLoadConstant(lastNode, totalFrameSize, gr4, codeGen, cursor);
       cursor = generateTrg1Src2Instruction(codeGen, ARMOp_add, lastNode, stackPtr, stackPtr, gr4, cursor);
       }
@@ -841,7 +841,7 @@ printf("private: totalSize %d offset %d\n", totalSize, offset); fflush(stdout);
 #endif
 
    int32_t                spOffset = totalSize - offset - TR::Compiler->om.sizeofReferenceAddress();
-   TR::RealRegister    *sp       = cg()->machine()->getARMRealRegister(properties.getStackPointerRegister());
+   TR::RealRegister    *sp       = cg()->machine()->getRealRegister(properties.getStackPointerRegister());
    TR::MemoryReference *result   = new (trHeapMemory()) TR::MemoryReference(sp, spOffset, cg());
    memArg.argRegister = argReg;
    memArg.argMemory   = result;
@@ -871,14 +871,14 @@ void TR::ARMPrivateLinkage::buildVirtualDispatch(TR::Node *callNode,
    TR::Register        *gr11 = dependencies->searchPreConditionRegister(TR::RealRegister::gr11);
    TR::Register        *gr0  = dependencies->searchPreConditionRegister(TR::RealRegister::gr0);
    TR::Register        *gr4  = dependencies->searchPreConditionRegister(TR::RealRegister::gr4);
-   TR::RealRegister *gr14 = machine->getARMRealRegister(TR::RealRegister::gr14);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr14 = machine->getRealRegister(TR::RealRegister::gr14);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
 #else
    TR::Register        *gr11 = dependencies->searchPreConditionRegister(TR::RealRegister::gr11);
    TR::Register        *gr14 = dependencies->searchPreConditionRegister(TR::RealRegister::gr14);
    TR::Register        *gr0  = dependencies->searchPreConditionRegister(TR::RealRegister::gr0);
    TR::Register        *gr4  = dependencies->searchPreConditionRegister(TR::RealRegister::gr4);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
 #endif
 
    TR::SymbolReference  *methodSymRef = callNode->getSymbolReference();
@@ -1083,13 +1083,13 @@ TR::Register *TR::ARMPrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    /* Dependency #0 is for vftReg. */
    TR::Register        *gr11 = deps->searchPreConditionRegister(TR::RealRegister::gr11);
    TR::Register        *gr0  = deps->searchPreConditionRegister(TR::RealRegister::gr0);
-   TR::RealRegister *gr14 = machine->getARMRealRegister(TR::RealRegister::gr14);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr14 = machine->getRealRegister(TR::RealRegister::gr14);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
 #else
    TR::Register        *gr11 = deps->searchPreConditionRegister(TR::RealRegister::gr11);
    TR::Register        *gr14 = deps->searchPreConditionRegister(TR::RealRegister::gr14);
    TR::Register        *gr0  = deps->searchPreConditionRegister(TR::RealRegister::gr0);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
 #endif
 
    TR::Register        *returnRegister;

--- a/runtime/compiler/arm/codegen/ARMRecompilation.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,8 +69,8 @@ TR::Instruction *TR_ARMRecompilation::generatePrePrologue()
    // see PicBuilder.s and Recompilation.s
    TR::Instruction *cursor=NULL;
    TR::Machine *machine = cg()->machine();
-   TR::Register   *gr4 = machine->getARMRealRegister(TR::RealRegister::gr4);
-   TR::Register   *lr = machine->getARMRealRegister(TR::RealRegister::gr14); // link register
+   TR::Register   *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
+   TR::Register   *lr = machine->getRealRegister(TR::RealRegister::gr14); // link register
    TR::Node       *firstNode = _compilation->getStartTree()->getNode();
    TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMsamplingRecompileMethod, false, false, false);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
@@ -106,9 +106,9 @@ TR::Instruction *TR_ARMRecompilation::generatePrologue(TR::Instruction *cursor)
       // gr12 may contain the vtable offset, and must be preserved here
       // see PicBuilder.s and Recompilation.s
       TR::Machine *machine = cg()->machine();
-      TR::Register   *gr4 = machine->getARMRealRegister(TR::RealRegister::gr4);
-      TR::Register   *gr5 = machine->getARMRealRegister(TR::RealRegister::gr5);
-      TR::Register   *lr = machine->getARMRealRegister(TR::RealRegister::gr14); // link register
+      TR::Register   *gr4 = machine->getRealRegister(TR::RealRegister::gr4);
+      TR::Register   *gr5 = machine->getRealRegister(TR::RealRegister::gr5);
+      TR::Register   *lr = machine->getRealRegister(TR::RealRegister::gr14); // link register
       TR::Node       *firstNode = _compilation->getStartTree()->getNode();
       intptrj_t        addr = (intptrj_t)getCounterAddress();
       TR::LabelSymbol *snippetLabel = TR::LabelSymbol::create(cg()->trHeapMemory(), cg());

--- a/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
+++ b/runtime/compiler/arm/codegen/ARMRecompilationSnippet.cpp
@@ -74,7 +74,7 @@ uint8_t *TR::ARMEDORecompilationSnippet::emitSnippetBody()
    getSnippetLabel()->setCodeLocation(buffer);
 
    TR_ARMRegisterDependencyConditions *deps = _doneLabel->getInstruction()->getDependencyConditions();
-   TR_ARMRealRegister *startPCReg  = getARMMachine(cg())->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+   TR_ARMRealRegister *startPCReg  = getARMMachine(cg())->getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
 
    TR_ARMOpCode opcode;
 

--- a/runtime/compiler/arm/codegen/CallSnippet.cpp
+++ b/runtime/compiler/arm/codegen/CallSnippet.cpp
@@ -62,7 +62,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 4;
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getARMRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkage.getRightToLeft())
@@ -76,10 +76,10 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 8;
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getARMRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                if (intArgNum < linkage.getNumIntArgRegs()-1)
            	  {
-           	  buffer = storeArgumentItem(ARMOp_str, buffer, machine->getARMRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
+           	  buffer = storeArgumentItem(ARMOp_str, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
            	  }
                }
             intArgNum += 2;
@@ -93,7 +93,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 4;
                if (floatArgNum < linkage.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_stfs, buffer, machine->getARMRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_stfs, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
                if (linkage.getRightToLeft())
@@ -106,7 +106,7 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
                offset -= 8;
                if (floatArgNum < linkage.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(ARMOp_stfd, buffer, machine->getARMRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(ARMOp_stfd, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
                floatArgNum++;
                if (linkage.getRightToLeft())

--- a/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
+++ b/runtime/compiler/arm/codegen/J9ARMSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,9 +72,9 @@ uint8_t *TR::ARMMonitorEnterSnippet::emitSnippetBody()
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
 
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *dataReg  = cg()->machine()->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-   TR::RealRegister *addrReg  = cg()->machine()->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
-   TR::RealRegister *tempReg  = cg()->machine()->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+   TR::RealRegister *dataReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+   TR::RealRegister *addrReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *tempReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
 
    TR_ARMOpCode opcode;
    TR_ARMOpCodes opCodeValue;
@@ -146,9 +146,9 @@ TR::ARMMonitorEnterSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
    TR::LabelSymbol *restartLabel = getRestartLabel();
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *dataReg  = machine->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-   TR::RealRegister *addrReg  = machine->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
-   TR::RealRegister *tempReg  = machine->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+   TR::RealRegister *dataReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+   TR::RealRegister *addrReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *tempReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
 
    debug->printPrefix(pOutFile, NULL, bufferPos, 4);
    //    mvn     tempReg, (OBJECT_HEADER_LOCK_BITS_MASK - OBJECT_HEADER_LOCK_LAST_RECURSION_BIT) -> 0x7f
@@ -228,9 +228,9 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
 
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *objReg = cg()->machine()->getARMRealRegister(TR::RealRegister::gr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-   TR::RealRegister *threadReg  = cg()->machine()->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *objReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+   TR::RealRegister *threadReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    TR_ARMOpCode opcode;
    TR_ARMOpCodes opCodeValue;
@@ -251,7 +251,7 @@ uint8_t *TR::ARMMonitorExitSnippet::emitSnippetBody()
       //    bl   jitMonitorExit
       //    b    doneLabel;
 
-      TR::RealRegister *offsetReg = cg()->machine()->getARMRealRegister(TR::RealRegister::gr4);
+      TR::RealRegister *offsetReg = cg()->machine()->getRealRegister(TR::RealRegister::gr4);
       _decLabel->setCodeLocation(buffer);
 
       opcode.setOpCodeValue(ARMOp_andi_r);
@@ -458,9 +458,9 @@ TR::ARMMonitorExitSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
    TR::LabelSymbol *restartLabel = getRestartLabel();
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *objReg = machine->getARMRealRegister(TR::RealRegister::gr0);
-   TR::RealRegister *monitorReg = machine->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-   TR::RealRegister *threadReg  = machine->getARMRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *objReg = machine->getRealRegister(TR::RealRegister::gr0);
+   TR::RealRegister *monitorReg = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+   TR::RealRegister *threadReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    debug->printPrefix(pOutFile, NULL, bufferPos, 4);
    //    mvn     threadReg, OBJECT_HEADER_LOCK_RECURSION_MASK  // mask out count field

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -67,7 +67,7 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
                offset -= TR::Compiler->om.sizeofReferenceAddress();
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::stw, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::stw, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkage.getRightToLeft())
@@ -78,7 +78,7 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
                offset -= TR::Compiler->om.sizeofReferenceAddress();
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(storeGPROp, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(storeGPROp, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkage.getRightToLeft())
@@ -89,12 +89,12 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
                offset -= 2*TR::Compiler->om.sizeofReferenceAddress();
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = storeArgumentItem(storeGPROp, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = storeArgumentItem(storeGPROp, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                if (TR::Compiler->target.is32Bit())
                   {
                   if (intArgNum < linkage.getNumIntArgRegs()-1)
                      {
-                     buffer = storeArgumentItem(TR::InstOpCode::stw, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
+                     buffer = storeArgumentItem(TR::InstOpCode::stw, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
                      }
                   }
                }
@@ -107,7 +107,7 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
                offset -= TR::Compiler->om.sizeofReferenceAddress();
             if (floatArgNum < linkage.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::stfs, buffer, machine->getPPCRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::stfs, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
             if (linkage.getRightToLeft())
@@ -118,7 +118,7 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
                offset -= 2*TR::Compiler->om.sizeofReferenceAddress();
             if (floatArgNum < linkage.getNumFloatArgRegs())
                {
-               buffer = storeArgumentItem(TR::InstOpCode::stfd, buffer, machine->getPPCRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = storeArgumentItem(TR::InstOpCode::stfd, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
             if (linkage.getRightToLeft())
@@ -155,7 +155,7 @@ uint8_t *TR::PPCCallSnippet::setUpArgumentsInRegister(uint8_t *buffer, TR::Node 
                offset -= TR::Compiler->om.sizeofReferenceAddress();
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = loadArgumentItem(TR::InstOpCode::lwz, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = loadArgumentItem(TR::InstOpCode::lwz, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkage.getRightToLeft())
@@ -166,7 +166,7 @@ uint8_t *TR::PPCCallSnippet::setUpArgumentsInRegister(uint8_t *buffer, TR::Node 
                offset -= TR::Compiler->om.sizeofReferenceAddress();
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = loadArgumentItem(loadGPROp, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = loadArgumentItem(loadGPROp, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
             if (linkage.getRightToLeft())
@@ -177,10 +177,10 @@ uint8_t *TR::PPCCallSnippet::setUpArgumentsInRegister(uint8_t *buffer, TR::Node 
                offset -= 2*TR::Compiler->om.sizeofReferenceAddress();
             if (intArgNum < linkage.getNumIntArgRegs())
                {
-               buffer = loadArgumentItem(loadGPROp, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
+               buffer = loadArgumentItem(loadGPROp, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), offset, cg);
                if (TR::Compiler->target.is32Bit() && (intArgNum < linkage.getNumIntArgRegs()-1))
                      {
-                     buffer = loadArgumentItem(TR::InstOpCode::lwz, buffer, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
+                     buffer = loadArgumentItem(TR::InstOpCode::lwz, buffer, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum+1)), offset+4, cg);
                      }
                }
             intArgNum += TR::Compiler->target.is64Bit() ? 1 : 2;
@@ -192,7 +192,7 @@ uint8_t *TR::PPCCallSnippet::setUpArgumentsInRegister(uint8_t *buffer, TR::Node 
                offset -= TR::Compiler->om.sizeofReferenceAddress();
             if (floatArgNum < linkage.getNumFloatArgRegs())
                {
-               buffer = loadArgumentItem(TR::InstOpCode::lfs, buffer, machine->getPPCRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = loadArgumentItem(TR::InstOpCode::lfs, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
             if (linkage.getRightToLeft())
@@ -203,7 +203,7 @@ uint8_t *TR::PPCCallSnippet::setUpArgumentsInRegister(uint8_t *buffer, TR::Node 
                offset -= 2*TR::Compiler->om.sizeofReferenceAddress();
             if (floatArgNum < linkage.getNumFloatArgRegs())
                {
-               buffer = loadArgumentItem(TR::InstOpCode::lfd, buffer, machine->getPPCRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
+               buffer = loadArgumentItem(TR::InstOpCode::lfd, buffer, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
             if (linkage.getRightToLeft())
@@ -1174,7 +1174,7 @@ TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cu
                trfprintf(pOutFile, "stw [");
                print(pOutFile, stackPtr, TR_WordReg);
                trfprintf(pOutFile, ", %d], ", offset);
-               print(pOutFile, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), TR_WordReg);
+               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), TR_WordReg);
                cursor += 4;
                }
             intArgNum++;
@@ -1190,7 +1190,7 @@ TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cu
                trfprintf(pOutFile, "%s [", storeGPROpName);
                print(pOutFile, stackPtr, TR_WordReg);
                trfprintf(pOutFile, ", %d], ", offset);
-               print(pOutFile, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), TR_WordReg);
+               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), TR_WordReg);
                cursor += 4;
                }
             intArgNum++;
@@ -1206,7 +1206,7 @@ TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cu
                trfprintf(pOutFile, "%s [", storeGPROpName);
                print(pOutFile, stackPtr, TR_WordReg);
                trfprintf(pOutFile, ", %d], ", offset);
-               print(pOutFile, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), TR_WordReg);
+               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum)), TR_WordReg);
                cursor += 4;
                if (TR::Compiler->target.is32Bit() && (intArgNum < linkage.getNumIntArgRegs() - 1))
                   {
@@ -1214,7 +1214,7 @@ TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cu
                   trfprintf(pOutFile, "stw [");
                   print(pOutFile, stackPtr, TR_WordReg);
                   trfprintf(pOutFile, ", %d], ", offset + 4);
-                  print(pOutFile, machine->getPPCRealRegister(linkage.getIntegerArgumentRegister(intArgNum + 1)), TR_WordReg);
+                  print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(intArgNum + 1)), TR_WordReg);
                   cursor += 4;
                   }
                }
@@ -1234,7 +1234,7 @@ TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cu
                trfprintf(pOutFile, "stfs [");
                print(pOutFile, stackPtr, TR_WordReg);
                trfprintf(pOutFile, ", %d], ", offset);
-               print(pOutFile, machine->getPPCRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), TR_WordReg);
+               print(pOutFile, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), TR_WordReg);
                cursor += 4;
                }
             floatArgNum++;
@@ -1250,7 +1250,7 @@ TR_Debug::printPPCArgumentsFlush(TR::FILE *pOutFile, TR::Node *node, uint8_t *cu
                trfprintf(pOutFile, "stfd [");
                print(pOutFile, stackPtr, TR_WordReg);
                trfprintf(pOutFile, ", %d], ", offset);
-               print(pOutFile, machine->getPPCRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), TR_WordReg);
+               print(pOutFile, machine->getRealRegister(linkage.getFloatArgumentRegister(floatArgNum)), TR_WordReg);
                cursor += 4;
                }
             floatArgNum++;

--- a/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/p/codegen/ForceRecompilationSnippet.cpp
@@ -51,7 +51,7 @@ uint8_t *TR::PPCForceRecompilationSnippet::emitSnippetBody()
    getSnippetLabel()->setCodeLocation(buffer);
 
    TR::RegisterDependencyConditions *deps = _doneLabel->getInstruction()->getDependencyConditions();
-   TR::RealRegister *startPCReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+   TR::RealRegister *startPCReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
 
    TR::InstOpCode opcode;
 
@@ -145,7 +145,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCForceRecompilationSnippet * snippet)
    uint8_t   *cursor = snippet->getSnippetLabel()->getCodeLocation();
 
    TR::RegisterDependencyConditions *deps = snippet->getDoneLabel()->getInstruction()->getDependencyConditions();
-   TR::RealRegister *startPCReg  = _cg->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+   TR::RealRegister *startPCReg  = _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "EDO Recompilation Snippet");
 

--- a/runtime/compiler/p/codegen/InterfaceCastSnippet.cpp
+++ b/runtime/compiler/p/codegen/InterfaceCastSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,11 +52,11 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
    if (_checkCast)
       {
       TR::RegisterDependencyConditions *deps = _doneLabel->getInstruction()->getDependencyConditions();
-      TR::RealRegister *objReg       = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
-      TR::RealRegister *castClassReg = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-      TR::RealRegister *objClassReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
-      TR::RealRegister *cndReg       = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
-      TR::RealRegister *scratch1Reg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+      TR::RealRegister *objReg       = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+      TR::RealRegister *castClassReg = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+      TR::RealRegister *objClassReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+      TR::RealRegister *cndReg       = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+      TR::RealRegister *scratch1Reg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
       // checkcast
 
@@ -155,12 +155,12 @@ TR::PPCInterfaceCastSnippet::emitSnippetBody()
       {
       auto firstArgReg = getNode()->getSymbol()->castToMethodSymbol()->getLinkageConvention() == TR_CHelper ? TR::RealRegister::gr4 : TR::RealRegister::gr3;
       TR::RegisterDependencyConditions *deps = _doneLabel->getInstruction()->getDependencyConditions();
-      TR::RealRegister *castClassReg = cg()->machine()->getPPCRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg));
-      TR::RealRegister *objClassReg = cg()->machine()->getPPCRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 3));
-      TR::RealRegister *resultReg = cg()->machine()->getPPCRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 5));
-      TR::RealRegister *cndReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-      TR::RealRegister *scratch1Reg = cg()->machine()->getPPCRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 2));
-      TR::RealRegister *scratch2Reg = cg()->machine()->getPPCRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 4));
+      TR::RealRegister *castClassReg = cg()->machine()->getRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg));
+      TR::RealRegister *objClassReg = cg()->machine()->getRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 3));
+      TR::RealRegister *resultReg = cg()->machine()->getRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 5));
+      TR::RealRegister *cndReg = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+      TR::RealRegister *scratch1Reg = cg()->machine()->getRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 2));
+      TR::RealRegister *scratch2Reg = cg()->machine()->getRealRegister(static_cast<TR::RealRegister::RegNum>(firstArgReg + 4));
 
       // instanceof
 
@@ -400,11 +400,11 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCInterfaceCastSnippet * snippet)
       printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Interface Cast Snippet for Checkcast");
 
       TR::RegisterDependencyConditions *deps = snippet->getDoneLabel()->getInstruction()->getDependencyConditions();
-      TR::RealRegister *objReg       = _cg->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
-      TR::RealRegister *castClassReg = _cg->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-      TR::RealRegister *objClassReg  = _cg->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
-      TR::RealRegister *cndReg       = _cg->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
-      TR::RealRegister *scratch1Reg  = _cg->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+      TR::RealRegister *objReg       = _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+      TR::RealRegister *castClassReg = _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+      TR::RealRegister *objClassReg  = _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+      TR::RealRegister *cndReg       = _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+      TR::RealRegister *scratch1Reg  = _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
       int32_t value;
 
@@ -480,12 +480,12 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCInterfaceCastSnippet * snippet)
          printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Interface Cast Snippet for ifInstanceOf");
 
       TR::RegisterDependencyConditions *deps = snippet->getDoneLabel()->getInstruction()->getDependencyConditions();
-      TR::RealRegister *castClassReg = _cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-      TR::RealRegister *objClassReg = _cg->machine()->getPPCRealRegister(TR::RealRegister::gr6);
-      TR::RealRegister *resultReg = _cg->machine()->getPPCRealRegister(TR::RealRegister::gr8);
-      TR::RealRegister *cndReg = _cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-      TR::RealRegister *scratch1Reg = _cg->machine()->getPPCRealRegister(TR::RealRegister::gr5);
-      TR::RealRegister *scratch2Reg = _cg->machine()->getPPCRealRegister(TR::RealRegister::gr7);
+      TR::RealRegister *castClassReg = _cg->machine()->getRealRegister(TR::RealRegister::gr3);
+      TR::RealRegister *objClassReg = _cg->machine()->getRealRegister(TR::RealRegister::gr6);
+      TR::RealRegister *resultReg = _cg->machine()->getRealRegister(TR::RealRegister::gr8);
+      TR::RealRegister *cndReg = _cg->machine()->getRealRegister(TR::RealRegister::cr0);
+      TR::RealRegister *scratch1Reg = _cg->machine()->getRealRegister(TR::RealRegister::gr5);
+      TR::RealRegister *scratch2Reg = _cg->machine()->getRealRegister(TR::RealRegister::gr7);
 
       int32_t value;
 

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -119,12 +119,12 @@ uint8_t *TR::PPCMonitorEnterSnippet::emitSnippetBody()
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
    TR::RealRegister *objReg;
    if (_objectClassReg)
-      objReg = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+      objReg = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
    else
-      objReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::RealRegister *cndReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister *threadReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+      objReg = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *cndReg = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *threadReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    TR::InstOpCode opcode;
    TR::InstOpCode::Mnemonic opCodeValue;
@@ -135,7 +135,7 @@ uint8_t *TR::PPCMonitorEnterSnippet::emitSnippetBody()
 
    if (isReservationPreserving())
       {
-      TR::RealRegister *tempReg = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+      TR::RealRegister *tempReg = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
       opcode.setOpCodeValue(TR::InstOpCode::li);
       buffer = opcode.copyBinaryToBuffer(buffer);
@@ -249,15 +249,15 @@ TR::PPCMonitorEnterSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    TR::Machine *machine = cg()->machine();
    TR::RealRegister *metaReg    = cg()->getMethodMetaDataRegister();
    TR::RealRegister *objReg = _objectClassReg ?
-      machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister()) :
-      machine->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::RealRegister *condReg    = machine->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg  = machine->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister *threadReg = machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+      machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister()) :
+      machine->getRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *condReg    = machine->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg  = machine->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *threadReg = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    if (isReservationPreserving())
       {
-      TR::RealRegister *tempReg = machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+      TR::RealRegister *tempReg = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
       debug->printPrefix(pOutFile, NULL, cursor, 4);
       trfprintf(pOutFile, "li \t%s, 0x%x\t;", debug->getName(tempReg), LOCK_RES_PRESERVE_ENTER_COMPLEMENT);
@@ -372,12 +372,12 @@ uint8_t *TR::PPCMonitorExitSnippet::emitSnippetBody()
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
    TR::RealRegister *objReg;
    if (_objectClassReg)
-      objReg = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+      objReg = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
    else
-      objReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::RealRegister *cndReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister *threadReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+      objReg = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *cndReg = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *threadReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    TR::InstOpCode opcode;
    TR::InstOpCode::Mnemonic opCodeValue;
@@ -398,7 +398,7 @@ uint8_t *TR::PPCMonitorExitSnippet::emitSnippetBody()
       //    bl   jitMonitorExit
       //    b    doneLabel;
 
-      TR::RealRegister *offsetReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr4);
+      TR::RealRegister *offsetReg = cg()->machine()->getRealRegister(TR::RealRegister::gr4);
       _decLabel->setCodeLocation(buffer);
 
       opcode.setOpCodeValue(TR::InstOpCode::andi_r);
@@ -629,12 +629,12 @@ TR::PPCMonitorExitSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
 
    TR::RegisterDependencyConditions *conditions = getRestartLabel()->getInstruction()->getDependencyConditions();
    TR::RealRegister *objReg     = _objectClassReg ?
-      cg()->machine()->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(4)->getRealRegister()) :
-      cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
+      cg()->machine()->getRealRegister(conditions->getPostConditions()->getRegisterDependency(4)->getRealRegister()) :
+      cg()->machine()->getRealRegister(TR::RealRegister::gr3);
    TR::RealRegister *metaReg    = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *condReg    = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg  = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister *threadReg = cg()->machine()->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *condReg    = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg  = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *threadReg = cg()->machine()->getRealRegister(conditions->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    if (isReservationPreserving())
       {
@@ -844,14 +844,14 @@ TR::PPCLockReservationEnterSnippet::emitSnippetBody()
    if (_objectClassReg)
       objReg = ( TR::RealRegister *) _objectClassReg->getRealRegister();
    else
-      objReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::RealRegister *cndReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
+      objReg = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *cndReg = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
 
    int32_t regNum = 3;
 
-   TR::RealRegister *valReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(regNum)->getRealRegister());
-   TR::RealRegister *tempReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(regNum + 1)->getRealRegister());
+   TR::RealRegister *valReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(regNum)->getRealRegister());
+   TR::RealRegister *tempReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(regNum + 1)->getRealRegister());
 
    TR::InstOpCode  opcode;
    TR::InstOpCode::Mnemonic opCodeValue;
@@ -1032,12 +1032,12 @@ TR::PPCLockReservationEnterSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    debug->printSnippetLabel(pOutFile, getStartLabel(), cursor, isPrimitive?"Primitive Reservation Enter":"Reservation Enter");
 
    TR::RegisterDependencyConditions *conditions = getRestartLabel()->getInstruction()->getDependencyConditions();
-   TR::RealRegister *objReg     = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *objReg     = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
    TR::RealRegister *metaReg    = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *condReg    = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister *valReg     = cg()->machine()->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(3)->getRealRegister());
-   TR::RealRegister *tempReg    = cg()->machine()->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+   TR::RealRegister *condReg    = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *valReg     = cg()->machine()->getRealRegister(conditions->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+   TR::RealRegister *tempReg    = cg()->machine()->getRealRegister(conditions->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
    debug->printPrefix(pOutFile, NULL, cursor, 4);
    if (TR::Compiler->target.is64Bit())
@@ -1220,15 +1220,15 @@ TR::PPCLockReservationExitSnippet::emitSnippetBody()
    if (_objectClassReg)
      objReg = (TR::RealRegister *) _objectClassReg->getRealRegister();
   else
-     objReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
+     objReg = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
 
-   TR::RealRegister *cndReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *cndReg = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
 
    int32_t regNum = 3;
 
-   TR::RealRegister *valReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(regNum)->getRealRegister());
-   TR::RealRegister *tempReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(regNum + 1)->getRealRegister());
+   TR::RealRegister *valReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(regNum)->getRealRegister());
+   TR::RealRegister *tempReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(regNum + 1)->getRealRegister());
 
    TR::InstOpCode  opcode;
    TR::InstOpCode::Mnemonic opCodeValue;
@@ -1341,12 +1341,12 @@ TR::PPCLockReservationExitSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
    debug->printSnippetLabel(pOutFile, getStartLabel(), cursor, isPrimitive?"Primitive Reservation Exit":"Reservation Exit");
 
    TR::RegisterDependencyConditions *conditions = getRestartLabel()->getInstruction()->getDependencyConditions();
-   TR::RealRegister *objReg     = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *objReg     = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
    TR::RealRegister *metaReg    = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *condReg    = cg()->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::RealRegister *monitorReg = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister *valReg     = cg()->machine()->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(3)->getRealRegister());
-   TR::RealRegister *tempReg    = cg()->machine()->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+   TR::RealRegister *condReg    = cg()->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister *monitorReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *valReg     = cg()->machine()->getRealRegister(conditions->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+   TR::RealRegister *tempReg    = cg()->machine()->getRealRegister(conditions->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
    debug->printPrefix(pOutFile, NULL, cursor, 4);
    trfprintf(pOutFile, "li \t%s, 0x%x\t;", debug->getName(tempReg), LOCK_RES_OWNING_COMPLEMENT);
@@ -1471,11 +1471,11 @@ uint8_t *TR::PPCReadMonitorSnippet::emitSnippetBody()
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
 
    TR::RealRegister *metaReg  = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *monitorReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
-   TR::RealRegister *cndReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
-   TR::RealRegister *loadResultReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+   TR::RealRegister *monitorReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+   TR::RealRegister *cndReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *loadResultReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
    bool                isResultCollectable = deps->getPostConditions()->getRegisterDependency(3)->getRegister()->containsCollectedReference();
-   TR::RealRegister *loadBaseReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+   TR::RealRegister *loadBaseReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
    TR::Compilation *comp = cg()->comp();
    TR::InstOpCode opcode;
 
@@ -1592,10 +1592,10 @@ TR::PPCReadMonitorSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
 
    TR::Machine *machine = cg()->machine();
    TR::RealRegister *metaReg    = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *monitorReg  = machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
-   TR::RealRegister *condReg  = machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
-   TR::RealRegister *loadResultReg  = machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
-   TR::RealRegister *loadBaseReg  = machine->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
+   TR::RealRegister *monitorReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+   TR::RealRegister *condReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister *loadResultReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(3)->getRealRegister());
+   TR::RealRegister *loadBaseReg  = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(4)->getRealRegister());
 
    debug->printPrefix(pOutFile, NULL, cursor, 4);
    if (TR::Compiler->target.is64Bit())
@@ -1694,13 +1694,13 @@ uint8_t *TR::PPCHeapAllocSnippet::emitSnippetBody()
 
    TR::InstOpCode opcode;
 
-   TR::RealRegister *callRetReg  = cg()->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::RealRegister *resultReg  = cg()->machine()->getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(6)->getRealRegister());   // Refer to VMnewEvaluator
+   TR::RealRegister *callRetReg  = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *resultReg  = cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(6)->getRealRegister());   // Refer to VMnewEvaluator
 
    if (getInsertType())
       {
       TR::RealRegister *objectReg  = cg()->machine()->
-         getPPCRealRegister(deps->getPostConditions()->getRegisterDependency(0)->
+         getRealRegister(deps->getPostConditions()->getRegisterDependency(0)->
          getRealRegister());   // Refer to VMnewEvaluator
 
       opcode.setOpCodeValue(TR::InstOpCode::li);
@@ -1764,8 +1764,8 @@ TR::PPCHeapAllocSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
 
    debug->printSnippetLabel(pOutFile, getSnippetLabel(), cursor, "Heap Allocation Snippet");
 
-   TR::RealRegister *resultReg  = machine->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(6)->getRealRegister());
-   TR::RealRegister *callRetReg = machine->getPPCRealRegister(TR::RealRegister::gr3);
+   TR::RealRegister *resultReg  = machine->getRealRegister(conditions->getPostConditions()->getRegisterDependency(6)->getRealRegister());
+   TR::RealRegister *callRetReg = machine->getRealRegister(TR::RealRegister::gr3);
 
    char    *info = "";
    if (debug->isBranchToTrampoline(getDestination(), cursor, distance))
@@ -1773,7 +1773,7 @@ TR::PPCHeapAllocSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
 
    if (getInsertType())
       {
-      TR::RealRegister *arrayTypeReg  = machine->getPPCRealRegister(conditions->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+      TR::RealRegister *arrayTypeReg  = machine->getRealRegister(conditions->getPostConditions()->getRegisterDependency(0)->getRealRegister());
       debug->printPrefix(pOutFile, NULL, cursor, 4);
       trfprintf(pOutFile, "li \t%s, 0x%x", debug->getName(arrayTypeReg), getNode()->getSecondChild()->getInt());
       cursor += 4;
@@ -1921,10 +1921,10 @@ static uint8_t* initializeCCPreLoadedPrefetch(uint8_t *buffer, void **CCPreLoade
    TR::Instruction *cursor = entry;
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r8 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr8);
-   TR::Register *r10 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr10);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
+   TR::Register *r8 = cg->machine()->getRealRegister(TR::RealRegister::gr8);
+   TR::Register *r10 = cg->machine()->getRealRegister(TR::RealRegister::gr10);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
 
    static bool    doL1Pref = feGetEnv("TR_doL1Prefetch") != NULL;
    const uint32_t ppcCacheLineSize = getPPCCacheLineSize();
@@ -2051,10 +2051,10 @@ static uint8_t* initializeCCPreLoadedNonZeroPrefetch(uint8_t *buffer, void **CCP
    TR::Instruction *cursor = entry;
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r8 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr8);
-   TR::Register *r10 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr10);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
+   TR::Register *r8 = cg->machine()->getRealRegister(TR::RealRegister::gr8);
+   TR::Register *r10 = cg->machine()->getRealRegister(TR::RealRegister::gr10);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
 
    static bool    doL1Pref = feGetEnv("TR_doL1Prefetch") != NULL;
    const uint32_t ppcCacheLineSize = getPPCCacheLineSize();
@@ -2267,14 +2267,14 @@ static uint8_t* initializeCCPreLoadedObjectAlloc(uint8_t *buffer, void **CCPreLo
 #endif
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r3 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::Register *r4 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr4);
-   TR::Register *r8 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr8);
-   TR::Register *r10 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr10);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::Register *cr1 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr1);
-   TR::Register *cr2 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr2);
+   TR::Register *r3 = cg->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::Register *r4 = cg->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register *r8 = cg->machine()->getRealRegister(TR::RealRegister::gr8);
+   TR::Register *r10 = cg->machine()->getRealRegister(TR::RealRegister::gr10);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::Register *cr1 = cg->machine()->getRealRegister(TR::RealRegister::cr1);
+   TR::Register *cr2 = cg->machine()->getRealRegister(TR::RealRegister::cr2);
 
 #if defined(DEBUG)
    // Trap if size not word aligned
@@ -2484,15 +2484,15 @@ static uint8_t* initializeCCPreLoadedArrayAlloc(uint8_t *buffer, void **CCPreLoa
 #endif
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r3 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::Register *r4 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr4);
-   TR::Register *r5 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr5);
-   TR::Register *r8 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr8);
-   TR::Register *r10 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr10);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::Register *cr1 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr1);
-   TR::Register *cr2 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr2);
+   TR::Register *r3 = cg->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::Register *r4 = cg->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register *r5 = cg->machine()->getRealRegister(TR::RealRegister::gr5);
+   TR::Register *r8 = cg->machine()->getRealRegister(TR::RealRegister::gr8);
+   TR::Register *r10 = cg->machine()->getRealRegister(TR::RealRegister::gr10);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::Register *cr1 = cg->machine()->getRealRegister(TR::RealRegister::cr1);
+   TR::Register *cr2 = cg->machine()->getRealRegister(TR::RealRegister::cr2);
 
    // This is the distance between the end of the heap and the end of the address space,
    // such that adding this value or less to any heap pointer is guaranteed not to overflow
@@ -2762,13 +2762,13 @@ static uint8_t* initializeCCPreLoadedWriteBarrier(uint8_t *buffer, void **CCPreL
                                              J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST >> 16 : J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST;
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r3 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::Register *r4 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr4);
-   TR::Register *r5 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr5);
-   TR::Register *r6 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr6);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::Register *cr1 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr1);
+   TR::Register *r3 = cg->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::Register *r4 = cg->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register *r5 = cg->machine()->getRealRegister(TR::RealRegister::gr5);
+   TR::Register *r6 = cg->machine()->getRealRegister(TR::RealRegister::gr6);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::Register *cr1 = cg->machine()->getRealRegister(TR::RealRegister::cr1);
 
    TR_ASSERT((J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST <= UPPER_IMMED && J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST >= LOWER_IMMED) ||
            (J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST & 0xffff) == 0, "Expecting J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST to fit in immediate field");
@@ -2871,13 +2871,13 @@ static uint8_t* initializeCCPreLoadedWriteBarrierAndCardMark(uint8_t *buffer, vo
                                         trailingZeroes((uint32_t)comp->getOptions()->getGcCardSize());
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r3 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::Register *r4 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr4);
-   TR::Register *r5 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr5);
-   TR::Register *r6 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr6);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
-   TR::Register *cr1 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr1);
+   TR::Register *r3 = cg->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::Register *r4 = cg->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register *r5 = cg->machine()->getRealRegister(TR::RealRegister::gr5);
+   TR::Register *r6 = cg->machine()->getRealRegister(TR::RealRegister::gr6);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
+   TR::Register *cr1 = cg->machine()->getRealRegister(TR::RealRegister::cr1);
 
    TR_ASSERT((J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE <= UPPER_IMMED && J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >= LOWER_IMMED) ||
            (J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE & 0xffff) == 0, "Expecting J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE to fit in immediate field");
@@ -2985,11 +2985,11 @@ static uint8_t* initializeCCPreLoadedCardMark(uint8_t *buffer, void **CCPreLoade
                                         trailingZeroes((uint32_t)comp->getOptions()->getGcCardSize());
 
    TR::Register *metaReg = cg->getMethodMetaDataRegister();
-   TR::Register *r3 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::Register *r4 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr4);
-   TR::Register *r5 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr5);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
+   TR::Register *r3 = cg->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::Register *r4 = cg->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register *r5 = cg->machine()->getRealRegister(TR::RealRegister::gr5);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
 
    TR_ASSERT((J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE <= UPPER_IMMED && J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >= LOWER_IMMED) ||
                        (J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE & 0xffff) == 0, "Expecting J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE to fit in immediate field");
@@ -3074,13 +3074,13 @@ static uint8_t* initializeCCPreLoadedArrayStoreCHK(uint8_t *buffer, void **CCPre
    const TR::InstOpCode::Mnemonic Op_lclass =TR::InstOpCode::Op_load;
 #endif
 
-   TR::Register *r3 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr3);
-   TR::Register *r4 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr4);
-   TR::Register *r5 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr5);
-   TR::Register *r6 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr6);
-   TR::Register *r7 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr7);
-   TR::Register *r11 = cg->machine()->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::Register *cr0 = cg->machine()->getPPCRealRegister(TR::RealRegister::cr0);
+   TR::Register *r3 = cg->machine()->getRealRegister(TR::RealRegister::gr3);
+   TR::Register *r4 = cg->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register *r5 = cg->machine()->getRealRegister(TR::RealRegister::gr5);
+   TR::Register *r6 = cg->machine()->getRealRegister(TR::RealRegister::gr6);
+   TR::Register *r7 = cg->machine()->getRealRegister(TR::RealRegister::gr7);
+   TR::Register *r11 = cg->machine()->getRealRegister(TR::RealRegister::gr11);
+   TR::Register *cr0 = cg->machine()->getRealRegister(TR::RealRegister::cr0);
 
    cursor = generateTrg1MemInstruction(cg,Op_lclass, n, r5,
                                        new (cg->trHeapMemory()) TR::MemoryReference(r3, TR::Compiler->om.offsetOfObjectVftField(), TR::Compiler->om.sizeofReferenceField(), cg),

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -231,7 +231,7 @@ uint8_t *J9::Power::UnresolvedDataSnippet::emitSnippetBody()
       toRealRegister(getMemoryReference()->getModBase())->setRegisterFieldRT((uint32_t *)cursor);
       if (getMemoryReference()->getBaseRegister() == NULL)
          {
-         cg()->machine()->getPPCRealRegister(TR::RealRegister::gr0)->setRegisterFieldRA((uint32_t *)cursor);
+         cg()->machine()->getRealRegister(TR::RealRegister::gr0)->setRegisterFieldRA((uint32_t *)cursor);
          }
       else
          {

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -366,9 +366,9 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
       {
       if (linkage.getReserved((TR::RealRegister::RegNum)icount))
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
          ++lockedGPRs;
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getPPCRealRegister((TR::RealRegister::RegNum)icount));
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getRealRegister((TR::RealRegister::RegNum)icount));
          }
       else
          {
@@ -388,7 +388,7 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
                weight = icount;
                }
             }
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(weight);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(weight);
          }
       }
 
@@ -397,11 +397,11 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
       {
       if (linkage.getReserved((TR::RealRegister::RegNum)icount))
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
          ++lockedGPRs;
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getPPCRealRegister((TR::RealRegister::RegNum)icount));
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getRealRegister((TR::RealRegister::RegNum)icount));
          }
-      machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
       }
 
    int lowestFPRWeight = TR::RealRegister::FirstFPR;
@@ -411,11 +411,11 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
       {
       if (linkage.getPreserved((TR::RealRegister::RegNum)icount))
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
          }
       else
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(lowestFPRWeight);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(lowestFPRWeight);
          }
       }
 
@@ -424,11 +424,11 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
       {
       if (linkage.getPreserved((TR::RealRegister::RegNum)icount))
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
          }
       else
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
          }
       }
 
@@ -437,11 +437,11 @@ void TR::PPCPrivateLinkage::initPPCRealRegisterLinkage()
       {
       if (linkage.getPreserved((TR::RealRegister::RegNum)icount))
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
          }
       else
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
          }
       }
 
@@ -733,7 +733,7 @@ static TR::Instruction *unrollPrologueInitLoop(TR::CodeGenerator *cg, TR::Node *
       int32_t wordsUnrolledPerIteration = (128 * 4) / (TR::Compiler->om.sizeofReferenceAddress() * 8); // (number of bits cleared by one iteration using 4 stxvw4x) / (number of bits per word i.e. bits in a java pointer)
       if (wordsToUnroll >= wordsUnrolledPerIteration)
          {
-         TR::RealRegister *vectorNullReg = cg->machine()->getPPCRealRegister(TR::RealRegister::vr0);
+         TR::RealRegister *vectorNullReg = cg->machine()->getRealRegister(TR::RealRegister::vr0);
          cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::xxlxor, node, vectorNullReg, vectorNullReg, vectorNullReg, cursor);
 
          int32_t loopIterations = wordsToUnroll / wordsUnrolledPerIteration;
@@ -886,7 +886,7 @@ static int32_t calculateFrameSize(TR::RealRegister::RegNum &intSavedFirst,
       argSize = cg->getLargestOutgoingArgSize() + properties.getOffsetToFirstParm();
       }
 
-   while (intSavedFirst<=TR::RealRegister::LastGPR && !machine->getPPCRealRegister(intSavedFirst)->getHasBeenAssignedInMethod())
+   while (intSavedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(intSavedFirst)->getHasBeenAssignedInMethod())
       intSavedFirst=(TR::RealRegister::RegNum)((uint32_t)intSavedFirst+1);
 
    // the registerSaveDescription is emitted as follows:
@@ -949,10 +949,10 @@ void TR::PPCPrivateLinkage::createPrologue(TR::Instruction *cursor)
    TR::ResolvedMethodSymbol      *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister        *stackPtr = cg()->getStackPointerRegister();
    TR::RealRegister        *metaBase = cg()->getMethodMetaDataRegister();
-   TR::RealRegister        *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
-   TR::RealRegister        *gr11 = machine->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister        *gr12 = machine->getPPCRealRegister(TR::RealRegister::gr12);
-   TR::RealRegister        *cr0 = machine->getPPCRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister        *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
+   TR::RealRegister        *gr11 = machine->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister        *gr12 = machine->getRealRegister(TR::RealRegister::gr12);
+   TR::RealRegister        *cr0 = machine->getRealRegister(TR::RealRegister::cr0);
    TR::Node                   *firstNode = comp()->getStartTree()->getNode();
    int32_t                    size = -(bodySymbol->getLocalMappingCursor());
    int32_t                    residualSize, saveSize=0, argSize;
@@ -1079,14 +1079,14 @@ void TR::PPCPrivateLinkage::createPrologue(TR::Instruction *cursor)
          {
          for (regIndex=intSavedFirst; regIndex<=TR::RealRegister::LastGPR; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex+1))
             {
-            cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(stackPtr, argSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), machine->getPPCRealRegister(regIndex), cursor);
+            cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(stackPtr, argSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), machine->getRealRegister(regIndex), cursor);
 
             argSize = argSize + TR::Compiler->om.sizeofReferenceAddress();
             }
          }
       else
          {
-         cursor = generateMemSrc1Instruction(cg(), (intSavedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, new (trHeapMemory()) TR::MemoryReference(stackPtr, argSize, 4*(TR::RealRegister::LastGPR-intSavedFirst+1), cg()), machine->getPPCRealRegister(intSavedFirst), cursor);
+         cursor = generateMemSrc1Instruction(cg(), (intSavedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, new (trHeapMemory()) TR::MemoryReference(stackPtr, argSize, 4*(TR::RealRegister::LastGPR-intSavedFirst+1), cg()), machine->getRealRegister(intSavedFirst), cursor);
          
          argSize += (TR::RealRegister::LastGPR - intSavedFirst + 1) * 4;
          }
@@ -1323,8 +1323,8 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
    const TR::PPCLinkageProperties& properties = getProperties();
    TR::ResolvedMethodSymbol      *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister        *stackPtr = cg()->getStackPointerRegister();
-   TR::RealRegister        *gr12 = machine->getPPCRealRegister(TR::RealRegister::gr12);
-   TR::RealRegister        *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
+   TR::RealRegister        *gr12 = machine->getRealRegister(TR::RealRegister::gr12);
+   TR::RealRegister        *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
    TR::Node                   *currentNode = cursor->getNode();
    int32_t                   saveSize;
    int32_t                   frameSize = cg()->getFrameSizeInBytes();
@@ -1354,7 +1354,7 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
       saveSize = cg()->getLargestOutgoingArgSize() + properties.getOffsetToFirstParm();
       }
 
-   while (savedFirst<=TR::RealRegister::LastGPR && !machine->getPPCRealRegister(savedFirst)->getHasBeenAssignedInMethod())
+   while (savedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
       savedFirst=(TR::RealRegister::RegNum)((uint32_t)savedFirst+1);
 
    if (savedFirst <= TR::RealRegister::LastGPR)
@@ -1365,14 +1365,14 @@ void TR::PPCPrivateLinkage::createEpilogue(TR::Instruction *cursor)
          {
          for (regIndex=savedFirst; regIndex<=TR::RealRegister::LastGPR; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex+1))
             {
-            cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getPPCRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
+            cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
 
             saveSize = saveSize + TR::Compiler->om.sizeofReferenceAddress();
             }
          }
       else
          {
-         cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getPPCRealRegister(savedFirst), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), cursor);
+         cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getRealRegister(savedFirst), new (trHeapMemory()) TR::MemoryReference(stackPtr, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), cursor);
          
          saveSize += (TR::RealRegister::LastGPR - savedFirst + 1) * 4;
          }
@@ -1478,7 +1478,7 @@ int32_t TR::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                 
          {
          traceMsg(comp(), "Special arg %s in %s\n",
             comp()->getDebug()->getName(callNode->getChild(from)),
-            comp()->getDebug()->getName(cg()->machine()->getPPCRealRegister(specialArgReg)));
+            comp()->getDebug()->getName(cg()->machine()->getRealRegister(specialArgReg)));
          }
       // Skip the special arg in the first loop
       from += step;
@@ -2881,7 +2881,7 @@ TR::MemoryReference *TR::PPCPrivateLinkage::getOutgoingArgumentMemRef(int32_t ar
    {
    TR::Machine *machine = cg()->machine();
 
-   TR::MemoryReference *result=new (trHeapMemory()) TR::MemoryReference(machine->getPPCRealRegister(properties.getNormalStackPointerRegister()),
+   TR::MemoryReference *result=new (trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
                                         argSize+properties.getOffsetToFirstParm(), length, cg());
    memArg.argRegister = argReg;
    memArg.argMemory = result;

--- a/runtime/compiler/p/codegen/PPCRecompilation.cpp
+++ b/runtime/compiler/p/codegen/PPCRecompilation.cpp
@@ -81,7 +81,7 @@ TR::Instruction *TR_PPCRecompilation::generatePrePrologue()
    // see PicBuilder.s and Recompilation.s
    TR::Instruction *cursor=NULL;
    TR::Machine *machine = cg()->machine();
-   TR::Register   *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
+   TR::Register   *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
    TR::Node       *firstNode = _compilation->getStartTree()->getNode();
    TR::SymbolReference *recompileMethodSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCsamplingRecompileMethod, false, false, false);
    TR_PersistentJittedBodyInfo *info = getJittedBodyInfo();
@@ -123,9 +123,9 @@ TR::Instruction *TR_PPCRecompilation::generatePrologue(TR::Instruction *cursor)
       // gr12 may contain the vtable offset, and must be preserved here
       // see PicBuilder.s and Recompilation.s
       TR::Machine *machine = cg()->machine();
-      TR::Register   *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
-      TR::Register   *gr11 = machine->getPPCRealRegister(TR::RealRegister::gr11);
-      TR::Register   *cr0 = machine->getPPCRealRegister(TR::RealRegister::cr0);
+      TR::Register   *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
+      TR::Register   *gr11 = machine->getRealRegister(TR::RealRegister::gr11);
+      TR::Register   *cr0 = machine->getRealRegister(TR::RealRegister::cr0);
       TR::Node       *firstNode = _compilation->getStartTree()->getNode();
       intptrj_t        addr = (intptrj_t)getCounterAddress();          // What is the RL category?
       TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());

--- a/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/p/codegen/StackCheckFailureSnippet.cpp
@@ -90,7 +90,7 @@ uint8_t *TR::PPCStackCheckFailureSnippet::emitSnippetBody()
    TR::InstOpCode         addi_opCode(TR::InstOpCode::addi);
    TR::InstOpCode         subf_opCode(TR::InstOpCode::subf);
    TR::RealRegister  *stackPtr = cg()->getLinkage()->cg()->getStackPointerRegister();
-   TR::RealRegister  *gr12 = machine->getPPCRealRegister(TR::RealRegister::gr12);
+   TR::RealRegister  *gr12 = machine->getRealRegister(TR::RealRegister::gr12);
 
    getSnippetLabel()->setCodeLocation(buffer);
 

--- a/runtime/compiler/p/codegen/StackCheckFailureSnippet.hpp
+++ b/runtime/compiler/p/codegen/StackCheckFailureSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -99,7 +99,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(
    TR::Register *returnReg;
 
    TR::X86VFPDedicateInstruction *vfpDedicateInstruction =
-      generateVFPDedicateInstruction(machine()->getX86RealRegister(getProperties().getIntegerScratchRegister(0)), callNode, cg());
+      generateVFPDedicateInstruction(machine()->getRealRegister(getProperties().getIntegerScratchRegister(0)), callNode, cg());
 
    TR::J9LinkageUtils::switchToMachineCStack(callNode, cg());
 
@@ -161,7 +161,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(
       {
       // adjust sp is neccessary, because for java, the stack is native stack, not java stack.
       // we need to restore native stack sp properly to the correct place.
-      TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+      TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
       TR_X86OpCodes op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? ADDRegImms() : ADDRegImm4();
       generateRegImmInstruction(op, callNode, espReal, memoryArgSize, cg());
       }

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -210,7 +210,7 @@ int32_t TR::AMD64JNILinkage::buildArgs(
    TR::MethodSymbol       *methodSymbol      = methodSymRef->getSymbol()->castToMethodSymbol();
    TR::Machine             *machine           = cg()->machine();
    TR::RealRegister::RegNum noReg             = TR::RealRegister::NoReg;
-   TR::RealRegister        *espReal           = machine->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister        *espReal           = machine->getRealRegister(TR::RealRegister::esp);
    int32_t                  firstNodeArgument = callNode->getFirstArgumentIndex();
    int32_t                  lastNodeArgument  = callNode->getNumChildren() - 1;
    int32_t                  offset            = 0;
@@ -493,7 +493,7 @@ TR::AMD64JNILinkage::buildVolatileAndReturnDependencies(
 
 void TR::AMD64JNILinkage::switchToMachineCStack(TR::Node *callNode)
    {
-   TR::RealRegister *espReal     = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal     = machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register        *vmThreadReg = cg()->getVMThreadRegister();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
@@ -523,7 +523,7 @@ void TR::AMD64JNILinkage::buildJNICallOutFrame(
    TR_ResolvedMethod *resolvedMethod = callSymbol->getResolvedMethod();
    TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
    TR::Register *scratchReg = NULL;
-   TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
@@ -816,7 +816,7 @@ TR::AMD64JNILinkage::generateMethodDispatch(
       uintptrj_t targetAddress)
    {
    TR::ResolvedMethodSymbol *callSymbol  = callNode->getSymbol()->castToResolvedMethodSymbol();
-   TR::RealRegister *espReal     = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal     = machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
    intptrj_t argSize     = _JNIDispatchInfo.argSize;
    TR::SymbolReference *methodSymRef= callNode->getSymbolReference();
@@ -902,7 +902,7 @@ TR::AMD64JNILinkage::generateMethodDispatch(
 
 void TR::AMD64JNILinkage::switchToJavaStack(TR::Node *callNode)
    {
-   TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
@@ -1107,7 +1107,7 @@ void TR::AMD64JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode)
                              cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-   TR::MemoryReference *mr = generateX86MemoryReference(cg()->machine()->getX86RealRegister(TR::RealRegister::esp), intptrj_t(0), cg());
+   TR::MemoryReference *mr = generateX86MemoryReference(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptrj_t(0), cg());
    mr->setRequiresLockPrefix();
    generateMemImmInstruction(OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -1144,7 +1144,7 @@ void TR::AMD64JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode)
                              cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-   TR::MemoryReference *mr = generateX86MemoryReference(cg()->machine()->getX86RealRegister(TR::RealRegister::esp), intptrj_t(0), cg());
+   TR::MemoryReference *mr = generateX86MemoryReference(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptrj_t(0), cg());
    mr->setRequiresLockPrefix();
    generateMemImmInstruction(OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -1268,7 +1268,7 @@ void TR::AMD64JNILinkage::cleanupJNIRefPool(TR::Node *callNode)
    uintptrj_t flagValue = fej9->constJNIReferenceFrameAllocatedFlags();
    uintptrj_t flagsOffset = fej9->constJNICallOutFrameFlagsOffset();
 
-   TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
    TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
@@ -1378,7 +1378,7 @@ TR::Register *TR::AMD64JNILinkage::buildDirectJNIDispatch(TR::Node *callNode)
    static bool keepVMDuringGPUHelper = feGetEnv("TR_KeepVMDuringGPUHelper") ? true : false;
 
    TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
-   TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    TR::ResolvedMethodSymbol *resolvedMethodSymbol;
    TR_ResolvedMethod       *resolvedMethod;
@@ -1471,7 +1471,7 @@ TR::Register *TR::AMD64JNILinkage::buildDirectJNIDispatch(TR::Node *callNode)
    // This should be fixed in a subsquent revision of that code.
    //
    TR::X86VFPDedicateInstruction *vfpDedicateInstruction =
-      generateVFPDedicateInstruction(machine()->getX86RealRegister(_JNIDispatchInfo.dedicatedFrameRegisterIndex), callNode, cg());
+      generateVFPDedicateInstruction(machine()->getRealRegister(_JNIDispatchInfo.dedicatedFrameRegisterIndex), callNode, cg());
 
    // First, build a JNI callout frame on the Java stack.
    //

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -280,7 +280,7 @@ static uint8_t *flushArgument(
    ModRM |= (offset >= -128 && offset <= 127) ? 0x40 : 0x80;
 
    *(cursor - 1) = ModRM;
-   cg->machine()->getX86RealRegister(regIndex)->setRegisterFieldInModRM(cursor - 1);
+   cg->machine()->getRealRegister(regIndex)->setRegisterFieldInModRM(cursor - 1);
 
    // Scale = 0x00, Index = none, Base = rsp
    //
@@ -739,17 +739,17 @@ TR::Instruction *TR::AMD64PrivateLinkage::savePreservedRegisters(TR::Instruction
         pindex >= 0;
         pindex--)
       {
-      TR::RealRegister *scratch = machine()->getX86RealRegister(getProperties().getIntegerScratchRegister(0));
+      TR::RealRegister *scratch = machine()->getRealRegister(getProperties().getIntegerScratchRegister(0));
       TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
       TR::RealRegister::RegNum r8  = TR::RealRegister::r8;
-      TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+      TR::RealRegister *reg = machine()->getRealRegister(idx);
       if (reg->getHasBeenAssignedInMethod() &&
             (reg->getState() != TR::RealRegister::Locked))
          {
          cursor = generateMemRegInstruction(
             cursor,
             TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(reg)),
-            generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
+            generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
             reg,
             cg()
             );
@@ -775,14 +775,14 @@ TR::Instruction *TR::AMD64PrivateLinkage::restorePreservedRegisters(TR::Instruct
         pindex--)
       {
       TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-      TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+      TR::RealRegister *reg = machine()->getRealRegister(idx);
       if (reg->getHasBeenAssignedInMethod())
          {
          cursor = generateRegMemInstruction(
             cursor,
             TR::Linkage::movOpcodes(RegMem, fullRegisterMovType(reg)),
             reg,
-            generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
+            generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
             cg()
             );
          offsetCursor -= _properties.getPointerSize();
@@ -900,7 +900,7 @@ int32_t TR::AMD64PrivateLinkage::buildPrivateLinkageArgs(TR::Node               
                                                         bool                                 passArgsOnStack)
    {
    TR::RealRegister::RegNum   noReg         = TR::RealRegister::NoReg;
-   TR::RealRegister          *stackPointer  = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister          *stackPointer  = machine()->getRealRegister(TR::RealRegister::esp);
    int32_t                    firstArgument = callNode->getFirstArgumentIndex();
    int32_t                    lastArgument  = callNode->getNumChildren() - 1;
    int32_t                    offset        = 0;

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -97,7 +97,7 @@ void J9LinkageUtils::cleanupReturnValue(
 void J9LinkageUtils::switchToMachineCStack(TR::Node *callNode, TR::CodeGenerator *cg)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-   TR::RealRegister *espReal = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register *vmThreadReg = cg->getMethodMetaDataRegister();
 
    // Squirrel Java SP away into VM thread.
@@ -120,7 +120,7 @@ void J9LinkageUtils::switchToMachineCStack(TR::Node *callNode, TR::CodeGenerator
 void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-   TR::RealRegister *espReal = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register *vmThreadReg = cg->getMethodMetaDataRegister();
 
    //  Load up the java sp so we have the callout frame on top of the java stack.

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -955,7 +955,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
                if (debug("traceConditionalHelperEvaluator"))
                   {
                   TR_Debug *debug = cg->getDebug();
-                  diagnostic("conditionalHelperEvaluator:    [%s : %s]\n", debug->getName(cursorPostCondition->getRegister()), debug->getName(machine->getX86RealRegister(cursorPostCondition->getRealRegister())));
+                  diagnostic("conditionalHelperEvaluator:    [%s : %s]\n", debug->getName(cursorPostCondition->getRegister()), debug->getName(machine->getRealRegister(cursorPostCondition->getRealRegister())));
                   }
                }
             }
@@ -3211,7 +3211,7 @@ TR::Register *J9::X86::TreeEvaluator::barrierFenceEvaluator(TR::Node *node, TR::
       }
    else
       {
-      TR::RealRegister *stackReg = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+      TR::RealRegister *stackReg = cg->machine()->getRealRegister(TR::RealRegister::esp);
       TR::MemoryReference *mr = generateX86MemoryReference(stackReg, intptrj_t(0), cg);
 
       mr->setRequiresLockPrefix();
@@ -8623,7 +8623,7 @@ inlineNanoTime(
    if (debug("traceInlInlining"))
       diagnostic("nanoTime called by %s\n", comp->signature());
 
-   TR::RealRegister  *espReal = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister  *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register *vmThreadReg = cg->getVMThreadRegister();
    TR::Register *temp2 = 0;
 
@@ -12385,7 +12385,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
       TR::MemoryReference *mr = generateX86MemoryReference(tempSymRef, cg);
       generateMemRegInstruction(SMemReg(), node, mr, valueReg, cg);
       */
-      TR::RealRegister  *espReg = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+      TR::RealRegister  *espReg = cg->machine()->getRealRegister(TR::RealRegister::esp);
       generateRegInstruction(PUSHReg, node, valueReg, cg);
       TR::MemoryReference *mr = generateX86MemoryReference(espReg, 0, cg);
       generateRegMemInstruction(LEARegMem(), node, valueReferenceReg, mr, cg);

--- a/runtime/compiler/x/codegen/WriteBarrierSnippet.cpp
+++ b/runtime/compiler/x/codegen/WriteBarrierSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -255,7 +255,7 @@ uint8_t *TR::AMD64WriteBarrierSnippet::buildArgs(
    TR::RealRegister::RegNum r1 = r1Real->getRegisterNumber();
    TR::RealRegister::RegNum arg1Linkage = linkage->getProperties().getIntegerArgumentRegister(0);
    TR_ASSERT(arg1Linkage == TR::RealRegister::eax, "unsupported AMD64 linkage");
-   TR::RealRegister *raxReal = machine->getX86RealRegister(arg1Linkage);
+   TR::RealRegister *raxReal = machine->getRealRegister(arg1Linkage);
 
    TR::RealRegister *r2Real = NULL, *rsiReal = NULL;
    TR::RealRegister::RegNum r2 = TR::RealRegister::NoReg, arg2Linkage = TR::RealRegister::NoReg;
@@ -266,7 +266,7 @@ uint8_t *TR::AMD64WriteBarrierSnippet::buildArgs(
       r2 = r2Real->getRegisterNumber();
       arg2Linkage = linkage->getProperties().getIntegerArgumentRegister(1);
       TR_ASSERT(arg2Linkage == TR::RealRegister::esi, "unsupported AMD64 linkage");
-      rsiReal = machine->getX86RealRegister(arg2Linkage);
+      rsiReal = machine->getRealRegister(arg2Linkage);
       }
 
    // Fast path the single argument case.  Presently, only a batch arraycopy write barrier applies.

--- a/runtime/compiler/x/codegen/WriteBarrierSnippet.hpp
+++ b/runtime/compiler/x/codegen/WriteBarrierSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,17 +45,17 @@ class X86WriteBarrierSnippet : public TR::X86HelperCallSnippet
 
    TR::RealRegister *getDestOwningObjectRegister()
       {
-      return cg()->machine()->getX86RealRegister(_deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
+      return cg()->machine()->getRealRegister(_deps->getPostConditions()->getRegisterDependency(0)->getRealRegister());
       }
 
    TR::RealRegister *getSourceRegister()
       {
-      return cg()->machine()->getX86RealRegister(_deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
+      return cg()->machine()->getRealRegister(_deps->getPostConditions()->getRegisterDependency(1)->getRealRegister());
       }
 
    TR::RealRegister *getDestAddressRegister()
       {
-      return cg()->machine()->getX86RealRegister(_deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+      return cg()->machine()->getRealRegister(_deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
       }
 
    int32_t getHelperArgCount() {return _helperArgCount;}

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -224,7 +224,7 @@ TR::Register* TR::X86HelperCallSite::BuildCall()
       traceMsg(cg()->comp(), "X86 HelperCall: [%04d] %s\n", _SymRef->getReferenceNumber(), cg()->getDebug()->getName(_SymRef));
       }
    RealRegisterManager RealRegisters(cg());
-   TR::RealRegister*   ESP = cg()->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister*   ESP = cg()->machine()->getRealRegister(TR::RealRegister::esp);
 
    // Preserve caller saved registers
    for (size_t i = 0;

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -171,7 +171,7 @@ TR::Instruction *TR::X86PrivateLinkage::movLinkageRegisters(TR::Instruction *cur
    TR_ASSERT(cursor, "assertion failure");
 
    TR::Machine *machine = cg()->machine();
-   TR::RealRegister  *rspReal = machine->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister  *rspReal = machine->getRealRegister(TR::RealRegister::esp);
 
    TR::ResolvedMethodSymbol             *bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>  paramIterator(&(bodySymbol->getParameterList()));
@@ -188,7 +188,7 @@ TR::Instruction *TR::X86PrivateLinkage::movLinkageRegisters(TR::Instruction *cur
       if (lri != NOT_LINKAGE) // This param should be in a linkage reg
          {
          TR_MovDataTypes movDataType = paramMovType(paramCursor);
-         TR::RealRegister     *reg = machine->getX86RealRegister(getProperties().getArgumentRegister(lri, isFloat(movDataType)));
+         TR::RealRegister     *reg = machine->getRealRegister(getProperties().getArgumentRegister(lri, isFloat(movDataType)));
          TR::MemoryReference  *memRef = generateX86MemoryReference(rspReal, paramCursor->getParameterOffset(), cg());
 
          if (isStore)
@@ -215,7 +215,7 @@ TR::Instruction *TR::X86PrivateLinkage::movLinkageRegisters(TR::Instruction *cur
 TR::Instruction *TR::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored)
    {
    TR::Machine *machine = cg()->machine();
-   TR::RealRegister  *framePointer = machine->getX86RealRegister(TR::RealRegister::vfp);
+   TR::RealRegister  *framePointer = machine->getRealRegister(TR::RealRegister::vfp);
 
    TR::ResolvedMethodSymbol             *bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>  paramIterator(&(bodySymbol->getParameterList()));
@@ -270,7 +270,7 @@ TR::Instruction *TR::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruc
             loadCursor = generateRegMemInstruction(
                loadCursor,
                TR::Linkage::movOpcodes(RegMem, movDataType),
-               machine->getX86RealRegister(ai),
+               machine->getRealRegister(ai),
                generateX86MemoryReference(framePointer, offset, cg()),
                cg()
                );
@@ -298,7 +298,7 @@ TR::Instruction *TR::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruc
                   cursor,
                   TR::Linkage::movOpcodes(MemReg, movDataType),
                   generateX86MemoryReference(framePointer, offset, cg()),
-                  machine->getX86RealRegister(sourceIndex),
+                  machine->getRealRegister(sourceIndex),
                   cg()
                   );
                }
@@ -390,8 +390,8 @@ TR::Instruction *TR::X86PrivateLinkage::copyParametersToHomeLocation(TR::Instruc
             cursor = generateRegRegInstruction(
                cursor,
                TR::Linkage::movOpcodes(RegReg, movStatus[source].outgoingDataType),
-               machine->getX86RealRegister(regCursor),
-               machine->getX86RealRegister(source),
+               machine->getRealRegister(regCursor),
+               machine->getRealRegister(source),
                cg()
                );
             // Update movStatus as we go so we don't generate redundant movs
@@ -567,9 +567,9 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
 #endif
    bool trace = comp()->getOption(TR_TraceCG);
 
-   TR::RealRegister  *espReal      = machine()->getX86RealRegister(TR::RealRegister::esp);
-   TR::RealRegister  *scratchReg   = machine()->getX86RealRegister(getProperties().getIntegerScratchRegister(0));
-   TR::RealRegister  *metaDataReg  = machine()->getX86RealRegister(getProperties().getMethodMetaDataRegister());
+   TR::RealRegister  *espReal      = machine()->getRealRegister(TR::RealRegister::esp);
+   TR::RealRegister  *scratchReg   = machine()->getRealRegister(getProperties().getIntegerScratchRegister(0));
+   TR::RealRegister  *metaDataReg  = machine()->getRealRegister(getProperties().getMethodMetaDataRegister());
 
    TR::ResolvedMethodSymbol             *bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>  paramIterator(&(bodySymbol->getParameterList()));
@@ -605,7 +605,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
    // Preserved register index
    for (int32_t pindex = 0; pindex < properties.getMaxRegistersPreservedInPrologue(); pindex++)
       {
-      TR::RealRegister *reg = machine()->getX86RealRegister(properties.getPreservedRegister((uint32_t)pindex));
+      TR::RealRegister *reg = machine()->getRealRegister(properties.getPreservedRegister((uint32_t)pindex));
       if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked)
          {
          preservedRegsSize += properties.getPointerSize();
@@ -678,7 +678,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
       debugFrameSlotInfo = new (trHeapMemory()) TR_DebugFrameSegmentInfo(comp(),
          paramCursor->getOffset(), paramCursor->getSize(), "Parameter",
          debugFrameSlotInfo,
-         (ai==NOT_ASSIGNED)? NULL : machine()->getX86RealRegister(ai)
+         (ai==NOT_ASSIGNED)? NULL : machine()->getRealRegister(ai)
          );
       }
 
@@ -764,7 +764,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
          // At this point, cg()->getAppendInstruction() is already in the cold code section.
          generateVFPRestoreInstruction(vfp, cursor->getNode(), cg());
          generateLabelInstruction(LABEL, cursor->getNode(), checkLabel, cg());
-         generateRegImmInstruction(MOV4RegImm4, cursor->getNode(), machine()->getX86RealRegister(TR::RealRegister::edi), allocSize, cg());
+         generateRegImmInstruction(MOV4RegImm4, cursor->getNode(), machine()->getRealRegister(TR::RealRegister::edi), allocSize, cg());
          if (doAllocateFrameSpeculatively)
             {
             generateRegImmInstruction(ADDRegImm4(), cursor->getNode(), espReal, allocSize, cg());
@@ -848,7 +848,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
       uint64_t paintValue64 = 0;
 
       TR::RealRegister *paintReg = NULL;
-      TR::RealRegister *frameSlotIndexReg = machine()->getX86RealRegister(TR::RealRegister::edi);
+      TR::RealRegister *frameSlotIndexReg = machine()->getRealRegister(TR::RealRegister::edi);
       uint32_t paintBound = 0;
       uint32_t paintSlotsOffset = 0;
       uint32_t paintSize = allocSize-sizeof(uintptrj_t);
@@ -880,7 +880,7 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
 
       //Load the 64 bit paint value into a paint reg.
 #ifdef TR_TARGET_64BIT
-       paintReg = machine()->getX86RealRegister(TR::RealRegister::r8);
+       paintReg = machine()->getRealRegister(TR::RealRegister::r8);
        cursor = new (trHeapMemory()) TR::AMD64RegImm64Instruction(cursor, MOV8RegImm64, paintReg, paintValue64, cg());
 #endif
 
@@ -908,11 +908,11 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
 
    // Initialize any local pointers that could otherwise confuse the GC.
    //
-   TR::RealRegister *framePointer = machine()->getX86RealRegister(TR::RealRegister::vfp);
+   TR::RealRegister *framePointer = machine()->getRealRegister(TR::RealRegister::vfp);
    if (atlas)
       {
       TR_ASSERT(_properties.getNumScratchRegisters() >= 2, "Need two scratch registers to initialize reference locals");
-      TR::RealRegister *loopReg = machine()->getX86RealRegister(properties.getIntegerScratchRegister(1));
+      TR::RealRegister *loopReg = machine()->getRealRegister(properties.getIntegerScratchRegister(1));
 
       int32_t numReferenceLocalSlotsToInitialize = atlas->getNumberOfSlotsToBeInitialized();
       int32_t numInternalPointerSlotsToInitialize = 0;
@@ -1017,7 +1017,7 @@ TR::Instruction *TR::X86PrivateLinkage::deallocateFrameIfNeeded(TR::Instruction 
 
 void TR::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   TR::RealRegister* espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister* espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    cursor = cg()->generateDebugCounter(cursor, "cg.epilogues", 1, TR::DebugCounter::Expensive);
 
@@ -1031,8 +1031,8 @@ void TR::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
       {
       // Restore stack pointer from frame pointer
       //
-      cursor = generateRegRegInstruction(cursor, MOVRegReg(), espReal, machine()->getX86RealRegister(_properties.getFramePointerRegister()), cg());
-      cursor = generateRegInstruction(cursor, POPReg, machine()->getX86RealRegister(_properties.getFramePointerRegister()), cg());
+      cursor = generateRegRegInstruction(cursor, MOVRegReg(), espReal, machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
+      cursor = generateRegInstruction(cursor, POPReg, machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
       }
    else
       {
@@ -2316,7 +2316,7 @@ TR::Register *TR::X86PrivateLinkage::buildCallPostconditions(TR::X86CallSite &si
          {
          // Skip non-assignable registers
          //
-         if (machine()->getX86RealRegister(regIndex)->getState() == TR::RealRegister::Locked)
+         if (machine()->getRealRegister(regIndex)->getState() == TR::RealRegister::Locked)
             continue;
 
          // Skip registers already present

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -167,7 +167,7 @@ TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
          if (TR::Compiler->target.is64Bit())
             {
             TR_ASSERT(linkage->getMinimumFirstInstructionSize() <= 10, "Can't satisfy first instruction size constraint");
-            TR::RealRegister *scratchReg = machine->getX86RealRegister(TR::RealRegister::edi);
+            TR::RealRegister *scratchReg = machine->getRealRegister(TR::RealRegister::edi);
             cursor = new (trHeapMemory()) TR::AMD64RegImm64Instruction(cursor, MOV8RegImm64, scratchReg, (uintptrj_t)getCounterAddress(), cg());
             mRef = generateX86MemoryReference(scratchReg, 0, cg());
             }

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -78,7 +78,7 @@ TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPReg
       }
 #endif
 
-   TR::RealRegister    *espReal      = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister    *espReal      = machine()->getRealRegister(TR::RealRegister::esp);
    TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
    TR::MethodSymbol    *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
    uint8_t numXmmRegs = 0;

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -100,7 +100,7 @@ TR::Register *TR::IA32JNILinkage::buildJNIDispatch(TR::Node *callNode)
       }
 
    TR::Register*     ebpReal = cg()->getVMThreadRegister();
-   TR::RealRegister* espReal = cg()->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister* espReal = cg()->machine()->getRealRegister(TR::RealRegister::esp);
    TR::LabelSymbol*           returnAddrLabel = NULL;
 
    // Build parameters
@@ -122,7 +122,7 @@ TR::Register *TR::IA32JNILinkage::buildJNIDispatch(TR::Node *callNode)
       {
       // Anchored frame pointer register.
       //
-      TR::RealRegister *ebxReal = cg()->machine()->getX86RealRegister(TR::RealRegister::ebx);
+      TR::RealRegister *ebxReal = cg()->machine()->getRealRegister(TR::RealRegister::ebx);
 
 
       // Begin: mask out the magic bit that indicates JIT frames below

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -158,13 +158,13 @@ TR::Instruction *TR::IA32PrivateLinkage::savePreservedRegisters(TR::Instruction 
          pindex--)
       {
       TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-      TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+      TR::RealRegister *reg = machine()->getRealRegister(idx);
       if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked)
          {
          cursor = generateMemRegInstruction(
                      cursor,
                      S4MemReg,
-                     generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
+                     generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
                      reg,
                      cg()
                      );
@@ -187,14 +187,14 @@ TR::Instruction *TR::IA32PrivateLinkage::restorePreservedRegisters(TR::Instructi
         pindex--)
       {
       TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-      TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+      TR::RealRegister *reg = machine()->getRealRegister(idx);
       if (reg->getHasBeenAssignedInMethod())
          {
          cursor = generateRegMemInstruction(
                      cursor,
                      L4RegMem,
                      reg,
-                     generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
+                     generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
                      cg()
                      );
          offsetCursor -= pointerSize;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3703,7 +3703,7 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
    cursor = static_cast<TR::Instruction*>(self()->getS390PrivateLinkage()->saveArguments(cursor, false, true));
 
    // Load the EP register with the address of the next instruction
-   cursor = generateRRInstruction(self(), TR::InstOpCode::BASR, node, self()->getEntryPointRealRegister(), self()->machine()->getS390RealRegister(TR::RealRegister::GPR0), cursor);
+   cursor = generateRRInstruction(self(), TR::InstOpCode::BASR, node, self()->getEntryPointRealRegister(), self()->machine()->getRealRegister(TR::RealRegister::GPR0), cursor);
 
    TR::Instruction* basrInstruction = cursor;
 
@@ -3711,7 +3711,7 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
    TR::MemoryReference* j9MethodAddressMemRef = generateS390MemoryReference(self()->getEntryPointRealRegister(), 0, self());
 
    // Load the address of the J9Method corresponding to this JIT compilation
-   cursor = generateRXInstruction(self(), TR::InstOpCode::getLoadOpCode(), node, self()->machine()->getS390RealRegister(TR::RealRegister::GPR1), j9MethodAddressMemRef, cursor);
+   cursor = generateRXInstruction(self(), TR::InstOpCode::getLoadOpCode(), node, self()->machine()->getRealRegister(TR::RealRegister::GPR1), j9MethodAddressMemRef, cursor);
 
    // Displacement will be updated later once we know the offset
    TR::MemoryReference* vmCallHelperAddressMemRef = generateS390MemoryReference(self()->getEntryPointRealRegister(), 0, self());

--- a/runtime/compiler/z/codegen/J9Linkage.cpp
+++ b/runtime/compiler/z/codegen/J9Linkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
          case TR::Int32:
             if (hasToLoadFromStack && numIntArgs < self()->getNumIntegerArgumentRegisters())
                {
-               argRegister = self()->getS390RealRegister(self()->getIntegerArgumentRegister(numIntArgs));
+               argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs));
                TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
                cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, argRegister,
                            memRef, cursor);
@@ -68,7 +68,7 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
             if ((hasToLoadFromStack || isRecompilable) &&
                  numIntArgs < self()->getNumIntegerArgumentRegisters())
                {
-               argRegister = self()->getS390RealRegister(self()->getIntegerArgumentRegister(numIntArgs));
+               argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs));
                TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
                cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode, argRegister,
                            memRef, cursor);
@@ -79,14 +79,14 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
          case TR::Int64:
             if (hasToLoadFromStack && numIntArgs < self()->getNumIntegerArgumentRegisters())
                {
-               argRegister = self()->getS390RealRegister(self()->getIntegerArgumentRegister(numIntArgs));
+               argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs));
                TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
                cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode, argRegister,
                            memRef, cursor);
                cursor->setBinLocalFreeRegs(binLocalRegs);
                if (TR::Compiler->target.is32Bit() && numIntArgs < self()->getNumIntegerArgumentRegisters() - 1)
                   {
-                  argRegister = self()->getS390RealRegister(self()->getIntegerArgumentRegister(numIntArgs + 1));
+                  argRegister = self()->getRealRegister(self()->getIntegerArgumentRegister(numIntArgs + 1));
                   cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, argRegister,
                               generateS390MemoryReference(stackPtr, offset + 4, self()->cg()), cursor);
                   cursor->setBinLocalFreeRegs(binLocalRegs);
@@ -98,7 +98,7 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
          case TR::DecimalFloat:
             if (hasToLoadFromStack && numFloatArgs < self()->getNumFloatArgumentRegisters())
                {
-               argRegister = self()->getS390RealRegister(self()->getFloatArgumentRegister(numFloatArgs));
+               argRegister = self()->getRealRegister(self()->getFloatArgumentRegister(numFloatArgs));
                TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
                cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, argRegister,
                            memRef, cursor);
@@ -110,7 +110,7 @@ J9::Z::Linkage::loadUpArguments(TR::Instruction * cursor)
          case TR::DecimalDouble:
             if (hasToLoadFromStack && numFloatArgs < self()->getNumFloatArgumentRegisters())
                {
-               argRegister = self()->getS390RealRegister(self()->getFloatArgumentRegister(numFloatArgs));
+               argRegister = self()->getRealRegister(self()->getFloatArgumentRegister(numFloatArgs));
                TR::MemoryReference* memRef = generateS390MemoryReference(stackPtr, offset, self()->cg());
                cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, argRegister,
                            memRef, cursor);

--- a/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390CHelperLinkage.cpp
@@ -265,7 +265,7 @@ TR::Register * TR::S390CHelperLinkage::buildDirectDispatch(TR::Node * callNode, 
    traceMsg(comp(),"%s: Internal Control Flow in OOL : %s\n",callNode->getOpCode().getName(),isHelperCallWithinICF  ? "true" : "false" );
    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastHPR; i++)
       {
-      if (!self()->getPreserved(REGNUM(i)) && cg()->machine()->getS390RealRegister(i)->getState() != TR::RealRegister::Locked)
+      if (!self()->getPreserved(REGNUM(i)) && cg()->machine()->getRealRegister(i)->getState() != TR::RealRegister::Locked)
          {
          RealRegisters.use((TR::RealRegister::RegNum)i);
          }

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
@@ -79,13 +79,13 @@ public:
 
    virtual TR::RealRegister::RegNum setMethodMetaDataRegister(TR::RealRegister::RegNum r) { return _methodMetaDataRegister = r; }
    virtual TR::RealRegister::RegNum getMethodMetaDataRegister() { return _methodMetaDataRegister; }
-   virtual TR::RealRegister *getMethodMetaDataRealRegister() {return getS390RealRegister(_methodMetaDataRegister);}
+   virtual TR::RealRegister *getMethodMetaDataRealRegister() {return getRealRegister(_methodMetaDataRegister);}
 
    virtual uint32_t setPreservedRegisterMapForGC(uint32_t m)  { return _preservedRegisterMapForGC = m; }
    virtual uint32_t getPreservedRegisterMapForGC()        { return _preservedRegisterMapForGC; }
 
    virtual TR::RealRegister::RegNum getSystemStackPointerRegister(){ return cg()->getLinkage(TR_System)->getStackPointerRegister(); }
-   virtual TR::RealRegister *getSystemStackPointerRealRegister() {return getS390RealRegister(getSystemStackPointerRegister());}
+   virtual TR::RealRegister *getSystemStackPointerRealRegister() {return getRealRegister(getSystemStackPointerRegister());}
 
    virtual int32_t setupLiteralPoolRegister(TR::Snippet *firstSnippet);
    

--- a/runtime/compiler/z/codegen/J9S390Snippet.cpp
+++ b/runtime/compiler/z/codegen/J9S390Snippet.cpp
@@ -72,7 +72,7 @@ TR::S390HeapAllocSnippet::emitSnippetBody()
 
    TR::Machine *machine = codeGen->machine();
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
-   TR::RealRegister * resReg = machine->getS390RealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister * resReg = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
    uint32_t resRegEncoding = resReg->getRegisterNumber() - 1;
    bool is64BitTarget = TR::Compiler->target.is64Bit();
 
@@ -216,7 +216,7 @@ TR::S390HeapAllocSnippet::print(TR::FILE *pOutFile, TR_Debug *debug)
 
    TR::Machine *machine = cg()->machine();
    TR::RegisterDependencyConditions *deps = getRestartLabel()->getInstruction()->getDependencyConditions();
-   TR::RealRegister * resReg = machine->getS390RealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
+   TR::RealRegister * resReg = machine->getRealRegister(deps->getPostConditions()->getRegisterDependency(2)->getRealRegister());
 
    debug->printSnippetLabel(pOutFile, getSnippetLabel(), buffer, "HeapAlloc Snippet", debug->getName(getDestination()));
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -9838,7 +9838,7 @@ J9::Z::TreeEvaluator::restoreGPR7(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference * tempMR = generateS390MemoryReference(cg->getMethodMetaDataRealRegister(), offsetof(J9VMThread, tempSlot), cg);
    TR::Register * tempReg = cg->allocateRegister();
-   generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node,   cg->machine()->getS390RealRegister(TR::RealRegister::GPR7), tempMR);
+   generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node,   cg->machine()->getRealRegister(TR::RealRegister::GPR7), tempMR);
    }
 
 void J9::Z::TreeEvaluator::genWrtbarForArrayCopy(TR::Node *node, TR::Register *srcReg, TR::Register *dstReg, bool srcNonNull, TR::CodeGenerator *cg)
@@ -10906,7 +10906,7 @@ inlineAtomicFieldUpdater(
    TR::Register * thisReg = cg->evaluate(node->getFirstChild());
    TR::Register * objReg = cg->evaluate(node->getSecondChild());
    TR::Register * tempReg = cg->allocateRegister();
-   TR::Register * trueReg = cg->machine()->getS390RealRegister(TR::RealRegister::GPR5);
+   TR::Register * trueReg = cg->machine()->getRealRegister(TR::RealRegister::GPR5);
    TR::Register * deltaReg;
    TR::Register * offsetReg = cg->allocateRegister();
    TR::Register * tClassReg = cg->allocateRegister();
@@ -11266,7 +11266,7 @@ inlineConcurrentLinkedQueueTMOffer(
 
       cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneLabel, deps);
 
-      cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR0),0,cg));
+      cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0),0,cg));
       }
 
    if (useNonConstrainedTM || disableTMOffer)
@@ -11451,7 +11451,7 @@ inlineConcurrentLinkedQueueTMPoll(
       else
          cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneLabel, deps);
 
-      cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR0),0,cg));
+      cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0),0,cg));
       }
 
    if (useNonConstrainedTM || disableTMPoll)
@@ -12048,7 +12048,7 @@ J9::Z::TreeEvaluator::tstartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, startLabel, deps, cursor);
 
-   TR::MemoryReference * tempMR1 = generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR0),0,cg);
+   TR::MemoryReference * tempMR1 = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0),0,cg);
 
    // use TEND + BRC instead of TABORT for better performance
    cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, tempMR1, cursor);
@@ -12073,7 +12073,7 @@ J9::Z::TreeEvaluator::tfinishEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
 #ifndef PUBLIC_BUILD
    PRINT_ME("tfinish", node, cg);
-   TR::MemoryReference * tempMR1 = generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR0),0,cg);
+   TR::MemoryReference * tempMR1 = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0),0,cg);
    TR::Instruction * cursor = generateSInstruction(cg, TR::InstOpCode::TEND, node, tempMR1);
 #endif
 

--- a/runtime/compiler/z/codegen/S390Recompilation.cpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.cpp
@@ -157,7 +157,7 @@ TR_S390Recompilation::generatePrePrologue()
       cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->getStackPointerRealRegister(), -2 * cg->machine()->getGPRSize(), cursor);
 
       // Save the return address
-      cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);
+      cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);
 
       TR::MemoryReference * epSaveAreaMemRef = generateS390MemoryReference(cg->getStackPointerRealRegister(), 0, cg);
 
@@ -165,7 +165,7 @@ TR_S390Recompilation::generatePrePrologue()
       cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->getEntryPointRealRegister(), epSaveAreaMemRef, cursor);
 
       // Load the EP register with the address of the next instruction
-      cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->getEntryPointRealRegister(), cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cursor);
+      cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->getEntryPointRealRegister(), cg->machine()->getRealRegister(TR::RealRegister::GPR0), cursor);
 
       basrInstruction = cursor;
 
@@ -345,15 +345,15 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    TR::MemoryReference* spillSlotMemRef = generateS390MemoryReference(cg->getStackPointerRealRegister(), cg->machine()->getGPRSize(), cg);
 
    // Spill GPR1 and GPR2
-   cursor = generateRSInstruction(cg, TR::InstOpCode::getStoreMultipleOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR1), cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), spillSlotMemRef, cursor);
+   cursor = generateRSInstruction(cg, TR::InstOpCode::getStoreMultipleOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR1), cg->machine()->getRealRegister(TR::RealRegister::GPR2), spillSlotMemRef, cursor);
 
    // Load the EP register with the address of the next instruction
-   cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->getEntryPointRealRegister(), cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->getEntryPointRealRegister(), cg->machine()->getRealRegister(TR::RealRegister::GPR0), cursor);
 
    TR::Instruction* basrInstruction = cursor;
 
    // Copy EP register into GPR1
-   cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR1), cg->getEntryPointRealRegister(), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR1), cg->getEntryPointRealRegister(), cursor);
 
    // Use a negative offset since pre-prologue is generated before the prologue
    int32_t offsetToIntEP = -CalcCodeSize(startOfPrologueLabel->getInstruction(), basrInstruction) - _loadArgumentSize;
@@ -364,19 +364,19 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    // Use a negative offset since pre-prologue is generated before the prologue
    int32_t offsetToBodyInfo = -CalcCodeSize(bodyInfoDataConstant, basrInstruction);
 
-   TR::MemoryReference* bodyInfoAddressMemRef = generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR1), offsetToBodyInfo, cg);
+   TR::MemoryReference* bodyInfoAddressMemRef = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR1), offsetToBodyInfo, cg);
 
    // Load the body info address. Note the use of getExtendedLoadOpCode because our offset is negative. This means on
    // a 31-bit target we will generate an LY instruction (6-byte) vs. and L instruction (4-byte).
-   cursor = generateRXInstruction(cg, TR::InstOpCode::getExtendedLoadOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR1), bodyInfoAddressMemRef, cursor);
+   cursor = generateRXInstruction(cg, TR::InstOpCode::getExtendedLoadOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR1), bodyInfoAddressMemRef, cursor);
 
-   TR::MemoryReference* counterFieldMemRef = generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR1), offsetof(TR_PersistentJittedBodyInfo, _counter), cg);
+   TR::MemoryReference* counterFieldMemRef = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR1), offsetof(TR_PersistentJittedBodyInfo, _counter), cg);
 
    // Load the counter field value from the body info pointer
-   cursor = generateRXInstruction(cg, TR::InstOpCode::L, node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), counterFieldMemRef, cursor);
+   cursor = generateRXInstruction(cg, TR::InstOpCode::L, node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), counterFieldMemRef, cursor);
 
    // Compare the counter value to zero
-   cursor = generateRRInstruction(cg, TR::InstOpCode::LTR, node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::LTR, node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), cg->machine()->getRealRegister(TR::RealRegister::GPR2), cursor);
 
    TR::LabelSymbol* resumeMethodExecutionLabel = generateLabelSymbol(cg);
 
@@ -384,35 +384,35 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, resumeMethodExecutionLabel, cursor);
 
    // Load GPR2 with the address of the next instruction
-   cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), cg->machine()->getRealRegister(TR::RealRegister::GPR0), cursor);
 
    TR::Instruction* basrForCountingRecompileInstruction = cursor;
 
    // Adjust GPR2 to point to the end of the prologue. Displacement will be updated later once we know the offset.
-   cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), 0, cursor);
+   cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), 0, cursor);
 
    TR::S390RIInstruction* addImmediateToEndOfPrologueInstruction = static_cast<TR::S390RIInstruction*>(cursor);
 
    TR::MemoryReference* endOfPrologueSlotMemRef = generateS390MemoryReference(cg->getStackPointerRealRegister(), 0, cg);
 
    // Store GPR2 off to the stack so countingRecompileMethod can access it
-   cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), endOfPrologueSlotMemRef, cursor);
+   cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), endOfPrologueSlotMemRef, cursor);
 
    // Adjust GPR2 to point to the countingRecompileMethod address
-   cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), 0, cursor);
+   cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), 0, cursor);
 
    TR::S390RIInstruction* addImmediateToCountingRecompileMethodAddressInstruction = static_cast<TR::S390RIInstruction*>(cursor);
 
-   TR::MemoryReference* countingRecompileMethodAddressMemRef = generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), 0, cg);
+   TR::MemoryReference* countingRecompileMethodAddressMemRef = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR2), 0, cg);
 
    // Load the countingRecompileMethod address
-   cursor = generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), countingRecompileMethodAddressMemRef, cursor);
+   cursor = generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR2), countingRecompileMethodAddressMemRef, cursor);
 
    // Save the return address in GPR0 so countingRecompileMethod can access it
-   cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);
 
    // Call countingRecompileMethod
-   cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BCR, node, TR::InstOpCode::COND_BCR, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), cursor);
+   cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BCR, node, TR::InstOpCode::COND_BCR, cg->machine()->getRealRegister(TR::RealRegister::GPR2), cursor);
 
    TR::Instruction* countingRecompileMethodAddressDataConstant = NULL;
 
@@ -460,10 +460,10 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->getEntryPointRealRegister(), epRegisterSlotMemRef, cursor);
 
    // Save the return address in GPR0 so the patching assembly stub can access it
-   cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);
 
    // Load GPR14 with the address of the next instruction
-   cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->getReturnAddressRealRegister(), cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cursor);
+   cursor = generateRRInstruction(cg, TR::InstOpCode::BASR, node, cg->getReturnAddressRealRegister(), cg->machine()->getRealRegister(TR::RealRegister::GPR0), cursor);
 
    basrInstruction = cursor;
 
@@ -532,7 +532,7 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    spillSlotMemRef = generateS390MemoryReference(*spillSlotMemRef, 0, cg);
 
    // Fill GPR1 and GPR2
-   cursor = generateRSInstruction(cg, TR::InstOpCode::getLoadMultipleOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR1), cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), spillSlotMemRef, cursor);
+   cursor = generateRSInstruction(cg, TR::InstOpCode::getLoadMultipleOpCode(), node, cg->machine()->getRealRegister(TR::RealRegister::GPR1), cg->machine()->getRealRegister(TR::RealRegister::GPR2), spillSlotMemRef, cursor);
 
    // Free space on stack for four register sized spill slots
    cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->getStackPointerRealRegister(), 4 * cg->machine()->getGPRSize(), cursor);


### PR DESCRIPTION
OMR issue eclipse/omr#2645 (Consolidate implementation of RegisterIterators) is being solved under PR ~~eclipse/omr#2981~~ eclipse/omr#3287 There are a series of commits where such methods of the `Machine` classes as `getARCHRealRegister()` are renamed to `getRealRegister()`. The methods are actively used within OpenJ9 so that in order to exclude the possibility of getting an OpenJ9 broken build the methods must be renamed across the codebase.

**Warnings**: 
 * `build-all` is needed
 * the PR may be merged only after eclipse/omr#3287.