### PR TITLE
Optimized Reference ArrayCopy on X86

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2062,6 +2062,29 @@ old_slow_jitThrowArrayIndexOutOfBounds(J9VMThread *currentThread)
 }
 
 void* J9FASTCALL
+impl_jitReferenceArrayCopy(J9VMThread *currentThread, UDATA lengthInBytes)
+{
+	SLOW_JIT_HELPER_PROLOGUE();
+	void* exception = NULL;
+	if (-1 != currentThread->javaVM->memoryManagerFunctions->referenceArrayCopy(currentThread,
+																				(J9IndexableObject*)currentThread->floatTemp1,
+																				(J9IndexableObject*)currentThread->floatTemp2,
+																				(fj9object_t*)currentThread->floatTemp3,
+																				(fj9object_t*)currentThread->floatTemp4,
+#if defined(J9VM_GC_COMPRESSED_POINTERS) || !defined(J9VM_ENV_DATA64)
+																				(I_32)(lengthInBytes >> 2)
+#else
+																				(I_32)(lengthInBytes >> 3)
+#endif /* J9VM_INTERP_COMPRESSED_OBJECT_HEADER || !J9VM_ENV_DATA64 */
+    ))
+	{
+        exception = (void*)-1;
+	}
+	SLOW_JIT_HELPER_EPILOGUE();
+	return exception;
+}
+
+void* J9FASTCALL
 old_slow_jitThrowArrayStoreException(J9VMThread *currentThread)
 {
 	OLD_JIT_HELPER_PROLOGUE(0);

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -967,4 +967,32 @@ END_PROC(jitDecompileOnReturnJ)
 
 })	dnl ASM_J9VM_ENV_DATA64
 
+START_PROC(jitReferenceArrayCopy)
+	FASTCALL_EXTERN(impl_jitReferenceArrayCopy,2)
+	pop uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
+	SWITCH_TO_C_STACK
+	SAVE_ALL_REGS
+
+	mov    uword ptr [_rbp+J9TR_VMThread_floatTemp3], _rsi
+	mov    uword ptr [_rbp+J9TR_VMThread_floatTemp4], _rdi
+ifdef({ASM_J9VM_ENV_DATA64},{
+ifdef({WIN32},{
+	mov    _rdx, _rcx
+	mov    _rcx, _rbp
+},{
+	mov    _rsi, _rcx
+	mov    _rdi, _rbp
+})
+},{
+	mov    _rdx, _rcx
+	mov    _rcx, _rbp
+})
+	call   FASTCALL_SYMBOL(impl_jitReferenceArrayCopy,2)
+	test   _rax, _rax
+	RESTORE_ALL_REGS
+	SWITCH_TO_JAVA_STACK
+	push uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
+	ret
+END_PROC(jitReferenceArrayCopy)
+
 	FILE_END

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1005,8 +1005,13 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_MTUnresolvedFloatStore,     (void *)MTUnresolvedFloatStore,    TR_Helper);
    SET(TR_MTUnresolvedDoubleStore,    (void *)MTUnresolvedDoubleStore,   TR_Helper);
    SET(TR_MTUnresolvedAddressStore,   (void *)MTUnresolvedAddressStore,  TR_Helper);
-
-   SET(TR_referenceArrayCopy,         (void *)jitConfig->javaVM->memoryManagerFunctions->referenceArrayCopy, TR_System);
+#if defined(TR_HOST_X86)
+   static bool UseOldReferenceArrayCopy = (bool)feGetEnv("TR_UseOldReferenceArrayCopy");
+   if (UseOldReferenceArrayCopy)
+      SET(TR_referenceArrayCopy, (void *)jitConfig->javaVM->memoryManagerFunctions->referenceArrayCopy, TR_System);
+   else
+      SET(TR_referenceArrayCopy,         (void *)jitReferenceArrayCopy,     TR_Helper);
+#endif
 
 #if !defined(TR_HOST_64BIT)
 #if !defined (TR_HOST_X86)

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -88,6 +88,7 @@ JIT_HELPER(jitNewObject);  // asm calling-convention helper
 JIT_HELPER(jitObjectHashCode);  // asm calling-convention helper
 JIT_HELPER(jitPostJNICallOffloadCheck);  // asm calling-convention helper
 JIT_HELPER(jitPreJNICallOffloadCheck);  // asm calling-convention helper
+JIT_HELPER(jitReferenceArrayCopy);  // asm calling-convention helper
 JIT_HELPER(jitReleaseVMAccess);  // asm calling-convention helper
 JIT_HELPER(jitReportMethodEnter);  // asm calling-convention helper
 JIT_HELPER(jitReportMethodExit);  // asm calling-convention helper
@@ -121,9 +122,9 @@ JIT_HELPER(jitThrowArithmeticException);  // asm calling-convention helper
 JIT_HELPER(jitThrowArrayIndexOutOfBounds);  // asm calling-convention helper
 JIT_HELPER(jitThrowArrayStoreException);  // asm calling-convention helper
 JIT_HELPER(jitThrowArrayStoreExceptionWithIP);  // asm calling-convention helper
+JIT_HELPER(jitThrowClassCastException);  // asm calling-convention helper
 JIT_HELPER(jitThrowCurrentException);  // asm calling-convention helper
 JIT_HELPER(jitThrowException);  // asm calling-convention helper
-JIT_HELPER(jitThrowClassCastException);  // asm calling-convention helper
 JIT_HELPER(jitThrowExceptionInInitializerError);  // asm calling-convention helper
 JIT_HELPER(jitThrowInstantiationException);  // asm calling-convention helper
 JIT_HELPER(jitThrowNullPointerException);  // asm calling-convention helper

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -52,6 +52,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *asynccheckEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *newEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *multianewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraylengthEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *exceptionRangeFenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *NULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Reference ArrayCopy has been optimized that reduces the code-path length,
and potentially improves performance.

Part of Issue: #3054

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>