### PR TITLE
Fix RPATH and dylib install_name on OSX

### DIFF
--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -47,7 +47,7 @@ $(UMA_EXETARGET): $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 UMA_BEGIN_DASH_L =
 UMA_END_DASH_L =
 
-UMA_EXE_POSTFIX_FLAGS += -lm -liconv -lc -ldl -lutil -Wl,-rpath,\$$ORIGIN
+UMA_EXE_POSTFIX_FLAGS += -lm -liconv -lc -ldl -lutil -Wl,-rpath,@loader_path
 
 <#if uma.spec.processor.amd64>
   UMA_MASM2GAS_FLAGS += --64
@@ -118,8 +118,8 @@ endif
 </#if>
 
 # https://stackoverflow.com/questions/21907504/how-to-compile-shared-lib-with-clang-on-osx
-UMA_DLL_LINK_FLAGS += -shared -undefined dynamic_lookup -install_name lib$(UMA_TARGET_NAME).dylib
-UMA_DLL_LINK_FLAGS += -Xlinker -rpath -Xlinker \$$ORIGIN
+UMA_DLL_LINK_FLAGS += -shared -undefined dynamic_lookup -install_name @rpath/lib$(UMA_TARGET_NAME).dylib
+UMA_DLL_LINK_FLAGS += -Xlinker -rpath -Xlinker @loader_path
 
 UMA_DLL_LINK_POSTFLAGS += $(UMA_LINK_STATIC_LIBRARIES)
 UMA_DLL_LINK_POSTFLAGS += $(UMA_LINK_SHARED_LIBRARIES)


### PR DESCRIPTION
On OSX, -rpath,\\$$ORIGIN doesn't work. -rpath needs to correspond to
either @executable_path, @loader_path or some other path. More
information can be seen in the man pages of dyld. I have chosen to set
rpath as "-rpath,@loader_path/.". @loader_path points to the directory
where dylib being loaded exists. This works since libjvm is able to load
all the dependent dylibs.

When naming dylibs, @rpath/ should be appended to dylib names. Example:
@rpath/libj9thr29.dylib. Appending @rpath to the dylib name instructs
the dynamic linker to search the list of run paths for the dylib.

Reference:
https://wincent.com/wiki/%40executable_path%2C_%40load_path_and_%40rpath

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>