### PR TITLE
CopyForwardHybrid

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -632,6 +632,11 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 
 			continue;
 		}
+		if (try_scan(&scan_start, "tarokEnableCopyForwardMarkCompactHybrid")) {
+			extensions->tarokEnableCopyForwardHybrid = true;
+			continue;
+		}
+
 #endif /* defined (J9VM_GC_VLHGC) */
 
 		if(try_scan(&scan_start, "packetListLockSplit=")) {
@@ -1121,6 +1126,20 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 		if (try_scan(&scan_start, "fvtest_forceReferenceChainWalkerMarkMapCommitFailure")) {
 			extensions->fvtest_forceReferenceChainWalkerMarkMapCommitFailure = 1;
 			extensions->fvtest_forceReferenceChainWalkerMarkMapCommitFailureCounter = 0;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "fvtest_forceCopyForwardHybridMarkCompactRatio=")) {
+			/* the percentage of the collectionSet regions would like to markCompact instead of copyForward */
+			if(!scan_udata_helper(vm, &scan_start, &(extensions->fvtest_forceCopyForwardHybridRatio), "fvtest_forceCopyForwardHybridMarkCompactRatio=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			if ((extensions->fvtest_forceCopyForwardHybridRatio < 1) || (100 < extensions->fvtest_forceCopyForwardHybridRatio)) {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTIONS_INTEGER_OUT_OF_RANGE, "fvtest_forceCopyForwardHybridMarkCompactRatio=", (UDATA)1, (UDATA)100);
+				returnValue = JNI_EINVAL;
+				break;
+			}
 			continue;
 		}
 

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -400,7 +400,7 @@ MM_VerboseHandlerOutputVLHGC::handleCopyForwardEnd(J9HookInterface** hook, UDATA
 				copyForwardStats->_copyObjectsNonEden, copyForwardStats->_copyBytesNonEden, copyForwardStats->_copyDiscardBytesNonEden);
 	writer->formatAndOutput(env, 1, "<memory-cardclean objects=\"%zu\" bytes=\"%zu\" />",
 				copyForwardStats->_objectsCardClean, copyForwardStats->_bytesCardClean);
-	if(copyForwardStats->_aborted) {
+	if(copyForwardStats->_aborted || (0 != copyForwardStats->_nonEvacuateRegionCount)) {
 		writer->formatAndOutput(env, 1, "<memory-traced type=\"eden\" objects=\"%zu\" bytes=\"%zu\" />",
 					copyForwardStats->_scanObjectsEden, copyForwardStats->_scanBytesEden);
 		writer->formatAndOutput(env, 1, "<memory-traced type=\"other\" objects=\"%zu\" bytes=\"%zu\" />",
@@ -425,6 +425,9 @@ MM_VerboseHandlerOutputVLHGC::handleCopyForwardEnd(J9HookInterface** hook, UDATA
 	
 	if(copyForwardStats->_scanCacheOverflow) {
 		writer->formatAndOutput(env, 1, "<warning details=\"scan cache overflow (storage acquired from heap)\" />");
+	}
+	if (0 != copyForwardStats->_nonEvacuateRegionCount) {
+		writer->formatAndOutput(env, 1, "<warning details=\"running under hybrid mode, JNI Critical region count=%zu\" />", copyForwardStats->_nonEvacuateRegionCount);
 	}
 	if(copyForwardStats->_aborted) {
 		writer->formatAndOutput(env, 1, "<warning details=\"operation aborted due to insufficient free space\" />");

--- a/runtime/gc_vlhgc/CollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/CollectionSetDelegate.cpp
@@ -164,7 +164,10 @@ MM_CollectionSetDelegate::createNurseryCollectionSet(MM_EnvironmentVLHGC *env)
 			bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 			bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
 
-			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions)) {
+			/* For CopyForwardHybrid mode we allow eden regions, which has jniCritical,to be part of nursery collectionSet, those regions would be marked instead of copyforwarded.
+			 * Would not add any non Eden regions with jniCritical to collectionSet for copyforward
+			 * For Non CopyForwardHybrid mode we do not check Eden regions with jniCritical here, because we have already set MarkCompact PGC mode for the case in early. */
+			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && region->isEden()))) {
 				if(MM_CompactGroupManager::isRegionInNursery(env, region)) {
 					UDATA compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
 					/* on collection phase, mark all non-overflowed regions and those that RSCL is not being rebuilt */
@@ -459,6 +462,7 @@ MM_CollectionSetDelegate::deleteRegionCollectionSetForPartialGC(MM_EnvironmentVL
 
 		region->_markData._shouldMark = false;
 		region->_reclaimData._shouldReclaim = false;
+		region->_markData._noEvacuation = false;
 	}
 }
 

--- a/runtime/gc_vlhgc/CopyForwardDelegate.hpp
+++ b/runtime/gc_vlhgc/CopyForwardDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,6 +104,18 @@ public:
 	 * @return the estimated number of bytes which will survive 
 	 */
 	UDATA estimateRequiredSurvivorBytes(MM_EnvironmentVLHGC *env);
+
+	/**
+	 * Return true if the copyForward is running under Hybrid mode
+	 */
+	bool isHybrid(MM_EnvironmentVLHGC *env)
+	{
+		bool ret = false;
+		if (NULL != _breadthFirstCopyForwardScheme) {
+			ret = _breadthFirstCopyForwardScheme->isHybrid(env);
+		}
+		return ret;
+	}
 };
 
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -308,12 +308,15 @@ MM_CopyForwardScheme::MM_CopyForwardScheme(MM_EnvironmentVLHGC *env, MM_HeapRegi
 	, _scanCacheListSize(_extensions->_numaManager.getMaximumNodeNumber() + 1)
 	, _scanCacheWaitCount(0)
 	, _scanCacheMonitor(NULL)
+	, _workQueueWaitCountPtr(&_scanCacheWaitCount)
+	, _workQueueMonitorPtr(&_scanCacheMonitor)
 	, _doneIndex(0)
 	, _markMap(NULL)
 	, _heapBase(NULL)
 	, _heapTop(NULL)
 	, _abortFlag(false)
 	, _abortInProgress(false)
+	, _regionCountCannotBeEvacuated(0)
 	, _cacheLineAlignment(0)
 	, _clearableProcessingStarted(false)
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
@@ -520,16 +523,16 @@ MM_CopyForwardScheme::raiseAbortFlag(MM_EnvironmentVLHGC *env)
 {
 	if (!_abortFlag) {
 		bool didSetFlag = false;
-		omrthread_monitor_enter(_scanCacheMonitor);
+		omrthread_monitor_enter(*_workQueueMonitorPtr);
 		if (!_abortFlag) {
 			_abortFlag = true;
 			didSetFlag = true;
 			/* if any threads are waiting, notify them so that they can get out of the monitor since nobody else is going to push work for them */
-			if (0 != _scanCacheWaitCount) {
-				omrthread_monitor_notify_all(_scanCacheMonitor);
+			if (0 != *_workQueueWaitCountPtr) {
+				omrthread_monitor_notify_all(*_workQueueMonitorPtr);
 			}
 		}
-		omrthread_monitor_exit(_scanCacheMonitor);
+		omrthread_monitor_exit(*_workQueueMonitorPtr);
 
 		if (didSetFlag) {
 			env->_copyForwardStats._aborted = true;
@@ -598,12 +601,15 @@ MM_CopyForwardScheme::preProcessRegions(MM_EnvironmentVLHGC *env)
 
 	UDATA ownableSynchronizerCandidates = 0;
 	UDATA ownableSynchronizerCountInEden = 0;
-	
+
+	_regionCountCannotBeEvacuated = 0;
+
 	while(NULL != (region = regionIterator.nextRegion())) {
 		region->_copyForwardData._survivorBase = NULL;
 
 		if(region->containsObjects()) {
 			region->_copyForwardData._initialLiveSet = true;
+			region->_copyForwardData._evacuateSet = region->_markData._shouldMark;
 			if (region->_markData._shouldMark) {
 				region->getUnfinalizedObjectList()->startUnfinalizedProcessing();
 				ownableSynchronizerCandidates += region->getOwnableSynchronizerObjectList()->getObjectCount();
@@ -612,9 +618,14 @@ MM_CopyForwardScheme::preProcessRegions(MM_EnvironmentVLHGC *env)
 				}
 				region->getOwnableSynchronizerObjectList()->startOwnableSynchronizerProcessing();
 				Assert_MM_true(region->getRememberedSetCardList()->isAccurate());
-				Assert_MM_true(0 == region->_criticalRegionsInUse);
+				if ((region->_criticalRegionsInUse > 0) || (randomDecideForceNonEvacuatedRegion(_extensions->fvtest_forceCopyForwardHybridRatio))) {
+					/* set the region is noEvacation for copyforward collector */
+					region->_markData._noEvacuation = true;
+					_regionCountCannotBeEvacuated += 1;
+				} else {
+					region->_markData._noEvacuation = false;
+				}
 			}
-			region->_copyForwardData._evacuateSet = region->_markData._shouldMark;
 		} else {
 			region->_copyForwardData._evacuateSet = false;
 		}
@@ -694,7 +705,7 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 
 		if (region->_copyForwardData._evacuateSet) {
 			Assert_MM_true(region->_sweepData._alreadySwept);
-			if (abortFlagRaised()) {
+			if (abortFlagRaised() || region->_markData._noEvacuation) {
 				if (region->getRegionType() == MM_HeapRegionDescriptor::BUMP_ALLOCATED) {
 					region->setRegionType(MM_HeapRegionDescriptor::BUMP_ALLOCATED_MARKED);
 				} else {
@@ -714,6 +725,7 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 	}
 
 	env->_cycleState->_pgcData._survivorSetRegionCount = survivorSetRegionCount;
+	static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats._nonEvacuateRegionCount = _regionCountCannotBeEvacuated;
 }
 
 /****************************************
@@ -1747,6 +1759,11 @@ MM_CopyForwardScheme::copyForwardCollectionSet(MM_EnvironmentVLHGC *env)
 	/* Perform any pre copy forwarding changes to the region set */
 	preProcessRegions(env);
 
+	if (0 != _regionCountCannotBeEvacuated) {
+		/* need to run Hybrid mode, reuse InputListMonitor for both workPackets and ScanCopyCache */
+		_workQueueMonitorPtr = env->_cycleState->_workPackets->getInputListMonitorPtr();
+		_workQueueWaitCountPtr = env->_cycleState->_workPackets->getInputListWaitCountPtr();
+	}
 	/* Perform any master-specific setup */
 	masterSetupForCopyForward(env);
 
@@ -1772,6 +1789,11 @@ MM_CopyForwardScheme::copyForwardCollectionSet(MM_EnvironmentVLHGC *env)
 	if(_extensions->tarokEnableExpensiveAssertions) {
 		/* Verify the result of the copy forward operation (heap integrity, etc) */
 		verifyCopyForwardResult(MM_EnvironmentVLHGC::getEnvironment(env));
+	}
+
+	if (0 != _regionCountCannotBeEvacuated) {
+		_workQueueMonitorPtr = &_scanCacheMonitor;
+		_workQueueWaitCountPtr = &_scanCacheWaitCount;
 	}
 
 	/* Do any final work to regions in order to release them back to the master collector implementation */
@@ -1825,11 +1847,11 @@ MM_CopyForwardScheme::getFreeCache(MM_EnvironmentVLHGC *env)
 		}
 	}
 	/* Overflow or abort was hit so alert other threads that are waiting */
-	omrthread_monitor_enter(_scanCacheMonitor);
-	if(0 != _scanCacheWaitCount) {
-		omrthread_monitor_notify(_scanCacheMonitor);
+	omrthread_monitor_enter(*_workQueueMonitorPtr);
+	if(0 != *_workQueueWaitCountPtr) {
+		omrthread_monitor_notify(*_workQueueMonitorPtr);
 	}
-	omrthread_monitor_exit(_scanCacheMonitor);
+	omrthread_monitor_exit(*_workQueueMonitorPtr);
 	return cache;
 }
 
@@ -1844,11 +1866,11 @@ MM_CopyForwardScheme::addCacheEntryToScanCacheListAndNotify(MM_EnvironmentVLHGC 
 {
 	UDATA numaNode = _regionManager->tableDescriptorForAddress(newCacheEntry->scanCurrent)->getNumaNode();
 	_cacheScanLists[numaNode].pushCache(env, newCacheEntry);
-	if (0 != _scanCacheWaitCount) {
+	if (0 != *_workQueueWaitCountPtr) {
 		/* Added an entry to the scan list - notify any other threads that a new entry has appeared on the list */
-		omrthread_monitor_enter(_scanCacheMonitor);
-		omrthread_monitor_notify(_scanCacheMonitor);
-		omrthread_monitor_exit(_scanCacheMonitor);
+		omrthread_monitor_enter(*_workQueueMonitorPtr);
+		omrthread_monitor_notify(*_workQueueMonitorPtr);
+		omrthread_monitor_exit(*_workQueueMonitorPtr);
 	}
 }
 
@@ -2011,8 +2033,13 @@ MM_CopyForwardScheme::copy(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *
 	UDATA objectCopySizeInBytes = 0;
 	UDATA objectReserveSizeInBytes = 0;
 
-	if (_abortInProgress) {
-		/* Once threads agreed that abort is in progress, only mark/push should be happening, no attempts even to allocate/copy */
+	bool noEvacuation = false;
+	if (0 != _regionCountCannotBeEvacuated) {
+		noEvacuation = isObjectInNoEvacuationRegions(env, object);
+	}
+
+	if (_abortInProgress || noEvacuation) {
+		/* Once threads agreed that abort is in progress or the object is in noEvacation region, only mark/push should be happening, no attempts even to allocate/copy */
 
 		if (_markMap->atomicSetBit(object)) {
 			Assert_MM_false(MM_ScavengerForwardedHeader(object).isForwardedPointer());
@@ -2461,7 +2488,12 @@ MM_CopyForwardScheme::createNextSplitArrayWorkUnit(MM_EnvironmentVLHGC *env, J9I
 			UDATA nextIndex = startIndex + slotsToScan;
 			Assert_MM_true(nextIndex < sizeInElements);
 
-			if (_abortInProgress) {
+			bool noEvacuation = false;
+			if (0 != _regionCountCannotBeEvacuated) {
+				noEvacuation = isObjectInNoEvacuationRegions(env, (J9Object *) arrayPtr);
+			}
+
+			if (_abortInProgress || noEvacuation) {
 				if (!currentSplitUnitOnly) {
 					/* work stack driven */
 					env->_workStack.push(env, (void *)arrayPtr, (void *)((nextIndex << PACKET_ARRAY_SPLIT_SHIFT) | PACKET_ARRAY_SPLIT_TAG));
@@ -2661,6 +2693,12 @@ MM_CopyForwardScheme::isAnyScanCacheWorkAvailable()
 	return result;
 }
 
+bool
+MM_CopyForwardScheme::isAnyScanWorkAvailable(MM_EnvironmentVLHGC *env)
+{
+	return (isAnyScanCacheWorkAvailable() || ((0 != _regionCountCannotBeEvacuated) && !_abortInProgress && !abortFlagRaised() && env->_workStack.inputPacketAvailableFromWorkPackets(env)));
+}
+
 MM_CopyScanCacheVLHGC *
 MM_CopyForwardScheme::getSurvivorCacheForScan(MM_EnvironmentVLHGC *env)
 {
@@ -2676,66 +2714,54 @@ MM_CopyForwardScheme::getSurvivorCacheForScan(MM_EnvironmentVLHGC *env)
 	return NULL;
 }
 
-MM_CopyScanCacheVLHGC *
-MM_CopyForwardScheme::getNextScanCache(MM_EnvironmentVLHGC *env, UDATA preferredNumaNode)
+MM_CopyForwardScheme::ScanReason
+MM_CopyForwardScheme::getNextWorkUnit(MM_EnvironmentVLHGC *env, UDATA preferredNumaNode)
 {
+	env->_scanCache = NULL;
+	ScanReason ret = SCAN_REASON_NONE;
+
 	MM_CopyScanCacheVLHGC *cache = NULL;
 	/* Preference is to use survivor copy cache */
 	if(NULL != (cache = getSurvivorCacheForScan(env))) {
-		return cache;
+		env->_scanCache = cache;
+		ret = SCAN_REASON_COPYSCANCACHE;
+		return ret;
 	}
 
 	if (NULL != env->_deferredScanCache) {
 		/* there is deferred scanning to do from partial depth first scanning */
 		cache = (MM_CopyScanCacheVLHGC *)env->_deferredScanCache;
 		env->_deferredScanCache = NULL;
-		return cache;
+		env->_scanCache = cache;
+		ret = SCAN_REASON_COPYSCANCACHE;
+		return ret;
 	}
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	env->_copyForwardStats._acquireScanListCount += 1;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
-	UDATA nodeLists = _scanCacheListSize;
 	bool doneFlag = false;
 	volatile UDATA doneIndex = _doneIndex;
-	
-	while ((NULL == cache) && !doneFlag) {
-		/* local node first */
-		cache = getNextScanCacheOnNode(env, preferredNumaNode);
-		if (NULL == cache) {
-			/* we failed to find a scan cache on our preferred node */
-			if (COMMON_CONTEXT_INDEX != preferredNumaNode) {
-				/* try the common node */
-				cache = getNextScanCacheOnNode(env, COMMON_CONTEXT_INDEX);
-			}
-			/* now try the remaining nodes */
-			UDATA nextNode = (preferredNumaNode + 1) % nodeLists;
-			while ((NULL == cache) && (nextNode != preferredNumaNode)) {
-				if (COMMON_CONTEXT_INDEX != nextNode) {
-					cache = getNextScanCacheOnNode(env, nextNode);
-				}
-				nextNode = (nextNode + 1) % nodeLists;
-			}
-		}
 
-		if (NULL == cache) {
-			omrthread_monitor_enter(_scanCacheMonitor);
-			_scanCacheWaitCount += 1;
+	while ((SCAN_REASON_NONE == ret) && !doneFlag) {
+		if (SCAN_REASON_NONE == (ret = getNextWorkUnitNoWait(env, preferredNumaNode))) {
+			omrthread_monitor_enter(*_workQueueMonitorPtr);
+			*_workQueueWaitCountPtr += 1;
 
 			if(doneIndex == _doneIndex) {
-				if((_scanCacheWaitCount == env->_currentTask->getThreadCount()) && !isAnyScanCacheWorkAvailable()) {
-					_scanCacheWaitCount = 0;
+				if((*_workQueueWaitCountPtr == env->_currentTask->getThreadCount()) && !isAnyScanWorkAvailable(env)) {
+					*_workQueueWaitCountPtr = 0;
 					_doneIndex += 1;
-					omrthread_monitor_notify_all(_scanCacheMonitor);
+					omrthread_monitor_notify_all(*_workQueueMonitorPtr);
 				} else {
-					while(!isAnyScanCacheWorkAvailable() && (doneIndex == _doneIndex)) {
+					while(!isAnyScanWorkAvailable(env) && (doneIndex == _doneIndex)) {
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 						PORT_ACCESS_FROM_ENVIRONMENT(env);
 						U_64 waitEndTime, waitStartTime;
 						waitStartTime = j9time_hires_clock();
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-						omrthread_monitor_wait(_scanCacheMonitor);
+						omrthread_monitor_wait(*_workQueueMonitorPtr);
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 						waitEndTime = j9time_hires_clock();
 						if (doneIndex == _doneIndex) {
@@ -2751,31 +2777,65 @@ MM_CopyForwardScheme::getNextScanCache(MM_EnvironmentVLHGC *env, UDATA preferred
 			/* Set the local done flag and if we are done and the waiting count is 0 (last thread) exit */
 			doneFlag = (doneIndex != _doneIndex);
 			if (!doneFlag) {
-				_scanCacheWaitCount -= 1;
+				*_workQueueWaitCountPtr -= 1;
 			}
-			omrthread_monitor_exit(_scanCacheMonitor);
+			omrthread_monitor_exit(*_workQueueMonitorPtr);
 		}
 	}
 
-	return cache;
+	return ret;
 }
 
-MM_CopyScanCacheVLHGC *
-MM_CopyForwardScheme::getNextScanCacheOnNode(MM_EnvironmentVLHGC *env, UDATA numaNode)
+MM_CopyForwardScheme::ScanReason
+MM_CopyForwardScheme::getNextWorkUnitOnNode(MM_EnvironmentVLHGC *env, UDATA numaNode)
 {
+	ScanReason ret = SCAN_REASON_NONE;
+
 	MM_CopyScanCacheVLHGC *cache = _cacheScanLists[numaNode].popCache(env);
 	if(NULL != cache) {
 		/* Check if there are threads waiting that should be notified because of pending entries */
-		if((0 != _scanCacheWaitCount) && isScanCacheWorkAvailable(&_cacheScanLists[numaNode])) {
-			omrthread_monitor_enter(_scanCacheMonitor);
-			if(0 != _scanCacheWaitCount) {
-				omrthread_monitor_notify(_scanCacheMonitor);
+		if((0 != *_workQueueWaitCountPtr) && isScanCacheWorkAvailable(&_cacheScanLists[numaNode])) {
+			omrthread_monitor_enter(*_workQueueMonitorPtr);
+			if(0 != *_workQueueWaitCountPtr) {
+				omrthread_monitor_notify(*_workQueueMonitorPtr);
 			}
-			omrthread_monitor_exit(_scanCacheMonitor);
+			omrthread_monitor_exit(*_workQueueMonitorPtr);
 		}
+		env->_scanCache = cache;
+		ret = SCAN_REASON_COPYSCANCACHE;
 	}
 
-	return cache;
+	return ret;
+}
+
+MM_CopyForwardScheme::ScanReason
+MM_CopyForwardScheme::getNextWorkUnitNoWait(MM_EnvironmentVLHGC *env, UDATA preferredNumaNode)
+{
+	UDATA nodeLists = _scanCacheListSize;
+	ScanReason ret = SCAN_REASON_NONE;
+	/* local node first */
+	ret = getNextWorkUnitOnNode(env, preferredNumaNode);
+	if (SCAN_REASON_NONE == ret) {
+		/* we failed to find a scan cache on our preferred node */
+		if (COMMON_CONTEXT_INDEX != preferredNumaNode) {
+			/* try the common node */
+			ret = getNextWorkUnitOnNode(env, COMMON_CONTEXT_INDEX);
+		}
+		/* now try the remaining nodes */
+		UDATA nextNode = (preferredNumaNode + 1) % nodeLists;
+		while ((SCAN_REASON_NONE == ret) && (nextNode != preferredNumaNode)) {
+			if (COMMON_CONTEXT_INDEX != nextNode) {
+				ret = getNextWorkUnitOnNode(env, nextNode);
+			}
+			nextNode = (nextNode + 1) % nodeLists;
+		}
+	}
+	if (SCAN_REASON_NONE == ret && (0 != _regionCountCannotBeEvacuated) && !_abortInProgress && !abortFlagRaised()) {
+		if (env->_workStack.retrieveInputPacket(env)) {
+			ret = SCAN_REASON_PACKET;
+		}
+	}
+	return ret;
 }
 
 /**
@@ -2842,7 +2902,7 @@ MM_CopyForwardScheme::aliasToCopyCache(MM_EnvironmentVLHGC *env, MM_CopyScanCach
 	 * it aliases it's survivor cache then it will be the only thread able to consume.  This will alleviate the stalling issues
 	 * described in the above mentioned design.
 	 */
-	if (0 == _scanCacheWaitCount) {
+	if (0 == *_workQueueWaitCountPtr) {
 		interruptScanning = bestCacheForScanning(env->_survivorCopyScanCache, nextScanCache) || interruptScanning;
 	}
 #endif /* 0 */
@@ -2890,7 +2950,12 @@ MM_CopyForwardScheme::scanObject(MM_EnvironmentVLHGC *env, MM_AllocationContextT
 MMINLINE void
 MM_CopyForwardScheme::updateScanStats(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason)
 {
-	if (_abortInProgress && isObjectInEvacuateMemory(objectPtr)) {
+	bool noEvacuation = false;
+	if (0 != _regionCountCannotBeEvacuated) {
+		noEvacuation = isObjectInNoEvacuationRegions(env, objectPtr);
+	}
+
+	if ((_abortInProgress || noEvacuation) && isObjectInEvacuateMemory(objectPtr)) {
 		UDATA objectSize = _extensions->objectModel.getSizeInBytesWithHeader(objectPtr);
 		Assert_MM_false(SCAN_REASON_DIRTY_CARD == reason);
 		MM_HeapRegionDescriptorVLHGC * region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(objectPtr);
@@ -2924,8 +2989,13 @@ MM_CopyForwardScheme::scanPointerArrayObjectSlots(MM_EnvironmentVLHGC *env, MM_A
 {
 	UDATA index = 0;
 	bool currentSplitUnitOnly = false;
+
+	bool noEvacuation = false;
+	if (0 != _regionCountCannotBeEvacuated) {
+		noEvacuation = isObjectInNoEvacuationRegions(env, (J9Object *) arrayPtr);
+	}
 	
-	if (_abortInProgress) {
+	if (_abortInProgress || noEvacuation) {
 		UDATA peekValue = (UDATA)env->_workStack.peek(env);
 		if ((PACKET_ARRAY_SPLIT_TAG == (peekValue & PACKET_ARRAY_SPLIT_TAG))) {
 			UDATA workItem = (UDATA)env->_workStack.pop(env);
@@ -2977,6 +3047,7 @@ MM_CopyForwardScheme::completeScanCache(MM_EnvironmentVLHGC *env)
 				scanObject(env, reservingContext, objectPtr, SCAN_REASON_COPYSCANCACHE);
 			}
 		} while(scanCache->isScanWorkAvailable());
+
 	}
 	/* mark cache as no longer in use for scanning */
 	scanCache->clearCurrentlyBeingScanned();
@@ -3224,6 +3295,17 @@ MM_CopyForwardScheme::cleanRegion(MM_EnvironmentVLHGC *env, MM_HeapRegionDescrip
 }
 
 bool
+MM_CopyForwardScheme::isWorkPacketsOverflow(MM_EnvironmentVLHGC *env)
+{
+	MM_WorkPackets *packets = (MM_WorkPackets *)(env->_cycleState->_workPackets);
+	bool result = false;
+	if (packets->getOverflowFlag()) {
+		result = true;
+	}
+	return result;
+}
+
+bool
 MM_CopyForwardScheme::handleOverflow(MM_EnvironmentVLHGC *env)
 {
 	MM_WorkPackets *packets = (MM_WorkPackets *)(env->_cycleState->_workPackets);
@@ -3272,30 +3354,48 @@ MM_CopyForwardScheme::completeScanForAbort(MM_EnvironmentVLHGC *env)
 }
 
 void
+MM_CopyForwardScheme::completeScanWorkPacket(MM_EnvironmentVLHGC *env)
+{
+	MM_AllocationContextTarok *reservingContext = _commonContext;
+	J9Object *objectPtr = NULL;
+
+	while (NULL != (objectPtr = (J9Object *)env->_workStack.popNoWaitFromCurrentInputPacket(env))) {
+		Assert_MM_false(MM_ScavengerForwardedHeader(objectPtr).isForwardedPointer());
+		scanObject(env, reservingContext, objectPtr, SCAN_REASON_PACKET);
+	}
+}
+
+void
 MM_CopyForwardScheme::completeScan(MM_EnvironmentVLHGC *env)
 {
 	UDATA nodeOfThread = 0;
+
 	/* if we aren't using NUMA, we don't want to check the thread affinity since we will have only one list of scan caches */
 	if (_extensions->_numaManager.isPhysicalNUMASupported()) {
 		nodeOfThread = env->getNumaAffinity();
 		Assert_MM_true(nodeOfThread <= _extensions->_numaManager.getMaximumNodeNumber());
 	}
-	while((env->_scanCache = getNextScanCache(env, nodeOfThread)) != NULL) {
-		Assert_MM_true(env->_scanCache->cacheBase <= env->_scanCache->cacheAlloc);
-		Assert_MM_true(env->_scanCache->cacheAlloc <= env->_scanCache->cacheTop);
-		Assert_MM_true(env->_scanCache->scanCurrent <= env->_scanCache->cacheAlloc);
+	ScanReason scanReason = SCAN_REASON_NONE;
+	while(SCAN_REASON_NONE != (scanReason = getNextWorkUnit(env, nodeOfThread))) {
+		if (SCAN_REASON_COPYSCANCACHE == scanReason) {
+			Assert_MM_true(env->_scanCache->cacheBase <= env->_scanCache->cacheAlloc);
+			Assert_MM_true(env->_scanCache->cacheAlloc <= env->_scanCache->cacheTop);
+			Assert_MM_true(env->_scanCache->scanCurrent <= env->_scanCache->cacheAlloc);
 
-		switch (_extensions->scavengerScanOrdering) {
-		case MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST:
-			completeScanCache(env);
-			break;
-		case MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL:
-			incrementalScanCacheBySlot(env);
-			break;
-		default:
-			Assert_MM_unreachable();
-			break;
-		} /* end of switch on type of scan order */
+			switch (_extensions->scavengerScanOrdering) {
+			case MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST:
+				completeScanCache(env);
+				break;
+			case MM_GCExtensions::OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL:
+				incrementalScanCacheBySlot(env);
+				break;
+			default:
+				Assert_MM_unreachable();
+				break;
+			} /* end of switch on type of scan order */
+		} else if (SCAN_REASON_PACKET == scanReason) {
+			completeScanWorkPacket(env);
+		}
 	}
 
 	/* flush Mark Map caches before we start draining Work Stack (in case of Abort) */
@@ -3303,6 +3403,10 @@ MM_CopyForwardScheme::completeScan(MM_EnvironmentVLHGC *env)
 
 	if (((MM_CopyForwardSchemeTask*)env->_currentTask)->synchronizeGCThreadsAndReleaseMasterForAbort(env, UNIQUE_ID)) {
 		if (abortFlagRaised()) {
+			_abortInProgress = true;
+		}
+		/* using abort case to handle work packets overflow during copyforwardHybrid */
+		if (!_abortInProgress && (0 != _regionCountCannotBeEvacuated) && isWorkPacketsOverflow(env)) {
 			_abortInProgress = true;
 		}
 		env->_currentTask->releaseSynchronizedGCThreads(env);
@@ -3350,7 +3454,6 @@ MM_CopyForwardScheme::scanUnfinalizedObjects(MM_EnvironmentVLHGC *env)
 					J9Object* forwardedPtr = forwardedHeader.getForwardedObject();
 					if (NULL == forwardedPtr) {
 						if (_markMap->isBitSet(pointer)) {
-							Assert_MM_true(_abortInProgress);
 							forwardedPtr = pointer;
 						} else {
 							Assert_MM_mustBeClass(forwardedHeader.getPreservedClass());
@@ -3495,7 +3598,7 @@ MM_CopyForwardScheme::updateOrDeleteObjectsFromExternalCycle(MM_EnvironmentVLHGC
 				Assert_MM_false(region->isSurvivorRegion());
 				Assert_MM_true(region->containsObjects());
 
-				if(abortFlagRaised()) {
+				if(abortFlagRaised() || region->_markData._noEvacuation) {
 					/* Walk the mark map range for the region and fixing mark bits to be the subset of the current mark map.
 					 * (Those bits that are cleared have been moved and their bits are already set).
 					 */
@@ -3962,7 +4065,7 @@ MM_CopyForwardScheme::clearCardTableForPartialCollect(MM_EnvironmentVLHGC *env)
 		GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 		MM_CardTable *cardTable = _extensions->cardTable;
 		while(NULL != (region = regionIterator.nextRegion())) {
-			if (region->_copyForwardData._evacuateSet) {
+			if (region->_copyForwardData._evacuateSet && !region->_markData._noEvacuation) {
 				if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
 					void *low = region->getLowAddress();
 					void *bumpPointer = ((MM_MemoryPoolBumpPointer *)region->getMemoryPool())->getAllocationPointer();
@@ -4284,7 +4387,7 @@ private:
 		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(_env);
 
 		J9Object *objectPtr = *slotPtr;
-		if(!_copyForwardScheme->_abortInProgress && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
+		if(!_copyForwardScheme->_abortInProgress && !_copyForwardScheme->isObjectInNoEvacuationRegions(env, objectPtr) && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "Root slot points into evacuate!  Slot %p dstObj %p. RootScannerEntity=%zu\n", slotPtr, objectPtr, (UDATA)_scanningEntity);
 			Assert_MM_unreachable();
@@ -4343,7 +4446,7 @@ private:
 	virtual void doUnfinalizedObject(J9Object *objectPtr, MM_UnfinalizedObjectList *list) {
 		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(_env);
 
-		if(!_copyForwardScheme->_abortInProgress && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
+		if(!_copyForwardScheme->_abortInProgress && !_copyForwardScheme->isObjectInNoEvacuationRegions(env, objectPtr) && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "Unfinalized object list points into evacuate!  list %p object %p\n", list, objectPtr);
 			Assert_MM_unreachable();
@@ -4355,7 +4458,7 @@ private:
 	virtual void doFinalizableObject(j9object_t objectPtr) {
 		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(_env);
 
-		if(!_copyForwardScheme->_abortInProgress && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
+		if(!_copyForwardScheme->_abortInProgress && !_copyForwardScheme->isObjectInNoEvacuationRegions(env, objectPtr) && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "Finalizable object in evacuate!  object %p\n", objectPtr);
 			Assert_MM_unreachable();
@@ -4366,7 +4469,7 @@ private:
 	virtual void doOwnableSynchronizerObject(J9Object *objectPtr, MM_OwnableSynchronizerObjectList *list) {
 		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(_env);
 
-		if(!_copyForwardScheme->_abortInProgress && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
+		if(!_copyForwardScheme->_abortInProgress && !_copyForwardScheme->isObjectInNoEvacuationRegions(env, objectPtr) && _copyForwardScheme->verifyIsPointerInEvacute(env, objectPtr)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "OwnableSynchronizer object list points into evacuate!  list %p object %p\n", list, objectPtr);
 			Assert_MM_unreachable();
@@ -4497,7 +4600,7 @@ MM_CopyForwardScheme::verifyMixedObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 
 	while (NULL != (slotObject = mixedObjectIterator.nextSlot())) {
 		J9Object *dstObject = slotObject->readReferenceFromSlot();
-		if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+		if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "Mixed object slot points to evacuate!  srcObj %p slot %p dstObj %p\n", objectPtr, slotObject->readAddressFromSlot(), dstObject);
 			verifyDumpObjectDetails(env, "srcObj", objectPtr);
@@ -4519,7 +4622,7 @@ MM_CopyForwardScheme::verifyReferenceObjectSlots(MM_EnvironmentVLHGC *env, J9Obj
 {
 	fj9object_t referentToken = J9GC_J9VMJAVALANGREFERENCE_REFERENT(env, objectPtr);
 	J9Object* referentPtr = _extensions->accessBarrier->convertPointerFromToken(referentToken);
-	if(!_abortInProgress && verifyIsPointerInEvacute(env, referentPtr)) {
+	if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, referentPtr) && verifyIsPointerInEvacute(env, referentPtr)) {
 		PORT_ACCESS_FROM_ENVIRONMENT(env);
 		j9tty_printf(PORTLIB, "RefMixed referent slot points to evacuate!  srcObj %p dstObj %p\n", objectPtr, referentPtr);
 		Assert_MM_unreachable();
@@ -4537,7 +4640,7 @@ MM_CopyForwardScheme::verifyReferenceObjectSlots(MM_EnvironmentVLHGC *env, J9Obj
 
 	while (NULL != (slotObject = mixedObjectIterator.nextSlot())) {
 		J9Object *dstObject = slotObject->readReferenceFromSlot();
-		if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+		if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "RefMixed object slot points to evacuate!  srcObj %p slot %p dstObj %p\n", objectPtr, slotObject->readAddressFromSlot(), dstObject);
 			Assert_MM_unreachable();
@@ -4560,7 +4663,7 @@ MM_CopyForwardScheme::verifyPointerArrayObjectSlots(MM_EnvironmentVLHGC *env, J9
 
 	while((slotObject = pointerArrayIterator.nextSlot()) != NULL) {
 		J9Object *dstObject = slotObject->readReferenceFromSlot();
-		if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+		if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 			PORT_ACCESS_FROM_ENVIRONMENT(env);
 			j9tty_printf(PORTLIB, "Pointer array slot points to evacuate!  srcObj %p slot %p dstObj %p\n", objectPtr, slotObject->readAddressFromSlot(), dstObject);
 			Assert_MM_unreachable();
@@ -4592,7 +4695,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 			GC_ClassStaticsIterator classStaticsIterator(env, classPtr);
 			while(NULL != (slotPtr = classStaticsIterator.nextSlot())) {
 				J9Object *dstObject = *slotPtr;
-				if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+				if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 					PORT_ACCESS_FROM_ENVIRONMENT(env);
 					j9tty_printf(PORTLIB, "Class static slot points to evacuate!  srcObj %p J9Class %p slot %p dstObj %p\n", classObject, classPtr, slotPtr, dstObject);
 					Assert_MM_unreachable();
@@ -4612,7 +4715,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 			GC_CallSitesIterator callSitesIterator(classPtr);
 			while(NULL != (slotPtr = callSitesIterator.nextSlot())) {
 				J9Object *dstObject = *slotPtr;
-				if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+				if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 					PORT_ACCESS_FROM_ENVIRONMENT(env);
 					j9tty_printf(PORTLIB, "Class call site slot points to evacuate!  srcObj %p J9Class %p slot %p dstObj %p\n", classObject, classPtr, slotPtr, dstObject);
 					Assert_MM_unreachable();
@@ -4632,7 +4735,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 			GC_MethodTypesIterator methodTypesIterator(classPtr->romClass->methodTypeCount, classPtr->methodTypes);
 			while(NULL != (slotPtr = methodTypesIterator.nextSlot())) {
 				J9Object *dstObject = *slotPtr;
-				if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+				if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 					PORT_ACCESS_FROM_ENVIRONMENT(env);
 					j9tty_printf(PORTLIB, "Class MethodType slot points to evacuate!  srcObj %p J9Class %p slot %p dstObj %p\n", classObject, classPtr, slotPtr, dstObject);
 					Assert_MM_unreachable();
@@ -4652,7 +4755,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 			GC_MethodTypesIterator varHandleMethodTypesIterator(classPtr->romClass->varHandleMethodTypeCount, classPtr->varHandleMethodTypes);
 			while(NULL != (slotPtr = varHandleMethodTypesIterator.nextSlot())) {
 				J9Object *dstObject = *slotPtr;
-				if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+				if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 					PORT_ACCESS_FROM_ENVIRONMENT(env);
 					j9tty_printf(PORTLIB, "Class MethodType slot points to evacuate!  srcObj %p J9Class %p slot %p dstObj %p\n", classObject, classPtr, slotPtr, dstObject);
 					Assert_MM_unreachable();
@@ -4675,7 +4778,7 @@ MM_CopyForwardScheme::verifyClassObjectSlots(MM_EnvironmentVLHGC *env, J9Object 
 			GC_ConstantPoolObjectSlotIterator constantPoolIterator(_javaVM, classPtr);
 			while(NULL != (slotPtr = constantPoolIterator.nextSlot())) {
 				J9Object *dstObject = *slotPtr;
-				if(!_abortInProgress && verifyIsPointerInEvacute(env, dstObject)) {
+				if(!_abortInProgress && !isObjectInNoEvacuationRegions(env, dstObject) && verifyIsPointerInEvacute(env, dstObject)) {
 					PORT_ACCESS_FROM_ENVIRONMENT(env);
 					j9tty_printf(PORTLIB, "Class CP slot points to evacuate!  srcObj %p J9Class %p slot %p dstObj %p\n", classObject, classPtr, slotPtr, dstObject);
 					Assert_MM_unreachable();
@@ -4706,12 +4809,12 @@ MM_CopyForwardScheme::verifyClassLoaderObjectSlots(MM_EnvironmentVLHGC *env, J9O
 		GC_ClassLoaderClassesIterator iterator(_extensions, classLoader);
 		J9Class *clazz = NULL;
 		while (NULL != (clazz = iterator.nextClass())) {
-			if(!_abortInProgress && verifyIsPointerInEvacute(env, (J9Object *)clazz->classObject)) {
+			if (!_abortInProgress && !isObjectInNoEvacuationRegions(env, (J9Object *)clazz->classObject) && verifyIsPointerInEvacute(env, (J9Object *)clazz->classObject)) {
 				PORT_ACCESS_FROM_ENVIRONMENT(env);
 				j9tty_printf(PORTLIB, "Class loader table class object points to evacuate!  srcObj %p clazz %p clazzObj %p\n", classLoaderObject, clazz, clazz->classObject);
 				Assert_MM_unreachable();
 			}
-			if((NULL != clazz->classObject) && !_markMap->isBitSet((J9Object *)clazz->classObject)) {
+			if ((NULL != clazz->classObject) && !_markMap->isBitSet((J9Object *)clazz->classObject)) {
 				PORT_ACCESS_FROM_ENVIRONMENT(env);
 				j9tty_printf(PORTLIB, "Class loader table class object points to unmarked object!  srcObj %p clazz %p clazzObj %p\n", classLoaderObject, clazz, clazz->classObject);
 				verifyDumpObjectDetails(env, "classLoaderObject", classLoaderObject);
@@ -4738,7 +4841,7 @@ MM_CopyForwardScheme::verifyExternalState(MM_EnvironmentVLHGC *env)
 			if(region->_markData._shouldMark) {
 				Assert_MM_true(region->_copyForwardData._initialLiveSet);
 
-				if(_abortInProgress) {
+				if(_abortInProgress || region->_markData._noEvacuation) {
 					MM_HeapMapIterator mapIterator(_extensions, externalMarkMap, (UDATA *)region->getLowAddress(), (UDATA *)region->getHighAddress(), false);
 					J9Object *objectPtr = NULL;
 
@@ -4782,7 +4885,7 @@ MM_CopyForwardScheme::verifyExternalState(MM_EnvironmentVLHGC *env)
 				J9Object *object = *slot;
 				Assert_MM_true(NULL != object);
 				if (PACKET_INVALID_OBJECT != (UDATA)object) {
-					Assert_MM_false(!_abortInProgress && verifyIsPointerInEvacute(env, object));
+					Assert_MM_false(!_abortInProgress && !isObjectInNoEvacuationRegions(env, object) && verifyIsPointerInEvacute(env, object));
 					Assert_MM_true(!verifyIsPointerInSurvivor(env, object) || (_markMap->isBitSet(object) && externalMarkMap->isBitSet(object)));
 				}
 			}
@@ -5320,3 +5423,23 @@ MM_CopyForwardScheme::setAllocationAgeForMergedRegion(MM_EnvironmentVLHGC* env, 
 	region->setAllocationAgeSizeProduct(0.0);
 
 }
+
+bool
+MM_CopyForwardScheme::isObjectInNoEvacuationRegions(MM_EnvironmentVLHGC *env, J9Object *objectPtr)
+{
+	if ((NULL == objectPtr) || (0 == _regionCountCannotBeEvacuated)) {
+		return false;
+	}
+	MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(objectPtr);
+	return region->_markData._noEvacuation;
+}
+
+bool
+MM_CopyForwardScheme::randomDecideForceNonEvacuatedRegion(UDATA ratio) {
+	bool ret = false;
+	if ((0 < ratio) && (ratio <= 100)) {
+		ret = ((UDATA)(rand() % 100) <= (UDATA)(ratio - 1));
+	}
+	return ret;
+}
+

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,6 +70,7 @@ MM_HeapRegionDescriptorVLHGC::initialize(MM_EnvironmentBase *env, MM_HeapRegionM
 	}
 
 	_markData._shouldMark = false;
+	_markData._noEvacuation = false;
 	_markData._dynamicMarkCost = 0;
 	_markData._overflowFlags = 0x0;
 	_reclaimData._shouldReclaim = false;

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,7 @@ public:
 	};
 	struct {
 		bool _shouldMark;	/**< true if the collector is to mark this region during the collection cycle */
+		bool _noEvacuation; /**< true if the region is set that do not copyforward, it is valid if _shouldMark is true. */
 		UDATA _dynamicMarkCost;	/**< The cost of marking this region (that is, the number of other regions (not including this one) which will need to be scanned - this value is dynamic in that converting the regions which refer to it to scan or mark reduces this number.  It is only valid during GC setup */
 		U_8 _overflowFlags;	/**< Used to denote that work packet overflow occurred for an object in this region - bits 0x1 is GMP or global while 0x2 is PGC */
 	} _markData;

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
@@ -174,7 +174,8 @@ MM_ProjectedSurvivalCollectionSetDelegate::createNurseryCollectionSet(MM_Environ
 		if (region->containsObjects()) {
 			bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 			bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
-			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions)) {
+			/* allow jniCritical regions are part of nursery collectionSet for copyforward */
+			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && region->isEden()))) {
 				if(MM_CompactGroupManager::isRegionInNursery(env, region)) {
 					/* on collection phase, mark all non-overflowed regions and those that RSCL is not being rebuilt */
 					/* sweep/compact flags are set in ReclaimDelegate */
@@ -264,7 +265,8 @@ MM_ProjectedSurvivalCollectionSetDelegate::createRateOfReturnCollectionSet(MM_En
 			if (MM_CompactGroupManager::isRegionDCSSCandidate(env, region)) {
 				bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 				bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
-				if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions)) {
+				/* allow jniCritical regions are part ofRateOfReturnCollectionSet for copyforward */
+				if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && region->isEden()))) {
 					_dynamicSelectionRegionList[sortListSize] = region;
 					sortListSize += 1;
 				}
@@ -458,6 +460,7 @@ MM_ProjectedSurvivalCollectionSetDelegate::deleteRegionCollectionSetForPartialGC
 		Assert_MM_true(MM_RegionValidator(region).validate(env));
 
 		region->_markData._shouldMark = false;
+		region->_markData._noEvacuation = false;
 		region->_reclaimData._shouldReclaim = false;
 	}
 }

--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -265,8 +265,8 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 		UDATA nonEdenSurvivorCount = copyForwardStats->_nonEdenSurvivorRegionCount;
 		
 		/* estimate how many more regions we would have needed to avoid abort */
-		Assert_MM_true( (0 == copyForwardStats->_scanBytesEden) || copyForwardStats->_aborted);
-		Assert_MM_true( (0 == copyForwardStats->_scanBytesNonEden) || copyForwardStats->_aborted);
+		Assert_MM_true( (0 == copyForwardStats->_scanBytesEden) || copyForwardStats->_aborted || (0 != copyForwardStats->_nonEvacuateRegionCount));
+		Assert_MM_true( (0 == copyForwardStats->_scanBytesNonEden) || copyForwardStats->_aborted || (0 != copyForwardStats->_nonEvacuateRegionCount));
 		edenSurvivorCount += (copyForwardStats->_scanBytesEden + regionSize - 1) / regionSize;
 		nonEdenSurvivorCount += (copyForwardStats->_scanBytesNonEden + regionSize - 1) / regionSize;
 


### PR DESCRIPTION
 CopyForwardHybrid is hybrid mode of CopyForward Scheme that 
 GC can run both copyforward and markcompact on the collection set
 simultaneously (for balanced PGC only). During precollection, 
 GC can reserve some regions for markcompact only(non evacuated 
 regions -- such as jni critical regions) and copyforward for 
 the rest of collection set. CopyForwardHybrid intent to avoid 
 markcompact PGC due to nonEvacuated regions in collection set,
 in order to minimize the longer gc pause time and affection to
 concurrent gc.

 - new java Option -XXgc:tarokEnableCopyForwardMarkCompactHybrid for
enabling
 CopyForwardHybrid mode, default is disabled.
 - new java Option
-XXgc:fvtest_forceCopyForwardMarkCompactHybridRatio=nn,
 (1 <=nn<= 100) nn is the percentage of collection set to be reserved
for markcompact(for margin testing CopyForwardHybrid).
 - report copyforward is running hybrid mode in verbose gc
 - allow jni critical eden regions in nursery collectionSet for
copyforward
  - _noEvacuation flag in HeapRegionDescriptorVLHGC, set it true 
  if the regions can not be evacuated. decide which region can not 
  be evacuated in preProcessRegions.
  - pull scan work from both scanCache and workPacket in CompleteScan
  - synchronize working threads with both scanCache and workPacket
  - if live object in non evacurated regions mark map instead of
copyforward.
  - exception case 1: if abort case happens, stop to pull scan work
  from workPacket
  - exception case 2: if workPacket overflow during CompleteScan
  set it to abort case to handle overflow
 
Signed-off-by: Lin Hu <linhu@ca.ibm.com>