### PR TITLE
Removed ccache install from Dockerfile

### DIFF
--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update \
     autoconf \
     build-essential \
     ca-certificates \
-    ccache \
     cmake \
     cpio \
     curl \


### PR DESCRIPTION
Docker containers will not be running long enough to make good use of ccache, so it is being removed from the dockerfile.
[skip ci]
Signed-off-by: Colton Mills <millscolt3@gmail.com>