### PR TITLE
Fix inverted FSD test in DTFJ

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
@@ -191,7 +191,7 @@ public class DTFJJavaRuntime implements JavaRuntime {
 					properties.setProperty("AOT", "disabled");
 				}
 				
-				if (jitConfig.fsdEnabled().eq(new UDATA(0))) {
+				if (!jitConfig.fsdEnabled().eq(new UDATA(0))) {
 					properties.setProperty("FSD", "enabled");
 				} else {
 					properties.setProperty("FSD", "disabled");


### PR DESCRIPTION
The logic for determining if FSD is enabled is backwards.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>