### PR TITLE
Save local connector address in Attach API code

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/AttachHandler.java
@@ -699,6 +699,8 @@ public class AttachHandler extends Thread {
 				"sun.jvm.flags", //$NON-NLS-1$
 				"sun.java.command"			 //$NON-NLS-1$
 		};
+		Attachment.saveLocalConnectorAddress();
+		//If we don't have a local connector address, just continue and get the others
 		Properties agentProperties = new Properties();
 		for (String pName: agentPropertyNames) {
 			String pValue = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties().getProperty(pName);

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
@@ -407,6 +407,14 @@ final class Attachment extends Thread implements Response {
 			throw new IbmAttachOperationFailedException("startLocalManagementAgent error starting agent:" + e.getClass() + " " + e.getMessage());		 //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
+		String addr = saveLocalConnectorAddress();
+		if (Objects.isNull(addr)) {
+			throw new IbmAttachOperationFailedException("startLocalManagementAgent: " + LOCAL_CONNECTOR_ADDRESS + " not defined"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		return addr;
+	}
+
+	static String saveLocalConnectorAddress() {
 		Properties systemProperties = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties();
 		String addr;
 		synchronized (systemProperties) {
@@ -419,9 +427,9 @@ final class Attachment extends Thread implements Response {
 			}
 		}
 		if (Objects.isNull(addr)) {
-			/* startLocalAgent() should have set the property. */
+			/* property should be set at this point */
 			IPC.logMessage(LOCAL_CONNECTOR_ADDRESS + " not set"); //$NON-NLS-1$
-			throw new IbmAttachOperationFailedException("startLocalManagementAgent: " + LOCAL_CONNECTOR_ADDRESS + " not defined"); //$NON-NLS-1$ //$NON-NLS-2$
+			return null;
 		}
 		IPC.logMessage(LOCAL_CONNECTOR_ADDRESS + "=", addr); //$NON-NLS-1$
 		return addr;


### PR DESCRIPTION
From https://github.com/eclipse/openj9/issues/2742, VirtualMachine.getAgentProperties() doesn't get the local connector address if it isn't saved to our systems properties. Thus, we check VMSupport class for the local connector address and save it in system properties if it is not there already.

Fixes #2742

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>