### PR TITLE
Enable Concurrent Scavenge on X86-64 compressedrefs

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2853,6 +2853,9 @@ gcInitializeDefaults(J9JavaVM* vm)
 	if (gc_policy_gencon == extensions->configurationOptions._gcPolicy) {
 		/* after we parsed cmd line options, check if we can obey the request to run CS (valid for Gencon only) */
 		if (extensions->concurrentScavengerForced) {
+#if defined(J9VM_ARCH_X86)
+			extensions->softwareEvacuateReadBarrier = true;
+#endif /* J9VM_ARCH_X86 */
 			if (LOADED == (FIND_DLL_TABLE_ENTRY(J9_JIT_DLL_NAME)->loadFlags & LOADED)) {
 				/* If running jitted, it must be on supported h/w */
 				J9ProcessorDesc  processorDesc;

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -787,10 +787,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 		if(try_scan(&scan_start, "softwareEvacuateReadBarrier")) {
-			/* Software read barriers are only implemented on s390 for now */
-#if defined(S390) || defined(J9ZOS390)
 			extensions->softwareEvacuateReadBarrier = true;
-#endif /* defined(S390) || defined(J9ZOS390) */
 			continue;
 		}
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */


### PR DESCRIPTION
Concurrent Scavenge will be enabled if "-Xgc:concurrentScavenge" is set
on X86-64 compressedrefs builds.

Part of Issue #3054

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>