### PR TITLE
Change heuristics regarding AOT compilations

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -501,10 +501,7 @@ bool TR::CompilationInfo::shouldDowngradeCompReq(TR_MethodToBeCompiled *entry)
                  !TR::Options::getCmdLineOptions()->getOption(TR_DisableDowngradeToColdOnVMPhaseStartup))
                )
                {
-#if !defined(J9ZOS390)  // disable for zOS because we don't want to increase CPU time
-               if (!importantMethodForStartup(method))
-#endif
-                  doDowngrade = true;
+               doDowngrade = true;
                }
             // Downgrade if RI based recompilation is enabled
             else if (persistentInfo->isRuntimeInstrumentationRecompilationEnabled() && // RI and RI Recompilation is functional
@@ -6411,7 +6408,8 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
       {
       entry->_useAotCompilation = true;
       // In some circumstances AOT compilations are performed at warm
-      if (TR::Options::getCmdLineOptions()->getAggressivityLevel() == TR::Options::AGGRESSIVE_AOT &&
+      if ((TR::Options::getCmdLineOptions()->getAggressivityLevel() == TR::Options::AGGRESSIVE_AOT ||
+           getCompilationInfo()->importantMethodForStartup(method)) &&
           entry->_optimizationPlan->isOptLevelDowngraded() &&
           entry->_optimizationPlan->getOptLevel() == cold) // Is this test really needed?
          {


### PR DESCRIPTION
With the current heuristics only methods that have been downgraded from warm
to cold optimization level are eligible for AOT compilations. Moreover,
methods that are deemed "important for start-up" (string/zip/hash) are not
downgraded and therefore not AOTed.

This commit changes the heuristics such that the methods "important for
start-up" become subject to the downgrading policy (like any other method)
and therefore can be AOTed. However, when generating an AOT body for such
an "important method for start-up" the optimization level is raised back
to warm.

Performance experiments with Liberty Applicatioon Server show a 5-6% start-up
time improvement from this change.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>