### PR TITLE
Enable Concurrent Scavenge on x86-64 spec

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_x86.mk
@@ -79,6 +79,7 @@ ifeq (linux_x86-64, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		--enable-OMR_PORT_NUMA_SUPPORT
 endif


### PR DESCRIPTION
linux_x86-64.spec now supports Concurrent Scavenge.

Part of Issue #3338 

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>