### PR TITLE
Implement vectorized String.indexOf() on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -68,6 +68,10 @@ J9::Power::CodeGenerator::CodeGenerator() :
    cg->setSupportsPartialInlineOfMethodHooks();
    cg->setSupportsInliningOfTypeCoersionMethods();
 
+   if (TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX() &&
+      !comp->getOption(TR_DisableFastStringIndexOf) && !TR::Compiler->om.canGenerateArraylets())
+      cg->setSupportsInlineStringIndexOf();
+
    if (!comp->getOption(TR_DisableReadMonitors))
       cg->setSupportsReadOnlyLocks();
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11868,7 +11868,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
       {
       TR::Register *value = srm->findOrCreateScratchRegister();
 
-      generateTrg1MemInstruction(cg, scalarLoadOp, node, value, new (cg->trHeapMemory()) TR::MemoryReference(arrAddress, result, isLatin1 ? 1 : 2, cg));
+      generateTrg1MemInstruction(cg, scalarLoadOp, node, value, new (cg->trHeapMemory()) TR::MemoryReference(result, arrAddress, isLatin1 ? 1 : 2, cg));
       generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cr0, value, targetScalar);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, foundExactLabel, cr0);
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12101,19 +12101,29 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::srawi, node, result, result, 1);
 
       {
-      TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 14 + srm->numAvailableRegisters(), cg->trMemory());
+      TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 15 + srm->numAvailableRegisters(), cg->trMemory());
 
-      deps->addPostCondition(arrAddress, TR::RealRegister::NoReg);
+      deps->addPostCondition(arrObjectAddress, TR::RealRegister::NoReg);
+      deps->getPostConditions()->getRegisterDependency(0)->setExcludeGPR0();
       deps->addPostCondition(targetScalar, TR::RealRegister::NoReg);
+      if (node->getChild(2)->getReferenceCount() == 1)
+         deps->getPostConditions()->getRegisterDependency(1)->setExcludeGPR0();
       deps->addPostCondition(startIndex, TR::RealRegister::NoReg);
+      if (node->getChild(3)->getReferenceCount() == 1)
+         deps->getPostConditions()->getRegisterDependency(2)->setExcludeGPR0();
       deps->addPostCondition(endIndex, TR::RealRegister::NoReg);
+      if (node->getChild(4)->getReferenceCount() == 1)
+         deps->getPostConditions()->getRegisterDependency(3)->setExcludeGPR0();
 
       deps->addPostCondition(cr0, TR::RealRegister::cr0);
       deps->addPostCondition(cr6, TR::RealRegister::cr6);
 
       deps->addPostCondition(zeroRegister, TR::RealRegister::NoReg);
       deps->addPostCondition(result, TR::RealRegister::NoReg);
+      deps->getPostConditions()->getRegisterDependency(7)->setExcludeGPR0();
+      deps->addPostCondition(arrAddress, TR::RealRegister::NoReg);
       deps->addPostCondition(currentAddress, TR::RealRegister::NoReg);
+      deps->getPostConditions()->getRegisterDependency(9)->setExcludeGPR0();
       deps->addPostCondition(endAddress, TR::RealRegister::NoReg);
 
       deps->addPostCondition(targetVector, TR::RealRegister::NoReg);
@@ -12121,7 +12131,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
       deps->addPostCondition(searchVector, TR::RealRegister::NoReg);
       deps->addPostCondition(permuteVector, TR::RealRegister::NoReg);
 
-      srm->addScratchRegistersToDependencyList(deps);
+      srm->addScratchRegistersToDependencyList(deps, true);
 
       generateDepLabelInstruction(cg, TR::InstOpCode::label, node, endLabel, deps);
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11852,7 +11852,14 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
       generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, endAddress, endIndex);
       }
 
+   if (node->getChild(3)->getReferenceCount() == 1)
+      srm->donateScratchRegister(startIndex);
+   if (node->getChild(4)->getReferenceCount() == 1)
+      srm->donateScratchRegister(endIndex);
+
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, arrAddress, arrObjectAddress, TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+   if (node->getChild(1)->getReferenceCount() == 1)
+      srm->donateScratchRegister(arrObjectAddress);
 
    // Handle the first character using a simple scalar compare. Otherwise, first character matches
    // would be slower than the old scalar comparison loop. This is a problem since first character
@@ -11881,6 +11888,8 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
    // Splat the value to be compared against and its bitwise complement into two vector registers
    // for later use
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mtvsrwz, node, targetVector, targetScalar);
+   if (node->getChild(2)->getReferenceCount() == 1)
+      srm->donateScratchRegister(targetScalar);
    if (isLatin1)
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::vspltb, node, targetVector, targetVector, 7);
    else

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12116,6 +12116,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, bool isLatin1, TR::C
       deps->addPostCondition(cr6, TR::RealRegister::cr6);
 
       deps->addPostCondition(zeroRegister, TR::RealRegister::NoReg);
+      deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
       deps->addPostCondition(result, TR::RealRegister::NoReg);
       deps->getPostConditions()->getRegisterDependency(deps->getAddCursorForPost() - 1)->setExcludeGPR0();
       deps->addPostCondition(arrAddress, TR::RealRegister::NoReg);


### PR DESCRIPTION
An evaluator for the JITHelpers.intrinsicIndexOf* methods has been
implemented on Power that makes use of vector instructions to improve
the performance of String.indexOf().

Signed-off-by: Ben Thomas <ben@benthomas.ca>