### PR TITLE
 Cache information for j9Classes at server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2725,30 +2725,47 @@ ClientSessionHT::printStats()
 void 
 JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple)
    {
+   ClientSessionData::ClassInfo classInfo;
    OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+   if (it == clientSessionData->getROMClassMap().end())
+      {
+      JITaaSHelpers::cacheRemoteROMClass(clientSessionData, clazz, romClass, classInfoTuple, classInfo);
+      }
+   }
+
+void
+JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfoStruct)
+   {
    ClassInfoTuple &classInfo = *classInfoTuple;
-   J9Method *methods = std::get<1>(classInfo);
-   TR_OpaqueClassBlock *baseComponentClass = std::get<2>(classInfo);
-   int32_t numDims = std::get<3>(classInfo);
-   TR_OpaqueClassBlock *parentClass = std::get<4>(classInfo);
+
+   classInfoStruct.romClass = romClass;
+   classInfoStruct.methodsOfClass = std::get<1>(classInfo);
+   J9Method *methods = classInfoStruct.methodsOfClass;
+   classInfoStruct.baseComponentClass = std::get<2>(classInfo);
+   classInfoStruct.numDimensions = std::get<3>(classInfo);
+   classInfoStruct._remoteROMStringsCache = nullptr;
+   classInfoStruct._fieldOrStaticNameCache = nullptr;
+   classInfoStruct.parentClass = std::get<4>(classInfo);
    auto &tmpInterfaces = std::get<5>(classInfo);
-   auto interfaces = new (PERSISTENT_NEW) PersistentVector<TR_OpaqueClassBlock *>
+   classInfoStruct.interfaces = new (PERSISTENT_NEW) PersistentVector<TR_OpaqueClassBlock *>
       (tmpInterfaces.begin(), tmpInterfaces.end(),
        PersistentVector<TR_OpaqueClassBlock *>::allocator_type(TR::Compiler->persistentAllocator()));
    auto &methodTracingInfo = std::get<6>(classInfo);
-   bool classHasFinalFields = std::get<7>(classInfo);
-   uintptrj_t classDepthAndFlags = std::get<8>(classInfo);
-   bool classInitialized = std::get<9>(classInfo);
-   uint32_t byteOffsetToLockword = std::get<10>(classInfo);
-   TR_OpaqueClassBlock * leafComponentClass = std::get<11>(classInfo);
-   void *classLoader = std::get<12>(classInfo);
-   TR_OpaqueClassBlock * hostClass = std::get<13>(classInfo);
-   TR_OpaqueClassBlock * componentClass = std::get<14>(classInfo);
-   TR_OpaqueClassBlock * arrayClass = std::get<15>(classInfo);
-   uintptrj_t totalInstanceSize = std::get<16>(classInfo);
-   clientSessionData->getROMClassMap().insert({ clazz, { romClass, methods,
-      baseComponentClass, numDims,
-      nullptr, nullptr, parentClass, interfaces, classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass, classLoader, hostClass, componentClass, arrayClass, totalInstanceSize, nullptr} });
+   classInfoStruct.classHasFinalFields = std::get<7>(classInfo);
+   classInfoStruct.classDepthAndFlags = std::get<8>(classInfo);
+   classInfoStruct.classInitialized = std::get<9>(classInfo);
+   classInfoStruct.byteOffsetToLockword = std::get<10>(classInfo);
+   classInfoStruct.leafComponentClass = std::get<11>(classInfo);
+   classInfoStruct.classLoader = std::get<12>(classInfo);
+   classInfoStruct.hostClass = std::get<13>(classInfo);
+   classInfoStruct.componentClass = std::get<14>(classInfo);
+   classInfoStruct.arrayClass = std::get<15>(classInfo);
+   classInfoStruct.totalInstanceSize = std::get<16>(classInfo);
+   classInfoStruct._classOfStaticCache = nullptr;
+
+   clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
+
    uint32_t numMethods = romClass->romMethodCount;
    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
    for (uint32_t i = 0; i < numMethods; i++)
@@ -2815,4 +2832,169 @@ JITaaSHelpers::getRemoteROMClass(J9Class *clazz, JITaaS::J9ServerStream *stream,
    const auto &recv = stream->read<ClassInfoTuple>();
    *classInfoTuple = std::get<0>(recv);
    return romClassFromString(std::get<0>(*classInfoTuple), trMemory->trPersistentMemory());
+   }
+
+bool
+JITaaSHelpers::getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::J9ServerStream *stream, ClassInfoDataType dataType, void *data)
+   {
+   JITaaSHelpers::ClassInfoTuple classInfoTuple;
+   ClientSessionData::ClassInfo classInfo;
+   if (!clazz)
+      {
+      return false;
+      }
+      {
+      OMR::CriticalSection getRemoteROMClass(clientSessionData->getROMMapMonitor());
+      auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+      if (it != clientSessionData->getROMClassMap().end())
+         {
+         JITaaSHelpers::getROMClassData(it->second, dataType, data);
+         return true;
+         }
+      }
+   stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getRemoteROMClassAndMethods, clazz);
+   const auto &recv = stream->read<ClassInfoTuple>();
+   classInfoTuple = std::get<0>(recv);
+
+   OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find(clazz);
+   if (it == clientSessionData->getROMClassMap().end())
+      {
+      auto romClass = romClassFromString(std::get<0>(classInfoTuple), TR::comp()->trMemory()->trPersistentMemory());
+      JITaaSHelpers::cacheRemoteROMClass(clientSessionData, clazz, romClass, &classInfoTuple, classInfo);
+      JITaaSHelpers::getROMClassData(classInfo, dataType, data);
+      }
+   else
+      {
+      JITaaSHelpers::getROMClassData(it->second, dataType, data);
+      }
+   return true;
+   }
+
+bool
+JITaaSHelpers::getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::J9ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2)
+   {
+   JITaaSHelpers::ClassInfoTuple classInfoTuple;
+   ClientSessionData::ClassInfo classInfo;
+   if (!clazz)
+      {
+      return false;
+      }
+      {
+      OMR::CriticalSection getRemoteROMClass(clientSessionData->getROMMapMonitor());
+      auto it = clientSessionData->getROMClassMap().find((J9Class*)clazz);
+      if (it != clientSessionData->getROMClassMap().end())
+         {
+         JITaaSHelpers::getROMClassData(it->second, dataType1, data1);
+         JITaaSHelpers::getROMClassData(it->second, dataType2, data2);
+         return true;
+         }
+      }
+   stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getRemoteROMClassAndMethods, clazz);
+   const auto &recv = stream->read<ClassInfoTuple>();
+   classInfoTuple = std::get<0>(recv);
+
+   OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+   auto it = clientSessionData->getROMClassMap().find(clazz);
+   if (it == clientSessionData->getROMClassMap().end())
+      {
+      auto romClass = romClassFromString(std::get<0>(classInfoTuple), TR::comp()->trMemory()->trPersistentMemory());
+      JITaaSHelpers::cacheRemoteROMClass(clientSessionData, clazz, romClass, &classInfoTuple, classInfo);
+      JITaaSHelpers::getROMClassData(classInfo, dataType1, data1);
+      JITaaSHelpers::getROMClassData(classInfo, dataType2, data2);
+      }
+   else
+      {
+      JITaaSHelpers::getROMClassData(it->second, dataType1, data1);
+      JITaaSHelpers::getROMClassData(it->second, dataType2, data2);
+      }
+   return true;
+   }
+
+void
+JITaaSHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data)
+   {
+   switch (dataType)
+      {
+      case CLASSINFO_ROMCLASS_MODIFIERS :
+         {
+         *(uint32_t *)data = classInfo.romClass->modifiers;
+         }
+         break;
+      case CLASSINFO_ROMCLASS_EXTRAMODIFIERS :
+         {
+         *(uint32_t *)data = classInfo.romClass->extraModifiers;
+         }
+         break;
+      case CLASSINFO_BASE_COMPONENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo.baseComponentClass;
+         }
+         break;
+      case CLASSINFO_NUMBER_DIMENSIONS :
+         {
+         *(int32_t *)data = classInfo.numDimensions;
+         }
+         break;
+      case CLASSINFO_PARENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo.parentClass;
+         }
+         break;
+      case CLASSINFO_CLASS_HAS_FINAL_FIELDS :
+         {
+         *(bool *)data = classInfo.classHasFinalFields;
+         }
+         break;
+      case CLASSINFO_CLASS_DEPTH_AND_FLAGS :
+         {
+         *(uintptrj_t *)data = classInfo.classDepthAndFlags;
+         }
+         break;
+      case CLASSINFO_CLASS_INITIALIZED :
+         {
+         *(bool *)data = classInfo.classInitialized;
+         }
+         break;
+      case CLASSINFO_BYTE_OFFSET_TO_LOCKWORD :
+         {
+         *(uint32_t *)data = classInfo.byteOffsetToLockword;
+         }
+         break;
+      case CLASSINFO_LEAF_COMPONENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo.leafComponentClass;
+         }
+         break;
+      case CLASSINFO_CLASS_LOADER :
+         {
+         *(void **)data = classInfo.classLoader;
+         }
+         break;
+      case CLASSINFO_HOST_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo.hostClass;
+         }
+         break;
+      case CLASSINFO_COMPONENT_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo.componentClass;
+         }
+         break;
+      case CLASSINFO_ARRAY_CLASS :
+         {
+         *(TR_OpaqueClassBlock **)data = classInfo.arrayClass;
+         }
+         break;
+      case CLASSINFO_TOTAL_INSTANCE_SIZE :
+         {
+         *(uintptrj_t *)data = classInfo.totalInstanceSize;
+         }
+         break;
+      default :
+         {
+         TR_ASSERT(0, "Class Info not supported %u \n", dataType);
+         }
+         break;
+      }
    }

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -168,19 +168,41 @@ void printJITaaSMsgStats(J9JITConfig *);
 void printJITaaSCHTableStats(J9JITConfig *, TR::CompilationInfo *);
 void printJITaaSCacheStats(J9JITConfig *, TR::CompilationInfo *);
 
-
-
 class JITaaSHelpers
    {
    public:
+   enum ClassInfoDataType
+      {
+      CLASSINFO_ROMCLASS_MODIFIERS,
+      CLASSINFO_ROMCLASS_EXTRAMODIFIERS,
+      CLASSINFO_BASE_COMPONENT_CLASS,
+      CLASSINFO_NUMBER_DIMENSIONS,
+      CLASSINFO_PARENT_CLASS,
+      CLASSINFO_INTERFACE_CLASS,
+      CLASSINFO_CLASS_HAS_FINAL_FIELDS,
+      CLASSINFO_CLASS_DEPTH_AND_FLAGS,
+      CLASSINFO_CLASS_INITIALIZED,
+      CLASSINFO_BYTE_OFFSET_TO_LOCKWORD,
+      CLASSINFO_LEAF_COMPONENT_CLASS,
+      CLASSINFO_CLASS_LOADER,
+      CLASSINFO_HOST_CLASS,
+      CLASSINFO_COMPONENT_CLASS,
+      CLASSINFO_ARRAY_CLASS,
+      CLASSINFO_TOTAL_INSTANCE_SIZE,
+      CLASSINFO_CLASS_OF_STATIC_CACHE,
+      };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
    using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<std::tuple<bool, bool>>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t>;
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, TR_J9VM *fe, TR_Memory *trMemory);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
+   static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);
    static J9ROMClass *getRemoteROMClassIfCached(ClientSessionData *clientSessionData, J9Class *clazz);
-   static J9ROMClass * getRemoteROMClass(J9Class *, JITaaS::J9ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
-   static J9ROMClass * romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory);
+   static J9ROMClass *getRemoteROMClass(J9Class *, JITaaS::J9ServerStream *stream, TR_Memory *trMemory, ClassInfoTuple *classInfoTuple);
+   static J9ROMClass *romClassFromString(const std::string &romClassStr, TR_PersistentMemory *trMemory);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::J9ServerStream *stream, ClassInfoDataType dataType,  void *data);
+   static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData, JITaaS::J9ServerStream *stream, ClassInfoDataType dataType1, void *data1, ClassInfoDataType dataType2, void *data2);
+   static void getROMClassData(const ClientSessionData::ClassInfo &classInfo, ClassInfoDataType dataType, void *data);
    };
 
 #endif


### PR DESCRIPTION
The implementation is to fetch all the information of the class
when it is not cached.

Fixes: #3349
Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>