### PR TITLE
Changes to get ddrgen working on OSX

### DIFF
--- a/runtime/ddr/blacklist
+++ b/runtime/ddr/blacklist
@@ -61,6 +61,8 @@ type:PUNWIND_INFO
 type:_UNWIND_INFO
 type:PSLIST_HEADER
 type:_SLIST_HEADER
+type:__darwin_fp_control
+type:__darwin_fp_status
 
 # Ignore one (or all) of sets of types whose names differ only in case
 # (so we don't try to create Java source files whose names differ only
@@ -83,3 +85,6 @@ type:WSADATA
 # problem names on AIX
 type:Enum
 type:signed char
+
+# problem on OSX
+type:std

--- a/runtime/ddr/run_omrddrgen.mk.ftl
+++ b/runtime/ddr/run_omrddrgen.mk.ftl
@@ -40,6 +40,11 @@ DDR_INPUT_DEPENDS := $(addprefix $(TOP_DIR),$(foreach module,$(DDR_INPUT_MODULES
 DDR_INPUT_FILES := $(addprefix $(TOP_DIR),$(foreach module,$(DDR_INPUT_MODULES),$($(module)_pdb)))
 <#elseif uma.spec.flags.uma_gnuDebugSymbols.enabled>
 DDR_INPUT_FILES := $(addsuffix .dbg,$(DDR_INPUT_DEPENDS))
+<#if uma.spec.type.osx>
+# workaround for OSX not keeping anonymous enum symbols in shared library
+# so get it directly from object file instead
+DDR_INPUT_FILES += $(TOP_DIR)/omr/gc/base/standard/CompactScheme$(UMA_DOT_O)
+</#if>
 </#if>
 
 # The primary goals of this makefile.

--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -31,6 +31,7 @@ $(UMA_DLLTARGET): $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(VMLINK) $(UMA_LINK_PATH) -o $(UMA_DLLTARGET)\
 		$(UMA_OBJECTS) \
 		$(UMA_DLL_LINK_POSTFLAGS)
+	dsymutil -f $(UMA_DLLTARGET) -o $(UMA_DLLTARGET).dbg
 </#assign>
 
 <#assign exe_target_rule>


### PR DESCRIPTION
These are the changes required on the OpenJ9 side in order for ddrgen
to work on OSX:
- create the debug dSYM file for OpenJ9 shared libraries
- add OSX types with non 32-bit bitfields to the DDR blacklist as they
  are not supported yet
- add CompactScheme.o from OMR to DDR_INPUT, the list of modules
  processed by ddrgen, in order to get an enum literal from the object
  file that is not written to the shared library debug info

This PR and https://github.com/eclipse/omr/pull/3136 address the first item of issue #3483 

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>