### PR TITLE
Set domainCombiner from closest frame in result AccessControlContext

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -469,6 +469,7 @@ private static AccessControlContext getContextHelper(boolean forDoPrivilegedWith
 	int frameNbr = domains.length / OBJS_ARRAY_SIZE;
 	AccessControlContext accContext = null;
 	AccessControlContext accLower = null;
+	DomainCombiner dc = null; // store a non-null domainCombiner from a closest frame or null
 	for (int j = 0; j < frameNbr; ++j) {
 		AccessControlContext acc = (AccessControlContext) domains[j * OBJS_ARRAY_SIZE];
 		/*[PR JAZZ 66930] j.s.AccessControlContext.checkPermission() invoke untrusted ProtectionDomain.implies */
@@ -486,6 +487,10 @@ private static AccessControlContext getContextHelper(boolean forDoPrivilegedWith
 		}
 		if (null != acc && null != acc.domainCombiner) {
 			accTmp.domainCombiner = acc.domainCombiner;
+			if (dc == null) {
+				// this dc will be set to accContext.domainCombiner
+				dc = acc.domainCombiner;
+			}
 		}
 		if (null != domains[j * OBJS_ARRAY_SIZE + OBJS_INDEX_PERMS_OR_CACHECHECKED]) {
 			// this is frame with limited permissions
@@ -500,7 +505,9 @@ private static AccessControlContext getContextHelper(boolean forDoPrivilegedWith
 		}
 		accLower = accTmp;
 	}
-
+	if ((accContext != null) && (accContext.domainCombiner == null) && (dc != null)) {
+		accContext.domainCombiner = dc;
+	}
 	return accContext;
 }
 


### PR DESCRIPTION
Set `domainCombiner` from closest frame in result `AccessControlContext` of `j.s.AccessController.getContextHelper()`

For `JEP140` Format result of `j.s.AccessController.getAccSnapshot()`, returning `AccessControlContext.domainCombiner` is set to a `non-null DomainCombiner` of an `AccessControlContext` object from the closest frame objects or `null`.

Verified that the failed testcase passes and `pConfig` still compiles.

close: #2990 

Reviewer: @pshipton
FYI: @DanHeidinga

Signed-off-by: Jason Feng <fengj@ca.ibm.com>