### PR TITLE
PPC ABI updates and optimizations

### DIFF
--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -29,7 +29,7 @@ define({BEGIN_HELPER},{
 	staddr r0,JIT_GPR_SAVE_SLOT(0)
 	SAVE_LR
 	SAVE_JIT_GOT_REGISTERS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 })
 
 define({END_HELPER},{
@@ -202,7 +202,7 @@ define({NEW_DUAL_MODE_HELPER},{
 	START_PROC($1)
 	SAVE_LR
 	SAVE_JIT_GOT_REGISTERS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_DIRECT(fast_$1)
 	cmpliaddr r3,0
 	beq .L_done_$1
@@ -233,7 +233,7 @@ define({NEW_DUAL_MODE_HELPER_NO_RETURN_VALUE},{
 	START_PROC($1)
 	SAVE_LR
 	SAVE_JIT_GOT_REGISTERS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_DIRECT(fast_$1)
 	cmpliaddr r3,0
 	beq .L_done_$1
@@ -729,7 +729,7 @@ END_PROC(icallVMprJavaSendInvokeExactL)
 START_PROC(jitDecompileOnReturn0)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,0
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)
@@ -740,7 +740,7 @@ START_PROC(jitDecompileOnReturn1)
 	stw r3,J9TR_VMThread_returnValue(J9VMTHREAD)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,1
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)
@@ -751,7 +751,7 @@ START_PROC(jitDecompileOnReturnF)
 	stfs fp0,J9TR_VMThread_returnValue(J9VMTHREAD)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,1
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)
@@ -762,7 +762,7 @@ START_PROC(jitDecompileOnReturnD)
 	stfd fp0,J9TR_VMThread_returnValue(J9VMTHREAD)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,2
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)
@@ -772,7 +772,7 @@ END_PROC(jitDecompileOnReturnD)
 START_PROC(jitReportExceptionCatch)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitReportExceptionCatch)
 	RESTORE_PRESERVED_REGS
 	SWITCH_TO_JAVA_STACK
@@ -782,42 +782,42 @@ END_PROC(jitReportExceptionCatch)
 START_PROC(jitDecompileAtExceptionCatch)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitDecompileAtExceptionCatch)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitDecompileAtExceptionCatch)
 
 START_PROC(jitDecompileAtCurrentPC)
 	SWITCH_TO_C_STACK
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitDecompileAtCurrentPC)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitDecompileAtCurrentPC)
 
 START_PROC(jitDecompileBeforeReportMethodEnter)
 	SWITCH_TO_C_STACK
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitDecompileBeforeReportMethodEnter)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitDecompileBeforeReportMethodEnter)
 
 START_PROC(jitDecompileBeforeMethodMonitorEnter)
 	SWITCH_TO_C_STACK
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitDecompileBeforeMethodMonitorEnter)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitDecompileBeforeMethodMonitorEnter)
 
 START_PROC(jitDecompileAfterAllocation)
 	SWITCH_TO_C_STACK
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitDecompileAfterAllocation)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitDecompileAfterAllocation)
 
 START_PROC(jitDecompileAfterMonitorEnter)
 	SWITCH_TO_C_STACK
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	CALL_C_WITH_VMTHREAD(c_jitDecompileAfterMonitorEnter)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitDecompileAfterMonitorEnter)
@@ -867,7 +867,7 @@ START_PROC(jitDecompileOnReturnJ)
 	std r3,J9TR_VMThread_returnValue(J9VMTHREAD)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,2
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)
@@ -884,7 +884,7 @@ START_PROC(jitDecompileOnReturnL)
 	std r3,J9TR_VMThread_returnValue(J9VMTHREAD)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,1
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)
@@ -910,7 +910,7 @@ START_PROC(jitDecompileOnReturnJ)
 	stw r4,J9TR_VMThread_returnValue2(J9VMTHREAD)
 	SWITCH_TO_C_STACK
 	SAVE_PRESERVED_REGS
-	INIT_GOT(jitTOC)
+	INIT_JIT_TOC
 	li r0,2
 	staddr r0,J9TR_VMThread_tempSlot(J9VMTHREAD)
 	CALL_C_WITH_VMTHREAD(c_jitDecompileOnReturn)

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -526,7 +526,6 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #endif
 #if defined(J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_jitTOC", offsetof(J9JavaVM, jitTOC)) |
-			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_vmTOC", offsetof(J9JavaVM, vmTOC)) |
 #endif /* J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE */
 			/* J9VMEntryLocalStorage */
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_jitGlobalStorageBase", offsetof(J9VMEntryLocalStorage, jitGlobalStorageBase)) |

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5215,9 +5215,6 @@ typedef struct J9JavaVM {
 	UDATA aotDllHandle;
 	struct J9ROMImageHeader* arrayROMClasses;
 	struct J9BytecodeVerificationData* bytecodeVerificationData;
-#if defined(J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE) || defined(J9VM_ENV_CALL_VIA_TABLE)
-	UDATA vmTOC;
-#endif /* J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE || J9VM_ENV_CALL_VIA_TABLE */
 	char* jclDLLName;
 	UDATA defaultOSStackSize;
 #if defined(J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE) || defined(J9VM_ENV_CALL_VIA_TABLE)
@@ -5586,7 +5583,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA backChain; /* caller SP */
 	UDATA preservedCR; /* callee saves in caller frame */
 	UDATA preservedLR; /* callee saves in caller frame */
-	UDATA currentTOC; /* callee saves incoming TOC in own frame */
+	UDATA currentTOC; /* callee saves own TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	UDATA jitGPRs[32]; /* r0-r31 */
 	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */
@@ -5605,7 +5602,7 @@ typedef struct J9CInterpreterStackFrame {
 	UDATA preservedLR; /* callee saves in caller frame */
 	UDATA tocSave;
 	UDATA reserved;
-	UDATA currentTOC; /* callee saves incoming TOC in own frame */
+	UDATA currentTOC; /* callee saves own TOC in own frame */
 	UDATA outgoingArguments[J9_INLINE_JNI_MAX_ARG_COUNT];
 	UDATA jitGPRs[32]; /* r0-r31 */
 	U_8 jitFPRs[32 * 8]; /* fp0-fp31 */

--- a/runtime/oti/phelpers.m4
+++ b/runtime/oti/phelpers.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 1991, 2017 IBM Corp. and others
+dnl Copyright (c) 1991, 2018 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,8 +100,7 @@ define({staddrx},stdx)
 define({staddru},stdu)
 define({cmpliaddr},{cmpli 0,1,})
 define({ADDR},.llong)
-define({ALen},8)  
-
+define({ALen},{J9CONST(8,$1,$2)})
 define({J9VMTHREAD},{r15})
 
 },{ dnl ASM_J9VM_ENV_DATA64
@@ -116,7 +115,7 @@ define({staddrx},stwx)
 define({staddru},stwu)
 define({cmpliaddr},{cmpli 0,0,})
 define({ADDR},.long)
-define({ALen},4)       
+define({ALen},{J9CONST(4,$1,$2)})     
 
 define({J9VMTHREAD},{r13})
 
@@ -135,7 +134,11 @@ define({FUNC_PTR},{r11})
 
 define({CALL_INDIRECT},{
 	ifelse($1,,,{mr FUNC_PTR,$1})
-	bl ._ptrgl[pr]
+dnl inline version of _ptrgl follows
+	laddr r2,0(FUNC_PTR)
+	mtctr r2
+	laddr r2,ALen(FUNC_PTR)
+	bctrl
 })
 
 define({FUNC_LABEL},{.$1})
@@ -162,7 +165,6 @@ define({DECLARE_EXTERN},{
 })
 
 define({START_TEXT},{
-	.extern ._ptrgl[pr]
 	.csect .$1[pr]
 })
 
@@ -179,11 +181,6 @@ define({END_PROC},{endproc.$1:})
 define({CALL_DIRECT},{
 	bl BRANCH_SYMBOL($1)
 	cror 31,31,31
-})
-
-define({INIT_GOT},{
-	laddr r2,J9TR_VMThread_javaVM(J9VMTHREAD)
-    laddr r2,J9TR_JavaVM_$1(r2)
 })
 
 define({TOC_SAVE_OFFSET},{J9CONST(J9TR_cframe_currentTOC,$1,$2)})
@@ -207,10 +204,8 @@ define({FUNC_PTR},{r12})
 
 define({CALL_INDIRECT},{
 	ifelse($1,,,{mr FUNC_PTR,$1})
-	std r2,TOC_SAVE_OFFSET(r1)
-	mtctr r12
+	mtctr FUNC_PTR
 	bctrl
-	ld r2,TOC_SAVE_OFFSET(r1)
 })
 
 define({FUNC_LABEL},{$1})
@@ -230,7 +225,6 @@ define({START_TEXT},{
 })
 
 define({CALL_DIRECT},{
-	ori r0,r0,0
 	bl BRANCH_SYMBOL($1)
 	ori r0,r0,0
 })
@@ -243,11 +237,6 @@ define({START_PROC},{
 })
 
 define({END_PROC})
-
-define({INIT_GOT},{
-	laddr r2,J9TR_VMThread_javaVM(J9VMTHREAD)
-    laddr r2,J9TR_JavaVM_$1(r2)
-})
 
 define({TOC_SAVE_OFFSET},{J9CONST(J9TR_cframe_currentTOC,$1,$2)})
 define({GPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedGPRs+((($1)-14)*ALen))})
@@ -265,12 +254,11 @@ define({FUNC_PTR},{r11})
 
 define({CALL_INDIRECT},{
 	ifelse($1,,,{mr FUNC_PTR,$1})
-	std r2,TOC_SAVE_OFFSET(r1)
-	ld r2,0(r11)
+dnl inline version of _ptrgl follows
+	ld r2,0(FUNC_PTR)
 	mtctr r2
-	ld r2,8(r11)
+	ld r2,8(FUNC_PTR)
 	bctrl
-	ld r2,TOC_SAVE_OFFSET(r1)
 })
 
 define({FUNC_LABEL},{.$1})
@@ -314,11 +302,6 @@ define({START_PROC},{
 
 define({END_PROC})
 
-define({INIT_GOT},{
-	laddr r2,J9TR_VMThread_javaVM(J9VMTHREAD)
-    laddr r2,J9TR_JavaVM_$1(r2)
-})
-
 define({TOC_SAVE_OFFSET},{J9CONST(J9TR_cframe_currentTOC,$1,$2)})
 define({GPR_SAVE_OFFSET},{eval(J9TR_cframe_preservedGPRs+((($1)-14)*ALen))})
 define({GPR_SAVE_SLOT},{GPR_SAVE_OFFSET($1)(r1)})
@@ -328,13 +311,8 @@ define({CR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedCR
 define({LR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR),$1,$2)})
 
 define({CALL_DIRECT},{
-	ld r11, .tocL_$1@toc(r2)
-	std r2,TOC_SAVE_OFFSET(r1)
-	ld r2, 0(r11)
-	mtctr r2
-	ld r2, 8(r11)
-	bctrl
-	ld r2,TOC_SAVE_OFFSET(r1)
+	ld FUNC_PTR, .tocL_$1@toc(r2)
+	CALL_INDIRECT
 })
 
 }) dnl ASM_J9VM_ENV_LITTLE_ENDIAN
@@ -370,7 +348,7 @@ define({START_PROC},{
 
 define({END_PROC})
 
-define({INIT_GOT},{
+define({INIT_JIT_TOC},{
 	bl _GLOBAL_OFFSET_TABLE_@local-4
 	mflr r29
 })
@@ -392,6 +370,12 @@ define({LR_SAVE_OFFSET},{J9CONST(eval(CINTERP_STACK_SIZE+J9TR_cframe_preservedLR
 
 }) dnl ASM_J9VM_ENV_DATA64
 }) dnl AIXPPC
+
+ifdef({INIT_JIT_TOC},,{
+define({INIT_JIT_TOC},{
+	laddr r2,J9TR_VMThread_jitTOC(J9VMTHREAD)
+})
+}) dnl !INIT_JIT_TOC
 
 define({SAVE_GPR},{staddr r$1,GPR_SAVE_SLOT($1)})
 define({RESTORE_GPR},{laddr r$1,GPR_SAVE_SLOT($1)})

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5582,8 +5582,6 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 	registerIgnoredOptions(PORTLIB, vm->vmArgsArray);				/* Tags -D java options and options in ignoredOptionTable as not consumable */
 
-	TOC_STORE_TOC(vm->vmTOC, &initializeJavaVM);
-
 #if !defined(J9VM_INTERP_MINIMAL_JNI)
 	vm->EsJNIFunctions = GLOBAL_TABLE(EsJNIFunctions);
 #endif

--- a/runtime/vm/pcinterp.m4
+++ b/runtime/vm/pcinterp.m4
@@ -25,14 +25,18 @@ include(phelpers.m4)
 define({CSECT_NAME},{c_cInterpreter})
 
 START_PROC(c_cInterpreter)
+ifdef({ASM_J9VM_ENV_DATA64},{
+ifdef({ASM_J9VM_ENV_LITTLE_ENDIAN},{
+	addis r2,r12,(.TOC.-c_cInterpreter)@ha
+	addi r2,r2,(.TOC.-c_cInterpreter)@l
+	.localentry c_cInterpreter,.-c_cInterpreter
+}) dnl ASM_J9VM_ENV_LITTLE_ENDIAN
+}) dnl ASM_J9VM_ENV_DATA64
 	staddru r1,-CINTERP_STACK_SIZE(r1)
 	mflr r0
 	staddr r0,LR_SAVE_OFFSET(r1)
 	mfcr r0
 	staddr r0,CR_SAVE_OFFSET(r1)
-ifdef({TOC_SAVE_OFFSET},{
-	staddr r2,TOC_SAVE_OFFSET(r1)
-})
 ifdef({SAVE_R13},{
 	SAVE_GPR(13)
 })
@@ -92,7 +96,6 @@ ifdef({ASM_J9VM_ENV_DATA64},{
 	staddr r3,JIT_GPR_SAVE_SLOT(15)
 }) dnl ASM_J9VM_ENV_DATA64
 .L_cInterpOnCStack:
-	INIT_GOT(vmTOC)
 	mr r3,J9VMTHREAD
 	laddr FUNC_PTR,J9TR_VMThread_javaVM(J9VMTHREAD)
 	laddr FUNC_PTR,J9TR_JavaVM_bytecodeLoop(FUNC_PTR)


### PR DESCRIPTION
- c_cInterpreter does not use TOC, so don't load it
- c_cInterpreter now follows PPC LE ABI for entry
- unnecessary nop removed from direct calls
- fetch jitTOC from J9VMThread rather than J9JavaVM
- inline ptrgl for AIX
- don't save/restore TOC across calls as they are in the same module

There were no issues with the incorrect ABI in c_cInterpreter on PPC LE,
but it seems wise to follow the ABI in case future code needs the TOC,
or c_cInterpreter is called from another module.

See: #2994

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>