### PR TITLE
Apply FilePermCompat.newPermPlusAltPath to limited privileged permission

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -28,6 +28,9 @@ import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+/*[IF Sidecar19-SE-OpenJ9]*/
+import sun.security.util.FilePermCompat;
+/*[ENDIF] Sidecar19-SE-OpenJ9*/
 
 /**
  * An AccessControlContext encapsulates the information which is needed
@@ -582,6 +585,9 @@ static boolean checkPermWithCachedPermImplied(Permission perm, Permission[] perm
 					}
 				}
 			}
+			/*[IF Sidecar19-SE-OpenJ9]*/
+			permsLimited[j] = FilePermCompat.newPermPlusAltPath(permsLimited[j]);
+			/*[ENDIF] Sidecar19-SE-OpenJ9*/
 			if (!notImplied && permsLimited[j].implies(perm)) {
 				success = true; // just implied
 				if (null != cacheChecked) {


### PR DESCRIPTION
Apply `FilePermCompat.newPermPlusAltPath` to limited privileged permission

Apply `FilePermCompat.newPermPlusAltPath` to limited privileged permission before checking incoming permission to ensure `FilePermission` compatibility after [JDK-8164705](https://bugs.java.com/view_bug.do?bug_id=JDK-8164705).

Verified manually that the test suite `JTReg test: sun/security/util/FilePermCompat/CompatImpact.java` now passes. (#3104 fixed a specific sub-test within this test suite)

For what it's worth, following is a standalone testcase after digging deep into the regression test suite:

Test code `main` with default permission (i.e., without required security permission)
```
public static void main(String[] args) {
  CodebaseWithPerm.runWithPerm();
}
```
Code with `java.security.AllPermission`
```
public class CodebaseWithPerm {
	public static void runWithPerm() {
		AccessController.doPrivileged((PrivilegedAction<Boolean>)
			() -> new File("xxx").exists(),
			null,
			new FilePermission("/team/jasonf/tbd/xxx", "read"));
	}
}
```
Not adding this to the automated test since it is already included in the regression test suite.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>