### PR TITLE
Enable RAS Dump support on OSX

### DIFF
--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -1206,9 +1206,9 @@ JVM_OnUnload(JavaVM *vm, void *reserved)
 }
 
 /**
- * On Linux and OSX the first call to get a backtrace can cause some initialisation
+ * On Linux and OSX the first call to get a backtrace can cause some initialization
  * work. If this is called in a signal handler with other threads paused then one of
- * those can hold a lock required for the initialisation to complete. This causes
+ * those can hold a lock required for the initialization to complete. This causes
  * a hang. Therefore we do one redundant call to backtrace at startup to prevent
  * java dumps hanging the VM.
  * 
@@ -1291,7 +1291,7 @@ initSystemInfo(J9JavaVM *vm)
 }
 
 /**
- * We need to read the -Xdump:directory option before we start initialising the
+ * We need to read the -Xdump:directory option before we start initializing the
  * default dump agents.
  */
 static omr_error_t

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -1206,8 +1206,8 @@ JVM_OnUnload(JavaVM *vm, void *reserved)
 }
 
 /**
- * On Linux the first call to get a backtrace can cause some initialisation work.
- * If this is called in a signal handler with other threads paused then one of
+ * On Linux and OSX the first call to get a backtrace can cause some initialisation
+ * work. If this is called in a signal handler with other threads paused then one of
  * those can hold a lock required for the initialisation to complete. This causes
  * a hang. Therefore we do one redundant call to backtrace at startup to prevent
  * java dumps hanging the VM.
@@ -1217,7 +1217,7 @@ JVM_OnUnload(JavaVM *vm, void *reserved)
 static void
 initBackTrace(J9JavaVM *vm)
 {
-#ifdef LINUX
+#if defined(LINUX) || defined(OSX)
 	J9PlatformThread threadInfo;
 	J9Heap *heap;
 	char backingStore[8096];
@@ -1229,7 +1229,7 @@ initBackTrace(J9JavaVM *vm)
 	if( j9introspect_backtrace_thread(&threadInfo, heap, NULL) != 0 ) {
 		j9introspect_backtrace_symbols(&threadInfo, heap);
 	}
-#endif
+#endif /* defined(LINUX) || defined(OSX) */
 }
 
 /**

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1732,7 +1732,7 @@ JavaCoreDumpWriter::writeMonitorSection(void)
 		UDATA stateFault = stateClean;
 
 		if (i == 0) {
-			// The walk may have started or restarted which is why initialisation is in the loop.
+			// The walk may have started or restarted which is why initialization is in the loop.
 			memset(threadStore, 0, (_AllocatedVMThreadCount+1) * sizeof(blocked_thread_record));
 		}
 

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -69,7 +69,7 @@ typedef enum J9RASdumpMatchResult
 static UDATA rasDumpSuspendKey = 0;
 static UDATA rasDumpFirstThread = 0;
 
-/* Postpone GC and thread event hooks until later phases of VM initialisation */
+/* Postpone GC and thread event hooks until later phases of VM initialization. */
 UDATA rasDumpPostponeHooks = \
 	J9RAS_DUMP_ON_CLASS_UNLOAD | \
 	J9RAS_DUMP_ON_GLOBAL_GC | \
@@ -1160,11 +1160,11 @@ rasDumpEnableHooks(J9JavaVM *vm, UDATA eventFlags)
 
 /**
  * rasDumpFlushHooks() - enable hooks for events that were postponed from the initial dump agent 
- * initialisation. There are now two phases: GC event hooks are enabled at TRACE_ENGINE_INITIALIZED,
+ * initialization. There are now two phases: GC event hooks are enabled at TRACE_ENGINE_INITIALIZED,
  * and thread event hooks are enabled at VM_INITIALIZATION_COMPLETE. See CMVC 199853 and CMVC 200360.
  * 
  * @param[in] vm - pointer to J9JavaVM structure
- * @param[in] stage - VM initialisation stage
+ * @param[in] stage - VM initialization stage
  * @return void
  */
 void 


### PR DESCRIPTION
**1) Enable RAS Dump support on OSX**

More details here: https://github.com/eclipse/openj9/issues/3380.

closes: https://github.com/eclipse/openj9/issues/3380.
closes: https://github.com/eclipse/openj9/issues/3343.

**2) Make spelling of "initialize" consistent in runtime/rasdump**

This will make searching easier as one does not have to check for
alternate spellings.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>