### PR TITLE
Use omrsysinfo_is_running_in_container() to check if in container

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1367,6 +1367,7 @@ typedef struct J9SharedCacheAPI {
 	I_32 minJIT;
 	I_32 maxJIT;
 	U_8 sharedCacheEnabled;
+	U_8 inContainer; /* It is TRUE only when xShareClassesPresent is FALSE and J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) is TRUE and the JVM is running in container */
 } J9SharedCacheAPI;
 
 typedef struct J9SharedClassConfig {

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2916,3 +2916,4 @@ TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_SetMaxSize NoEnv Overhead=1 Level
 TraceEvent=Trc_SHR_INIT_j9shr_init_Entry Overhead=1 Level=6 Template="INIT entering j9shr_init"
 TraceEvent=Trc_SHR_INIT_j9shr_init_BootClassSharingEnabledByDefault Overhead=1 Level=1 Template="INIT j9shr_init: Bootstrap class sharing enabled by default"
 TraceException=Trc_SHR_INIT_j9shr_init_ExitOnNonFatal Overhead=1 Level=1 Template="INIT j9shr_init: exit on non-fatal error"
+TraceEvent=Trc_SHR_VMInitStages_Event_RunningInContainer Overhead=1 Level=1 Template="The JVM is running in container, class sharing is not enabled by default"

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
@@ -46,10 +46,12 @@
 	<!--Do not check the result of -Xshareclasses:destroy. It is possible another java process is holding the default shared cache open. In this case -Xshareclasses:destroy will fail on Windows -->
 	
 	<test id="Test 1: Test that only bootstrap class sharing is enabled by default" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ -XX:-UseContainerSupport -Xtrace:print={j9shr.1297,j9shr.1514,j9shr.2271,j9shr.2264,j9jcl.104,j9jcl.97} $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<command>$JAVA_EXE$ -Xtrace:print={j9shr.1297,j9shr.1514,j9shr.2271,j9shr.2272,j9shr.2264,j9jcl.104,j9jcl.97} $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<!-- Enable j9shr.2271 Trc_SHR_INIT_j9shr_init_ExitOnNonFatal and j9shr.2264 Trc_SHR_OSC_getCacheDir_j9shmem_getDir_failed1 for debugging purpose when failed -->
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.1514\s+ - CM commitROMClass : Data was stored in the cache for J9ROMClass</output>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.1297\s+ - CM findROMClass: class .* found at address</output>
+		<!--Let this test pass if someone is running in container-->
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.2272\s+ - The JVM is running in container, class sharing is not enabled by default</output>
 		<output type="required" caseSensitive="yes" regex="no">Puzzle solved!</output>
 		<!-- j9jcl.104, j9jcl.97 SharedClassURLClasspathHelperImpl.storeSharedClassImpl()/findSharedClassImpl() is not triggered, non-bootstrap class sharing is not enabled.  -->
 		<output type="failure" caseSensitive="no" regex="no">SharedClassURLClasspathHelperImpl</output>	

--- a/test/functional/cmdLineTests/verbosetest/verbosetests.xml
+++ b/test/functional/cmdLineTests/verbosetest/verbosetests.xml
@@ -492,7 +492,6 @@
   		<command>$EXE$ $VERBOSE$ $PROGRAM$</command>
  		<!-- check for -verbose:dynload message on a non-bootstrap class. When shared cache is enabled by default, -verbose:dynload won't show bootstrap classes loaded from the share cache-->
   		<output regex="no" type="required">Loaded jit/test/vich/Allocation</output>
-  		<output regex="no" type="required">Loaded java/lang/Object from</output>
  		<output regex="no" type="required">RAM class segment increment</output>
  		<output regex="no" type="required">JVMVERB000I Verbose stack</output>
  		<output regex="no" type="required"></output>


### PR DESCRIPTION
1. Use omrsysinfo_is_running_in_container() to check if JVM is running in container
2. Do not check bootstrap class in verboseTests
3. Let ShareClassesCMLOpenJ9 test pass when running in container.

Fixes #3264

Signed-off-by: hangshao <hangshao@ca.ibm.com>