### PR TITLE
Remove check for free memory return to OS in Softmx test

### DIFF
--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest_GC_Only.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest_GC_Only.java
@@ -31,7 +31,6 @@ import org.testng.AssertJUnit;
 import j9vm.test.softmx.MemoryExhauster;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
 import java.util.Iterator;
 import java.util.List;
 
@@ -84,49 +83,16 @@ public class SoftmxAdvanceTest_GC_Only{
 		logger.debug("	Forcing Aggressive GC. Will wait a maximum of 5 minutes for heap shrink..." );
 		TestNatives.setAggressiveGCPolicy();
 
-		/* figure out DisclaimVirtualMemory setting from VM arguments.
-		 * The arguments will contain -Xsoftmx and -XX:+DisclaimVirtualMemory/-XX:-DisclaimVirtualMemory
-		 */
-		boolean enableDisclaimMemory = false;
-		boolean disableDisclaimMemory = false;
-		boolean softmxExist = false;
-
-		RuntimeMXBean RuntimemxBean = ManagementFactory.getRuntimeMXBean();
-		List<String> arguments = RuntimemxBean.getInputArguments();
-
-		Iterator it = arguments.iterator();
-
-		while (it.hasNext()){
-			String s = (String)it.next();
-			if (s.equalsIgnoreCase(DISCLAIM_MEMORY)){
-				enableDisclaimMemory = true;
-			}
-			if (s.equalsIgnoreCase(NOT_DISCLAIM_MEMORY)){
-				disableDisclaimMemory = true;
-			}
-			if (s.contains(SOFTMX)){
-				softmxExist = true;
-			}
-		}
-
 		long startTime = System.currentTimeMillis();
 		boolean isShrink = false;
 
 		//waiting for maximum 5 min (300000ms)
 		while((System.currentTimeMillis() - startTime) < 300000 ){
-			if ( ibmMemoryMBean.getHeapMemoryUsage().getCommitted() <= new_softmx_value ) {
-				if ( enableDisclaimMemory ) {
-					if ( ibmOSMBean.getFreePhysicalMemorySize() > preMemSize ) {
-						isShrink = true;
-					}
-				} else {
-					isShrink = true;
-				}
-				if ( isShrink == true ) {
-					logger.debug( "	PASS: Heap has shrunk to " + ibmMemoryMBean.getHeapMemoryUsage().getCommitted() + " bytes"
-					+ " in " + (System.currentTimeMillis() - startTime) + " mSeconds");
-					break;
-				}
+			if (ibmMemoryMBean.getHeapMemoryUsage().getCommitted() <= new_softmx_value) {
+				isShrink = true;
+				logger.debug( "	PASS: Heap has shrunk to " + ibmMemoryMBean.getHeapMemoryUsage().getCommitted() + " bytes"
+				+ " in " + (System.currentTimeMillis() - startTime) + " mSeconds");
+				break;
 			} else {
 				try {
 					Thread.sleep(2000);


### PR DESCRIPTION
An expectation of test that decommited heap memory is going to be
returned to OS is not reliable. It is a source of intermittent failures.
From another side ibmMemoryMBean.getHeapMemoryUsage().getCommitted()
always returns true amount of commited memory. So the main goal of the
test to verify -Xsoftmx functionality.

fixes #1470 

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>