### PR TITLE
Donot use 64-bit atomic intrinsics on 32-bit platform

### DIFF
--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -80,11 +80,13 @@ static TR::SymbolReferenceTable::CommonNonhelperSymbol equivalentAtomicIntrinsic
    switch (rm)
       {
       case TR::sun_misc_Unsafe_getAndSetInt:
-      case TR::sun_misc_Unsafe_getAndSetLong:
            return TR::SymbolReferenceTable::atomicSwapSymbol;
+      case TR::sun_misc_Unsafe_getAndSetLong:
+           return TR::Compiler->target.is64Bit() ? TR::SymbolReferenceTable::atomicSwapSymbol : TR::SymbolReferenceTable::lastCommonNonhelperSymbol;
       case TR::sun_misc_Unsafe_getAndAddInt:
-      case TR::sun_misc_Unsafe_getAndAddLong:
            return TR::SymbolReferenceTable::atomicFetchAndAddSymbol;
+      case TR::sun_misc_Unsafe_getAndAddLong:
+           return TR::Compiler->target.is64Bit() ? TR::SymbolReferenceTable::atomicFetchAndAddSymbol : TR::SymbolReferenceTable::lastCommonNonhelperSymbol;
       default:
          break;
       }


### PR DESCRIPTION
64-bit atomic intrinsics are not implemented on 32-bit platforms, using
them will result in an illegal instruction at run time.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>