### PR TITLE
Fix failures in Condy Test

### DIFF
--- a/runtime/compiler/z/runtime/PicBuilder.m4
+++ b/runtime/compiler/z/runtime/PicBuilder.m4
@@ -1790,6 +1790,13 @@ ZZ ================================================
     START_FUNC(_jitResolveConstantDynamic,jRCD)
 
 LABEL(_jitResolveConstantDynamicBody)
+ZZ Store all the Regsiter on Java Stack and adjust J9SP.
+ZZ VM Helper old_slow_jitResolveConstantDynamic allocates
+ZZ Data resolve frame for unresolved field and these frame
+ZZ assumes all registers are stored off to the Java Stack
+ZZ upon entry and adjusts stack frames accordingly during
+ZZ stack walk.
+   SaveRegs
 ZZ Loading arguments for JIT helper
 ZZ R1 - Address of Constant Pool
 ZZ R2 - CPIndex
@@ -1816,7 +1823,7 @@ ZZ is address of resolved constant dynamic
 ZZ into the Literal Pool 
     L_GPR   r1,eq_literalPoolAddr_inDataSnippet(r14)
     ST_GPR  r2,0(,r1)
-
+    RestoreRegs
     L_GPR r14,eq_codeRA_inDataSnippet(,r14) # Get mainline RA
 
 ZZ Branch instruction in mainline will be patched here with NOP

--- a/test/TestConfig/scripts/tools/getDependencies.pl
+++ b/test/TestConfig/scripts/tools/getDependencies.pl
@@ -71,9 +71,9 @@ my %asm_all = (
 	sha1 => '535f141f6c8fc65986a3469839a852a3266d1025'
 );
 my %asm_7_0 = (
-	url => 'https://repository.ow2.org/nexus/content/repositories/snapshots/org/ow2/asm/asm/7.0-beta-SNAPSHOT/asm-7.0-beta-20180918.180157-14.jar',
+	url => 'https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/7.0-beta/asm-7.0-beta.jar',
 	fname => 'asm-7.0.jar',
-	sha1 => '79bf03b9e6aec5cc7a387cb397e3b12cbe519419'
+	sha1 => '7804855908e0a5e4f98e3364fa537426d9f5329c'
 );
 my %commons_cli = (
 	url => 'http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar',

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -111,6 +111,9 @@
 		Variation 3:
 			This variation runs test under -Xjit:count=0 option means JIT faces unresolved constant dynamic and it needs to resolve them before
 			using it.
+		Variation 4:
+			In addition to Variation 3 this test runs gc on resolving constant dynamic. This will test JIT to make sure it correctly prepares
+			GC map in code.
 		-->
 	<test>
 		<testCaseName>CondyPrimitive</testCaseName>
@@ -118,6 +121,7 @@
 			<variation>NoOptions</variation>
 			<variation>'-Xjit:count=1,disableAsyncCompilation,rtResolve'</variation>
 			<variation>'-Xjit:count=0,disableAsyncCompilation'</variation>
+			<variation>'-Xjit:count=0,disableAsyncCompilation,gcOnResolve'</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \


### PR DESCRIPTION
When GC kicks in when constant dynamic object is resolved, VM helper code expects all the registers are stored on Java Stack and while resolving frames it takes this adjustment into account while building frames. Condy Test was failing as it was not storing registers on Java Stack producing corrupted stack frame.

Changes originate from #3089 and #3095

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>