### PR TITLE
Set PPCVirtualUnresolvedSnippet as GCSafePoint

### DIFF
--- a/runtime/compiler/p/codegen/CallSnippet.hpp
+++ b/runtime/compiler/p/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,12 +138,12 @@ class PPCVirtualUnresolvedSnippet : public TR::PPCVirtualSnippet
    public:
 
    PPCVirtualUnresolvedSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s, TR::LabelSymbol *retl)
-      : TR::PPCVirtualSnippet(cg, c, lab, s, retl), thunkAddress(NULL)
+      : TR::PPCVirtualSnippet(cg, c, lab, s, retl, true), thunkAddress(NULL)
       {
       }
 
    PPCVirtualUnresolvedSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s, TR::LabelSymbol *retl, uint8_t *thunkPtr)
-      : TR::PPCVirtualSnippet(cg, c, lab, s, retl), thunkAddress(thunkPtr)
+      : TR::PPCVirtualSnippet(cg, c, lab, s, retl, true), thunkAddress(thunkPtr)
       {
       }
 


### PR DESCRIPTION
The recently added changes to PPCVirtualUnresolvedSnippet to support
private virtual calls now require the snippet to be considered a GC Safe
Point. This is necessary to generate GC map information.

The PPCVirtualUnresolvedSnippet constructor was changed so that it now
passed true for the value of isGCSafePoint to the parent constructor.

PR with the previously mentioned PPCVirtualUnresolvedSnippet changes:
https://github.com/eclipse/openj9/pull/2809

fixes #2821 
fixes #2917 
fixes #2934 
fixes #2958

Signed-off-by: jimmyk <jimmyk@ca.ibm.com>