### PR TITLE
Remove the compile option "-g"

### DIFF
--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -78,11 +78,6 @@ ifdef j9vm_uma_supportsIpv6
   CPPFLAGS += -DIPv6_FUNCTION_SUPPORT
 endif
 
-ifdef j9vm_uma_gnuDebugSymbols
-CFLAGS += -g
-CXXFLAGS += -g
-endif
-
 ifdef I5_VERSION
   CFLAGS += $(UMA_CC_MODE)
 else


### PR DESCRIPTION
"-g" was added by #2309, it increases the
operating system stack size needed to start up the JVM, resulting in
StackOverflowError on AIX.

Fixes #3248

Signed-off-by: hangshao <hangshao@ca.ibm.com>