### PR TITLE
Fix extern "C" naming issues on OSX

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -22,7 +22,7 @@
 
 #define J9_EXTERNAL_TO_VM
 
-#if SOLARIS || AIXPPC || LINUX
+#if SOLARIS || AIXPPC || LINUX || OSX
 #include <strings.h>
 #define J9OS_STRNCMP strncasecmp
 #else
@@ -4707,7 +4707,11 @@ bool TR::CompilationInfo::isQueuedForCompilation(J9Method * method, void *oldSta
    return linkageInfo->isBeingCompiled();
    }
 
+#if defined(OSX)
+JIT_HELPER(initialInvokeExactThunkGlue);
+#else
 JIT_HELPER(_initialInvokeExactThunkGlue);
+#endif
 
 void *TR::CompilationInfo::startPCIfAlreadyCompiled(J9VMThread * vmThread, TR::IlGeneratorMethodDetails & details, void *oldStartPC)
    {
@@ -4737,6 +4741,8 @@ void *TR::CompilationInfo::startPCIfAlreadyCompiled(J9VMThread * vmThread, TR::I
          initialInvokeExactThunkGlueAddress = (void*)TOC_UNWRAP_ADDRESS(_initialInvokeExactThunkGlue);
 #elif defined(TR_HOST_POWER) && (defined(TR_HOST_64BIT) || defined(AIXPPC)) && !defined(__LITTLE_ENDIAN__)
          initialInvokeExactThunkGlueAddress = (*(void **)_initialInvokeExactThunkGlue);
+#elif defined(OSX)
+         initialInvokeExactThunkGlueAddress = (void*)initialInvokeExactThunkGlue;
 #else
          initialInvokeExactThunkGlueAddress = (void*)_initialInvokeExactThunkGlue;
 #endif

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9095,8 +9095,11 @@ TR_J9VMBase::classNameChars(TR::Compilation *comp, TR::SymbolReference * symRef,
 
 // Native method bodies
 //
-
+#if defined(OSX)
+JIT_HELPER(initialInvokeExactThunkGlue);
+#else
 JIT_HELPER(_initialInvokeExactThunkGlue);
+#endif
 
 JNIEXPORT jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
    (JNIEnv *env, jclass clazz)
@@ -9105,6 +9108,8 @@ JNIEXPORT jlong JNICALL Java_java_lang_invoke_ThunkTuple_initialInvokeExactThunk
    return (jlong)TOC_UNWRAP_ADDRESS(_initialInvokeExactThunkGlue);
 #elif defined(TR_HOST_POWER) && (defined(TR_HOST_64BIT) || defined(AIXPPC)) && !defined(__LITTLE_ENDIAN__)
    return (jlong)(*(void **)_initialInvokeExactThunkGlue);
+#elif defined(OSX)
+   return (jlong)initialInvokeExactThunkGlue;
 #else
    return (jlong)_initialInvokeExactThunkGlue;
 #endif

--- a/runtime/compiler/runtime/CRuntimeImpl.cpp
+++ b/runtime/compiler/runtime/CRuntimeImpl.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,11 @@
 
 // To transfer control to VM during OSR
 extern "C" {
+#if defined(OSX)
+void prepareForOSR(uintptrj_t vmThreadArg, int32_t currentInlinedSiteIndex, int32_t slotData)
+#else
 void _prepareForOSR(uintptrj_t vmThreadArg, int32_t currentInlinedSiteIndex, int32_t slotData)
+#endif
    {
    const bool details = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseOSRDetails);
    const bool trace   = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseOSR) || details;

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1106,14 +1106,26 @@ extern "C" void _patchJNICallSite(J9Method *method, uint8_t *pc, uint8_t *newAdd
    }
 #endif
 
+#if defined(OSX)
+JIT_HELPER(prepareForOSR);
+#else
 JIT_HELPER(_prepareForOSR);
+#endif /* OSX */
 
 #ifdef TR_HOST_X86
+#if defined(OSX)
+JIT_HELPER(countingRecompileMethod);
+JIT_HELPER(samplingRecompileMethod);
+JIT_HELPER(countingPatchCallSite);
+JIT_HELPER(samplingPatchCallSite);
+JIT_HELPER(induceRecompilation);
+#else
 JIT_HELPER(_countingRecompileMethod);
 JIT_HELPER(_samplingRecompileMethod);
 JIT_HELPER(_countingPatchCallSite);
 JIT_HELPER(_samplingPatchCallSite);
 JIT_HELPER(_induceRecompilation);
+#endif /* OSX */
 
 #elif defined(TR_HOST_POWER)
 
@@ -1197,25 +1209,35 @@ void initializeJitRuntimeHelperTable(char isSMP)
 
 #if defined(J9ZOS390)
    SET_CONST(TR_prepareForOSR,                  (void *)_prepareForOSR);
+#elif defined(OSX)
+   SET(TR_prepareForOSR,                        (void *)prepareForOSR, TR_Helper);
 #else
    SET(TR_prepareForOSR,                        (void *)_prepareForOSR, TR_Helper);
 #endif
 
 #ifdef TR_HOST_X86
 
-#  if defined(TR_HOST_64BIT)
+#if defined(TR_HOST_64BIT)
+#if defined(OSX)
+   SET(TR_AMD64samplingRecompileMethod,         (void *)samplingRecompileMethod, TR_Helper);
+   SET(TR_AMD64countingRecompileMethod,         (void *)countingRecompileMethod, TR_Helper);
+   SET(TR_AMD64samplingPatchCallSite,           (void *)samplingPatchCallSite,   TR_Helper);
+   SET(TR_AMD64countingPatchCallSite,           (void *)countingPatchCallSite,   TR_Helper);
+   SET(TR_AMD64induceRecompilation,             (void *)induceRecompilation,     TR_Helper);
+#else /* OSX */
    SET(TR_AMD64samplingRecompileMethod,         (void *)_samplingRecompileMethod, TR_Helper);
    SET(TR_AMD64countingRecompileMethod,         (void *)_countingRecompileMethod, TR_Helper);
    SET(TR_AMD64samplingPatchCallSite,           (void *)_samplingPatchCallSite,   TR_Helper);
    SET(TR_AMD64countingPatchCallSite,           (void *)_countingPatchCallSite,   TR_Helper);
    SET(TR_AMD64induceRecompilation,             (void *)_induceRecompilation,     TR_Helper);
-#  else
+#endif /* OSX */
+#else /* TR_HOST_64BIT */
    SET(TR_IA32samplingRecompileMethod,          (void *)_samplingRecompileMethod, TR_Helper);
    SET(TR_IA32countingRecompileMethod,          (void *)_countingRecompileMethod, TR_Helper);
    SET(TR_IA32samplingPatchCallSite,            (void *)_samplingPatchCallSite,   TR_Helper);
    SET(TR_IA32countingPatchCallSite,            (void *)_countingPatchCallSite,   TR_Helper);
    SET(TR_IA32induceRecompilation,              (void *)_induceRecompilation,     TR_Helper);
-#  endif
+#endif /* TR_HOST_64BIT */
 
 #elif defined(TR_HOST_POWER)
 
@@ -1589,7 +1611,11 @@ uint8_t *compileMethodHandleThunk(j9object_t methodHandle, j9object_t arg, J9VMT
    return startPC;
    }
 
+#if defined(OSX)
+JIT_HELPER(initialInvokeExactThunkGlue);
+#else
 JIT_HELPER(_initialInvokeExactThunkGlue);
+#endif
 
 void *initialInvokeExactThunk(j9object_t methodHandle, J9VMThread *vmThread)
    {
@@ -1657,14 +1683,21 @@ void *initialInvokeExactThunk(j9object_t methodHandle, J9VMThread *vmThread)
    else
       {
       uintptrj_t fieldOffset = fej9->getInstanceFieldOffset(fej9->getObjectClass(thunkTuple), "invokeExactThunk", "J");
+#if defined(OSX)
+      bool success = fej9->compareAndSwapInt64Field(thunkTuple, "invokeExactThunk", (uint64_t)(uintptrj_t)initialInvokeExactThunkGlue, (uint64_t)(uintptrj_t)addressToDispatch);
+      
+      if (details)
+         TR_VerboseLog::writeLineLocked(TR_Vlog_MHD, "%p   %s updating ThunkTuple %p field %+d from %p to %p",
+            vmThread, success? "Succeeded" : "Failed", thunkTuple, (int)fieldOffset, initialInvokeExactThunkGlue, addressToDispatch);
+#else
       bool success = fej9->compareAndSwapInt64Field(thunkTuple, "invokeExactThunk", (uint64_t)(uintptrj_t)_initialInvokeExactThunkGlue, (uint64_t)(uintptrj_t)addressToDispatch);
       // If the CAS fails, we don't care much.  It just means another thread may already have put a MH thunk pointer in there.
 
       if (details)
          TR_VerboseLog::writeLineLocked(TR_Vlog_MHD, "%p   %s updating ThunkTuple %p field %+d from %p to %p",
             vmThread, success? "Succeeded" : "Failed", thunkTuple, (int)fieldOffset, _initialInvokeExactThunkGlue, addressToDispatch);
+#endif
       }
-
    return addressToDispatch;
    }
 

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -244,11 +244,17 @@ JIT_HELPER(callGPU);
 // --------------------------------------------------------------------------------
 //                                  X86 COMMON
 // --------------------------------------------------------------------------------
-
+#if defined(OSX)
+JIT_HELPER(doubleToLong);
+JIT_HELPER(doubleToInt);
+JIT_HELPER(floatToLong);
+JIT_HELPER(floatToInt);
+#else
 JIT_HELPER(_doubleToLong);
 JIT_HELPER(_doubleToInt);
 JIT_HELPER(_floatToLong);
 JIT_HELPER(_floatToInt);
+#endif /* OSX */
 
 JIT_HELPER(interpreterUnresolvedClassGlue);
 JIT_HELPER(interpreterUnresolvedClassFromStaticFieldGlue);
@@ -263,6 +269,22 @@ JIT_HELPER(interpreterUnresolvedFieldGlue);
 JIT_HELPER(interpreterUnresolvedFieldSetterGlue);
 JIT_HELPER(interpreterUnresolvedConstantDynamicGlue);
 
+#if defined(OSX)
+JIT_HELPER(SMPinterpreterUnresolvedStaticGlue);
+JIT_HELPER(SMPinterpreterUnresolvedSpecialGlue);
+JIT_HELPER(SMPinterpreterUnresolvedDirectVirtualGlue);
+JIT_HELPER(SMPinterpreterUnresolvedClassGlue);
+JIT_HELPER(SMPinterpreterUnresolvedClassGlue2);
+JIT_HELPER(SMPinterpreterUnresolvedStringGlue);
+JIT_HELPER(SMPinterpreterUnresolvedMethodTypeGlue);
+JIT_HELPER(SMPinterpreterUnresolvedMethodHandleGlue);
+JIT_HELPER(SMPinterpreterUnresolvedCallSiteTableEntryGlue);
+JIT_HELPER(SMPinterpreterUnresolvedMethodTypeTableEntryGlue);
+JIT_HELPER(SMPinterpreterUnresolvedStaticDataGlue);
+JIT_HELPER(SMPinterpreterUnresolvedStaticStoreDataGlue);
+JIT_HELPER(SMPinterpreterUnresolvedInstanceDataGlue);
+JIT_HELPER(SMPinterpreterUnresolvedInstanceStoreDataGlue);
+#else
 JIT_HELPER(_SMPinterpreterUnresolvedStaticGlue);
 JIT_HELPER(_SMPinterpreterUnresolvedSpecialGlue);
 JIT_HELPER(_SMPinterpreterUnresolvedDirectVirtualGlue);
@@ -277,6 +299,7 @@ JIT_HELPER(_SMPinterpreterUnresolvedStaticDataGlue);
 JIT_HELPER(_SMPinterpreterUnresolvedStaticStoreDataGlue);
 JIT_HELPER(_SMPinterpreterUnresolvedInstanceDataGlue);
 JIT_HELPER(_SMPinterpreterUnresolvedInstanceStoreDataGlue);
+#endif /* OSX */
 
 JIT_HELPER(resolveIPicClass);
 JIT_HELPER(populateIPicSlotClass);
@@ -315,17 +338,28 @@ JIT_HELPER(newPrefetchTLH);
 JIT_HELPER(outlinedNewObject);
 JIT_HELPER(outlinedNewArray);
 
+#if defined(OSX)
+JIT_HELPER(arrayTranslateTRTO);
+JIT_HELPER(arrayTranslateTROTNoBreak);
+JIT_HELPER(arrayTranslateTROT);
+#else
 JIT_HELPER(_arrayTranslateTRTO);
 JIT_HELPER(_arrayTranslateTROTNoBreak);
 JIT_HELPER(_arrayTranslateTROT);
+#endif /* OSX */
 
 // --------------------------------------------------------------------------------
 //                                   AMD64
 // --------------------------------------------------------------------------------
 
 #ifdef TR_HOST_64BIT
+#if defined(OSX)
+JIT_HELPER(SSEdoubleRemainder);
+JIT_HELPER(SSEfloatRemainder);
+#else
 JIT_HELPER(_SSEdoubleRemainder);
 JIT_HELPER(_SSEfloatRemainder);
+#endif /* OSX */
 JIT_HELPER(icallVMprJavaSendVirtual0);
 JIT_HELPER(icallVMprJavaSendVirtual1);
 JIT_HELPER(icallVMprJavaSendVirtualJ);
@@ -333,6 +367,15 @@ JIT_HELPER(icallVMprJavaSendVirtualL);
 JIT_HELPER(icallVMprJavaSendVirtualF);
 JIT_HELPER(icallVMprJavaSendVirtualD);
 
+#if defined(OSX)
+JIT_HELPER(compressString);
+JIT_HELPER(compressStringNoCheck);
+JIT_HELPER(compressStringJ);
+JIT_HELPER(compressStringNoCheckJ);
+JIT_HELPER(andORString);
+JIT_HELPER(encodeUTF16Big);
+JIT_HELPER(encodeUTF16Little);
+#else
 JIT_HELPER(_compressString);
 JIT_HELPER(_compressStringNoCheck);
 JIT_HELPER(_compressStringJ);
@@ -340,11 +383,17 @@ JIT_HELPER(_compressStringNoCheckJ);
 JIT_HELPER(_andORString);
 JIT_HELPER(_encodeUTF16Big);
 JIT_HELPER(_encodeUTF16Little);
+#endif /* OSX */
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
+#if defined (OSX)
+JIT_HELPER(doAESENCEncrypt);
+JIT_HELPER(doAESENCDecrypt);
+#else
 JIT_HELPER(_doAESENCEncrypt);
 JIT_HELPER(_doAESENCDecrypt);
-#endif
+#endif /* OSX */
+#endif /* J9VM_OPT_JAVA_CRYPTO_ACCELERATION */
 
 JIT_HELPER(interpreterEAXStaticGlue);
 JIT_HELPER(interpreterRAXStaticGlue);
@@ -1159,9 +1208,13 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_X86interpreterSyncDoubleStaticGlue,         (void *)interpreterSyncXMM0DStaticGlue, TR_Helper);
    SET(TR_X86interpreterAddressStaticGlue,            (void *)interpreterRAXStaticGlue,       TR_Helper);
    SET(TR_X86interpreterSyncAddressStaticGlue,        (void *)interpreterSyncRAXStaticGlue,   TR_Helper);
-
+#if defined(OSX)
+   SET(TR_AMD64floatRemainder,                        (void *)SSEfloatRemainder,  TR_Helper);
+   SET(TR_AMD64doubleRemainder,                       (void *)SSEdoubleRemainder, TR_Helper);
+#else
    SET(TR_AMD64floatRemainder,                        (void *)_SSEfloatRemainder,  TR_Helper);
    SET(TR_AMD64doubleRemainder,                       (void *)_SSEdoubleRemainder, TR_Helper);
+#endif /* OSX */
 
    SET(TR_AMD64icallVMprJavaSendVirtual0,             (void *)icallVMprJavaSendVirtual0, TR_Helper);
    SET(TR_AMD64icallVMprJavaSendVirtual1,             (void *)icallVMprJavaSendVirtual1, TR_Helper);
@@ -1171,7 +1224,22 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_AMD64icallVMprJavaSendVirtualD,             (void *)icallVMprJavaSendVirtualD, TR_Helper);
 
    SET(TR_AMD64jitCollapseJNIReferenceFrame,          (void *)jitCollapseJNIReferenceFrame,   TR_Helper);
-
+#if defined(OSX)
+   SET(TR_AMD64compressString,                        (void *)compressString,            TR_Helper);
+   SET(TR_AMD64compressStringNoCheck,                 (void *)compressStringNoCheck,     TR_Helper);
+   SET(TR_AMD64compressStringJ,                       (void *)compressStringJ,           TR_Helper);
+   SET(TR_AMD64compressStringNoCheckJ,                (void *)compressStringNoCheckJ,    TR_Helper);
+   SET(TR_AMD64andORString,                           (void *)andORString,               TR_Helper);
+   SET(TR_AMD64arrayTranslateTRTO,                    (void *)arrayTranslateTRTO,        TR_Helper);
+   SET(TR_AMD64arrayTranslateTROTNoBreak,             (void *)arrayTranslateTROTNoBreak, TR_Helper);
+   SET(TR_AMD64arrayTranslateTROT,                    (void *)arrayTranslateTROT,        TR_Helper);
+   SET(TR_AMD64encodeUTF16Big,                        (void *)encodeUTF16Big,            TR_Helper);
+   SET(TR_AMD64encodeUTF16Little,                     (void *)encodeUTF16Little,         TR_Helper);
+#ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
+   SET(TR_AMD64doAESENCEncrypt,                       (void *)doAESENCEncrypt,           TR_Helper);
+   SET(TR_AMD64doAESENCDecrypt,                       (void *)doAESENCDecrypt,           TR_Helper);
+#endif /* J9VM_OPT_JAVA_CRYPTO_ACCELERATION */
+#else /* OSX */
    SET(TR_AMD64compressString,                        (void *)_compressString,            TR_Helper);
    SET(TR_AMD64compressStringNoCheck,                 (void *)_compressStringNoCheck,     TR_Helper);
    SET(TR_AMD64compressStringJ,                       (void *)_compressStringJ,           TR_Helper);
@@ -1185,7 +1253,8 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
    SET(TR_AMD64doAESENCEncrypt,                       (void *)_doAESENCEncrypt,           TR_Helper);
    SET(TR_AMD64doAESENCDecrypt,                       (void *)_doAESENCDecrypt,           TR_Helper);
-#endif
+#endif /* J9VM_OPT_JAVA_CRYPTO_ACCELERATION */
+#endif /* OSX */
 #if defined(LINUX)
    SET(TR_AMD64clockGetTime,                          (void *)clock_gettime, TR_System);
 #endif

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -41,7 +41,7 @@ extern "C" {
 #else /* J9VM_ENV_LITTLE_ENDIAN */
 #define JIT_HELPER(x) extern "C" void * x
 #endif /* J9VM_ENV_LITTLE_ENDIAN */
-#elif defined(MVS) || defined(LINUX) || defined(J9ZOS390) || defined (J9HAMMER) || defined (WINDOWS)
+#elif defined(MVS) || defined(LINUX) || defined(J9ZOS390) || defined (J9HAMMER) || defined (WINDOWS) || defined (OSX)
 #define JIT_HELPER(x) extern "C" void x()
 #elif defined(NEUTRINO)
 #define JIT_HELPER(x) extern "C" char* x[]


### PR DESCRIPTION
This is the other side of #3004, where references from c/cpp to assembly symbols should not have a leading underscore, since Clang adds an underscore to them anyway. Currently, this fix is implemented just for macOS, but in the future, there will be a cleaner, more unified solution once NASM is used across all x86 operating systems.

Signed-off-by: Nazim Uddin Bhuiyan <nazim.uddin.bhuiyan@ibm.com>

Issue: #36 