### PR TITLE
Skip getJ2IThunk() when writing x86 PIC data

### DIFF
--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -134,17 +134,10 @@ uint8_t *TR::X86PicDataSnippet::encodeConstantPoolInfo(uint8_t *cursor)
 uint8_t *TR::X86PicDataSnippet::encodeJ2IThunkPointer(uint8_t *cursor)
    {
    TR_ASSERT_FATAL(_hasJ2IThunkInPicData, "did not expect j2i thunk pointer");
-
-   // Find the j2i thunk for this method's signature
-   TR_J9VMBase *fej9 = (TR_J9VMBase*)(cg()->fe());
-   TR::Symbol *symbol = _methodSymRef->getSymbol();
-   TR_Method *method = symbol->getMethodSymbol()->getMethod();
-   void *j2iThunk = fej9->getJ2IThunk(method, comp());
-   TR_ASSERT_FATAL(j2iThunk != NULL, "null virtual j2i thunk");
+   TR_ASSERT_FATAL(_thunkAddress != NULL, "null virtual j2i thunk");
 
    // DD/DQ j2iThunk
-   // TODO: AOT relocation
-   *(uintptrj_t *)cursor = (uintptrj_t)j2iThunk;
+   *(uintptrj_t *)cursor = (uintptrj_t)_thunkAddress;
    cursor += sizeof(uintptrj_t);
 
    return cursor;


### PR DESCRIPTION
X86PicDataSnippet already has its J2I thunk in _thunkAddress, so there
is no need to use getJ2IThunk() to find it.

This also sidesteps a problem whereby getJ2IThunk() would (somehow)
sometimes fail to find the thunk even though it was already generated,
particularly in ahead of time compilations.