### PR TITLE
Send setCallCount() queries to the client

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5816,7 +5816,8 @@ static void iProfilerActivationLogic(J9JITConfig * jitConfig, TR::CompilationInf
          TR_J9VMBase *fej9 = (TR_J9VMBase *)(TR_J9VMBase::get(jitConfig, 0));
          TR_IProfiler *iProfiler = fej9->getIProfiler();
          TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
-         if (iProfiler && iProfiler->getProfilerMemoryFootprint() < TR::Options::_iProfilerMemoryConsumptionLimit)
+         if (iProfiler && iProfiler->getProfilerMemoryFootprint() < TR::Options::_iProfilerMemoryConsumptionLimit &&
+             compInfo->getPersistentInfo()->getJITaaSMode() != SERVER_MODE)
             {
             // Turn on if classLoadPhase became active or
             // if many interpreted samples
@@ -7057,7 +7058,8 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
             {
             iProfiler->startIProfilerThread(javaVM);
             }
-         if (TR::Options::getCmdLineOptions()->getOption(TR_NoIProfilerDuringStartupPhase))
+         if (TR::Options::getCmdLineOptions()->getOption(TR_NoIProfilerDuringStartupPhase) ||
+             compInfo->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
             {
             interpreterProfilingState = IPROFILING_STATE_OFF;
             }

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2036,7 +2036,17 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(iProfiler->getMaxCallCount());
          }
          break;
-
+      case J9ServerMessageType::IProfiler_setCallCount:
+         {
+         auto recv = client->getRecvData<TR_OpaqueMethodBlock*, int32_t, int32_t>();
+         auto method = std::get<0>(recv);
+         auto bcIndex = std::get<1>(recv);
+         auto count = std::get<2>(recv);
+         TR_IProfiler * iProfiler = fe->getIProfiler();
+         iProfiler->setCallCount(method, bcIndex, count, comp);
+         client->write(JITaaS::Void());
+         }
+         break;
       case J9ServerMessageType::Recompilation_getExistingMethodInfo:
          {
          auto recomp = comp->getRecompilationInfo();

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -267,6 +267,7 @@ enum J9ServerMessageType
    IProfiler_profilingSample = 900;
    IProfiler_searchForMethodSample = 901;
    IProfiler_getMaxCallCount = 902;
+   IProfiler_setCallCount = 903;
 
    Recompilation_getExistingMethodInfo = 1000;
    Recompilation_getJittedBodyInfoFromPC = 1001;

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2941,9 +2941,6 @@ TR_IPBCDataCallGraph::isLocked()
 uint32_t
 TR_IPBCDataCallGraph::canBeSerialized(TR::PersistentInfo *info)
    {
-   if (!getCanPersistEntryFlag())
-      return IPBC_ENTRY_CANNOT_PERSIST;
-
    if (!lockEntry()) // Try to lock the entry; if entry is already locked, abort
       return IPBC_ENTRY_PERSIST_LOCK;
 
@@ -2999,17 +2996,8 @@ TR_IPBCDataCallGraph::deserialize(TR_IPBCDataStorageHeader *storage)
    TR_ASSERT(storage->ID == TR_IPBCD_CALL_GRAPH, "Incompatible types between storage and loading of iprofile persistent data");
    for (int32_t i = 0; i < NUM_CS_SLOTS; i++)
       {
-      J9Class * ramClass = (J9Class*) store->_csInfo.getClazz(i);
-      if (ramClass)
-         {
-         _csInfo.setClazz(i, (uintptrj_t)ramClass);
-         _csInfo._weight[i] = store->_csInfo._weight[i];
-         }
-      else
-         {
-         _csInfo.setClazz(i, 0);
-         _csInfo._weight[i] = 0;
-         }
+      _csInfo.setClazz(i, store->_csInfo.getClazz(i));
+      _csInfo._weight[i] = store->_csInfo._weight[i];
       }
    _csInfo._residueWeight = store->_csInfo._residueWeight;
    _csInfo._tooBigToBeInlined = store->_csInfo._tooBigToBeInlined;
@@ -3210,7 +3198,6 @@ TR_IProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_
 
       if (csInfo)
          {
-         csInfo->setClazz(0, 0);
          csInfo->_weight[0] = count;
 
          if (count>_maxCallFrequency)

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -532,7 +532,7 @@ public:
    int32_t getCallCount(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *method, int32_t bcIndex, TR::Compilation *);
    int32_t getCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, TR::Compilation *);
    int32_t getCallCount(TR_ByteCodeInfo &bcInfo, TR::Compilation *comp);
-   void    setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *);
+   virtual void setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *);
    void    setCallCount(TR_ByteCodeInfo &bcInfo, int32_t count, TR::Compilation *comp);
 
    int32_t getCGEdgeWeight (TR::Node *callerNode, TR_OpaqueMethodBlock *callee, TR::Compilation *comp);
@@ -676,8 +676,9 @@ private:
    TR_OpaqueMethodBlock           *_valueProfileMethod;
 
    // bytecode hashtable
+   protected:
    TR_IPBytecodeHashTableEntry   **_bcHashTable;
-
+   private:
 #if defined(EXPERIMENTAL_IPROFILER)
    // bytecode hashtable
    TR_IPBCDataAllocation         **_allocHashTable;

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -65,7 +65,8 @@ public:
    virtual TR_IPBytecodeHashTableEntry *profilingSample (TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex,
                                                          TR::Compilation *comp, uintptrj_t data = 0xDEADF00D, bool addIt = false) override;
 
-   virtual int32_t getMaxCallCount();
+   virtual int32_t getMaxCallCount() override;
+   virtual void setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *) override;
 
    TR_IPBytecodeHashTableEntry* ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptrj_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
    void printStats();


### PR DESCRIPTION
setCallCount() is invoked by the optimizer to add derived frequency
information to direct calls which are not tracked by the IProfiler.
This function may create new entries in the global IProfiler at the
JITaaS server which is wrong (the global IProfiler at the server
shouldn't even be used). getCallCount() retrieves the information
from the JITaaS client, so we will never find whatever the optimizer
tried to write. Moreover, setCallCount marks the entry as non-persistent
and the client will refuse to serialize anything marked as non-persistent.

This commit makes the required changes to send the setCallCount() issued
at the server to the client. An optimization is implemented where if the
server finds the desired IProfiler entry in the cache and this entry
has the same 'count' value as the one it wants to write, then no remote
message is sent.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>