### PR TITLE
Fix -install_name on OSX

### DIFF
--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -118,7 +118,7 @@ endif
 </#if>
 
 # https://stackoverflow.com/questions/21907504/how-to-compile-shared-lib-with-clang-on-osx
-UMA_DLL_LINK_FLAGS += -shared -undefined dynamic_lookup -install_name @rpath/lib$(UMA_TARGET_NAME).dylib
+UMA_DLL_LINK_FLAGS += -shared -undefined dynamic_lookup -install_name @rpath/lib$(UMA_LIB_NAME).dylib
 UMA_DLL_LINK_FLAGS += -Xlinker -rpath -Xlinker @loader_path
 
 UMA_DLL_LINK_POSTFLAGS += $(UMA_LINK_STATIC_LIBRARIES)

--- a/sourcetools/com.ibm.uma/com/ibm/uma/UMA.java
+++ b/sourcetools/com.ibm.uma/com/ibm/uma/UMA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -657,6 +657,14 @@ public class UMA {
 				break;
 			}
 			buffer.append("UMA_TARGET_NAME=" + artifact.getTargetNameWithScope() + "\n");
+			
+			/* On OSX, <LIB_NAME_DYLIB>.dylib should match the -install_name <LIB_NAME_INSTALL>. 
+			 * Otherwise, the linker is unable to find the required library. Currently, LIB_NAME_DYLIB
+			 * doesn't match LIB_NAME_INSTALL. LIB_NAME_DYLIB has major and minor build versions
+			 * appended whereas LIB_NAME_INSTALL doesn't contain version info. UMA_LIB_NAME will contain
+			 * LIB_NAME_INSTALL with major and minor build versions.
+			 */
+			buffer.append("UMA_LIB_NAME=" + platform.getTargetNameWithRelease(artifact) + "\n");
 			
 			if ( artifact.getTargetPath() != null ) {
 				buffer.append("UMA_TARGET_PATH=" + UMA_PATH_TO_ROOT_VAR + artifact.getTargetPath()+"\n");


### PR DESCRIPTION
On OSX, <LIB_NAME_DYLIB>.dylib should match the -install_name
<LIB_NAME_INSTALL>. Otherwise, the linker is unable to find the required
library. Currently, LIB_NAME_DYLIB doesn't match LIB_NAME_INSTALL.
LIB_NAME_DYLIB has major and minor build versions appended whereas
LIB_NAME_INSTALL doesn't contain version info. UMA_LIB_NAME will contain
LIB_NAME_INSTALL with major and minor build versions.

UMA_LIB_NAME will be used to specify -install_name. With this change,
the linker is able to find the required libraries on OSX, and OpenJ9 can
be built successfully with the JIT disabled. Other platforms shouldn't
be impacted since UMA_LIB_NAME is only used on OSX.

[ci skip] 

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>