### PR TITLE
Fold static final fields that are VarHandle

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1378,7 +1378,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
          TR_OpaqueClassBlock *declaringClass = owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
          if (declaringClass && fej9->isClassInitialized(declaringClass))
             {
-            static const char *foldVarHandle = feGetEnv("TR_FoldVarHandle");
+            static const char *dontFoldVarHandle = feGetEnv("TR_DontFoldVarHandle");
             int32_t clazzNameLength = 0;
             char *clazzName = fej9->getClassNameChars(declaringClass, clazzNameLength);
             bool createKnownObject = false;
@@ -1387,7 +1387,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
                {
                createKnownObject = true;
                }
-            else if ((foldVarHandle || comp()->getOption(TR_AggressiveOpts))
+            else if (!dontFoldVarHandle
                      && (clazzNameLength != 16 || strncmp(clazzName, "java/lang/System", 16)))
                {
                TR_OpaqueClassBlock *varHandleClass =  fej9->getSystemClassFromClassName("java/lang/invoke/VarHandle", 26);


### PR DESCRIPTION
Fold static final fields that are VarHandle such that the calls to
VarHandle access methods can be inlined by methodHandleInvokeInlining
opts.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>