### PR TITLE
Fix incorrect global and extern symbol references on OSX

### DIFF
--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -636,131 +636,131 @@ START_PROC(j2iVirtual)
 END_PROC(j2iVirtual)
 
 START_PROC(icallVMprJavaSendNativeStatic)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendNativeStatic)
 
 START_PROC(icallVMprJavaSendStatic0)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStatic0)
 
 START_PROC(icallVMprJavaSendStatic1)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStatic1)
 
 START_PROC(icallVMprJavaSendStaticJ)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticJ)
 
 START_PROC(icallVMprJavaSendStaticF)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticF)
 
 START_PROC(icallVMprJavaSendStaticD)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticD)
 
 START_PROC(icallVMprJavaSendStaticSync0)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticSync0)
 
 START_PROC(icallVMprJavaSendStaticSync1)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticSync1)
 
 START_PROC(icallVMprJavaSendStaticSyncJ)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticSyncJ)
 
 START_PROC(icallVMprJavaSendStaticSyncF)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticSyncF)
 
 START_PROC(icallVMprJavaSendStaticSyncD)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticSyncD)
 
 START_PROC(icallVMprJavaSendNativeVirtual)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendNativeVirtual)
 
 START_PROC(icallVMprJavaSendVirtual0)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtual0)
 
 START_PROC(icallVMprJavaSendVirtual1)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtual1)
 
 START_PROC(icallVMprJavaSendVirtualJ)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualJ)
 
 START_PROC(icallVMprJavaSendVirtualF)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualF)
 
 START_PROC(icallVMprJavaSendVirtualD)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualD)
 
 START_PROC(icallVMprJavaSendVirtualSync0)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualSync0)
 
 START_PROC(icallVMprJavaSendVirtualSync1)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualSync1)
 
 START_PROC(icallVMprJavaSendVirtualSyncJ)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualSyncJ)
 
 START_PROC(icallVMprJavaSendVirtualSyncF)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualSyncF)
 
 START_PROC(icallVMprJavaSendVirtualSyncD)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualSyncD)
 
 START_PROC(icallVMprJavaSendInvokeExact0)
-	jmp j2iInvokeExact
+	jmp GLOBAL_SYMBOL(j2iInvokeExact)
 END_PROC(icallVMprJavaSendInvokeExact0)
 
 START_PROC(icallVMprJavaSendInvokeExact1)
-	jmp j2iInvokeExact
+	jmp GLOBAL_SYMBOL(j2iInvokeExact)
 END_PROC(icallVMprJavaSendInvokeExact1)
 
 START_PROC(icallVMprJavaSendInvokeExactD)
-	jmp j2iInvokeExact
+	jmp GLOBAL_SYMBOL(j2iInvokeExact)
 END_PROC(icallVMprJavaSendInvokeExactD)
 
 START_PROC(icallVMprJavaSendInvokeExactF)
-	jmp j2iInvokeExact
+	jmp GLOBAL_SYMBOL(j2iInvokeExact)
 END_PROC(icallVMprJavaSendInvokeExactF)
 
 START_PROC(icallVMprJavaSendInvokeExactJ)
-	jmp j2iInvokeExact
+	jmp GLOBAL_SYMBOL(j2iInvokeExact)
 END_PROC(icallVMprJavaSendInvokeExactJ)
 
 START_PROC(icallVMprJavaSendInvokeExactL)
-	jmp j2iInvokeExact
+	jmp GLOBAL_SYMBOL(j2iInvokeExact)
 END_PROC(icallVMprJavaSendInvokeExactL)
 
 START_PROC(icallVMprJavaSendStaticL)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticL)
 
 START_PROC(icallVMprJavaSendStaticSyncL)
-	jmp j2iTransition
+	jmp GLOBAL_SYMBOL(j2iTransition)
 END_PROC(icallVMprJavaSendStaticSyncL)
 
 START_PROC(icallVMprJavaSendVirtualL)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualL)
 
 START_PROC(icallVMprJavaSendVirtualSyncL)
-	jmp j2iVirtual
+	jmp GLOBAL_SYMBOL(j2iVirtual)
 END_PROC(icallVMprJavaSendVirtualSyncL)
 
 	DECLARE_EXTERN(c_jitDecompileOnReturn)

--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -53,7 +53,7 @@ define({FILE_END},{
 define({START_PROC},{
 	align 16
 	DECLARE_PUBLIC($1)
-	$1 proc
+	GLOBAL_SYMBOL($1) proc
 })
 
 define({END_PROC},{$1 endp})
@@ -66,9 +66,13 @@ define({LABEL},$1)
 
 define({C_FUNCTION_SYMBOL},$1)
 
+define({GLOBAL_SYMBOL},$1)
+
 },{	dnl WIN32
 
 ifdef({OSX},{ 
+
+dnl OSX
 
 define({SHORT_JMP},{})
 
@@ -79,13 +83,11 @@ define({FILE_START},{
 
 define({C_FUNCTION_SYMBOL},_$1)
 
-define({START_PROC},{
-	.align 16
-	DECLARE_PUBLIC($1)
-	_$1:
-})
+define({GLOBAL_SYMBOL},_$1)
 
 },{	dnl OSX
+
+dnl LINUX
 
 define({SHORT_JMP},{short})
 
@@ -97,13 +99,17 @@ define({FILE_START},{
 
 define({C_FUNCTION_SYMBOL},$1)
 
+define({GLOBAL_SYMBOL},$1)
+
+})	dnl OSX
+
+dnl LINUX and OSX
+
 define({START_PROC},{
 	.align 16
 	DECLARE_PUBLIC($1)
-	$1:
+	GLOBAL_SYMBOL($1):
 })
-
-})	dnl OSX
 
 define({FILE_END})
 
@@ -116,9 +122,9 @@ ifdef({OSX},{
 })	dnl OSX
 })
 
-define({DECLARE_PUBLIC},{.global C_FUNCTION_SYMBOL($1)})
+define({DECLARE_PUBLIC},{.global GLOBAL_SYMBOL($1)})
 
-define({DECLARE_EXTERN},{.extern $1})
+define({DECLARE_EXTERN},{.extern C_FUNCTION_SYMBOL($1)})
 
 ifdef({OSX},{
 define({LABEL},$1)
@@ -265,7 +271,7 @@ define({SWITCH_TO_JAVA_STACK},{
 define({CALL_C_FUNC},{
 	mov uword ptr (J9TR_machineSP_vmStruct+$3+(J9TR_pointerSize*$2))[_rsp],_rbp
 	mov _rbp,uword ptr (J9TR_machineSP_machineBP+$3+(J9TR_pointerSize*$2))[_rsp]
-	call $1
+	call C_FUNCTION_SYMBOL($1)
 	mov _rbp,uword ptr (J9TR_machineSP_vmStruct+$3+(J9TR_pointerSize*$2))[_rsp]
 })
 
@@ -533,6 +539,13 @@ define({STORE_VIRTUAL_REGISTERS},{
 })
 
 })	dnl ASM_J9VM_ENV_DATA64
+
+ifdef({OSX},{
+	
+	define({FASTCALL_SYMBOL},{_$1})
+
+	define({FASTCALL_EXTERN},{DECLARE_EXTERN($1)})
+})
 
 ifdef({FASTCALL_SYMBOL},,{define({FASTCALL_SYMBOL},{$1})})
 

--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -542,10 +542,23 @@ define({STORE_VIRTUAL_REGISTERS},{
 
 ifdef({OSX},{
 	
-	define({FASTCALL_SYMBOL},{_$1})
+define({FASTCALL_SYMBOL},{_$1})
 
-	define({FASTCALL_EXTERN},{DECLARE_EXTERN($1)})
+define({FASTCALL_EXTERN},{DECLARE_EXTERN($1)})
+
+define({CALL_C_ADDR_WITH_VMTHREAD},{
+	mov _rdi,_rbp
+	mov uword ptr (J9TR_machineSP_vmStruct+(J9TR_pointerSize*$2))[_rsp],_rbp
+	mov _rbp,uword ptr (J9TR_machineSP_machineBP+(J9TR_pointerSize*$2))[_rsp]
+	call $1
+	mov _rbp,uword ptr (J9TR_machineSP_vmStruct+(J9TR_pointerSize*$2))[_rsp]
 })
+
+},{ dnl OSX
+
+define({CALL_C_ADDR_WITH_VMTHREAD},{CALL_C_WITH_VMTHREAD($1,$2)})
+
+}) dnl OSX
 
 ifdef({FASTCALL_SYMBOL},,{define({FASTCALL_SYMBOL},{$1})})
 

--- a/runtime/vm/xcinterp.m4
+++ b/runtime/vm/xcinterp.m4
@@ -165,7 +165,7 @@ START_PROC(c_cInterpreter)
 	mov uword ptr J9TR_ELS_jitFPRegisterStorageBase[_rax],_rbx
 C_FUNCTION_SYMBOL(cInterpreter):
 	mov _rax,uword ptr J9TR_VMThread_javaVM[_rbp]
-	CALL_C_WITH_VMTHREAD(uword ptr J9TR_JavaVM_bytecodeLoop[_rax],0)
+	CALL_C_ADDR_WITH_VMTHREAD(uword ptr J9TR_JavaVM_bytecodeLoop[_rax],0)
 	cmp _rax,J9TR_bcloop_exit_interpreter
 	je SHORT_JMP cInterpExit
 	RESTORE_PRESERVED_REGS


### PR DESCRIPTION
OSX requires all symbols that are either defined or used in
modules other than itself to have leading underscores
(only relevant when writing assembly code).
This fixes linker errors caused due to the missing underscores
in symbol declarations and references in xnathelp.o

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

Issue: #36 