### PR TITLE
Fix SharedCache Throughput Regression with IPdata

### DIFF
--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -383,7 +383,7 @@ TR_JITaaSClientIProfiler::TR_JITaaSClientIProfiler(J9JITConfig *jitConfig)
  */
 uint32_t
 TR_JITaaSClientIProfiler::walkILTreeForIProfilingEntries(uintptrj_t *pcEntries, uint32_t &numEntries, TR_J9ByteCodeIterator *bcIterator,
-                                                       TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort)
+                                                       TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort, TR::Compilation *comp)
    {
    abort = false; // optimistic
    uint32_t bytesFootprint = 0;
@@ -395,7 +395,7 @@ TR_JITaaSClientIProfiler::walkILTreeForIProfilingEntries(uintptrj_t *pcEntries, 
          {
          uintptrj_t thisPC = getSearchPCFromMethodAndBCIndex(method, bci);
 
-         TR_IPBytecodeHashTableEntry *entry = profilingSample(thisPC, 0, false);
+         TR_IPBytecodeHashTableEntry *entry = profilingSample(method, bci, comp);
          BCvisit->set(bci);
          if (entry && !invalidateEntryIfInconsistent(entry))
             {
@@ -516,7 +516,7 @@ TR_JITaaSClientIProfiler::serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodB
       // numEntries will indicate how many entries have been populated
       // These profiling entries have been 'locked' so we must remember to unlock them
       bool abort = false;
-      bytesFootprint = walkILTreeForIProfilingEntries(pcEntries, numEntries, &bci, method, BCvisit, abort);
+      bytesFootprint = walkILTreeForIProfilingEntries(pcEntries, numEntries, &bci, method, BCvisit, abort, comp);
       if (numEntries && !abort)
          {
          // Serialize the entries

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -95,7 +95,7 @@ class TR_JITaaSClientIProfiler : public TR_IProfiler
       // the base class. It may be better not to override any methods though
     
       uint32_t walkILTreeForIProfilingEntries(uintptrj_t *pcEntries, uint32_t &numEntries, TR_J9ByteCodeIterator *bcIterator,
-                                              TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort);
+                                              TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort, TR::Compilation *comp);
       uintptr_t serializeIProfilerMethodEntries(uintptrj_t *pcEntries, uint32_t numEntries, uintptr_t memChunk, uintptrj_t methodStartAddress);
       void serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::J9ClientStream *client);
    };


### PR DESCRIPTION
Currently when we send iprofile data from client to server,
we only grab ipdata from the hashtable. Changing it to grab ipdata from
hashtable and also the sharedcache.

[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>