### PR TITLE
Add support for atomic symbol reduction for Z

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -138,11 +138,17 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
    switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
       {
       case TR::sun_misc_Unsafe_getAndAddInt:
+         return !comp()->getOption(TR_DisableUnsafe) && !comp()->compileRelocatableCode() && !TR::Compiler->om.canGenerateArraylets() && 
+            cg()->supportsNonHelper(TR::SymbolReferenceTable::atomicFetchAndAddSymbol);
       case TR::sun_misc_Unsafe_getAndSetInt:
-         return TR::Compiler->target.cpu.isX86() && !comp()->getOption(TR_DisableUnsafe) && !comp()->compileRelocatableCode() && !TR::Compiler->om.canGenerateArraylets();
+         return !comp()->getOption(TR_DisableUnsafe) && !comp()->compileRelocatableCode() && !TR::Compiler->om.canGenerateArraylets() && 
+            cg()->supportsNonHelper(TR::SymbolReferenceTable::atomicSwapSymbol);
       case TR::sun_misc_Unsafe_getAndAddLong:
+         return !comp()->getOption(TR_DisableUnsafe) && !comp()->compileRelocatableCode() && !TR::Compiler->om.canGenerateArraylets() && TR::Compiler->target.is64Bit() && 
+            cg()->supportsNonHelper(TR::SymbolReferenceTable::atomicFetchAndAddSymbol);
       case TR::sun_misc_Unsafe_getAndSetLong:
-         return TR::Compiler->target.cpu.isX86() && !comp()->getOption(TR_DisableUnsafe) && !comp()->compileRelocatableCode() && TR::Compiler->target.is64Bit() && !TR::Compiler->om.canGenerateArraylets();
+         return !comp()->getOption(TR_DisableUnsafe) && !comp()->compileRelocatableCode() && !TR::Compiler->om.canGenerateArraylets() && TR::Compiler->target.is64Bit() && 
+            cg()->supportsNonHelper(TR::SymbolReferenceTable::atomicSwapSymbol);
       case TR::java_lang_Class_isAssignableFrom:
          return cg()->supportsInliningOfIsAssignableFrom();
       case TR::java_lang_Integer_rotateLeft:
@@ -170,16 +176,12 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop* treetop)
    switch(node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
       {
       case TR::sun_misc_Unsafe_getAndAddInt:
-         processUnsafeAtomicCall(treetop, node, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol);
+      case TR::sun_misc_Unsafe_getAndAddLong:
+         processUnsafeAtomicCall(treetop, node, TR::SymbolReferenceTable::atomicFetchAndAddSymbol);
          break;
       case TR::sun_misc_Unsafe_getAndSetInt:
-         processUnsafeAtomicCall(treetop, node, TR::SymbolReferenceTable::atomicSwap32BitSymbol);
-         break;
-      case TR::sun_misc_Unsafe_getAndAddLong:
-         processUnsafeAtomicCall(treetop, node, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol);
-         break;
       case TR::sun_misc_Unsafe_getAndSetLong:
-         processUnsafeAtomicCall(treetop, node, TR::SymbolReferenceTable::atomicSwap64BitSymbol);
+         processUnsafeAtomicCall(treetop, node, TR::SymbolReferenceTable::atomicSwapSymbol);
          break;
       case TR::java_lang_Class_isAssignableFrom:
          process_java_lang_Class_IsAssignableFrom(treetop, node);


### PR DESCRIPTION
In addition we make use of the new `supportsNonHelper` API defined at
the OMR level to remove platform checks in the common code generator
and delegate the question to the platform specific code generators as
to whether we support inlining of a particular intrinsic.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>