### PR TITLE
Set sun.jnu.encoding/file.encoding for Mac

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -394,64 +394,70 @@ jobject getPropertyList(JNIEnv *env)
  */
 jstring getEncoding(JNIEnv *env, jint encodingType)
 {
-	char* encoding, property[128];
+	char *encoding = NULL;
+	char property[128];
+	jstring result = NULL;
 
 	switch(encodingType) {
-		case 0:		/* initialize the locale */
-			getPlatformFileEncoding(env, NULL, 0, encodingType);
-			return NULL;
+	case 0:		/* initialize the locale */
+		getPlatformFileEncoding(env, NULL, 0, encodingType);
+		break;
 
-		case 1: 		/* platform encoding */
-			encoding = getPlatformFileEncoding(env, property, sizeof(property), encodingType);
+	case 1: 		/* platform encoding */
+#if defined(OSX)
+		encoding = "UTF-8";
+#else
+		encoding = getPlatformFileEncoding(env, property, sizeof(property), encodingType);
+#endif /* defined(OSX) */
 #if defined(J9VM_JCL_SE11)
-			{
-				UDATA handle = 0;
-				PORT_ACCESS_FROM_ENV(env);
-				/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
-				if (0 == j9sl_open_shared_library("../java", &handle, J9PORT_SLOPEN_DECORATE)) {
-					void (*nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
-					if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
-						/* invoke JCL native to initialize platform encoding explicitly */
-						nativeFuncAddrJNU(env, encoding);
-					}
+		{
+			UDATA handle = 0;
+			PORT_ACCESS_FROM_ENV(env);
+			/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
+			if (0 == j9sl_open_shared_library("../java", &handle, J9PORT_SLOPEN_DECORATE)) {
+				void (*nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
+				if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
+					/* invoke JCL native to initialize platform encoding explicitly */
+					nativeFuncAddrJNU(env, encoding);
 				}
 			}
-#endif /* J9VM_JCL_SE11 */
-			break;
+		}
+#endif /* defined(J9VM_JCL_SE11) */
+		break;
 
-		case 2:		/* file.encoding */
-			if (!(encoding = getDefinedEncoding(env, "-Dfile.encoding=")))
-			{
-				encoding = getPlatformFileEncoding(env, property, sizeof(property), encodingType);
-			}
+	case 2:		/* file.encoding */
+		encoding = getDefinedEncoding(env, "-Dfile.encoding=");
+		if (NULL == encoding) {
+			encoding = getPlatformFileEncoding(env, property, sizeof(property), encodingType);
+		}
 #if defined(J9ZOS390)
-			if (__CSNameType(encoding) == _CSTYPE_ASCII) {
-				__ccsid_t ccsid;
-				ccsid = __toCcsid(encoding);
-				atoe_setFileTaggingCcsid(&ccsid);
-			}       
-#endif
-			break;
+		if (__CSNameType(encoding) == _CSTYPE_ASCII) {
+			__ccsid_t ccsid;
+			ccsid = __toCcsid(encoding);
+			atoe_setFileTaggingCcsid(&ccsid);
+		}
+#endif /* defined(J9ZOS390) */
+		break;
 
-		case 3:		/* os.encoding */
-			if (!(encoding = getDefinedEncoding(env, "-Dos.encoding="))) {
+	case 3:		/* os.encoding */
+		encoding = getDefinedEncoding(env, "-Dos.encoding=");
+		if (NULL == encoding) {
 #if defined(J9ZOS390) || defined(J9ZTPF)
-				encoding = "ISO8859_1";
+			encoding = "ISO8859_1";
 #elif defined(WIN32)
-				encoding = "UTF8";
-#else
-				return NULL;
-#endif
-			 } 
-			break;
+			encoding = "UTF8";
+#endif /* defined(J9ZOS390) || defined(J9ZTPF) */
+		 } 
+		break;
 
-		default:
-			return NULL;
+	default:
+		break;
 	}
-
-	return (*env)->NewStringUTF(env, encoding);
+	if (NULL != encoding) {
+		result = (*env)->NewStringUTF(env, encoding);
+	}
+	return result;
 }
-
 
 static void JNICALL
 systemPropertyIterator(char* key, char* value, void* userData)


### PR DESCRIPTION
Set `sun.jnu.encoding` & `file.encoding` for Mac

`sun.jnu.encoding` is always set to `UTF-8` on Mac OS X as per https://bugs.java.com/view_bug.do?bug_id=8011194;
`file.encoding` is set to `UTF-8` unless `LC_ALL`, `LC_CTYPE` or `LANG` is set to `"C"` accordingly which matches RI behaviours;
Note:
`LC_ALL` overwrites `LC_CTYPE` or `LANG`;
`LC_CTYPE` applies to classification and conversion of characters, and to multibyte and wide characters;
`LANG` specifies the locale to use except as overridden by `LC_CTYPE`.
Did some refactoring on the functions affected.

Issue: https://github.com/eclipse/openj9/issues/3154#issuecomment-430773141
Verified manually that the test `java/lang/System/MacEncoding/MacJNUEncoding.java.MacJNUEncoding` passes with this PR.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>