### PR TITLE
Fixing Proper ABI Linkage on PPC when calling CHelpers from JIT

### DIFF
--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -1913,6 +1913,42 @@ int32_t TR::PPCPrivateLinkage::buildPrivateLinkageArgs(TR::Node                 
 	    addDependency(dependencies, NULL, (TR::RealRegister::RegNum)i, TR_VSX_SCALAR, cg());
       }
 
+
+
+   /*
+   PPC ABI --
+   AIX 32-bit BE & AIX 64-bit BE & Linux 64-bit BE: 
+   These follow aix-style linkage. 
+   There is a TOC-base register (gr2) that needs to be loaded from function descriptor of that function that is called. 
+   If the callee function is in libj9jitxx.so module, (as in the case of CHelper functions are) then the module's TOC-base can be found in the J9VMThread jitTOC field.
+   The TOC can be loaded from the jitTOC field of J9VMThread (pointed to by metaDataRegister).
+  
+   Linux 64-bit LE: There exists a TOC (gr2), but there is no such function descriptor. 
+   The TOC-base set-up is defined by ABI to go through a function's global-entry (relocation). 
+   The global-entry address will be set up in gr12.
+
+   Registers r12, and r2 are always added to the dependency in the situations that they're used. 
+   R12 is added at all times, and is an unreserved register across all platforms. 
+   R2 is added to the dependency only if we're not dealing with a linux 32 bit platform, where it's system reserved. 
+   Ultimately, we don't need an assert or NULL check when searching for these registers within the dependency. 
+   */
+   if(linkage == TR_CHelper)
+   {
+      if(TR::Compiler->target.isLinux() && TR::Compiler->target.is64Bit() && TR::Compiler->target.cpu.isLittleEndian())
+      {
+         int32_t helperOffset = (callNode->getSymbolReference()->getReferenceNumber() - 1)*sizeof(intptrj_t);
+         generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr12), 
+            new(trHeapMemory()) TR::MemoryReference(cg()->getTOCBaseRegister(), helperOffset, TR::Compiler->om.sizeofReferenceAddress(), cg()));
+
+      }
+      else if (TR::Compiler->target.isAIX() || (TR::Compiler->target.isLinux() && TR::Compiler->target.is64Bit()))
+      {
+         generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, callNode, dependencies->searchPreConditionRegister(TR::RealRegister::gr2), 
+            new(trHeapMemory()) TR::MemoryReference(cg()->getMethodMetaDataRegister(), offsetof(J9VMThread, jitTOC), TR::Compiler->om.sizeofReferenceAddress(), cg()));
+      }
+   }
+
+
    // This is a performance hack. CCRs are rarely live across calls,
    // particularly helper calls, but because we create scratch virtual
    // regs and re-use them during evaluation they appear live.


### PR DESCRIPTION
PPC ABI is not being followed correctly on Linux & AIX on PPC, when calling CHelpers from JIT compiled code.

In the case of PPCLE64, the ABI behavior requires that the caller of the C/C++ compiled method pass the CHelper's address in r12 before calling.
Otherwise for PPCBE64, and AIX the caller of the C/C++ compiled method is required to pass the TOC, or jitTOC in this case within r15(PPCBE64, AIX64) or r13(AIX32).

This commit implements PPC ABI compatability, making sure that instructions are generated to reflect loading the proper content in the respecive registers prior to calling the CHelpers.

Signed-off-by: Alen Badel Alen.Badel@ibm.com.