### PR TITLE
Use NASM assembler on x86-64 Windows and update NASM set-up process on OSX and xLinux makefiles

### DIFF
--- a/doc/build-instructions/Build_Instructions_V10.md
+++ b/doc/build-instructions/Build_Instructions_V10.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2018 IBM Corp. and others
+Copyright (c) 2018, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -321,6 +321,12 @@ You must install a number of software dependencies to create a suitable build en
 - [Microsoft Visual Studio 2013]( https://go.microsoft.com/fwlink/?LinkId=532495), which is the same compiler level used by OpenJDK. Later levels of this compiler are not supported.
 - [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download)
 - [Freetype2 V2.3 or newer](https://www.freetype.org/)
+- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
+
+Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
+```
+export PATH="/cygdrive/c/NASM:$PATH" (in Cygwin)
+```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
 

--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, 2018 IBM Corp. and others
+Copyright (c) 2018, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -366,10 +366,16 @@ You must install a number of software dependencies to create a suitable build en
 - [Microsoft Visual Studio 2017]( https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&rel=15), which is the default compiler level used by OpenJDK11; or [Microsoft Visual Studio 2013]( https://go.microsoft.com/fwlink/?LinkId=532495), which is chosen to compile if VS2017 isn't installed.
 - [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download)
 - [LLVM/Clang](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe)
+- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
 
 Add the binary path of Clang to the `PATH` environment variable to override the older version of clang integrated in Cygwin. e.g.
 ```
 export PATH="/cygdrive/c/LLVM/bin:$PATH" (in Cygwin)
+```
+
+Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
+```
+export PATH="/cygdrive/c/NASM:$PATH" (in Cygwin)
 ```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2018 IBM Corp. and others
+Copyright (c) 2017, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -356,12 +356,18 @@ OpenJ9 uses the mingw/GCC compiler during the build process. In the `Archive` ca
 - [Freetype2 V2.3 or newer](https://www.freetype.org/)
 - [LLVM/Clang 64bit](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe)
 - [LLVM/Clang 32bit](http://releases.llvm.org/7.0.0/LLVM-7.0.0-win32.exe)
+- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
 
 Add the binary path of Clang to the `PATH` environment variable to override the older version of clang integrated in Cygwin. e.g.
 ```
 export PATH="/cygdrive/c/LLVM/bin:$PATH" (in Cygwin for 64bit)
 or
 export PATH="/cygdrive/c/LLVM_32/bin:$PATH" (in Cygwin for 32bit)
+```
+
+Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
+```
+export PATH="/cygdrive/c/NASM:$PATH" (in Cygwin)
 ```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:

--- a/doc/build-instructions/Build_Instructions_V9.md
+++ b/doc/build-instructions/Build_Instructions_V9.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2018 IBM Corp. and others
+Copyright (c) 2017, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -313,6 +313,12 @@ You must install a number of software dependencies to create a suitable build en
 - [Microsoft Visual Studio 2013]( https://go.microsoft.com/fwlink/?LinkId=532495), which is the same compiler level used by OpenJDK. Later levels of this compiler are not supported.
 - [Freemarker V2.3.8](https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download)
 - [Freetype2 V2.3 or newer](https://www.freetype.org/)
+- [NASM Assembler v2.13.03 or newer](https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D)
+
+Add the path to `nasm.exe` to the `PATH` environment variable to override the older version of NASM installed in Cygwin. e.g.
+```
+export PATH="/cygdrive/c/NASM:$PATH" (in Cygwin)
+```
 
 Update your `LIB` and `INCLUDE` environment variables to provide a path to the Windows debugging tools with the following commands:
 

--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -33,6 +33,9 @@ if(OMR_ARCH_X86)
 	set(asm_inc_dirs
 		"-I${j9vm_SOURCE_DIR}/oti/"
 		"-I${CMAKE_CURRENT_SOURCE_DIR}/"
+		"-I${CMAKE_CURRENT_SOURCE_DIR}/x/runtime/"
+		"-I${CMAKE_CURRENT_SOURCE_DIR}/x/amd64/runtime/"
+		"-I${CMAKE_CURRENT_SOURCE_DIR}/x/i386/runtime/"
 	)
 	omr_append_flags(CMAKE_ASM_NASM_FLAGS ${asm_inc_dirs})
 endif()

--- a/runtime/compiler/build/platform/host/amd64-win64-mvs.mk
+++ b/runtime/compiler/build/platform/host/amd64-win64-mvs.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,3 +23,4 @@ HOST_SUBARCH=amd64
 HOST_BITS=64
 OS=win
 TOOLCHAIN=win-msvc
+NASM_ASSEMBLER=yes

--- a/runtime/compiler/build/rules/gnu/filetypes.mk
+++ b/runtime/compiler/build/rules/gnu/filetypes.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,26 +126,12 @@ endef # DEF_RULE.pasm
 
 RULE.pasm=$(eval $(DEF_RULE.pasm))
 
-### NASM-specific rules
-
-ifeq ($(OS),linux)
-	ifeq ($(HOST_BITS),32)
-		OBJ_FORMAT=-felf32
-	else
-		OBJ_FORMAT=-felf64
-	endif
-endif #(OS = linux)
-
-ifeq ($(OS),osx)
-	OBJ_FORMAT=-fmacho64
-endif #(OS = osx)
-
 #
 # Compile .nasm file into .o file
 #
 define DEF_RULE.nasm
 $(1): $(2) | jit_createdirs
-	nasm $(OBJ_FORMAT) $$(patsubst %,-D%=1,$$(S_DEFINES)) $$(patsubst %,-I'%/',$$(S_INCLUDES)) -o $$@ $$<
+	$$(NASM_CMD) $$(NASM_OBJ_FORMAT) $$(patsubst %,-D%=1,$$(NASM_DEFINES)) $$(patsubst %,-I'%/',$$(NASM_INCLUDES)) -o $$@ $$<
 
 JIT_DIR_LIST+=$(dir $(1))
 

--- a/runtime/compiler/build/rules/win-msvc/filetypes.mk
+++ b/runtime/compiler/build/rules/win-msvc/filetypes.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,6 +88,22 @@ $(call RULE.asm,$(1),$(1).asm)
 endef # DEF_RULE.pasm
 
 RULE.pasm=$(eval $(DEF_RULE.pasm))
+
+#
+# Compile .nasm file into .obj file
+#
+define DEF_RULE.nasm
+$(1): $(2) | jit_createdirs
+	$$(NASM_CMD) $$(NASM_OBJ_FORMAT) $$(patsubst %,-D%=1,$$(NASM_DEFINES)) $$(patsubst %,-I%/,$$(subst \,/,$$(NASM_INCLUDES))) -o $$(subst \,/,"$$@") $$(subst \,/,"$$<")
+
+JIT_DIR_LIST+=$(dir $(1))
+
+jit_cleanobjs::
+	$$(call RM,$(1))
+
+endef # DEF_RULE.nasm
+
+RULE.nasm=$(eval $(DEF_RULE.nasm))
 
 #
 # Compile .rc file into .res file

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -302,6 +302,56 @@ ifeq ($(HOST_ARCH),x)
 
     PASM_FLAGS+=$(PASM_FLAGS_EXTRA)
 endif
+
+ifeq ($(HOST_ARCH),x)
+#
+# Setup NASM
+#
+
+    NASM_CMD?=nasm
+
+    NASM_DEFINES=\
+        TR_HOST_X86 \
+        TR_TARGET_X86
+    
+    ifeq ($(OS),osx)
+        NASM_DEFINES+=\
+            OSX
+    else
+        NASM_DEFINES+=\
+            LINUX
+    endif
+
+    NASM_INCLUDES=\
+        $(J9SRC)/oti \
+        $(J9SRC)/compiler \
+        $(J9SRC)/compiler/x/runtime
+
+    ifeq ($(HOST_BITS),32)
+        NASM_OBJ_FORMAT=-felf32
+    
+        NASM_DEFINES+=\
+            TR_HOST_32BIT \
+            TR_TARGET_32BIT
+    
+        NASM_INCLUDES+=\
+            $(J9SRC)/compiler/x/i386/runtime
+    else
+        ifeq ($(OS),osx)
+            NASM_OBJ_FORMAT=-fmacho64
+        else
+            NASM_OBJ_FORMAT=-felf64
+        endif
+    
+        NASM_DEFINES+=\
+            TR_HOST_64BIT \
+            TR_TARGET_64BIT
+
+        NASM_INCLUDES+=\
+            $(J9SRC)/compiler/x/amd64/runtime
+    endif
+
+endif # HOST_ARCH == x
 
 #
 # Setup CPP and SED to preprocess PowerPC Assembly Files

--- a/runtime/compiler/build/toolcfg/win-msvc/common.mk
+++ b/runtime/compiler/build/toolcfg/win-msvc/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -207,6 +207,42 @@ ifeq ($(BUILD_CONFIG),prod)
 endif
 
 PASM_FLAGS+=$(PASM_FLAGS_EXTRA)
+
+#
+# Setup NASM
+#
+
+NASM_CMD?=nasm
+
+NASM_DEFINES=\
+    TR_HOST_X86 \
+    TR_TARGET_X86 \
+    WINDOWS
+
+NASM_INCLUDES=\
+    ../oti \
+    ../compiler \
+    ../compiler/x/runtime
+
+ifeq ($(HOST_BITS),32)
+    NASM_OBJ_FORMAT=-fwin32
+    
+    NASM_DEFINES+=\
+        TR_HOST_32BIT \
+        TR_TARGET_32BIT
+    
+    NASM_INCLUDES+=\
+        ../compiler/x/i386/runtime
+else
+    NASM_OBJ_FORMAT=-fwin64
+    
+    NASM_DEFINES+=\
+        TR_HOST_64BIT \
+        TR_TARGET_64BIT
+
+    NASM_INCLUDES+=\
+        ../compiler/x/amd64/runtime
+endif
 
 #
 # Setup RC

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -64,7 +64,7 @@ extern "C" {
  * is set for OS variants that currently use NASM and is used to
  * decide the version of helper names to use.
  */
-#if defined(OSX) || (defined(LINUX) && defined(TR_HOST_X86) && defined(TR_HOST_64BIT))
+#if defined(TR_HOST_X86) && defined(TR_HOST_64BIT)
 #define NASM_ASSEMBLER
 #endif
 

--- a/runtime/compiler/x/amd64/runtime/AMD64CompressString.nasm
+++ b/runtime/compiler/x/amd64/runtime/AMD64CompressString.nasm
@@ -20,12 +20,7 @@
 
 %ifdef TR_HOST_64BIT
 %include "jilconsts.inc"
-
-%ifdef WINDOWS
-%include "x\amd64\runtime\AMD64CompressString_nasm.inc"
-%else
-%include "x/amd64/runtime/AMD64CompressString_nasm.inc"
-%endif
+%include "AMD64CompressString_nasm.inc"
 
 J9TR_ObjectColorBlack equ 03h
 

--- a/runtime/compiler/x/amd64/runtime/AMD64CompressString.nasm
+++ b/runtime/compiler/x/amd64/runtime/AMD64CompressString.nasm
@@ -1,4 +1,4 @@
-; Copyright (c) 2000, 2018 IBM Corp. and others
+; Copyright (c) 2000, 2019 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,9 +21,11 @@
 %ifdef TR_HOST_64BIT
 %include "jilconsts.inc"
 
+%ifdef WINDOWS
+%include "x\amd64\runtime\AMD64CompressString_nasm.inc"
+%else
 %include "x/amd64/runtime/AMD64CompressString_nasm.inc"
-
-
+%endif
 
 J9TR_ObjectColorBlack equ 03h
 

--- a/runtime/compiler/x/runtime/X86LockReservation.nasm
+++ b/runtime/compiler/x/runtime/X86LockReservation.nasm
@@ -1,4 +1,4 @@
-; Copyright (c) 2000, 2018 IBM Corp. and others
+; Copyright (c) 2000, 2019 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,10 +34,10 @@
     DECLARE_GLOBAL jitMethodMonitorExitReservedPrimitive
 
 %ifdef WINDOWS
-    UseFastCall equ 1
+    %define UseFastCall 1
 %else
     %ifdef TR_HOST_32BIT
-        UseFastCall equ 1
+        %define UseFastCall 1
     %endif
 %endif
 

--- a/runtime/compiler/x/runtime/X86PicBuilder.nasm
+++ b/runtime/compiler/x/runtime/X86PicBuilder.nasm
@@ -29,12 +29,7 @@
       CPU PPRO
 
       %include "jilconsts.inc"
-      
-%ifdef WINDOWS
-      %include "x\runtime\X86PicBuilder_nasm.inc"
-%else
-      %include "x/runtime/X86PicBuilder_nasm.inc"
-%endif
+      %include "X86PicBuilder_nasm.inc"
 
       segment .text
 
@@ -1210,13 +1205,8 @@ ret                                                   ; branch will mispredict s
 ;
 ; --------------------------------------------------------------------------------
 
-%include "jilconsts.inc"
-
-%ifdef WINDOWS
-      %include "x\runtime\X86PicBuilder_nasm.inc"
-%else
-      %include "x/runtime/X86PicBuilder_nasm.inc"
-%endif
+      %include "jilconsts.inc"
+      %include "X86PicBuilder_nasm.inc"
 
 segment .text
 

--- a/runtime/compiler/x/runtime/X86PicBuilder.nasm
+++ b/runtime/compiler/x/runtime/X86PicBuilder.nasm
@@ -1,4 +1,4 @@
-; Copyright (c) 2000, 2018 IBM Corp. and others
+; Copyright (c) 2000, 2019 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,12 @@
       CPU PPRO
 
       %include "jilconsts.inc"
+      
+%ifdef WINDOWS
+      %include "x\runtime\X86PicBuilder_nasm.inc"
+%else
       %include "x/runtime/X86PicBuilder_nasm.inc"
+%endif
 
       segment .text
 
@@ -1206,7 +1211,12 @@ ret                                                   ; branch will mispredict s
 ; --------------------------------------------------------------------------------
 
 %include "jilconsts.inc"
-%include "x/runtime/X86PicBuilder_nasm.inc"
+
+%ifdef WINDOWS
+      %include "x\runtime\X86PicBuilder_nasm.inc"
+%else
+      %include "x/runtime/X86PicBuilder_nasm.inc"
+%endif
 
 segment .text
 

--- a/runtime/compiler/x/runtime/X86PicBuilder_nasm.inc
+++ b/runtime/compiler/x/runtime/X86PicBuilder_nasm.inc
@@ -1,4 +1,4 @@
-; Copyright (c) 2000, 2018 IBM Corp. and others
+; Copyright (c) 2000, 2019 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,11 +106,7 @@ eq_IPicData_j2iThunk           equ 22h    ; only present if direct invoke is pos
 ; It's omitted here since it would be unused anyway.
 
 %macro LoadHelperIndex 2 ; args: targetReg, helperIndexSym
-%ifdef WINDOWS
-        mov     %1, dword [%2]
-%else
         mov     %1, dword [rel + %2]
-%endif
 %endmacro
 
 

--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -32,12 +32,7 @@
       eq_offsetof_J9Object_clazz equ 8                            ; offset of class pointer in a J9Object
 
       %include "jilconsts.inc"
-
-%ifdef WINDOWS
-      %include "x\runtime\X86PicBuilder_nasm.inc"
-%else
-      %include "x/runtime/X86PicBuilder_nasm.inc"
-%endif
+      %include "X86PicBuilder_nasm.inc"
 
       segment .text
 
@@ -1118,12 +1113,7 @@ retn
 
 
       %include "jilconsts.inc"
-      
-%ifdef WINDOWS
-      %include "x\runtime\X86PicBuilder_nasm.inc"
-%else
-      %include "x/runtime/X86PicBuilder_nasm.inc"
-%endif
+      %include "X86PicBuilder_nasm.inc"
 
 %ifdef ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER
 eq_offsetof_J9Object_clazz equ   8        ; offset of class pointer in a J9Object

--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -32,7 +32,12 @@
       eq_offsetof_J9Object_clazz equ 8                            ; offset of class pointer in a J9Object
 
       %include "jilconsts.inc"
+
+%ifdef WINDOWS
+      %include "x\runtime\X86PicBuilder_nasm.inc"
+%else
       %include "x/runtime/X86PicBuilder_nasm.inc"
+%endif
 
       segment .text
 
@@ -1113,7 +1118,12 @@ retn
 
 
       %include "jilconsts.inc"
+      
+%ifdef WINDOWS
+      %include "x\runtime\X86PicBuilder_nasm.inc"
+%else
       %include "x/runtime/X86PicBuilder_nasm.inc"
+%endif
 
 %ifdef ASM_J9VM_INTERP_COMPRESSED_OBJECT_HEADER
 eq_offsetof_J9Object_clazz equ   8        ; offset of class pointer in a J9Object


### PR DESCRIPTION
Depends on: #3293 , #3461 , #3493 

This PR builds on top of the changeset in #3293 , and contains commits that are specific to x86_64 Linux, and will be rebased once #3293 is merged.

Issue: #3148 

Signed-off-by: Nazim Uddin Bhuiyan <nazim.uddin.bhuiyan@ibm.com>