### PR TITLE
Disable fastStringIndexOf feature added by #3165

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -68,10 +68,12 @@ J9::Power::CodeGenerator::CodeGenerator() :
    cg->setSupportsPartialInlineOfMethodHooks();
    cg->setSupportsInliningOfTypeCoersionMethods();
 
+#if 0   
    if (TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX() &&
       !comp->getOption(TR_DisableFastStringIndexOf) && !TR::Compiler->om.canGenerateArraylets())
       cg->setSupportsInlineStringIndexOf();
-
+#endif
+   
    if (!comp->getOption(TR_DisableReadMonitors))
       cg->setSupportsReadOnlyLocks();
 


### PR DESCRIPTION
   We suspect it causes latest build failure after #3165 was merged.

```
j> 20:44:43 Unhandled exception
j> 20:44:43 Type=Segmentation error vmState=0x00000000
j> 20:44:43 J9Generic_Signal_Number=00000004 Signal_Number=0000000b Error_Value=00000000 Signal_Code=00000001
j> 20:44:43 Handler1=00003FFF89364780 Handler2=00003FFF8917EE40
j> 20:44:43 R0=00003FFE8CEC79C8 R1=00003FFD748FBAF0 R2=00003FFF840E1758 R3=0000000200000000
j> 20:44:43 R4=000000000000002E R5=00003FFE8CEC79B8 R6=0000000000000002 R7=00003FFE0C758200
j> 20:44:43 R8=0000000000000000 R9=0000000000000001 R10=00003FFE6FD3CDFC R11=00003FFDEC030F28
j> 20:44:43 R12=00003FFF7D23769C R13=00003FFD74906900 R14=00003FFDEC034E00 R15=00003FFE0C758200
j> 20:44:43 R16=00003FFE6D7D0038 R17=FFFFFFFFFFFFFFFF R18=00003FFDEC0008C0 R19=00003FFDEC0008F0
j> 20:44:43 R20=00003FFF895B5AF0 R21=00003FFDEC0008E0 R22=00003FFF88E349C0 R23=00003FFE8D488228
j> 20:44:43 R24=0000000000000000 R25=0000000000000000 R26=00003FFE8D49EAE0 R27=0000000100000000
j> 20:44:43 R28=000000000000002E R29=0000000000000001 R30=00003FFE8CEC79A0 R31=00003FFE8D7C7418
j> 20:44:43 NIP=00003FFE6F1DFD9C MSR=800000010280F033 ORIG_GPR3=C0000000000103E8 CTR=00003FFE6FD3CDFC
j> 20:44:43 LINK=00003FFE6FD3CE70 XER=0000000000000000 CCR=0000000084004881 SOFTE=0000000000000001
j> 20:44:43 TRAP=0000000000000300 DAR=000040008CEC79C8 dsisr=0000000040000000 RESULT=0000000000000000
j> 20:44:43 FPR0 000000000000024e (f: 590.000000, d: 2.914987e-321)
j> 20:44:43 FPR1 40827556027bede7 (f: 41676264.000000, d: 5.906670e+02)
j> 20:44:43 FPR2 3f93627e19c21cce (f: 432151744.000000, d: 1.893041e-02)
j> 20:44:43 FPR3 3f932667eadbf7e5 (f: 3940284416.000000, d: 1.870119e-02)
j> 20:44:43 FPR4 3fe65339572437b3 (f: 1461991296.000000, d: 6.976592e-01)
j> 20:44:43 FPR5 4022600000000000 (f: 0.000000, d: 9.187500e+00)
j> 20:44:43 FPR6 3f2430a99d37c94e (f: 2637678848.000000, d: 1.540381e-04)
j> 20:44:43 FPR7 bf081363540f3de0 (f: 1410285056.000000, d: -4.592082e-05)
j> 20:44:43 FPR8 3c7f300000000000 (f: 0.000000, d: 2.705084e-17)
j> 20:44:43 FPR9 c2f0000100003fef (f: 16367.000000, d: -2.814752e+14)
j> 20:44:43 FPR10 3f55e4b104c1194d (f: 79763792.000000, d: 1.336263e-03)
j> 20:44:43 FPR11 3f83b2ab6fa97093 (f: 1873375360.000000, d: 9.618129e-03)
j> 20:44:43 FPR12 3fcebfbdff82c59d (f: 4286760448.000000, d: 2.402265e-01)
j> 20:44:43 FPR13 3f50000000000000 (f: 0.000000, d: 9.765625e-04)
j> 20:44:43 FPR14 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR15 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR16 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR17 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR18 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR19 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR20 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR21 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR22 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR23 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR24 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR25 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR26 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR27 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR28 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR29 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR30 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 FPR31 0000000000000000 (f: 0.000000, d: 0.000000e+00)
j> 20:44:43 
j> 20:44:43 Compiled_method=java/lang/String.indexOf(II)I
j> 20:44:43 Target=2_90_20181018_400018 (Linux 3.10.0-327.10.1.el7.ppc64le)
j> 20:44:43 CPU=ppc64le (8 logical CPUs) (0x3fde00000 RAM)
j> 20:44:43 ----------- Stack Backtrace -----------
j> 20:44:43 (0x00003FFF891CE160 [libj9prt29.so+0xae160])
j> 20:44:43 (0x00003FFF8917D2CC [libj9prt29.so+0x5d2cc])
j> 20:44:43 (0x00003FFF891CE49C [libj9prt29.so+0xae49c])
j> 20:44:43 (0x00003FFF891CDD44 [libj9prt29.so+0xadd44])
j> 20:44:43 (0x00003FFF8917D2CC [libj9prt29.so+0x5d2cc])
j> 20:44:43 (0x00003FFF891CDE04 [libj9prt29.so+0xade04])
j> 20:44:43 (0x00003FFF89365240 [libj9vm29.so+0xc5240])
j> 20:44:43 (0x00003FFF8917D2CC [libj9prt29.so+0x5d2cc])
j> 20:44:43 (0x00003FFF89364A28 [libj9vm29.so+0xc4a28])
j> 20:44:43 (0x00003FFF89180858 [libj9prt29.so+0x60858])
j> 20:44:43 __kernel_sigtramp_rt64+0x0 (0x00003FFF8A1E0478)
j> 20:44:43 (0x00003FFF7D23F224 [libj9jit29.so+0x137f224])
j> 20:44:43 (0x00003FFF89349E7C [libj9vm29.so+0xa9e7c])
j> 20:44:43 (0x00003FFF893C0868 [libj9vm29.so+0x120868])
j> 20:44:43 (0x00003FFF8917D2CC [libj9prt29.so+0x5d2cc])
j> 20:44:43 (0x00003FFF893C0650 [libj9vm29.so+0x120650])
j> 20:44:43 (0x00003FFF892698F0 [libj9thr29.so+0x98f0])
j> 20:44:43 (0x00003FFF8A1A8728 [libpthread.so.0+0x8728])
j> 20:44:43 clone+0x98 (0x00003FFF8A079240 [libc.so.6+0x119240])
```

Signed-off-by: Gita Koblents <koblents@ca.ibm.com>