### PR TITLE
Inlining changes for MethodHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -240,13 +240,6 @@ public abstract class MethodHandle {
 	// Until the JIT can synthesize calls to virtual methods, we must synthesize calls to these static ones instead
 	/*[ENDIF]*/
 	private static MethodHandle asType(MethodHandle mh, MethodType newType) {
-		/*
-		 * JIT can easily propagate type information and fold the if when it can prove early return always happen.
-		 * The early return also saves the JIT from having to inline full asType call
-		 */
-		if (mh.type == newType) {
-			return mh;
-		}
 		return mh.asType(newType);
 	}
 	/*[IF Sidecar19-SE]*/

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3197,7 +3197,6 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
       // This first if statement controls inlining of a large class of JSR292 methods, which we want to consider ONLY in certain cases in early rounds of inlining...
       if ( resolvedMethod->convertToMethod()->isArchetypeSpecimen() ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact ||
-         resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_asType ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MutableCallSite_getTarget ||
          resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_DirectHandle_invokeExact ||
@@ -3208,7 +3207,6 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
          {
          if ( resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MutableCallSite_getTarget ||
-             resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_asType ||
              TR_J9MethodBase::isVarHandleOperationMethod(resolvedMethod->getRecognizedMethod()) ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_DirectHandle_invokeExact ||
              resolvedMethod->getRecognizedMethod() == TR::java_lang_invoke_InterfaceHandle_invokeExact ||
@@ -3324,7 +3322,7 @@ int TR_J9VMBase::checkInlineableTarget (TR_CallTarget* target, TR_CallSite* call
       case TR::com_ibm_jit_JITHelpers_getClassInitializeStatus:
       case TR::java_lang_StringUTF16_getChar:
       case TR::java_lang_StringUTF16_toBytes:
-      case TR::java_lang_invoke_MethodHandle_asType_instance:
+      case TR::java_lang_invoke_MethodHandle_asType:
             return DontInline_Callee;
       default:
          break;

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -303,8 +303,6 @@ TR_J9InlinerPolicy::mustBeInlinedEvenInDebug(TR_ResolvedMethod * calleeMethod, T
          // call to invokeExactTargetAddress are generated out of thin air by our JSR292
          // implementation, but we never want the VM or anyone else to know this so we must
          // always inlne the implementation
-         case TR::java_lang_invoke_MethodHandle_asType:
-            return true;
          case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress:
             {
             TR::TreeTop *scanTT = callNodeTreeTop->getNextTreeTop();
@@ -356,9 +354,11 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
    if (calleeMethod->isDAAWrapperMethod())
       return true;
 
+   if (TR_J9MethodBase::isVarHandleOperationMethod(calleeMethod->convertToMethod()->getMandatoryRecognizedMethod()))
+      return true;
+
    switch (calleeMethod->convertToMethod()->getMandatoryRecognizedMethod())
       {
-      case TR::java_lang_invoke_MethodHandle_asType:
       case TR::java_lang_invoke_MethodHandle_invokeExactTargetAddress:
          return true;
       default:
@@ -420,6 +420,14 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       {
       return true;
       }
+
+   int32_t length = calleeMethod->classNameLength();
+   char* className = calleeMethod->classNameChars();
+
+   if (length == 24 && !strncmp(className, "jdk/internal/misc/Unsafe", 24))
+      return true;
+   else if (length == 15 && !strncmp(className, "sun/misc/Unsafe", 15))
+      return true;
 
    return false;
    }
@@ -2004,6 +2012,8 @@ TR_J9InlinerPolicy::inlineUnsafeCall(TR::ResolvedMethodSymbol *calleeSymbol, TR:
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
       case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
+         if (callNode->isSafeForCGToFastPathUnsafeCall())
+            return false;
          switch (callerSymbol->castToMethodSymbol()->getRecognizedMethod())
             {
             case TR::java_util_concurrent_ConcurrentHashMap_addCount:
@@ -4926,15 +4936,11 @@ bool TR_J9InlinerUtil::needTargetedInlining(TR::ResolvedMethodSymbol *callee)
    // Trees from archetype specimens may not match the archetype method's bytecodes,
    // so there may be some calls things that inliner missed.
    //
-   // We also inline again if MethodHandle.asType has been inlined because VP might be able to
-   // prove invokeHandleGeneric is invoke exact
-   //
    // Tactically, we also inline again based on hasMethodHandleInvokes because EstimateCodeSize
    // doesn't yet cope with invokeHandle, invokeHandleGeneric, and invokeDynamic (but it should).
    //
    if (callee->getMethod()->isArchetypeSpecimen() ||
-       callee->hasMethodHandleInvokes() ||
-       callee->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_asType)
+       callee->hasMethodHandleInvokes())
       return true;
    return false;
    }


### PR DESCRIPTION
- Remove inlining heuristics for MethodHandle.asType because VP now can
  fold the whole call to a constant with known object constraint.
- Always fold Unsafe methods to reveal the native Unsafe methods.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>