### PR TITLE
Do not set a call count for bytecodes tracked by IProfiler

### DIFF
--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -631,6 +631,13 @@ TR_JITaaSIProfiler::setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, 
    {
    uintptr_t methodStart = TR::Compiler->mtd.bytecodeStart(method);
    uint8_t bytecode = *((uint8_t*)(methodStart+bcIndex));
+   // The following bytecode types are tracked by IProfiler, so we
+   // don't need to artificially set a call count for them
+   if (bytecode == JBinvokevirtual ||
+       bytecode == JBinvokeinterface ||
+       bytecode == JBinvokeinterface2)
+      return;
+
    bool sendRemoteMessage = false; 
    ClientSessionData *clientData = TR::compInfoPT->getClientData(); // Find clientSessionData
    if (_useCaching)


### PR DESCRIPTION
The optimizer may try to artificially create IProfiler entries for bytecodes
that it does not track. This should be the case for "invokeStatic" and
"invokeSpecial". However, we see this happening for "invokeVirtual" as well.
In this commit we will add a filter such that setCallCount() will do nothing
for calls that are already tracked by IProfiler.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>