### PR TITLE
Mark VarHandle call sites with cannotAttemptOSR

### DIFF
--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -205,6 +205,9 @@ int32_t TR_VarHandleTransformer::perform()
                comp()->failCompilation<J9::FSDHasInvokeHandle>("A call to a VarHandle access method is not supported in FSD. Failing ilgen.");
                }
 
+            if (comp()->getOption(TR_EnableOSR) && !comp()->isPeekingMethod())
+               methodSymbol->setCannotAttemptOSR(node->getByteCodeInfo().getByteCodeIndex());
+
             // Anchoring all the children for varhandle
             anchorAllChildren(node, tt);
             performTransformation(comp(), "%sVarHandle access methods found, working on node %p\n", optDetailString(), node);


### PR DESCRIPTION
VarHandle calls are virtual calls that will be recognized and
transformed into a sequence of nodes by the JIT. The nodes includes
potential OSR points that don't have OSR support.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>