### PR TITLE
Fix jit crash in Symbol staticName

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -2208,7 +2208,7 @@ static bool matchFieldOrStaticName(TR::Compilation* comp, TR::Node* node, char* 
       int32_t index = symRef->getReferenceNumber();
       int32_t nonhelperIndex = comp->getSymRefTab()->getNonhelperIndex(comp->getSymRefTab()->getLastCommonNonhelperSymbol());
       int32_t numHelperSymbols = comp->getSymRefTab()->getNumHelperSymbols();
-      if ((index < numHelperSymbols) || (index < nonhelperIndex) || sym->isConstString()) return false;
+      if ((index < numHelperSymbols) || (index < nonhelperIndex) || !sym->isStaticField()) return false;
 
       const char * nodeName = method->staticName(symRef->getCPIndex(), comp->trMemory(), stackAlloc);
       return !strcmp(nodeName, staticOrFieldName);

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2224,7 +2224,7 @@ bool TR_EscapeAnalysis::checkOtherDefsOfLoopAllocation(TR::Node *useNode, Candid
                         int32_t fieldNameLen = -1;
                         char *fieldName = NULL;
                         if (underlyingArray && underlyingArray->getOpCode().hasSymbolReference() &&
-                            (underlyingArray->getSymbolReference()->getSymbol()->isStatic()))
+                            underlyingArray->getSymbolReference()->getSymbol()->isStaticField())
                            {
                            fieldName = underlyingArray->getSymbolReference()->getOwningMethod(comp())->staticName(underlyingArray->getSymbolReference()->getCPIndex(), fieldNameLen, comp()->trMemory());
                            }

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -846,7 +846,7 @@ TR::InterProceduralAnalyzer::addWrittenGlobal(TR::SymbolReference *symRef)
    {
    char *sig = NULL;
    int32_t length = 0;
-   if (symRef->getSymbol()->isStatic())
+   if (symRef->getSymbol()->isStaticField())
       sig = symRef->getOwningMethod(comp())->staticName(symRef->getCPIndex(), length, trMemory());
    else if (symRef->getSymbol()->isShadow())
       sig = symRef->getOwningMethod(comp())->fieldName(symRef->getCPIndex(), length, trMemory());
@@ -857,7 +857,7 @@ TR::InterProceduralAnalyzer::addWrittenGlobal(TR::SymbolReference *symRef)
       TR::SymbolReference *currSymReference = currSymRef->getData()->_symRef;
       char *currSig = NULL;
       int32_t currLength = 0;
-      if (currSymReference->getSymbol()->isStatic())
+      if (currSymReference->getSymbol()->isStaticField())
          currSig = currSymReference->getOwningMethod(comp())->staticName(currSymReference->getCPIndex(), currLength, trMemory());
       else if (currSymReference->getSymbol()->isShadow())
          currSig = currSymReference->getOwningMethod(comp())->fieldName(currSymReference->getCPIndex(), currLength, trMemory());
@@ -878,7 +878,7 @@ TR::InterProceduralAnalyzer::addWrittenGlobal(TR::SymbolReference *symRef)
       TR::SymbolReference *currSymReference = currSym->_symRef;
       char *currSig = NULL;
       int32_t currLength = 0;
-      if (currSymReference->getSymbol()->isStatic())
+      if (currSymReference->getSymbol()->isStaticField())
          currSig = currSymReference->getOwningMethod(comp())->staticName(currSymReference->getCPIndex(), currLength, trMemory());
       else if (currSymReference->getSymbol()->isShadow())
          currSig = currSymReference->getOwningMethod(comp())->fieldName(currSymReference->getCPIndex(), currLength, trMemory());


### PR DESCRIPTION
Caller of Symbol::staticName typically assumes the underlying symbol
represents a static field. However, the condition that guards the
call currently only checks for a staic symbol, which is insufficient
as other types like Constant Dynamic. Method Handle, Method Type all
use static symbols. Use the correct check Symbol::isStaticField which
precludes the above mentioned non-static field types.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>