### PR TITLE
Enable building openssl on AIX

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -164,7 +164,7 @@ aix_ppc-64_cmprssptrs:
       11: 'hw.arch.ppc && sw.os.aix'
       next: 'hw.arch.ppc && sw.os.aix'
   extra_configure_options:
-    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8'
+    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8 --with-openssl=fetched --enable-openssl-bundling'
     9: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     10: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     11: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'


### PR DESCRIPTION
Reverts part of #3171 to enable AIX.
Previous problem was fixed by the merge of
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/124

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>