### PR TITLE
Enable DDR tests for AIX

### DIFF
--- a/runtime/ddr/run_omrddrgen.mk.ftl
+++ b/runtime/ddr/run_omrddrgen.mk.ftl
@@ -42,6 +42,13 @@ DDR_INPUT_FILES := $(addprefix $(TOP_DIR),$(foreach module,$(DDR_INPUT_MODULES),
 DDR_INPUT_FILES := $(addsuffix .dbg,$(DDR_INPUT_DEPENDS))
 </#if>
 
+# workaround to find libomrsig
+<#if uma.spec.type.aix>
+DDR_LIB_PATH := LIBPATH=..
+<#else>
+DDR_LIB_PATH :=
+</#if>
+
 # The primary goals of this makefile.
 DDR_BLOB := $(TOP_DIR)j9ddr.dat
 DDR_SUPERSET_FILE := $(TOP_DIR)superset.dat
@@ -74,7 +81,7 @@ clean :
 	rm -f $(DDR_PRODUCTS)
 
 $(DDR_BLOB) : $(TOP_DIR)ddrgen$(UMA_DOT_EXE) $(DDR_MACRO_LIST) blacklist $(wildcard overrides*)
-	$(TOP_DIR)ddrgen $(DDR_OPTIONS) \
+	$(DDR_LIB_PATH) $(TOP_DIR)ddrgen $(DDR_OPTIONS) \
 		$(DDR_INPUT_FILES)
 
 $(DDR_MACRO_LIST) : $(DDR_INPUT_DEPENDS)

--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -98,17 +98,12 @@
 		<delete dir="${build}" />
 	</target>
 
-	<!-- Temporarily disable compilation on zos and aix until ddr is supported; github.com/eclipse/openj9/issues/1511 -->
+	<!-- Temporarily disable compilation on zos until ddr is supported; github.com/eclipse/openj9/issues/1511 -->
 	<target name="build" >
 		<if>
-			<and>
-				<not>
-					<equals arg1="${os.name}" arg2="z/OS" />
-				</not>
-				<not>
-					<matches string="${os.name}" pattern="AIX" />
-				</not>
-			</and>
+			<not>
+				<equals arg1="${os.name}" arg2="z/OS" />
+			</not>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -53,8 +53,8 @@
 	-DTEST_RESROOT=$(TEST_RESROOT) -DRESOURCES_DIR=${RESOURCES_DIR} -DREPORTDIR=${REPORTDIR} -DOS=${OS} -DBITS=$(BITS) \
 	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.aix,^os.zos,^os.win</platformRequirements>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.zos,^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/callsitedbgddrext/callsiteddrtests.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/callsiteddrtests.xml
@@ -48,7 +48,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ -Xmx256m $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
@@ -104,7 +104,4 @@
   <output regex="no" type="failure">dump event</output>
  </test>
 
-
 </suite>
-
-

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -28,8 +28,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
 	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
@@ -56,8 +56,8 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+		<command>$perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
 	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
@@ -85,15 +85,14 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
 	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
 		<platformRequirements>^os.aix,^os.zos</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -111,4 +110,37 @@
 			<subset>11</subset>
 		</subsets>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_callsitedbgddrext_openj9_aix_zos</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
+	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>os.aix,^os.zos</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>9</subset>
+			<subset>10</subset>
+			<subset>11</subset>
+		</subsets>
+	</test>
+
 </playlist>

--- a/test/functional/cmdLineTests/classesdbgddrext/classesddrtests.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/classesddrtests.xml
@@ -48,7 +48,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xaot:forceaot,count=0 -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ -Xmx256m $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
@@ -196,7 +196,4 @@
   <output regex="no" type="failure">dump event</output>
  </test>
 
-
 </suite>
-
-

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -24,11 +24,11 @@
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>cmdLineTester_classesdbgddrext_zos</testCaseName>
+		<testCaseName>cmdLineTester_classesdbgddrext_aix_zos</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
 	-DRESJAR=$(CMDLINETESTER_RESJAR) \
 	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
@@ -39,7 +39,8 @@
 	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>os.zos</platformRequirements>
+		<!-- j9ddr.jar is not supported on z/OS; OpenJ9 issue 1511 -->
+		<platformRequirements>os.aix,^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -71,7 +72,6 @@
 	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- j9ddr.jar is not supported on AIX or z/OS; OpenJ9 issue 1511 -->
 		<platformRequirements>^os.aix,^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
@@ -85,37 +85,5 @@
 			<subset>10</subset>
 			<subset>11</subset>
 		</subsets>
-	</test>
-	<test>
-		<testCaseName>cmdLineTester_classesdbgddrext_aix</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
-		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl aix ; \
-	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
-	-DRESJAR=$(CMDLINETESTER_RESJAR) \
-	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
-	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
-	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
-	-jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)classesddrtests.xml$(Q) \
-	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
-	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
-	${TEST_STATUS}</command>
-		<platformRequirements>os.aix</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
-		<disabled>github.com/eclipse/openj9/issues/1511</disabled>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
@@ -38,7 +38,7 @@
   <exec command="tso delete J9CORE.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE$" />
-  <command>$EXE$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xmx256m $XDUMP$ $PROGRAM$</command>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
   <output regex="no" type="failure">0001.dmp</output>
@@ -372,5 +372,5 @@
   <output regex="no" type="failure">DDRInteractiveCommandException</output>
 
  </test>
- 
+
  </suite>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -40,8 +40,40 @@
 	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- Tests excluded on zos and aix because neither platform supports DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
 		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>9</subset>
+			<subset>10</subset>
+			<subset>11</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_modularityddrtests_aix_zos</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+		cd $(REPORTDIR); \
+		perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xmx1G \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
+	-DJDMPVIEW_EXE=$(Q)$(JDK_HOME)$(D)bin$(D)jdmpview$(EXECUTABLE_SUFFIX)$(Q) \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
+	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
+	${TEST_STATUS}</command>
+		<!-- Tests excluded on zos since it does not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<platformRequirements>os.aix,^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -30,7 +30,7 @@
 			<variation>Mode610</variation>
 			<variation>Mode201</variation>
 		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
 	cp $(CMDLINETESTER_RESJAR) .; \
 	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf cmdlinetestresources.jar; \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
@@ -41,7 +41,6 @@
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
 		<platformRequirements>^os.aix,^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
@@ -58,11 +57,11 @@
 	</test>
 
 	<test>
-		<testCaseName>cmdLineTester_shrcdbgddrext_zos</testCaseName>
+		<testCaseName>cmdLineTester_shrcdbgddrext_aix_zos</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl zos ; \
+		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
 	cp $(CMDLINETESTER_RESJAR) .; \
 	$(Q)$(JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf cmdlinetestresources.jar; \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \
@@ -73,7 +72,8 @@
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<platformRequirements>os.zos</platformRequirements>
+		<!-- temporarily disable this test on z/OS; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>os.aix,^os.zos</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/shrcdbgddrext/shrcdbgextddrtests.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/shrcdbgextddrtests.xml
@@ -77,7 +77,7 @@
   <exec command="tso delete J9CORE1.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE1.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE1$" />
-  <command>$EXE$ -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ $PROGRAM$</command>
+  <command>$EXE$ -Xshareclasses:name=$CACHENAME$ $CP$ $XDUMP$ -Xmx256m $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps -->
@@ -413,7 +413,7 @@
   <exec command="tso delete J9CORE2.DMP.*" platforms="zos_390-64.*" />
   <exec command="tso delete J9CORE2.DMP" platforms="zos_390-31.*" />
   <exec command="rm -f $DUMPFILE2$" />
-  <command>$EXE$  -Xjit:disableAsyncCompilation,count=20 $SHARECLASSESOPTION$ $CP$ $XDUMP2$ $PROGRAM$</command>
+  <command>$EXE$  -Xjit:disableAsyncCompilation,count=20 $SHARECLASSESOPTION$ $CP$ $XDUMP2$ -Xmx256ms $PROGRAM$</command>
   <output regex="no" type="success">Moved disk 0 to 1</output>
   <output regex="no" type="success">System dump written</output>
   <!-- check for unexpected core dumps  -->


### PR DESCRIPTION
Enables tests for DDR on AIX, closes https://github.com/eclipse/openj9/issues/1769
- enable callsitedbgddrext, classesdbgddrext, shrcdbgddrext, and
  modularityddrtests cmdlinetests for AIX
- enable DDR_Test for AIX
- create new AIX and zOS targets in playlist.xml for the DDR cmdline
  tests and use correct arguments to sysvcleanup.pl script. Pass in zos
  option since zos and aix options are identical in sysvcleanup.pl
- limit heap size in DDR tests to 256MB, since on AIX the core file
  scales with heap size, which can hit filesystem limits

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

This PR depends on the following extensions repo PRs, since the DDR tests do not compile without DDR enabled on AIX:
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/116
https://github.com/ibmruntimes/openj9-openjdk-jdk9/pull/178
https://github.com/ibmruntimes/openj9-openjdk-jdk10/pull/59
https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/23
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/35

Doc issue is https://github.com/eclipse/openj9-docs/issues/92