### PR TITLE
Improve MethodHandles.lookup() field accesses

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/ChildMHLookupField.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/ChildMHLookupField.java
@@ -1,0 +1,86 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.lang.invoke.MethodHandles;
+import org.testng.Assert;
+
+// This class is loaded by ClassLoaderOne.
+public class ChildMHLookupField extends Parent {
+	private final ClassLoader clOne = ChildMHLookupField.class.getClassLoader();
+	private final Object objDummyOne = clOne.loadClass("org.openj9.test.java.security.Dummy").newInstance();
+	private final Class<?> clzDummyOne = objDummyOne.getClass();
+	private final ClassLoader clTwo = Parent.class.getClassLoader();
+	private final Object objDummyTwo = clTwo.loadClass("org.openj9.test.java.security.Dummy").newInstance();
+	private final Class<?> clzDummyTwo = objDummyTwo.getClass();
+	private final MethodHandles.Lookup mhLookup = MethodHandles.lookup();
+	
+	public ChildMHLookupField() throws Exception {
+		// Verify that the classes are loaded by appropriate class loaders
+		Assert.assertEquals(clOne.getClass(), ClassLoaderOne.class);
+		Assert.assertEquals(clzDummyOne.getClassLoader().getClass(), ClassLoaderOne.class);
+
+		Assert.assertEquals(clTwo.getClass(), ClassLoaderTwo.class);
+		Assert.assertEquals(clzDummyTwo.getClassLoader().getClass(), ClassLoaderTwo.class);
+	}
+
+	// Loading constraints are violated when reference and type classes (instance field getter) are loaded by different class loaders.
+	public void instanceFieldGetter1() throws Throwable {
+		mhLookup.findGetter(Parent.class, "instanceField", clzDummyOne);
+	}
+	
+	// Loading constraints are violated when reference/type(instance field getter) and access classes are loaded by different class loaders.
+	public void instanceFieldGetter2() throws Throwable {
+		mhLookup.findGetter(Parent.class, "instanceField", clzDummyTwo);
+	}
+
+	// Loading constraints are violated when reference and type classes (static field getter) are loaded by different class loaders.
+	public void staticFieldGetter1() throws Throwable {
+		mhLookup.findStaticGetter(Parent.class, "staticField", clzDummyOne);
+	}
+	
+	// Loading constraints are violated when reference/type(static field getter) and access classes are loaded by different class loaders.
+	public void staticFieldGetter2() throws Throwable {
+		mhLookup.findStaticGetter(Parent.class, "staticField", clzDummyTwo);
+	}
+
+	// Loading constraints are violated when reference and type classes (instance field setter) are loaded by different class loaders.
+	public void instanceFieldSetter1() throws Throwable {
+		mhLookup.findSetter(Parent.class, "instanceField", clzDummyOne);
+	}
+	
+	// Loading constraints are violated when reference/type(instance field setter) and access classes are loaded by different class loaders.
+	public void instanceFieldSetter2() throws Throwable {
+		mhLookup.findSetter(Parent.class, "instanceField", clzDummyTwo);
+	}
+
+	// Loading constraints are violated when reference and type classes (static field setter) are loaded by different class loaders.
+	public void staticFieldSetter1() throws Throwable {
+		mhLookup.findStaticSetter(Parent.class, "staticField", clzDummyOne);
+	}
+	
+	// Loading constraints are violated when reference/type(static field setter) and access classes are loaded by different class loaders.
+	public void staticFieldSetter2() throws Throwable {
+		mhLookup.findStaticSetter(Parent.class, "staticField", clzDummyTwo);
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/ClassLoaderOne.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/ClassLoaderOne.java
@@ -1,0 +1,80 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Set;
+import java.util.HashSet;
+
+// This classloader loads classes ChildMHLookupField and Dummy.
+public class ClassLoaderOne extends ClassLoader {
+	private ClassLoader clTwo;
+	private final Set<String> names = new HashSet<>();
+	
+	public ClassLoaderOne(String... names) {
+		for (String name : names) {
+			this.names.add(name);
+		}
+	}
+	
+	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		if (name.equals("org.openj9.test.java.security.Parent")) {
+			if (clTwo == null) {
+				clTwo = new ClassLoaderTwo(this, "org.openj9.test.java.security.Dummy", "org.openj9.test.java.security.Parent");
+			}
+			Class<?> parent = clTwo.loadClass("org.openj9.test.java.security.Parent");
+			return parent;
+		}
+		if (!names.contains(name)) {
+			return super.loadClass(name, resolve);
+		}
+		Class<?> result = findLoadedClass(name);
+		if (result == null) {
+			String filename = name.replace('.', '/') + ".class";
+			try (InputStream data = getResourceAsStream(filename)) {
+				if (data == null) {
+					throw new ClassNotFoundException();
+				}
+				try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+					int b;
+					do {
+						b = data.read();
+						if (b >= 0) {
+							buffer.write(b);
+						}
+					} while (b >= 0);
+					byte[] bytes = buffer.toByteArray();
+					result = defineClass(name, bytes, 0, bytes.length);
+				}
+			} catch (IOException e) {
+				throw new ClassNotFoundException("Error reading" + filename, e);
+			}
+		}
+		if (resolve) {
+			resolveClass(result);
+		}
+		return result;
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/ClassLoaderTwo.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/ClassLoaderTwo.java
@@ -1,0 +1,79 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Set;
+import java.util.HashSet;
+
+// This classloader loads classes Parent and Dummy.
+public class ClassLoaderTwo extends ClassLoader {
+	private final Set<String> names = new HashSet<>();
+	private ClassLoader clOne;
+	public ClassLoaderTwo(ClassLoader cl, String... names) {
+		clOne = cl;
+		for (String name : names) {
+			this.names.add(name);
+		}
+	}
+	
+	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		if (name.equals("org.openj9.test.java.security.ChildMHLookupField")) {
+			return clOne.loadClass(name);
+		}
+		if (!names.contains(name)) {
+			return super.loadClass(name, resolve);
+		}
+		Class<?> result = findLoadedClass(name);
+		if (result == null) {
+			if (name.equals("org.openj9.test.java.security.Parent")) {
+				loadClass("org.openj9.test.java.security.Dummy", resolve);
+			}
+			String filename = name.replace('.', '/') + ".class";
+			try (InputStream data = getResourceAsStream(filename)) {
+				if (data == null) {
+					throw new ClassNotFoundException();
+				}
+				try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+					int b;
+					do {
+						b = data.read();
+						if (b >= 0) {
+							buffer.write(b);
+						}
+					} while (b >= 0);
+					byte[] bytes = buffer.toByteArray();
+					result = defineClass(name, bytes, 0, bytes.length);
+				}
+			} catch (IOException e) {
+				throw new ClassNotFoundException("Error reading" + filename, e);
+			}
+		}
+		if (resolve) {
+			resolveClass(result);
+		}
+		return result;
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/Dummy.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/Dummy.java
@@ -1,0 +1,27 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+// This class will be loaded by ClassLoaderOne and ClassLoaderTwo.
+public class Dummy {
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/Parent.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/Parent.java
@@ -1,0 +1,32 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+//This class will be loaded by ClassLoaderTwo.
+public class Parent {
+	public Dummy instanceField;
+	public static Dummy staticField = new Dummy();
+	public Parent() { 
+		instanceField = new Dummy(); 
+	}
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/java/security/Test_MHLoaderConstraints.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/security/Test_MHLoaderConstraints.java
@@ -1,0 +1,201 @@
+package org.openj9.test.java.security;
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+import java.lang.reflect.Method;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+@Test(groups = { "level.sanity" })
+public class Test_MHLoaderConstraints {
+	private ClassLoader clOne = new ClassLoaderOne("org.openj9.test.java.security.Dummy", 
+		"org.openj9.test.java.security.ChildMHLookupField");
+	private Class<?> clzChildMHLookupField = clOne.loadClass("org.openj9.test.java.security.ChildMHLookupField");
+	private Object instChildMHLookupField = clzChildMHLookupField.newInstance();
+
+	public Test_MHLoaderConstraints() throws Exception {
+	}
+	
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findGetter()
+	 *  Loading constraints are violated when reference and type classes (instance field getter) 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHInstanceFieldGetter1() throws Throwable {
+		Method testInstanceFieldGetter = clzChildMHLookupField.getDeclaredMethod("instanceFieldGetter1");
+		try {
+			testInstanceFieldGetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findGetter()
+	 *  Loading constraints are violated when reference/type(instance field getter) and access classes 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHInstanceFieldGetter2() throws Throwable {
+		Method testInstanceFieldGetter = clzChildMHLookupField.getDeclaredMethod("instanceFieldGetter2");
+		try {
+			testInstanceFieldGetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+	
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findSetter()
+	 *  Loading constraints are violated when reference and type classes (instance field setter) 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHInstanceFieldSetter1() throws Throwable {
+		Method testInstanceFieldSetter = clzChildMHLookupField.getDeclaredMethod("instanceFieldSetter1");
+		try {
+			testInstanceFieldSetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findSetter()
+	 *  Loading constraints are violated when reference/type(instance field setter) and access classes 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHInstanceFieldSetter2() throws Throwable {
+		Method testInstanceFieldSetter = clzChildMHLookupField.getDeclaredMethod("instanceFieldSetter2");
+		try {
+			testInstanceFieldSetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+	
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findStaticGetter()
+	 *  Loading constraints are violated when reference and type classes (static field getter) 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHStaticFieldGetter1() throws Throwable {
+		Method testStaticFieldGetter = clzChildMHLookupField.getDeclaredMethod("staticFieldGetter1");
+		try {
+			testStaticFieldGetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findStaticGetter()
+	 *  Loading constraints are violated when reference/type(static field getter) and access classes 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHStaticFieldGetter2() throws Throwable {
+		Method testStaticFieldGetter = clzChildMHLookupField.getDeclaredMethod("staticFieldGetter2");
+		try {
+			testStaticFieldGetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+	
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findStaticSetter()
+	 *  Loading constraints are violated when reference and type classes (static field setter) 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHStaticFieldSetter1() throws Throwable {
+		Method testStaticFieldSetter = clzChildMHLookupField.getDeclaredMethod("staticFieldSetter1");
+		try {
+			testStaticFieldSetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+
+	/**
+	 *  java.lang.invoke.MethodHandles.lookup()#findStaticSetter()
+	 *  Loading constraints are violated when reference/type(static field setter) and access classes 
+	 *  are loaded by different class loaders.
+	 *  IllegalAccessException with LinkageError cause is expected to be wrapped within InvocationTargetException.
+	 */
+	@Test
+	public void test_MHStaticFieldSetter2() throws Throwable {
+		Method testStaticFieldSetter = clzChildMHLookupField.getDeclaredMethod("staticFieldSetter2");
+		try {
+			testStaticFieldSetter.invoke(instChildMHLookupField);
+			Assert.fail("InvocationTargetException expected");
+		} catch (InvocationTargetException e) {
+			Throwable e2 = e.getCause();
+			Assert.assertNotNull(e2, "Expected IllegalAccessException to be cause of InvocationTargetException");
+			Assert.assertTrue(e2 instanceof IllegalAccessException);
+			Assert.assertTrue(e2.getCause() instanceof LinkageError);
+		}
+	}
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -200,6 +200,7 @@
 		<classes>
 			<class name="org.openj9.test.java.security.Test_AccessController"/>
 			<class name="org.openj9.test.java.security.Test_AccessControlContext"/>
+			<class name="org.openj9.test.java.security.Test_MHLoaderConstraints"/>
 		</classes>
 	</test>
 	<test name="JCL_TEST_IBM-VM">


### PR DESCRIPTION
Improve `MethodHandles.lookup()` field accesses

Perform loader constraints check when accessing a field via a `FindGetter` or `FindSetter` `MethodHandle`. This applies to both `instance` and `static` fields.
Added tests to check `IllegalAccessException` with `LinkageError` cause thrown in following cases:
* `MH instance/static field getter/setter` for `reference` and `type` classes loaded by different class loaders
* `MH instance/static field getter/setter` for `reference/type` and `access` classes loaded by different class loaders


Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>