### PR TITLE
Add missing params to build and pipeline jobs

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -568,10 +568,9 @@ def set_job_properties(JOB_TYPE) {
             add_string_params(['TESTS_TARGETS':''])
         }
 
-        // Build - Commented out as there are currently no params specific to only Build
-        //if (JOB_TYPE == 'build') {
-
-        //}
+        if (JOB_TYPE == 'build') {
+            add_string_params(['NODE':''])
+        }
 
         /********************
         * TRIGGER

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -572,6 +572,14 @@ def set_job_properties(JOB_TYPE) {
             add_string_params(['NODE':''])
         }
 
+        if (JOB_TYPE == 'pipeline') {
+            add_string_params([
+                'BUILD_NODE':'',
+                'TEST_NODE':'',
+                'PERSONAL_BUILD':'',
+                'SLACK_CHANNEL':''])
+        }
+
         /********************
         * TRIGGER
         ********************/


### PR DESCRIPTION
Add back NODE param for Build jobs
- Accidentally removed in #2952

Add missing params for pipeline builds
- Add BUILD_NODE, TEST_NODE, PERSONAL_BUILD and SLACK_CHANNEL
- Missed in original PR #2138