### PR TITLE
Revert "Enable openssl within nightly and pr builds"

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -81,7 +81,7 @@ def get_sources() {
         checkout_pullrequest()
     } else {
         sh "git checkout ${OPENJDK_SHA}"
-        sh "bash ./get_source.sh ${EXTRA_GETSOURCE_OPTIONS} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${OMR_REPO_OPTION} ${OMR_BRANCH_OPTION} ${OMR_SHA_OPTION}"
+        sh "bash ./get_source.sh ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${OMR_REPO_OPTION} ${OMR_BRANCH_OPTION} ${OMR_SHA_OPTION}"
     }
 }
 

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -341,7 +341,6 @@ def set_build_variables() {
     // fetch values per spec and Java version from the variables file
     BOOT_JDK = get_value(VARIABLES."${SPEC}".boot_jdk, SDK_VERSION)
     FREEMARKER = VARIABLES."${SPEC}".freemarker
-    EXTRA_GETSOURCE_OPTIONS = get_value(VARIABLES.extra_getsource_options, SDK_VERSION)
     EXTRA_CONFIGURE_OPTIONS = get_value(VARIABLES."${SPEC}".extra_configure_options, SDK_VERSION)
     EXTRA_MAKE_OPTIONS = get_value(VARIABLES."${SPEC}".extra_make_options, SDK_VERSION)
     OPENJDK_REFERENCE_REPO = VARIABLES."${SPEC}".openjdk_reference_repo

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -56,8 +56,6 @@ build_discarder:
     build: 10
     pipeline: 0
     pullRequest: 0
-extra_getsource_options:
-  8: '--openssl-version=1.1.1'
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#
@@ -89,8 +87,6 @@ linux_ppc-64_cmprssptrs_le:
       10: 'hw.arch.ppc64le && sw.os.ubuntu'
       11: 'hw.arch.ppc64le && sw.os.ubuntu'
       next: 'hw.arch.ppc64le && sw.os.ubuntu'
-  extra_configure_options:
-    8: '--with-openssl=fetched --enable-openssl-bundling'
   build_env:
     vars:
       11: 'CC=gcc-7 CXX=g++-7'
@@ -128,8 +124,6 @@ linux_390-64_cmprssptrs:
       10: 'hw.arch.s390x && sw.os.ubuntu'
       11: 'hw.arch.s390x && sw.os.ubuntu'
       next: 'hw.arch.s390x && sw.os.ubuntu'
-  extra_configure_options:
-    8: '--with-openssl=fetched --enable-openssl-bundling'
   build_env:
     vars:
       11: 'CC=gcc-7 CXX=g++-7'
@@ -166,7 +160,7 @@ aix_ppc-64_cmprssptrs:
       11: 'hw.arch.ppc && sw.os.aix'
       next: 'hw.arch.ppc && sw.os.aix'
   extra_configure_options:
-    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8 --with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8'
     9: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     10: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     11: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
@@ -202,8 +196,6 @@ linux_x86-64_cmprssptrs:
       10: 'hw.arch.x86 && sw.os.ubuntu'
       11: 'hw.arch.x86 && sw.os.ubuntu'
       next: 'hw.arch.x86 && sw.os.ubuntu'
-  extra_configure_options:
-    8: '--with-openssl=fetched --enable-openssl-bundling'
   build_env:
     vars:
       11: 'CC=gcc-7 CXX=g++-7'
@@ -240,7 +232,7 @@ linux_x86-64_cmprssptrs_cmake:
       11: 'hw.arch.x86 && sw.os.ubuntu'
       next: 'hw.arch.x86 && sw.os.ubuntu'
   extra_configure_options:
-    8: '--with-cmake --disable-ddr --with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-cmake --disable-ddr'
     9: '--with-cmake --disable-ddr'
     10: '--with-cmake --disable-ddr'
     11: '--with-cmake --disable-ddr'
@@ -287,7 +279,7 @@ linux_x86-64:
       11: 'hw.arch.x86 && sw.os.ubuntu'
       next: 'hw.arch.x86 && sw.os.ubuntu'
   extra_configure_options:
-    8: '--with-noncompressedrefs --with-openssl=fetched --enable-openssl-bundling'
+    8: '--with-noncompressedrefs'
     9: '--with-noncompressedrefs'
     10: '--with-noncompressedrefs'
     11: '--with-noncompressedrefs'


### PR DESCRIPTION
Reverts eclipse/openj9#3158

Changes are causing build failures i.e. https://ci.eclipse.org/openj9/job/PullRequest-Compile-JDK8-linux_390-64_cmprssptrs-OpenJ9/43/console