### PR TITLE
Fix j.l.m.ThreadMXBean API signatures

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -632,8 +632,8 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 */
 	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
 			boolean lockedSynchronizers);
-	/*[IF Java10]*/
 
+	/*[IF Java10]*/
 	/**
 	 * Returns an array of {@link ThreadInfo} objects holding information on all
 	 * threads that were alive when the call was invoked.
@@ -664,9 +664,11 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 * @since 10
 	 */
 
-	public ThreadInfo[] dumpAllThreads(boolean lockedMonitors,
-            boolean lockedSynchronizers,
-            int maxDepth);
+	public default ThreadInfo[] dumpAllThreads(
+		boolean lockedMonitors, boolean lockedSynchronizers, int maxDepth
+	) {
+		throw new UnsupportedOperationException();
+	}
 
 
 	/**
@@ -728,9 +730,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
 	 *  </ul>
 	 * @since 10
 	 */
-	public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors,
-			boolean lockedSynchronizers, int maxDepth);
-
-
-	/*[ENDIF]*/ // Java 10
+	public default ThreadInfo[] getThreadInfo(
+		long[] ids, boolean lockedMonitors, boolean lockedSynchronizers, int maxDepth
+	) {
+		throw new UnsupportedOperationException();
+	}
+	/*[ENDIF] Java10*/
 }


### PR DESCRIPTION
Fix `j.l.m.ThreadMXBean` API signatures

The API have been changed to following:
```
public java.lang.management.ThreadInfo[] getThreadInfo(long[], boolean,
boolean, int);
public java.lang.management.ThreadInfo[] dumpAllThreads(boolean,
boolean, int);
```

Manually verified that `pConfig` still compiles.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>