### PR TITLE
OSX: Enable x86_64 linkage creation in CodeGenerator

### DIFF
--- a/runtime/compiler/x/amd64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/amd64/codegen/J9CodeGenerator.cpp
@@ -66,7 +66,7 @@ J9::X86::AMD64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
             systemLinkage = new (self()->trHeapMemory()) TR::AMD64J9Win64FastCallLinkage(self());
             linkage = new (self()->trHeapMemory()) TR::AMD64JNILinkage(systemLinkage, self());
             }
-         else if (TR::Compiler->target.isLinux())
+         else if (TR::Compiler->target.isLinux() || TR::Compiler->target.isOSX())
             {
             systemLinkage = new (self()->trHeapMemory()) TR::AMD64J9ABILinkage(self());
             linkage = new (self()->trHeapMemory()) TR::AMD64JNILinkage(systemLinkage, self());
@@ -84,7 +84,7 @@ J9::X86::AMD64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
             {
             linkage = new (self()->trHeapMemory()) TR::AMD64J9Win64FastCallLinkage(self());
             }
-         else if (TR::Compiler->target.isLinux())
+         else if (TR::Compiler->target.isLinux() || TR::Compiler->target.isOSX())
             {
             linkage = new (self()->trHeapMemory()) TR::AMD64J9ABILinkage(self());
             }


### PR DESCRIPTION
Issue: #36 

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>