### PR TITLE
Fix profilingSample SharedClassCache bug

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -1576,8 +1576,6 @@ TR_IProfiler::profilingSample (TR_OpaqueMethodBlock *method, uint32_t byteCodeIn
             int32_t persistentCount = getSamplingCount(persistentEntry, comp);
             if(currentCount >= persistentCount)
                {
-               _STATS_IPEntryChoosePersistent++;
-               currentEntry->copyFromEntry(persistentEntry, comp);
                return currentEntry;
                }
             else


### PR DESCRIPTION
When we have profiling data in both HashTable and SCC, we pick
the one with higher sampling count. Should return HashTable's entry
when its sampling count is higher. Currently we are returning SCC's entry
for both cases.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>