### PR TITLE
Reduce number of messages related to inlining

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2009,27 +2009,16 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          break;
       case J9ServerMessageType::IProfiler_searchForMethodSample:
          {
-         auto recv = client->getRecvData<TR_OpaqueMethodBlock*, int32_t>();
+         auto recv = client->getRecvData<TR_OpaqueMethodBlock*>();
          auto method = std::get<0>(recv);
-         auto bucket = std::get<1>(recv);
-         TR_IProfiler *iProfiler = fe->getIProfiler();
+         TR_JITaaSClientIProfiler *iProfiler = (TR_JITaaSClientIProfiler *) fe->getIProfiler();
          if (!iProfiler)
             {
             // iProfiler is enabled on the server if we got here, but not enabled here on the client
             client->write(std::string());
             break;
             }
-         auto entry = iProfiler->searchForMethodSample(method, bucket);
-         if (entry)
-            {
-            auto serialEntry = TR_ContiguousIPMethodHashTableEntry::serialize(entry);
-            std::string entryStr((char *) &serialEntry, sizeof(TR_ContiguousIPMethodHashTableEntry));
-            client->write(entryStr);
-            }
-         else
-            {
-            client->write(std::string());
-            }
+         client->write(iProfiler->serializeIProfilerMethodEntry(method));
          }
          break;
       case J9ServerMessageType::IProfiler_profilingSample:

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -68,7 +68,9 @@ public:
    virtual int32_t getMaxCallCount() override;
    virtual void setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *) override;
 
-   TR_IPBytecodeHashTableEntry* ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptrj_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
+
+   TR_IPBytecodeHashTableEntry *ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptrj_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
+   TR_IPMethodHashTableEntry *deserializeMethodEntry(TR_ContiguousIPMethodHashTableEntry *serialEntry, TR_Memory *trMemory);
    void printStats();
 
 private:
@@ -98,6 +100,7 @@ class TR_JITaaSClientIProfiler : public TR_IProfiler
                                               TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort, TR::Compilation *comp);
       uintptr_t serializeIProfilerMethodEntries(uintptrj_t *pcEntries, uint32_t numEntries, uintptr_t memChunk, uintptrj_t methodStartAddress);
       void serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::J9ClientStream *client);
+      std::string serializeIProfilerMethodEntry(TR_OpaqueMethodBlock *omb);
    };
 
 #endif


### PR DESCRIPTION
JITaaS part of #3506

- Reduce number of calls to IProfiler_searchForMethodSample.
Override methods of ResolvedJ9Method that access fanin info.
This enables us to get number and weight of callers, total weight and
other bucket weight at the creation of client-side mirror
and cache these values on the server.
The number of callers and their weights might change
during compilation, so cached information will not always be
up to date, but it should be a good enough approximation.
Since fanin information is only used at warm and above opt levels,
do not send this information to the server at levels below warm. 

Addresses:#3401