### PR TITLE
Set proper shared library suffix for operating system

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
@@ -23,6 +23,8 @@ package org.openj9.test.attachAPI;
 
 import static org.testng.AssertJUnit.assertTrue;
 import static org.openj9.test.util.FileUtilities.deleteRecursive;
+import static org.openj9.test.util.PlatformInfo.isWindows;
+import static org.openj9.test.util.PlatformInfo.isMacOS;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -202,14 +204,6 @@ public class TestAttachAPI extends AttachApiTest {
 
 	}
 
-	private boolean isWindows() {
-		String osName = System.getProperty("os.name");
-		if ((null != osName) && osName.startsWith("Windows")) {
-			return true;
-		}
-		return false;
-	}
-
 	@Test
 	public void test_agntld03() {
 		
@@ -222,12 +216,13 @@ public class TestAttachAPI extends AttachApiTest {
 		String[] libDirs = lipPath.split(File.pathSeparator);
 		char fs = File.separatorChar;
 		String decoration = "lib";
-		String suffix = ".so";
-		String errOutput = "";
+		String suffix = ".so"; // default for Linux, AIX, and z/OS
 		if (isWindows()) {
 			/* kludgy test if we are on MS Windows */
 			decoration = "";
 			suffix = ".dll";
+		} else if (isMacOS()) {
+			suffix = ".dylib";
 		}
 		int pIndex = 0;
 		String outOutput = null;
@@ -274,7 +269,7 @@ public class TestAttachAPI extends AttachApiTest {
 			logExceptionInfoAndFail(e);
 		}
 		target.terminateTarget();
-		errOutput = target.getErrOutput();
+		String errOutput = target.getErrOutput();
 		outOutput = target.getOutOutput();
 		logger.debug(outOutput);
 		assertTrue("missing Agent_OnAttach string",

--- a/test/functional/TestUtilities/src/org/openj9/test/util/PlatformInfo.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/PlatformInfo.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.util;
+
+public class PlatformInfo {
+	private static final String OS_NAME = "os.name";
+	private static final String osName = System.getProperty(OS_NAME);
+
+	public static boolean isWindows() {
+		return ((null != osName) && osName.startsWith("Windows"));
+	}
+
+	public static boolean isMacOS() {
+		return ((null != osName) && osName.startsWith("Mac OS"));
+	}
+
+}


### PR DESCRIPTION
Set file suffix to ".so", ".dylib", or ".dll" for Linux (et al.), MacOS, and
Windows respectively.

Create PlatformInfo to hold methods which report the operating system type.

Fixes https://github.com/eclipse/openj9/issues/3266 (fix for
https://github.com/eclipse/openj9/issues/3292 also required).

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>