### PR TITLE
WIP: OpenJ9 JDK8 Support for OSX

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -458,9 +458,13 @@ UMA_PASM_INCLUDES:=$(addprefix -I ,$(UMA_INCLUDES))
 </#if>
 
 <#if uma.spec.type.osx>
+UMA_OSX_M4_FLAGS=-DOSX
+ifeq "$(VERSION_MAJOR)" "8"
+	UMA_OSX_M4_FLAGS+=-DOSX_JAVA8
+endif
 #compilation rule for .m4 files
 %$(UMA_DOT_O): %.m4
-	m4 -DOSX $(UMA_M4_FLAGS) $(UMA_C_INCLUDES) $< > $*.s
+	m4 $(UMA_OSX_M4_FLAGS) $(UMA_M4_FLAGS) $(UMA_C_INCLUDES) $< > $*.s
 	$(AS) $(ASFLAGS) -o $*.o $*.s
 	-mv -f $*.s $*.hold
 </#if>

--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -122,7 +122,11 @@ ifdef({OSX},{
 })	dnl OSX
 })
 
+ifdef({OSX_JAVA8},{
+define({DECLARE_PUBLIC},{.globl GLOBAL_SYMBOL($1)})
+},{	dnl OSX_JAVA8
 define({DECLARE_PUBLIC},{.global GLOBAL_SYMBOL($1)})
+})	dnl OSX_JAVA8
 
 define({DECLARE_EXTERN},{.extern C_FUNCTION_SYMBOL($1)})
 

--- a/runtime/vm/xa64/stackswap.m4
+++ b/runtime/vm/xa64/stackswap.m4
@@ -27,7 +27,10 @@ eqS_swapStacksAndRunHandler = 33
 eqSR_swapStacksAndRunHandler = 6
 eqSRS_swapStacksAndRunHandler = 48
 eqSS_swapStacksAndRunHandler = 264
+ifdef({OSX_JAVA8},{
+},{	dnl OSX_JAVA8
         DECLARE_PUBLIC(vmSignalHandler)
+})	dnl OSX_JAVA8
         DECLARE_PUBLIC(swapStacksAndRunHandler)
 
 dnl Intel syntax: instruction dest source


### PR DESCRIPTION
**1) Add flag to toggle assembly syntax while building OpenJ9 JDK8 on OSX** 

OpenJ9 JDK8 is built on OSX 10.10 Yosemite with Xcode4.6.3. The assembly
syntax is different in this setup.

While building m4 files, `-DOSX_JAVA8` is enabled to recognize the setup
for JDK8 on OSX.

gcc version on Xcode4 and Xcode9 is 4.2.1. So, compiler version can't be
used to recognize the setup for JDK8 on OSX.

**2) Replace .global with .globl for JDK8 on OSX**

The setup for JDK8 on OSX uses old assembly syntax where `.global` is not
recognized. `.global` is replaced with `.globl`.

**3) Fix compiler error related to stackswap.s for JDK8 on OSX**

The following compiler error is seen when building OpenJ9 JDK8 on OSX:
```
stackswap.s:133:Alignment too large: 15. assumed.
stackswap.s:153:suffix or operands invalid for `call'
```
Assembly code on stackswap.s:153 -
```
        call _vmSignalHandler
```
In stackswap.s, `_vmSignalHandler` is declared as:
```
        .globl _vmSignalHandler
```
Removing `.globl _vmSignalHandler` resolves the compiler error.

JDK8 on OSX is built using Xcode4, which has an old assembler. In this
assembler, all symbols are considered external by default, and
stackswap.s doesn't contain the definition of `_vmSignalHandler`. So,
`_vmSignalHandler` doesn't need to be declared as a global in stackswap.s.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>