### PR TITLE
Add a new OMR compiler file to the list of removed files

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -111,6 +111,7 @@ set(REMOVED_OMR_FILES
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineRegister.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineRegisterInStruct.cpp
 	${omr_SOURCE_DIR}/compiler/ilgen/OMRVirtualMachineState.cpp
 )
 


### PR DESCRIPTION
https://github.com/eclipse/omr/pull/2915 adds a new file in the compiler
directory that should be ignored by OpenJ9. This commit adds the file
to the list of removed OMR files.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>