### PR TITLE
WIP: Ensure GC map is generated at BB entry on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11506,9 +11506,9 @@ VMgenerateCatchBlockBBStartPrologue(
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
 
-   if (comp->getOption(TR_FullSpeedDebug))
+   if (comp->getOptions()->getReportByteCodeInfoAtCatchBlock())
       {
-      fenceInstruction->setNeedsGCMap(); // a catch entry is a gc point in FSD mode
+      node->getBlock()->getFirstInstruction()->setNeedsGCMap();
       }
 
    if (comp->getJittedMethodSymbol()->usesSinglePrecisionMode() &&


### PR DESCRIPTION
Stack maps are required at the entry of exception catch
blocks under FSD mode and when Agent is attached.

Closes #3374

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>