### PR TITLE
Improve generated PTX code

### DIFF
--- a/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/PtxKernelGenerator.java
+++ b/jcl/src/openj9.gpu/share/classes/com/ibm/gpu/PtxKernelGenerator.java
@@ -127,8 +127,8 @@ final class PtxKernelGenerator {
 			// need to swap. The 'gtu' comparison is true if the first operand is
 			// larger than the second or if either operand is NaN. By ruling out
 			// the second operand being a NaN, we achieve the desired test.
-			format("testp.number%s p0,vl%d;", typeName, index1);
-			format("setp.gtu.and%s p0,vl%d,vl%d,p0;", typeName, index0, index1);
+			format("testp.number%s p1,vl%d;", typeName, index1);
+			format("setp.gtu.and%s p0,vl%d,vl%d,p1;", typeName, index0, index1);
 
 			// Finally we must order -0.0 before +0.0.
 
@@ -139,11 +139,8 @@ final class PtxKernelGenerator {
 			// compare for floating point equality
 			format("@!p0 setp.eq%s p1,vl%d,vl%d;", typeName, index0, index1);
 
-			// compare as scalars 
-			format("@!p0 setp.gt.and.s%d p1,vs0,vs1,p1;", typeSize * 8);
-
-			// if not originally seen to be out of order, use this result
-			append("@!p0 mov.pred p0,p1;");
+			// compare as scalars, updating the result
+			format("@!p0 setp.gt.and.s%d p0,vs0,vs1,p1;", typeSize * 8);
 		}
 	}
 
@@ -306,9 +303,9 @@ final class PtxKernelGenerator {
 		append("add.u32 globalIndex,baseIndex,workId;");
 
 		// sharedData[workId] = (globalIndex < length) ? data[globalIndex] : maxValue;
-		append("setp.lt.u32 p0,globalIndex,length;");
-		format("mad.wide.u32 dataPtr,globalIndex,%d,data;", typeSize);
 		format("mov%s vl0,%s;", typeName, maxValue);
+		append("setp.lt.u32 p0,globalIndex,length;");
+		format("@p0 mad.wide.u32 dataPtr,globalIndex,%d,data;", typeSize);
 		format("@p0 ld.global%s vl0,[dataPtr];", typeName);
 		format("mad.wide.u32 sharedPtr0,workId,%d,sharedData;", typeSize);
 		format("st.shared%s [sharedPtr0],vl0;", typeName);
@@ -446,7 +443,7 @@ final class PtxKernelGenerator {
 			// vl[i] = maxValue; if (ix[i] < length) { vl[i] = data[ix[i]]; }
 			format("mov%s vl%d,%s;", typeName, i, maxValue);
 			format("setp.lt.u32 p0,ix%d,length;", i);
-			format("mad.wide.u32 ptr,ix%d,%d,data;", i, typeSize);
+			format("@p0 mad.wide.u32 ptr,ix%d,%d,data;", i, typeSize);
 			format("@p0 ld.global%s vl%d,[ptr];", typeName, i);
 		}
 	}
@@ -475,7 +472,7 @@ final class PtxKernelGenerator {
 			// if (moved & (1 << i)) { data[ix[i]] = vl[i]; }
 			format("and.b32 bit,moved,%s;", constant(1 << i));
 			append("setp.ne.b32 p0,bit,0;");
-			format("mad.wide.u32 ptr,ix%d,%d,data;", i, typeSize);
+			format("@p0 mad.wide.u32 ptr,ix%d,%d,data;", i, typeSize);
 			format("@p0 st.global%s [ptr],vl%d;", typeName, i);
 		}
 	}

--- a/test/functional/Java8andUp/src/org/openj9/test/gpu/SortTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/gpu/SortTest.java
@@ -72,7 +72,7 @@ public final class SortTest {
 
 	private static final Logger logger = Logger.getLogger(SortTest.class);
 
-	private static final Pattern SeedPattern = makePattern("-srand", 6, "=(\\d+)");
+	private static final Pattern SeedPattern = makePattern("-srand", 6, "=(-?\\d+)");
 
 	private static final Pattern TypesPattern = makePattern("-types", 5, "=(\\S+)");
 


### PR DESCRIPTION
The previous version would generate (see `compare()`) the sequences like:
```
testp.number.f64 p0,vl1;
setp.gtu.and.f64 p0,vl0,vl1,p0;
```
Using `p0` as both an input and an output (in the second instruction) seems not to work in all environments (failures have been seen with CUDA 5.5 on a K1100M and with CUDA 8.0 on a GTX960).

Using distinct predicate registers avoids the problem:
```
testp.number.f64 p1,vl1;
setp.gtu.and.f64 p0,vl0,vl1,p1;
```

Some instructions can be predicated to avoid unnecessary work.

This also fixes pattern for `-srand` test option: often the seed will be negative; such values should be accepted.