### PR TITLE
Use reflection to access attach API internal APIs

### DIFF
--- a/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetVM.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetVM.java
@@ -24,11 +24,10 @@ package org.openj9.test.attachAPI;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Method;
 import java.util.Properties;
 
-import com.ibm.tools.attach.target.AttachHandler;
 
-@SuppressWarnings("nls")
 public class TargetVM {
 
 	public static final String WAITING_FOR_INITIALIZATION = "STATUS_WAIT_INITIALIZATION";
@@ -43,10 +42,14 @@ public class TargetVM {
 		System.err.println("starting");
 		long pid = 0;
 		try {
-			pid = AttachHandler.getProcessId();
+			Class<?> attachHandlerClass = Class.forName(TargetManager.COM_IBM_TOOLS_ATTACH_TARGET_ATTACH_HANDLER);
+			final Method getVmId = attachHandlerClass.getMethod("getVmId");
+			final Method getProcessId = attachHandlerClass.getMethod("getProcessId");
+			final Method waitForAttachApiInitialization = attachHandlerClass.getMethod("waitForAttachApiInitialization");
+			pid = (long) getProcessId.invoke(attachHandlerClass);
 			System.out.println(TargetManager.PID_PREAMBLE + pid);
-			if (AttachHandler.waitForAttachApiInitialization()) {
-				System.out.println(TargetManager.VMID_PREAMBLE + AttachHandler.getVmId());
+			if ((boolean) waitForAttachApiInitialization.invoke(attachHandlerClass)) {
+				System.out.println(TargetManager.VMID_PREAMBLE + getVmId.invoke(attachHandlerClass));
 				System.out.println(TargetManager.STATUS_PREAMBLE
 						+ TargetManager.STATUS_INIT_SUCESS);
 				System.out.flush();


### PR DESCRIPTION
Remove unnecessary compiler options related to exposing the APIs.

Fixes 
https://github.com/eclipse/openj9/issues/2938.

@llxia I ran a personal build with sanity tests on Java 10.  Would you kindly start builds to cover extended and Java 8.  Thank you.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>