### PR TITLE
Fold away only use of ExtCodeBase register

### DIFF
--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -129,7 +129,6 @@ TR::S390PrivateLinkage::S390PrivateLinkage(TR::CodeGenerator * codeGen,TR_S390Li
    setJ9MethodArgumentRegister    (TR::RealRegister::GPR1);
 
    setLitPoolRegister       (TR::RealRegister::GPR6  );
-   setExtCodeBaseRegister   (TR::RealRegister::GPR7  );
    setMethodMetaDataRegister(TR::RealRegister::GPR13 );
 
    setIntegerArgumentRegister(0, TR::RealRegister::GPR1);


### PR DESCRIPTION
Since long displacement stack slot is being folded away as always being
available this means the extended code base register is never needed
and is hence slated for deprecation.

All paths using the extended code base register have either a check for
whether we have long displacement slot available (always true) or a
check for `isExtCodeBaseFreeForAssignment` which under the hood also
returns false if long long displacement slot is available.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>