### PR TITLE
Add Restart option for failed downstream jobs

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -227,10 +227,10 @@ def get_causes_recursively(cause) {
     return cause_string
 }
 
-def build_with_slack(JOB_NAME, PARAMETERS) {
+def build_with_slack(DOWNSTREAM_JOB_NAME, PARAMETERS) {
     def DOWNSTREAM_JOB_NUMBER = ''
     def DOWNSTREAM_JOB_URL = ''
-    def JOB = build job: JOB_NAME, parameters: PARAMETERS, propagate: false
+    def JOB = build job: DOWNSTREAM_JOB_NAME, parameters: PARAMETERS, propagate: false
 
     if (JOB.resultIsWorseOrEqualTo('UNSTABLE')) {
         try {
@@ -248,16 +248,21 @@ def build_with_slack(JOB_NAME, PARAMETERS) {
         build_causes_string = get_causes(currentBuild)
 
         if (JOB.result == "UNSTABLE") {
-            echo "WARNING: Downstream job ${JOB_NAME} is unstable. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
+            echo "WARNING: Downstream job ${DOWNSTREAM_JOB_NAME} is unstable. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
             currentBuild.result = "UNSTABLE"
             if (SLACK_CHANNEL) {
-                slackSend channel: SLACK_CHANNEL, color: 'warning', message: "Unstable: ${JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${env.JOB_NAME} #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)\n${build_causes_string}"
+                slackSend channel: SLACK_CHANNEL, color: 'warning', message: "Unstable: ${DOWNSTREAM_JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)\n${build_causes_string}"
             }
         } else {
             if (SLACK_CHANNEL) {
-                slackSend channel: SLACK_CHANNEL, color: 'danger', message: "Failure in: ${JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${env.JOB_NAME} #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)\n${build_causes_string}"
+                slackSend channel: SLACK_CHANNEL, color: 'danger', message: "Failure in: ${DOWNSTREAM_JOB_NAME} #${DOWNSTREAM_JOB_NUMBER} (<${DOWNSTREAM_JOB_URL}|Open>)\nStarted by ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)\n${build_causes_string}\nWould you like to restart the job? (<${RUN_DISPLAY_URL}|Open>)"
             }
-            error "Downstream job ${JOB_NAME} did not pass. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}"
+            timeout(time: RESTART_TIMEOUT, unit: RESTART_TIMEOUT_UNITS) {
+                input message: "Downstream job ${DOWNSTREAM_JOB_NAME} failed. Job Number: ${DOWNSTREAM_JOB_NUMBER} Job URL: ${DOWNSTREAM_JOB_URL}\nRestart failed job '${DOWNSTREAM_JOB_NAME}'?", ok: 'Restart'
+                // If restart is aborted or is timed-out, an error is thrown
+            }
+            // If restart is approved, recursively call this function until we get a pass or a restart-rejection
+            return build_with_slack(DOWNSTREAM_JOB_NAME, PARAMETERS)
         }
     }
     return JOB

--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -492,6 +492,17 @@ def set_artifactory_config() {
     }
 }
 
+def set_restart_timeout() {
+    RESTART_TIMEOUT = params.RESTART_TIMEOUT
+    if (!RESTART_TIMEOUT) {
+        RESTART_TIMEOUT = VARIABLES.restart_timeout.time
+    }
+    RESTART_TIMEOUT_UNITS = params.RESTART_TIMEOUT_UNITS
+    if (!RESTART_TIMEOUT_UNITS) {
+        RESTART_TIMEOUT_UNITS = VARIABLES.restart_timeout.units
+    }
+}
+
 def set_job_properties(JOB_TYPE) {
     /*************************
     * Setup Jenkins Properties
@@ -629,7 +640,9 @@ def set_job_properties(JOB_TYPE) {
                 'BUILD_NODE':'',
                 'TEST_NODE':'',
                 'PERSONAL_BUILD':'',
-                'SLACK_CHANNEL':''])
+                'SLACK_CHANNEL':'',
+                'RESTART_TIMEOUT':'',
+                'RESTART_TIMEOUT_UNITS':''])
         }
 
         /********************
@@ -713,10 +726,12 @@ def set_job_variables(job_type) {
             set_vendor_variables()
             set_test_targets()
             set_slack_channel()
+            set_restart_timeout()
             break
         case "wrapper":
             //set variable for pipeline all/personal
             set_repos_variables(BUILD_SPECS)
+            set_restart_timeout()
             break
         default:
             error("Unknown Jenkins job type!")

--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Build-Test-All
@@ -96,7 +96,7 @@ OPENJDK_SHA = [:]
 BUILD_SPECS = [:]
 builds = [:]
 
-timeout(time: 10, unit: 'HOURS') {
+timeout(time: 12, unit: 'HOURS') {
     timestamps {
         node(LABEL) {
             try {
@@ -221,7 +221,9 @@ def build(OPENJDK_REPO, OPENJDK_BRANCH, SHAS, OPENJ9_REPO, OPENJ9_BRANCH, OMR_RE
                     string(name: 'BUILD_NODE', value: BUILD_NODE),
                     string(name: 'TEST_NODE', value: TEST_NODE),
                     string(name: 'PERSONAL_BUILD', value: PERSONAL_BUILD),
-                    string(name: 'SLACK_CHANNEL', value: SLACK_HANDLE)]
+                    string(name: 'SLACK_CHANNEL', value: SLACK_HANDLE),
+                    string(name: 'RESTART_TIMEOUT', value: RESTART_TIMEOUT),
+                    string(name: 'RESTART_TIMEOUT_UNITS', value: RESTART_TIMEOUT_UNITS)]
         return JOB
     }
 }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -67,6 +67,9 @@ build_discarder:
     pullRequest: 0
 extra_getsource_options:
   8: '--openssl-version=1.1.1'
+restart_timeout:
+  time: 5
+  units: 'HOURS'
 #========================================#
 # Linux PPCLE 64bits Compressed Pointers
 #========================================#


### PR DESCRIPTION
- Test jobs become UNSTABLE when tests fail. Jobs FAIL
  when there is something wrong so only give the
  restart option to failed jobs.
- Set the TIMEOUT to wait for user input to 5 HOURS
  by default via the variable yml.
- Option to overwrite RESTART_TIMEOUT and RESTART_TIMEOUT_UNITS
  via job paramaters.
- This will work for all builds that use the
  'pipeline of jobs' functionality including Nightly,
  Release, OMR Acceptance and PullRequests once #2836
  is resolved.
- Increase Timeout on PBT-All from 10 to 12 Hours.

Fixes #2017
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>