### PR TITLE
Silence clang compiler warning in J9ValueProfiler.hpp

### DIFF
--- a/runtime/compiler/runtime/J9ValueProfiler.hpp
+++ b/runtime/compiler/runtime/J9ValueProfiler.hpp
@@ -817,8 +817,8 @@ TR_HashTableProfilerInfo<T>::initialHashConfig(HashFunction &hash, T value)
 
    // A bit index hash should try to nominate one bit that is zero for all
    // A bit shift hash should try to nominate one bit that is zero for all and to the left of all
-   if (getHashType() == BitIndexHash && ~value != 0 ||
-       getHashType() == BitShiftHash && (~value >> 8) != 0)
+   if (((getHashType() == BitIndexHash) && (~value != 0)) ||
+       ((getHashType() == BitShiftHash) && ((~value >> 8) != 0)))
       {
       size_t firstZero = 0;
       if (getHashType() == BitShiftHash)


### PR DESCRIPTION
```
J9ValueProfiler.hpp:820:38: warning: '&&' within '||' [-Wlogical-op-parentheses]
   if (getHashType() == BitIndexHash && ~value != 0 ||
```

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>