### PR TITLE
Add lib path env variable to find libomrsig on AIX

### DIFF
--- a/runtime/ddr/run_omrddrgen.mk.ftl
+++ b/runtime/ddr/run_omrddrgen.mk.ftl
@@ -42,6 +42,13 @@ DDR_INPUT_FILES := $(addprefix $(TOP_DIR),$(foreach module,$(DDR_INPUT_MODULES),
 DDR_INPUT_FILES := $(addsuffix .dbg,$(DDR_INPUT_DEPENDS))
 </#if>
 
+# workaround to find libomrsig
+<#if uma.spec.type.aix>
+DDR_LIB_PATH := LIBPATH=..
+<#else>
+DDR_LIB_PATH :=
+</#if>
+
 # The primary goals of this makefile.
 DDR_BLOB := $(TOP_DIR)j9ddr.dat
 DDR_SUPERSET_FILE := $(TOP_DIR)superset.dat
@@ -74,7 +81,7 @@ clean :
 	rm -f $(DDR_PRODUCTS)
 
 $(DDR_BLOB) : $(TOP_DIR)ddrgen$(UMA_DOT_EXE) $(DDR_MACRO_LIST) blacklist $(wildcard overrides*)
-	$(TOP_DIR)ddrgen $(DDR_OPTIONS) \
+	$(DDR_LIB_PATH) $(TOP_DIR)ddrgen $(DDR_OPTIONS) \
 		$(DDR_INPUT_FILES)
 
 $(DDR_MACRO_LIST) : $(DDR_INPUT_DEPENDS)


### PR DESCRIPTION
Add LD_LIBRARY_PATH and LIBPATH env variables when running ddrgen due to its new dependency on libomrsig. On AIX, the search path is not saved in the executable when it is created since we do not have a direct equivalent to setting `rpath=$ORIGIN` as a compiler flag.

Signed-off-by: mikezhang <mike.h.zhang@ibm.com>

This PR should be merged before the extension repo PRs enabling DDR by default:
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/116
https://github.com/ibmruntimes/openj9-openjdk-jdk9/pull/178
https://github.com/ibmruntimes/openj9-openjdk-jdk10/pull/59
https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/23
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/35

PR should also be tested with the extension repo PR since DDR isn't enabled by default on AIX without them.