### PR TITLE
Read Barrier aware ref array GC copy helper

### DIFF
--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -324,17 +324,7 @@ public:
 		bool copyLockword = true;
 		
 		if (OBJECT_HEADER_SHAPE_POINTERS == J9CLASS_SHAPE(objectClass)) {
-			if (j9gc_modron_readbar_none != _readBarrierType) {
-				copyLockword = false;
-				if (j9gc_modron_readbar_evacuate == _readBarrierType) {
-					/* TODO implement HW barriers */
-					currentThread->javaVM->memoryManagerFunctions->j9gc_objaccess_cloneIndexableObject(currentThread, (J9IndexableObject*)original, (J9IndexableObject*)copy);
-				} else {
-					currentThread->javaVM->memoryManagerFunctions->j9gc_objaccess_cloneIndexableObject(currentThread, (J9IndexableObject*)original, (J9IndexableObject*)copy);
-				}
-			} else {
-				VM_ArrayCopyHelpers::referenceArrayCopy(currentThread, original, 0, copy, 0, size);
-			}
+			VM_ArrayCopyHelpers::referenceArrayCopy(currentThread, original, 0, copy, 0, size);
 		} else {
 			VM_ArrayCopyHelpers::primitiveArrayCopy(currentThread, original, 0, copy, 0, size, (((J9ROMArrayClass*)objectClass->romClass)->arrayShape & 0x0000FFFF));
 		}

--- a/runtime/gc_modron_standard/StandardAccessBarrier.hpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.hpp
@@ -53,7 +53,12 @@ private:
 #endif /* OMR_GC_REALTIME */
 	void postObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject, J9Object *srcObject);
 	void preBatchObjectStoreImpl(J9VMThread *vmThread, J9Object *dstObject);
-    
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	I_32 doCopyContiguousBackwardWithReadBarrier(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
+	I_32 doCopyContiguousForwardWithReadBarrier(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);


### PR DESCRIPTION
Introduce optimized variant of reference array GC copy helper for
Concurrent Scavenger. It will execute RB for every single ref slot of
the source arrays (and as for regular Gencon config will just do post
batch WB).

JITed code in H/W based CS was not relying on this, but now that we are
introducing S/W variant (https://github.com/eclipse/openj9/issues/3054)
this may be called more often.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>