### PR TITLE
Limit heap size for jvmtitests

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -315,7 +315,7 @@
 	</test>
 
 	<test id="vgc001">
-		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:vgc001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<command>$EXE$ -Xmx512m $JVM_OPTS$ $AGENTLIB$=test:vgc001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 


### PR DESCRIPTION
Some jvmti tests are exceedingly slow if run on machines with large amounts of
RAM.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>