### PR TITLE
Remove implicit NULL checks on java/lang/String.value

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1347,9 +1347,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		byte[] s1Value = s1.value;
 		byte[] s2Value = s2.value;
-		
-		s1Value.getClass(); // Implicit null check
-		s2Value.getClass(); // Implicit null check
 
 		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			while (o1 < end) {
@@ -1416,9 +1413,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		
 		byte[] s1Value = s1.value;
 		byte[] s2Value = s2.value;
-		
-		s1Value.getClass(); // Implicit null check
-		s2Value.getClass(); // Implicit null check
 
 		if (enableCompression && (null == compressionFlag || (s1.coder | s2.coder) == LATIN1)) {
 			while (o1 < end) {
@@ -2105,8 +2099,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			if (c >= 0 && c <= Character.MAX_VALUE) {
 				byte[] array = value;
-				
-				array.getClass(); // Implicit null check
 				
 				// Check if the String is compressed
 				if (enableCompression && (null == compressionFlag || coder == LATIN1)) {
@@ -2842,8 +2834,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		int last = lengthInternal() - 1;
 		int end = last;
 
-		value.getClass(); // Implicit null check
-
 		// Check if the String is compressed
 		if (enableCompression &&  (null == compressionFlag || coder == LATIN1)) {
 			while ((start <= end) && (helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(value, start)) <= ' ')) {
@@ -3238,7 +3228,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			final boolean compressed = enableCompression &&  (null == compressionFlag || coder == LATIN1);
 
-			chars.getClass();
 			int start = 0, current = 0, end = lengthInternal();
 			if (regex.lengthInternal() == 1) {
 				char splitChar = regex.charAtInternal(0);
@@ -3259,7 +3248,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 				byte[]
 				splitChars = regex.value;
 
-				splitChars.getClass();
 				char firstChar = charAtInternal(0, regex.value);
 				while (current < end) {
 					if (charAtInternal(current, chars) == firstChar) {
@@ -5340,9 +5328,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
-		
-		s1Value.getClass(); // Implicit null check
-		s2Value.getClass(); // Implicit null check
 
 		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 			while (o1 < end) {
@@ -5404,9 +5389,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
-		
-		s1Value.getClass(); // Implicit null check
-		s2Value.getClass(); // Implicit null check
 
 		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 			while (o1 < end) {
@@ -5964,8 +5946,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			if (c >= 0 && c <= Character.MAX_VALUE) {
 				char[] array = value;
-				
-				array.getClass(); // Implicit null check
 
 				// Check if the String is compressed
 				if (enableCompression && (null == compressionFlag || count >= 0)) {
@@ -6050,9 +6030,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 			char[] s1Value = s1.value;
 			char[] s2Value = s2.value;
-
-			s1Value.getClass(); // Implicit null check
-			s2Value.getClass(); // Implicit null check
 
 			if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 				char firstChar = helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s2Value, 0));
@@ -6157,8 +6134,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			if (c >= 0 && c <= Character.MAX_VALUE) {
 				char[] array = value;
 				
-				array.getClass(); // Implicit null check
-				
 				// Check if the String is compressed
 				if (enableCompression && (null == compressionFlag || count >= 0)) {
 					if (c <= 255) {
@@ -6249,9 +6224,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 				char[] s1Value = s1.value;
 				char[] s2Value = s2.value;
-
-				s1Value.getClass(); // Implicit null check
-				s2Value.getClass(); // Implicit null check
 
 				if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 					char firstChar = helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s2Value, 0));
@@ -6456,9 +6428,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 
 		char[] s1Value = s1.value;
 		char[] s2Value = s2.value;
-
-		s1Value.getClass(); // Implicit null check
-		s2Value.getClass(); // Implicit null check
 
 		if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
 			while (o1 < end) {
@@ -6803,8 +6772,6 @@ written authorization of the copyright holder.
 
 		StringBuilder builder = null;
 
-		value.getClass(); // Implicit null check
-
 		int len = lengthInternal();
 
 		for (int i = 0; i < len; i++) {
@@ -7139,8 +7106,6 @@ written authorization of the copyright holder.
 
 		StringBuilder builder = null;
 
-		value.getClass(); // Implicit null check
-
 		int len = lengthInternal();
 
 		for (int i = 0; i < len; i++) {
@@ -7219,8 +7184,6 @@ written authorization of the copyright holder.
 		int start = 0;
 		int last = lengthInternal() - 1;
 		int end = last;
-
-		value.getClass(); // Implicit null check
 
 		// Check if the String is compressed
 		if (enableCompression &&  (null == compressionFlag || count >= 0)) {
@@ -7579,12 +7542,10 @@ written authorization of the copyright holder.
 			}
 			java.util.ArrayList<String> parts = new java.util.ArrayList<String>((max > 0 && max < 100) ? max : 10);
 
-			char[]
-			chars = this.value;
+			char[] chars = this.value;
 
 			final boolean compressed = enableCompression &&  (null == compressionFlag || count >= 0);
 
-			chars.getClass();
 			int start = 0, current = 0, end = lengthInternal();
 			if (regex.lengthInternal() == 1) {
 				char splitChar = regex.charAtInternal(0);
@@ -7602,10 +7563,8 @@ written authorization of the copyright holder.
 			} else {
 				int rLength = regex.lengthInternal();
 
-				char[]
-				splitChars = regex.value;
+				char[] splitChars = regex.value;
 
-				splitChars.getClass();
 				char firstChar = charAtInternal(0, regex.value);
 				while (current < end) {
 					if (charAtInternal(current, chars) == firstChar) {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3409,8 +3409,6 @@ TR_J9ByteCodeIlGenerator::genCompressedRefs(TR::Node * address, bool genTT, int3
 TR::Node *
 TR_J9ByteCodeIlGenerator::genNullCheck(TR::Node * first)
    {
-   // TODO : Can we get rid of the "value.getClass()" nullchecks in the Java code due to this function?
-
    // By default, NULLCHKs will be skipped on String.value fields.  A more general mechanism
    // is needed for skipping NULL/BNDCHKs on certain recognized fields...
    //


### PR DESCRIPTION
The implicit NULL checks on java/lang/String.value are unnecessary
since at IL gen time we check for this particular field and we avoid
generating the NULL checks anyway.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>