### PR TITLE
Coalesce the number of messages for improper interface method from 2 to 1

### DIFF
--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -98,7 +98,7 @@ enum J9ServerMessageType
    ResolvedMethod_methodIsNotzAAPEligible = 144;
    ResolvedMethod_setClassForNewInstance = 145;
    ResolvedMethod_getJittedBodyInfo = 146;
-   ResolvedMethod_getResolvedImproperInterfaceMethod = 147;
+   ResolvedMethod_getResolvedImproperInterfaceMethodAndMirror = 147;
    ResolvedMethod_isUnresolvedString = 148;
    ResolvedMethod_stringConstant = 149;
 


### PR DESCRIPTION
`getResolvedImproperInterfaceMethod` used to make one message to
fetch a RAM method from the client, and another to create a resolved
method mirror on the client.
Now it will do both of these things in one message, reducing the
number of `mirrorResolvedJ9Method` messages.