### PR TITLE
Remove workaround related to persistentJittedBodyInfo

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -4132,10 +4132,6 @@ int32_t TR_MultipleCallTargetInliner::scaleSizeBasedOnBlockFrequency(int32_t byt
 
 bool TR_MultipleCallTargetInliner::isLargeCompiledMethod(TR_ResolvedMethod *calleeResolvedMethod, int32_t bytecodeSize, int32_t callerBlockFrequency)
    {
-   // JITaaS TODO: remove this early return when jitted body info is working
-   if (TR::CompilationInfo::getStream())
-      return false;
-
    TR_OpaqueMethodBlock* methodCallee = calleeResolvedMethod->getPersistentIdentifier();
    if (TR::Compiler->mtd.isCompiledMethod(methodCallee))
       {


### PR DESCRIPTION
A while ago when JITaaS did not have suport for persistentJittedBodyInfo,
TR_MultipleCallTargetInliner::isLargeCompiledMethod() was changed to return
early, thus allowing the inlining of very large compiled methods.
This commit removes that workaround resulting in ~7% lower compilation time,
~3% lower footprint (due to smaller jitted bodies), but ~1% throughput loss.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>