### PR TITLE
Fix decoding of string parameters

### DIFF
--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/Message.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/Message.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,9 +183,9 @@ final public class Message
                  offset += utf8Length;
              } else {
                  s = Util.constructString(buffer, offset);
-                 offset += (s.length() + 1) ;
+                 offset += (s.length() + 1);
              }
-
+             s = Util.escapeControlCharacters(s);
              result.append(format(s, fspec));
              str = str.substring(1, str.length());
              break;
@@ -211,15 +211,15 @@ final public class Message
              str = str.substring(1, str.length());
              break;
 
-         case 'f': 
-        	 /* CMVC 164940 All %f tracepoints were promoted to double in runtime trace code.
-        	  * Affects:
-        	  *  TraceFormat  com/ibm/jvm/format/Message.java
-        	  *  TraceFormat  com/ibm/jvm/trace/format/api/Message.java
-        	  *  runtime    ute/ut_trace.c
-        	  *  TraceGen     OldTrace.java
-        	  * Intentional fall through to next case.
-        	  */
+         case 'f':
+             /* CMVC 164940 All %f tracepoints were promoted to double in runtime trace code.
+              * Affects:
+              *  TraceFormat  com/ibm/jvm/format/Message.java
+              *  TraceFormat  com/ibm/jvm/trace/format/api/Message.java
+              *  runtime    ute/ut_trace.c
+              *  TraceGen     OldTrace.java
+              * Intentional fall through to next case.
+              */
          case 'g':
             l = Util.constructUnsignedLong(buffer, offset).longValue();
             offset += Util.LONG;
@@ -246,7 +246,8 @@ final public class Message
          case 'c':
             s = Util.constructString(buffer, offset, 1);
             offset += 1;
-            result.append(format(s,fspec));
+            s = Util.escapeControlCharacters(s);
+            result.append(format(s, fspec));
             str = str.substring(1, str.length());
             break;
 
@@ -538,9 +539,9 @@ final public class Message
    }
 
    protected String getFormattingTemplate(){
-	   return message;
+       return message;
    }
-   
+
    class FormatSpec
    {
       protected Integer width;         // this are object types to have


### PR DESCRIPTION
`com.ibm.jvm.format.Util.constructString()` returned a string whose length was longer than the number of bytes consumed from the buffer whenever it escaped certain ASCII control characters. Then callers like `com.ibm.jvm.format.Message.processPercents()` used the length of the resulting string to compute the offset of the next parameter leaving too few bytes remaining to be decoded successfully.

In a failing test, a string parameter has the 3 character value `"\u0008\u00ef\u00f8"` (using Java literal notation) which is expanded to `"\\u0010\u00ef\u00f8"` (an 8 character string).

A second problem is that the encoding should use hex rather than octal (e.g. `"\u0008"` should not be presented as `"\u0010"`).

This fixes these problems by escaping control characters _after_ advancing the offset into the decode buffer.