### PR TITLE
Add wrtbar/wrtbari opcodes

### DIFF
--- a/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/arm/codegen/J9TreeEvaluator.cpp
@@ -68,7 +68,7 @@ static void VMCardCheckEvaluator(TR::Node *node, TR::Register *dstReg, TR::Regis
    bool definitelyHeapObject = false, definitelyNonHeapObject = false;
    TR_WriteBarrierKind gcMode = options->getGcMode();
 
-   if (node->getOpCodeValue() == TR::wrtbari || node->getOpCodeValue() == TR::wrtbar)
+   if (node->getOpCodeValue() == TR::awrtbari || node->getOpCodeValue() == TR::awrtbar)
       wrtbarNode = node;
    else if (node->getOpCodeValue() == TR::ArrayStoreCHK)
       wrtbarNode = node->getFirstChild();

--- a/runtime/compiler/codegen/CodeGenGPU.cpp
+++ b/runtime/compiler/codegen/CodeGenGPU.cpp
@@ -66,13 +66,13 @@ static const char * nvvmOpCodeNames[] =
    "load",          // TR::bload
    "load",          // TR::sload
    "load",          // TR::lload
-   "rdbar",         // TR::irdbar
-   "rdbar",         // TR::frdbar
-   "rdbar",         // TR::drdbar
-   "rdbar",         // TR::ardbar
-   "rdbar",         // TR::brdbar
-   "rdbar",         // TR::srdbar
-   "rdbar",         // TR::lload
+   NULL,            // TR::irdbar
+   NULL,            // TR::frdbar
+   NULL,            // TR::drdbar
+   NULL,            // TR::ardbar
+   NULL,            // TR::brdbar
+   NULL,            // TR::srdbar
+   NULL,            // TR::lrdbar
    "load",          // TR::iloadi
    "load",          // TR::floadi
    "load",          // TR::dloadi
@@ -80,32 +80,41 @@ static const char * nvvmOpCodeNames[] =
    "load",          // TR::bloadi
    "load",          // TR::sloadi
    "load",          // TR::lloadi
-   "rdbar",         // TR::irdbari
-   "rdbar",         // TR::frdbari
-   "rdbar",         // TR::drdbari
-   "rdbar",         // TR::ardbari
-   "rdbar",         // TR::brdbari
-   "rdbar",         // TR::srdbari
-   "rdbar",         // TR::lrdbari
-
+   NULL,            // TR::irdbari
+   NULL,            // TR::frdbari
+   NULL,            // TR::drdbari
+   NULL,            // TR::ardbari
+   NULL,            // TR::brdbari
+   NULL,            // TR::srdbari
+   NULL,            // TR::lrdbari
    "store",          // TR::istore
    "store",          // TR::lstore
    "store",          // TR::fstore
    "store",          // TR::dstore
    "store",          // TR::astore
-
-   NULL,          // TR::wrtbar
-
    "store",          // TR::bstore
    "store",          // TR::sstore
+   NULL,             // TR::iwrtbar
+   NULL,             // TR::lwrtbar
+   NULL,             // TR::fwrtbar
+   NULL,             // TR::dwrtbar
+   NULL,             // TR::awrtbar
+   NULL,             // TR::bwrtbar
+   NULL,             // TR::swrtbar
    "store",          // TR::lstorei
    "store",          // TR::fstorei
    "store",          // TR::dstorei
    "store",          // TR::astorei
-   NULL,          // TR::wrtbari
    "store",          // TR::bstorei
    "store",          // TR::sstorei
    "store",          // TR::istorei
+   NULL,             // TR::lwrtbari
+   NULL,             // TR::fwrtbari
+   NULL,             // TR::dwrtbari
+   NULL,             // TR::awrtbari
+   NULL,             // TR::bwrtbari
+   NULL,             // TR::swrtbari
+   NULL,             // TR::iwrtbari
    "br",          // TR::Goto
    "ret",          // TR::ireturn
    "ret",          // TR::lreturn

--- a/runtime/compiler/il/J9IL.cpp
+++ b/runtime/compiler/il/J9IL.cpp
@@ -351,6 +351,16 @@ J9::IL::opCodeForDirectStore(TR::DataType dt)
    return J9::IL::opCodesForDirectStore[dt - TR::FirstJ9Type];
    }
 
+TR::ILOpCodes
+J9::IL::opCodeForDirectWriteBarrier(TR::DataType dt)
+   {
+   if (dt == TR::Int8 || dt == TR::Int16)
+      {
+      return TR::iwrtbar;
+      }
+
+   return OMR::IL::opCodeForDirectWriteBarrier(dt);
+   }
 
 TR::ILOpCodes
 J9::IL::opCodeForIndirectReadBarrier(TR::DataType dt)
@@ -394,6 +404,18 @@ J9::IL::opCodeForIndirectStore(TR::DataType dt)
 
    return J9::IL::opCodesForIndirectStore[dt - TR::FirstJ9Type];
    }
+
+TR::ILOpCodes
+J9::IL::opCodeForIndirectWriteBarrier(TR::DataType dt)
+   {
+   if (dt == TR::Int8 || dt == TR::Int16)
+      {
+      return TR::iwrtbari;
+      }
+
+   return OMR::IL::opCodeForIndirectWriteBarrier(dt);
+   }
+
 
 TR::ILOpCodes
 J9::IL::opCodeForIndirectArrayLoad(TR::DataType dt)

--- a/runtime/compiler/il/J9IL.hpp
+++ b/runtime/compiler/il/J9IL.hpp
@@ -65,9 +65,11 @@ class OMR_EXTENSIBLE IL : public OMR::ILConnector
    TR::ILOpCodes opCodeForDirectLoad(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectReadBarrier(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectStore(TR::DataType dt);
+   TR::ILOpCodes opCodeForDirectWriteBarrier(TR::DataType dt);
    TR::ILOpCodes opCodeForIndirectLoad(TR::DataType dt);
    TR::ILOpCodes opCodeForIndirectReadBarrier(TR::DataType dt);
    TR::ILOpCodes opCodeForIndirectStore(TR::DataType dt);
+   TR::ILOpCodes opCodeForIndirectWriteBarrier(TR::DataType dt);
    TR::ILOpCodes opCodeForIndirectArrayLoad(TR::DataType dt);
    TR::ILOpCodes opCodeForIndirectArrayStore(TR::DataType dt);
    TR::ILOpCodes opCodeForRegisterLoad(TR::DataType dt);

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -1016,7 +1016,7 @@ static bool isStoreToSameField(TR::Node *callNode, TR::Node *nextNode, TR::Node 
           nextNode->getOpCode().isNullCheck())
          nextNode = nextNode->getFirstChild();
 
-      if ((nextNode->getOpCodeValue() == TR::wrtbari) ||
+      if ((nextNode->getOpCodeValue() == TR::awrtbari) ||
           (nextNode->getOpCodeValue() == TR::astorei))
         {
         if (nextNode->getSymbolReference() == loadNode->getSymbolReference())
@@ -1032,7 +1032,7 @@ static bool isStoreToSameField(TR::Node *callNode, TR::Node *nextNode, TR::Node 
               }
            }
         }
-      else if ((nextNode->getOpCodeValue() == TR::wrtbar) ||
+      else if ((nextNode->getOpCodeValue() == TR::awrtbar) ||
                (nextNode->getOpCodeValue() == TR::astore))
         {
         if (nextNode->getSymbolReference() == loadNode->getSymbolReference())
@@ -1170,7 +1170,7 @@ void TR_ClassLookahead::invalidateIfEscapingLoad(TR::TreeTop *nextTree, TR::Node
               (!parent->getOpCode().isArrayLength()) &&
               (!parent->getOpCode().isAnchor()) &&
               (parent->getOpCodeValue() != TR::ArrayStoreCHK) &&
-              ((parent->getOpCodeValue() != TR::wrtbari) || (childNum != 2))))
+              ((parent->getOpCodeValue() != TR::awrtbari) || (childNum != 2))))
               {
               if (_traceIt)
                   traceMsg(comp(), "2Invalidating dimension and type info for symbol %x at node %x\n", sym, node);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -7206,7 +7206,7 @@ TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
    TR::Node * node;
    if (type == TR::Address && _generateWriteBarriers)
       {
-      node = TR::Node::createWithSymRef(TR::wrtbari, 3, 3, addressNode, value, parentObject, symRef);
+      node = TR::Node::createWithSymRef(TR::awrtbari, 3, 3, addressNode, value, parentObject, symRef);
       }
    else
       {
@@ -7354,7 +7354,7 @@ TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
          push(node);
          }
 
-      node = TR::Node::createWithSymRef(TR::wrtbar, 2, 2, value, pop(), symRef);
+      node = TR::Node::createWithSymRef(TR::awrtbar, 2, 2, value, pop(), symRef);
       }
    else if (symbol->isVolatile() && type == TR::Int64 && !symRef->isUnresolved() && TR::Compiler->target.is32Bit() &&
             !comp()->cg()->getSupportsInlinedAtomicLongVolatiles() && 0)
@@ -7556,7 +7556,7 @@ TR_J9ByteCodeIlGenerator::storeArrayElement(TR::DataType dataType, TR::ILOpCodes
    TR::Node * storeNode, * resultNode;
    if (generateWriteBarrier)
       {
-      storeNode = resultNode = TR::Node::createWithSymRef(TR::wrtbari, 3, 3, elementAddress, value, arrayBaseAddress, symRef);
+      storeNode = resultNode = TR::Node::createWithSymRef(TR::awrtbari, 3, 3, elementAddress, value, arrayBaseAddress, symRef);
       usedArrayBaseAddress = true;
       }
    else

--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -503,11 +503,11 @@ bool TR_DynamicLiteralPool::transformStaticSymRefToIndirectLoad(TR::TreeTop * tt
 
       TR::Node * loadLiteralFromThePool = TR::Node::createWithSymRef(TR::aloadi, 1, 1, getAloadFromCurrentBlock(child), childSymRef);
       loadLiteralFromThePool->getSymbol()->setNotCollected();
-      if (childOpcodeValue==TR::wrtbar)
+      if (childOpcodeValue==TR::awrtbar)
          {
          child->getFirstChild()->decReferenceCount();
          child->getSecondChild()->decReferenceCount();
-         child = TR::Node::create(TR::wrtbari, 3, loadLiteralFromThePool, child->getFirstChild(), child->getSecondChild());
+         child = TR::Node::create(TR::awrtbari, 3, loadLiteralFromThePool, child->getFirstChild(), child->getSecondChild());
          if (parent)
             parent->setAndIncChild(0, child);
          else

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -3641,7 +3641,7 @@ void TR_EscapeAnalysis::checkEscapeViaNonCall(TR::Node *node, TR::NodeChecklist&
                 (!baseObject->getOpCode().hasSymbolReference() ||
                  !node->getSecondChild()->getOpCode().hasSymbolReference() ||
                  ((baseObject->getReferenceCount() != 1) &&
-                  (!((baseObject->getReferenceCount() == 2) && (node->getOpCodeValue() == TR::wrtbari) && (node->getChild(2) == baseObject)))) ||
+                  (!((baseObject->getReferenceCount() == 2) && (node->getOpCodeValue() == TR::awrtbari) && (node->getChild(2) == baseObject)))) ||
                  (node->getSecondChild()->getReferenceCount() != 1) ||
                  (baseObject->getSymbolReference() != node->getSecondChild()->getSymbolReference())))
                {
@@ -6360,7 +6360,7 @@ void TR_EscapeAnalysis::heapifyBeforeColdBlocks(Candidate *candidate)
                   TR::TreeTop *translateTT = NULL;
                   if (stackFieldLoad->getDataType() == TR::Address)
                      {
-                     heapFieldStore = TR::Node::createWithSymRef(TR::wrtbari, 3, 3, heapAllocation->getFirstChild(), stackFieldLoad, heapAllocation->getFirstChild(), field.fieldSymRef());
+                     heapFieldStore = TR::Node::createWithSymRef(TR::awrtbari, 3, 3, heapAllocation->getFirstChild(), stackFieldLoad, heapAllocation->getFirstChild(), field.fieldSymRef());
                      if (comp()->useCompressedPointers())
                         {
                         translateTT = TR::TreeTop::create(comp(), TR::Node::createCompressedRefsAnchor(heapFieldStore), NULL, NULL);

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -175,7 +175,7 @@ TR_CISCNode::isEqualOpc(TR_CISCNode *t)
          case TR_indload:
             return (t->_ilOpCode.isLoadIndirect());
          case TR_indstore:
-            return (t->_ilOpCode.isStoreIndirect() || tOpc == TR::wrtbari);
+            return (t->_ilOpCode.isStoreIndirect() || tOpc == TR::awrtbari);
          case TR_ibcload:
             return (t->_ilOpCode.isLoadIndirect() && (t->_ilOpCode.isByte() || (t->_ilOpCode.isShort() && t->_ilOpCode.isUnsigned())));
          case TR_ibcstore:
@@ -4461,7 +4461,7 @@ TR_CISCTransformer::analyzeConnectionOnePair(TR_CISCNode *const p, TR_CISCNode *
    if (p->getParents()->isEmpty() ||
        t->getParents()->isEmpty() ||
        t->getOpcode() == TR::Case ||
-       t->getOpcode() == TR::wrtbari) t->setIsParentSimplyConnected();
+       t->getOpcode() == TR::awrtbari) t->setIsParentSimplyConnected();
 
    // Analyze connectivities for children and parents
    if (num == 0)

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -5762,7 +5762,7 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
 
    // Prepare the arraycopy node.
    bool needWriteBarrier = comp->getOptions()->needWriteBarriers() &&
-                           (inStoreNode->getOpCodeValue() == TR::wrtbari);
+                           (inStoreNode->getOpCodeValue() == TR::awrtbari);
 
    if (!comp->cg()->getSupportsReferenceArrayCopy() && needWriteBarrier)
       {

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1172,7 +1172,7 @@ TR_J9InlinerPolicy::createUnsafePutWithOffset(TR::ResolvedMethodSymbol *calleeSy
                                                  1, valueWithoutConversion);
       valueWithConversion = conversionNode;
       unsafeNodeWithConversion = type == TR::Address && (comp()->getOptions()->getGcMode() != TR_WrtbarNone)
-         ? TR::Node::createWithSymRef(TR::wrtbari, 3, 3, unsafeAddress, valueWithConversion, unsafeCall->getChild(1), symRef)
+         ? TR::Node::createWithSymRef(TR::awrtbari, 3, 3, unsafeAddress, valueWithConversion, unsafeCall->getChild(1), symRef)
          : TR::Node::createWithSymRef(comp()->il.opCodeForIndirectArrayStore(type), 2, 2, unsafeAddress, valueWithConversion, symRef);
 
       if(comp()->getOption(TR_TraceUnsafeInlining))
@@ -1180,7 +1180,7 @@ TR_J9InlinerPolicy::createUnsafePutWithOffset(TR::ResolvedMethodSymbol *calleeSy
 
       }
    TR::Node * unsafeNode = type == TR::Address && (comp()->getOptions()->getGcMode() != TR_WrtbarNone)
-      ? TR::Node::createWithSymRef(TR::wrtbari, 3, 3, unsafeAddress, valueWithoutConversion, unsafeCall->getChild(1), symRef)
+      ? TR::Node::createWithSymRef(TR::awrtbari, 3, 3, unsafeAddress, valueWithoutConversion, unsafeCall->getChild(1), symRef)
       : TR::Node::createWithSymRef(comp()->il.opCodeForIndirectStore(type), 2, 2, unsafeAddress, valueWithoutConversion, symRef);
 
 

--- a/runtime/compiler/optimizer/NewInitialization.cpp
+++ b/runtime/compiler/optimizer/NewInitialization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1720,7 +1720,7 @@ void TR_NewInitialization::modifyReferences(Candidate *candidate, Candidate *sta
    // If this is a write barrier store of one candidate into a field of another
    // the write barrier store can be changed into a simple indirect store.
    //
-   if (node->getOpCodeValue() == TR::wrtbari && firstChildIsCandidate && secondChildIsCandidate && !comp()->getOptions()->realTimeGC())
+   if (node->getOpCodeValue() == TR::awrtbari && firstChildIsCandidate && secondChildIsCandidate && !comp()->getOptions()->realTimeGC())
       {
       if (performTransformation(comp(), "%sChanging write barrier store into iastore [%p]\n", OPT_DETAILS, node))
          {

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -1566,7 +1566,7 @@ TR::TreeTop *TR_StringPeepholes::detectBDPattern(TR::TreeTop *tt, TR::TreeTop *e
 
                      if (targetNode->getOpCode().hasSymbolReference() &&
                          targetNode->getSymbolReference() == sourceNode->getSymbolReference() &&
-                        (targetNode->getOpCodeValue() == TR::astorei || targetNode->getOpCodeValue() == TR::wrtbari))
+                        (targetNode->getOpCodeValue() == TR::astorei || targetNode->getOpCodeValue() == TR::awrtbari))
                         {
 
                         int32_t len;

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -729,7 +729,7 @@ int32_t TR_UnsafeFastPath::perform()
                   // This is a store
                   if (type == TR::Address && (comp()->getOptions()->getGcMode() != TR_WrtbarNone))
                      {
-                     node = TR::Node::recreateWithoutProperties(node, TR::wrtbari, 3, addrCalc, value, object, unsafeSymRef);
+                     node = TR::Node::recreateWithoutProperties(node, TR::awrtbari, 3, addrCalc, value, object, unsafeSymRef);
                      spineCHK->setAndIncChild(0, addrCalc);
                      }
                   else
@@ -795,7 +795,7 @@ int32_t TR_UnsafeFastPath::perform()
                   node = TR::Node::createCompressedRefsAnchor(node);
                   newTree = newTree->insertAfter(TR::TreeTop::create(comp(), node));
                   }
-               else if (node->getOpCodeValue() == TR::wrtbari)
+               else if (node->getOpCodeValue() == TR::awrtbari)
                   {
                   node = TR::Node::create(TR::treetop, 1, node);
                   newTree = newTree->insertAfter(TR::TreeTop::create(comp(), node));
@@ -820,7 +820,7 @@ int32_t TR_UnsafeFastPath::perform()
                   {
                   // This is a store
                   if (type == TR::Address && (comp()->getOptions()->getGcMode() != TR_WrtbarNone))
-                     node = TR::Node::recreateWithoutProperties(node, TR::wrtbari, 3, addrCalc, value, object, unsafeSymRef);
+                     node = TR::Node::recreateWithoutProperties(node, TR::awrtbari, 3, addrCalc, value, object, unsafeSymRef);
                   else
                      {
                      if (value->getDataType() != type)

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -723,7 +723,7 @@ J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register
             }
          }
       }
-   else if (node->getOpCodeValue() == TR::wrtbari &&
+   else if (node->getOpCodeValue() == TR::awrtbari &&
             comp()->getMethodHotness() >= scorching &&
             TR::Compiler->target.cpu.id() >= TR_PPCp6 &&
               (TR::Compiler->target.is32Bit() ||

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -277,8 +277,8 @@ extern void TEMPORARY_initJ9PPCTreeEvaluatorTable(TR::CodeGenerator *cg)
    {
    TR_TreeEvaluatorFunctionPointer *tet = cg->getTreeEvaluatorTable();
 
-   tet[TR::wrtbar] = TR::TreeEvaluator::wrtbarEvaluator;
-   tet[TR::wrtbari] = TR::TreeEvaluator::iwrtbarEvaluator;
+   tet[TR::awrtbar] = TR::TreeEvaluator::awrtbarEvaluator;
+   tet[TR::awrtbari] = TR::TreeEvaluator::awrtbariEvaluator;
    tet[TR::monent] = TR::TreeEvaluator::monentEvaluator;
    tet[TR::monexit] = TR::TreeEvaluator::monexitEvaluator;
    tet[TR::monexitfence] = TR::TreeEvaluator::monexitfenceEvaluator;
@@ -497,7 +497,7 @@ static void VMnonNullSrcWrtBarCardCheckEvaluator(TR::Node *node, TR::Register *s
       addDependency(deps, temp3Reg, TR::RealRegister::NoReg, TR_GPR, cg);
       }
 
-   if (node->getOpCodeValue() == TR::wrtbari || node->getOpCodeValue() == TR::wrtbar)
+   if (node->getOpCodeValue() == TR::awrtbari || node->getOpCodeValue() == TR::awrtbar)
       wrtbarNode = node;
    else if (node->getOpCodeValue() == TR::ArrayStoreCHK)
       wrtbarNode = node->getFirstChild();
@@ -514,7 +514,7 @@ static void VMnonNullSrcWrtBarCardCheckEvaluator(TR::Node *node, TR::Register *s
       wbRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreGenerationalSymbolRef(comp->getMethodSymbol());
    else if (TR::Options::getCmdLineOptions()->realTimeGC())
       {
-      if (wrtbarNode->getOpCodeValue() == TR::wrtbar || wrtbarNode->isUnsafeStaticWrtBar())
+      if (wrtbarNode->getOpCodeValue() == TR::awrtbar || wrtbarNode->isUnsafeStaticWrtBar())
          wbRef = comp->getSymRefTab()->findOrCreateWriteBarrierClassStoreRealTimeGCSymbolRef(comp->getMethodSymbol());
       else
          wbRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreRealTimeGCSymbolRef(comp->getMethodSymbol());
@@ -692,7 +692,7 @@ static void VMCardCheckEvaluator(TR::Node *node, TR::Register *dstReg, TR::Regis
    bool definitelyHeapObject = false, definitelyNonHeapObject = false;
    TR_WriteBarrierKind gcMode = comp->getOptions()->getGcMode();
 
-   if (node->getOpCodeValue() == TR::wrtbari || node->getOpCodeValue() == TR::wrtbar)
+   if (node->getOpCodeValue() == TR::awrtbari || node->getOpCodeValue() == TR::awrtbar)
       wrtbarNode = node;
    else if (node->getOpCodeValue() == TR::ArrayStoreCHK)
       wrtbarNode = node->getFirstChild();
@@ -897,7 +897,7 @@ static void VMwrtbarEvaluator(TR::Node *node, TR::Register *srcReg, TR::Register
    cg->stopUsingRegister(temp2Reg);
    }
 
-TR::Register *J9::Power::TreeEvaluator::wrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *J9::Power::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation * comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (comp->fe());
@@ -1014,7 +1014,7 @@ TR::Register *J9::Power::TreeEvaluator::wrtbarEvaluator(TR::Node *node, TR::Code
    return NULL;
    }
 
-TR::Register *J9::Power::TreeEvaluator::iwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *J9::Power::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation * comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg->fe());

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.hpp
@@ -47,8 +47,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    {
    public:
 
-   static TR::Register *wrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *iwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monexitfenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -570,8 +570,8 @@ static void fixupHelperCall(bool              moveFPRegSpill,
 extern void TEMPORARY_initJ9X86TreeEvaluatorTable(TR::CodeGenerator *cg)
    {
    TR_TreeEvaluatorFunctionPointer *tet = cg->getTreeEvaluatorTable();
-   tet[TR::wrtbar] =                TR::TreeEvaluator::writeBarrierEvaluator;
-   tet[TR::wrtbari] =               TR::TreeEvaluator::writeBarrierEvaluator;
+   tet[TR::awrtbar] =               TR::TreeEvaluator::writeBarrierEvaluator;
+   tet[TR::awrtbari] =              TR::TreeEvaluator::writeBarrierEvaluator;
    tet[TR::monent] =                TR::TreeEvaluator::monentEvaluator;
    tet[TR::monexit] =               TR::TreeEvaluator::monexitEvaluator;
    tet[TR::monexitfence] =          TR::TreeEvaluator::monexitfenceEvaluator;
@@ -1034,7 +1034,7 @@ TR::Register *J9::X86::TreeEvaluator::irdbarEvaluator(TR::Node *node, TR::CodeGe
 #endif
    }
 
-// Should only be called for pure TR::wrtbar and TR::wrtbari nodes.
+// Should only be called for pure TR::awrtbar and TR::awrtbari nodes.
 //
 TR::Register *J9::X86::TreeEvaluator::writeBarrierEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -1046,7 +1046,7 @@ TR::Register *J9::X86::TreeEvaluator::writeBarrierEvaluator(TR::Node *node, TR::
    bool                   usingLowMemHeap = false;
    bool                   useShiftedOffsets = (TR::Compiler->om.compressedReferenceShiftOffset() != 0);
 
-   if (node->getOpCodeValue() == TR::wrtbari)
+   if (node->getOpCodeValue() == TR::awrtbari)
       {
       destOwningObject = node->getChild(2);
       sourceObject = node->getSecondChild();
@@ -1103,7 +1103,7 @@ TR::Register *J9::X86::TreeEvaluator::writeBarrierEvaluator(TR::Node *node, TR::
       }
    else
       {
-      TR_ASSERT((node->getOpCodeValue() == TR::wrtbar), "expecting a TR::wrtbar");
+      TR_ASSERT((node->getOpCodeValue() == TR::awrtbar), "expecting a TR::wrtbar");
       destOwningObject = node->getSecondChild();
       sourceObject = node->getFirstChild();
       }
@@ -1117,11 +1117,11 @@ TR::Register *J9::X86::TreeEvaluator::writeBarrierEvaluator(TR::Node *node, TR::
       scratchRegisterManager,
       destOwningObject,
       sourceObject,
-      (node->getOpCodeValue() == TR::wrtbari) ? true : false,
+      (node->getOpCodeValue() == TR::awrtbari) ? true : false,
       cg,
       false);
 
-   if (comp->useAnchors() && (node->getOpCodeValue() == TR::wrtbari))
+   if (comp->useAnchors() && (node->getOpCodeValue() == TR::awrtbari))
       node->setStoreAlreadyEvaluated(true);
 
    if (usingCompressedPointers)
@@ -10300,8 +10300,8 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(
       case TR::arraycopy:
          wrtbarNode = NULL;
          break;
-      case TR::wrtbari:
-      case TR::wrtbar:
+      case TR::awrtbari:
+      case TR::awrtbar:
          wrtbarNode = node;
          break;
       default:
@@ -10357,7 +10357,7 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(
       }
 
    TR::SymbolReference *wrtBarSymRef = NULL;
-   if (wrtbarNode && (wrtbarNode->getOpCodeValue()==TR::wrtbar || wrtbarNode->isUnsafeStaticWrtBar()))
+   if (wrtbarNode && (wrtbarNode->getOpCodeValue()==TR::awrtbar || wrtbarNode->isUnsafeStaticWrtBar()))
       wrtBarSymRef = comp->getSymRefTab()->findOrCreateWriteBarrierClassStoreRealTimeGCSymbolRef();
    else
       wrtBarSymRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreRealTimeGCSymbolRef();
@@ -10546,8 +10546,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
       case TR::arraycopy:
          wrtbarNode = NULL;
          break;
-      case TR::wrtbari:
-      case TR::wrtbar:
+      case TR::awrtbari:
+      case TR::awrtbar:
          wrtbarNode = node;
          break;
       default:
@@ -10940,7 +10940,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
          // handling it out of line is justified.
          //
          if (!comp->getOption(TR_DisableWriteBarriersRangeCheck)
-             && (node->getOpCodeValue() == TR::wrtbari)
+             && (node->getOpCodeValue() == TR::awrtbari)
              && doInternalControlFlow)
             {
             bool is64Bit = TR::Compiler->target.is64Bit(); // On compressed refs, owningObjectReg is already uncompressed, and the vmthread fields are 64 bits

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -90,8 +90,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    {
    public:
 
-   static TR::Register *wrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *iwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monexitfenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
The xwrtbar/xwrtbari opcodes are added to represent both the store
as well as its side effects like checking object address against
tenure address range for GC, notifying the VM of the store or
other similar activities.

This PR adds the most basic supports for write barrier opcodes in openj9.
The exist wrtbar/wrtbari are change to awrtbar/awrtbari for consistency.
By default write barriers use store handlers and evaluators.

issue: #2948

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>