### PR TITLE
fix invalid assertion check in test

### DIFF
--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementFactory.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestManagementFactory.java
@@ -833,7 +833,7 @@ public class TestManagementFactory {
 			MemoryUsage directUsage = realBean.getCollectionUsage();
 			validateMemoryUsage(proxyUsage);
 			validateMemoryUsage(directUsage);
-			AssertJUnit.assertEquals(directUsage, proxyUsage);
+			/* directUsage and proxyUsage could be different, if gc happened between getCollectionUsage() calls*/
 
 			if (realBean.isCollectionUsageThresholdSupported()) {
 				AssertJUnit.assertEquals(realBean.getCollectionUsageThreshold(), proxy.getCollectionUsageThreshold());


### PR DESCRIPTION
	- collection Usage of the same memoryPool might be different
	between getCollectionUsage() calls.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>