### PR TITLE
Fix issue with default JDK_IMPL

### DIFF
--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -77,14 +77,15 @@ endif
 
 # temporarily support both JAVA_IMPL and JDK_IMPL
 ifndef JDK_IMPL
-	JDK_IMPL=$(JAVA_IMPL)
-endif
-
-ifndef JDK_IMPL
-	export JDK_IMPL:=openj9
+	ifndef JAVA_IMPL
+		export JDK_IMPL:=openj9
+	else
+		export JDK_IMPL:=$(JAVA_IMPL)
+	endif
 else
 	export JDK_IMPL:=$(JDK_IMPL)
 endif
+
 
 ifndef JVM_VERSION
 ifeq ($(JDK_VERSION), 8)


### PR DESCRIPTION
- JDK_IMPL was empty when both JDK_IMPL and JAVA_IMPL are not given
- fix the above issue

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>