### PR TITLE
Use generateRXInstruction API

### DIFF
--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -2311,8 +2311,8 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
                         generateS390MemoryReference(snippetReg, slotOffset, cg()), cursor);
 
                   //load cached methodEP from current cache slot
-                  cursor = new (trHeapMemory()) TR::S390RXInstruction(TR::InstOpCode::getLoadOpCode(), callNode, methodRegister,
-                        generateS390MemoryReference(snippetReg, slotOffset+TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor, cg());
+                  cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), callNode, methodRegister,
+                        generateS390MemoryReference(snippetReg, slotOffset+TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
 
                   cursor = generateS390RegInstruction(cg(), TR::InstOpCode::BCR, callNode, methodRegister, cursor);
                   ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BER);


### PR DESCRIPTION
Use generateRXInstruction API instead of manually allocating an RX
instruction as the generate API may return an RXY instruction if the
displacement is constrained.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>