### PR TITLE
WIP: Turn Mode150-CS on for linux_x86-64_cmprssptrs

### DIFF
--- a/test/TestConfig/resources/ottawa.csv
+++ b/test/TestConfig/resources/ottawa.csv
@@ -54,7 +54,7 @@ variation:Mode147,yes,yes,yes,yes,no,no,no,yes,yes,yes,yes,yes,yes,no,no,no,no,y
 variation:Mode148,yes,yes,yes,yes,yes,yes,no,yes,yes,no,yes,yes,no,yes,yes,no,no,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,no,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes
 variation:Mode149,yes,yes,yes,yes,yes,yes,no,yes,yes,no,yes,yes,no,yes,yes,no,no,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,no,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes,yes
 variation:Mode150,no,no,no,no,yes,yes,no,no,no,no,no,no,no,yes,yes,no,yes,no,no,no,no,yes,yes,no,yes,no,yes,no,no,no,no,yes,yes,yes,no,no,no,no,yes,yes,no,no,no,no,yes,yes,no,no,yes
-variation:Mode150-CS,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,no,no,no
+variation:Mode150-CS,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,yes,yes,no,no,no
 variation:Mode152,no,no,no,no,yes,yes,no,no,no,no,no,no,no,yes,yes,no,yes,no,no,no,no,yes,yes,no,yes,no,yes,no,no,no,no,yes,yes,yes,no,no,no,no,yes,yes,no,no,no,no,yes,yes,no,no,yes
 variation:Mode153,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no,no
 variation:Mode154,no,no,no,no,yes,yes,no,no,no,no,no,no,no,yes,yes,no,yes,no,no,no,no,yes,yes,no,yes,no,yes,no,no,no,no,no,no,no,no,no,no,no,yes,yes,no,no,no,no,yes,yes,no,no,yes


### PR DESCRIPTION
Concurrent Scavenge is now supported by linux_x86-64_cmprssptrs, enabling Mode150-CS.

Part of #3294 

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>