### PR TITLE
Eliminate remote calls for isWarmCallGraphTooBig

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1437,14 +1437,6 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(mirror->isInlineable(comp));
          }
          break;
-      case J9ServerMessageType::ResolvedMethod_isWarmCallGraphTooBig:
-         {
-         auto recv = client->getRecvData<TR_ResolvedJ9Method *, uint32_t>();
-         TR_ResolvedJ9Method *mirror = std::get<0>(recv);
-         uint32_t bcIndex = std::get<1>(recv);
-         client->write(mirror->isWarmCallGraphTooBig(bcIndex, comp));
-         }
-         break;
       case J9ServerMessageType::ResolvedMethod_setWarmCallGraphTooBig:
          {
          auto recv = client->getRecvData<TR_ResolvedJ9Method *, uint32_t>();

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1041,16 +1041,12 @@ TR_ResolvedJ9JITaaSServerMethod::isInlineable(TR::Compilation *comp)
       }
    }
 
-bool
-TR_ResolvedJ9JITaaSServerMethod::isWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *comp)
-   {
-   _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_isWarmCallGraphTooBig, _remoteMirror, bcIndex);
-   return std::get<0>(_stream->read<bool>()); 
-   }
-
 void
 TR_ResolvedJ9JITaaSServerMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *comp)
    {
+   // set the variable in the server IProfiler
+   TR_ResolvedJ9Method::setWarmCallGraphTooBig(bcIndex, comp);
+   // set it on the client IProfiler too, in case a server crashes, client will still have the correct value
    _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_setWarmCallGraphTooBig, _remoteMirror, bcIndex);
    _stream->read<JITaaS::Void>();
    }

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -152,7 +152,6 @@ public:
    virtual TR_ResolvedMethod * getResolvedDynamicMethod( TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP) override;
    virtual bool isSameMethod(TR_ResolvedMethod *) override;
    virtual bool isInlineable(TR::Compilation *) override;
-   virtual bool isWarmCallGraphTooBig(uint32_t, TR::Compilation *) override;
    virtual void setWarmCallGraphTooBig(uint32_t, TR::Compilation *) override;
    virtual void setVirtualMethodIsOverridden() override;
    virtual void * addressContainingIsOverriddenBit() override { return _addressContainingIsOverriddenBit; }

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -91,7 +91,7 @@ enum J9ServerMessageType
    ResolvedMethod_isBigDecimalConvertersMethod = 137;
    ResolvedMethod_osrFrameSize = 138;
    ResolvedMethod_isInlineable = 139;
-   ResolvedMethod_isWarmCallGraphTooBig = 140;
+   // ResolvedMethod_isWarmCallGraphTooBig = 140; 
    ResolvedMethod_setWarmCallGraphTooBig = 141;
    ResolvedMethod_setVirtualMethodIsOverridden = 142;
    ResolvedMethod_addressContainingIsOverriddenBit = 143;


### PR DESCRIPTION
Previously, calls to `isWarmCallGraphTooBig`
always made remote calls to the client, which used IProfiler to
determine
whether the callgraph is too big to be inlined from the bytecode entry.
However, since we are already caching IProfiler bytecode entries on the
server, we can just access the cached result.
We ensure that `isWarmCallGraphTooBig` always returns the correct value
by making `setWarmCallGraphTooBig` update the value in cached
entries, as well as on the client. This way, even if a current server
crashes, the new server will still receive correct values.