### PR TITLE
Race condition fix for findThunkFromTerseSignature

### DIFF
--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -178,8 +178,8 @@ TR_J2IThunkTable::findThunkFromTerseSignature(
       TR_FrontEnd *fe,
       bool isForCurrentRun)
    {
-   Node *match = NULL;
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe);
+   TR_J2IThunk *returnThunk = NULL;
 
    if (fej9->isAOT_DEPRECATED_DO_NOT_USE() && !isForCurrentRun)
       {
@@ -189,10 +189,12 @@ TR_J2IThunkTable::findThunkFromTerseSignature(
    else
       {
       OMR::CriticalSection critialSection(_monitor);
-      match = root()->get(terseSignature, _nodes, false);
+
+      Node *match = root()->get(terseSignature, _nodes, false);
+      returnThunk = match ? match->_thunk : NULL;
       }
 
-   return match? match->_thunk : NULL;
+   return returnThunk;
    }
 
 


### PR DESCRIPTION
match points to an entry inside a TR_PersistentArray in TR_J2IThunkTable.
Before returning from findThunkFromTerseSignature, the code attempts to
read from match->_thunk after leaving the critical section. This is bad
because if the TR_PersistentArray grows, the match pointer is stale and
may not point to the correct entry anymore.

This fix moves the read from match->_thunk into the critical section.
Assuming locking is handled properly in other areas, this will prevent the
match pointer from going stale unexpectedly and ensures a valid
match->_thunk.

Fixes: #3006
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>