### PR TITLE
Test all cases of exception catch

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1018,6 +1018,11 @@ fixStackForNewDecompilation(J9VMThread * currentThread, J9StackWalkState * walkS
 			Trc_Decomp_addDecompilation_atAllocate(currentThread);
 			*pcStoreAddress = (U_8 *) J9_BUILDER_SYMBOL(jitDecompileAfterAllocation);
 			break;
+		case J9_STACK_FLAGS_JIT_EXCEPTION_CATCH_RESOLVE:
+			/* Decompile during jitReportExceptionCatch */
+			Trc_Decomp_addDecompilation_atExceptionCatch(currentThread);
+			*pcStoreAddress = (U_8 *) J9_BUILDER_SYMBOL(jitDecompileAtExceptionCatch);
+			break;
 		default:
 			Trc_Decomp_addDecompilation_atCurrentPC(currentThread);
 			*pcStoreAddress = (U_8 *) J9_BUILDER_SYMBOL(jitDecompileAtCurrentPC);

--- a/runtime/tests/jvmtitests/agent/agent.c
+++ b/runtime/tests/jvmtitests/agent/agent.c
@@ -135,7 +135,7 @@ runTest(agentEnv *env, char * options)
 	test = getTest(env->testName);
 
 	if (NULL != test) {
-		rc = test->fn(env, NULL);
+		rc = test->fn(env, env->testArgs);
 	} else {
 		error(env, JVMTI_ERROR_ILLEGAL_ARGUMENT, "Unknown testcase: [%s]\n", env->testName);
 		rc = JNI_ERR;

--- a/runtime/tests/jvmtitests/agent/error.c
+++ b/runtime/tests/jvmtitests/agent/error.c
@@ -151,7 +151,7 @@ static agentError *
 __error(agentEnv * env, jvmtiError err, agentErrorType errType, char *file, const char *fnname, int line, char * errorMsg)
 {
 	agentError *e;
-	char *errorName;
+	char *errorName = "Unknown JVMTI error";
 	JVMTI_ACCESS_FROM_AGENT(env);
 
 

--- a/test/functional/cmdLineTests/jvmtitests/decompilationtests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/decompilationtests.xml
@@ -45,8 +45,28 @@
 		<return type="success" value="0"/>
 	</test>
 
-	<test id="decomp003">
+	<test id="decomp003-XINT">
+		<command>$EXE$ $JVM_OPTS$ -Xint $AGENTLIB$=test:decomp003 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="decomp003-NON-FSD">
+		<command>$EXE$ $JVM_OPTS$ -Xjit:count=0,limit={*.jit*},tryToInline={*.jit*} $AGENTLIB$=test:decomp003,args:nostep -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="decomp003-FSD-NO-DECOMP">
+		<command>$EXE$ $JVM_OPTS$ -Xjit:count=0,limit={*.jit*},tryToInline={*.jit*},forcefullspeeddebug $AGENTLIB$=test:decomp003,args:nostep -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="decomp003-FSD-EXISTING-DECOMP">
 		<command>$EXE$ $JVM_OPTS$ -Xjit:count=0,limit={*.jit*},tryToInline={*.jit*} $AGENTLIB$=test:decomp003 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
+	<test id="decomp003-FSD-DECOMP-DURING-EVENT">
+		<command>$EXE$ $JVM_OPTS$ -Xjit:count=0,limit={*.jit*},tryToInline={*.jit*} $AGENTLIB$=test:decomp003,args:stepincatch -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 


### PR DESCRIPTION
- fix decompiler for the case where decompile occurs during exception
catch event report
- fix jvmtitest harness to pass arguments
- fix jvmtitest harness to handle unknown errors

These are the cases that need to be tested:

- decomp003-XINT: interpreted
- decomp003-NON-FSD: JIT without FSD
- decomp003-FSD-NO-DECOMP: JIT FSD, no decompilation
- decomp003-FSD-EXISTING-DECOMP: JIT FSD, decompilation exists before
event report
- decomp003-FSD-DECOMP-DURING-EVENT: JIT FSD, decompilation occurs
during event report

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>