### PR TITLE
Don't fingerprint artifacts

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -299,7 +299,7 @@ def archive() {
                 echo "ARTIFACTORY_CREDS:'${ARTIFACTORY_CREDS}'"
             } else {
                 echo "ARTIFACTORY server is not set saving artifacts on jenkins."
-                archiveArtifacts artifacts: "**/${SDK_FILENAME},**/${TEST_FILENAME}", fingerprint: true, onlyIfSuccessful: true
+                archiveArtifacts artifacts: "**/${SDK_FILENAME},**/${TEST_FILENAME}", fingerprint: false, onlyIfSuccessful: true
             }
         }
     }


### PR DESCRIPTION
- Fingerprinting will store md5 checksums for artifacts in a DB
- This takes time to execute
- It is useful for tracking artifact dependencies around builds
- We don't use this functionality so we should remove it to save time
- More info: https://wiki.jenkins.io/display/JENKINS/Fingerprint

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>