### PR TITLE
Don't reserve DataCaches on the client's side

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8463,7 +8463,7 @@ TR::CompilationInfoPerThreadBase::compile(
       // to reset when throwing the data away
       //
       if ((_jitConfig->runtimeFlags & J9JIT_TOSS_CODE)
-            || compiler->getPersistentInfo()->getJITaaSMode() != NONJITaaS_MODE // JITaaS FIXME: we need to reserve only for server mode
+            || compiler->getPersistentInfo()->getJITaaSMode() == SERVER_MODE
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
             || vm.isAOT_DEPRECATED_DO_NOT_USE()
 #endif //endif J9VM_INTERP_AOT_COMPILE_SUPPORT


### PR DESCRIPTION
Reserving a DataCache will cause a one to be created
if one isn't available to reserve, leading to excessive
memory usage. Reserving a DataCache is needed on the
server to ensure that all of our data is in contiguous
memory, however we don't need this on the client.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>