### PR TITLE
Simplify cleanWs commands

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -335,13 +335,7 @@ def build_all() {
                 archive()
             }
         } finally {
-            try {
-                cleanWs()
-            } catch(e) {
-                echo e.toString()
-                echo e.printStackTrace()
-                sh "ps -ef"
-            }
+            cleanWs notFailBuild: true, disableDeferredWipeout: true
         }
     }
 }

--- a/buildenv/jenkins/common/test
+++ b/buildenv/jenkins/common/test
@@ -112,25 +112,15 @@ def add_node_to_description() {
 
 def test_all() {
     timeout(time: 8, unit: 'HOURS') {
-        add_node_to_description()
-        configure()
-        get_dependencies()
-        compile()
-        test()
-        publish()
-
         try {
-            cleanWs()
-        } catch(e) {
-            /*
-            *  If clean workspace fails on Windows, show
-            *  the running processes. This has benn added
-            *  in an attempt to help debug what may be
-            *  holding open the file(s).
-            */
-            echo e.toString()
-            echo e.printStackTrace()
-            sh "ps -ef"
+            add_node_to_description()
+            configure()
+            get_dependencies()
+            compile()
+            test()
+            publish()
+        } finally {
+            cleanWs notFailBuild: true, disableDeferredWipeout: true
         }
     }
 }

--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -55,11 +55,7 @@ timeout(time: 10, unit: 'HOURS') {
                     buildFile = load 'buildenv/jenkins/common/build'
                 }
             } finally {
-                try{
-                    cleanWs()
-                } catch(e) {
-                    variableFile.printStackTrace(e)
-                }
+                cleanWs notFailBuild: true, disableDeferredWipeout: true
             }
         }
     }

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -143,15 +143,7 @@ timeout(time: 10, unit: 'HOURS') {
                     }
                 }
             } finally {
-                try{
-                    cleanWs()
-                } catch(e) {
-                    if (variableFile) {
-                        printStackTrace(e)
-                    } else {
-                        echo e.toString()
-                    }
-                }
+                cleanWs notFailBuild: true, disableDeferredWipeout: true
             }
         }
 

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-Any-Platform
@@ -32,13 +32,7 @@ timestamps {
             buildFile = load 'buildenv/jenkins/common/pipeline-functions'
             SHAS = buildFile.get_shas(OPENJDK_REPO, OPENJDK_BRANCH, OPENJ9_REPO, OPENJ9_BRANCH, OMR_REPO, OMR_BRANCH, VENDOR_TEST_REPOS_MAP, VENDOR_TEST_BRANCHES_MAP, VENDOR_TEST_SHAS_MAP)
         } finally {
-            try{
-                cleanWs()
-            } catch(e) {
-                if (variableFile) {
-                    variableFile.printStackTrace(e)
-                }
-            }
+            cleanWs notFailBuild: true, disableDeferredWipeout: true
         }
     }
 }


### PR DESCRIPTION
- CleanWs commands at the end of builds were inconsistent
- Adding notFailBuild: true so that the build will
  not fail if the cleanWs fails
- Adding disableDeferredWipeout: true to avoid
  asynchronous WS cleanups failing and getting left behind

[skip ci]
https://jenkins.io/doc/pipeline/steps/ws-cleanup/

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>