### PR TITLE
Fix crash in HCR with concurrent scavenger

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1088,15 +1088,15 @@ redefineClassesCommon(jvmtiEnv* env,
 				/* Fix static refs */
 				fixStaticRefs(currentThread, classPairs, extensionsUsed);
  
-				/* Copy preserved values */
-				copyPreservedValues(currentThread, classPairs, extensionsUsed);
-
 				/* Update heap references */
 				fixHeapRefs(vm, classPairs);
 
 				/* Update method references in DirectHandles */
 				fixDirectHandles(currentThread, classPairs, methodPairs);
  
+				/* Copy preserved values */
+				copyPreservedValues(currentThread, classPairs, extensionsUsed);
+
 				/* Update the componentType and leafComponentType fields of array classes */
 				fixArrayClasses(currentThread, classPairs);
 


### PR DESCRIPTION
Defer poisoning of the totalInstanceSize of replaced classes until after
heap iteration.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>