### PR TITLE
Remove setting specialized for direction flag in Z CodeGen

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -137,8 +137,6 @@ J9::Z::CodeGenerator::CodeGenerator() :
    // Invoke Class.newInstanceImpl() from the JIT directly
    cg->setSupportsNewInstanceImplOpt();
 
-   cg->setSupportsPostProcessArrayCopy();
-
    // Still being set in the S390CodeGenerator constructor, as zLinux sTR requires this.
    //cg->setSupportsJavaFloatSemantics();
 


### PR DESCRIPTION
Remove setting flag that Value Propagation checks to generate array copy trees for specialized direction with test to decide direction as it is not java specific.
 
Signed-off-by: Rahil Shah <rahil@ca.ibm.com>