### PR TITLE
Fix stack walker for new interface formats

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/AlgorithmVersion.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/AlgorithmVersion.java
@@ -50,6 +50,7 @@ public class AlgorithmVersion {
 	public static final String STACK_WALKER_VERSION = "ALG_STACKWALKER_VERSION";
 	public static final String FOUR_BYTE_OFFSETS_VERSION = "FOUR_BYTE_OFFSETS_VERSION";
 	public static final String VTABLE_VERSION = "ALG_VM_VTABLE_VERSION";
+	public static final String ITABLE_VERSION = "ALG_VM_ITABLE_VERSION";
 	
 	public static final String GC_ARRAYLET_OBJECT_MODEL_VERSION = "ALG_GC_ARRAYLET_OBJECT_MODEL_VERSION";
 	public static final String GC_CLASS_MODEL_VERSION = "ALG_GC_CLASS_MODEL_VERSION";

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -69,6 +69,9 @@ import com.ibm.j9ddr.vm29.structure.J9SFNativeMethodFrame;
 import com.ibm.j9ddr.vm29.structure.J9SFSpecialFrame;
 import com.ibm.j9ddr.vm29.types.U8;
 import com.ibm.j9ddr.vm29.types.UDATA;
+import com.ibm.j9ddr.vm29.structure.J9ITable;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ITablePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
 
 import static com.ibm.j9ddr.vm29.j9.JITLook.*;
 import static com.ibm.j9ddr.vm29.j9.ROMHelp.*;
@@ -405,13 +408,47 @@ public class JITStackWalker
 				walkState.unwindSP = walkState.unwindSP.add(getJitRecompilationResolvePushes());
 			} else if (resolveFrameType.eq(J9_STACK_FLAGS_JIT_LOOKUP_RESOLVE)) {
 				UDATAPointer interfaceObjectAndISlot = UDATAPointer.cast(JIT_RESOLVE_PARM(walkState,2));
-				J9ClassPointer interfaceClass = J9ClassPointer.cast(interfaceObjectAndISlot.at(0));
-				UDATA methodIndex = interfaceObjectAndISlot.at(1);
-				J9ROMMethodPointer romMethod = interfaceClass.romClass().romMethods();
-
-				while (! methodIndex.eq(0)) {
-					romMethod = nextROMMethod(romMethod);
-					methodIndex = methodIndex.sub(1);
+				J9ClassPointer resolvedClass = J9ClassPointer.cast(interfaceObjectAndISlot.at(0));
+				J9ROMMethodPointer romMethod;
+				if (AlgorithmVersion.getVersionOf(AlgorithmVersion.ITABLE_VERSION).getAlgorithmVersion() < 1) {
+					UDATA methodIndex = interfaceObjectAndISlot.at(1);
+					romMethod = resolvedClass.romClass().romMethods();
+					while (! methodIndex.eq(0)) {
+						romMethod = nextROMMethod(romMethod);
+						methodIndex = methodIndex.sub(1);
+					}
+				} else {
+					long iTableOffset = interfaceObjectAndISlot.at(1).longValue();
+					J9MethodPointer ramMethod;
+					if (0 != (iTableOffset & J9_ITABLE_OFFSET_DIRECT)) {
+						ramMethod = J9MethodPointer.cast(iTableOffset).untag(J9_ITABLE_OFFSET_TAG_BITS);
+					} else if (0 != (iTableOffset & J9_ITABLE_OFFSET_VIRTUAL)) {
+						long vTableOffset = iTableOffset & ~J9_ITABLE_OFFSET_TAG_BITS;
+						J9JavaVMPointer vm = walkState.walkThread.javaVM();
+						// C code uses Object from the VM contant pool, but that's not easily
+						// accessible to DDR. Any class will do.
+						J9ClassPointer clazz = vm.booleanArrayClass();
+						ramMethod = J9MethodPointer.cast(PointerPointer.cast(clazz.longValue() + vTableOffset).at(0));
+					} else {
+						long methodIndex = (iTableOffset - J9ITable.SIZEOF) / UDATA.SIZEOF;
+						/* The iTable now contains every method from inherited interfaces.
+						 * Find the appropriate segment for the referenced method within the
+						 * resolvedClass iTable.
+						 */
+						J9ITablePointer allInterfaces = J9ITablePointer.cast(resolvedClass.iTable());
+						for(;;) {
+							J9ClassPointer interfaceClass = allInterfaces.interfaceClass();
+							long methodCount = interfaceClass.romClass().romMethodCount().longValue();
+							if (methodIndex < methodCount) {
+								/* iTable segment located */
+								ramMethod = interfaceClass.ramMethods().add(methodIndex);
+								break;
+							}
+							methodIndex -= methodCount;
+							allInterfaces = allInterfaces.next();
+						}
+					}
+					romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
 				}
 
 				signature = J9ROMMETHOD_SIGNATURE(romMethod);

--- a/runtime/ddr/algorithm_versions.c
+++ b/runtime/ddr/algorithm_versions.c
@@ -39,6 +39,7 @@
 #define ALG_ROM_HELP_VERSION 1
 #define FOUR_BYTE_OFFSETS_VERSION 1
 #define ALG_VM_VTABLE_VERSION 1
+#define ALG_VM_ITABLE_VERSION 1
 
 J9DDRConstantTableBegin(DDRAlgorithmVersions)
 	J9DDRConstantTableEntryWithValue("VM_MAJOR_VERSION", VM_MAJOR_VERSION)
@@ -55,6 +56,7 @@ J9DDRConstantTableBegin(DDRAlgorithmVersions)
 	J9DDRConstantTableEntryWithValue("ALG_ROM_HELP_VERSION", ALG_ROM_HELP_VERSION)
 	J9DDRConstantTableEntryWithValue("FOUR_BYTE_OFFSETS_VERSION", FOUR_BYTE_OFFSETS_VERSION)
 	J9DDRConstantTableEntryWithValue("ALG_VM_VTABLE_VERSION", ALG_VM_VTABLE_VERSION)
+	J9DDRConstantTableEntryWithValue("ALG_VM_ITABLE_VERSION", ALG_VM_ITABLE_VERSION)
 J9DDRConstantTableEnd
 
 J9DDRStructTableBegin(AlgorithmVersions)


### PR DESCRIPTION
Fix runtime and DDR stack walkers to understand the expanded iTable
format in the interpreter and the enhanced JIT interface call snippet.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>