### PR TITLE
OpenJ9 fixes for OSX support [Part 3]

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1074,7 +1074,7 @@ preloadLibraries(void)
 	/* detect if we're in a subdir or not */
 	jvmDLLNameBuffer = jvmBufferCat(jvmDLLNameBuffer, "/lib");
 	jvmDLLNameBuffer = jvmBufferCat(jvmDLLNameBuffer, vmDllName);
-	jvmDLLNameBuffer = jvmBufferCat(jvmDLLNameBuffer, ".so");
+	jvmDLLNameBuffer = jvmBufferCat(jvmDLLNameBuffer, J9PORT_LIBRARY_SUFFIX);
 
 	if(-1 != stat (jvmBufferData(jvmDLLNameBuffer), &statBuf)) {
 		jvmInSubdir = TRUE;

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -879,7 +879,7 @@ getj9bin()
 	result = jvmBufferCat(NULL, libraryInfo.dli_fname);
 	/* remove libjvm.so */
 	truncatePath(jvmBufferData(result));
-#elif defined(J9ZOS390) || defined(J9ZTPF) || defined(OSX)
+#elif defined(J9ZOS390) || defined(J9ZTPF)
 #define VMDLL_NAME J9_VM_DLL_NAME
 
 	int foundPosition = 0;


### PR DESCRIPTION
**1) Fix value of j9binBuffer/jrebinBuffer [OSX]**

On OSX, `j9binBuffer` and `jrebinBuffer` don't point to the `compressedrefs`
directory. This prevents `jvm.c::preloadLibrary` to derive correct paths
to libraries such as `omrsig`, `j9vm*` etc.

`j9binBuffer` and `jrebinBuffer` are derived using `jvmDLLNameBuffer`.
`jvmDLLNameBuffer` relies on the path to `libj9vm*.so/dll/dylib`. On OSX,
incorrect suffix is used for `libj9vm*.<SUFFIX>`. This causes `j9binBuffer`
and `jrebinBuffer` to be incorrectly set and `jvm.c::preloadLibrary` to
malfunction.

This fix will correctly set the library suffix for `libj9vm*` on OSX.

**2) Fix ifdefs in jvm.c::getj9bin**

Current ifdefs in `jvm.c::getj9bin`:
```
#if (defined(LINUX) && !defined(J9ZTPF)) || defined(OSX)
   /* Code 1 */
#elif defined(J9ZOS390) || defined(J9ZTPF) || defined(OSX)
   /* Code 2 */
#else /* must be AIX / RS6000 */
   /* Code 3 */
#endif
```
Code 1 (#if block) applies to OSX but Code 2 (#elif block) doesn't apply
to OSX. It seems incorrect to include defined(OSX) in both #if and #elif
boolean expressions. defined(OSX) is removed from the #elif boolean
expression.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>