### PR TITLE
Remove retry(5) around checkouts on master

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -26,9 +26,7 @@ timeout(time: 10, unit: 'HOURS') {
     timestamps {
         node('master') {
             try{
-                retry(5){
-                    checkout scm
-                }
+                checkout scm
 
                 variableFile = load 'buildenv/jenkins/common/variables-functions'
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -25,9 +25,7 @@ ARGS = ['SDK_VERSION', 'PLATFORM']
 timestamps {
     node('master') {
         try{
-            retry(5) {
-                checkout scm
-            }
+            checkout scm
             variableFile = load 'buildenv/jenkins/common/variables-functions'
             variableFile.set_job_variables('pipeline')
 


### PR DESCRIPTION
- #1787 is resolved so this should be removed
- Leaving it in can hide future problems
- Killing a build in a retry will not actually
  stop the build, it will just loop into the next
  retry iteration which is problematic and annoying.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>