### PR TITLE
Remove redundant checks for SSE/SSE2 on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -125,20 +125,9 @@ J9::X86::CodeGenerator::CodeGenerator() :
       comp->setOption(TR_DisableWriteBarriersRangeCheck);
       }
 
-   // Enable copy propagation of floats if using SSE.
+   // Enable copy propagation of floats.
    //
-   if (cg->useSSEForDoublePrecision())
-      {
-      cg->setSupportsJavaFloatSemantics();
-      }
-   else
-      {
-      static char *commonFPAcrossBranches = feGetEnv("TR_commonFPAcrossBranches");
-      if (commonFPAcrossBranches)
-         {
-         cg->setSupportsJavaFloatSemantics();
-         }
-      }
+   cg->setSupportsJavaFloatSemantics();
 
    /*
     * "Statically" initialize the FE-specific tree evaluator functions.
@@ -170,10 +159,10 @@ J9::X86::CodeGenerator::CodeGenerator() :
          returnInfo = TR::Compiler->target.is64Bit() ? TR_ObjectReturn : TR_IntReturn;
          break;
       case TR::Float:
-         returnInfo = cg->useSSEForDoublePrecision() ? TR_FloatXMMReturn : TR_FloatReturn;
+         returnInfo = TR_FloatXMMReturn;
          break;
       case TR::Double:
-         returnInfo = cg->useSSEForDoublePrecision()? TR_DoubleXMMReturn : TR_DoubleReturn;
+         returnInfo = TR_DoubleXMMReturn;
          break;
       }
     comp->setReturnInfo(returnInfo);

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -61,16 +61,10 @@ TR::IA32PrivateLinkage::IA32PrivateLinkage(TR::CodeGenerator *cg)
 
    for (int i = 0; i <= 7; i++)
       {
-      if (cg->useSSEForSinglePrecision())
-         _properties._registerFlags[TR::RealRegister::xmmIndex(i)] = 0;
-      else
-         _properties._registerFlags[TR::RealRegister::xmmIndex(i)] = Preserved; // TODO: Safe assumption?
+      _properties._registerFlags[TR::RealRegister::xmmIndex(i)] = 0;
       }
 
-   if (cg->useSSEForSinglePrecision() || cg->useSSEForDoublePrecision())
-      _properties._registerFlags[TR::RealRegister::xmm0] = FloatReturn;
-   else
-      _properties._registerFlags[TR::RealRegister::st0]  = FloatReturn;
+   _properties._registerFlags[TR::RealRegister::xmm0] = FloatReturn;
 
    _properties._preservedRegisters[0] = TR::RealRegister::ebx;
    _properties._preservedRegisters[1] = TR::RealRegister::ecx;
@@ -88,12 +82,7 @@ TR::IA32PrivateLinkage::IA32PrivateLinkage(TR::CodeGenerator *cg)
    _properties._firstFloatArgumentRegister   = 0;
 
    _properties._returnRegisters[0] = TR::RealRegister::eax;
-
-   if (cg->useSSEForDoublePrecision())
-      _properties._returnRegisters[1] = TR::RealRegister::xmm0;
-   else
-      _properties._returnRegisters[1] = TR::RealRegister::st0;
-
+   _properties._returnRegisters[1] = TR::RealRegister::xmm0;
    _properties._returnRegisters[2] = TR::RealRegister::edx;
 
    _properties._scratchRegisters[0] = TR::RealRegister::edi;


### PR DESCRIPTION
SSE/SSE2 is part of prerequisites of OpenJ9 on X86, and
JVM guarantees the availablity of SSE/SSE2; therefore,
checking for SSE/SSE2 is redundant and should be removed.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>