### PR TITLE
Reduce the messages for the various class flags

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -107,6 +107,14 @@ J9::ClassEnv::classDepthOf(TR_OpaqueClassBlock * clazzPointer)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
+         {
+         OMR::CriticalSection getRemoteROMClass(TR::compInfoPT->getClientData()->getROMMapMonitor());
+         auto it = TR::compInfoPT->getClientData()->getROMClassMap().find((J9Class*)clazzPointer);
+         if (it != TR::compInfoPT->getClientData()->getROMClassMap().end())
+            {
+            return (it->second.classDepthAndFlags & J9_JAVA_CLASS_DEPTH_MASK);
+            }
+         }
       stream->write(JITaaS::J9ServerMessageType::ClassEnv_classDepthOf, clazzPointer);
       return std::get<0>(stream->read<uintptrj_t>());
       }

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -768,6 +768,15 @@ TR_J9ServerVM::getClassFromNewArrayType(int32_t arrayType)
 bool
 TR_J9ServerVM::isCloneable(TR_OpaqueClassBlock *clazzPointer)
    {
+      {
+      OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
+      auto it = _compInfoPT->getClientData()->getROMClassMap().find((J9Class*) clazzPointer);
+      if (it != _compInfoPT->getClientData()->getROMClassMap().end())
+         {
+         return ((it->second.classDepthAndFlags & J9AccClassCloneable) != 0);
+         }
+      }
+
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::J9ServerMessageType::VM_isCloneable, clazzPointer);
    return std::get<0>(stream->read<bool>());
@@ -1042,6 +1051,14 @@ TR_J9ServerVM::getJavaLangClassHashCode(TR::Compilation *comp, TR_OpaqueClassBlo
 bool
 TR_J9ServerVM::hasFinalizer(TR_OpaqueClassBlock *clazz)
    {
+      {
+      OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
+      auto it = _compInfoPT->getClientData()->getROMClassMap().find((J9Class*) clazz);
+      if (it != _compInfoPT->getClientData()->getROMClassMap().end())
+         {
+         return ((it->second.classDepthAndFlags & (J9_JAVA_CLASS_FINALIZE | J9_JAVA_CLASS_OWNABLE_SYNCHRONIZER)) != 0);
+         }
+      }
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::J9ServerMessageType::VM_hasFinalizer, clazz);
    return std::get<0>(stream->read<bool>());
@@ -1166,6 +1183,15 @@ TR_J9ServerVM::getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *clazz)
 bool
 TR_J9ServerVM::isOwnableSyncClass(TR_OpaqueClassBlock *clazz)
    {
+      {
+      OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
+      auto it = _compInfoPT->getClientData()->getROMClassMap().find((J9Class*) clazz);
+      if (it != _compInfoPT->getClientData()->getROMClassMap().end())
+         {
+         return ((it->second.classDepthAndFlags & J9_JAVA_CLASS_OWNABLE_SYNCHRONIZER) != 0);
+         }
+      }
+
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::J9ServerMessageType::VM_isOwnableSyncClass, clazz);
    return std::get<0>(stream->read<bool>());


### PR DESCRIPTION
Class flags are already cached so reducing the messages for the classes which are cached.

Messages reduced are:
 1. hasFinalizer
 2. isOwnableSyncClass
 3. classDepthOf
 4. isCloneable

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>