### PR TITLE
Match RI StackTraceElement format

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -4,7 +4,7 @@ package java.lang;
 import java.security.ProtectionDomain;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2017 IBM Corp. and others
+ * Copyright (c) 2002, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -257,6 +257,12 @@ public String toString() {
  * Helper method for toString and for Throwable.print output with PrintStream and PrintWriter
  */
 void appendTo(Appendable buf) {
+	/*[IF Sidecar19-SE]*/
+	if (null != moduleName) {
+		appendTo(buf, moduleName);
+		appendTo(buf, "/"); //$NON-NLS-1$
+	}
+	/*[ENDIF] Sidecar19-SE*/
 	/*[PR CMVC 90361] print "\tat " in Throwable.printStackTrace() for compatibility */
 	appendTo(buf, getClassName());
 	/*[PR CMVC 121726] Exception traces print '46' instead of '.' */
@@ -264,16 +270,6 @@ void appendTo(Appendable buf) {
 	appendTo(buf, getMethodName());
   
 	appendTo(buf, "("); //$NON-NLS-1$
-	/*[IF Sidecar19-SE]*/
-	if (null != moduleName) {
-		appendTo(buf, moduleName);
-		if (null != moduleVersion) {
-			appendTo(buf, "@"); //$NON-NLS-1$
-			appendTo(buf, moduleVersion);
-		}
-		appendTo(buf, "/"); //$NON-NLS-1$
-	}
-	/*[ENDIF]*/
 	if (isNativeMethod()) {
 		appendTo(buf, "Native Method"); //$NON-NLS-1$
 	} else {


### PR DESCRIPTION
Match `RI StackTraceElement` format

Moved module name to the beginning of output;
Removed module version info.

Manually verified that `pConfig` still compiles.
Now `OpenJ9` has following `StackTraceElement` format:
```
java.base/java.security.AccessController.throwACE(AccessController.java:176)
java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:237)
java.base/java.security.AccessController.checkPermission(AccessController.java:373)
java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
java.base/java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1066)
java.base/java.lang.System.getProperty(System.java:450)
java.base/java.lang.System.getProperty(System.java:419)
atestse.java_lang.TestSTE.testAll(TestSTE.java:11)
atestse.java_lang.TestSTE.main(TestSTE.java:6)
```
While `RI JDK11 ea b27` has following:
```
java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
java.base/java.security.AccessController.checkPermission(AccessController.java:895)
java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
java.base/java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1066)
java.base/java.lang.System.getProperty(System.java:810)
atestse.java_lang.TestSTE.testAll(TestSTE.java:11)
atestse.java_lang.TestSTE.main(TestSTE.java:6)
```

close:#2922

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>