### PR TITLE
CMake: Fix FFI on osx

### DIFF
--- a/runtime/libffi/CMakeLists.txt
+++ b/runtime/libffi/CMakeLists.txt
@@ -56,9 +56,13 @@ if(OMR_ARCH_X86)
 		x86/ffi.c
 		x86/ffi64.c
 		x86/sysv.S
-		x86/unix64.S
 	)
-	if(OMR_HOST_OS STREQUAL "osx")
+	if(OMR_HOST_OS STREQUAL "linux")
+		target_sources(ffi
+			PRIVATE
+			x86/unix64.S
+		)
+	elseif(OMR_HOST_OS STREQUAL "osx")
 		target_sources(ffi
 			PRIVATE
 			x86/darwin64.s


### PR DESCRIPTION
x86/unix64.S should only be built on linux

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>