### PR TITLE
Refactor MH.bind to use standard handle search

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -253,10 +253,13 @@ public class MethodHandles {
 			Class<?> receiverClass = receiver.getClass();
 			MethodHandle handle = handleForMHInvokeMethods(receiverClass, methodName, type);
 			if (handle == null) {
-				// Use the priviledgedLookup to allow probe the findSpecial cache without restricting the receiver
-				handle = internalPrivilegedLookup.findSpecialImpl(receiverClass, methodName, type, receiverClass);
-				handle = handle.asFixedArity(); // remove unnecessary varargsCollector from the middle of the MH chain.
-				handle = convertToVarargsIfRequired(handle.bindTo(receiver));
+				try {
+					handle = findSpecialImpl(receiverClass, methodName, type, receiverClass);
+					handle = handle.asFixedArity(); // remove unnecessary varargsCollector from the middle of the MH chain.
+					handle = convertToVarargsIfRequired(handle.bindTo(receiver));
+				} catch (ClassCastException e) {
+					throw new IllegalAccessException(e.getMessage());
+				}
 			}
 			checkAccess(handle, false);
 			checkSecurity(handle.getDefc(), receiverClass, handle.getModifiers());


### PR DESCRIPTION
- remove internalPrivilegedLookup call
- always restrict the receiver of 'bind'

Close: #3273 

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>