### PR TITLE
Concurrent Scavenger Read Barrier evaluator on X86-64

### DIFF
--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -967,6 +967,25 @@ END_PROC(jitDecompileOnReturnJ)
 
 })	dnl ASM_J9VM_ENV_DATA64
 
+START_PROC(jitReadBarrier)
+ifdef({OMR_GC_CONCURRENT_SCAVENGER},{
+	SWITCH_TO_C_STACK
+	SAVE_C_VOLATILE_REGS
+	dnl currentThread->javaVM->memoryManagerFunctions->J9ReadBarrier(currentThread,(fj9object_t*)currentThread->floatTemp1);
+	mov _rax,uword ptr J9TR_VMThread_javaVM[_rbp]
+	mov PARM_REG(2),uword ptr J9TR_VMThread_floatTemp1[_rbp]
+	mov _rax,uword ptr J9TR_JavaVM_memoryManagerFunctions[_rax]
+	mov PARM_REG(1),_rbp
+	call uword ptr J9TR_J9MemoryManagerFunctions_J9ReadBarrier[_rax]
+	RESTORE_C_VOLATILE_REGS
+	SWITCH_TO_JAVA_STACK
+	ret
+},{ dnl OMR_GC_CONCURRENT_SCAVENGER
+	dnl not supported
+	int 3
+})	dnl OMR_GC_CONCURRENT_SCAVENGER
+END_PROC(jitReadBarrier)
+
 START_PROC(jitReferenceArrayCopy)
 	FASTCALL_EXTERN(impl_jitReferenceArrayCopy,2)
 	SWITCH_TO_C_STACK

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1107,6 +1107,9 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_typeCheckArrayStore,        (void *)jitTypeCheckArrayStoreWithNullCheck,   TR_Helper);
 #endif
 
+#if defined (TR_HOST_X86)
+   SET(TR_readBarrier,                                      (void *)jitReadBarrier,                                    TR_Helper);
+#endif
    SET(TR_writeBarrierStore,                                (void *)jitWriteBarrierStore,                              TR_Helper);
    SET(TR_writeBarrierStoreGenerational,                    (void *)jitWriteBarrierStoreGenerational,                  TR_Helper);
    SET(TR_writeBarrierStoreGenerationalAndConcurrentMark,   (void *)jitWriteBarrierStoreGenerationalAndConcurrentMark, TR_Helper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -88,6 +88,7 @@ JIT_HELPER(jitNewObject);  // asm calling-convention helper
 JIT_HELPER(jitObjectHashCode);  // asm calling-convention helper
 JIT_HELPER(jitPostJNICallOffloadCheck);  // asm calling-convention helper
 JIT_HELPER(jitPreJNICallOffloadCheck);  // asm calling-convention helper
+JIT_HELPER(jitReadBarrier);  // asm calling-convention helper
 JIT_HELPER(jitReferenceArrayCopy);  // asm calling-convention helper
 JIT_HELPER(jitReleaseVMAccess);  // asm calling-convention helper
 JIT_HELPER(jitReportMethodEnter);  // asm calling-convention helper

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -45,6 +45,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    {
    public:
 
+   static TR::Register *irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *writeBarrierEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -569,12 +569,14 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_bytecodeLoop", offsetof(J9JavaVM, bytecodeLoop)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_extendedRuntimeFlags", offsetof(J9JavaVM, extendedRuntimeFlags)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVMInternalFunctionTable", offsetof(J9JavaVM, internalVMFunctions)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_memoryManagerFunctions", offsetof(J9JavaVM, memoryManagerFunctions)) |
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_invokeJ9ReadBarrier", offsetof(J9JavaVM, invokeJ9ReadBarrier)) |
 #endif
 #if defined(J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_jitTOC", offsetof(J9JavaVM, jitTOC)) |
 #endif /* J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE */
+			writeConstant(OMRPORTLIB, fd, "J9TR_J9MemoryManagerFunctions_J9ReadBarrier", offsetof(J9MemoryManagerFunctions, J9ReadBarrier)) |
 			/* J9VMEntryLocalStorage */
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_jitGlobalStorageBase", offsetof(J9VMEntryLocalStorage, jitGlobalStorageBase)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_jitFPRegisterStorageBase", offsetof(J9VMEntryLocalStorage, jitFPRegisterStorageBase)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4998,8 +4998,12 @@ typedef struct J9VMThread {
 #endif /* J9VM_JIT_TRANSACTION_DIAGNOSTIC_THREAD_BLOCK */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	struct J9GSParameters gsParameters;
-	void* evacuateBase;
-	void* evacuateTop;
+	UDATA evacuateBase;
+	UDATA evacuateTop;
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
+	U_32 evacuateBaseCompressed;
+	U_32 evacuateTopCompressed;
+#endif /* J9VM_GC_COMPRESSED_POINTERS */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	UDATA safePointCount;
 } J9VMThread;

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -210,6 +210,16 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 	newThread->mgmtWaitedStart = JNI_FALSE;
 #endif
 
+#ifdef OMR_GC_CONCURRENT_SCAVENGER
+	/* Initialize fields used by Concurrent Scavenger */
+	newThread->evacuateBase = UDATA_MAX;
+	newThread->evacuateTop = 0;
+#ifdef J9VM_GC_COMPRESSED_POINTERS
+	newThread->evacuateBaseCompressed = U_32_MAX;
+	newThread->evacuateTopCompressed = 0;
+#endif /* J9VM_GC_COMPRESSED_POINTERS */
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 	/* Attach the thread to OMR */
 	if (JNI_OK != attachVMThreadToOMR(vm, newThread, osThread)) {
 		goto fail;


### PR DESCRIPTION
X86-64 compressedrefs now supports read barriers for Concurrent Scavenger.

Part of Issue #3054

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>