### PR TITLE
Fix bug in canAllocateInlineClass

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -785,7 +785,7 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
          if (it->second.classInitialized)
             {
             return ((it->second.romClass->modifiers & (J9_JAVA_ABSTRACT | J9_JAVA_INTERFACE ))?
-                     true:false);
+                     false:true);
             }
          }
       }
@@ -802,7 +802,7 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
          {
          it->second.classInitialized = classInitialized;
          return ((it->second.romClass->modifiers & (J9_JAVA_ABSTRACT | J9_JAVA_INTERFACE ))?
-                     true:false);
+                  false:true);
          }
       else
          {


### PR DESCRIPTION
Due to a bug canAllocateInlineClass returns true only if the class is
abstract or interface. It should be the other way around.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>