### PR TITLE
Add OSX support for get thread user time

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -993,14 +993,14 @@ getCurrentThreadUserTime(omrthread_t self)
 	
 	userTime = omrthread_get_self_user_time(self);
 	
-#if defined(J9ZOS390) || defined(LINUX)
+#if defined(J9ZOS390) || defined(LINUX) || defined(OSX)
 	if (-1 == userTime) {
-		/* For z/OS and Linux, user time is not available from the OS.
+		/* For z/OS, Linux and OSX, user time is not available from the OS.
 		 * So provide cpu time in its place.
 		 */
 		userTime = omrthread_get_self_cpu_time(self);
 	}
-#endif /* ZOS or LINUX */
+#endif /* defined(J9ZOS390) || defined(LINUX) || defined(OSX) */
 		
 	return userTime;
 }


### PR DESCRIPTION
Add `OSX` support for get thread user time

Added `OSX` support for `getCurrentThreadUserTime`, provide cpu time when the user time is not available from the `OS` just like `zOS` and `Linux`.

Manually verified that this PR fixes two `AssertionError`: `testGetCurrentThreadUserTime` and `testGetThreadUserTime` as per https://github.com/eclipse/openj9/issues/3154#issuecomment-429427629.
Note: another `AssertionError testGetMBeanInfo` within the test `JLM_Tests_interface` is a known failure #1626.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>