### PR TITLE
Add caching for resolved methods

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -45,6 +45,7 @@
 #include "control/CompilationRuntime.hpp"
 #include "control/CompilationThread.hpp"
 #include "runtime/IProfiler.hpp"
+#include "env/j9methodServer.hpp"
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
 #include "j9jitnls.h"
@@ -2816,6 +2817,9 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Mem
    J9JITConfig *jitConfig = (J9JITConfig *) _feBase;
    if (rtResolve)
       jitConfig->runtimeFlags |= J9JIT_RUNTIME_RESOLVE;
+
+   // disable caching of resolved methods if env variable TR_DisableResolvedMethodsCaching is set
+   TR_ResolvedJ9JITaaSServerMethod::_useCaching = !feGetEnv("TR_DisableResolvedMethodsCaching");
 
    unpackRegex(options->_disabledOptTransformations);
    unpackRegex(options->_disabledInlineSites);


### PR DESCRIPTION
- To reduce the number of remote messages for resolved methods, cache return values of `getResolved[Virtual|Static|Special|Interface]Method` in a per-compilation, per-resolved method cache.

- Fix formatting of `TR_RemoteROMStringKey` hash function, replace `typedef` of `TR_ResolvedJ9JITaaSServerMethodInfo` with `using`.