### PR TITLE
Update vm->applicationClassLoader with custom classloader

### DIFF
--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -729,8 +729,6 @@ getStackTraceForThread (J9VMThread * vmThread, J9VMThread *targetThread, UDATA s
 /* J9SourceJclStandardInit*/
 jint JCL_OnUnload (J9JavaVM* vm, void* reserved);
 jint standardPreconfigure ( JavaVM *jvm);
-jint
-standardInitAndCompleteInitialization (J9JavaVM *vm, char* dllName);
 void
 internalInitializeJavaLangClassLoader (JNIEnv * env);
 IDATA checkJCL (J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Version, UDATA jclVersion);


### PR DESCRIPTION
Update `vm->applicationClassLoader` with custom classloader set via system property `java.system.class.loader`.

A custom classloader set via system property `java.system.class.loader` need to be updated at `vm->applicationClassLoader`.
Removed unused method define for `standardInitAndCompleteInitialization` (the method body has been removed a while ago).

An automated test is going to be added to prevent regression.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>