### PR TITLE
Remove emma build tool from DDR compilation

### DIFF
--- a/debugtools/DDR_VM/compile_ddr.xml
+++ b/debugtools/DDR_VM/compile_ddr.xml
@@ -54,10 +54,6 @@
 	<property name="mat_plugin_jar" value="${output.libs.dir}/com.ibm.dtfj.j9ddr_0.0.1.jar"/>
 
 	<property name="junit.jar" value="${j9_core_lib}/junit.jar"/>
-	<property name="emma.jar" value="${j9_core_lib}/emma.jar" />
-	<property name="emma_ant.jar" value="${j9_core_lib}/emma_ant.jar" />
-	<property name="emma_bin" value="${output.bin.dir}/emma" />
-	<property name="emma_jar" value="${output.libs.dir}/j9ddr-emma.jar"/>
 
 	<if>
 		<!-- VM_VERSION is inherited from DDR_VM/generate.xml -->
@@ -100,11 +96,6 @@
 
 	<taskdef resource='net/sf/antcontrib/antlib.xml' classpathref="runtime.cp"/>
 
-	<path id="emma.lib">
-		<pathelement location="${emma.jar}" />
-		<pathelement location="${emma_ant.jar}" />
-	</path>
-
 	<target name="dist" depends="compile,package">
 	</target>
 
@@ -122,7 +113,6 @@
 				<!-- ant delete appears to be flaky most of the time and fails to delete an otherwise
 				     accessible and empty directory. Fix it by using proper tooling, avoid rm -rf to avoid non-fun deletions -->
 				<shellscript shell="bash" dir="/tmp">
-				      	rmdir ${output.dir}/bin/emma
 						rmdir ${output.dir}/bin
 						rmdir ${output.dir}/findbugs
 				</shellscript>
@@ -134,26 +124,6 @@
 		<antcall target="package.j9_core"/>
 		<!--<antcall target="package.mat_plugin"/>-->
 		<antcall target="package.j9ddr"/>
- 		<if>
- 			<equals arg1="${product}" arg2="java8" />
- 			<then>
- 				<antcall target="package.emma"/>
- 			</then>
- 		</if>
-	</target>
-
-	<target name="package.emma">
-		<!--Load the EMMA task-->
-		<taskdef resource="emma_ant.properties" classpathref="emma.lib"/>
-		<echo>Instrumenting classes (J9 core)</echo>
-		<emma>
-			<instr outdir="${emma_bin}" merge="yes" mode="fullcopy" outfile="${emma_bin}/coverage.em" instrpath="${j9_core_bin}" filter="-*generated*" />
-		</emma>
-		<echo>Creating jar file</echo>
-		<jar destfile="${emma_jar}">
-			<fileset dir="${emma_bin}/classes" />
-			<zipfileset src="${j9_core_jar}"/>
-		</jar>
 	</target>
 
 	<target name="package.j9_core">
@@ -334,7 +304,6 @@
 		<mkdir dir="${findbugs.dir}"/>
 		<mkdir dir="${findbugs.results.dir}"/>
 		<mkdir dir="${findbugs.unpack.dir}"/>
-		<mkdir dir="${emma_bin}"/>
 
 		<if>
 			<os family="unix"/>


### PR DESCRIPTION
Emma was removed due to
- Causing issues with Java 8 builds
- Not being used, so can be removed without issues

Signed-off-by: Andrew Crowther <acrowthe3388@gmail.com>