### PR TITLE
Software RangeCheck Read Barrier

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -122,7 +122,7 @@ public:
     * \brief Determine whether to replace guarded loads with software read barrier sequence
     *
     * \return
-    *     true if debug gc option -XXgc:softwareEvacuateReadBarrier is used
+    *     true if debug gc option -XXgc:softwareRangeCheckReadBarrier is used
     */
    bool shouldReplaceGuardedLoadWithSoftwareReadBarrier();
 

--- a/runtime/gc_modron_startup/mmhelpers.cpp
+++ b/runtime/gc_modron_startup/mmhelpers.cpp
@@ -142,7 +142,7 @@ j9gc_concurrent_scavenger_enabled(J9JavaVM *javaVM)
 UDATA
 j9gc_software_read_barrier_enabled(J9JavaVM *javaVM)
 {
-	return MM_GCExtensions::getExtensions(javaVM)->isSoftwareEvacuateReadBarrierEnabled() ? 1 : 0;
+	return MM_GCExtensions::getExtensions(javaVM)->isSoftwareRangeCheckReadBarrierEnabled() ? 1 : 0;
 }
 
 /**

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2854,7 +2854,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 		/* after we parsed cmd line options, check if we can obey the request to run CS (valid for Gencon only) */
 		if (extensions->concurrentScavengerForced) {
 #if defined(J9VM_ARCH_X86)
-			extensions->softwareEvacuateReadBarrier = true;
+			extensions->softwareRangeCheckReadBarrier = true;
 #endif /* J9VM_ARCH_X86 */
 			if (LOADED == (FIND_DLL_TABLE_ENTRY(J9_JIT_DLL_NAME)->loadFlags & LOADED)) {
 				/* If running jitted, it must be on supported h/w */
@@ -2864,8 +2864,8 @@ gcInitializeDefaults(J9JavaVM* vm)
 						j9sysinfo_processor_has_feature(&processorDesc, J9PORT_S390_FEATURE_SIDE_EFFECT_ACCESS);
 
 				/* Software Barrier request overwrites HW usage */
-				extensions->concurrentScavengerHWSupport = hwSupported && !extensions->softwareEvacuateReadBarrier;
-				extensions->concurrentScavenger = hwSupported || extensions->softwareEvacuateReadBarrier;
+				extensions->concurrentScavengerHWSupport = hwSupported && !extensions->softwareRangeCheckReadBarrier;
+				extensions->concurrentScavenger = hwSupported || extensions->softwareRangeCheckReadBarrier;
 			} else {
 				/* running interpreted is ok on any h/w */
 				extensions->concurrentScavenger = true;

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -791,8 +791,8 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->setDebugConcurrentScavengerPageAlignment(true);
 			continue;
 		}
-		if(try_scan(&scan_start, "softwareEvacuateReadBarrier")) {
-			extensions->softwareEvacuateReadBarrier = true;
+		if(try_scan(&scan_start, "softwareRangeCheckReadBarrier")) {
+			extensions->softwareRangeCheckReadBarrier = true;
 			continue;
 		}
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */


### PR DESCRIPTION
Renaming flag and command line option S/W Evacuate RB to S/W RangeCheck
RB. Evacuate is an action that is required by RB in Concurrent
Scavenger. It's always executed in software. What has alternative
implementation in S/W vs H/W is the trigger mechanism, which is the
range check against Evacuate area boundaries (or a set of areas).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>