### PR TITLE
Add ddr dumpmodules command

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
@@ -45,6 +45,7 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRegionsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllRomClassLinearCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpAllSegmentsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpContendedLoadTable;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleReadsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleExportsCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.DumpModuleDirectedExportsCommand;
@@ -191,6 +192,7 @@ public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnab
 		toPassBack.add(new DumpModuleDirectedExportsCommand());
 		toPassBack.add(new DumpAllClassesInModuleCommand());
 		toPassBack.add(new FindModulesCommand());
+		toPassBack.add(new DumpModuleCommand());
 
 		loadPlugins(toPassBack, loader);
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ModularityHelper.java
@@ -22,6 +22,7 @@
 package com.ibm.j9ddr.vm29.tools.ddrinteractive;
 
 import java.io.PrintStream;
+import java.util.Iterator;
 
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.j9.DataType;
@@ -30,15 +31,31 @@ import com.ibm.j9ddr.vm29.j9.ModuleHashTable;
 import com.ibm.j9ddr.vm29.j9.PackageHashTable;
 import com.ibm.j9ddr.vm29.j9.SlotIterator;
 import com.ibm.j9ddr.vm29.j9.gc.GCClassLoaderIterator;
+import com.ibm.j9ddr.vm29.j9.walkers.ClassIterator;
+import com.ibm.j9ddr.vm29.j9.walkers.ClassSegmentIterator;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassLoaderPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9HashTablePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9PackagePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 
 
 public class ModularityHelper {
+	@FunctionalInterface
+	public interface ClassIteratorFilter {
+		boolean filter(J9ClassPointer classPtr, String arg) throws CorruptDataException;
+	}
+
+	@FunctionalInterface
+	public interface ClassOutput {
+		void print(J9ClassPointer classPtr, PrintStream out) throws CorruptDataException;
+	}
+
 	@FunctionalInterface
 	public interface ModuleIteratorFilter {
 		boolean filter(J9ModulePointer modulePtr, String arg) throws CorruptDataException;
@@ -104,6 +121,75 @@ public class ModularityHelper {
 		printJ9Module(modulePtr, out);
 	}
 
+
+	/**
+	 * Prints the name and hex address of a J9Package.
+	 * Example:
+	 * moduleB/packageB    !j9package 0x00007F84903B5860
+	 * 
+	 * @param    packagePtr The package which is to have its details
+	 *                      printed.
+	 * @param    out        The PrintStream that the details will
+	 *                      be outputted to.
+	 */
+	public static void printJ9Package(J9PackagePointer packagePtr, PrintStream out) throws CorruptDataException {
+		String packageName = J9UTF8Helper.stringValue(packagePtr.packageName());
+		String hexAddress = packagePtr.getHexAddress();
+		out.printf("%-45s !j9package %s%n", packageName, hexAddress);
+	}
+
+	/**
+	 * Prints the name and hex address of a J9Class.
+	 * Example:
+	 * moduleA/packageA/classA        !j9class 0x00000000022CCD00
+	 * 
+	 * @param    ClassPtr   The class which is to have its details
+	 *                      printed.
+	 * @param    out        The PrintStream that the details will
+	 *                      be outputted to.
+	 */
+	public static void printJ9Class(J9ClassPointer classPtr, PrintStream out) throws CorruptDataException {
+		String className = J9ClassHelper.getName(classPtr);
+		String classAddress = classPtr.getHexAddress();
+		out.printf("%-30s !j9class %s%n", className, classAddress);
+	}
+
+	/**
+	 * Prints the name and hex address of all
+	 * J9Modules the provided package is exported to.
+	 * Output is formated similar to the format of
+	 * module exports within a module-info.java file.
+	 * Example:
+	 * Exports moduleA/packageA        !j9module 0x00000000022CCD00
+	 *      to moduleB    !j9module 0x00007FAC2008EAC8
+	 * 
+	 * @param    packagePtr The package which is to have the
+	 *                      modules it is exported to printed.
+	 * @param    out        The PrintStream that the result will
+	 *                      be output to.
+	 */
+	public static void printPackageExportVerbose(J9PackagePointer packagePtr, PrintStream out) throws CorruptDataException {
+		out.print("Exports ");
+		ModularityHelper.printJ9Package(packagePtr, out);
+		if (packagePtr.exportToAll().isZero()) {
+			printPackageExportTo(packagePtr, out, "     to ");
+		}
+	}
+
+	private static void printPackageExportTo(J9PackagePointer packagePtr, PrintStream out, String linePrefix) throws CorruptDataException {
+		J9HashTablePointer exportsHashTable = packagePtr.exportsHashTable();
+		HashTable<J9ModulePointer> exportsModuleHashTable = ModuleHashTable.fromJ9HashTable(exportsHashTable);
+		SlotIterator<J9ModulePointer> exportsSlotIterator = exportsModuleHashTable.iterator();
+		while (exportsSlotIterator.hasNext()) {
+			J9ModulePointer modulePtr = exportsSlotIterator.next();
+			out.print(linePrefix);
+			ModularityHelper.printJ9Module(modulePtr, out);
+		}
+		if (!packagePtr.exportToAllUnnamed().isZero()) {
+			out.printf("%sALL-UNNAMED%n", linePrefix);
+		}
+	}
+
 	/**
 	 * Traverses through all loaded modules. Uses
 	 * outtputter to print details about modules
@@ -142,14 +228,14 @@ public class ModularityHelper {
 
 
 	/**
-	 * Traverses through all loaded modules.
-	 * Uses outtputter to print details about modules
-	 * matched by filter.
+	 * Traverses through all loaded packages.
+	 * Uses outtputter to print details about
+	 * packages matched by filter.
 	 * 
 	 * @param    out        The printstream that will be provided to outputter
-	 * @param    filter     Used to determine whether a module will be output.
-	 *                      Will be run on all loaded modules.
-	 * @param   outputter   Used to output details about a module that was matched
+	 * @param    filter     Used to determine whether a package will be output.
+	 *                      Will be run on all loaded packages.
+	 * @param   outputter   Used to output details about a package that was matched
 	 *                      by the filter. Will be run on any module that filter
 	 *                      returns true for.
 	 * @param   filterArg   A string that is to be used as additional data for filter.
@@ -161,16 +247,72 @@ public class ModularityHelper {
 		if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
 			GCClassLoaderIterator iterator = GCClassLoaderIterator.from();
 			while (iterator.hasNext()) {
-				J9ClassLoaderPointer classLoaderPointer = iterator.next();
-				HashTable<J9PackagePointer> packageHashTable = PackageHashTable
-						.fromJ9HashTable(classLoaderPointer.packageHashTable());
-				SlotIterator<J9PackagePointer> slotIterator = packageHashTable.iterator();
-				while (slotIterator.hasNext()) {
-					J9PackagePointer packagePtr = slotIterator.next();
-					if (filter.filter(packagePtr, filterArg)) {
-						count++;
-						outputter.print(packagePtr, out);
-					}
+				count += iterateClassLoaderPackages(out, filter, outputter, filterArg, iterator.next());
+			}
+		}
+		return count;
+	}
+
+	/**
+	 * Traverses through all loaded packages that are
+	 * owned by the given class loader. Uses
+	 * outtputter to print details about packages
+	 * matched by filter.
+	 * 
+	 * @param    out        The printstream that will be provided to outputter
+	 * @param    filter     Used to determine whether a packages will be output. Will
+	 *                      be run on all loaded packages owned by the class loader.
+	 * @param   outputter   Used to output details about a packages that was matched
+	 *                      by the filter. Will be run on any packages that filter
+	 *                      returns true for.
+	 * @param   filterArg   A string that is to be used as additional data for filter.
+	 *                      Will be passed to filter everytime filter is called.
+	 */
+	public static int iterateClassLoaderPackages(PrintStream out, PackageIteratorFilter filter, PackageOutput outputter, String filterArg, J9ClassLoaderPointer classLoaderPtr) throws CorruptDataException {
+		int count = 0;
+		J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+		if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+			HashTable<J9PackagePointer> packageHashTable = PackageHashTable
+					.fromJ9HashTable(classLoaderPtr.packageHashTable());
+			SlotIterator<J9PackagePointer> slotIterator = packageHashTable.iterator();
+			while (slotIterator.hasNext()) {
+				J9PackagePointer packagePtr = slotIterator.next();
+				if (filter.filter(packagePtr, filterArg)) {
+					count++;
+					outputter.print(packagePtr, out);
+				}
+			}
+		}
+		return count;
+	}
+
+
+	/**
+	 * Traverses through all loaded classes in a
+	 * classloader. Uses outtputter to print details
+	 * about classes within the classloader that are
+	 * matched by filter.
+	 * 
+	 * @param    out            The printstream that will be provided to outputter
+	 * @param    filter         Used to determine whether a class will be output.
+	 *                          Will be run on all loaaded classes owned by the module.
+	 * @param    outputter      Used to output details about a class that was matched
+	 *                          by the filter. Will be run on any class that filter
+	 *                          returns true for.
+	 * @param    filterArg      A string that is to be used as additional data for filter.
+	 *                          Will be passed to filter everytime filter is called.
+	 * @param    classLoaderPtr The classloader which will have it's classes traversed.
+	 */
+	public static int iterateClassLoaderClasses(PrintStream out, ClassIteratorFilter filter, ClassOutput outputter, String filterArg, J9ClassLoaderPointer classLoaderPtr) throws CorruptDataException {
+		int count = 0;
+		J9JavaVMPointer vm = J9RASHelper.getVM(DataType.getJ9RASPointer());
+		if (JavaVersionHelper.ensureJava9AndUp(vm, out)) {
+			Iterator<J9ClassPointer> classIterator = ClassIterator.fromJ9Classloader(classLoaderPtr);
+			while (classIterator.hasNext()) {
+				J9ClassPointer classPtr = classIterator.next();
+				if (filter.filter(classPtr, filterArg)) {
+					count++;
+					outputter.print(classPtr, out);
 				}
 			}
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleCommand.java
@@ -1,0 +1,261 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+import java.util.Iterator;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.corereaders.memory.MemoryFault;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.DataType;
+import com.ibm.j9ddr.vm29.j9.HashTable;
+import com.ibm.j9ddr.vm29.j9.ModuleHashTable;
+import com.ibm.j9ddr.vm29.j9.PackageHashTable;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.j9.gc.GCClassLoaderIterator;
+import com.ibm.j9ddr.vm29.j9.walkers.ClassIterator;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassLoaderPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9HashTablePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9JavaVMPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9ModulePointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9PackagePointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
+import com.ibm.j9ddr.vm29.pointer.helper.J9RASHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.JavaVersionHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.ClassIteratorFilter;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.ClassOutput;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.ModuleIteratorFilter;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.ModuleOutput;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.PackageIteratorFilter;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.ModularityHelper.PackageOutput;
+
+public class DumpModuleCommand extends Command 
+{
+	enum Subcommand {
+		CLASS, MODULE, PACKAGE, ALL, HELP, INVALID
+	}
+
+	public DumpModuleCommand()
+	{
+		addCommand("dumpmodule", "[all|requires|exports|classes|packages] <moduleAddress>|help", "List details about a module");
+	}
+	
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
+	{
+		final Subcommand subcommand;
+		ClassIteratorFilter classFilter = null;
+		ClassOutput classOutput = null;
+		ModuleIteratorFilter moduleFilter = null;
+		ModuleOutput moduleOutputter = null;
+		PackageIteratorFilter packageFilter = null;
+		PackageOutput packageOutputter = null;
+		String filterArg = null;
+		switch (args.length) {
+		case 1:
+			switch (args[0]) {
+			case "help":
+				subcommand = Subcommand.HELP;
+				break;
+			default:
+				filterArg = args[0];
+				subcommand = Subcommand.ALL;
+				break;
+			}
+			break;
+		case 2:
+			filterArg = args[1];
+			switch (args[0]) {
+			case "all":
+				subcommand = Subcommand.ALL;
+				break;
+			case "requires":
+				moduleFilter = DumpModuleCommand::filterModuleRequired;
+				moduleOutputter = ModularityHelper::printJ9Module;
+				subcommand = Subcommand.MODULE;
+				break;
+			case "exports":
+				packageFilter = DumpModuleCommand::filterPackageModuleAndExport;
+				packageOutputter = ModularityHelper::printPackageExportVerbose;
+				subcommand = Subcommand.PACKAGE;
+				break;
+			case "classes":
+				classFilter = DumpModuleCommand::filterClassByModule;
+				classOutput = ModularityHelper::printJ9Class;
+				subcommand = Subcommand.CLASS;
+				break;
+			case "packages":
+				packageFilter = DumpModuleCommand::filterPackageModule;
+				packageOutputter = ModularityHelper::printJ9Package;
+				subcommand = Subcommand.PACKAGE;
+				break;
+			default:
+				subcommand = Subcommand.INVALID;
+				break;
+			}
+			break;
+		default:
+			subcommand = Subcommand.INVALID;
+			break;
+		}
+		try {
+			int result;
+			J9ModulePointer modulePtr = null;
+			J9ClassLoaderPointer classLoaderPtr = null;
+			if (null != filterArg) {
+				try {
+					modulePtr = J9ModulePointer.cast(Long.decode(filterArg));
+					classLoaderPtr = modulePtr.classLoader();
+				} catch (NumberFormatException e) {
+					throw new DDRInteractiveCommandException("The argument \"" + filterArg + "\" is not a valid number. It should be the address of a J9Module.");
+				} catch (NullPointerException e) {
+					throw new DDRInteractiveCommandException("The argument \"" + filterArg + "\" is not the address of a valid J9Module.");
+				} catch (MemoryFault e) {
+					System.out.println(e.getMessage());
+					throw new DDRInteractiveCommandException("The argument \"" + filterArg + "\" is not the address of a valid J9Module.");
+				}
+			}
+			switch (subcommand) {
+			case CLASS:
+				result = ModularityHelper.iterateClassLoaderClasses(out, classFilter, classOutput, filterArg, classLoaderPtr);
+				System.out.printf("Found %d class%s%n", result, (1 == result ? "" : "es"));
+				break;
+			case MODULE:
+				result = ModularityHelper.iterateModules(out, moduleFilter, moduleOutputter, filterArg);
+				System.out.printf("Found %d module%s%n", result, (1 == result ? "" : "s"));
+				break;
+			case PACKAGE:
+				result = ModularityHelper.iterateClassLoaderPackages(out, packageFilter, packageOutputter, filterArg, classLoaderPtr);
+				System.out.printf("Found %d package%s%n", result, (1 == result ? "" : "s"));
+				break;
+			case ALL:
+				out.println("Module:");
+				ModularityHelper.printJ9Module(modulePtr, out);
+				/* Run requires */
+				out.println("Requires:");
+				moduleFilter = DumpModuleCommand::filterModuleRequired;
+				moduleOutputter = ModularityHelper::printJ9Module;
+				result = ModularityHelper.iterateModules(out, moduleFilter, moduleOutputter, filterArg);
+				System.out.printf("Found %d required module%s%n", result, (1 == result ? "" : "s"));
+				/* Run exports */
+				out.println("Exports:");
+				packageFilter = DumpModuleCommand::filterPackageModuleAndExport;
+				packageOutputter = ModularityHelper::printPackageExportVerbose;
+				result = ModularityHelper.iteratePackages(out, packageFilter, packageOutputter, filterArg);
+				System.out.printf("Found %d exported package%s%n", result, (1 == result ? "" : "s"));
+				break;
+			case HELP:
+				printHelp(out);
+				break;
+			default:
+				out.println("Argument failed to parse or was parsed to an unhandled subcommand.");
+				printHelp(out);
+				break;
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException(e);
+		}
+	}
+
+	private static boolean filterClassByModule(J9ClassPointer classPtr, String targetModuleAddress) throws CorruptDataException {
+		String moduleAddress = classPtr.module().getHexAddress();
+		return targetModuleAddress.equalsIgnoreCase(moduleAddress);
+	}
+
+	private static boolean filterModuleRequired(J9ModulePointer modulePtr, String targetModuleAddress) throws CorruptDataException {
+		boolean result = false;
+		J9HashTablePointer readTable = modulePtr.readAccessHashTable();
+		HashTable<J9ModulePointer> readModuleHashTable = ModuleHashTable.fromJ9HashTable(readTable);
+		SlotIterator<J9ModulePointer> readSlotIterator = readModuleHashTable.iterator();
+		while (readSlotIterator.hasNext()) {
+			J9ModulePointer readModulePtr = readSlotIterator.next();
+			String readHexAddress = readModulePtr.getHexAddress();
+			if (targetModuleAddress.equals(readHexAddress)) {
+				result = true;
+				break;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Check whether a givin package is exported. Both
+	 * `export <package>` and `export <package> to
+	 * <module>` are matched.
+	 * 
+	 * @param    packagePtr The package that is to be filtered.
+	 * @param    arg        Unused.
+	 * @return   true if the package is globaly exported or exported to a
+	 *           specific module.
+	 */
+	private static boolean filterPackageExported(J9PackagePointer packagePtr, String arg) throws CorruptDataException {
+		boolean result = false;
+		if (packagePtr.exportToAll().isZero() && packagePtr.exportToAllUnnamed().isZero()) {
+			J9HashTablePointer exportsHashTable = packagePtr.exportsHashTable();
+			HashTable<J9ModulePointer> exportsModuleHashTable = ModuleHashTable.fromJ9HashTable(exportsHashTable);
+			SlotIterator<J9ModulePointer> exportsSlotIterator = exportsModuleHashTable.iterator();
+			if (exportsSlotIterator.hasNext()) {
+				result = true;
+			}
+		} else {
+			result = true;
+		}
+		return result;
+	}
+
+	private static boolean filterPackageModule(J9PackagePointer packagePtr, String targetModuleAddress) throws CorruptDataException {
+		return packagePtr.module().getHexAddress().equals(targetModuleAddress);
+	}
+
+	/**
+	 * Run both filterPackageModule and filterPackageExported
+	 * 
+	 * @param    packagePtr             The package to be passed to both filters.
+	 * @param    targetModuleAddress    The module address to be passed to both filters.
+	 * @return   (filterPackageModule result && filterPackageExported result)
+	 */
+	private static boolean filterPackageModuleAndExport(J9PackagePointer packagePtr, String targetModuleAddress) throws CorruptDataException {
+		return filterPackageModule(packagePtr, targetModuleAddress) && filterPackageExported(packagePtr, targetModuleAddress);
+	}
+
+	private static void printHelp(PrintStream out) {
+		out.println("Usage:");
+		out.println("  !dumpmodule <moduleAddress>");
+		out.println("      Lists !dumpmodule all <moduleAddress>");
+		out.println("  !dumpmodule all <moduleAddress>");
+		out.println("      Lists the requires and exports of the target module");
+		out.println("  !dumpmodule requires <moduleAddress>");
+		out.println("      Lists all modules required by the target module");
+		out.println("  !dumpmodule exports <moduleAddress>");
+		out.println("      Lists all packages exported by the target module");
+		out.println("  !dumpmodule classes <moduleAddress>");
+		out.println("      Lists all loaded classes in the target module");
+		out.println("  !dumpmodule packages <moduleAddress>");
+		out.println("      Lists all packages in the target module");
+	}
+}


### PR DESCRIPTION
Implement !dumpmodule DDR modularity command

Usage: !dumpmodule [option] <moduleAddress>
Includes options to list the following details about a module:
- all: List requires, exports and opens
- requires: Lists all modules required by given module
- exports: Lists all packages exported by given module
- classes: Lists all loaded classes within the given module
- packages: Lists all packages within the given module

Implements part of second proposal within #1859.

Example Commands:
`!dumpmodule <moduleA hex address>` or `!dumpmodule all <moduleA hex address>`
```
> !dumpmodule 0x00007FA2D43A9D40
Module:
moduleA                        !j9module 0x00007FA2D43A9D40
Requires:
java.base                      !j9module 0x00007FA2D408EAC8
moduleB                        !j9module 0x00007FA2D4336090
moduleC                        !j9module 0x00007FA2D43B2498
Exports:
Exports moduleA/packageA                              !j9package 0x00007FA2D43A9D88
```
`!dumpmodule exports <moduleA hex address>`
```
> !dumpmodule exports 0x00007FA2D43A9D40
Exports moduleA/packageA                              !j9package 0x00007FA2D43A9D88
Exports moduleA/packageExportUnnamed                  !j9package 0x00007F47043BB2F8
     to ALL-UNNAMED
```
`!dumpmodule exports <moduleB hex address>`
```
Exports moduleB/packageB                              !j9package 0x00007FA2D43360D8
     to moduleA                        !j9module 0x00007FA2D43A9D40
```
`!dumpmodule classes <moduleA hex address>`
- With both classes loaded:
```
> !dumpmodule classes 0x00007FA2D43A9D40
moduleA/packageA/classA        !j9class 0x000000000188CD00
moduleA/packageNonExported/classNonExported !j9class 0x000000000188D000
```
- Without classNonExported loaded:
```
> !dumpmodule classes 0x00007FA2D43A9D40
moduleA/packageA/classA        !j9class 0x000000000188CD00
```
!dumpmodule packages <moduleA hex address>
```
> !dumpmodule packages 0x00007FA2D43A9D40
moduleA/packageA                              !j9package 0x00007FA2D43A9D88
moduleA/packageNonExported                    !j9package 0x00007FA2D43A9DD0
```

Modules for Examples:
```
moduleA
 | packageA
    \ classA
 | packageNonExported
    \ classNonExported
 | packageExportUnnamed
    \ classExportUnnamed
 \ module-info.java
moduleB
 | packageB
    \ classB
 \ module-info.java
moduleC
 \ module-info.java
```
moduleA module-info file:
```
module moduleA{
	exports moduleA.packageA;
	requires moduleB;
	requires moduleC;
}
```
- packageExportUnnamed is exported using the java option `--add-exports moduleA/packageExportUnnamed=ALL-UNNAMED`

moduleB module-info file:
```module moduleB {
	exports moduleB.packageB to moduleA;
	requires moduleC;
}
```
moduleC module-info file:
```
module moduleC { }
```

Signed-off-by: Andrew Crowther <acrowthe3388@gmail.com>