### PR TITLE
Fix JIT on macOS crash in compressedrefs builds

### DIFF
--- a/runtime/compiler/x/runtime/X86Unresolveds.pnasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.pnasm
@@ -2,9 +2,9 @@
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
-; distribution and is available at https:
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 ; or the Apache License, Version 2.0 which accompanies this distribution and
-; is available at https:
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
 ;
 ; This Source Code may also be made available under the following
 ; Secondary Licenses when the conditions for such availability set
@@ -17,8 +17,6 @@
 ; [2] http://openjdk.java.net/legal/assembly-exception.html
 ;
 ; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
-
-%include "x/runtime/X86PicBuilder_nasm.inc"
 
 #include "j9cfg.h"
 
@@ -36,6 +34,7 @@
       eq_offsetof_J9Object_clazz equ 8                            ; offset of class pointer in a J9Object
 
       %include "jilconsts.inc"
+      %include "x/runtime/X86PicBuilder_nasm.inc"
 
       segment .text
 
@@ -1123,7 +1122,8 @@ eq_offsetof_J9Object_clazz equ   8        ; offset of class pointer in a J9Objec
 eq_offsetof_J9Object_clazz equ   16       ; offset of class pointer in a J9Object
 #endif
 
-%include "jilconsts.inc"
+      %include "jilconsts.inc"
+      %include "x/runtime/X86PicBuilder_nasm.inc"
 
 segment .text
 

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -76,11 +76,13 @@ createConstant(OMRPortLibrary *OMRPORTLIB, char const *name, UDATA value)
 	return omrstr_printf(line, sizeof(line), "#define %s %zu\n", name, value);
 #elif defined(LINUX) /* J9VM_ARCH_POWER || J9VM_ARCH_ARM */
 	return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
-#elif defined(WIN32) || defined(OSX) /* LINUX */
+#elif defined(WIN32) /* LINUX */
 	return omrstr_printf(line, sizeof(line), "%s equ %zu\n", name, value);
 #elif defined(J9ZOS390) /* WIN32 */
 	return omrstr_printf(line, sizeof(line), "%s EQU %zu\n", name, value);
-#else /* J9ZOS390 */
+#elif defined(OSX) /* J9ZOS390 */
+	return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
+#else /* OSX */
 #error "Unknown constant format"
 #endif /* J9VM_ARCH_POWER || J9VM_ARCH_ARM */
 }


### PR DESCRIPTION
Fixed by: 

1. Using `%define` instead of `equ` to define constants in jilconsts.inc
2. Fixing the order of file inclusion in X86Unresolveds.pnasm

Closes: #3223 
Issue: #36 

Signed-off-by: Nazim Uddin Bhuiyan <nazim.uddin.bhuiyan@ibm.com>