### PR TITLE
WIP: Optimize CH table serialization

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1996,7 +1996,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->getRecvData<JITaaS::Void>();
          auto table = (TR_JITaaSClientPersistentCHTable*)comp->getPersistentInfo()->getPersistentCHTable();
          auto encoded = table->serializeUpdates();
-         client->write(encoded.first, encoded.second);
+         client->write(encoded.first, encoded.second, table->_commitNumber);
          }
          break;
       case J9ServerMessageType::CHTable_clearReservable:

--- a/runtime/compiler/env/JITaaSPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.hpp
@@ -97,20 +97,22 @@ public:
    uint32_t _updateBytes;
    uint32_t _maxUpdateBytes;
 #endif
+   uint32_t _commitNumber = 0;
 
 private:
    void markSuperClassesAsDirty(TR_FrontEnd *fe, TR_OpaqueClassBlock *classId);
    void markForRemoval(TR_OpaqueClassBlock *clazz);
    void markDirty(TR_OpaqueClassBlock *clazz);
-   void markExtended(TR_OpaqueClassBlock *clazz);
+   void markExtended(TR_OpaqueClassBlock *parentClass, TR_OpaqueClassBlock *subClass);
    uint32_t getNumAddedSubClasses(TR_OpaqueClassBlock *clazz);
+   std::vector<TR_OpaqueClassBlock *> *getAddedSubClasses(TR_OpaqueClassBlock *clazz);
 
    std::string serializeRemoves();
    std::string serializeModifications();
 
    PersistentUnorderedSet<TR_OpaqueClassBlock*> _dirty;
    PersistentUnorderedSet<TR_OpaqueClassBlock*> _remove;
-   PersistentUnorderedMap<TR_OpaqueClassBlock*, uint32_t> _extended;
+   PersistentUnorderedMap<TR_OpaqueClassBlock*, std::vector<TR_OpaqueClassBlock *>> _extended;
    };
 
 class FlatPersistentClassInfo
@@ -119,7 +121,7 @@ public:
    static std::string serializeHierarchy(TR_PersistentClassInfo *orig);
    static std::vector<TR_PersistentClassInfo*> deserializeHierarchy(std::string& data);
    static size_t classSize(TR_PersistentClassInfo *clazz, int32_t numSubClasses=-1);
-   static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info, int32_t numSubClasses=-1);
+   static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info, bool addAll=true, std::vector<TR_OpaqueClassBlock *> *subClasses=nullptr);
    static size_t deserializeClassSimple(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo *info);
 
    TR_OpaqueClassBlock                *_classId;
@@ -137,6 +139,7 @@ public:
 
    uint32_t                            _numSubClasses;
    TR_OpaqueClassBlock                *_subClasses[0];
+   bool                                _addAll;
    };
 
 #endif // JITaaS_PERSISTENT_CHTABLE_H

--- a/runtime/compiler/env/JITaaSPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.hpp
@@ -102,12 +102,15 @@ private:
    void markSuperClassesAsDirty(TR_FrontEnd *fe, TR_OpaqueClassBlock *classId);
    void markForRemoval(TR_OpaqueClassBlock *clazz);
    void markDirty(TR_OpaqueClassBlock *clazz);
+   void markExtended(TR_OpaqueClassBlock *clazz);
+   uint32_t getNumAddedSubClasses(TR_OpaqueClassBlock *clazz);
 
    std::string serializeRemoves();
    std::string serializeModifications();
 
    PersistentUnorderedSet<TR_OpaqueClassBlock*> _dirty;
    PersistentUnorderedSet<TR_OpaqueClassBlock*> _remove;
+   PersistentUnorderedMap<TR_OpaqueClassBlock*, uint32_t> _extended;
    };
 
 class FlatPersistentClassInfo
@@ -115,8 +118,8 @@ class FlatPersistentClassInfo
 public:
    static std::string serializeHierarchy(TR_PersistentClassInfo *orig);
    static std::vector<TR_PersistentClassInfo*> deserializeHierarchy(std::string& data);
-   static size_t classSize(TR_PersistentClassInfo *clazz);
-   static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info);
+   static size_t classSize(TR_PersistentClassInfo *clazz, int32_t numSubClasses=-1);
+   static size_t serializeClass(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo* info, int32_t numSubClasses=-1);
    static size_t deserializeClassSimple(TR_PersistentClassInfo *clazz, FlatPersistentClassInfo *info);
 
    TR_OpaqueClassBlock                *_classId;


### PR DESCRIPTION
When serializing modifications to the persistent CH table, serialize subclasses only if a class got extended or it is the first CH table commit. Otherwise, we know that class hierarchy hasn't changed, so there is no point in sending subclasses. Also, only send subclasses that got
added.
This should improve CPU usage, because some classes can have hundreds
of subclasses, which makes CH table commits very large.