### PR TITLE
Use ProtectionDomain.impliesWithAltFilePerm()

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -521,7 +521,11 @@ static int checkPermWithCachedPDsImplied(Permission perm, Object[] toCheck, Acce
 					}
 				}
 			}
+			/*[IF Sidecar19-SE-OpenJ9]*/
+			if (!((ProtectionDomain) domain).impliesWithAltFilePerm(perm)) {
+			/*[ELSE]*/
 			if (!((ProtectionDomain) domain).implies(perm)) {
+			/*[ENDIF] Sidecar19-SE-OpenJ9*/
 				return i; // NOT implied
 			}
 		}

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -243,7 +243,11 @@ private static boolean checkPermissionHelper(Permission perm, AccessControlConte
 			if (pDomains != null) {
 				for (int i = 0; i < length ; ++i) {
 					// invoke PD within acc.context first
+					/*[IF Sidecar19-SE-OpenJ9]*/
+					if ((pDomains[length - i - 1] != null) && !pDomains[length - i - 1].impliesWithAltFilePerm(perm)) {
+					/*[ELSE]*/
 					if ((pDomains[length - i - 1] != null) && !pDomains[length - i - 1].implies(perm)) {
+					/*[ENDIF] Sidecar19-SE-OpenJ9*/
 						throwACE((debug & AccessControlContext.DEBUG_ACCESS_DENIED) != 0, perm, pDomains[length - i - 1], false);
 					}
 				}


### PR DESCRIPTION
Use `ProtectionDomain.impliesWithAltFilePerm()`

Uses `j.s.ProtectionDomain.impliesWithAltFilePerm()` to ensure `FilePermission` compatibility after [JDK-8164705](https://bugs.java.com/view_bug.do?bug_id=JDK-8164705).
This change only applies to `Java 9` and onward, decorate it with current level `Java11`. 

Manually verified the failed testcase (#3008) passes with this PR.

close: #3008 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>