### PR TITLE
Read Barrier Support for Atomic CAS on X86

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -667,7 +667,10 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       {
       // J9
       //
-      if (self()->comp()->useCompressedPointers())
+      // Hiding compressedref logic from CodeGen doesn't seem a good practise, the evaluator always need the uncompressedref node for write barrier,
+      // therefore, this part is deprecated. It'll be removed once P and Z update their corresponding evaluators.
+      static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+      if (self()->comp()->useCompressedPointers() && (UseOldCompareAndSwapObject || !TR::Compiler->target.cpu.isX86()))
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
          // In Java9 Unsafe could be the jdk.internal JNI method or the sun.misc ordinary method wrapper,

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2066,10 +2066,13 @@ TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode
         !comp->fej9()->traceableMethodsCanBeInlined()))
       return false;
 
-   if (method->convertToMethod()->isUnsafeWithObjectArg(comp))
+   if (method->convertToMethod()->isUnsafeWithObjectArg(comp) || method->convertToMethod()->isUnsafeCAS(comp))
       {
+      // In Java9 sun/misc/Unsafe methods are simple Java wrappers to JNI
+      // methods in jdk.internal, and the enum values above match both. Only
+      // return true for the methods that are native.
       if (!TR::Compiler->om.canGenerateArraylets() || (callNode && callNode->isUnsafeGetPutCASCallOnNonArray()))
-         return true;
+         return method->isNative();
       else
          return false;
       }
@@ -2116,14 +2119,6 @@ TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode
       case TR::sun_misc_Unsafe_storeFence:
       case TR::sun_misc_Unsafe_fullFence:
          return true;
-
-      case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
-      case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
-      case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
-         // In Java9 sun/misc/Unsafe methods are simple Java wrappers to JNI
-         // methods in jdk.internal, and the enum values above match both. Only
-         // return true for the methods that are native.
-         return method->isNative();
 
       case TR::sun_misc_Unsafe_staticFieldBase:
          return false; // todo


### PR DESCRIPTION
Updated inlinig logic of atomic compare and swap so that a read barrier can be inserted where necessary.

Part of Issue #3054

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>