### PR TITLE
Correct links to AdoptOpenJDK in release notes

### DIFF
--- a/doc/release-notes/0.10/0.10.md
+++ b/doc/release-notes/0.10/0.10.md
@@ -30,9 +30,9 @@ These release notes support the [Eclipse OpenJ9 0.10.0 release plan](https://pro
 
 ## Binaries and supported environments
 
-This release adds compatibility with OpenJDK v11. Builds of OpenJDK 11 with OpenJ9 will be available from the AdoptOpenJDK community at the following link:
+This release adds compatibility with OpenJDK v11. Builds of OpenJDK 11 with OpenJ9 are available from the AdoptOpenJDK community at the following link:
 
-- [OpenJDK version 11](https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=openj9)
+- [OpenJDK version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 
 Builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK. Builds are compatible with OpenJDK 11. Compliance with the specification is tracked at the AdoptOpenJDK website where compliant builds are marked with a blue check mark.
 

--- a/doc/release-notes/0.9/0.9.md
+++ b/doc/release-notes/0.9/0.9.md
@@ -32,9 +32,9 @@ These release notes support the [Eclipse OpenJ9 0.9.0 release plan](https://proj
 
 The following additional OpenJDK binaries that contain the OpenJ9 VM are now available from the AdoptOpenJDK community:
 
-- [OpenJDK version 10](https://adoptopenjdk.net/releases.html?variant=openjdk10&jvmVariant=openj9)
-- [OpenJDK version 8 32-bit Windows](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9#x32_win)
-- [OpenJDK version 8 x86-64 Linux (non-compressed references VM for large heaps)](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=openj9#x64_linuxlh)
+- [OpenJDK version 10](https://adoptopenjdk.net/archive.html?variant=openjdk10&jvmVariant=openj9)
+- [OpenJDK version 8 32-bit Windows](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
+- [OpenJDK version 8 x86-64 Linux (non-compressed references VM for large heaps)](https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9)
 
 Builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
 Not all tests are complete for AIX and Windows platforms.


### PR DESCRIPTION
In the 0.9 and 0.10 release notes we should be
poiting to the archive pages at Adopt, not
the release pages.

All fixed with the exception of 0.9 XL heap,
because this is only available on the nightly
page at the moment.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>