### PR TITLE
Task thread count

### DIFF
--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -753,9 +753,9 @@ void MM_Scheduler::yieldFromGC(MM_EnvironmentRealtime *env, bool distanceChecked
 }
 
 void
-MM_Scheduler::prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task)
+MM_Scheduler::prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount)
 {
-	MM_ParallelDispatcher::prepareThreadsForTask(env, task);
+	MM_ParallelDispatcher::prepareThreadsForTask(env, task, threadCount);
 	pushYieldCollaborator(((MM_IncrementalParallelTask *)task)->getYieldCollaborator());	
 }
 

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -1,6 +1,6 @@
  
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,7 +205,7 @@ public:
 	virtual bool startUpThreads();
 	virtual void shutDownThreads();	
 	
-	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task);
+	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount);
 	virtual void completeTask(MM_EnvironmentBase *env);
 
 	void checkStartGC(MM_EnvironmentRealtime *env);


### PR DESCRIPTION
Comply with new API for prepareThreadsForTask (part of Dispatcher
framework to run a parallel GC task) that takes an extra argument that
specifies explict parallel thread count per Task basis. 

Metronome does not really make use of this API, but the old one is to be
removed.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>