### PR TITLE
Create remote calls to get constant strings from resolved method

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1494,6 +1494,23 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
                           std::string((char*) bodyInfo->getMethodInfo(), sizeof(TR_PersistentMethodInfo)));
          }
          break;
+      case J9ServerMessageType::ResolvedMethod_isUnresolvedString:
+         {
+         auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t, bool>();
+         auto mirror = std::get<0>(recv);
+         auto cpIndex = std::get<1>(recv);
+         auto optimizeForAOT = std::get<2>(recv);
+         client->write(mirror->isUnresolvedString(cpIndex, optimizeForAOT));
+         }
+         break;
+      case J9ServerMessageType::ResolvedMethod_stringConstant:
+         {
+         auto recv = client->getRecvData<TR_ResolvedJ9Method *, int32_t>();
+         auto mirror = std::get<0>(recv);
+         auto cpIndex = std::get<1>(recv);
+         client->write(mirror->stringConstant(cpIndex));
+         }
+         break;
       case J9ServerMessageType::CompInfo_isCompiled:
          {
          J9Method *method = std::get<0>(client->getRecvData<J9Method *>());

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -177,7 +177,8 @@ TR_ResolvedJ9JITaaSServerMethod::isConstantDynamic(I_32 cpIndex)
 bool
 TR_ResolvedJ9JITaaSServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
    {
-   return true;
+   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex, optimizeForAOT);
+   return std::get<0>(_stream->read<bool>());
    }
 
 TR_ResolvedMethod *
@@ -864,7 +865,8 @@ void *
 TR_ResolvedJ9JITaaSServerMethod::stringConstant(I_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
-   return (void *) ((U_8 *)&(((J9RAMStringRef *) romLiterals())[cpIndex].stringObject));
+   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
+   return std::get<0>(_stream->read<void *>());
    }
 
 

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -99,6 +99,8 @@ enum J9ServerMessageType
    ResolvedMethod_setClassForNewInstance = 145;
    ResolvedMethod_getJittedBodyInfo = 146;
    ResolvedMethod_getResolvedImproperInterfaceMethod = 147;
+   ResolvedMethod_isUnresolvedString = 148;
+   ResolvedMethod_stringConstant = 149;
 
    // For TR_J9ServerVM methods
    VM_isClassLibraryClass = 200;


### PR DESCRIPTION
Make remote calls for `isUnresolvedString` and `constantString`.
This is needed to correctly determine whether a String sym reference
is resolved. Previously, `isUnresolvedString` was always returning true,
which caused all corresponding sym references to be marked as
unresolved. This caused some blocks to be incorrectly marked as cold,
which prevented inlinining and caused a throughput regression.