### PR TITLE
Implement vector String.indexOf(String)

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -568,6 +568,97 @@ public final class JITHelpers {
 		}
 	}
 
+	/**
+	 * Searches in the source character array for the index of the target character array.
+	 * Both arrays must be Latin1 arrays consisting of compressible characters ranging from \u0000 to \u00FF.
+	 * The source and target character arrays have their lengths specified. The search for the array starts
+	 * at the specified offset and moves towards the end of source array.
+	 * 
+	 * @param s1Value
+	 * 		 	the source character array to serach in
+	 * @param s1len
+	 * 		    the length of the source array
+	 * @param s2Value
+	 * 			the target character array to search for
+	 * @param s2len
+	 * 			the length of the target array
+	 * @param start
+	 * 			the starting offset
+	 * 
+	 * @return the index of the target array inside the source array, or -1 if the target array is not found
+	 * */
+	public int intrinsicIndexOfStringLatin1(char[] s1Value, int s1len, char[] s2Value, int s2len, int start) {
+		char firstChar = byteToCharUnsigned(getByteFromArrayByIndex(s2Value, 0));
+
+		while (true) {
+			int i = -1;
+			if (start < s1len) {
+				i = intrinsicIndexOfLatin1(s1Value, (byte)firstChar, start, s1len);
+			}
+						
+			// Handles subCount > count || start >= count
+			if (i == -1 || s2len + i > s1len) {
+				return -1;
+			}
+
+			int o1 = i;
+			int o2 = 0;
+
+			while (++o2 < s2len && getByteFromArrayByIndex(s1Value, ++o1) == getByteFromArrayByIndex(s2Value, o2))
+				;
+
+			if (o2 == s2len) {
+				return i;
+			}
+
+			start = i + 1;
+		}
+	}
+	
+	/**
+	 * Searches in the source character array for the index of the target character array.
+	 * Both arrays consisting of UTF16 characters.
+	 * The source and target character arrays have their lengths specified. The search for the array starts
+	 * at the specified offset and moves towards the end of source array.
+	 * 
+	 * @param s1Value
+	 * 		 	the source character array to serach in
+	 * @param s1len
+	 * 		    the length of the source array
+	 * @param s2Value
+	 * 			the target character array to search for
+	 * @param s2len
+	 * 			the length of the target array
+	 * @param start
+	 * 			the starting offset
+	 * 
+	 * @return the index of the target array inside the source array, or -1 if the target array is not found
+	 * */
+	public int intrinsicIndexOfStringUTF16(char[] s1Value, int s1len, char[] s2Value, int s2len, int start) {
+		char firstChar = s2Value[0];
+
+		while (true) {
+			int i = intrinsicIndexOfUTF16(s1Value, firstChar, start, s1len);
+			
+			// Handles subCount > count || start >= count
+			if ((i == -1) || (s2len + i > s1len)) {
+				return -1;
+			}
+
+			int o1 = i;
+			int o2 = 0;
+
+			while ((++o2 < s2len) && (s1Value[++o1] == s2Value[o2]))
+				;
+
+			if (o2 == s2len) {
+				return i;
+			}
+
+			start = i + 1;
+		}
+	}
+	
 	public int intrinsicIndexOfLatin1(Object array, byte ch, int offset, int length) {
 		for (int i = offset; i < length; i++) {
 			if(getByteFromArrayByIndex(array, i) == ch) {

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -2011,6 +2011,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @see #lastIndexOf(String, int)
 	 */
 	public int indexOf(String subString, int start) {
+		if (subString.length() == 1) {
+			return indexOf(subString.charAtInternal(0), start);
+		}
+		
 		return indexOf(value, coder, lengthInternal(), subString, start);
 	}
 
@@ -6013,6 +6017,10 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 * @see #lastIndexOf(String, int)
 	 */
 	public int indexOf(String subString, int start) {
+		if (subString.length() == 1) {
+			return indexOf(subString.charAtInternal(0), start);
+		}
+		
 		if (start < 0) {
 			start = 0;
 		}
@@ -6032,29 +6040,13 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 			char[] s2Value = s2.value;
 
 			if (enableCompression && (null == compressionFlag || (s1.count | s2.count) >= 0)) {
-				char firstChar = helpers.byteToCharUnsigned(helpers.getByteFromArrayByIndex(s2Value, 0));
-
-				while (true) {
-					int i = indexOf(firstChar, start);
-
-					// Handles subCount > count || start >= count
-					if (i == -1 || s2len + i > s1len) {
-						return -1;
-					}
-
-					int o1 = i;
-					int o2 = 0;
-
-					while (++o2 < s2len && helpers.getByteFromArrayByIndex(s1Value, ++o1) == helpers.getByteFromArrayByIndex(s2Value, o2))
-						;
-
-					if (o2 == s2len) {
-						return i;
-					}
-
-					start = i + 1;
-				}
+				// both s1 and s2 are compressed
+				return helpers.intrinsicIndexOfStringLatin1(s1Value, s1len, s2Value, s2len, start);
+			} else if (s1.count < 0 && s2.count < 0) {
+				// both s1 and s2 are decompressed
+				return helpers.intrinsicIndexOfStringUTF16(s1Value, s1len, s2Value, s2len, start);
 			} else {
+				// s1 decompressed and s2 compressed
 				char firstChar = s2.charAtInternal(0, s2Value);
 
 				while (true) {

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -199,7 +199,10 @@
    java_lang_String_getChars_charArray,
    java_lang_String_getChars_byteArray,
 
+   java_lang_StringLatin1_indexOf,
+
    java_lang_StringUTF16_getChar,
+   java_lang_StringUTF16_indexOf,
    java_lang_StringUTF16_toBytes,
 
    java_lang_StringBuffer_append,
@@ -672,6 +675,8 @@
 
    com_ibm_jit_JITHelpers_is32Bit,
    com_ibm_jit_JITHelpers_isArray,
+   com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1,
+   com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16,
    com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1,
    com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16,
    com_ibm_jit_JITHelpers_getJ9ClassFromObject32,

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3114,6 +3114,10 @@ bool TR_J9VMBase::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, 
                dontInlineRecognizedMethod = true;
                }
             break;
+         case TR::java_lang_StringLatin1_indexOf:
+         case TR::java_lang_StringUTF16_indexOf:
+         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
+         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
             if (comp->cg()->getSupportsInlineStringIndexOf())

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3384,6 +3384,8 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       {
       {x(TR::com_ibm_jit_JITHelpers_is32Bit,                                  "is32Bit", "()Z")},
       {x(TR::com_ibm_jit_JITHelpers_isArray,                                  "isArray", "(Ljava/lang/Object;)Z")},
+      {x(TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1,             "intrinsicIndexOfStringLatin1", "([CI[CII)I")},
+      {x(TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16,              "intrinsicIndexOfStringUTF16", "([CI[CII)I")},
       {x(TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1,                   "intrinsicIndexOfLatin1", "(Ljava/lang/Object;BII)I")},
       {x(TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16,                    "intrinsicIndexOfUTF16", "(Ljava/lang/Object;CII)I")},
 #ifdef TR_TARGET_32BIT
@@ -3477,10 +3479,17 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       { TR::unknownMethod}
       };
 
+   static X StringLatin1Methods[] =
+      {
+      { x(TR::java_lang_StringLatin1_indexOf,                                 "indexOf",       "([BI[BII)I")},
+      { TR::unknownMethod }
+      };
+
    static X StringUTF16Methods[] =
       {
-      { x(TR::java_lang_StringUTF16_getChar,                                  "getChar", "([BI)C")},
-      { x(TR::java_lang_StringUTF16_toBytes,                                  "toBytes", "([CII)[B")},
+      { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",        "([BI)C")},
+      { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",        "([BI[BII)I")},
+      { x(TR::java_lang_StringUTF16_toBytes,                                  "toBytes",        "([CII)[B")},
       { TR::unknownMethod }
       };
 
@@ -4331,6 +4340,7 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
       { "java/text/NumberFormat", NumberFormatMethods },
       { "com/ibm/jit/JITHelpers", JITHelperMethods},
       { "java/lang/StringCoding", StringCodingMethods },
+      { "java/lang/StringLatin1", StringLatin1Methods },
       { 0 }
       };
 

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1909,7 +1909,33 @@
 			<subset>11</subset>
 		</subsets>
 	</test>
-
+	<test>
+		<testCaseName>testStringIndexOfString</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>'-Xjit:disableAsyncCompilation,tryToInline={java/lang/String.indexOf*},limit={org/openj9/test/string/StringIndexOfString.doTest*},{org/openj9/test/string/StringIndexOfString.doTest*}(count=50)'</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames testStringIndexOfString \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>9</subset>
+			<subset>10</subset>
+			<subset>11</subset>
+		</subsets>
+	</test>
+	
 	<test>
 		<testCaseName>floatSanityTests</testCaseName>
 		<variations>

--- a/test/functional/Java8andUp/src/org/openj9/test/string/StringIndexOfString.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/string/StringIndexOfString.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.string;
+
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import java.lang.reflect.Field;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
+/**
+ * Designed to test SIMD accelerated String.indexOf(String) on platforms such as
+ * z/Architecture. The vector register size is assumed to be 16 bytes.
+ */
+@Test(groups = { "level.sanity" })
+public class StringIndexOfString {
+
+	public static final Logger logger = Logger.getLogger(StringIndexOfString.class);
+
+	public static String shortString200Char = "Canada ic *a zzthe xxwwthi xx country located in ...zzthe xxwwthi xx northern part of North Americann. Its ten provinces and three territories extend from the Atlantic to the e xxwwthi xx northern part of North America. Its te Pacific and northward into the Arctic Ocean, covering 9.98 million square kilometres (3.85 million square miles), making it the world's second-largest country by total area. \";\r\n";
+	private static final int NUM_TEST_CASE = 19;
+	private static final int VECTOR_SIZE = 16;
+
+	private static String searchString;
+	private static String[] inputStrings;
+	private static int[] expectedResults;
+
+	/**
+	 * Initialize an array of sub-strings with different offsets and alignments.
+	 */
+	static {
+		searchString = shortString200Char;
+		inputStrings = new String[NUM_TEST_CASE];
+		expectedResults = new int[NUM_TEST_CASE];
+
+		int subStringByteIndex = 0;
+		int subStringByteLen = (VECTOR_SIZE - 4);;
+
+		for (int testCaseNum = 1; testCaseNum <= NUM_TEST_CASE; ++testCaseNum) {
+			switch (testCaseNum) {
+			case 1:
+				// sub-string head is 16B aligned, and its length < VECTOR_SIZE.
+				subStringByteIndex = 0;
+				subStringByteLen = (VECTOR_SIZE - 4);
+				break;
+			case 2:
+				// sub-string head is not 16B aligned, and its length < VECTOR_SIZE.
+				subStringByteIndex = 2;
+				subStringByteLen = (VECTOR_SIZE - 6);
+				break;
+			case 3:
+				// sub-string head not 16B aligned but is aligned at the end. s2Len < vector
+				// size.
+				subStringByteIndex = 4;
+				subStringByteLen = (VECTOR_SIZE - 4);
+				break;
+			case 4:
+				// sub-sting head is not 16B aligned, and its length < VECTOR_SIZE, and crosses
+				// a 16B boundary.
+				subStringByteIndex = 8;
+				subStringByteLen = (VECTOR_SIZE - 4);
+				break;
+			case 5:
+				// sub-string head is 16B aligned at the second 16B boundary. Its length <
+				// VECTOR_SIZE.
+				subStringByteIndex = VECTOR_SIZE;
+				subStringByteLen = (VECTOR_SIZE - 2);
+				break;
+			case 6:
+				// sub-string head and tail are not alighed to 16B bounary. Its length <
+				// VECTOR_SIZE.
+				subStringByteIndex = (VECTOR_SIZE + 2);
+				subStringByteLen = (VECTOR_SIZE - 4);
+				break;
+			case 7:
+				// This case has 1st-char-collision (1st char of sub-string appears multiple 
+				// times before the sub-string index).
+				// sub-string crosses the 4th 16B boundary. sub-string length <= VECTOR_SIZE.
+				subStringByteIndex = (VECTOR_SIZE * 3 + 12);
+				subStringByteLen = (VECTOR_SIZE);
+				break;
+			case 8:
+				// Similar to case 6. The whole sub-string is between the 5th and 6th 16B
+				// boundary.
+				subStringByteIndex = (VECTOR_SIZE * 4 + 18);
+				subStringByteLen = (VECTOR_SIZE - 4);
+				break;
+			case 9:
+				// sub-string head aligned to byte 0 of source string. Length = VECTOR_SIZE
+				subStringByteIndex = 0;
+				subStringByteLen = VECTOR_SIZE;
+				break;
+			case 10:
+				// sub-string head aligned to byte 0 of source string. Length = VECTOR_SIZE +
+				// 1-char
+				subStringByteIndex = 0;
+				subStringByteLen = (VECTOR_SIZE + 2);
+				break;
+			case 11:
+				// sub-string head aligned to byte 0 of source string. Length = VECTOR_SIZE x 2
+				subStringByteIndex = 0;
+				subStringByteLen = VECTOR_SIZE * 2;
+				break;
+			case 12:
+				// sub-string head aligned to byte 0 of source string. Length = VECTOR_SIZE x 2 +
+				// 4B
+				subStringByteIndex = 0;
+				subStringByteLen = VECTOR_SIZE * 2 + 4;
+				break;
+
+			case 13:
+				// 1st char collision
+				// Sub-string is 3*VECTOR_SIZE long, spanning bettween the 4th and 7th 16B
+				// boundary.
+				subStringByteIndex = VECTOR_SIZE * 3;
+				subStringByteLen = VECTOR_SIZE * 3;
+				break;
+			case 14:
+				// s2 header collision.
+				// sub-string length > 3*VECTOR_SIZE long, starting from the 8th boundary and
+				// goes slightly pass the 11th boundary.
+				subStringByteIndex = (VECTOR_SIZE * 7);
+				subStringByteLen = (VECTOR_SIZE * 3 + 6);
+				break;
+			case 15:
+				// s2 header collision.
+				// Sub-string length > 6*VECTOR_SIZE long; its head and tail are not aligned to
+				// boundaries.
+				subStringByteIndex = (VECTOR_SIZE * 7 + 8);
+				subStringByteLen = (VECTOR_SIZE * 6 + 6);
+				break;
+			case 16:
+				// s2 header match but body mismatch.
+				subStringByteIndex = 350;
+				subStringByteLen = 102;
+				break;
+			case 17:
+				// Same as case 16, Sub-string to be modified.
+				// Test case for string not found. Mismatch at the beginning.
+				subStringByteIndex = 350;
+				subStringByteLen = 102;
+				break;
+			case 18:
+				// Same as case 15, sub-string to be modified.
+				// Test case for string not found. Mismatch in the middle.
+				subStringByteIndex = (VECTOR_SIZE * 7 + 8);
+				subStringByteLen = (VECTOR_SIZE * 6 + 6);
+				break;
+			case 19:
+				// Same as case 15, sub-string to be modified.
+				// Test case for string not found. mismatch at the end
+				subStringByteIndex = (VECTOR_SIZE * 7 + 8);
+				subStringByteLen = (VECTOR_SIZE * 6 + 6);
+				break;
+			default:
+				AssertJUnit.assertTrue("Unexpected testcase number in test initialization", false);
+			}
+
+			subStringByteIndex /= 2;
+			subStringByteLen /= 2;
+
+			String subString = searchString.substring(subStringByteIndex, subStringByteIndex + subStringByteLen);
+			int expectedResult = subStringByteIndex;
+
+			if (testCaseNum == 17) {
+				subString = "::" + subString;
+				expectedResult = -1;
+			} else if (testCaseNum == 18) {
+				int splicePoint = (int) (subString.length() * 0.6);
+				String sub1 = subString.substring(0, splicePoint - 1);
+				String sub2 = subString.substring(splicePoint + 2, subString.length() - 1);
+				subString = sub1 + "::" + sub2;
+				expectedResult = -1;
+			} else if (testCaseNum == 19) {
+				subString += "::";
+				expectedResult = -1;
+			}
+
+			expectedResults[testCaseNum - 1] = expectedResult;
+			inputStrings[testCaseNum - 1] = subString;
+		}
+	}
+
+	@Test
+	public void testStringIndexOfString() {
+		// Warm up loop
+		for (int iter = 0; iter < 10; iter++) {
+			for (int testcaseNum = 1; testcaseNum <= NUM_TEST_CASE; ++testcaseNum) {
+				doTest(testcaseNum, inputStrings[testcaseNum - 1], false);
+			}
+		}
+
+		for (int testcaseNum = 1; testcaseNum <= NUM_TEST_CASE; ++testcaseNum) {
+			doTest(testcaseNum, inputStrings[testcaseNum - 1], true);
+		}
+	}
+
+	private void doTest(int testcase, String x, boolean checkResult) {
+
+		int index = searchString.indexOf(x);
+
+		if (checkResult) {
+			AssertJUnit.assertEquals("compare indexOf() result to expected result", index,
+					expectedResults[testcase - 1]);
+		}
+
+		return;
+	}
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -406,6 +406,11 @@
 			<class name="org.openj9.test.string.StringInterning" />
 		</classes>
 	</test>
+	<test name="testStringIndexOfString">
+		<classes>
+			<class name="org.openj9.test.string.StringIndexOfString" />
+		</classes>
+	</test>
 	<test name="floatSanityTests">
 		<classes>
 			<class name="org.openj9.test.floatsanity.TestFactory" />


### PR DESCRIPTION
Implement the String.indexOf(String) intrinsic for Java 8 and Java 9 JCL
for z13 and z14. This is able to detect the intrinsic methods and inline
them with a vector assembly sequence to accelerate indexOf(String) search.

For Java 8 JCL, refactor Java 8 indexOf(String) APIs and introduce
JITHelper intrinsic functions. These new JITHelper APIs will be recognized
as intrinsic and inlined with the aforementioned vector sequence.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>