### PR TITLE
Deprecate ShrinkWrapping - Part II

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -215,12 +215,9 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/ReachingDefinitions.cpp \
     omr/compiler/optimizer/RedundantAsyncCheckRemoval.cpp \
     omr/compiler/optimizer/RegDepCopyRemoval.cpp \
-    omr/compiler/optimizer/RegisterAnticipatability.cpp \
-    omr/compiler/optimizer/RegisterAvailability.cpp \
     omr/compiler/optimizer/RegisterCandidate.cpp \
     omr/compiler/optimizer/RematTools.cpp \
     omr/compiler/optimizer/ReorderIndexExpr.cpp \
-    omr/compiler/optimizer/ShrinkWrapping.cpp \
     omr/compiler/optimizer/SinkStores.cpp \
     omr/compiler/optimizer/StripMiner.cpp \
     omr/compiler/optimizer/StructuralAnalysis.cpp \


### PR DESCRIPTION
This is a continuation of "Part I". It is to be merged once both "Part
I" and the corresponding OMR "Part I" PRs have been merged. It simply
removes some empty files from the build list.

Issue: https://github.com/eclipse/omr/issues/2107

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>