### PR TITLE
Pre-load instance fields that are Qtypes

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1845,3 +1845,11 @@ J9NLS_VM_NESTMATES_CLASS_FAILED_TO_LOAD.system_action=The JVM will throw an Inco
 J9NLS_VM_NESTMATES_CLASS_FAILED_TO_LOAD.user_response=Load class and nest host class with same classloader.
 # END NON-TRANSLATABLE
 
+J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE=bad class %2$.*1$s: Qtype instance field is not a value type
+# START NON-TRANSLATABLE
+J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.sample_input_1=3
+J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.sample_input_2=Foo
+J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.explanation=The class has a field with a q signature which is not a value type.
+J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.system_action=The JVM will throw a IncompatibleClassChangeError.
+J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -775,3 +775,5 @@ TraceException=Trc_VM_registerOSHandler_invalidPortlibSignalFlag NoEnv Overhead=
 
 TraceEntry=Trc_VM_sendResolveConstantDynamic_Entry Overhead=1 Level=2 Template="sendResolveConstantDynamic(ramCP=%p, cpIndex=%zu, nameAndSig=%p, bsmData=%p)"
 TraceExit=Trc_VM_sendResolveConstantDynamic_Exit Overhead=1 Level=2 Template="sendResolveConstantDynamic"
+
+TraceException=Trc_VM_CreateRAMClassFromROMClass_nestedValueClassNotVisible Overhead=1 Level=1 Template="Nested field (RAM class=%p, classloader=%p, this classloader=%p) is not visible. Throw IllegalAccessError"


### PR DESCRIPTION
Pre-load instance fields that are Qtypes

During class loading all Qtypes that are instance fields must be
pre-loaded so the size and layout of the instance can be determined.

This is based on Eric's and Ali's previous work

Signed-off-by: tajila <atobia@ca.ibm.com>