### PR TITLE
Optimize unsafe methods called from VarHandle

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -307,6 +307,9 @@
    sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z,
    sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z,
    sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z,
+   sun_misc_Unsafe_compareAndExchangeInt_jlObjectJII_Z,
+   sun_misc_Unsafe_compareAndExchangeLong_jlObjectJJJ_Z,
+   sun_misc_Unsafe_compareAndExchangeObject_jlObjectJjlObjectjlObject_Z,
 
    sun_misc_Unsafe_putBoolean_jlObjectJZ_V,
    sun_misc_Unsafe_putByte_jlObjectJB_V,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3287,6 +3287,14 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {x(TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z, "compareAndSwapObject", "(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z")},
       {x(TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z, "compareAndSetObject", "(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z")},
 
+      {x(TR::sun_misc_Unsafe_compareAndExchangeInt_jlObjectJII_Z,                  "compareAndExchangeInt",    "(Ljava/lang/Object;JII)I")},
+      {x(TR::sun_misc_Unsafe_compareAndExchangeLong_jlObjectJJJ_Z,                 "compareAndExchangeLong",   "(Ljava/lang/Object;JJJ)J")},
+      {x(TR::sun_misc_Unsafe_compareAndExchangeObject_jlObjectJjlObjectjlObject_Z, "compareAndExchangeObject", "(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")},
+
+      {x(TR::sun_misc_Unsafe_compareAndExchangeInt_jlObjectJII_Z,                  "compareAndExchangeIntVolatile",    "(Ljava/lang/Object;JII)I")},
+      {x(TR::sun_misc_Unsafe_compareAndExchangeLong_jlObjectJJJ_Z,                 "compareAndExchangeLongVolatile",   "(Ljava/lang/Object;JJJ)J")},
+      {x(TR::sun_misc_Unsafe_compareAndExchangeObject_jlObjectJjlObjectjlObject_Z, "compareAndExchangeObjectVolatile", "(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")},
+
       {x(TR::sun_misc_Unsafe_staticFieldBase,               "staticFieldBase",   "(Ljava/lang/reflect/Field;)Ljava/lang/Object")},
       {x(TR::sun_misc_Unsafe_staticFieldOffset,             "staticFieldOffset", "(Ljava/lang/reflect/Field;)J")},
       {x(TR::sun_misc_Unsafe_objectFieldOffset,             "objectFieldOffset", "(Ljava/lang/reflect/Field;)J")},

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -49,6 +49,183 @@
 #include "optimizer/Optimization.hpp"          // for Optimization
 #include "optimizer/Optimization_inlines.hpp"  // for trace()
 #include "optimizer/TransformUtil.hpp"         // for calculateElementAddress
+#include "infra/Checklist.hpp"                 // for NodeChecklist, etc
+
+
+static TR::RecognizedMethod getVarHandleAccessMethodFromInlinedCallStack(TR::Compilation* comp, TR::Node* node)
+   {
+   int16_t callerIndex = node->getInlinedSiteIndex();
+   while (callerIndex > -1)
+      {
+      TR_ResolvedMethod* caller = comp->getInlinedResolvedMethod(callerIndex);
+      TR::RecognizedMethod callerRm = caller->getRecognizedMethod();
+      if (TR_J9MethodBase::isVarHandleOperationMethod(callerRm))
+         {
+         return callerRm;
+         }
+
+      TR_InlinedCallSite callSite = comp->getInlinedCallSite(callerIndex);
+      callerIndex = callSite._byteCodeInfo.getCallerIndex();
+      }
+
+   TR::RecognizedMethod rm = comp->getJittedMethodSymbol()->getRecognizedMethod();
+   if (TR_J9MethodBase::isVarHandleOperationMethod(rm))
+      return rm;
+
+   return TR::unknownMethod;
+   }
+
+static TR::SymbolReferenceTable::CommonNonhelperSymbol equivalentAtomicIntrinsic(TR::RecognizedMethod rm)
+   {
+   switch (rm)
+      {
+      case TR::sun_misc_Unsafe_getAndSetInt:
+      case TR::sun_misc_Unsafe_getAndSetLong:
+           return TR::SymbolReferenceTable::atomicSwapSymbol;
+      case TR::sun_misc_Unsafe_getAndAddInt:
+      case TR::sun_misc_Unsafe_getAndAddLong:
+           return TR::SymbolReferenceTable::atomicFetchAndAddSymbol;
+      default:
+         break;
+      }
+   return TR::SymbolReferenceTable::lastCommonNonhelperSymbol;
+   }
+
+static bool isTransformableUnsafeAtomic(TR::RecognizedMethod rm)
+   {
+   if (equivalentAtomicIntrinsic(rm) != TR::SymbolReferenceTable::lastCommonNonhelperSymbol)
+      return true;
+
+   return false;
+   }
+
+static bool isVarHandleOperationMethodOnArray(TR::RecognizedMethod rm)
+   {
+   switch (rm)
+      {
+      case TR::java_lang_invoke_ArrayVarHandle_ArrayVarHandleOperations_OpMethod:
+      case TR::java_lang_invoke_ByteArrayViewVarHandle_ByteArrayViewVarHandleOperations_OpMethod:
+         return true;
+      default:
+         return false;
+      }
+   return false;
+   }
+
+
+/**
+ * \brief
+ *    Transform unsafe atomic method called from VarHandle to codegen intrinsic
+ *
+ * \parm callTree
+ *    Tree containing the call
+ *
+ * \parm callerMethod
+ *    VarHandle concreate operation method
+ *
+ * \parm calleeMethod
+ *    The unsafe method
+ *
+ */
+void TR_UnsafeFastPath::transformUnsafeAtomicCallInVarHandleAccessMethod(TR::TreeTop* callTree, TR::RecognizedMethod callerMethod, TR::RecognizedMethod calleeMethod)
+   {
+   TR::Node* node = callTree->getNode()->getFirstChild();
+   if (!performTransformation(comp(), "%s turning the call [" POINTER_PRINTF_FORMAT "] into atomic intrinsic\n", optDetailString(), node))
+      return;
+
+    TR::MethodSymbol *symbol = node->getSymbol()->castToMethodSymbol();
+   // Codegen will inline the call with the flag
+   //
+   if (symbol->getMethod()->isUnsafeCAS(comp()))
+      {
+      // codegen doesn't optimize CAS on a static field
+      //
+      if (callerMethod != TR::java_lang_invoke_StaticFieldVarHandle_StaticFieldVarHandleOperations_OpMethod)
+         {
+         node->setIsSafeForCGToFastPathUnsafeCall(true);
+         if (trace())
+            {
+            traceMsg(comp(), "Found Unsafe CAS node %p n%dn on non-static field, set the flag\n", node, node->getGlobalIndex());
+            }
+         }
+
+      return;
+      }
+
+   TR::SymbolReferenceTable::CommonNonhelperSymbol helper = equivalentAtomicIntrinsic(calleeMethod);
+   if (!comp()->cg()->supportsNonHelper(helper))
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Equivalent atomic intrinsic is not supported on current platform, quit\n");
+         }
+      return;
+      }
+
+   // Give up on arraylet
+   //
+   if (isVarHandleOperationMethodOnArray(callerMethod)
+       && TR::Compiler->om.canGenerateArraylets())
+      {
+      if (trace())
+         {
+         traceMsg(comp(), "Call %p n%dn is accessing an element from an array that might be arraylet, quit\n", node, node->getGlobalIndex());
+         }
+      return;
+      }
+
+   TR::Node* unsafeAddress = NULL;
+   if (callerMethod == TR::java_lang_invoke_StaticFieldVarHandle_StaticFieldVarHandleOperations_OpMethod)
+      {
+      TR::Node *jlClass = node->getChild(1);
+      TR::Node *j9Class = TR::Node::createWithSymRef(node, TR::aloadi, 1, jlClass, comp()->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef());
+      TR::Node *ramStatics = TR::Node::createWithSymRef(node, TR::aloadi, 1, j9Class, comp()->getSymRefTab()->findOrCreateRamStaticsFromClassSymbolRef());
+      TR::Node *offset = node->getChild(2);
+      // The offset for a static field is low taged, mask out the flag bit to get the real offset
+      //
+      offset = TR::Node::create(node, TR::land, 2, offset,
+                                                   TR::Node::lconst(node, ~J9_SUN_FIELD_OFFSET_MASK));
+      unsafeAddress = TR::Compiler->target.is32Bit() ? TR::Node::create(node, TR::aiadd, 2, ramStatics, TR::Node::create(node, TR::l2i, 1, offset)) :
+                                                       TR::Node::create(node, TR::aladd, 2, ramStatics, offset);
+      }
+   else
+      {
+      TR::Node* object = node->getChild(1);
+      TR::Node* offset = node->getChild(2);
+      unsafeAddress = TR::Compiler->target.is32Bit() ? TR::Node::create(node, TR::aiadd, 2, object, TR::Node::create(node, TR::l2i, 1, offset)) :
+                                                       TR::Node::create(node, TR::aladd, 2, object, offset);
+      unsafeAddress->setIsInternalPointer(true);
+      }
+
+
+   if (callTree->getNode()->getOpCode().isNullCheck())
+      {
+      TR::Node* nullChkNode = callTree->getNode();
+      TR::Node *passthrough = TR::Node::create(nullChkNode, TR::PassThrough, 1);
+      passthrough->setAndIncChild(0, node->getFirstChild());
+      TR::Node * checkNode = TR::Node::createWithSymRef(nullChkNode, TR::NULLCHK, 1, passthrough, nullChkNode->getSymbolReference());
+      callTree->insertBefore(TR::TreeTop::create(comp(), checkNode));
+      TR::Node::recreate(nullChkNode, TR::treetop);
+
+      if (trace())
+         {
+         traceMsg(comp(), "Created node %p n%dn to preserve null check on call %p n%dn\n", checkNode, checkNode->getGlobalIndex(), node, node->getGlobalIndex());
+         }
+      }
+
+   // Transform the symbol on the call to equivalent atomic method symbols
+   TR::Node* unsafeObject = node->getChild(0);
+   node->setAndIncChild(0, unsafeAddress);
+   unsafeObject->recursivelyDecReferenceCount();
+   node->removeChild(2); // Remove offset child
+   node->removeChild(1); // Remove object child
+   node->setSymbolReference(comp()->getSymRefTab()->findOrCreateCodeGenInlinedHelper(helper));
+
+   if (trace())
+      {
+      traceMsg(comp(), "Transformed the call %p n%dn to codegen inlineable intrinsic\n", node, node->getGlobalIndex());
+      }
+   }
 
 /**
  * This replaces recognized unsafe calls to direct memory operations
@@ -58,14 +235,31 @@ int32_t TR_UnsafeFastPath::perform()
    if (comp()->getOption(TR_DisableUnsafe))
       return 0;
 
+   TR::NodeChecklist transformed(comp());
+
    TR::ResolvedMethodSymbol *methodSymbol = comp()->getMethodSymbol();
    for (TR::TreeTop * tt = methodSymbol->getFirstTreeTop(); tt != NULL; tt = tt->getNextTreeTop())
       {
-      TR::Node *node = tt->getNode()->getChild(0); // Get the first child of the tree
-      if (node && node->getOpCode().isCall())
+      TR::Node *ttNode = tt->getNode();
+      TR::Node *node = ttNode->getNumChildren() > 0 ? ttNode->getFirstChild() : NULL; // Get the first child of the tree
+      if (node && node->getOpCode().isCall() && !node->getSymbol()->castToMethodSymbol()->isHelper())
          {
          TR::SymbolReference *symRef = node->getSymbolReference();
          TR::MethodSymbol *symbol = node->getSymbol()->castToMethodSymbol();
+
+         if (!transformed.contains(node))
+            {
+            TR::RecognizedMethod caller = getVarHandleAccessMethodFromInlinedCallStack(comp(), node);
+            TR::RecognizedMethod callee = symbol->getRecognizedMethod();
+            if (TR_J9MethodBase::isVarHandleOperationMethod(caller) &&
+                (isTransformableUnsafeAtomic(callee) ||
+                 symbol->getMethod()->isUnsafeCAS(comp())))
+               {
+               transformUnsafeAtomicCallInVarHandleAccessMethod(tt, caller, callee);
+               transformed.add(node);
+               continue;
+               }
+            }
 
          // Unsafe for TR::java_math_BigDecimal_storeTwoCharsFromInt
          if (!symRef->isUnresolved() &&

--- a/runtime/compiler/optimizer/UnsafeFastPath.hpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,5 +42,6 @@ class TR_UnsafeFastPath : public TR::Optimization
 
    virtual int32_t perform();
    virtual const char * optDetailString() const throw();
+   void transformUnsafeAtomicCallInVarHandleAccessMethod(TR::TreeTop* callTree, TR::RecognizedMethod callerMethod, TR::RecognizedMethod calleeMethod);
    };
 #endif


### PR DESCRIPTION
VarHandle concreate access methods contain information on the field to
be accessed, thus the unsafe calls can be transformed into direct
memory access or codegen intrinsics.

Part of Issue #3019

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>