### PR TITLE
Halt thread before getting owned monitor data

### DIFF
--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -597,6 +597,8 @@ jvmtiGetOwnedMonitorStackDepthInfo(jvmtiEnv* env,
 			J9ObjectMonitorInfo * monitorEnterRecords = NULL;
 			jvmtiMonitorStackDepthInfo * resultArray = NULL;
 
+			vm->internalVMFunctions->haltThreadForInspection(currentThread, targetThread);
+
 			/* Get the count of owned monitors */
 
 			maxRecords = vm->internalVMFunctions->getOwnedObjectMonitors(currentThread, targetThread, NULL, 0);
@@ -660,6 +662,7 @@ doneRelease:
 				j9mem_free_memory(monitorEnterRecords);
 			}
 
+			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
 			releaseVMThread(currentThread, targetThread);
 		}
 done:

--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -61,6 +61,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "gaste001", gaste001, "com.ibm.jvmti.tests.getAllStackTracesExtended.gaste001", "GetAllStackTracesExtended" },
 	{ "gtlste001", gtlste001, "com.ibm.jvmti.tests.getThreadListStackTracesExtended.gtlste001", "GetThreadListStackTracesExtended" },
 	{ "gomsdi001", gomsdi001, "com.ibm.jvmti.tests.getOwnedMonitorStackDepthInfo.gomsdi001", "GetOwnedMonitorStackDepthInfo" },
+	{ "gomsdi002", gomsdi002, "com.ibm.jvmti.tests.getOwnedMonitorStackDepthInfo.gomsdi002", "GetOwnedMonitorStackDepthInfo" },
 	{ "gomi001", gomi001, "com.ibm.jvmti.tests.getOwnedMonitorInfo.gomi001", "GetOwnedMonitorInfo" },
 	{ "abcl001", abcl001, "com.ibm.jvmti.tests.addToBootstrapClassLoaderSearch.abcl001", "AddToBootstrapClassLoaderSearch during OnLoad" },
 	{ "abcl002", abcl002, "com.ibm.jvmti.tests.addToBootstrapClassLoaderSearch.abcl002", "AddToBootstrapClassLoaderSearch during live" },

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -208,6 +208,7 @@ jint JNICALL gctcti001(agentEnv * env, char * args);
 jint JNICALL gtgc001(agentEnv * env, char * args);
 jint JNICALL gtgc002(agentEnv * env, char * args);
 jint JNICALL gomsdi001(agentEnv * env, char * args);
+jint JNICALL gomsdi002(agentEnv * env, char * args);
 jint JNICALL gomi001(agentEnv * env, char * args);
 jint JNICALL gts001(agentEnv * env, char * args);
 jint JNICALL ghftm001(agentEnv * env, char * args);

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -120,6 +120,7 @@
 		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_gomsdi001_nDepth"/>
 		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_ThreadNDepth_verify"/>
 		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_ThreadNDepth_verifyDeeper"/>
+		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_gomsdi002_callGet"/>
 		<export name="Java_com_ibm_jvmti_tests_getThreadState_gts001_getThreadStates"/>
 		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorInfo_ThreadMonitorInfoTest_verifyMonitors"/>
 		<export name="Java_com_ibm_jvmti_tests_getHeapFreeTotalMemory_ghftm001_getHeapFreeMemory"/>

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/getOwnedMonitorInfo/gomi001.c
 
 	com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi001.c
+	com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi002.c
 
 	com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
 	com/ibm/jvmti/tests/getPotentialCapabilities/gpc002.c

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi002.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi002.c
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+
+#include "ibmjvmti.h"
+#include "jvmti_test.h"
+
+static agentEnv * env;                                                    
+
+jint JNICALL
+gomsdi002(agentEnv * agent_env, char * args)
+{
+	JVMTI_ACCESS_FROM_AGENT(agent_env);                                
+	jvmtiCapabilities capabilities;
+	jvmtiError err;                                
+
+	env = agent_env;
+
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	capabilities.can_get_owned_monitor_stack_depth_info = 1;
+	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+	if (err != JVMTI_ERROR_NONE) {
+		error(env, err, "Failed to add capabilities");
+		return JNI_ERR;
+	}				
+			
+	return JNI_OK;
+}
+
+void JNICALL
+Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_gomsdi002_callGet(
+		JNIEnv *jni_env, 
+		jclass klass, 
+		jthread thread) 
+{
+	JVMTI_ACCESS_FROM_AGENT(env);
+	jint infoCount;
+	jvmtiMonitorStackDepthInfo *info;
+	(*jvmti_env)->GetOwnedMonitorStackDepthInfo(jvmti_env, thread, &infoCount, &info);
+}

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -224,6 +224,11 @@
 		<return type="success" value="0"/>
 	</test>
 
+ 	<test id="gomsdi002">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:gomsdi002 -Xint -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
  	<test id="gomi001">
 		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:gomi001 -Xint -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi002.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi002.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.getOwnedMonitorStackDepthInfo;
+
+public class gomsdi002
+{	
+	static Object lock = new Object();
+	static boolean running = false;
+	static volatile boolean stop = false;
+	
+	native static void callGet(Thread t);
+	
+	public boolean testForeignThread() throws Throwable
+	{
+		Thread runner = new Thread() {
+			public long recurse(int i, long v) {
+				if (i > 0) {
+					v = System.currentTimeMillis() + recurse(i - 1, v);
+				}
+				return v;
+			}
+			public void run() {
+				synchronized(lock) {
+					running = true;
+					lock.notifyAll();
+				}
+				while (!stop) {
+					recurse(100, 0);
+				}
+			}
+		};		
+
+		runner.start();
+		synchronized(lock) {
+			while(!running) {
+				lock.wait();
+			}
+		}
+
+		long start = System.currentTimeMillis();
+		while((System.currentTimeMillis() - start) < 5000) {
+			callGet(runner);
+			Thread.sleep(100);
+		}
+
+		stop = true;
+		runner.join();
+		
+		return true;
+	}
+		
+	public String helpForeignThread()
+	{
+		return "test GetOwnedMonitorStackDepthInfo on non-current thread which is running";
+	}
+}


### PR DESCRIPTION
- halt target thread in GetOwnedMonitorStackDepthInfo
- add test for targetting non-current thread

Note the test validates nothing - it just calls the API repeatedly on a
foreign thread. This crashes on unfixed VMs.

Fixes: #3400

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>