### PR TITLE
Disclaim the stored meta data in the shared cache

### DIFF
--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -410,6 +410,8 @@ public:
 	
 	void increaseUnstoredBytes(U_32 blockBytes, U_32 aotBytes, U_32 jitBytes);
 
+	bool isNewCache(void);
+
 private:
 	J9SharedClassConfig* _sharedClassConfig;
 	SH_OSCache* _oscache;
@@ -494,6 +496,8 @@ private:
 	bool _canStoreClasspaths;
 
 	bool _reduceStoreContentionDisabled;
+
+	bool _initializingNewCache;
 
 #if defined(J9SHR_CACHELET_SUPPORT)
 	/**

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2912,3 +2912,5 @@ TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_getDirFailed NoEnv Overhead=1 Lev
 TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_DiskSpaceLow NoEnv Overhead=1 Level=1 Template="INIT::isFreeDiskSpaceLow Exception: The free disk space is low (%llu bytes)."
 TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_StatFileSystemFailed NoEnv Overhead=1 Level=1 Template="INIT::isFreeDiskSpaceLow Exception: Failed to check the free disk space for %s. Error number: %d. Error message: %s "
 TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_SetMaxSize NoEnv Overhead=1 Level=1 Template="INIT::isFreeDiskSpaceLow returning true, the maximum shared cache size allowed is %llu bytes"
+
+TraceEvent=Trc_SHR_CC_startup_Event_InitializingNewCache Overhead=1 Level=1 Template="CC startup: initializing a new cache"


### PR DESCRIPTION
The change is to ensure all stored meta data
are disclaimed when exiting the startup stage
in the cold run.

Fix: #2024

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>