### PR TITLE
Cleanup Artifactory code

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -261,37 +261,46 @@ def build() {
 def archive() {
     stage('Archive') {
         timestamps {
-              def buildDir = "build/${RELEASE}/images/"
-              def testDir = "test/openj9"
+            def buildDir = "build/${RELEASE}/images/"
+            def testDir = "test/openj9"
 
-              sh "tar -C ${buildDir} -zcvf ${SDK_FILENAME} ${JDK_FOLDER}"
-              // test if the test natives directory is present, only in JDK11+
-              sh "if test -d ${buildDir}${testDir}; then tar -C ${buildDir} -zcvf ${TEST_FILENAME} ${testDir} --transform 's,${testDir},native-test-libs,'; fi"
-              if (ARTIFACTORY_SERVER) {
+            sh "tar -C ${buildDir} -zcvf ${SDK_FILENAME} ${JDK_FOLDER}"
+            // test if the test natives directory is present, only in JDK11+
+            if (fileExists("${buildDir}${testDir}")) {
+               sh "tar -C ${buildDir} -zcvf ${TEST_FILENAME} ${testDir} --transform 's,${testDir},native-test-libs,'"
+            }
+            if (ARTIFACTORY_SERVER) {
                 def server = Artifactory.server ARTIFACTORY_SERVER
-                // if the archive location is modified the definition of CUSTOMIZED_SDK_URL will also need to be updated
+                def artifactory_upload_dir = "${ARTIFACTORY_REPO}/${JOB_NAME}/${BUILD_ID}/"
                 def uploadSpec = """{
-                  "files":[
-                    {
-                      "pattern": "${env.WORKSPACE}/${SDK_FILENAME}",
-                      "target": "${ARTIFACTORY_REPO}/${env.JOB_NAME}/${env.BUILD_ID}/"
-                    },
-                    {
-                      "pattern": "${env.WORKSPACE}/${TEST_FILENAME}",
-                      "target": "${ARTIFACTORY_REPO}/${env.JOB_NAME}/${env.BUILD_ID}/"
-                    }
-                  ]
+                    "files":[
+                        {
+                            "pattern": "${env.WORKSPACE}/${SDK_FILENAME}",
+                            "target": "${artifactory_upload_dir}"
+                        },
+                        {
+                            "pattern": "${env.WORKSPACE}/${TEST_FILENAME}",
+                            "target": "${artifactory_upload_dir}"
+                        }
+                    ]
                 }"""
 
                 def buildInfo = Artifactory.newBuildInfo()
-                // hardcoded to 30 for now, this need follow up for usage on per platform level or across all jobs
-                buildInfo.retention maxBuilds: 30, deleteBuildArtifacts: true
+                buildInfo.retention maxBuilds: ARTIFACTORY_NUM_ARTIFACTS, deleteBuildArtifacts: true
                 server.upload spec: uploadSpec, buildInfo: buildInfo
                 server.publishBuildInfo buildInfo
-              } else {
+                // Write URL to env so that we can pull it from the upstream pipeline job
+                ARTIFACTORY_URL = server.getUrl()
+                env.CUSTOMIZED_SDK_URL = "${ARTIFACTORY_URL}/${artifactory_upload_dir}/${SDK_FILENAME}"
+                if (fileExists("${TEST_FILENAME}")) {
+                    env.CUSTOMIZED_SDK_URL += " ${ARTIFACTORY_URL}/${artifactory_upload_dir}/${TEST_FILENAME}"
+                }
+                echo "CUSTOMIZED_SDK_URL:'${CUSTOMIZED_SDK_URL}'"
+                echo "ARTIFACTORY_CREDS:'${ARTIFACTORY_CREDS}'"
+            } else {
                 echo "ARTIFACTORY server is not set saving artifacts on jenkins."
                 archiveArtifacts artifacts: "**/${SDK_FILENAME},**/${TEST_FILENAME}", fingerprint: true, onlyIfSuccessful: true
-              }
+            }
         }
     }
 }

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -135,7 +135,7 @@ def get_date() {
     ).trim()
 }
 
-def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE, SDK_FILENAME, TEST_FILENAME) {
+def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO, OPENJ9_BRANCH, OPENJ9_SHA, OMR_REPO, OMR_BRANCH, OMR_SHA, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, VENDOR_CREDENTIALS_ID, NODE) {
     stage ("${BUILD_JOB_NAME}") {
         return build_with_slack(BUILD_JOB_NAME,
             [string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
@@ -151,9 +151,7 @@ def build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, OPENJDK_SHA, OPENJ9_REPO
             string(name: 'VENDOR_REPO', value: VENDOR_REPO),
             string(name: 'VENDOR_BRANCH', value: VENDOR_BRANCH),
             string(name: 'VENDOR_CREDENTIALS_ID', value: VENDOR_CREDENTIALS_ID),
-            string(name: 'NODE', value: NODE),
-            string(name: 'SDK_FILENAME', value: SDK_FILENAME),
-            string(name: 'TEST_FILENAME', value: TEST_FILENAME)])
+            string(name: 'NODE', value: NODE)])
     }
 }
 
@@ -240,7 +238,7 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
 
     // compile the source and build the SDK
     def BUILD_JOB_NAME = "Build-JDK${SDK_VERSION}-${SPEC}"
-    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.BUILD_NODE, SDK_FILENAME, TEST_FILENAME)
+    jobs["build"] = build(BUILD_JOB_NAME, OPENJDK_REPO, OPENJDK_BRANCH, SHAS['OPENJDK'], OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], OMR_REPO, OMR_BRANCH, SHAS['OMR'], params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.BUILD_NODE)
     echo "JOB: ${BUILD_JOB_NAME} PASSED in: ${jobs['build'].getDurationString()}"
 
     if (TESTS_TARGETS.trim() != "none") {
@@ -269,17 +267,24 @@ def workflow(SDK_VERSION, SPEC, SHAS, OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO,
             }
         }
 
+        // Determine if Build job archived to Artifactory
+        def BUILD_JOB_ENV = jobs["build"].getBuildVariables()
+        ARTIFACTORY_CREDS = ''
+        echo "BUILD_JOB_ENV:'${BUILD_JOB_ENV}'"
+        if (BUILD_JOB_ENV['CUSTOMIZED_SDK_URL']) {
+            CUSTOMIZED_SDK_URL = BUILD_JOB_ENV['CUSTOMIZED_SDK_URL']
+            ARTIFACTORY_CREDS = BUILD_JOB_ENV['ARTIFACTORY_CREDS']
+            echo "Passing CUSTOMIZED_SDK_URL:'${CUSTOMIZED_SDK_URL}'"
+            echo "Using ARTIFACTORY_CREDS:'${ARTIFACTORY_CREDS}'"
+        }
         for (name in TARGET_NAMES) {
             def TEST_JOB_NAME = "Test-${name}-JDK${SDK_VERSION}-${SPEC}"
             testjobs["${TEST_JOB_NAME}"] = {
-                // run tests against the SDK build in the upstream job: Build-JDK${SDK_VERSION}-${SPEC}
-                     if (ARTIFACTORY_SERVER) {
-                          def CUSTOMIZED_SDK_URL = "${ARTIFACTORY_BASE_URL}/${BUILD_JOB_NAME}/${jobs["build"].getNumber()}/${SDK_FILENAME} ${ARTIFACTORY_BASE_URL}/${BUILD_JOB_NAME}/${jobs["build"].getNumber()}/${TEST_FILENAME}"
-                          echo "Using CUSTOMIZED_SDK_URL = ${CUSTOMIZED_SDK_URL}, ARTIFACTORY_CREDS = ${ARTIFACTORY_CREDS}"
-                          jobs["${TEST_JOB_NAME}"] = build_with_artifactory(TEST_JOB_NAME, params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST, CUSTOMIZED_SDK_URL, ARTIFACTORY_CREDS)
-                     } else {
-                          jobs["${TEST_JOB_NAME}"] = build_with_one_upstream(TEST_JOB_NAME, BUILD_JOB_NAME, jobs["build"].getNumber(), params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST)
-                     }
+                if (ARTIFACTORY_CREDS) {
+                    jobs["${TEST_JOB_NAME}"] = build_with_artifactory(TEST_JOB_NAME, params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST, CUSTOMIZED_SDK_URL, ARTIFACTORY_CREDS)
+                } else {
+                    jobs["${TEST_JOB_NAME}"] = build_with_one_upstream(TEST_JOB_NAME, BUILD_JOB_NAME, jobs["build"].getNumber(), params.VARIABLE_FILE, params.VENDOR_REPO, params.VENDOR_BRANCH, params.VENDOR_CREDENTIALS_ID, params.TEST_NODE, OPENJ9_REPO, OPENJ9_BRANCH, SHAS['OPENJ9'], VENDOR_TEST_REPOS, VENDOR_TEST_BRANCHES, VENDOR_TEST_SHAS, VENDOR_TEST_DIRS, USER_CREDENTIALS_ID, BUILD_LIST)
+                }
                 echo "JOB: ${TEST_JOB_NAME} PASSED in: ${jobs[TEST_JOB_NAME].getDurationString()}"
             }
         }

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -383,19 +383,14 @@ def set_build_variables() {
 }
 
 def set_sdk_variables() {
-    SDK_FILENAME = params.SDK_FILENAME
-    TEST_FILENAME = params.TEST_FILENAME
-    if (!SDK_FILENAME) {
-        DATESTAMP = sh (
-            script: 'date +%Y%d%m%H%M',
-            returnStdout: true
-            ).trim()
-        SDK_FILENAME = "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}.tar.gz"
-        echo "Using SDK_FILENAME = ${SDK_FILENAME}"
-    }
-    if (!TEST_FILENAME) {
-        TEST_FILENAME = "native-test-libs.tar.gz"
-    }
+    DATESTAMP = sh (
+        script: 'date +%Y%d%m%H%M',
+        returnStdout: true
+        ).trim()
+    SDK_FILENAME = "OpenJ9-JDK${SDK_VERSION}-${SPEC}-${DATESTAMP}.tar.gz"
+    TEST_FILENAME = "native-test-libs.tar.gz"
+    echo "Using SDK_FILENAME = ${SDK_FILENAME}"
+    echo "Using TEST_FILENAME = ${TEST_FILENAME}"
 }
 
 /*
@@ -435,12 +430,13 @@ def set_slack_channel() {
 def set_artifactory_config() {
     ARTIFACTORY_SERVER = VARIABLES.artifactory_server
     ARTIFACTORY_REPO = VARIABLES.artifactory_repo
-    ARTIFACTORY_CREDS = VARIABLES.artifactory_creds
+    // Set Creds to env so that the parent pipeline can retireve them.
+    env.ARTIFACTORY_CREDS = VARIABLES.artifactory_creds
+    ARTIFACTORY_NUM_ARTIFACTS = VARIABLES.artifactory_num_artifacts
     if (ARTIFACTORY_SERVER) {
-        ARTIFACTORY_BASE_URL = "https://" + "${ARTIFACTORY_SERVER}" + ".com/artifactory/" + "${ARTIFACTORY_REPO}"
         echo "Using artifactory server/repo: ${ARTIFACTORY_SERVER} / ${ARTIFACTORY_REPO}"
-        echo "Using artifactory base url: ${ARTIFACTORY_BASE_URL}"
         echo "Using artifactory credentials: ${ARTIFACTORY_CREDS}"
+        echo "Keeping '${ARTIFACTORY_NUM_ARTIFACTS}' artifacts"
     }
 }
 
@@ -572,10 +568,10 @@ def set_job_properties(JOB_TYPE) {
             add_string_params(['TESTS_TARGETS':''])
         }
 
-        // Build
-        if (JOB_TYPE == 'build') {
-            add_string_params(['NODE':'', 'SDK_FILENAME':''])
-        }
+        // Build - Commented out as there are currently no params specific to only Build
+        //if (JOB_TYPE == 'build') {
+
+        //}
 
         /********************
         * TRIGGER
@@ -618,7 +614,6 @@ def set_job_variables(job_type) {
 
     // fetch credentials required to connect to GitHub using ssh protocol
     set_user_credentials()
-    set_artifactory_config()
 
     // Setup Jenkins Job Parameters
     set_job_properties(job_type)
@@ -637,6 +632,7 @@ def set_job_variables(job_type) {
             // set variables for a build job
             set_build_variables()
             set_sdk_variables()
+            set_artifactory_config()
             break
         case "test":
             // set the node the tests would run on
@@ -656,7 +652,6 @@ def set_job_variables(job_type) {
             // set variables for a pipeline job
             set_repos_variables()
             set_vendor_variables()
-            set_sdk_variables()
             set_test_targets()
             set_slack_channel()
             break


### PR DESCRIPTION
- Only set SDK_FILENAME in Build jobs
- Only set Artifactory variables in Build jobs
- Get Artifactory url from Artifacotry server object
- Write CUSTOMIZED_SDK_URL to Build job env
- Write ARTIFACTORY_CREDS to Build job env
- Fetch CUSTOMIZED_SDK_URL and ARTIFACOTRY_CREDS in
  Pipeline job from Build job env
- Pull number of artifacts from variable file
- No longer accept SDK_FILENAME or TEST_FILENAME as
  job parameters
- Remove SDK_FILENAME parameter from Build job properties
- Change to groovy check for test dir on tar
- Only add Test URL to CUSTOMIZED_SDK_URL if test tar exists
- Move logic for Artifacotry in Pipeline job outside of loop

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>