### PR TITLE
Prepare for JVMTI ExceptionCatch not forcing FSD

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1215,16 +1215,18 @@ c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 
 	/* Determine in which inlined frame the exception is being caught */
 	UDATA newNumberOfFrames = 1;
+	void *stackMap = NULL;
+	void *inlineMap = NULL;
+	void *inlinedCallSite = NULL;
+	/* Note we need to add 1 to the JIT PC here in order to get the correct map at the exception handler
+	 * because jitGetMapsFromPC is expecting a return address, so it subtracts 1.  The value stored in the
+	 * decomp record is the start address of the compiled exception handler.
+	 */
+	jitGetMapsFromPC(vm, metaData, (UDATA)jitPC + 1, &stackMap, &inlineMap);
+	Assert_CodertVM_false(NULL == stackMap);
 	if (NULL != getJitInlinedCallInfo(metaData)) {
-		void *stackMap = NULL;
-		void *inlineMap = NULL;
-		/* Note we need to add 1 to the JIT PC here in order to get the correct map at the exception handler
-		 * because jitGetMapsFromPC is expecting a return address, so it subtracts 1.  The value stored in the
-		 * decomp record is the start address of the compiled exception handler.
-		 */
-		jitGetMapsFromPC(vm, metaData, (UDATA)jitPC + 1, &stackMap, &inlineMap);
 		if (NULL != inlineMap) {
-			void *inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
+			inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
 			if (inlinedCallSite != NULL) {
 				newNumberOfFrames = getJitInlineDepthFromCallSite(metaData, inlinedCallSite) + 1;
 			}
@@ -1248,7 +1250,7 @@ c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 	/* Fix the OSR frame to resume at the catch point with an empty pending stack (the caught exception
 	 * is pushed after decompilation completes).
 	 */
-	osrFrame->bytecodePCOffset = getJitPCOffsetFromExceptionHandler(metaData, jitPC);
+	osrFrame->bytecodePCOffset = getCurrentByteCodeIndexAndIsSameReceiver(metaData, stackMap, inlinedCallSite, NULL);
 	Trc_Decomp_jitInterpreterPCFromWalkState_Entry(jitPC);
 	Trc_Decomp_jitInterpreterPCFromWalkState_exHandler(osrFrame->bytecodePCOffset);
 	osrFrame->pendingStackHeight = 0;

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1320,11 +1320,8 @@ jvmtiHookExceptionThrow(J9HookInterface** hook, UDATA eventNum, void* eventData,
 		exception = (j9object_t) vm->internalVMFunctions->walkStackForExceptionThrow(currentThread, exception, TRUE);
 		switch((UDATA) currentThread->stackWalkState->userData3) {
 			case J9_EXCEPT_SEARCH_JIT_HANDLER:
-				if (vm->jitConfig->jitGetExceptionCatcher(currentThread, currentThread->stackWalkState->userData2, currentThread->stackWalkState->jitInfo, &catchMethod, &catchLocation)) {
-					/* Inlined catcher found */
-					break;
-				}
-				/* Intentional fall-through */
+				catchMethod = vm->jitConfig->jitGetExceptionCatcher(currentThread, currentThread->stackWalkState->userData2, currentThread->stackWalkState->jitInfo, &catchLocation);
+				break;
 
 			case J9_EXCEPT_SEARCH_JAVA_HANDLER:
 				catchMethod =  currentThread->stackWalkState->method;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3742,7 +3742,7 @@ typedef struct J9JITConfig {
 	void* b_i2jTransition;
 	void  ( *promoteGPUCompile)(struct J9VMThread * currentThread) ;
 	void ( *jitDiscardPendingCompilationsOfNatives)(struct J9VMThread *currentThread, J9Class *clazz) ;
-	UDATA ( *jitGetExceptionCatcher)(struct J9VMThread *currentThread, void *handlerPC, struct J9JITExceptionTable *metaData, struct J9Method **method, IDATA *location) ;
+	J9Method* ( *jitGetExceptionCatcher)(struct J9VMThread *currentThread, void *handlerPC, struct J9JITExceptionTable *metaData, IDATA *location) ;
 	void ( *jitMethodBreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitMethodUnbreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitIllegalFinalFieldModification)(struct J9VMThread *currentThread, struct J9Class *fieldClass);
@@ -4107,7 +4107,7 @@ typedef struct J9AOTConfig {
 	void* b_i2jTransition;
 	void  ( *promoteGPUCompile)(struct J9VMThread * currentThread) ;
 	void ( *jitDiscardPendingCompilationsOfNatives)(struct J9VMThread *currentThread, J9Class *clazz) ;
-	UDATA ( *jitGetExceptionCatcher)(struct J9VMThread *currentThread, void *handlerPC, struct J9JITExceptionTable *metaData, struct J9Method **method, IDATA *location) ;
+	J9Method* ( *jitGetExceptionCatcher)(struct J9VMThread *currentThread, void *handlerPC, struct J9JITExceptionTable *metaData, IDATA *location) ;
 	void ( *jitMethodBreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	void ( *jitMethodUnbreakpointed)(struct J9VMThread *currentThread, struct J9Method *method) ;
 	struct J9AOTCallbackFunctionTable* callbackFunctionTable;

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2427,8 +2427,9 @@ ffi_exit:
 			/* Drop the decompilation records for frames removed from the stack if FSD is enabled */
 			J9JITConfig *jitConfig = _vm->jitConfig;
 			if (NULL != jitConfig) {
-				if (jitConfig->fsdEnabled) {
-					jitConfig->jitExceptionCaught(_currentThread);
+				void (*jitExceptionCaught)(J9VMThread *currentThread) = jitConfig->jitExceptionCaught;
+				if (NULL != jitExceptionCaught) {
+					jitExceptionCaught(_currentThread);
 				}
 			}
 		}


### PR DESCRIPTION
- use getCurrentByteCodeIndexAndIsSameReceiver instead of
getJitPCOffsetFromExceptionHandler to fetch the bytecode PC of exception
handlers (this avoids reading the bytecode PC from the JIT exception
handler data which is only filled in for FSD)

- report exceptions caught by JIT if the callback is filled in rather
than explicitly checking for FSD mode

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>