### PR TITLE
Fix MSVC compile error

### DIFF
--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
@@ -22,6 +22,10 @@
 
 #include "jvmti_test.h"
 #include <string.h>
+#if defined(_MSC_VER)
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#endif /* _MSC_VER */
 
 
 static agentEnv * env;


### PR DESCRIPTION
Use _stricmp instead of strcasecmp on MSVC.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>