### PR TITLE
Modify the path to libjava to include "../" 

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -407,7 +407,8 @@ jstring getEncoding(JNIEnv *env, jint encodingType)
 			{
 				UDATA handle = 0;
 				PORT_ACCESS_FROM_ENV(env);
-				if (0 == j9sl_open_shared_library("java", &handle, J9PORT_SLOPEN_DECORATE)) {
+				/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
+				if (0 == j9sl_open_shared_library("../java", &handle, J9PORT_SLOPEN_DECORATE)) {
 					void (*nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
 					if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
 						/* invoke JCL native to initialize platform encoding explicitly */


### PR DESCRIPTION
Mac OSX build requires this to initialize correctly when building JDK11.
The directory layout for a JDK11 build is jdk/lib/[compressedrefs|default].
Since the library doing the lookup is in the compressedrefs or default
directory, using ../java to lookup libjava is the correct path.

issue: #36

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>