### PR TITLE
Move zeroOutAutoOnEdge to OpenJ9

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -100,6 +100,8 @@ public:
 
    void allocateLinkageRegisters();
 
+   void zeroOutAutoOnEdge(TR::SymbolReference * liveAutoSym, TR::Block *block, TR::Block *succBlock, TR::list<TR::Block*> *newBlocks, TR_ScratchList<TR::Node> *fsdStores);
+
    TR::Linkage *createLinkageForCompilation();
 
    bool enableAESInHardwareTransformations() {return false;}


### PR DESCRIPTION
This PR Moves zeroOutAutoOnEdge from OMR to OpenJ9 since it is not used in OMR.

Issue: https://github.com/eclipse/omr/issues/1866
Signed-off-by: nanjekyejoannah <nanjekyejoannah@gmail.com>