### PR TITLE
Test cases for BoostrapMethod arguments

### DIFF
--- a/runtime/verutil/cfrerr.c
+++ b/runtime/verutil/cfrerr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,7 @@ getJ9CfrErrorBsmMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8* cl
 	char *errorString = NULL;
 
 	/* J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY=BootstrapMethod (%1$d) arguments contain invalid constantpool entry at index (#%2$u) of type (%3$u); class=%5$.*4$s, offset=%6$u */
-	const char *template = j9nls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY, "(%d)(#%u)(%u);%.*s,%u");
+	const char *template = j9nls_lookup_message(J9NLS_ERROR | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_CFR_ERR_BAD_BOOTSTRAP_ARGUMENT_ENTRY, NULL);
 
 	allocSize = strlen(template) + classNameLength + (MAX_INT_SIZE * 4);
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/bsmargstest.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/bsmargstest.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="BootstrapMethod Arguments Tests" timeout="3000">
+
+ <variable name="CP" value="-cp $TESTSJARPATH$" />
+ <variable name="INVALID_CP_ENTRY_UTF8" value="org.openj9.test.bsmargs.RejectInvalidCPEntryUtf8" />
+ <variable name="INVALID_CP_ENTRY_FIELDREF" value="org.openj9.test.bsmargs.RejectInvalidCPEntryFieldref" />
+ <variable name="INVALID_CP_ENTRY_METHODREF" value="org.openj9.test.bsmargs.RejectInvalidCPEntryMethodref" />
+ <variable name="INVALID_CP_ENTRY_NAMEANDTYPE" value="org.openj9.test.bsmargs.RejectInvalidCPEntryNameAndType" />
+ <variable name="INVALID_CP_ENTRY_INVOKEDYNAMIC" value="org.openj9.test.bsmargs.RejectInvalidCPEntryInvokeDynamic" />
+ <variable name="INVALID_CP_ENTRY_INTERFACEMETHODREF" value="org.openj9.test.bsmargs.RejectInvalidCPEntryInterfaceMethodref" />
+
+	<test id="Test an invalid constant pool entry (UTF8) is captured during verification">
+		<command>$JAVA_EXE$ $CP$ $INVALID_CP_ENTRY_UTF8$</command>
+		<output type="success" caseSensitive="yes" regex="no">java.lang.ClassFormatError</output>
+		<output type="required" caseSensitive="yes" regex="no">arguments contain invalid constantpool entry at index</output>
+		<output type="required" caseSensitive="yes" regex="no">class=org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8</output>
+		<output type="failure" caseSensitive="no" regex="no">unexpected EOF</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test an invalid constant pool entry (Fieldref) is captured during verification">
+		<command>$JAVA_EXE$ $CP$ $INVALID_CP_ENTRY_FIELDREF$</command>
+		<output type="success" caseSensitive="yes" regex="no">java.lang.ClassFormatError</output>
+		<output type="required" caseSensitive="yes" regex="no">arguments contain invalid constantpool entry at index</output>
+		<output type="required" caseSensitive="yes" regex="no">class=org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref</output>
+		<output type="failure" caseSensitive="no" regex="no">unexpected EOF</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test an invalid constant pool entry (Methodref) is captured during verification">
+		<command>$JAVA_EXE$ $CP$ $INVALID_CP_ENTRY_METHODREF$</command>
+		<output type="success" caseSensitive="yes" regex="no">java.lang.ClassFormatError</output>
+		<output type="required" caseSensitive="yes" regex="no">arguments contain invalid constantpool entry at index</output>
+		<output type="required" caseSensitive="yes" regex="no">class=org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref</output>
+		<output type="failure" caseSensitive="no" regex="no">unexpected EOF</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test an invalid constant pool entry (NameAndType) is captured during verification">
+		<command>$JAVA_EXE$ $CP$ $INVALID_CP_ENTRY_NAMEANDTYPE$</command>
+		<output type="success" caseSensitive="yes" regex="no">java.lang.ClassFormatError</output>
+		<output type="required" caseSensitive="yes" regex="no">arguments contain invalid constantpool entry at index</output>
+		<output type="required" caseSensitive="yes" regex="no">class=org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType</output>
+		<output type="failure" caseSensitive="no" regex="no">unexpected EOF</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test an invalid constant pool entry (InvokeDynamic) is captured during verification">
+		<command>$JAVA_EXE$ $CP$ $INVALID_CP_ENTRY_INVOKEDYNAMIC$</command>
+		<output type="success" caseSensitive="yes" regex="no">java.lang.ClassFormatError</output>
+		<output type="required" caseSensitive="yes" regex="no">arguments contain invalid constantpool entry at index</output>
+		<output type="required" caseSensitive="yes" regex="no">class=org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic</output>
+		<output type="failure" caseSensitive="no" regex="no">unexpected EOF</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<test id="Test an invalid constant pool entry (InterfaceMethodref) is captured during verification">
+		<command>$JAVA_EXE$ $CP$ $INVALID_CP_ENTRY_INTERFACEMETHODREF$</command>
+		<output type="success" caseSensitive="yes" regex="no">java.lang.ClassFormatError</output>
+		<output type="required" caseSensitive="yes" regex="no">arguments contain invalid constantpool entry at index</output>
+		<output type="required" caseSensitive="yes" regex="no">class=org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref</output>
+		<output type="failure" caseSensitive="no" regex="no">unexpected EOF</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="bootstrapMethodArgumentTest" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build bootstrapMethodArgumentTest
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/bootstrapMethodArgumentTest" />
+	<property name="src" location="./src"/>
+	<property name="build" location="./org/openj9/test/bsmargs"/>
+	<property name="javaexecutable" value="${TEST_JDK_HOME}/bin/java" />
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+	
+	<target name="generate" depends="init" description="Run with asmtools.jar to generate bytecode">
+		<echo>Generating bytecode from jcod files</echo>
+		<exec executable="${javaexecutable}" dir="${build}">
+			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jcoder ${src}/org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8.jcod"/>
+		</exec>
+		<exec executable="${javaexecutable}" dir="${build}">
+			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jcoder ${src}/org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref.jcod"/>
+		</exec>
+		<exec executable="${javaexecutable}" dir="${build}">
+			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jcoder ${src}/org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref.jcod"/>
+		</exec>
+		<exec executable="${javaexecutable}" dir="${build}">
+			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jcoder ${src}/org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType.jcod"/>
+		</exec>
+		<exec executable="${javaexecutable}" dir="${build}">
+			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jcoder ${src}/org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic.jcod"/>
+		</exec>
+		<exec executable="${javaexecutable}" dir="${build}">
+			<arg line="-jar ${TEST_ROOT}/TestConfig/lib/asmtools.jar jcoder ${src}/org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref.jcod"/>
+		</exec>
+	</target>
+	
+	<target name="dist" depends="generate" description="generate the distribution">
+		<jar jarfile="${DEST}/bsmargstest.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="./" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+		<delete>
+			<fileset dir=".">
+				<include name="*.class"/>
+			</fileset>
+		</delete>
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/playlist.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/playlist.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_bootstrapMethodArgumentTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)bsmargstest.jar$(Q) \
+		-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
+		-config $(Q)$(TEST_RESROOT)$(D)bsmargstest.xml$(Q) \
+		-xids all,$(PLATFORM) \
+		-nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>11</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref.jcod
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* A valid index stored in the bootstrap_arguments array only belongs to of the following types:
+ * CONSTANT_String_info, CONSTANT_Class_info, CONSTANT_Integer_info, CONSTANT_Long_info,
+ * CONSTANT_Float_info, CONSTANT_Double_info, CONSTANT_MethodHandle_info, CONSTANT_MethodType_info
+ * and CFR_CONSTANT_Dynamic; otherwise, it is invalid.
+ *
+ * In this test, the original index in bootstrap_arguments is #31 (MethodHandle).
+ * Now Change it to #8 (Field) which is treated as invalid for bootstrap_arguments.
+ */
+
+class org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPEntryFieldref.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #8;        // Modified to an invalid constant pool entry #8 (Field)
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPEntryFieldref

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref.jcod
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* A valid index stored in the bootstrap_arguments array only belongs to of the following types:
+ * CONSTANT_String_info, CONSTANT_Class_info, CONSTANT_Integer_info, CONSTANT_Long_info,
+ * CONSTANT_Float_info, CONSTANT_Double_info, CONSTANT_MethodHandle_info, CONSTANT_MethodType_info
+ * and CFR_CONSTANT_Dynamic; otherwise, it is invalid.
+ *
+ * In this test, the original index in bootstrap_arguments is #31 (MethodHandle).
+ * Now Change it to #5 (InterfaceMethod) which is treated as invalid for bootstrap_arguments.
+ */
+
+class org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPEntryInterfaceMethodref.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #5;        // Modified to an invalid constant pool entry #5 (InterfaceMethod)
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPEntryInterfaceMethodref

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic.jcod
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* A valid index stored in the bootstrap_arguments array only belongs to of the following types:
+ * CONSTANT_String_info, CONSTANT_Class_info, CONSTANT_Integer_info, CONSTANT_Long_info,
+ * CONSTANT_Float_info, CONSTANT_Double_info, CONSTANT_MethodHandle_info, CONSTANT_MethodType_info
+ * and CFR_CONSTANT_Dynamic; otherwise, it is invalid.
+ *
+ * In this test, the original index in bootstrap_arguments is #31 (MethodHandle).
+ * Now Change it to #6 (InvokeDynamic) which is treated as invalid for bootstrap_arguments.
+ */
+
+class org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPEntryInvokeDynamic.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #6;        // Modified to an invalid constant pool entry #6 (InvokeDynamic)
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPEntryInvokeDynamic

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref.jcod
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* A valid index stored in the bootstrap_arguments array only belongs to of the following types:
+ * CONSTANT_String_info, CONSTANT_Class_info, CONSTANT_Integer_info, CONSTANT_Long_info,
+ * CONSTANT_Float_info, CONSTANT_Double_info, CONSTANT_MethodHandle_info, CONSTANT_MethodType_info
+ * and CFR_CONSTANT_Dynamic; otherwise, it is invalid.
+ *
+ * In this test, the original index in bootstrap_arguments is #31 (MethodHandle).
+ * Now Change it to #9 (Method) which is treated as invalid for bootstrap_arguments.
+ */
+
+class org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPEntryMethodref.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #9;        // Modified to an invalid constant pool entry #9 (Method)
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPEntryMethodref

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType.jcod
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* A valid index stored in the bootstrap_arguments array only belongs to of the following types:
+ * CONSTANT_String_info, CONSTANT_Class_info, CONSTANT_Integer_info, CONSTANT_Long_info,
+ * CONSTANT_Float_info, CONSTANT_Double_info, CONSTANT_MethodHandle_info, CONSTANT_MethodType_info
+ * and CFR_CONSTANT_Dynamic; otherwise, it is invalid.
+ *
+ * In this test, the original index in bootstrap_arguments is #31 (MethodHandle).
+ * Now Change it to #22 (NameAndType) which is treated as invalid for bootstrap_arguments.
+ */
+
+class org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPEntryNameAndType.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #22;        // Modified to an invalid constant pool entry #22 (NameAndType)
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPEntryNameAndType

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8.jcod
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* A valid index stored in the bootstrap_arguments array only belongs to of the following types:
+ * CONSTANT_String_info, CONSTANT_Class_info, CONSTANT_Integer_info, CONSTANT_Long_info,
+ * CONSTANT_Float_info, CONSTANT_Double_info, CONSTANT_MethodHandle_info, CONSTANT_MethodType_info
+ * and CFR_CONSTANT_Dynamic; otherwise, it is invalid.
+ *
+ * In this test, the original index in bootstrap_arguments is #31 (MethodHandle).
+ * Now Change it to #14 (Utf8) which is treated as invalid for bootstrap_arguments.
+ */
+
+class org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8 {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPEntryUtf8.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #14;        // Modified to an invalid constant pool entry #14 (Utf8)
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPEntryUtf8

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPTestTemplate.java
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPTestTemplate.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* This is a test template is used to generate jcod files with invalid boostrap method arguments */
+package org.openj9.test.bsmargs;
+
+import java.util.*;
+public class RejectInvalidCPTestTemplate {
+	public static void main(String[] args) {
+		List<Integer> list=new ArrayList<Integer>();
+		list.add(100);
+		list.forEach((n)->System.out.println(n));
+	}
+}

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPTestTemplate.jcod
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/src/org/openj9/test/bsmargs/RejectInvalidCPTestTemplate.jcod
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/* This is a test template is used to generate jcod files with invalid boostrap method arguments */
+
+class org/openj9/test/bsmargs/RejectInvalidCPTestTemplate {
+  0xCAFEBABE;
+  0; // minor version
+  55; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #11 #22; // #1    
+    class #23; // #2    
+    Method #2 #22; // #3    
+    Method #24 #25; // #4    
+    InterfaceMethod #26 #27; // #5    
+    InvokeDynamic 0s #33; // #6    
+    InterfaceMethod #26 #34; // #7    
+    Field #35 #36; // #8    
+    Method #37 #38; // #9    
+    class #39; // #10    
+    class #40; // #11    
+    Utf8 "<init>"; // #12    
+    Utf8 "()V"; // #13    
+    Utf8 "Code"; // #14    
+    Utf8 "LineNumberTable"; // #15    
+    Utf8 "main"; // #16    
+    Utf8 "([Ljava/lang/String;)V"; // #17    
+    Utf8 "lambda$main$0"; // #18    
+    Utf8 "(Ljava/lang/Integer;)V"; // #19    
+    Utf8 "SourceFile"; // #20    
+    Utf8 "RejectInvalidCPTestTemplate.java"; // #21    
+    NameAndType #12 #13; // #22    
+    Utf8 "java/util/ArrayList"; // #23    
+    class #41; // #24    
+    NameAndType #42 #43; // #25    
+    class #44; // #26    
+    NameAndType #45 #46; // #27    
+    Utf8 "BootstrapMethods"; // #28    
+    MethodHandle 6b #47; // #29    
+    MethodType #48; // #30    
+    MethodHandle 6b #49; // #31    
+    MethodType #19; // #32    
+    NameAndType #50 #51; // #33    
+    NameAndType #52 #53; // #34    
+    class #54; // #35    
+    NameAndType #55 #56; // #36    
+    class #57; // #37    
+    NameAndType #58 #48; // #38    
+    Utf8 "org/openj9/test/bsmargs/RejectInvalidCPTestTemplate"; // #39    
+    Utf8 "java/lang/Object"; // #40    
+    Utf8 "java/lang/Integer"; // #41    
+    Utf8 "valueOf"; // #42    
+    Utf8 "(I)Ljava/lang/Integer;"; // #43    
+    Utf8 "java/util/List"; // #44    
+    Utf8 "add"; // #45    
+    Utf8 "(Ljava/lang/Object;)Z"; // #46    
+    Method #59 #60; // #47    
+    Utf8 "(Ljava/lang/Object;)V"; // #48    
+    Method #10 #61; // #49    
+    Utf8 "accept"; // #50    
+    Utf8 "()Ljava/util/function/Consumer;"; // #51    
+    Utf8 "forEach"; // #52    
+    Utf8 "(Ljava/util/function/Consumer;)V"; // #53    
+    Utf8 "java/lang/System"; // #54    
+    Utf8 "out"; // #55    
+    Utf8 "Ljava/io/PrintStream;"; // #56    
+    Utf8 "java/io/PrintStream"; // #57    
+    Utf8 "println"; // #58    
+    class #62; // #59    
+    NameAndType #63 #67; // #60    
+    NameAndType #18 #19; // #61    
+    Utf8 "java/lang/invoke/LambdaMetafactory"; // #62    
+    Utf8 "metafactory"; // #63    
+    class #69; // #64    
+    Utf8 "Lookup"; // #65    
+    Utf8 "InnerClasses"; // #66    
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #67    
+    class #70; // #68    
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #69    
+    Utf8 "java/lang/invoke/MethodHandles"; // #70    
+  } // Constant Pool
+
+  0x0021; // access
+  #10;// this_cpx
+  #11;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0001; // access
+      #12; // name_cpx
+      #13; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  27;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x0009; // access
+      #16; // name_cpx
+      #17; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          2; // max_locals
+          Bytes[]{
+            0xBB000259B700034C;
+            0x2B1064B80004B900;
+            0x050200572BBA0006;
+            0x0000B900070200B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  29;
+                8  30;
+                20  31;
+                31  32;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member
+      0x100A; // access
+      #18; // name_cpx
+      #19; // sig_cpx
+      [] { // Attributes
+        Attr(#14) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB200082AB60009B1;
+          };
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#15) { // LineNumberTable
+              [] { // LineNumberTable
+                0  31;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+    Attr(#20) { // SourceFile
+      #21;
+    } // end SourceFile
+    ;
+    Attr(#66) { // InnerClasses
+      [] { // InnerClasses
+        #64 #68 #65 25;
+      }
+    } // end InnerClasses
+    ;
+    Attr(#28) { // BootstrapMethods
+      [] { // bootstrap_methods
+        {  //  bootstrap_method
+          #29; // bootstrap_method_ref
+          [] { // bootstrap_arguments
+            #30;
+            #31;
+            #32;
+          }  //  bootstrap_arguments
+        }  //  bootstrap_method
+      }
+    } // end BootstrapMethods
+  } // Attributes
+} // end class org/openj9/test/bsmargs/RejectInvalidCPTestTemplate


### PR DESCRIPTION
The changes are to add some test cases  to check
that invalid constant pool entries stored in 
BoostrapMethod arguments must be captured during 
static verification.

issue: #2856

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>