### PR TITLE
Change heuristics for activating compilation threads

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -388,22 +388,23 @@ TR_YesNoMaybe TR::CompilationInfo::shouldActivateNewCompThread()
    // determined based on the number of CPUs, then the upper bound of comp threads is _numTargetCPUs-1
    // However, if the compilation threads are starved (on Linux) we may want
    // to activate additional comp threads irrespective of the CPU entitlement
-   if (TR::Options::_useCPUsToDetermineMaxNumberOfCompThreadsToActivate ||
-       !_starvationDetected)
+   if (TR::Options::_useCPUsToDetermineMaxNumberOfCompThreadsToActivate)
       {
-      if (getNumCompThreadsActive() >= getNumTargetCPUs() - 1)
-         {
-         return TR_no;
-         }
-      else
+      if (getNumCompThreadsActive() < getNumTargetCPUs() - 1)
          {
          if (_queueWeight > compThreadActivationThresholds[getNumCompThreadsActive()])
             return TR_yes;
          }
+      else if (_starvationDetected)
+         {
+         // comp thread starvation; may activate threads beyond numCpu-1
+         if (_queueWeight > compThreadActivationThresholdsonStarvation[getNumCompThreadsActive()])
+            return TR_yes;
+         }
       }
-   else // comp thread starvation; may activate threads beyond numCpu-1
+   else // number of compilation threads indicated by the user
       {
-      if (_queueWeight > compThreadActivationThresholdsonStarvation[getNumCompThreadsActive()])
+      if (_queueWeight > compThreadActivationThresholds[getNumCompThreadsActive()])
          return TR_yes;
       }
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1990,14 +1990,16 @@ J9::Options::fePostProcessJIT(void * base)
    //
    if (_numUsableCompilationThreads <= 0)
       {
-#ifdef LINUX
-      // For linux we may want to create more threads to overcome thread
-      // starvation due to lack of priorities
-      //
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableRampupImprovements) &&
-          !TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableRampupImprovements))
-         _numUsableCompilationThreads = MAX_USABLE_COMP_THREADS;
-#endif // LINUX
+      _useCPUsToDetermineMaxNumberOfCompThreadsToActivate = true;
+      if (TR::Compiler->target.isLinux())
+         {
+         // For linux we may want to create more threads to overcome thread
+         // starvation due to lack of priorities
+         //
+         if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableRampupImprovements) &&
+            !TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableRampupImprovements))
+            _numUsableCompilationThreads = MAX_USABLE_COMP_THREADS;
+         }
       if (_numUsableCompilationThreads <= 0)
          {
          // Determine the number of compilation threads based on number of online processors
@@ -2005,7 +2007,6 @@ J9::Options::fePostProcessJIT(void * base)
          //
          uint32_t numOnlineCPUs = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE);
          _numUsableCompilationThreads = numOnlineCPUs > 1 ? std::min((numOnlineCPUs - 1), static_cast<uint32_t>(MAX_USABLE_COMP_THREADS)) : 1;
-         _useCPUsToDetermineMaxNumberOfCompThreadsToActivate = true;
          }
       }
 


### PR DESCRIPTION
Currently the logic for activating compilation threads does not work as
intended when the number of compilation threads is specified by the user.
Ideally, when the user sets the number of compilation threads with
`-XcompilationThreads<n>` option, the JVM should activate new threads up to
'n' based on its internal activation thresholds. However, currently the JIT
will activate only (numProc-1) compilation threads (regardless of how many
the user specified) and the extra compilation threads could be activated
only if 'starvation' of the compilation threads is detected.

This commit will change the logic as follows:
1) If the user specifies the number of compilation threads the JIT will
assume that the user knows best and will activate the compilation threads
based on its internal activation threasholds irrespective of the number
of CPUs the JVM is allowed to run on.

2) If the user does not specify the number of compilation threads, the JVM
will activate up to numProc-1 compilation threads based on its internal
activation thresholds. Moreover, if more compilation threads are present
and starvation of compilation is detected (this could happen in linux)
then the additional existent compilation threads are activated based on
a more conservative activation policy.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>