### PR TITLE
JDK8 OSX <arch> (=amd64) not defined

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -1096,10 +1096,15 @@ preloadLibraries(void)
 		jrebinBuffer = jvmBufferCat(NULL, jvmBufferData(j9binBuffer));
 	}
 	j9libBuffer = jvmBufferCat(NULL, jvmBufferData(jrebinBuffer));
-#if J9VM_JAVA9_BUILD < 150
+#if !defined(OSX)
+	/* <arch> directory doesn't exist on OSX so j9libBuffer shouldn't
+	 * be truncated on OSX for removing <arch>.
+	 */
+#if (J9VM_JAVA9_BUILD < 150)
 	/* Remove <arch> */
 	truncatePath(jvmBufferData(j9libBuffer));
-#endif /* J9VM_JAVA9_BUILD < 150 */
+#endif /* (J9VM_JAVA9_BUILD < 150) */
+#endif /* !defined(OSX) */
 	j9libvmBuffer = jvmBufferCat(NULL, jvmBufferData(j9binBuffer));
 	j9Buffer = jvmBufferCat(NULL, jvmBufferData(jrebinBuffer));
 	truncatePath(jvmBufferData(j9Buffer));


### PR DESCRIPTION
Don't remove \<arch\> (=amd64) from j9libBuffer. JDK8 on OSX doesn't have
amd64 directory. Removing \<arch\> invalidates the directory path stored
in j9libBuffer. This prevents java.home system property to be properly
defined. Incorrect java.home system property leads to JVM initialization
error. Paths to JAR files are incorrect; thus, the JAR files can't be
loaded.

I am guessing that (J9VM_JAVA9_BUILD < 150) won't have amd64 directory
on OSX since JDK8 doesn't have one. Also, (J9VM_JAVA9_BUILD < 150) is no
longer supported.
 
Issue: https://github.com/eclipse/openj9/issues/3327

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>