### PR TITLE
Add NASM to Ubuntu 16 and 18 on x86-64 Docker images

### DIFF
--- a/buildenv/docker/jdk10/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk10/x86_64/ubuntu16/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    nasm \
     pkg-config \
     realpath \
     ssh \

--- a/buildenv/docker/jdk10/x86_64/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk10/x86_64/ubuntu18/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
 	  libxt-dev \
 	  libxtst-dev \
 	  make \
+	  nasm \
 	  pkg-config \
       software-properties-common \
 	  ssh \

--- a/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    nasm \
     pkg-config \
     realpath \
     ssh \

--- a/buildenv/docker/jdk8/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu16/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    nasm \
     openjdk-7-jdk \
     pkg-config \
     realpath \

--- a/buildenv/docker/jdk8/x86_64/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk8/x86_64/ubuntu18/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
 	  libxt-dev \
 	  libxtst-dev \
 	  make \
+	  nasm \
 	  pkg-config \
       software-properties-common \
 	  ssh \

--- a/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk9/x86_64/ubuntu16/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    nasm \
     pkg-config \
     realpath \
     ssh \

--- a/buildenv/docker/jdk9/x86_64/ubuntu18/Dockerfile
+++ b/buildenv/docker/jdk9/x86_64/ubuntu18/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
 	  libxt-dev \
 	  libxtst-dev \
 	  make \
+	  nasm \
 	  pkg-config \
       software-properties-common \
 	  ssh \


### PR DESCRIPTION
NASM will be used for building the compiler's  X86 assembly files across all X86 OSes soon. These Docker images need to be updated because #3293 adds dependency on NASM to build OpenJ9 on x86-64 Linux.

Issue: #3148 