### PR TITLE
Minor CHTable cleanup

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7954,7 +7954,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             uint64_t proposedScratchMemoryLimit = (uint64_t)TR::Options::getScratchSpaceLimit();
 
             // update our cached CHTable
-            if (details.isRemoteMethod() && !comp()->getOption(TR_DisableCHOpts))
+            if (details.isRemoteMethod() && !compiler->getOption(TR_DisableCHOpts))
                {
                auto table = (TR_JITaaSServerPersistentCHTable*)compiler->getPersistentInfo()->getPersistentCHTable();
                table->doUpdate(compiler);

--- a/runtime/compiler/env/JITaaSPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.hpp
@@ -45,7 +45,7 @@ public:
 
    TR_JITaaSServerPersistentCHTable(TR_PersistentMemory *);
 
-   void initializeIfNeeded(TR::Compilation *comp);
+   void initializeIfNeeded();
    void doUpdate(TR::Compilation *comp);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId) override;
@@ -62,10 +62,10 @@ public:
 #endif
 
 private:
-   void commitRemoves(TR::Compilation *comp, std::string &data);
-   void commitModifications(TR::Compilation *comp, std::string &data);
+   void commitRemoves(std::string &data);
+   void commitModifications(std::string &data);
 
-   PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> &getData(TR::Compilation *comp);
+   PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> &getData();
    };
 
 class TR_JITaaSClientPersistentCHTable : public TR_PersistentCHTable


### PR DESCRIPTION
Removing the comp parameter from a bunch of methods because they don't need it.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>