### PR TITLE
Add check before invokePrivate from virtual call

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1574,7 +1574,10 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 		if (method != NULL) {
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 			J9ROMMethod* romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-			if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccPrivate)) {
+			/* Only allow non-interface method to call invokePrivate, private interface method should use "invokeInterface" bytecode
+			 * The else case will throw ICCE for private interface method 
+			 */
+			if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccPrivate) && J9_ARE_NO_BITS_SET(resolvedClass->romClass->modifiers, J9_JAVA_INTERFACE)) {
 				/* Private method found, will not be in vTable, point vTable index to invokePrivate */
 				if (ramCPEntry != NULL) {
 					ramCPEntry->method = method;


### PR DESCRIPTION
- only allow non-interface method to enter invokePrivate path from `resolveVirtual`
- interface method will be handle by vtable lookup

Close: #2957 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>