### PR TITLE
Concurrent Scavenger Read Barrier evaluator on X86-64

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1916,7 +1916,11 @@ UDATA TR_J9VMBase::thisThreadGetConcurrentScavengeActiveByteAddressOffset()
 UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
+#if defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86)
+   return offsetof(J9VMThread, evacuateBaseCompressed);
+#else
    return offsetof(J9VMThread, evacuateBase);
+#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    TR_ASSERT(0,"Field evacuateBase does not exists in J9VMThread.");
    return 0;
@@ -1929,7 +1933,11 @@ UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
 UDATA TR_J9VMBase::thisThreadGetEvacuateTopAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
+#if defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86)
+   return offsetof(J9VMThread, evacuateTopCompressed);
+#else
    return offsetof(J9VMThread, evacuateTop);
+#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    TR_ASSERT(0,"Field evacuateTop does not exists in J9VMThread.");
    return 0;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -45,6 +45,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    {
    public:
 
+   static TR::Register *ardbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *writeBarrierEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -116,6 +117,9 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
 
    class CaseConversionManager;
    static TR::Register *stringCaseConversionHelper(TR::Node *node, TR::CodeGenerator *cg, CaseConversionManager& manager);
+
+   private:
+   static TR::Register* performHeapLoadWithReadBarrier(TR::Node* node, TR::CodeGenerator* cg);
    };
 
 }


### PR DESCRIPTION
X86-64 default now supports read barriers for Concurrent Scavenger.

Part of Issue #3338

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>