### PR TITLE
Add Java11 JPP tag to ConstantDynamic methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -812,11 +812,6 @@ public abstract class MethodHandle {
 	 */
 	private static final native MethodHandle getCPMethodHandleAt(Object internalRamClass, int index);
 
-	/*
-	 * sun.reflect.ConstantPool doesn't have a getConstantDynamicAt method.  This is the 
-	 * equivalent for ConstantDynamic.
-	 */
-	private static final native Object getCPConstantDynamicAt(Object internalRamClass, int index);
 	
 	/**
 	 * Get the class name from a constant pool class element, which is located
@@ -840,6 +835,13 @@ public abstract class MethodHandle {
 	private static final int BSM_NAME_ARGUMENT_INDEX = 1;
 	private static final int BSM_TYPE_ARGUMENT_INDEX = 2;
 	private static final int BSM_OPTIONAL_ARGUMENTS_START_INDEX = 3;
+	
+/*[IF Java11]*/
+	/*
+	 * sun.reflect.ConstantPool doesn't have a getConstantDynamicAt method.  This is the 
+	 * equivalent for ConstantDynamic.
+	 */
+	private static final native Object getCPConstantDynamicAt(Object internalRamClass, int index);
 
 	@SuppressWarnings("unused")
 	private static final Object resolveConstantDynamic(long j9class, String name, String fieldDescriptor, long bsmData) throws Throwable {
@@ -1000,6 +1002,7 @@ public abstract class MethodHandle {
 		
 		return result;
 	}
+/*[ENDIF] Java11*/
 
 	@SuppressWarnings("unused")
 	private static final MethodHandle resolveInvokeDynamic(long j9class, String name, String methodDescriptor, long bsmData) throws Throwable {
@@ -1108,9 +1111,11 @@ public abstract class MethodHandle {
 				case 14:
 					cpEntry = getCPMethodHandleAt(internalRamClass, index);
 					break;
+/*[IF Java11]*/
 				case 17:
 					cpEntry = getCPConstantDynamicAt(internalRamClass, index);
 					break;
+/*[ENDIF] Java11*/
 				default:
 					// Do nothing. The null check below will throw the appropriate exception.
 				}


### PR DESCRIPTION
Add `Java11 JPP` tag to `ConstantDynamic` methods

`ConstantDynamic` methods are only available for `Java 11`

Verified manually that `pConfig Java 8/9/1011/12` still compile.
Note: also noticed that there are significant code duplication between `resolveConstantDynamic` and `resolveInvokeDynamic`, leave refactoring to another PR instead.

closes: #2986 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>