### PR TITLE
WIP: Add test dependencies to build Dockerfiles

### DIFF
--- a/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
@@ -32,7 +32,10 @@ RUN apt-get update \
   && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    ant \
+    ant-contrib \
     autoconf \
+    build-essential \
     ca-certificates \
     ccache \
     cpio \
@@ -55,6 +58,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    perl \
     pkg-config \
     realpath \
     ssh \
@@ -62,6 +66,9 @@ RUN apt-get update \
     wget \
     zip \
   && rm -rf /var/lib/apt/lists/*
+
+# Install Docker module to run test framework
+RUN echo yes | cpan install JSON Text::CSV
 
 # Install optional tools
 RUN apt-get update \

--- a/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
@@ -32,7 +32,10 @@ RUN apt-get update \
   && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
+    ant \
+    ant-contrib \
     autoconf \
+    build-essential \
     ca-certificates \
     ccache \
     cmake \
@@ -54,6 +57,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    perl \
     pkg-config \
     realpath \
     ssh \
@@ -61,6 +65,9 @@ RUN apt-get update \
     wget \
     zip \
   && rm -rf /var/lib/apt/lists/*
+
+# Install Docker module to run test framework
+RUN echo yes | cpan install JSON Text::CSV
 
 # Install optional tools
 RUN apt-get update \

--- a/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
@@ -34,7 +34,10 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     gcc-7 \
     g++-7 \
+    ant \
+    ant-contrib \
     autoconf \
+    build-essential \
     ca-certificates \
     ccache \
     cmake \
@@ -55,6 +58,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    perl \
     pkg-config \
     realpath \
     ssh \
@@ -63,6 +67,9 @@ RUN apt-get update \
     zip \
     vim \
   && rm -rf /var/lib/apt/lists/*
+
+# Install Docker module to run test framework
+RUN echo yes | cpan install JSON Text::CSV
 
 # Create links for c++,g++,cc,gcc
 RUN ln -s g++ /usr/bin/c++ \


### PR DESCRIPTION
There are a few additional test dependencies needed to be able to build
and test OpenJ9 from within the same docker container. We add these
test dependencies to our Dockerfile so that a user is able to
simultaneously build and test a JDK from within the same container.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>