### PR TITLE
Deprecate ShrinkWrapping - Part I

### DIFF
--- a/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -55,7 +55,6 @@
 
     RegisterAssigningPhase,
     MapStackPhase,
-    ShrinkWrappingPhase,
     PeepholePhase,
     BinaryEncodingPhase,
     EmitSnippetsPhase,

--- a/runtime/compiler/codegen/J9GCStackAtlas.cpp
+++ b/runtime/compiler/codegen/J9GCStackAtlas.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,8 +81,6 @@ J9::GCStackAtlas::close(TR::CodeGenerator *cg)
           map->getRegisterMap() == nextMap->getRegisterMap() &&
           map->getHighWordRegisterMap() == nextMap->getHighWordRegisterMap() &&
           !memcmp(map->getMapBits(), nextMap->getMapBits(), mapBytes) &&
-          (comp->getOption(TR_DisableShrinkWrapping) ||
-           (map->getRegisterSaveDescription() == nextMap->getRegisterSaveDescription())) &&
           (comp->getOption(TR_DisableLiveMonitorMetadata) ||
            ((map->getLiveMonitorBits() != 0) == (nextMap->getLiveMonitorBits() != 0) &&
             (map->getLiveMonitorBits() == 0 ||

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7285,12 +7285,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                options->setOption(TR_DisableGuardedCountingRecompilations);
                }
 
-            // Shrink wrapping does not help at cold
-            if (options->getOptLevel() < warm && !options->getOption(TR_DisableJava8StartupHeuristics))
-               {
-               options->setOption(TR_DisableShrinkWrapping);
-               }
-
             if (that->_methodBeingCompiled->_oldStartPC != 0)
                {
                TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(that->_methodBeingCompiled->_oldStartPC);
@@ -7431,7 +7425,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             // Disable some expensive optimizations
             if (options->getOptLevel() <= warm && !options->getOption(TR_EnableExpensiveOptsAtWarm))
                {
-               options->setOption(TR_DisableShrinkWrapping);
                options->setOption(TR_DisableStoreSinking);
                }
             } // end of compilation strategy tweaks for Java

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.hpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,22 +82,9 @@ class PPCPrivateLinkage : public TR::Linkage
          TR::RegisterDependencyConditions *dependencies,
          uint32_t sizeOfArguments);
 
-   // shrinkwrapping
-   virtual bool mapPreservedRegistersToStackOffsets(int32_t *mapRegsToStack, int32_t &numPreserved, TR_BitVector *&);
-   virtual int32_t getRegisterSaveSize() { return _registerSaveSize; }
-   void setRegisterSaveSize(int32_t v) { _registerSaveSize = v; }
-   int32_t getStackOffsetForReg(int32_t regIndex) { return _mapRegsToStack[regIndex]; }
-   void setStackOffsetForReg(int32_t regIndex, int32_t offset) { _mapRegsToStack[regIndex] = offset; }
-   virtual TR::Instruction *savePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
-   virtual TR::Instruction *restorePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
-   virtual TR::Instruction *composeSavesRestores(TR::Instruction *start, int32_t firstReg, int32_t lastReg, int32_t offset, int32_t numRegs, bool doSaves);
-
    protected:
 
    TR::PPCLinkageProperties _properties;
-
-   int32_t _registerSaveSize;
-   int32_t *_mapRegsToStack;
 
    int32_t buildPrivateLinkageArgs(
          TR::Node *callNode,

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -703,8 +703,6 @@ mapsAreIdentical(
 #ifdef TR_HOST_S390
        (mapCursor->getHighWordRegisterMap() == nextMapCursor->getHighWordRegisterMap()) &&
 #endif
-       (comp->getOption(TR_DisableShrinkWrapping) ||
-        (mapCursor->getRegisterSaveDescription() == nextMapCursor->getRegisterSaveDescription())) &&
        (comp->getOption(TR_DisableLiveMonitorMetadata) ||
         ((mapCursor->getLiveMonitorBits() != 0) == (nextMapCursor->getLiveMonitorBits() != 0) &&
          (mapCursor->getLiveMonitorBits() == 0 ||
@@ -1493,31 +1491,7 @@ createMethodMetaData(
          ((uint8_t *)data + exceptionTableSize + inlinedCallSize),
          sizeOfStackAtlasInBytes);
 
-   if (comp->cg()->getShrinkWrappingDone())
-      {
-      traceMsg(comp, "lowestSavedRegister %x\n", comp->cg()->getLowestSavedRegister());
-      data->registerSaveDescription = J9TR_SHRINK_WRAP;
-
-      // Stash the lowest register saved in the prologue in the last byte of the
-      // rsd hung off the method's metadata. this is consulted during the stackwalk
-      // so that the right stack slots are checked
-      //
-      // note: on x86, the preserved registers are not necessarily allocated in sequence,
-      // so the info looks like this:
-      // data->registerSaveDescription = 0x....| abcd
-      // the low 16bits are used to store a bitvector of registers that are shrinkwrapped
-      // in this method. this bitvector is consulted during the stackwalk to determine
-      // which stack slots need to be checked
-      //
-      // on ppc and s390, the registers are always allocated in sequence, so just store
-      // the lowest number in the low byte
-      //
-      data->registerSaveDescription |= (comp->cg()->getLowestSavedRegister() & 0xFFFF);
-      }
-   else
-      {
-      data->registerSaveDescription = comp->cg()->getRegisterSaveDescription();
-      }
+   data->registerSaveDescription = comp->cg()->getRegisterSaveDescription();
 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
    if (vm->isAOT_DEPRECATED_DO_NOT_USE())

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.hpp
@@ -48,8 +48,6 @@ class AMD64PrivateLinkage : public TR::X86PrivateLinkage
 
    virtual TR::Instruction *savePreservedRegisters(TR::Instruction *cursor);
    virtual TR::Instruction *restorePreservedRegisters(TR::Instruction *cursor);
-   virtual TR::Instruction *savePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
-   virtual TR::Instruction *restorePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
 
    virtual int32_t buildCallArguments(
          TR::Node *callNode,

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1029,7 +1029,6 @@ void TR::X86PrivateLinkage::createPrologue(TR::Instruction *cursor)
 #endif
    }
 
-// for shrinkwrapping
 bool TR::X86PrivateLinkage::needsFrameDeallocation()
    {
    // frame needs a deallocation if FrameSize == 0
@@ -1075,50 +1074,6 @@ void TR::X86PrivateLinkage::createEpilogue(TR::Instruction *cursor)
       {
       toIA32ImmInstruction(cursor->getNext())->setSourceImmediate(comp()->getJittedMethodSymbol()->getNumParameterSlots() << getProperties().getParmSlotShift());
       }
-   }
-
-bool TR::X86PrivateLinkage::mapPreservedRegistersToStackOffsets(
-      int32_t *mapRegsToStack,
-      int32_t &numPreserved,
-      TR_BitVector *&preservedRegsInLinkage)
-   {
-   // this routine provides a mapping between the preserved registers and
-   // their location on the stack ; so shrinkWrapping can use the right
-   // offsets when sinking the save/restores
-   //
-   TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();
-   const int32_t          localSize   = getProperties().getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
-   const int32_t          pointerSize = getProperties().getPointerSize();
-   bool                   traceIt     = comp()->getOption(TR_TraceShrinkWrapping);
-
-   int32_t offsetCursor = -localSize - pointerSize;
-   numPreserved = getProperties().getMaxRegistersPreservedInPrologue();
-
-   if (traceIt)
-      traceMsg(comp(), "Preserved registers for this linkage: { ");
-
-   for (int32_t pindex = numPreserved-1;
-        pindex >= 0;
-        pindex--)
-      {
-      TR::RealRegister::RegNum idx = getProperties().getPreservedRegister((uint32_t)pindex);
-      if (traceIt)
-         traceMsg(comp(), "%s ", comp()->getDebug()->getRealRegisterName(idx-1));
-      preservedRegsInLinkage->set(idx);
-      TR::RealRegister *reg = machine()->getX86RealRegister(idx);
-      if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked)
-         {
-         mapRegsToStack[idx] = offsetCursor;
-         offsetCursor -= pointerSize;
-         }
-      }
-
-   if (traceIt)
-      traceMsg(comp(), "}\n");
-   // return true or false depending on whether
-   // the linkage uses pushes for preserved regs
-   //
-   return false;
    }
 
 TR::Register *

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.hpp
@@ -282,10 +282,8 @@ class X86PrivateLinkage : public TR::Linkage
 
    protected:
 
-   // for shrinkwrapping
    virtual TR::Instruction *savePreservedRegisters(TR::Instruction *cursor)=0;
    virtual TR::Instruction *restorePreservedRegisters(TR::Instruction *cursor)=0;
-   virtual bool mapPreservedRegistersToStackOffsets(int32_t *mapRegsToStack, int32_t &numPreserved, TR_BitVector *&);
    virtual bool needsFrameDeallocation();
    virtual TR::Instruction *deallocateFrameIfNeeded(TR::Instruction *cursor, int32_t size);
 

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.hpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.hpp
@@ -46,8 +46,6 @@ class IA32PrivateLinkage : public TR::X86PrivateLinkage
    virtual TR::Instruction *restorePreservedRegisters(TR::Instruction *cursor);
    virtual int32_t buildCallArguments(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies){ return buildArgs(callNode, dependencies); }
 
-   virtual TR::Instruction *savePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
-   virtual TR::Instruction *restorePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
    virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies);
 
    virtual void buildVirtualOrComputedCall(TR::X86CallSite &site, TR::LabelSymbol *entryLabel, TR::LabelSymbol *doneLabel, uint8_t *thunk);

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -60,7 +60,6 @@
     PreRAPeepholePhase,
     RegisterAssigningPhase,
     MapStackPhase,
-    ShrinkWrappingPhase,
     PeepholePhase,
     BinaryEncodingPhase,
     EmitSnippetsPhase,

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -172,11 +172,6 @@ TR::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390Li
 
    setPreservedRegisterMapForGC(0x00001fc0);
    setLargestOutgoingArgumentAreaSize(0);
-
-   // shrink wrapping
-   setRegisterSaveSize(0);
-   _mapRegsToStack = (int32_t *) trMemory()->allocateHeapMemory(TR::RealRegister::NumRegisters*sizeof(int32_t));
-   memset(_mapRegsToStack, -1, (TR::RealRegister::NumRegisters*sizeof(int32_t)));
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1024,141 +1019,6 @@ initStg(TR::CodeGenerator * codeGen, TR::Node * node, TR::RealRegister * tmpReg,
    return op.generate(baseReg, baseReg, indexReg, itersReg, baseOffset, cursor);
    }
 
-
-bool
-TR::S390PrivateLinkage::mapPreservedRegistersToStackOffsets(int32_t *mapRegsToStack, int32_t &numPreserved, TR_BitVector *&preservedRegsInLinkage)
-   {
-   // this routine provides a mapping between the preserved registers and
-   // their location on the stack ; so shrinkWrapping can use the right
-   // offsets when sinking the save/restores
-   //
-   TR::ResolvedMethodSymbol *bodySymbol  = comp()->getJittedMethodSymbol();
-   // localSize also accounts for
-   // {collected + uncollected} locals + Return Address + longDispSlot
-   //
-   int32_t                localSize   = -1 * (int32_t) (bodySymbol->getLocalMappingCursor());  // Auto+Spill size
-   const int32_t          pointerSize = TR::Compiler->om.sizeofReferenceAddress();
-   bool                   traceIt     = comp()->getOption(TR_TraceShrinkWrapping);
-   int32_t offsetCursor = -localSize;
-   numPreserved = 0;
-   TR::RealRegister::RegNum firstUsedReg = getFirstSavedRegister(TR::RealRegister::GPR6,
-                                                              TR::RealRegister::GPR12);
-   TR::RealRegister::RegNum lastUsedReg  = getLastSavedRegister(TR::RealRegister::GPR6,
-                                                              TR::RealRegister::GPR12);
-
-
-   // HPR6-HPR12 are also preserved on 32-bit
-   TR::RealRegister::RegNum lastUsedHighWordReg  =  TR::RealRegister::NoReg;
-   TR::RealRegister::RegNum firstUsedHighWordReg =  TR::RealRegister::NoReg;
-   if (cg()->supportsHighWordFacility() &&  !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is32Bit())
-      {
-      lastUsedHighWordReg  =  getLastSavedRegister(TR::RealRegister::HPR6, TR::RealRegister::HPR12);
-      firstUsedHighWordReg =  getFirstSavedRegister(TR::RealRegister::HPR6, TR::RealRegister::HPR12);
-      }
-
-   if (lastUsedReg == TR::RealRegister::NoReg)
-      return false;
-
-   int32_t argSize = cg()->getLargestOutgoingArgSize() + getOffsetToFirstParm();
-   int32_t numIntSaved = 0, numFloatSaved = 0, numHighWordRegSaved = 0, registerSaveDescription = 0;
-   int32_t regSaveSize = calculateRegisterSaveSize(firstUsedReg, lastUsedReg,
-                                                   firstUsedHighWordReg, lastUsedHighWordReg,
-                                                   registerSaveDescription,
-                                                   numIntSaved, numFloatSaved, numHighWordRegSaved);
-   // total frame size
-   int32_t size = regSaveSize + localSize + argSize;
-
-   if (1)
-      {
-      if (traceIt)
-         traceMsg(comp(), "Preserved registers for this linkage: { ");
-      for (int32_t pindex = TR::RealRegister::GPR6;
-            pindex <= TR::RealRegister::GPR12;
-            pindex++)
-         {
-         TR::RealRegister::RegNum idx = REGNUM(pindex);
-         preservedRegsInLinkage->set(idx);
-         if (traceIt)
-            traceMsg(comp(), "%s ", comp()->getDebug()->getRealRegisterName(idx-1));
-         }
-
-      if (traceIt)
-         traceMsg(comp(), "}\n");
-      }
-
-   // iterate in reverse order because createprologue will
-   // assign the stack indices in increasing order of register numbers
-   //
-   for (int32_t pindex = lastUsedReg;
-        pindex >= firstUsedReg;
-        pindex--)
-      {
-      TR::RealRegister::RegNum idx = REGNUM(pindex);
-      TR::RealRegister *reg = getS390RealRegister(idx);
-      if (reg->getHasBeenAssignedInMethod())
-         {
-         offsetCursor -= pointerSize;
-         traceMsg(comp(), "idx %d is assigned gets offsetcursor %d\n", idx, offsetCursor);
-         int32_t stackOffset = offsetCursor + size; // add the frame size to get the right offsets;
-         mapRegsToStack[idx] = stackOffset;
-         setStackOffsetForReg(idx, stackOffset);
-         }
-      }
-
-   // return true or false depending on whether
-   // the linkage uses pushes for preserved regs
-   //
-   return false;
-   }
-
-TR::Instruction *
-TR::S390PrivateLinkage::savePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset)
-   {
-   TR::Node *n = comp()->getStartTree()->getNode();
-   if (offset == -1)
-      offset = getStackOffsetForReg(regIndex);
-
-   TR::MemoryReference *rsa = generateS390MemoryReference(getStackPointerRealRegister(), offset, cg());
-   cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), n, getS390RealRegister(REGNUM(regIndex)), rsa, cursor);
-   return cursor;
-   }
-
-TR::Instruction *
-TR::S390PrivateLinkage::restorePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset)
-   {
-   TR::Node *n = comp()->getStartTree()->getNode();
-   if (offset == -1)
-      offset = getStackOffsetForReg(regIndex);
-
-   TR::MemoryReference *rsa = generateS390MemoryReference(getStackPointerRealRegister(), offset, cg());
-   cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), n, getS390RealRegister(REGNUM(regIndex)), rsa, cursor);
-   return cursor;
-   }
-
-TR::Instruction *
-TR::S390PrivateLinkage::composeSavesRestores(TR::Instruction *start,
-                                           int32_t firstReg,
-                                           int32_t lastReg,
-                                           int32_t offset,
-                                           int32_t numRegs, bool doSaves)
-   {
-   // first determine if we can use load/store multiple
-   // the registers have to be in sequence
-   //
-   if (offset == -1)
-      offset = getStackOffsetForReg(firstReg);
-
-   TR::MemoryReference *rsa = generateS390MemoryReference(getS390RealRegister(getStackPointerRegister()), offset, cg());
-   if (!doSaves)
-      start = generateRSInstruction(cg(), TR::InstOpCode::getLoadMultipleOpCode(), comp()->getStartTree()->getNode(),
-                                    getS390RealRegister(REGNUM(firstReg)), getS390RealRegister(REGNUM(lastReg)), rsa, start);
-   else
-      start = generateRSInstruction(cg(), TR::InstOpCode::getStoreMultipleOpCode(), comp()->getStartTree()->getNode(),
-                                    getS390RealRegister(REGNUM(firstReg)), getS390RealRegister(REGNUM(lastReg)), rsa, start);
-   return start;
-   }
-
-
 int32_t
 TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum firstUsedReg,
                                                  TR::RealRegister::RegNum lastUsedReg,
@@ -1177,7 +1037,6 @@ TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum first
    int32_t i;
    if (lastUsedReg != TR::RealRegister::NoReg)
       {
-      cg()->setLowestSavedRegister(firstUsedReg);
       for (i = firstUsedReg ; i <= lastUsedReg ; ++i)
          {
          registerSaveDescription |= 1 << (i - 1);
@@ -1210,10 +1069,6 @@ TR::S390PrivateLinkage::calculateRegisterSaveSize(TR::RealRegister::RegNum first
    int32_t firstLocalOffset = getOffsetToFirstLocal();
    int32_t localSize = -1 * (int32_t) (comp()->getJittedMethodSymbol()->getLocalMappingCursor());  // Auto+Spill size
 
-   // stash the info on the linkage so we can use it to emit the metadata
-   // for shrinkwrapping
-   //
-   setRegisterSaveSize(localSize + firstLocalOffset + regSaveSize);
    return regSaveSize;
    }
 
@@ -1460,44 +1315,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
 
          if (firstUsedReg != lastUsedReg)
             {
-            TR_BitVector *p = cg()->getPreservedRegsInPrologue();
-            TR::RegisterDependencyConditions * STMDeps = NULL;
-            static char * stmThreshold = feGetEnv("TR_STMThreshold");
-            if (!p && !stmThreshold)
-               {
-               cursor = generateRSInstruction(cg(), TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getS390RealRegister(firstUsedReg),
-                     getS390RealRegister(lastUsedReg), rsa, cursor);
-               }
-            else
-               {
-               int32_t numUsedRegs = lastUsedReg - firstUsedReg + 1;
-               int8_t threshold = stmThreshold ? atoi(stmThreshold) : -1;
-               TR_ASSERT( threshold > -2, "Can't use a value smaller than -1 for STMThreshold\n");
-               if (!p && (threshold == -1 || (threshold > 0 && numUsedRegs >= threshold))) // use STM
-                  {
-                  cursor = generateRSInstruction(cg(), TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getS390RealRegister(firstUsedReg),
-                     getS390RealRegister(lastUsedReg), rsa, cursor);
-                  }
-               else //otherwise break it all down
-                  {
-                  if (comp()->getOption(TR_DisableShrinkWrapping))
-                     {
-                     int32_t numToIsolate = numUsedRegs;
-                     int32_t curReg = firstUsedReg;
-                     int32_t localStackDisp = disp;
-                     for (int32_t i = 0; i < numToIsolate; i++)
-                        {
-                        if (!p || p->get(curReg))
-                           cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getS390RealRegister(REGNUM(curReg)), rsa, cursor);
-                        localStackDisp += cg()->machine()->getGPRSize();
-                        rsa = generateS390MemoryReference(spReg, localStackDisp, cg());
-                        curReg++;
-                        }
-                     }
-                  else
-                     cursor = cg()->saveOrRestoreRegisters(p, cursor, true); // true for saves
-                  }
-               }
+            cursor = generateRSInstruction(cg(), TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getS390RealRegister(firstUsedReg), getS390RealRegister(lastUsedReg), rsa, cursor);
             }
          else
             {
@@ -1675,8 +1493,7 @@ TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
 
    static const char *disableRARestoreOpt = feGetEnv("TR_DisableRAOpt");
 
-   // Any one of these conditions will force us to restore RA - unless shrinkwrapping determined we have
-   // restored it already.
+   // Any one of these conditions will force us to restore RA
    bool restoreRA = disableRARestoreOpt                                                                  ||
                     !(performTransformation(comp(), "O^O No need to restore RAREG in epilog\n")) ||
                     getS390RealRegister(getReturnAddressRegister())->getHasBeenAssignedInMethod()                       ||
@@ -1721,42 +1538,7 @@ TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
       {
       if (firstUsedReg != lastUsedReg)
          {
-         TR_BitVector *p = cg()->getPreservedRegsInPrologue();
-         static char * lmThreshold = feGetEnv("TR_LMThreshold");
-         if (!p && !lmThreshold)
-            {
-            cursor = restorePreservedRegs(firstUsedReg, lastUsedReg, blockNumber, cursor, nextNode, spReg, rsa, getStackPointerRegister());
-            }
-         else
-            {
-            int32_t numUsedRegs = lastUsedReg - firstUsedReg + 1;
-            int8_t threshold = lmThreshold ? atoi(lmThreshold) : -1;
-            TR_ASSERT( threshold > -2, "Can't use a value smaller than -1 for LMThreshold\n");
-            if (!p && (threshold == -1 || (threshold > 0 && numUsedRegs >= threshold))) // use LM
-               {
-               cursor = generateRSInstruction(cg(), TR::InstOpCode::getLoadMultipleOpCode(), nextNode,
-                  getS390RealRegister(firstUsedReg), getS390RealRegister(lastUsedReg), rsa, cursor);
-               }
-            else //otherwise break it all down
-               {
-               if (comp()->getOption(TR_DisableShrinkWrapping))
-                  {
-                  int32_t numToIsolate = numUsedRegs;
-                  int32_t curReg = firstUsedReg;
-                  int32_t localStackDisp = getOffsetToRegSaveArea();
-                  for (int32_t i = 0; i < numToIsolate; i++)
-                     {
-                     if (!p || p->get(curReg))
-                        cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getS390RealRegister(REGNUM(curReg)), rsa, cursor);
-                     localStackDisp += cg()->machine()->getGPRSize();
-                     rsa = generateS390MemoryReference(spReg, localStackDisp, cg());
-                     curReg++;
-                     }
-                  }
-               else
-                  cursor = cg()->saveOrRestoreRegisters(p, cursor, false); // false for restores
-               }
-            }
+         cursor = restorePreservedRegs(firstUsedReg, lastUsedReg, blockNumber, cursor, nextNode, spReg, rsa, getStackPointerRegister());
          }
       else
          {

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
@@ -43,9 +43,6 @@ class S390PrivateLinkage : public TR::Linkage
 
    TR::RealRegister::RegNum _methodMetaDataRegister;
 
-   int32_t _registerSaveSize;
-   int32_t *_mapRegsToStack;
-
 public:
 
    S390PrivateLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaPrivate, TR_LinkageConventions lc=TR_Private);
@@ -90,17 +87,8 @@ public:
    virtual TR::RealRegister::RegNum getSystemStackPointerRegister(){ return cg()->getLinkage(TR_System)->getStackPointerRegister(); }
    virtual TR::RealRegister *getSystemStackPointerRealRegister() {return getS390RealRegister(getSystemStackPointerRegister());}
 
-   virtual bool mapPreservedRegistersToStackOffsets(int32_t *mapRegsToStack, int32_t &numPreserved, TR_BitVector *&);
-   virtual int32_t getRegisterSaveSize() { return _registerSaveSize; }
-   void setRegisterSaveSize(int32_t v) { _registerSaveSize = v; }
-   int32_t getStackOffsetForReg(int32_t regIndex) { return _mapRegsToStack[regIndex]; }
-   void setStackOffsetForReg(int32_t regIndex, int32_t offset) { _mapRegsToStack[regIndex] = offset; }
    virtual int32_t setupLiteralPoolRegister(TR::Snippet *firstSnippet);
-
-   virtual TR::Instruction *savePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
-   virtual TR::Instruction *restorePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset);
-   virtual TR::Instruction *composeSavesRestores(TR::Instruction *start, int32_t firstReg, int32_t lastReg, int32_t offset, int32_t numRegs, bool doSaves);
-
+   
    //called by buildNativeDispatch
    virtual void setupRegisterDepForLinkage(TR::Node *, TR_DispatchType, TR::RegisterDependencyConditions * &, int64_t &, TR::SystemLinkage *, TR::Node * &, bool &, TR::Register **, TR::Register *&);
    virtual void setupBuildArgForLinkage(TR::Node *, TR_DispatchType, TR::RegisterDependencyConditions *, bool, bool, int64_t &, TR::Node *, bool, TR::SystemLinkage *);


### PR DESCRIPTION
ShrinkWrapping is currently disabled on all platforms due to functional
issues. It has been disabled for several years and it's benefit is
questionable at best given the compile time costs.

This commit folds away some code related to ShrinkWrapping so as to not
cause build breaks when the optimization is removed from OMR. There
will be a subsequent "Part II" PR which will remove all the rest of the
code which is dependent on OMR.

Issue: https://github.com/eclipse/omr/issues/2107

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>