### PR TITLE
Fix Class.toGenericString array output on jdk9+

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2203,6 +2203,11 @@ public String toString() {
  * kind is one of "class", "enum", "interface", "&#64;interface", or
  * empty string for primitive types. The type parameter list is
  * omitted if there are no type parameters.
+ *[IF Sidecar19-SE]
+ * For array classes, the string has the following format instead:
+ * name&#60;typeparam1, typeparam2, ...&#62; followed by a number of
+ * &#91;&#93; characters equal to the dimension of the array
+ *[ENDIF]
  * 
  * @return		a formatted string describing this class.
  * @since 1.8
@@ -2236,6 +2241,26 @@ public String toGenericString() {
 	}
 	
 	// Build generic string
+/*[IF Sidecar19-SE]*/
+	if (isArray) {
+		int depth = 0;
+		Class inner = this;
+		Class component = this;
+		do {
+			inner = inner.getComponentType();
+			if (inner != null) {
+				component = inner;
+				depth += 1;
+			}
+		} while (inner != null);
+		result.append(component.getName());
+		component.appendTypeParameters(result);
+		for (int i = 0; i < depth; i++) {
+			result.append('[').append(']');
+		}
+		return result.toString();
+	}
+/*[ENDIF]*/
 	result.append(Modifier.toString(modifiers));
 	if (result.length() > 0) {
 		result.append(' ');
@@ -2243,20 +2268,23 @@ public String toGenericString() {
 	result.append(kindOfType);
 	result.append(getName());
 	
-	// Add type parameters if present
+	appendTypeParameters(result);
+	return result.toString();
+}
+
+// Add type parameters to stringbuilder if present
+private void appendTypeParameters(StringBuilder nameBuilder) {
 	TypeVariable<?>[] typeVariables = getTypeParameters();
 	if (0 != typeVariables.length) {
-		result.append('<');		
+		nameBuilder.append('<');
 		boolean comma = false;
 		for (TypeVariable<?> t : typeVariables) {
-			if (comma) result.append(',');
-			result.append(t);
+			if (comma) nameBuilder.append(',');
+			nameBuilder.append(t);
 			comma = true;
 		}
-		result.append('>');
+		nameBuilder.append('>');
 	}
-	
-	return result.toString();
 }
 
 /**

--- a/test/functional/Java8andUp/src_110/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110/org/openj9/test/java/lang/Test_Class.java
@@ -1567,7 +1567,7 @@ public void test_toGenericString() {
 	AssertJUnit.assertEquals("public class org.openj9.test.java.lang.PublicStrictFPClass", PublicStrictFPClass.class.toGenericString());
 	AssertJUnit.assertEquals("public final class org.openj9.test.java.lang.PublicFinalClass", PublicFinalClass.class.toGenericString());
 	AssertJUnit.assertEquals("public final enum org.openj9.test.java.lang.PublicEnum", PublicEnum.class.toGenericString());
-	AssertJUnit.assertEquals("public abstract final class [Lorg.openj9.test.java.lang.PublicFinalClass;", PublicFinalClass[].class.toGenericString());
+	AssertJUnit.assertEquals("org.openj9.test.java.lang.PublicFinalClass[]", PublicFinalClass[].class.toGenericString());
 	AssertJUnit.assertEquals("class org.openj9.test.java.lang.GenericClass<E>", GenericClass.class.toGenericString());
 	AssertJUnit.assertEquals("class org.openj9.test.java.lang.GenericsClass<first,second>", GenericsClass.class.toGenericString());
 	AssertJUnit.assertEquals("public class org.openj9.test.java.lang.InnerClasses$InnerClass", InnerClasses.InnerClass.class.toGenericString());
@@ -1576,7 +1576,7 @@ public void test_toGenericString() {
 	AssertJUnit.assertEquals("private class org.openj9.test.java.lang.InnerClasses$PrivateClass", InnerClasses.getPrivateClass().toGenericString());
 	AssertJUnit.assertEquals("abstract interface org.openj9.test.java.lang.Interface", Interface.class.toGenericString());
 	AssertJUnit.assertEquals("public abstract @interface org.openj9.test.java.lang.AnnotationType", AnnotationType.class.toGenericString());
-	AssertJUnit.assertEquals("public abstract final class [C", char[].class.toGenericString());
+	AssertJUnit.assertEquals("char[]", char[].class.toGenericString());
 	Class[] classes = getTestClasses();
 	AssertJUnit.assertEquals("public class org.openj9.test.java.lang.Test_Class", classes[0].toGenericString());
 	AssertJUnit.assertEquals("static class org.openj9.test.java.lang.Test_Class$StaticMember$Class", classes[1].toGenericString());

--- a/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_90/org/openj9/test/java/lang/Test_Class.java
@@ -1567,7 +1567,7 @@ public void test_toGenericString() {
 	AssertJUnit.assertEquals("public class org.openj9.test.java.lang.PublicStrictFPClass", PublicStrictFPClass.class.toGenericString());
 	AssertJUnit.assertEquals("public final class org.openj9.test.java.lang.PublicFinalClass", PublicFinalClass.class.toGenericString());
 	AssertJUnit.assertEquals("public final enum org.openj9.test.java.lang.PublicEnum", PublicEnum.class.toGenericString());
-	AssertJUnit.assertEquals("public abstract final class [Lorg.openj9.test.java.lang.PublicFinalClass;", PublicFinalClass[].class.toGenericString());
+	AssertJUnit.assertEquals("org.openj9.test.java.lang.PublicFinalClass[]", PublicFinalClass[].class.toGenericString());
 	AssertJUnit.assertEquals("class org.openj9.test.java.lang.GenericClass<E>", GenericClass.class.toGenericString());
 	AssertJUnit.assertEquals("class org.openj9.test.java.lang.GenericsClass<first,second>", GenericsClass.class.toGenericString());
 	AssertJUnit.assertEquals("public class org.openj9.test.java.lang.InnerClasses$InnerClass", InnerClasses.InnerClass.class.toGenericString());
@@ -1576,7 +1576,7 @@ public void test_toGenericString() {
 	AssertJUnit.assertEquals("private class org.openj9.test.java.lang.InnerClasses$PrivateClass", InnerClasses.getPrivateClass().toGenericString());
 	AssertJUnit.assertEquals("abstract interface org.openj9.test.java.lang.Interface", Interface.class.toGenericString());
 	AssertJUnit.assertEquals("public abstract @interface org.openj9.test.java.lang.AnnotationType", AnnotationType.class.toGenericString());
-	AssertJUnit.assertEquals("public abstract final class [C", char[].class.toGenericString());
+	AssertJUnit.assertEquals("char[]", char[].class.toGenericString());
 	Class[] classes = getTestClasses();
 	AssertJUnit.assertEquals("public class org.openj9.test.java.lang.Test_Class", classes[0].toGenericString());
 	AssertJUnit.assertEquals("static class org.openj9.test.java.lang.Test_Class$StaticMember$Class", classes[1].toGenericString());


### PR DESCRIPTION
Java 9 and up have different output for toGenericString for array
classes in order to be more human readable instead of using encodings
like '[[Ljava.lang.string'. This commit changes the implementation in
order to match the new standard for Java 9 and up.

Fixes: #3041

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>