### PR TITLE
CMake: Add compiler/z/env folder

### DIFF
--- a/runtime/compiler/z/CMakeLists.txt
+++ b/runtime/compiler/z/CMakeLists.txt
@@ -29,3 +29,5 @@ endif()
 if(TR_TARGET_ARCH STREQUAL "z")
 	add_subdirectory(codegen)
 endif() 
+
+add_subdirectory(env)


### PR DESCRIPTION
Files in compiler/z/env should be compiled when jit is hosted on
or targeting z architecrture

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>