### PR TITLE
Implement DDR findmodules command

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
@@ -60,6 +60,7 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindAllModulesCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindAllReadsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindMethodFromPcCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindModuleByNameCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindModulesCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindOverlappingSegmentsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindPatternCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindStackValueCommand;
@@ -189,6 +190,7 @@ public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnab
 		toPassBack.add(new FindAllReadsCommand());
 		toPassBack.add(new DumpModuleDirectedExportsCommand());
 		toPassBack.add(new DumpAllClassesInModuleCommand());
+		toPassBack.add(new FindModulesCommand());
 
 		loadPlugins(toPassBack, loader);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.HashTable;
+import com.ibm.j9ddr.vm29.j9.ModuleHashTable;
+import com.ibm.j9ddr.vm29.j9.PackageHashTable;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.j9.gc.GCClassLoaderIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassLoaderPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PackagePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+
+
+public class ModularityHelper {
+	@FunctionalInterface
+	public interface ModuleIteratorFilter {
+		boolean filter(J9ModulePointer modulePtr, String arg) throws CorruptDataException;
+	}
+
+	@FunctionalInterface
+	public interface ModuleOutput {
+		void print(J9ModulePointer modulePtr, PrintStream out) throws CorruptDataException;
+	}
+
+	@FunctionalInterface
+	public interface PackageIteratorFilter {
+		boolean filter(J9PackagePointer packagePtr, String arg) throws CorruptDataException;
+	}
+
+	@FunctionalInterface
+	public interface PackageOutput {
+		void print(J9PackagePointer packagePtr, PrintStream out) throws CorruptDataException;
+	}
+
+	/**
+	 * Matches all modules. Fits the
+	 * ModuleIteratorFilter functional interface.
+	 * 
+	 * @param    modulePtr  unused
+	 * @param    arg        unused
+	 * @return   true
+	 */
+	public static boolean moduleFilterMatchAll(J9ModulePointer modulePtr, String arg) {
+		return true;
+	}
+
+	/**
+	 * Prints the name and hex address of a J9Module.
+	 * Example:
+	 * java.base    !j9module 0x00007FAC2008EAC8
+	 * 
+	 * @param    modulePtr  The module which is to have its details
+	 *                      printed.
+	 * @param    out        The PrintStream that the details will
+	 *                      be outputted to.
+	 */
+	public static void printJ9Module(J9ModulePointer modulePtr, PrintStream out) throws CorruptDataException {
+		String moduleName = J9ObjectHelper.stringValue(modulePtr.moduleName());
+		String hexAddress = modulePtr.getHexAddress();
+		out.printf("%-30s !j9module %s%n", moduleName, hexAddress);
+	}
+
+	/**
+	 * Prints the details of the J9Module that owns a
+	 * J9Package. Uses printJ9Module to output the
+	 * module details.
+	 * 
+	 * @param    packagePtr The package which is to have its
+	 *                      owner's details printed.
+	 * @param    out        The PrintStream that the details will
+	 *                      be outputted to.
+	 * 
+	 * @see      printJ9Module(J9ModulePointer, PrintStream)
+	 */
+	public static void printPackageJ9Module(J9PackagePointer packagePtr, PrintStream out) throws CorruptDataException {
+		J9ModulePointer modulePtr = packagePtr.module();
+		printJ9Module(modulePtr, out);
+	}
+
+	/**
+	 * Traverses through all loaded modules. Uses
+	 * outtputter to print details about modules
+	 * matched by filter.
+	 * 
+	 * @param    out        The printstream that will be provided to outputter.
+	 * @param    filter     Used to determine whether a module will be output.
+	 *                      Will be run on all loaded modules.
+	 * @param    outputter  Used to output details about a module that was
+	 *                      matched by the filter. Will be run on any module that
+	 *                      filter returns true for.
+	 * @param    filterArg  A string that is to be used as additional data for filter.
+	 *                      Will be passed to filter everytime filter is called.
+	 */
+	public static void iterateModules(PrintStream out, ModuleIteratorFilter filter, ModuleOutput outputter, String filterArg) throws CorruptDataException {
+		J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+		if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+			GCClassLoaderIterator iterator = GCClassLoaderIterator.from();
+			while (iterator.hasNext()) {
+				J9ClassLoaderPointer classLoaderPointer = iterator.next();
+				HashTable<J9ModulePointer> moduleHashTable = ModuleHashTable
+						.fromJ9HashTable(classLoaderPointer.moduleHashTable());
+				SlotIterator<J9ModulePointer> slotIterator = moduleHashTable.iterator();
+				while (slotIterator.hasNext()) {
+					J9ModulePointer modulePtr = slotIterator.next();
+					if (filter.filter(modulePtr, filterArg)) {
+						outputter.print(modulePtr, out);
+					}
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Traverses through all loaded modules.
+	 * Uses outtputter to print details about modules
+	 * matched by filter.
+	 * 
+	 * @param    out        The printstream that will be provided to outputter
+	 * @param    filter     Used to determine whether a module will be output.
+	 *                      Will be run on all loaded modules.
+	 * @param   outputter   Used to output details about a module that was matched
+	 *                      by the filter. Will be run on any module that filter
+	 *                      returns true for.
+	 * @param   filterArg   A string that is to be used as additional data for filter.
+	 *                      Will be passed to filter everytime filter is called.
+	 */
+	public static void iteratePackages(PrintStream out, PackageIteratorFilter filter, PackageOutput outputter, String filterArg) throws CorruptDataException {
+		J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+		if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+			GCClassLoaderIterator iterator = GCClassLoaderIterator.from();
+			while (iterator.hasNext()) {
+				J9ClassLoaderPointer classLoaderPointer = iterator.next();
+				HashTable<J9PackagePointer> packageHashTable = PackageHashTable
+						.fromJ9HashTable(classLoaderPointer.packageHashTable());
+				SlotIterator<J9PackagePointer> slotIterator = packageHashTable.iterator();
+				while (slotIterator.hasNext()) {
+					J9PackagePointer packagePtr = slotIterator.next();
+					if (filter.filter(packagePtr, filterArg)) {
+						outputter.print(packagePtr, out);
+					}
+				}
+			}
+		}
+	}
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FindModulesCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/FindModulesCommand.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.HashTable;
+import com.ibm.j9ddr.vm29.j9.ModuleHashTable;
+import com.ibm.j9ddr.vm29.j9.PackageHashTable;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.j9.gc.GCClassLoaderIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassLoaderPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9HashTablePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PackagePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.ModuleIteratorFilter;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.ModuleOutput;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.PackageIteratorFilter;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.PackageOutput;
+
+import static com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.FindModulesCommand.Status.*;
+
+public class FindModulesCommand extends Command 
+{
+	enum Status {
+		MODULE, PACKAGE, HELP
+	}
+	
+	public FindModulesCommand() 
+	{
+		addCommand("findmodules", "[all|name <moduleName>|requires <moduleName>|package <packageName>|help]", "Find a module or set of modules that are loaded by the runtime.");
+	}
+	
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+	{
+		Status status = HELP;
+		String filterArg = null;
+		ModuleIteratorFilter moduleFilter = null;
+		ModuleOutput moduleOutput = ModularityHelper::printJ9Module;
+		PackageIteratorFilter packageFilter = null;
+		switch (args.length) {
+		case 0:
+			moduleFilter = ModularityHelper::moduleFilterMatchAll;
+			status = MODULE;
+			break;
+		case 1:
+			if (args[0].equalsIgnoreCase("all")) {
+				moduleFilter = ModularityHelper::moduleFilterMatchAll;
+				status = MODULE;
+			} /* else stay status.HELP */
+			break;
+		case 2:
+			filterArg = args[1]; /* use args[1] as a hex address */
+			switch (args[0]) {
+			case "name":
+				moduleFilter = FindModulesCommand::filterModuleName;
+				status = MODULE;
+				break;
+			case "requires":
+				moduleFilter = FindModulesCommand::filterModuleName;
+				moduleOutput = FindModulesCommand::printModuleReads;
+				status = MODULE;
+				break;
+			case "package":
+				packageFilter = FindModulesCommand::filterPackageName;
+				status = PACKAGE;
+				break;
+			default:
+				break; /* default stay status.HELP */
+			}
+			break;
+		default:
+			break; /* default stay status.HELP */
+		}
+		
+		try {
+			switch (status) {
+			case MODULE:
+				ModularityHelper.iterateModules(out, moduleFilter, moduleOutput, filterArg);
+				break;
+			case PACKAGE:
+				ModularityHelper.PackageOutput packageOutput = ModularityHelper::printPackageJ9Module; 
+				ModularityHelper.iteratePackages(out, packageFilter, packageOutput, filterArg);
+				break;
+			case HELP:
+				printHelp(out);
+				break;
+			default:
+				CommandUtils.dbgError(out, "Argument failed to parse or was parsed to an unhandled option within !FindModulesCommand.\n");
+				printHelp(out);
+				break;
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException(e);
+		}
+		return;
+	}
+
+	private static void printModuleReads(J9ModulePointer modulePtr, PrintStream out) throws CorruptDataException {
+		J9HashTablePointer readTable = modulePtr.readAccessHashTable();
+		HashTable<J9ModulePointer> moduleHashTable = ModuleHashTable.fromJ9HashTable(readTable);
+		SlotIterator<J9ModulePointer> slotIterator = moduleHashTable.iterator();
+		while (slotIterator.hasNext()) {
+			J9ModulePointer readModulePtr = slotIterator.next();
+			ModularityHelper.printJ9Module(readModulePtr, out);
+		}
+	}
+	
+	/**
+	 * Matches all modules with the provided name.
+	 * Fits the ModuleIteratorFilter functional
+	 * interface. Case sensitive.
+	 * 
+	 * @param    modulePtr  The module to check the name of.
+	 * @param    targetName The name that should be matched.
+	 * @return   true if the names are equal, false otherwise.
+	 */
+	private static boolean filterModuleName(J9ModulePointer modulePtr, String targetName) throws CorruptDataException {
+		return J9ObjectHelper.stringValue(modulePtr.moduleName()).equals(targetName);
+	}
+
+
+	private static boolean filterRequiresTargetModule(J9ModulePointer modulePtr, String targetModule) throws CorruptDataException {
+		boolean result = false;
+		J9HashTablePointer readTable = modulePtr.readAccessHashTable();
+		HashTable<J9ModulePointer> moduleHashTable = ModuleHashTable.fromJ9HashTable(readTable);
+		SlotIterator<J9ModulePointer> slotIterator = moduleHashTable.iterator();
+		while (slotIterator.hasNext()) {
+			J9ModulePointer readModulePtr = slotIterator.next();
+			if (J9ObjectHelper.stringValue(readModulePtr.moduleName()).equals(targetModule)) {
+				result = true;
+				break;
+			}
+		}
+		return result;
+	}
+
+	private static boolean filterPackageName(J9PackagePointer packagePtr, String targetName) throws CorruptDataException  {
+		return J9UTF8Helper.stringValue(packagePtr.packageName()).equals(targetName);
+	}
+
+	private static void printHelp(PrintStream out) {
+		out.append("Usage: \n");
+		out.append("  !findmodules\n");
+		out.append("      Returns !findmodules all\n");
+		out.append("  !findmodules all\n");
+		out.append("      Returns all loaded modules\n");
+		out.append("  !findmodules name <moduleName>\n");
+		out.append("      Returns all loaded modules with the same name as provided\n");
+		out.append("  !findmodules requires <moduleName>\n");
+		out.append("      Returns all loaded modules which require the provided module\n");
+		out.append("  !findmodules package <packageName>\n");
+		out.append("      Returns the loaded module which owns the provided package\n");
+		out.append("Output Format:\n");
+		out.append("  <module name>                  !j9module <module hexaddress>\n");
+		out.append("Output Example:\n");
+		out.append("  java.base                      !j9module 0x00007FAC2008EAC8\n");
+	}
+}


### PR DESCRIPTION
 Implement DDR findmodules command

Added new command: !findmodules. Display all modules matching one of
the below options:
- all (default). Lists all modules loaded by the runtime
- name <module name>. Lists all modules with the same name as the parameter
- requires <module name>. Lists all modules that require the input module
- package <package name>. Lists the loaded module that owns the input package

Implements part of the new proposal within #1859

Created ModularityHelper.java
- Will assist in implementing other parts of the second proposal,
such as !dumppackage and !dumpmodule
- Used to traverse module and package lists
- Provides filter and output support

Example modules:
moduleA
```
module moduleA {
	exports moduleA.packageA;
	requires moduleB;
}
```
moduleB
```
module moduleB {
	exports moduleB.packageB to moduleA;
}
```
Example calls
!findmodules name moduleA
```
moduleA                        !j9module 0x00007FAC203C55B8
```
!findmodules requires moduleB
```
moduleA                        !j9module 0x00007FCA242F0960
```
!findmodules package moduleA.packageA
```
moduleA                        !j9module 0x00007FAC203C55B8
```
!findmodules
or
!findmodules all
```
jdk.naming.rmi                 !j9module 0x00007FAC20335E48
java.desktop                   !j9module 0x00007FAC203A1CB8
java.xml                       !j9module 0x00007FAC203B4D10
java.security.sasl             !j9module 0x00007FAC20335C98
jdk.management.jfr             !j9module 0x00007FAC203CD958
java.logging                   !j9module 0x00007FAC20335A58
java.datatransfer              !j9module 0x00007FAC20399068
java.naming                    !j9module 0x00007FAC20399410
jdk.jfr                        !j9module 0x00007FAC203A1490
java.rmi                       !j9module 0x00007FAC202EECC8
java.prefs                     !j9module 0x00007FAC20335788
openj9.sharedclasses           !j9module 0x00007FAC203358F0
java.management                !j9module 0x00007FAC20336118
java.management.rmi            !j9module 0x00007FAC203A1B08
jdk.management                 !j9module 0x00007FAC202EF148
java.base                      !j9module 0x00007FAC2008EAC8
java.compiler                  !j9module 0x00007FAC203998D8
java.security.jgss             !j9module 0x00007FAC203C5690
jdk.localedata                 !j9module 0x00007FAC202EF6E8
jdk.security.auth              !j9module 0x00007FAC202EEAD0
jdk.charsets                   !j9module 0x00007FAC202EEC38
jdk.crypto.ec                  !j9module 0x00007FAC203359C8
jdk.security.jgss              !j9module 0x00007FAC20335F20
jdk.crypto.cryptoki            !j9module 0x00007FAC203A13B8
java.xml.crypto                !j9module 0x00007FAC20390718
jdk.zipfs                      !j9module 0x00007FAC203A1C28
java.smartcardio               !j9module 0x00007FAC20335818
jdk.naming.dns                 !j9module 0x00007FAC20399188
moduleA                        !j9module 0x00007FAC203C55B8
jdk.javadoc                    !j9module 0x00007FAC203CD2E0
moduleC                        !j9module 0x00007FAC20399020
jdk.jartool                    !j9module 0x00007FAC20399260
openj9.gpu                     !j9module 0x00007FAC20335BC0
jdk.unsupported.desktop        !j9module 0x00007FAC203CDA30
moduleB                        !j9module 0x00007FAC203CDB08
jdk.jdeps                      !j9module 0x00007FAC203A1880
jdk.internal.opt               !j9module 0x00007FAC20335FF8
openj9.cuda                    !j9module 0x00007FAC2038FCF8
jdk.compiler                   !j9module 0x00007FAC2038FDD0
jdk.jlink                      !j9module 0x00007FAC202EF3D0
```

Signed-off-by: Andrew Crowther <acrowthe3388@gmail.com>