### PR TITLE
Partially enable final static field folding

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -135,6 +135,9 @@ class ClientSessionData
    void decNumActiveThreads() { --_numActiveThreads;  }
    void printStats();
 
+   TR::Monitor *getStaticMapMonitor() { return _staticMapMonitor; }
+   PersistentUnorderedMap<void *, TR_StaticFinalData> &getStaticFinalDataMap() { return _staticFinalDataMap; }
+
    private:
    const uint64_t _clientUID;
    int64_t  _timeOfLastAccess; // in ms
@@ -168,6 +171,8 @@ class ClientSessionData
 
    TR_AddressSet *_unloadedClassAddresses; // Per-client versions of the unloaded class and method addresses kept in J9PersistentInfo
    bool           _requestUnloadedClasses; // If true we need to request the current state of unloaded classes from the client
+   TR::Monitor *_staticMapMonitor;
+   PersistentUnorderedMap<void *, TR_StaticFinalData> _staticFinalDataMap; // stores values at static final addresses in JVM
    }; // ClientSessionData
 
 // Hashtable that maps clientUID to a pointer that points to ClientSessionData

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8395,6 +8395,44 @@ TR_J9VM::getPrimitiveArrayAllocationClass(J9Class *clazz)
    }
 
 
+TR_StaticFinalData
+TR_J9VM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType)
+   {
+   TR_StaticFinalData data;
+   if (!staticAddress)
+      {
+      data.dataAddress = 0;
+      return data;
+      }
+   TR::VMAccessCriticalSection dereferenceStaticFinalAddress(this);
+   switch (addressType)
+      {
+      case TR::Int8:
+         data.dataInt8Bit = *(int8_t *) staticAddress;
+         break;
+      case TR::Int16:
+         data.dataInt16Bit = *(int16_t *) staticAddress;
+         break;
+      case TR::Int32:
+         data.dataInt32Bit = *(int32_t *) staticAddress;
+         break;
+      case TR::Int64:
+         data.dataInt64Bit = *(int64_t *) staticAddress;
+         break;
+      case TR::Float:
+         data.dataFloat = *(float *) staticAddress;
+         break;
+      case TR::Double:
+         data.dataDouble = *(double *) staticAddress;
+         break;
+      case TR::Address:
+         data.dataAddress = *(uintptrj_t *) staticAddress;
+         break;
+      default:
+         TR_ASSERT(0, "Unexpected type %s", addressType.toString());
+      }
+   return data;
+   }
 
 //////////////////////////////////////////////////////////
 // TR_J9SharedCacheVM

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -158,6 +158,20 @@ typedef struct TR_JitPrivateConfig
    } TR_JitPrivateConfig;
 
 
+// JITaaS: union containing all possible datatypes of static final fields
+union
+TR_StaticFinalData
+   {
+   int8_t dataInt8Bit;
+   int16_t dataInt16Bit;
+   int32_t dataInt32Bit;
+   int64_t dataInt64Bit;
+   float dataFloat;
+   double dataDouble;
+   uintptrj_t dataAddress;
+   };
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1097,6 +1111,7 @@ public:
    virtual uint32_t               getPrimitiveArrayOffsetInJavaVM(uint32_t arrayType);
 
    virtual bool isDecimalFormatPattern( TR::Compilation *comp, TR_ResolvedMethod *method);
+   virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType);
 
    TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPool * constantPool);
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1380,3 +1380,30 @@ TR_J9ServerVM::getIProfiler()
       }
    return _iProfiler;
    }
+
+TR_StaticFinalData
+TR_J9ServerVM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType)
+   {
+   if (!staticAddress)
+      return {.dataAddress = 0};
+
+      {
+      // check if the value is cached
+      OMR::CriticalSection dereferenceStaticFinalAddress(_compInfoPT->getClientData()->getStaticMapMonitor());
+      auto &staticMap = _compInfoPT->getClientData()->getStaticFinalDataMap();
+      auto it = staticMap.find(staticAddress);
+      if (it != staticMap.end())
+         return it->second;
+      }
+
+   // value at the static address is not cached, ask the client
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITaaS::J9ServerMessageType::VM_dereferenceStaticAddress, staticAddress, addressType);
+   auto data =  std::get<0>(stream->read<TR_StaticFinalData>());
+   // cache the result
+   OMR::CriticalSection dereferenceStaticFinalAddress(_compInfoPT->getClientData()->getStaticMapMonitor());
+   auto &staticMap = _compInfoPT->getClientData()->getStaticFinalDataMap();
+   auto it = staticMap.insert({staticAddress, data}).first;
+   return it->second;
+   }
+

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -158,11 +158,13 @@ public:
    virtual intptrj_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset) override;
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptrj_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
+   virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) { return false; } // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
    using TR_J9VM :: isAnonymousClass;
    virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;
    virtual TR_IProfiler *getIProfiler() override;
+   virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType) override;
    };
 
 #endif // VMJ9SERVER_H

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1082,8 +1082,6 @@ J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node
 bool
 J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *node)
    {
-   if (TR::CompilationInfo::getStream())
-      return false;
    TR_ASSERT(node->getOpCode().isLoadVarDirect() && node->isLoadOfStaticFinalField(), "Expecting direct load of static final field on %s %p", node->getOpCode().getName(), node);
    TR::SymbolReference *symRef = node->getSymbolReference();
    TR::Symbol           *sym    = node->getSymbol();
@@ -1142,6 +1140,7 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
       }
 
    TR::StaticSymbol *staticSym = sym->castToStaticSymbol();
+   TR_StaticFinalData data = ((TR_J9VM *) comp->fej9())->dereferenceStaticFinalAddress(staticSym->getStaticAddress(), loadType);
    if (typeIsConstible)
       {
       if (performTransformation(comp, "O^O foldStaticFinalField: turn [%p] %s %s into load const\n", node, node->getOpCode().getName(), symRef->getName(comp->getDebug())))
@@ -1151,27 +1150,27 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
             {
             case TR::Int8:
                TR::Node::recreate(node, TR::bconst);
-               node->setByte(*(int8_t*)staticSym->getStaticAddress());
+               node->setByte(data.dataInt8Bit);
                break;
             case TR::Int16:
                TR::Node::recreate(node, TR::sconst);
-               node->setShortInt(*(int16_t*)staticSym->getStaticAddress());
+               node->setShortInt(data.dataInt16Bit);
                break;
             case TR::Int32:
                TR::Node::recreate(node, TR::iconst);
-               node->setInt(*(int32_t*)staticSym->getStaticAddress());
+               node->setInt(data.dataInt32Bit);
                break;
             case TR::Int64:
                TR::Node::recreate(node, TR::lconst);
-               node->setLongInt(*(int64_t*)staticSym->getStaticAddress());
+               node->setLongInt(data.dataInt64Bit);
                break;
             case TR::Float:
                TR::Node::recreate(node, TR::fconst);
-               node->setFloat(*(float*)staticSym->getStaticAddress());
+               node->setFloat(data.dataFloat);
                break;
             case TR::Double:
                TR::Node::recreate(node, TR::dconst);
-               node->setDouble(*(double*)staticSym->getStaticAddress());
+               node->setDouble(data.dataDouble);
                break;
             default:
                TR_ASSERT(0, "Unexpected type %s", loadType.toString());
@@ -1184,7 +1183,7 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
                                                          symRef->getName(comp->getDebug())));
       return true;
       }
-   else if (*(uintptrj_t*)staticSym->getStaticAddress() == 0) // Seems ok just to check for a static to be NULL without vm access
+   else if (data.dataAddress == 0) // Seems ok just to check for a static to be NULL without vm access
       {
       switch (staticSym->getRecognizedField())
          {
@@ -1356,7 +1355,7 @@ J9::TransformUtil::transformIndirectLoadChainImpl(TR::Compilation *comp, TR::Nod
    {
    TR_J9VMBase *fej9 = comp->fej9();
    
-   if (comp->compileRelocatableCode() || comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+   if (comp->compileRelocatableCode())
       {
       return false;
       }
@@ -1377,7 +1376,7 @@ J9::TransformUtil::transformIndirectLoadChainImpl(TR::Compilation *comp, TR::Nod
       J9Class* clazz = (J9Class*)baseAddress;
       traceMsg(comp, "Looking at node %p with initializeStatusFromClassSymbol, class %p initialize status is %d\n", node, clazz, clazz->initializeStatus);
       // Only fold the load if the class has been initialized
-      if (clazz->initializeStatus == J9ClassInitSucceeded)
+      if (fej9->isClassInitialized((TR_OpaqueClassBlock *) clazz) == J9ClassInitSucceeded)
          {
          if (node->getDataType() == TR::Int32)
             {

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -209,6 +209,7 @@ enum J9ServerMessageType
    VM_getResolvedMethodsAndMirror = 300;
    VM_getVMInfo = 301;
    VM_isAnonymousClass = 302;
+   VM_dereferenceStaticAddress = 303;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
Add support for final field folding in `J9::TransformUtil::transformDirectLoad`. This method dereferences a static address on the client, so replace dereferencing with calling a new method of
ResolvedJ9Method, which will make an appropriate remote call on the server.
Returned dereferenced values are cached to minimize the nubmer of remote
calls.