### PR TITLE
Proper set SupportsReferenceArrayCopy in CodeGen X86

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -60,6 +60,11 @@ J9::X86::CodeGenerator::CodeGenerator() :
 
    cg->setAheadOfTimeCompile(new (cg->trHeapMemory()) TR::AheadOfTimeCompile(cg));
 
+   if (!TR::Compiler->om.canGenerateArraylets())
+      {
+      cg->setSupportsReferenceArrayCopy();
+      }
+
    if (comp->requiresSpineChecks())
       {
       // Spine check code doesn't officially support codegen register rematerialization


### PR DESCRIPTION
OMR incorrectly set SupportsReferenceArrayCopy and is going to
remove it; therefore, OpenJ9 should set the flag own its own.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>