### PR TITLE
Rename VMThread evacuate fields

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1917,12 +1917,12 @@ UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 #if defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86)
-   return offsetof(J9VMThread, evacuateBaseCompressed);
+   return offsetof(J9VMThread, readBarrierRangeCheckBaseCompressed);
 #else
-   return offsetof(J9VMThread, evacuateBase);
+   return offsetof(J9VMThread, readBarrierRangeCheckBase);
 #endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
-   TR_ASSERT(0,"Field evacuateBase does not exists in J9VMThread.");
+   TR_ASSERT(0,"Field readBarrierRangeCheckBase does not exists in J9VMThread.");
    return 0;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    }
@@ -1934,12 +1934,12 @@ UDATA TR_J9VMBase::thisThreadGetEvacuateTopAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 #if defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86)
-   return offsetof(J9VMThread, evacuateTopCompressed);
+   return offsetof(J9VMThread, readBarrierRangeCheckTopCompressed);
 #else
-   return offsetof(J9VMThread, evacuateTop);
+   return offsetof(J9VMThread, readBarrierRangeCheckTop);
 #endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
-   TR_ASSERT(0,"Field evacuateTop does not exists in J9VMThread.");
+   TR_ASSERT(0,"Field readBarrierRangeCheckTop does not exists in J9VMThread.");
    return 0;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    }

--- a/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.cpp
+++ b/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.cpp
@@ -680,16 +680,16 @@ MM_CollectorLanguageInterfaceImpl::scavenger_switchConcurrentForThread(MM_Enviro
 		void* top = _extensions->scavenger->getEvacuateTop();
 
 		/*
-		 * vmThread->evacuateTop is defined as the last address possible in the evacuate region;
+		 * vmThread->readBarrierRangeCheckTop is defined as the last address possible in the evacuate region;
 		 * however, top is the first address above the evacuate region;
-		 * therefore, vmThread->evacuateTop = top - 1.
-		 * In short, the evacuate region is [vmThread->evacuateBase, vmThread->evacuateTop].
+		 * therefore, vmThread->readBarrierRangeCheckTop = top - 1.
+		 * In short, the evacuate region is [vmThread->readBarrierRangeCheckBase, vmThread->readBarrierRangeCheckTop].
 		 */
-		vmThread->evacuateBase = (UDATA)base;
-		vmThread->evacuateTop = (UDATA)top - 1;
+		vmThread->readBarrierRangeCheckBase = (UDATA)base;
+		vmThread->readBarrierRangeCheckTop = (UDATA)top - 1;
 #if defined(J9VM_GC_COMPRESSED_POINTERS)
-		vmThread->evacuateBaseCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->evacuateBase);
-		vmThread->evacuateTopCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->evacuateTop);
+		vmThread->readBarrierRangeCheckBaseCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckBase);
+		vmThread->readBarrierRangeCheckTopCompressed = _extensions->accessBarrier->convertTokenFromPointer((mm_j9object_t)vmThread->readBarrierRangeCheckTop);
 #endif /* J9VM_GC_COMPRESSED_POINTERS */
 		vmThread->privateFlags |= J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE;
 
@@ -721,17 +721,17 @@ MM_CollectorLanguageInterfaceImpl::scavenger_switchConcurrentForThread(MM_Enviro
 			j9gs_disable(&vmThread->gsParameters);
 		}
 		/*
-		 * By setting evacuateTop to NULL and evacuateBase to ~evacuateTop
+		 * By setting readBarrierRangeCheckTop to NULL and readBarrierRangeCheckBase to the highest possible address
 		 * it gives an empty range that contains no address. Therefore,
 		 * when decide whether to read barrier, a simple range is sufficient and
 		 * checking J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE can be skipped.
 		 */
 		vmThread->privateFlags &= ~J9_PRIVATE_FLAGS_CONCURRENT_SCAVENGER_ACTIVE;
-		vmThread->evacuateBase = UDATA_MAX;
-		vmThread->evacuateTop = 0;
+		vmThread->readBarrierRangeCheckBase = UDATA_MAX;
+		vmThread->readBarrierRangeCheckTop = 0;
 #ifdef J9VM_GC_COMPRESSED_POINTERS
-		vmThread->evacuateBaseCompressed = U_32_MAX;
-		vmThread->evacuateTopCompressed = 0;
+		vmThread->readBarrierRangeCheckBaseCompressed = U_32_MAX;
+		vmThread->readBarrierRangeCheckTopCompressed = 0;
 #endif
     }
 }

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4998,11 +4998,11 @@ typedef struct J9VMThread {
 #endif /* J9VM_JIT_TRANSACTION_DIAGNOSTIC_THREAD_BLOCK */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	struct J9GSParameters gsParameters;
-	UDATA evacuateBase;
-	UDATA evacuateTop;
+	UDATA readBarrierRangeCheckBase;
+	UDATA readBarrierRangeCheckTop;
 #if defined(J9VM_GC_COMPRESSED_POINTERS)
-	U_32 evacuateBaseCompressed;
-	U_32 evacuateTopCompressed;
+	U_32 readBarrierRangeCheckBaseCompressed;
+	U_32 readBarrierRangeCheckTopCompressed;
 #endif /* J9VM_GC_COMPRESSED_POINTERS */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	UDATA safePointCount;

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -212,11 +212,11 @@ allocateVMThread(J9JavaVM * vm, omrthread_t osThread, UDATA privateFlags, void *
 
 #ifdef OMR_GC_CONCURRENT_SCAVENGER
 	/* Initialize fields used by Concurrent Scavenger */
-	newThread->evacuateBase = UDATA_MAX;
-	newThread->evacuateTop = 0;
+	newThread->readBarrierRangeCheckBase = UDATA_MAX;
+	newThread->readBarrierRangeCheckTop = 0;
 #ifdef J9VM_GC_COMPRESSED_POINTERS
-	newThread->evacuateBaseCompressed = U_32_MAX;
-	newThread->evacuateTopCompressed = 0;
+	newThread->readBarrierRangeCheckBaseCompressed = U_32_MAX;
+	newThread->readBarrierRangeCheckTopCompressed = 0;
 #endif /* J9VM_GC_COMPRESSED_POINTERS */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 


### PR DESCRIPTION
Renaming evacuateBase/Top fields to readBarrierRangeCheckBase/Top.
Evacuate is a specific action of Read Barrier for Concurrent Scavegner
GC, while the trigger is range check against the bounds. This check can
be used to trigger the barrier that will do completely different action
(for some diffrent type of GC, some profiler/debug tool etc). 

Similar things have been done already for GC specific atributes:
https://github.com/eclipse/omr/pull/3066

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>