### PR TITLE
Make getClass() private

### DIFF
--- a/runtime/gc_base/JavaObjectAllocationModel.hpp
+++ b/runtime/gc_base/JavaObjectAllocationModel.hpp
@@ -61,10 +61,11 @@ private:
 	 */
 private:
 
+	MMINLINE J9Class *getClass() { return J9_CURRENT_CLASS(_class); }
+
 protected:
 
 public:
-	MMINLINE J9Class *getClass() { return J9_CURRENT_CLASS(_class); }
 
 	/**
 	 * Initializer.


### PR DESCRIPTION
getClass() in JavaObjectAllocationModel should not be used as a public
method to prevent class replacement miss. This behavior has been fixed,
so make method private.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>