### PR TITLE
Override the isAnonymousClass at JITaaS server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -947,6 +947,13 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(fe->transformJlrMethodInvoke(method, clazz));
          }
          break;
+      case J9ServerMessageType::VM_isAnonymousClass:
+         {
+         auto recv = client->getRecvData<TR_OpaqueClassBlock *>();
+         TR_OpaqueClassBlock *clazz = std::get<0>(recv);
+         client->write(fe->isAnonymousClass(clazz));
+         }
+         break;
       case J9ServerMessageType::mirrorResolvedJ9Method:
          {
          // allocate a new TR_ResolvedRelocatableJ9Method on the heap, to be used as a mirror for performing actions which are only

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1459,3 +1459,19 @@ TR_J9ServerVM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerC
    stream->write(JITaaS::J9ServerMessageType::VM_transformJlrMethodInvoke, callerMethod, callerClass);
    return std::get<0>(stream->read<bool>());
    }
+
+bool
+TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
+   {
+      {
+      OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
+      auto it = _compInfoPT->getClientData()->getROMClassMap().find((J9Class*) j9clazz);
+      if (it != _compInfoPT->getClientData()->getROMClassMap().end())
+         {
+         return (J9_ARE_ALL_BITS_SET(it->second.romClass->extraModifiers, J9AccClassAnonClass));
+         }
+      }
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITaaS::J9ServerMessageType::VM_isAnonymousClass, j9clazz);
+   return std::get<0>(stream->read<bool>());
+   }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -160,6 +160,8 @@ public:
    virtual uintptrj_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
+   using TR_J9VM :: isAnonymousClass;
+   virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;
    };
 
 #endif // VMJ9SERVER_H

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -207,6 +207,7 @@ enum J9ServerMessageType
    VM_getConstantPoolFromClass = 299;
    VM_getResolvedMethodsAndMirror = 300;
    VM_getVMInfo = 301;
+   VM_isAnonymousClass = 302;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
This frontend method access J9Class members , needs to be overridden on the server to work properly.
Adding a new server message(VM_isAnonymousClass) to protobuf.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>