### PR TITLE
Fake region should have containsInternalCycles set

### DIFF
--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -137,6 +137,8 @@ TR_Structure *fakeRegion(TR::Compilation *comp)
       }
 
    region->setContainsImproperRegion(true);
+   if (comp->mayHaveLoops())
+      region->setContainsInternalCycles(true);
    region->setEntry((*blocks)[0]);
    return region;
    }


### PR DESCRIPTION
Since the construction of a fake region does not do a full structural
analysis, it should always assume the method contains internal cycles
such that the data flow analysis check for every change for correctness.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>