### PR TITLE
WIP Exclude tests broken by issue #2871

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_10.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_10.txt
@@ -26,3 +26,4 @@ org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	AN-https://
 org.openj9.test.java.lang.management.TestRuntimeMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.java.lang.management.TestThreadMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
+org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2871 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_11.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_11.txt
@@ -26,3 +26,4 @@ org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	AN-https://
 org.openj9.test.java.lang.management.TestRuntimeMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.java.lang.management.TestThreadMXBean:testGetMBeanInfo													1626 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
+org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2871 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_8.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_8.txt
@@ -24,3 +24,4 @@
 
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
+org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2871 generic-all

--- a/test/TestConfig/resources/excludes/latest_exclude_9.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_9.txt
@@ -27,3 +27,4 @@ org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all
 org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
 org.openj9.test.vmArguments.VmArgumentTests:testCrNocr																	244 generic-all
 j9vm.test.softmx.SoftmxRemoteTest																						480 generic-all
+org.openj9.test.attachAPI.TestAttachErrorHandling:test_startupShutdownRobustness										2871 generic-all


### PR DESCRIPTION
Disable these tests while investigating issue #2871 "Writing to closed socket
connection kills the JVM".

FYI @pshipton @llxia per 
https://github.com/eclipse/openj9/issues/2871#issuecomment-423154657.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>