### PR TITLE
Add support for z/OS platforms to Jenkins pipelines

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -43,7 +43,9 @@ def get_source() {
             OMR_BRANCH_OPTION = (OMR_BRANCH != "")? "-omr-branch=${OMR_BRANCH}" : ""
             OMR_SHA_OPTION = (OMR_SHA != "") ? "-omr-sha=${OMR_SHA}" : ""
 
-            if (USER_CREDENTIALS_ID != '') {
+            // use sshagent with Jenkins credentials ID for all platforms except zOS
+            // on zOS use the user's ssh key
+            if (!SPEC.startsWith('zos') && (USER_CREDENTIALS_ID != '')) {
                 get_sources_with_authentication()
             } else {
                 get_sources()
@@ -59,6 +61,14 @@ def get_sources_with_authentication() {
 }
 
 def get_sources() {
+    // use credentials ID for all platforms except zOS
+    // for zOS use ssh key
+
+    def remote_config_parameters = [url: "${OPENJDK_REPO}"]
+    if (!SPEC.startsWith('zos') && USER_CREDENTIALS_ID) {
+        remote_config_parameters.put(credentialsId: "${USER_CREDENTIALS_ID}")
+    }
+
     checkout changelog: false,
             poll: false,
             scm: [$class: 'GitSCM',
@@ -72,8 +82,7 @@ def get_sources() {
                                 shallow: false,
                                 timeout: 30]],
                 submoduleCfg: [],
-                userRemoteConfigs: [[credentialsId: "${USER_CREDENTIALS_ID}",
-                                    url: "${OPENJDK_REPO}"]]]
+                userRemoteConfigs: [remote_config_parameters]]
 
     // Check if this build is a PR
     if (params.ghprbGhRepository) {
@@ -246,8 +255,10 @@ def checkoutRef (REF) {
 def build() {
     stage('Compile') {
         timestamps {
+            // 'all' target dependencies broken for zos, use 'images'
+            def make_target = SPEC.startsWith('zos') ? 'images' : 'all'
             withEnv(BUILD_ENV_VARS_LIST) {
-                sh "${BUILD_ENV_CMD} bash configure --with-freemarker-jar='$FREEMARKER' --with-boot-jdk='$BOOT_JDK' $EXTRA_CONFIGURE_OPTIONS && make $EXTRA_MAKE_OPTIONS all"
+                sh "${BUILD_ENV_CMD} bash configure --with-freemarker-jar='$FREEMARKER' --with-boot-jdk='$BOOT_JDK' $EXTRA_CONFIGURE_OPTIONS && make $EXTRA_MAKE_OPTIONS ${make_target}"
             }
         }
     }
@@ -325,12 +336,12 @@ def build_all() {
             }
         } finally {
             try {
-		cleanWs()
-	    } catch(e) {
-		echo e.toString()
-		echo e.printStackTrace()
-		sh "ps -ef"
-	    }
+                cleanWs()
+            } catch(e) {
+                echo e.toString()
+                echo e.printStackTrace()
+                sh "ps -ef"
+            }
         }
     }
 }

--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -34,14 +34,28 @@ def get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO,
             // fetch SHAs for all OpenJDK repositories
             def OPENJDK_SHAS_BY_RELEASES = [:]
 
-            OPENJDK_SHA.each { release, sha ->
-                if (!sha) {
-                    sha = get_repository_sha(OPENJDK_REPO[release], OPENJDK_BRANCH[release])
+            // e.g. OPENJDK_SHA = [ 8: [linux_x86-64: sha1, linux_x86-64_cmprssptrs: sha2, ...], 
+            //                     10: [linux_x86-64: sha1, linux_x86-64_cmprssptrs: sha2, ...],...]
+            OPENJDK_SHA.each { release, shas_by_specs ->
+                def unique_shas = [:]
+
+                shas_by_specs.each { spec, sha ->
+                    def repoUrl = OPENJDK_REPO.get(release).get(spec)
+
+                    if (!unique_shas.containsKey(repoUrl)) {
+                        if (!sha) {
+                            sha = get_repository_sha(repoUrl, OPENJDK_BRANCH.get(release).get(spec))
+                        }
+                        unique_shas.put(repoUrl, sha)
+
+                        def repo_short_name = repoUrl.substring(repoUrl.lastIndexOf('/') + 1, repoUrl.indexOf('.git'))
+                        description += "<br/>OpenJDK${release}: ${get_short_sha(sha)} - ${repo_short_name}"
+                        echo "OPENJDK${release}_SHA:${sha} - ${repo_short_name}"
+                    }
                 }
-                OPENJDK_SHAS_BY_RELEASES[release] = sha
-                description += "<br/>OpenJDK${release}: ${get_short_sha(sha)}"
-                echo "OPENJDK${release}_SHA:${sha}"
+                OPENJDK_SHAS_BY_RELEASES.put(release, unique_shas)
             }
+
             SHAS['OPENJDK'] = OPENJDK_SHAS_BY_RELEASES
         } else {
             // fetch SHA for an OpenJDK repository

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -88,19 +88,19 @@ def checkout_file() {
 * When no values are available as build parameters set them to the values
 * available with the variable file otherwise set them to empty strings.
 */
-def set_repos_variables(RELEASES=null) {
+def set_repos_variables(BUILD_SPECS=null) {
     // check if passed as Jenkins build parameters
     // if not set as params, check the variables file
 
-    if (!RELEASES) {
-        // set variables (as strings) for a single OpenJDK release
+    if (!BUILD_SPECS) {
+        // set variables (as strings) for a single OpenJDK release build
 
         // fetch OpenJDK repo and branch from variables file as a map
-        def OPENJDK_INFO = get_openjdk_info(SDK_VERSION)
+        def openjdk_info = get_openjdk_info(SDK_VERSION, [SPEC], false)
 
-        OPENJDK_REPO = OPENJDK_INFO['REPO']
-        OPENJDK_BRANCH = OPENJDK_INFO['BRANCH']
-        OPENJDK_SHA = OPENJDK_INFO['SHA']
+        OPENJDK_REPO = openjdk_info.get(SPEC).get('REPO')
+        OPENJDK_BRANCH = openjdk_info.get(SPEC).get('BRANCH')
+        OPENJDK_SHA = openjdk_info.get(SPEC).get('SHA')
 
         echo "Using OPENJDK_REPO = ${OPENJDK_REPO} OPENJDK_BRANCH = ${OPENJDK_BRANCH} OPENJDK_SHA = ${OPENJDK_SHA}"
 
@@ -108,14 +108,26 @@ def set_repos_variables(RELEASES=null) {
         set_extensions_variables()
 
      } else {
-        // set OpenJDK variables (as maps) for given releases
-        RELEASES.each { RELEASE ->
-            // fetch OpenJDK repo and branch from variables file as a map
-            def OPENJDK_INFO = get_openjdk_info(RELEASE, RELEASES)
+        // set OpenJDK variables (as maps) for a multiple releases build
 
-            OPENJDK_REPO[RELEASE] = OPENJDK_INFO['REPO']
-            OPENJDK_BRANCH[RELEASE] = OPENJDK_INFO['BRANCH']
-            OPENJDK_SHA[RELEASE] = OPENJDK_INFO['SHA']
+        def build_releases = get_build_releases(BUILD_SPECS)
+        build_releases.each { release ->
+            // fetch OpenJDK repo and branch from variables file as a map
+            def openjdk_info = get_openjdk_info(release, get_build_specs_by_release(release, BUILD_SPECS), true)
+
+            def repos = [:]
+            def branches = [:]
+            def shas = [:]
+
+            openjdk_info.each { build_spec, info_map ->
+                repos.put(build_spec, info_map['REPO'])
+                branches.put(build_spec, info_map['BRANCH'])
+                shas.put(build_spec, info_map['SHA'])
+            }
+
+            OPENJDK_REPO[release] = repos
+            OPENJDK_BRANCH[release] = branches
+            OPENJDK_SHA[release] = shas
         }
 
         echo "Using OPENJDK_REPO = ${OPENJDK_REPO.toString()} OPENJDK_BRANCH = ${OPENJDK_BRANCH.toString()} OPENJDK_SHA = ${OPENJDK_SHA.toString()}"
@@ -135,37 +147,65 @@ def set_repos_variables(RELEASES=null) {
 * Build parameters take precedence over custom variables (see variables file).
 * Throws an error if repository URL or branch are not provided. 
 */
-def get_openjdk_info(SDK_VERSION, RELEASES=null) {
-    // initialize OPENJDK_INFO map with values from variables file
-    def OPENJDK_INFO = ['REPO'  : convert_url(get_value(VARIABLES.openjdk_repo, SDK_VERSION)), 
-                        'BRANCH': get_value(VARIABLES.openjdk_branch, SDK_VERSION),
-                        'SHA'   : '']
+def get_openjdk_info(SDK_VERSION, SPECS, MULTI_RELEASE) {
+    // map to store git repository information by spec
+    def openjdk_info = [:]
 
-    def PARAM_NAME = "OPENJDK"
-    if (RELEASES) {
-        PARAM_NAME += SDK_VERSION
+    // fetch values from variables file
+    def default_openjdk_info = get_value(VARIABLES.openjdk, SDK_VERSION)
+
+    // the build expects the following parameters:
+    // OPENJDK*_REPO, OPENJDK*_BRANCH, OPENJDK*_SHA,
+    // OPENJDK*_REPO_<spec>, OPENJDK*_BRANCH_<spec>, OPENJDK*_SHA_<spec>
+    def param_name = "OPENJDK"
+    if (MULTI_RELEASE) {
+        // if a wrapper pipeline build, expect parameters names to be prefixed with "OPENJDK<version>_"
+        param_name += SDK_VERSION
     }
 
-    // check if any OPENJDK* build parameters are provided
-    // and override OPENJDK_INFO map with those values
-    OPENJDK_INFO.keySet().each { KEY ->
-        def VALUE = params."${PARAM_NAME}_${KEY}"
+    for (build_spec in SPECS) {
+        // default values from variables file
+        def repo = default_openjdk_info.get('default').get('repoUrl')
+        def branch = default_openjdk_info.get('default').get('branch')
 
-        if (VALUE) {
-            // build parameter provided, now override map value
-            if (KEY == 'REPO') { 
-                OPENJDK_INFO[KEY] = convert_url(VALUE)
-            } else {
-                OPENJDK_INFO[KEY] = VALUE
+        if (default_openjdk_info[build_spec]) {
+            repo = default_openjdk_info.get(build_spec).get('repoUrl')
+
+            if (params."${param_name}_REPO_${build_spec}") {
+                // got OPENJDK*_REPO_<spec> build parameter, overwrite repo
+                repo = params."${param_name}_REPO_${build_spec}"
             }
+
+            branch = default_openjdk_info.get(build_spec).get('branch')
+
+            if (params."${param_name}_BRANCH_${build_spec}") {
+                // got OPENJDK*_BRANCH_<spec> build parameter, overwrite branch
+                branch = params."${param_name}_BRANCH_${build_spec}"
+            }
+
+            sha = params."${param_name}_SHA_${build_spec}"
+        } else {
+            // check build parameters
+            if (params."${param_name}_REPO") {
+                repo = params."${param_name}_REPO"
+            }
+
+            if (params."${param_name}_BRANCH") {
+                branch = params."${param_name}_BRANCH"
+            }
+
+            sha = params."${param_name}_SHA"
         }
 
-        if ((KEY != 'SHA') && (!OPENJDK_INFO[KEY])) {
-            error("Missing ${PARAM_NAME}_${KEY}!")
+        if (!sha) {
+            sha = ''
         }
+
+        // populate the map
+        openjdk_info.put(build_spec, ['REPO': convert_url(repo), 'BRANCH': branch, 'SHA': sha])
     }
 
-    return OPENJDK_INFO
+    return openjdk_info
 }
 
 /*
@@ -251,7 +291,12 @@ def get_value(MAP, KEY) {
     if (MAP != null) {
         for (item in MAP) {
             if ("${item.key}" == "${KEY}") {
-                return "${item.value}"
+                if ((item.value instanceof Map) || (item.value instanceof java.util.List)) {
+                    return item.value
+                } else {
+                    // stringify value
+                    return "${item.value}"
+                }
             }
         }
     }
@@ -671,7 +716,7 @@ def set_job_variables(job_type) {
             break
         case "wrapper":
             //set variable for pipeline all/personal
-            set_repos_variables(BUILD_RELEASES)
+            set_repos_variables(BUILD_SPECS)
             break
         default:
             error("Unknown Jenkins job type!")
@@ -851,5 +896,35 @@ def set_vendor_variables() {
 def get_repo_name_from_url(URL) {
     return URL.substring(URL.lastIndexOf('/') + 1, URL.lastIndexOf('.git')).toUpperCase()
 }
+
+/*
+* Returns a list of releases to build.
+*/
+def get_build_releases(releases_by_specs) {
+    def build_releases = []
+    
+    // find releases to build based on given specs
+    releases_by_specs.values().each { versions ->
+        build_releases.addAll(versions)
+    }
+
+    return build_releases.unique()
+}
+
+/*
+* Returns a list of specs for a given version.
+*/
+def get_build_specs_by_release(version, specs) {
+    def specs_by_release = []
+
+    specs.each { build_spec, build_releases ->
+        if (build_releases.contains(version)) {
+            specs_by_release.add(build_spec)
+        }
+    }
+
+    return specs_by_release
+}
+
 
 return this

--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -47,7 +47,7 @@ timeout(time: 10, unit: 'HOURS') {
                     variableFile.set_job_variables('build')
                 }
 
-                if (!params.UPSTREAM_JOB_NAME && !params.UPSTREAM_JOB_NAME) {
+                if (!params.UPSTREAM_JOB_NAME && !params.UPSTREAM_JOB_NUMBER) {
                     // the test pipeline requires resources(e.g. a jdk) from an
                     // upstream build pipeline identified by the UPSTREAM_JOB_NAME,
                     // UPSTREAM_JOB_NAME parameters

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -36,25 +36,14 @@
 *              linux_ppc-64_cmprssptrs_le,
 *              linux_390-64_cmprssptrs,
 *              win_x86-64_cmprssptrs,
-*              win_x86 (Java 8 support only)
-*   Java8: Boolean
-*   Java9: Boolean 
-*   Java10: Boolean (at least one of the Java8, Java9, Java10 is required)
+*              win_x86 (Java 8 support only),
+*              zos_390-64_cmprssptrs (Java 11 support only)
 *   OPENJ9_REPO: String - the OpenJ9 git repository URL: e.g. https://github.com/eclipse/openj9.git (default)
 *   OPENJ9_BRANCH: String - the OpenJ9 branch to clone from: e.g. master (default)
 *   OPENJ9_SHA: String - the last commit SHA of the OpenJ9 repository
 *   OMR_REPO: String - the OMR git repository URL: e.g. https://github.com/eclipse/openj9-omr.git (default)
 *   OMR_BRANCH: String - the OMR branch to clone from: e.g. openj9 (default)
 *   OMR_SHA: the last commit SHA of the OMR repository
-*   OPENJDK8_REPO: String - the OpenJDK8 repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk8.git (default)
-*   OPENJDK8_BRANCH: String - the OpenJDK8 branch to clone from: e.g. openj9 (default)
-*   OPENJDK8_SHA: String - the OpenJDK8 last commit SHA
-*   OPENJDK9_REPO: String - the OpenJDK9 repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk9.git (default)
-*   OPENJDK9_BRANCH: String - the OpenJDK9 branch to clone from: e.g. openj9 (default)
-*   OPENJDK9_SHA: String - the OpenJDK9 last commit SHA 
-*   OPENJDK10_REPO: String - the OpenJDK10 repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk10.git (default)
-*   OPENJDK10_BRANCH: String - the OpenJDK10 branch to clone from: e.g. openj9 (default)
-*   OPENJDK10_SHA: String - the OpenJDK10 last commit SHA
 *   TESTS_TARGETS: String - The test targets to run. Expected values: _sanity, _extended, none
 *   VARIABLE_FILE: String - the custom variables file. Uses defaults.yml when no value is provided.
 *   VENDOR_REPO: String - the repository URL of a Git repository that stores a custom variables file
@@ -70,6 +59,16 @@
 *   Expected value for single platforms builds: label (no platform name required), e.g. csp70027
 *
 *   PERSONAL_BUILD: Choice: true, false - Indicates if is a personal build or not
+*
+*   Note: replicate the following parameters for each supported version, where supported version are: 8, 9, 10, 11, next
+*   Java<version>: Boolean (at least one of the following is required: Java8, Java9, Java10, etc)
+*   OPENJDK<version>_REPO: String - the OpenJDK<version> repository URL: e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk<version>.git (default)
+*   OPENJDK<version>_BRANCH: String - the OpenJDK<version> branch to clone from: e.g. openj9 (default)
+*   OPENJDK<version>_SHA: String - the OpenJDK<version> last commit SHA
+*
+*   OPENJDK<version>_REPO_<platform>: String - the OpenJDK<version> repository URL for <platform>
+*   OPENJDK<version>_BRANCH_<platform>: String - the branch to clone from
+*   OPENJDK<version>_SHA_<platform>: String - the last commit SHA
 */
 
 RELEASES = ['8', '9', '10', '11', 'next']
@@ -82,7 +81,8 @@ SPECS = ['aix_ppc-64_cmprssptrs'      : CURRENT_RELEASES,
          'linux_x86-64_cmprssptrs'    : CURRENT_RELEASES,
          'linux_x86-64_cmprssptrs_cmake' : ['9'],
          'win_x86'                    : ['8'],
-         'win_x86-64_cmprssptrs'      : CURRENT_RELEASES]
+         'win_x86-64_cmprssptrs'      : CURRENT_RELEASES,
+         'zos_390-64_cmprssptrs'      : ['11']]
 
 LABEL = params.LABEL
 if (!LABEL) {
@@ -93,7 +93,7 @@ OPENJDK_REPO = [:]
 OPENJDK_BRANCH = [:]
 OPENJDK_SHA = [:]
 
-BUILD_RELEASES = []
+BUILD_SPECS = [:]
 builds = [:]
 
 timeout(time: 10, unit: 'HOURS') {
@@ -104,9 +104,7 @@ timeout(time: 10, unit: 'HOURS') {
                 def variableFile = load 'buildenv/jenkins/common/variables-functions'
                 buildFile = load 'buildenv/jenkins/common/pipeline-functions'
 
-                def BUILD_SPECS = get_specs(SPECS)
-                // find releases to build based on given specs
-                BUILD_RELEASES.addAll(get_build_releases(BUILD_SPECS))
+                BUILD_SPECS.putAll(get_specs(SPECS))
 
                 // parse variables file and initialize variables
                 variableFile.set_job_variables('wrapper')
@@ -128,8 +126,8 @@ timeout(time: 10, unit: 'HOURS') {
                 BUILD_SPECS.each { SPEC, SDK_VERSIONS ->
                     SDK_VERSIONS.each { SDK_VERSION ->
                         // set OpenJDK repos and branch for the downstream build
-                        def REPO = OPENJDK_REPO[SDK_VERSION]
-                        def BRANCH = OPENJDK_BRANCH[SDK_VERSION]
+                        def REPO = OPENJDK_REPO.get(SDK_VERSION).get(SPEC)
+                        def BRANCH = OPENJDK_BRANCH.get(SDK_VERSION).get(SPEC)
 
                         // set nodes for the downstream builds
                         def BUILD_NODE = ''
@@ -175,31 +173,31 @@ timeout(time: 10, unit: 'HOURS') {
 def build(OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, SPEC, SDK_VERSION, BUILD_NODE, TEST_NODE) {
     def JOB_NAME = "Pipeline-Build-Test-JDK${SDK_VERSION}-${SPEC}"
 
-    TESTS_TARGETS = params.TESTS_TARGETS    
+    TESTS_TARGETS = params.TESTS_TARGETS
     if (!TESTS_TARGETS) {
         TESTS_TARGETS = ''
     }
-    VARIABLE_FILE = params.VARIABLE_FILE    
+    VARIABLE_FILE = params.VARIABLE_FILE
     if (!VARIABLE_FILE) {
         VARIABLE_FILE = ''
     }
-    VENDOR_REPO = params.VENDOR_REPO    
+    VENDOR_REPO = params.VENDOR_REPO
     if (!VENDOR_REPO) {
         VENDOR_REPO = ''
     }
-    VENDOR_BRANCH = params.VENDOR_BRANCH    
+    VENDOR_BRANCH = params.VENDOR_BRANCH
     if (!VENDOR_BRANCH) {
         VENDOR_BRANCH = ''
     }
-    VENDOR_CREDENTIALS_ID = params.VENDOR_CREDENTIALS_ID    
+    VENDOR_CREDENTIALS_ID = params.VENDOR_CREDENTIALS_ID
     if (!VENDOR_CREDENTIALS_ID) {
         VENDOR_CREDENTIALS_ID = ''
     }
-    PERSONAL_BUILD = params.PERSONAL_BUILD    
+    PERSONAL_BUILD = params.PERSONAL_BUILD
     if (!PERSONAL_BUILD) {
         PERSONAL_BUILD = ''
     }
-    SLACK_HANDLE = params.SLACK_HANDLE    
+    SLACK_HANDLE = params.SLACK_HANDLE
     if (!SLACK_HANDLE) {
         SLACK_HANDLE = ''
     }
@@ -208,7 +206,7 @@ def build(OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_RE
                 parameters: [
                     string(name: 'OPENJDK_REPO', value: OPENJDK_REPO),
                     string(name: 'OPENJDK_BRANCH', value: OPENJDK_BRANCH),
-                    string(name: 'OPENJDK_SHA', value: SHAS['OPENJDK'].get(SDK_VERSION)),
+                    string(name: 'OPENJDK_SHA', value: SHAS.get('OPENJDK').get(SDK_VERSION).get(OPENJDK_REPO)),
                     string(name: 'OPENJ9_REPO', value: OPENJ9_REPO),
                     string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH),
                     string(name: 'OPENJ9_SHA', value: SHAS['OPENJ9']),
@@ -281,19 +279,6 @@ def get_specs(SUPPORTED_SPECS) {
     }
 
     return SPECS
-}
-
-/*
-* Returns a list of releases to build.
-*/
-def get_build_releases(BUILD_SPECS) {
-    def BUILD_RELEASES = []
-
-    BUILD_SPECS.values().each { SDK_VERSIONS ->
-        BUILD_RELEASES.addAll(SDK_VERSIONS)
-    }
-
-    return BUILD_RELEASES.unique()
 }
 
 /*

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -22,18 +22,27 @@
 #========================================#
 # Git repositories
 #========================================#
-openjdk_repo:
-  8: 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git'
-  9: 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git'
-  10: 'https://github.com/ibmruntimes/openj9-openjdk-jdk10.git'
-  11: 'https://github.com/ibmruntimes/openj9-openjdk-jdk11.git'
-  next: 'https://github.com/ibmruntimes/openj9-openjdk-jdk.git'
-openjdk_branch:
-  8: 'openj9'
-  9: 'openj9'
-  10: 'openj9'
-  11: 'openj9'
-  next: 'openj9-jdk'
+openjdk:
+  8:
+    default:
+      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk8.git'
+      branch: 'openj9'
+  9:
+    default:
+      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk9.git'
+      branch: 'openj9'
+  10:
+    default:
+      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk10.git'
+      branch: 'openj9'
+  11:
+    default:
+      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk11.git'
+      branch: 'openj9'
+  next:
+    default:
+      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk.git'
+      branch: 'openj9-jdk'
 #========================================#
 # Miscellaneous settings
 #========================================#


### PR DESCRIPTION
- enable pipelines for z/OS platforms
- reformat variables file: add support for OpenJDK repositories per spec

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>