### PR TITLE
Add amd64-osx-gcc.mk platform file for the JIT

### DIFF
--- a/runtime/compiler/build/platform/host/amd64-osx-gcc.mk
+++ b/runtime/compiler/build/platform/host/amd64-osx-gcc.mk
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+HOST_ARCH=x
+HOST_SUBARCH=amd64
+HOST_BITS=64
+OS=osx
+C_COMPILER=gcc
+TOOLCHAIN=gnu


### PR DESCRIPTION
This is needed for building OpenJ9 with gcc when using older versions of
XCode.

amd64-osx-clang.mk is still going to be the default makefile used
unless "PLATFORM" environment variable is set.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

Closes: #3326 

Note: You must set the PLATFORM variable as `amd64-osx-gcc` in order to make use of this makefile.