### PR TITLE
Add java/lang/String.value to isArrayWithConstantElements query

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -191,6 +191,7 @@ static bool isArrayWithConstantElements(TR::SymbolReference *symRef, TR::Compila
       switch (symbol->getRecognizedField())
          {
          case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
+         case TR::Symbol::Java_lang_String_value:
             return true;
          default:
             break;


### PR DESCRIPTION
The java/lang/String.value field is a constant which will not change
during the lifetime of the object and hence so are its elements.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>