### PR TITLE
Ensure JVMTI return values are filled in

### DIFF
--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -103,7 +103,7 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 	J9JVMTIEnv * j9env = (J9JVMTIEnv *) env;
 	J9JavaVM * vm = j9env->vm;
 	J9JVMTIData * jvmtiData = J9JVMTI_DATA_FROM_VM(vm);
-	jvmtiCapabilities capabilities;
+	jvmtiCapabilities rv_capabilities;
 	J9HookInterface ** vmHook = vm->internalVMFunctions->getVMHookInterface(vm);
 	jvmtiError rc;
 
@@ -113,144 +113,140 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 
 	ENSURE_NON_NULL(capabilities_ptr);
 
-	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+	memset(&rv_capabilities, 0, sizeof(jvmtiCapabilities));
 
 	/* Get the JVMTI mutex to ensure to prevent multple agents acquiring capabilities that can only be held by one agent at a time */
 
 	omrthread_monitor_enter(jvmtiData->mutex);
 
-/*
-	capabilities.can_redefine_any_class = 0;
-*/
-
 	if (J9_ARE_ALL_BITS_SET(vm->requiredDebugAttributes, J9VM_DEBUG_ATTRIBUTE_MAINTAIN_ORIGINAL_METHOD_ORDER)
 	|| (JVMTI_PHASE_ONLOAD == jvmtiData->phase)
 	) {
-		capabilities.can_maintain_original_method_order = 1;
+		rv_capabilities.can_maintain_original_method_order = 1;
 	}
 
-	capabilities.can_generate_all_class_hook_events = 1;
+	rv_capabilities.can_generate_all_class_hook_events = 1;
 
-	capabilities.can_get_bytecodes = 1;
+	rv_capabilities.can_get_bytecodes = 1;
 
-	capabilities.can_get_constant_pool = 1;
+	rv_capabilities.can_get_constant_pool = 1;
 
-	capabilities.can_get_synthetic_attribute = 1;
+	rv_capabilities.can_get_synthetic_attribute = 1;
 
-	capabilities.can_signal_thread = 1;
+	rv_capabilities.can_signal_thread = 1;
 
-	capabilities.can_suspend = 1;
+	rv_capabilities.can_suspend = 1;
 
 	if (isEventHookable(j9env, JVMTI_EVENT_METHOD_ENTRY)) {
-		capabilities.can_generate_method_entry_events = 1;
+		rv_capabilities.can_generate_method_entry_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_GARBAGE_COLLECTION_START) &&
 		isEventHookable(j9env, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH)
 	) {
-		capabilities.can_generate_garbage_collection_events = 1;		
+		rv_capabilities.can_generate_garbage_collection_events = 1;		
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_OBJECT_FREE)) {
-		capabilities.can_generate_object_free_events = 1;
+		rv_capabilities.can_generate_object_free_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_SINGLE_STEP)) {
-		capabilities.can_generate_single_step_events = 1;
+		rv_capabilities.can_generate_single_step_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_FIELD_MODIFICATION)) {
-		capabilities.can_generate_field_modification_events = 1;
+		rv_capabilities.can_generate_field_modification_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_FIELD_ACCESS)) {
-		capabilities.can_generate_field_access_events = 1;
+		rv_capabilities.can_generate_field_access_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_VM_OBJECT_ALLOC)) {
-		capabilities.can_generate_vm_object_alloc_events = 1;
+		rv_capabilities.can_generate_vm_object_alloc_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_NATIVE_METHOD_BIND)) {
-		capabilities.can_generate_native_method_bind_events = 1;
+		rv_capabilities.can_generate_native_method_bind_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_COMPILED_METHOD_LOAD) &&
 		isEventHookable(j9env, JVMTI_EVENT_COMPILED_METHOD_UNLOAD)
 	) {
-		capabilities.can_generate_compiled_method_load_events = 1;
+		rv_capabilities.can_generate_compiled_method_load_events = 1;
 	}
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_POP_FRAMES_INTERRUPT)) {
-		capabilities.can_pop_frame = 1;
-		capabilities.can_force_early_return = 1;
+		rv_capabilities.can_pop_frame = 1;
+		rv_capabilities.can_force_early_return = 1;
 	}
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_REQUIRED_DEBUG_ATTRIBUTES) ||
 		(vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_CAN_REDEFINE_CLASSES)
 	) {
-		capabilities.can_redefine_classes = 1;
+		rv_capabilities.can_redefine_classes = 1;
 	}
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_REQUIRED_DEBUG_ATTRIBUTES) ||
 		(vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_LINE_NUMBER_TABLE)
 	) {
-		capabilities.can_get_line_numbers = 1;
+		rv_capabilities.can_get_line_numbers = 1;
 	}
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_REQUIRED_DEBUG_ATTRIBUTES) ||
 		(vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_SOURCE_FILE)
 	) {
-		capabilities.can_get_source_file_name = 1;
+		rv_capabilities.can_get_source_file_name = 1;
 	}
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_REQUIRED_DEBUG_ATTRIBUTES) ||
 		(vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_CAN_ACCESS_LOCALS)
 	) {
-		capabilities.can_access_local_variables = 1;
+		rv_capabilities.can_access_local_variables = 1;
 	}
 
-	capabilities.can_tag_objects = 1;
+	rv_capabilities.can_tag_objects = 1;
 
 #ifdef J9VM_OPT_DEBUG_JSR45_SUPPORT
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_REQUIRED_DEBUG_ATTRIBUTES) ||
 		(vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_SOURCE_DEBUG_EXTENSION)
 	) {
-		capabilities.can_get_source_debug_extension = 1;
+		rv_capabilities.can_get_source_debug_extension = 1;
 	}
 #endif
 
 	if (isEventHookable(j9env, JVMTI_EVENT_BREAKPOINT)) {
-		capabilities.can_generate_breakpoint_events = 1;
+		rv_capabilities.can_generate_breakpoint_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_EXCEPTION) &&
 		isEventHookable(j9env, JVMTI_EVENT_EXCEPTION_CATCH)
 	) {
-		capabilities.can_generate_exception_events = 1;
+		rv_capabilities.can_generate_exception_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_FRAME_POP)) {
-		capabilities.can_generate_frame_pop_events = 1;
+		rv_capabilities.can_generate_frame_pop_events = 1;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_METHOD_EXIT)) {
-		capabilities.can_generate_method_exit_events = 1;
+		rv_capabilities.can_generate_method_exit_events = 1;
 	}
 
 	if (omrthread_get_self_cpu_time(omrthread_self()) != -1) {
-		capabilities.can_get_current_thread_cpu_time = 1;
+		rv_capabilities.can_get_current_thread_cpu_time = 1;
 	}
 
 	if (omrthread_get_cpu_time(omrthread_self()) != -1 ) {
-		capabilities.can_get_thread_cpu_time = 1;
+		rv_capabilities.can_get_thread_cpu_time = 1;
 	}
 
-	capabilities.can_get_owned_monitor_info = 1;
+	rv_capabilities.can_get_owned_monitor_info = 1;
 
-	capabilities.can_get_current_contended_monitor = 1;
+	rv_capabilities.can_get_current_contended_monitor = 1;
 
-	capabilities.can_get_monitor_info = 1;
+	rv_capabilities.can_get_monitor_info = 1;
 
 
 	if (isEventHookable(j9env, JVMTI_EVENT_MONITOR_CONTENDED_ENTER) &&
@@ -258,37 +254,39 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 		isEventHookable(j9env, JVMTI_EVENT_MONITOR_WAIT) &&
 		isEventHookable(j9env, JVMTI_EVENT_MONITOR_WAITED)
 	) {
-		capabilities.can_generate_monitor_events = 1;
+		rv_capabilities.can_generate_monitor_events = 1;
 	}
 
-	capabilities.can_get_owned_monitor_stack_depth_info = 1;
+	rv_capabilities.can_get_owned_monitor_stack_depth_info = 1;
 
 	if (((j9env->flags & (J9JVMTIENV_FLAG_CLASS_LOAD_HOOK_EVER_ENABLED | J9JVMTIENV_FLAG_RETRANSFORM_CAPABLE)) != J9JVMTIENV_FLAG_CLASS_LOAD_HOOK_EVER_ENABLED) &&
 		((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_REQUIRED_DEBUG_ATTRIBUTES) || (vm->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_ALLOW_RETRANSFORM))
 	) {
-		capabilities.can_retransform_classes = 1;	
+		rv_capabilities.can_retransform_classes = 1;	
 	}
 
-	capabilities.can_set_native_method_prefix = 1;
+	rv_capabilities.can_set_native_method_prefix = 1;
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_RESOURCE_EXHAUSTED)) {
-		capabilities.can_generate_resource_exhaustion_threads_events = 1;
+		rv_capabilities.can_generate_resource_exhaustion_threads_events = 1;
 	}
 
 	if ((*vmHook)->J9HookIsEnabled(vmHook, J9HOOK_VM_RESOURCE_EXHAUSTED)) {
-		capabilities.can_generate_resource_exhaustion_heap_events = 1;
+		rv_capabilities.can_generate_resource_exhaustion_heap_events = 1;
 	}
 
 	if (JVMTI_PHASE_ONLOAD == jvmtiData->phase) {
-		capabilities.can_generate_early_vmstart = 1;
-		capabilities.can_generate_early_class_hook_events = 1;
+		rv_capabilities.can_generate_early_vmstart = 1;
+		rv_capabilities.can_generate_early_class_hook_events = 1;
 	}
 
-	*capabilities_ptr = capabilities;
 	rc = JVMTI_ERROR_NONE;
-
 	omrthread_monitor_exit(jvmtiData->mutex);
 done:
+
+	if (NULL != capabilities_ptr) {
+		*capabilities_ptr = rv_capabilities;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetPotentialCapabilities);
 }
 

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -112,6 +112,8 @@ jvmtiGetLoadedClasses(jvmtiEnv* env,
 	jclass * classRefs = NULL;
 	jvmtiError rc;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jclass *rv_classes = NULL;
+	jint rv_class_count = 0;
 
 	Trc_JVMTI_jvmtiGetLoadedClasses_Entry(env);
 
@@ -173,8 +175,8 @@ jvmtiGetLoadedClasses(jvmtiEnv* env,
 			vm->internalVMFunctions->allLiveClassesEndDo(&classWalkState);
 
 			jvmtiData->lastClassCount = (UDATA) i;
-			*class_count_ptr = i;
-			*classes_ptr = classRefs;
+			rv_class_count = i;
+			rv_classes = classRefs;
 		}
 
 		omrthread_monitor_exit(vm->classTableMutex);
@@ -183,6 +185,12 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != class_count_ptr) {
+		*class_count_ptr = rv_class_count;
+	}
+	if (NULL != classes_ptr) {
+		*classes_ptr = rv_classes;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetLoadedClasses);
 }
 
@@ -200,6 +208,8 @@ jvmtiGetClassLoaderClasses(jvmtiEnv* env,
 	J9HashTableState walkState;
 	J9Class* clazz;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_class_count = 0;
+	jclass *rv_classes = NULL;
 
 	Trc_JVMTI_jvmtiGetClassLoaderClasses_Entry(env);
 
@@ -221,11 +231,6 @@ jvmtiGetClassLoaderClasses(jvmtiEnv* env,
 		} else {
 			loader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(initiating_loader));
 			if (NULL == loader) {
-				*class_count_ptr = 0;
-				*classes_ptr = j9mem_allocate_memory(0, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-				if (NULL == *classes_ptr) {
-					rc = JVMTI_ERROR_OUT_OF_MEMORY;
-				}
 				goto done;
 			}
 		}
@@ -250,8 +255,8 @@ jvmtiGetClassLoaderClasses(jvmtiEnv* env,
 		} else {
 
 			/* Save count before it gets modified below... */
-			*class_count_ptr = (jint) stats.classCount;
-			*classes_ptr = stats.classRefs;
+			rv_class_count = (jint) stats.classCount;
+			rv_classes = stats.classRefs;
 
 			/* Record classes who have this class loader as the initiating loader (wind down count) */
 			clazz = vm->internalVMFunctions->hashClassTableStartDo(loader, &walkState);
@@ -267,6 +272,12 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != class_count_ptr) {
+		*class_count_ptr = rv_class_count;
+	}
+	if (NULL != classes_ptr) {
+		*classes_ptr = rv_classes;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassLoaderClasses);
 }
 
@@ -283,6 +294,8 @@ jvmtiGetClassSignature(jvmtiEnv* env,
 	char * signature = NULL;
 	char * generic = NULL;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	char *rv_signature = NULL;
+	char *rv_generic = NULL;
 
 	Trc_JVMTI_jvmtiGetClassSignature_Entry(env);
 
@@ -371,12 +384,8 @@ jvmtiGetClassSignature(jvmtiEnv* env,
 			}
 		}
 
-		if (signature_ptr != NULL) {
-			*signature_ptr = signature; 
-		}
-		if (generic_ptr != NULL) {
-			*generic_ptr = generic;
-		}
+		rv_signature = signature;
+		rv_generic = generic;
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
@@ -385,6 +394,13 @@ done:
 	if (rc != JVMTI_ERROR_NONE) {
 		j9mem_free_memory(signature);
 		j9mem_free_memory(generic);
+	}
+
+	if (NULL != signature_ptr) {
+		*signature_ptr = rv_signature; 
+	}
+	if (NULL != generic_ptr) {
+		*generic_ptr = rv_generic;
 	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassSignature);
 }
@@ -398,6 +414,7 @@ jvmtiGetClassStatus(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jint rv_status = JVMTI_CLASS_STATUS_ERROR;
 
 	Trc_JVMTI_jvmtiGetClassStatus_Entry(env);
 
@@ -413,12 +430,15 @@ jvmtiGetClassStatus(jvmtiEnv* env,
 		ENSURE_NON_NULL(status_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
-		*status_ptr = getClassStatus(clazz);
+		rv_status = getClassStatus(clazz);
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != status_ptr) {
+		*status_ptr = rv_status;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassStatus);
 }
 
@@ -431,6 +451,7 @@ jvmtiGetSourceFileName(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	char *rv_source_name = NULL;
 
 	Trc_JVMTI_jvmtiGetSourceFileName_Entry(env);
 
@@ -453,13 +474,16 @@ jvmtiGetSourceFileName(jvmtiEnv* env,
 		rc = JVMTI_ERROR_ABSENT_INFORMATION;
 		sourceFileName = getSourceFileNameForROMClass(vm, clazz->classLoader, clazz->romClass);
 		if (sourceFileName != NULL) {
-			rc = cStringFromUTF(env, sourceFileName, source_name_ptr);
+			rc = cStringFromUTF(env, sourceFileName, &rv_source_name);
 			releaseOptInfoBuffer(vm, clazz->romClass);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != source_name_ptr) {
+		*source_name_ptr = rv_source_name;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetSourceFileName);
 }
 
@@ -472,6 +496,7 @@ jvmtiGetClassModifiers(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jint rv_modifiers = 0;
 
 	Trc_JVMTI_jvmtiGetClassModifiers_Entry(env);
 
@@ -513,12 +538,15 @@ jvmtiGetClassModifiers(jvmtiEnv* env,
 
 		/* Only the low 16 bit of the modifiers are specified - the rest are J9 internal */
 
-		*modifiers_ptr = (jint) (modifiers & 0xFFFF);
+		rv_modifiers = (jint) (modifiers & 0xFFFF);
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != modifiers_ptr) {
+		*modifiers_ptr = rv_modifiers;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassModifiers);
 }
 
@@ -533,6 +561,8 @@ jvmtiGetClassMethods(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_method_count = 0;
+	jmethodID *rv_methods = NULL;
 
 	Trc_JVMTI_jvmtiGetClassMethods_Entry(env);
 
@@ -574,13 +604,19 @@ jvmtiGetClassMethods(jvmtiEnv* env,
 				}
 				methodIDs[i] = (jmethodID) methodID;
 			}
-			*method_count_ptr = (jint) methodCount;
-			*methods_ptr = methodIDs;
+			rv_method_count = (jint) methodCount;
+			rv_methods = methodIDs;
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != method_count_ptr) {
+		*method_count_ptr = rv_method_count;
+	}
+	if (NULL != methods_ptr) {
+		*methods_ptr = rv_methods;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassMethods);
 }
 
@@ -595,6 +631,8 @@ jvmtiGetClassFields(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_field_count = 0;
+	jfieldID *rv_fields = NULL;
 
 	Trc_JVMTI_jvmtiGetClassFields_Entry(env);
 
@@ -645,13 +683,15 @@ jvmtiGetClassFields(jvmtiEnv* env,
 				result = vmFuncs->fieldOffsetsNextDo(&state);
 			}
 
-			*field_count_ptr = (jint) fieldCount;
-			*fields_ptr = fieldIDs;
+			rv_field_count = (jint) fieldCount;
+			rv_fields = fieldIDs;
 		}
 done:
 		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
+	*field_count_ptr = rv_field_count;
+	*fields_ptr = rv_fields;
 	TRACE_JVMTI_RETURN(jvmtiGetClassFields);
 }
 
@@ -666,6 +706,8 @@ jvmtiGetImplementedInterfaces(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_interface_count = 0;
+	jclass *rv_interfaces = NULL;
 
 	Trc_JVMTI_jvmtiGetImplementedInterfaces_Entry(env);
 
@@ -673,8 +715,8 @@ jvmtiGetImplementedInterfaces(jvmtiEnv* env,
 	if (rc == JVMTI_ERROR_NONE) {
 		J9Class * clazz;
 		J9ROMClass * romClass;
-		jint interfaceCount;
-		jclass * interfaces;
+		jint interfaceCount = 0;
+		jclass * interfaces = NULL;
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
@@ -691,11 +733,7 @@ jvmtiGetImplementedInterfaces(jvmtiEnv* env,
 
 		/* Array and primitive classes must return an empty list */
 
-		if (J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass)) {
-			interfaceCount = 0;
-			interfaces = NULL;
-		} else {
-
+		if (!J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass)) {
 			/* Must walk the interface names in the ROM class to be sure to get the whole list */
  
 			interfaceCount = (jint) romClass->interfaceCount;
@@ -719,12 +757,18 @@ jvmtiGetImplementedInterfaces(jvmtiEnv* env,
 			}
 		}
 
-		*interface_count_ptr = interfaceCount;
-		*interfaces_ptr = interfaces;
+		rv_interface_count = interfaceCount;
+		rv_interfaces = interfaces;
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != interface_count_ptr) {
+		*interface_count_ptr = rv_interface_count;
+	}
+	if (NULL != interfaces_ptr) {
+		*interfaces_ptr = rv_interfaces;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetImplementedInterfaces);
 }
 
@@ -737,6 +781,7 @@ jvmtiIsInterface(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jboolean rv_is_interface = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsInterface_Entry(env);
 
@@ -752,12 +797,15 @@ jvmtiIsInterface(jvmtiEnv* env,
 		ENSURE_NON_NULL(is_interface_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
-		*is_interface_ptr = (clazz->romClass->modifiers & J9AccInterface) ? JNI_TRUE : JNI_FALSE;
+		rv_is_interface = (clazz->romClass->modifiers & J9AccInterface) ? JNI_TRUE : JNI_FALSE;
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != is_interface_ptr) {
+		*is_interface_ptr = rv_is_interface;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsInterface);
 }
 
@@ -770,6 +818,7 @@ jvmtiIsArrayClass(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jboolean rv_is_array_class = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsArrayClass_Entry(env);
 
@@ -785,12 +834,15 @@ jvmtiIsArrayClass(jvmtiEnv* env,
 		ENSURE_NON_NULL(is_array_class_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
-		*is_array_class_ptr = (J9ROMCLASS_IS_ARRAY(clazz->romClass)) ? JNI_TRUE : JNI_FALSE;
+		rv_is_array_class = (J9ROMCLASS_IS_ARRAY(clazz->romClass)) ? JNI_TRUE : JNI_FALSE;
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != is_array_class_ptr) {
+		*is_array_class_ptr = rv_is_array_class;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsArrayClass);
 }
 
@@ -803,6 +855,7 @@ jvmtiGetClassLoader(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jobject rv_classloader = NULL;
 
 	Trc_JVMTI_jvmtiGetClassLoader_Entry(env);
 
@@ -821,14 +874,17 @@ jvmtiGetClassLoader(jvmtiEnv* env,
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
 		classLoader = clazz->classLoader;
 		if (classLoader == vm->systemClassLoader) {
-			*classloader_ptr = NULL;
+			rv_classloader = NULL;
 		} else {
-			*classloader_ptr = vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *)currentThread, J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, classLoader));
+			rv_classloader = vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *)currentThread, J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, classLoader));
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != classloader_ptr) {
+		*classloader_ptr = rv_classloader;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassLoader);
 }
 
@@ -843,6 +899,7 @@ jvmtiGetSourceDebugExtension(jvmtiEnv* env,
 #if defined(J9VM_OPT_DEBUG_JSR45_SUPPORT)
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	J9VMThread * currentThread;
+	char *rv_source_debug_extension = NULL;
 
 	Trc_JVMTI_jvmtiGetSourceDebugExtension_Entry(env);
 
@@ -868,7 +925,7 @@ jvmtiGetSourceDebugExtension(jvmtiEnv* env,
 			U_32 length = sourceDebugExtension->size;
 
 			if (length != 0) {
-				rc = cStringFromUTFChars(env, (U_8 *) (sourceDebugExtension + 1), length, source_debug_extension_ptr);
+				rc = cStringFromUTFChars(env, (U_8 *) (sourceDebugExtension + 1), length, &rv_source_debug_extension);
 			}
 			releaseOptInfoBuffer(vm, clazz->romClass);
 		}
@@ -880,6 +937,9 @@ done:
 	rc = JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
 #endif
 
+	if (NULL != source_debug_extension_ptr) {
+		*source_debug_extension_ptr = rv_source_debug_extension;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetSourceDebugExtension);
 }
 
@@ -1458,13 +1518,13 @@ jvmtiIsModifiableClass(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jboolean rv_is_modifiable = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsModifiableClass_Entry(env);
 
 	rc = getCurrentVMThread(vm, &currentThread);
 	if (rc == JVMTI_ERROR_NONE) {
 		J9Class * clazz;
-		jboolean modifiable = JNI_FALSE;
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
 		ENSURE_PHASE_START_OR_LIVE(env);
@@ -1478,21 +1538,23 @@ jvmtiIsModifiableClass(jvmtiEnv* env,
 			JVMTI_ERROR(JVMTI_ERROR_INVALID_CLASS);
 		}
 
-		modifiable = classIsModifiable(vm, clazz);
-		if (modifiable) {
+		rv_is_modifiable = classIsModifiable(vm, clazz);
+		if (rv_is_modifiable) {
 			if (((J9JVMTIEnv *) env)->capabilities.can_retransform_classes) {
 				J9MemorySegmentList * classSegments = vm->classMemorySegments;
 
 				omrthread_monitor_enter(classSegments->segmentMutex);
-				modifiable = (WSRP_GET(clazz->romClass->intermediateClassData, U_8*) != NULL);
+				rv_is_modifiable = (WSRP_GET(clazz->romClass->intermediateClassData, U_8*) != NULL);
 				omrthread_monitor_exit(classSegments->segmentMutex);
 			}
 		}
-		*is_modifiable_class_ptr = modifiable;
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != is_modifiable_class_ptr) {
+		*is_modifiable_class_ptr = rv_is_modifiable;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsModifiableClass);
 }
 
@@ -1506,6 +1568,8 @@ jvmtiGetClassVersionNumbers(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jint rv_minor_version = 0;
+	jint rv_major_version = 0;
 
 	Trc_JVMTI_jvmtiGetClassVersionNumbers_Entry(env);
 
@@ -1528,14 +1592,20 @@ jvmtiGetClassVersionNumbers(jvmtiEnv* env,
 		if (J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass)) {
 			rc = JVMTI_ERROR_ABSENT_INFORMATION;
 		} else {
-			*minor_version_ptr = (jint) romClass->minorVersion;
-			*major_version_ptr = (jint) romClass->majorVersion;
+			rv_minor_version = (jint) romClass->minorVersion;
+			rv_major_version = (jint) romClass->majorVersion;
 		}
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != minor_version_ptr) {
+		*minor_version_ptr = rv_minor_version;
+	}
+	if (NULL != major_version_ptr) {
+		*major_version_ptr = rv_major_version;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetClassVersionNumbers);
 }
 
@@ -1620,7 +1690,10 @@ jvmtiGetConstantPool(jvmtiEnv* env,
 	J9VMThread * currentThread;
 	jvmtiGcp_translation translation;
 	unsigned char *constantPoolBuf;
-	
+	jint rv_constant_pool_count = 0;
+	jint rv_constant_pool_byte_count = 0;
+	unsigned char *rv_constant_pool_bytes = NULL;
+
 	Trc_JVMTI_jvmtiGetConstantPool_Entry(env);
 
     memset(&translation, 0x00, sizeof(jvmtiGcp_translation));
@@ -1671,16 +1744,25 @@ jvmtiGetConstantPool(jvmtiEnv* env,
 			JVMTI_ERROR(rc);
 		}
 
-		*constant_pool_count_ptr = translation.cpSize;
-		*constant_pool_byte_count_ptr = translation.totalSize;
-		*constant_pool_bytes_ptr = constantPoolBuf;
-		
+		rv_constant_pool_count = translation.cpSize;
+		rv_constant_pool_byte_count = translation.totalSize;
+		rv_constant_pool_bytes = constantPoolBuf;
+
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 
 		jvmtiGetConstantPool_free(PORTLIB, &translation);
 	}
 
+	if (NULL != constant_pool_count_ptr) {
+		*constant_pool_count_ptr = rv_constant_pool_count;
+	}
+	if (NULL != constant_pool_byte_count_ptr) {
+		*constant_pool_byte_count_ptr = rv_constant_pool_byte_count;
+	}
+	if (NULL != constant_pool_bytes_ptr) {
+		*constant_pool_bytes_ptr = rv_constant_pool_bytes;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetConstantPool);
 }
 

--- a/runtime/jvmti/jvmtiField.c
+++ b/runtime/jvmti/jvmtiField.c
@@ -35,6 +35,9 @@ jvmtiGetFieldName(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	char *rv_name = NULL;
+	char *rv_signature = NULL;
+	char *rv_generic = NULL;
 
 	Trc_JVMTI_jvmtiGetFieldName_Entry(env);
 
@@ -65,7 +68,7 @@ jvmtiGetFieldName(jvmtiEnv* env,
 			}
 			memcpy(name, J9UTF8_DATA(utf), length);
 			name[length] = '\0';
-			*name_ptr = name; 
+			rv_name = name;
 		}
 
 		if (signature_ptr != NULL) {
@@ -79,7 +82,7 @@ jvmtiGetFieldName(jvmtiEnv* env,
 			}
 			memcpy(signature, J9UTF8_DATA(utf), length);
 			signature[length] = '\0';
-			*signature_ptr = signature; 
+			rv_signature = signature;
 		}
 
 		if (generic_ptr != NULL) {
@@ -98,8 +101,8 @@ jvmtiGetFieldName(jvmtiEnv* env,
 				memcpy(generic, J9UTF8_DATA(utf), length);
 				generic[length] = '\0';
 			}
-	
-			*generic_ptr = generic;
+
+			rv_generic = generic;
 		}	
 
 done:
@@ -111,6 +114,15 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != name_ptr) {
+		*name_ptr = rv_name;
+	}
+	if (NULL != signature_ptr) {
+		*signature_ptr = rv_signature;
+	}
+	if (NULL != generic_ptr) {
+		*generic_ptr = rv_generic;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetFieldName);
 }
 
@@ -124,6 +136,7 @@ jvmtiGetFieldDeclaringClass(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jclass rv_declaring_class = NULL;
 
 	Trc_JVMTI_jvmtiGetFieldDeclaringClass_Entry(env);
 
@@ -140,12 +153,15 @@ jvmtiGetFieldDeclaringClass(jvmtiEnv* env,
 		ENSURE_NON_NULL(declaring_class_ptr);
 
 		fieldClass = getCurrentClass(((J9JNIFieldID *) field)->declaringClass);
-		*declaring_class_ptr = (jclass) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VM_J9CLASS_TO_HEAPCLASS(fieldClass));
+		rv_declaring_class = (jclass) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VM_J9CLASS_TO_HEAPCLASS(fieldClass));
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != declaring_class_ptr) {
+		*declaring_class_ptr = rv_declaring_class;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetFieldDeclaringClass);
 }
 
@@ -159,6 +175,7 @@ jvmtiGetFieldModifiers(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jint rv_modifiers = 0;
 
 	Trc_JVMTI_jvmtiGetFieldModifiers_Entry(env);
 
@@ -175,7 +192,7 @@ jvmtiGetFieldModifiers(jvmtiEnv* env,
 		ENSURE_NON_NULL(modifiers_ptr);
 
 		romField = ((J9JNIFieldID *) field)->field;
-		*modifiers_ptr = (jint) (romField->modifiers &
+		rv_modifiers = (jint) (romField->modifiers &
 			(J9AccPublic | J9AccPrivate | J9AccProtected | J9AccStatic | J9AccFinal | J9AccVolatile | J9AccTransient | J9AccEnum));
 		rc = JVMTI_ERROR_NONE;
 
@@ -183,6 +200,9 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != modifiers_ptr) {
+		*modifiers_ptr = rv_modifiers;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetFieldModifiers);
 }
 
@@ -196,6 +216,7 @@ jvmtiIsFieldSynthetic(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jboolean rv_is_synthetic = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsFieldSynthetic_Entry(env);
 
@@ -213,12 +234,15 @@ jvmtiIsFieldSynthetic(jvmtiEnv* env,
 		ENSURE_NON_NULL(is_synthetic_ptr);
 
 		romFieldShape = ((J9JNIFieldID *) field)->field;
-		*is_synthetic_ptr = (romFieldShape->modifiers & J9AccSynthetic) ? JNI_TRUE : JNI_FALSE;
+		rv_is_synthetic = (romFieldShape->modifiers & J9AccSynthetic) ? JNI_TRUE : JNI_FALSE;
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != is_synthetic_ptr) {
+		*is_synthetic_ptr = rv_is_synthetic;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsFieldSynthetic);
 }
 

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -93,15 +93,19 @@ jvmtiGetPhase(jvmtiEnv* env,
 	jvmtiPhase* phase_ptr)
 {
 	jvmtiError rc;
+	jvmtiPhase rv_phase = JVMTI_PHASE_DEAD;
 
 	Trc_JVMTI_jvmtiGetPhase_Entry(env);
 
 	ENSURE_NON_NULL(phase_ptr);
 
-	*phase_ptr = (jvmtiPhase) J9JVMTI_DATA_FROM_ENV(env)->phase;
+	rv_phase = (jvmtiPhase) J9JVMTI_DATA_FROM_ENV(env)->phase;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != phase_ptr) {
+		*phase_ptr = rv_phase;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetPhase);
 }
 
@@ -152,15 +156,19 @@ jvmtiGetEnvironmentLocalStorage(jvmtiEnv* env,
 	void** data_ptr)
 {
 	jvmtiError rc;
+	void *rv_data = NULL;
 
 	Trc_JVMTI_jvmtiGetEnvironmentLocalStorage_Entry(env);
 
 	ENSURE_NON_NULL(data_ptr);
 
-	*data_ptr = ((J9JVMTIEnv *) env)->environmentLocalStorage;
+	rv_data = ((J9JVMTIEnv *) env)->environmentLocalStorage;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != data_ptr) {
+		*data_ptr = rv_data;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetEnvironmentLocalStorage);
 }
 
@@ -171,20 +179,22 @@ jvmtiGetVersionNumber(jvmtiEnv* env,
 {
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
+	jint rv_version = JVMTI_1_2_3_SPEC_VERSION;
 
 	Trc_JVMTI_jvmtiGetVersionNumber_Entry(env);
 
 	ENSURE_NON_NULL(version_ptr);
 
-	*version_ptr = JVMTI_1_2_3_SPEC_VERSION;
-
 	if (J2SE_VERSION(vm) >= J2SE_19) {
-		*version_ptr = JVMTI_VERSION_9_0;
+		rv_version = JVMTI_VERSION_9_0;
 	}
 
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != version_ptr) {
+		*version_ptr = rv_version;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetVersionNumber);
 }
 
@@ -197,6 +207,7 @@ jvmtiGetErrorName(jvmtiEnv* env,
 	const J9JvmtiErrorMapping *mapping = NULL;
 	jvmtiError rc = JVMTI_ERROR_ILLEGAL_ARGUMENT;
 	PORT_ACCESS_FROM_JVMTI(env);
+	char *rv_name = NULL;
 
 	Trc_JVMTI_jvmtiGetErrorName_Entry(env);
 
@@ -205,19 +216,22 @@ jvmtiGetErrorName(jvmtiEnv* env,
 	mapping = errorMap;
 	while (mapping->errorName != NULL) {
 		if (mapping->errorValue == error) {
-			*name_ptr = j9mem_allocate_memory(strlen(mapping->errorName) + 1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-			if (*name_ptr == NULL) {
+			rv_name = j9mem_allocate_memory(strlen(mapping->errorName) + 1, J9MEM_CATEGORY_JVMTI_ALLOCATE);
+			if (rv_name == NULL) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 			} else {
-				strcpy(*name_ptr, mapping->errorName);
+				strcpy(rv_name, mapping->errorName);
 				rc = JVMTI_ERROR_NONE;
 			}
 			break;
 		}
 		++mapping;
 	}
-
 done:
+
+	if (NULL != name_ptr) {
+		*name_ptr = rv_name;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetErrorName);
 }
 
@@ -269,15 +283,18 @@ jvmtiGetJLocationFormat(jvmtiEnv* env,
 	jvmtiJlocationFormat* format_ptr)
 {
 	jvmtiError rc;
+	jint rv_format = JVMTI_JLOCATION_JVMBCI;
 
 	Trc_JVMTI_jvmtiGetJLocationFormat_Entry(env);
 
 	ENSURE_NON_NULL(format_ptr);
 
-	*format_ptr = JVMTI_JLOCATION_JVMBCI;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != format_ptr) {
+		*format_ptr = rv_format;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetJLocationFormat);
 }
 

--- a/runtime/jvmti/jvmtiJNIFunctionInterception.c
+++ b/runtime/jvmti/jvmtiJNIFunctionInterception.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,6 +94,7 @@ jvmtiGetJNIFunctionTable(jvmtiEnv* env,
 	J9JVMTIData * jvmtiData = J9JVMTI_DATA_FROM_VM(vm);
 	jvmtiError rc = JVMTI_ERROR_NONE;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jniNativeInterface *rv_function_table = NULL;
 
 	Trc_JVMTI_jvmtiGetJNIFunctionTable_Entry(env);
 
@@ -103,8 +104,8 @@ jvmtiGetJNIFunctionTable(jvmtiEnv* env,
 
 	/* Copy the table into newly-allocated memory */
 
-	*function_table = j9mem_allocate_memory(sizeof(jniNativeInterface), J9MEM_CATEGORY_JVMTI_ALLOCATE);
-	if (*function_table == NULL) {
+	rv_function_table = j9mem_allocate_memory(sizeof(jniNativeInterface), J9MEM_CATEGORY_JVMTI_ALLOCATE);
+	if (rv_function_table == NULL) {
 		rc = JVMTI_ERROR_OUT_OF_MEMORY;
 	} else {
 		/* Get the JVMTI mutex to ensure this operation is atomic with SetJNIFunctionTable */
@@ -115,6 +116,9 @@ jvmtiGetJNIFunctionTable(jvmtiEnv* env,
 	}
 
 done:
+	if (NULL != function_table) {
+		*function_table = rv_function_table;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetJNIFunctionTable);
 }
 

--- a/runtime/jvmti/jvmtiLocalVariable.c
+++ b/runtime/jvmti/jvmtiLocalVariable.c
@@ -43,6 +43,7 @@ jvmtiGetLocalInstance(jvmtiEnv* env,
 	ENSURE_NON_NEGATIVE(depth);
 	ENSURE_NON_NULL(value_ptr);
 
+	*value_ptr = NULL;
 	rc = jvmtiGetOrSetLocal(env, thread, depth, 0, value_ptr, 'L', FALSE, TRUE);
 
 done:
@@ -67,6 +68,7 @@ jvmtiGetLocalObject(jvmtiEnv* env,
 	ENSURE_NON_NEGATIVE(depth);
 	ENSURE_NON_NULL(value_ptr);
 
+	*value_ptr = NULL;
 	rc = jvmtiGetOrSetLocal(env, thread, depth, slot, value_ptr, 'L', FALSE, FALSE);
 
 done:
@@ -91,6 +93,7 @@ jvmtiGetLocalInt(jvmtiEnv* env,
 	ENSURE_NON_NEGATIVE(depth);
 	ENSURE_NON_NULL(value_ptr);
 
+	*value_ptr = 0;
 	rc = jvmtiGetOrSetLocal(env, thread, depth, slot, value_ptr, 'I', FALSE, FALSE);
 
 done:
@@ -115,6 +118,7 @@ jvmtiGetLocalLong(jvmtiEnv* env,
 	ENSURE_NON_NEGATIVE(depth);
 	ENSURE_NON_NULL(value_ptr);
 
+	*value_ptr = 0;
 	rc = jvmtiGetOrSetLocal(env, thread, depth, slot, value_ptr, 'J', FALSE, FALSE);
 
 done:
@@ -139,6 +143,7 @@ jvmtiGetLocalFloat(jvmtiEnv* env,
 	ENSURE_NON_NEGATIVE(depth);
 	ENSURE_NON_NULL(value_ptr);
 
+	*(jint*)value_ptr = 0;
 	rc = jvmtiGetOrSetLocal(env, thread, depth, slot, value_ptr, 'F', FALSE, FALSE);
 
 done:
@@ -163,6 +168,7 @@ jvmtiGetLocalDouble(jvmtiEnv* env,
 	ENSURE_NON_NEGATIVE(depth);
 	ENSURE_NON_NULL(value_ptr);
 
+	*(jlong*)value_ptr = 0;
 	rc = jvmtiGetOrSetLocal(env, thread, depth, slot, value_ptr, 'D', FALSE, FALSE);
 
 done:

--- a/runtime/jvmti/jvmtiMemory.c
+++ b/runtime/jvmti/jvmtiMemory.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@ jvmtiAllocate(jvmtiEnv* env,
 	jlong size,
 	unsigned char** mem_ptr)
 {
-	void * allocatedMemory = NULL;
+	unsigned char *rv_mem = NULL;
 	jvmtiError rc;
 
 	Trc_JVMTI_jvmtiAllocate_Entry(env, mem_ptr);
@@ -46,17 +46,19 @@ jvmtiAllocate(jvmtiEnv* env,
 	if (size != 0) {
 		PORT_ACCESS_FROM_JVMTI(env);
 
-		allocatedMemory = j9mem_allocate_memory((UDATA) size, J9MEM_CATEGORY_JVMTI_ALLOCATE);
-		if (allocatedMemory == NULL) {
+		rv_mem = j9mem_allocate_memory((UDATA) size, J9MEM_CATEGORY_JVMTI_ALLOCATE);
+		if (rv_mem == NULL) {
 			JVMTI_ERROR(JVMTI_ERROR_OUT_OF_MEMORY);
 		}
 	}
 
-	*mem_ptr = (unsigned char *) allocatedMemory;
 	rc = JVMTI_ERROR_NONE;
-
 done:
-	Trc_JVMTI_jvmtiAllocate_Exit(rc, allocatedMemory);
+
+	if (NULL != mem_ptr) {
+		*mem_ptr = rv_mem;
+	}
+	Trc_JVMTI_jvmtiAllocate_Exit(rc, rv_mem);
 	return rc;
 }
 

--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -44,6 +44,9 @@ jvmtiGetMethodName(jvmtiEnv* env,
 	char * signature = NULL;
 	char * generic = NULL;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	char *rv_name = NULL;
+	char *rv_signature = NULL;
+	char *rv_generic = NULL;
 
 	Trc_JVMTI_jvmtiGetMethodName_Entry(env);
 
@@ -64,7 +67,7 @@ jvmtiGetMethodName(jvmtiEnv* env,
 		}
 		memcpy(name, J9UTF8_DATA(utf), length);
 		name[length] = '\0';
-		*name_ptr = name; 
+		rv_name = name; 
 	}
 
 	if (signature_ptr != NULL) {
@@ -78,7 +81,7 @@ jvmtiGetMethodName(jvmtiEnv* env,
 		}
 		memcpy(signature, J9UTF8_DATA(utf), length);
 		signature[length] = '\0';
-		*signature_ptr = signature; 
+		rv_signature = signature; 
 	}
 
 	if (generic_ptr != NULL) {
@@ -96,7 +99,7 @@ jvmtiGetMethodName(jvmtiEnv* env,
 			generic[length] = '\0';
 		}
 	
-		*generic_ptr = generic;
+		rv_generic = generic;
 	}	
 
 done:
@@ -104,6 +107,15 @@ done:
 		j9mem_free_memory(name);
 		j9mem_free_memory(signature);
 		j9mem_free_memory(generic);
+	}
+	if (name_ptr != NULL) {
+		*name_ptr = rv_name;
+	}
+	if (signature_ptr != NULL) {
+		*signature_ptr = rv_signature;
+	}
+	if (generic_ptr != NULL) {
+		*generic_ptr = rv_generic;
 	}
 	TRACE_JVMTI_RETURN(jvmtiGetMethodName);
 }
@@ -117,6 +129,7 @@ jvmtiGetMethodDeclaringClass(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jclass rv_declaring_class = NULL;
 
 	Trc_JVMTI_jvmtiGetMethodDeclaringClass_Entry(env);
 
@@ -132,12 +145,15 @@ jvmtiGetMethodDeclaringClass(jvmtiEnv* env,
 		ENSURE_NON_NULL(declaring_class_ptr);
 
 		methodClass = getCurrentClass(J9_CLASS_FROM_METHOD(((J9JNIMethodID *) method)->method));
-		*declaring_class_ptr = (jclass) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VM_J9CLASS_TO_HEAPCLASS(methodClass));
+		rv_declaring_class = (jclass) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VM_J9CLASS_TO_HEAPCLASS(methodClass));
 
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != declaring_class_ptr) {		
+		*declaring_class_ptr = rv_declaring_class;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetMethodDeclaringClass);
 }
 
@@ -149,6 +165,7 @@ jvmtiGetMethodModifiers(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9ROMMethod * romMethod;
+	jint rv_modifiers = 0;
 
 	Trc_JVMTI_jvmtiGetMethodModifiers_Entry(env);
 
@@ -158,11 +175,14 @@ jvmtiGetMethodModifiers(jvmtiEnv* env,
 	ENSURE_NON_NULL(modifiers_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
-	*modifiers_ptr = (jint) (romMethod->modifiers &
+	rv_modifiers = (jint) (romMethod->modifiers &
 			(J9AccPublic | J9AccPrivate | J9AccProtected | J9AccStatic | J9AccFinal | J9AccSynchronized | J9AccNative | J9AccAbstract | J9AccStrict | J9AccVarArgs | J9AccBridge));
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != modifiers_ptr) {
+		*modifiers_ptr = rv_modifiers;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetMethodModifiers);
 }
 
@@ -174,6 +194,7 @@ jvmtiGetMaxLocals(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9ROMMethod * romMethod;
+	jint rv_max = 0;
 
 	Trc_JVMTI_jvmtiGetMaxLocals_Entry(env);
 
@@ -190,13 +211,16 @@ jvmtiGetMaxLocals(jvmtiEnv* env,
 	/* Abstract methods have no code attribute in the .class file, so the max locals is 0 */
 
 	if (romMethod->modifiers & J9AccAbstract) {
-		*max_ptr = 0;
+		rv_max = 0;
 	} else {
-		*max_ptr = romMethod->argCount + romMethod->tempCount;
+		rv_max = romMethod->argCount + romMethod->tempCount;
 	}
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != max_ptr) {
+		*max_ptr = rv_max;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetMaxLocals);
 }
 
@@ -208,6 +232,7 @@ jvmtiGetArgumentsSize(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9ROMMethod * romMethod;
+	jint rv_size = 0;
 
 	Trc_JVMTI_jvmtiGetArgumentsSize_Entry(env);
 
@@ -220,10 +245,13 @@ jvmtiGetArgumentsSize(jvmtiEnv* env,
 	if (romMethod->modifiers & J9AccNative) {
 		JVMTI_ERROR(JVMTI_ERROR_NATIVE_METHOD);
 	}
-	*size_ptr = romMethod->argCount;
+	rv_size = romMethod->argCount;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != size_ptr) {
+		*size_ptr = rv_size;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetArgumentsSize);
 }
 
@@ -241,6 +269,8 @@ jvmtiGetLineNumberTable(jvmtiEnv* env,
 	J9ROMMethod * romMethod;
 	J9LineNumber lineNumber;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_entry_count = 0;
+	jvmtiLineNumberEntry *rv_table = NULL;
 
 	Trc_JVMTI_jvmtiGetLineNumberTable_Entry(env);
 
@@ -292,8 +322,8 @@ jvmtiGetLineNumberTable(jvmtiEnv* env,
 					jvmtiLineTable[i].line_number = (jint) lineNumber.lineNumber;
 
 				}
-				*entry_count_ptr = lineTableSize;
-				*table_ptr = jvmtiLineTable;
+				rv_entry_count = lineTableSize;
+				rv_table = jvmtiLineTable;
 			}
 		}
 release:
@@ -301,6 +331,12 @@ release:
 	}
 
 done:
+	if (NULL != entry_count_ptr) {
+		*entry_count_ptr = rv_entry_count;
+	}
+	if (NULL != table_ptr) {
+		*table_ptr = rv_table;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetLineNumberTable);
 }
 
@@ -313,6 +349,8 @@ jvmtiGetMethodLocation(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9ROMMethod * romMethod;
+	jlocation rv_start_location = 0;
+	jlocation rv_end_location = 0;
 
 	Trc_JVMTI_jvmtiGetMethodLocation_Entry(env);
 
@@ -327,15 +365,21 @@ jvmtiGetMethodLocation(jvmtiEnv* env,
 		JVMTI_ERROR(JVMTI_ERROR_NATIVE_METHOD);
 	}
 	if (romMethod->modifiers & J9AccAbstract) {
-		*start_location_ptr = -1;
-		*end_location_ptr = -1;
+		rv_start_location = -1;
+		rv_end_location = -1;
 	} else {
-		*start_location_ptr = 0;
-		*end_location_ptr = J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod) - 1;
+		rv_start_location = 0;
+		rv_end_location = J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod) - 1;
 	}
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != start_location_ptr) {
+		*start_location_ptr = rv_start_location;
+	}
+	if (NULL != end_location_ptr) {
+		*end_location_ptr = rv_end_location;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetMethodLocation);
 }
 
@@ -352,6 +396,8 @@ jvmtiGetLocalVariableTable(jvmtiEnv* env,
 	J9Method * ramMethod;
 	J9ROMMethod * romMethod;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_entry_count = 0;
+	jvmtiLocalVariableEntry *rv_table = NULL;
 
 	Trc_JVMTI_jvmtiGetLocalVariableTable_Entry(env);
 
@@ -413,8 +459,8 @@ jvmtiGetLocalVariableTable(jvmtiEnv* env,
 					values = variableInfoNextDo(&state);
 					i++;
 				}
-				*entry_count_ptr = variableCount;
-				*table_ptr = jvmtiVariableTable;
+				rv_entry_count = variableCount;
+				rv_table = jvmtiVariableTable;
 			}
 		}
 release:
@@ -422,6 +468,12 @@ release:
 	}
 
 done:
+	if (NULL != entry_count_ptr) {
+		*entry_count_ptr = rv_entry_count;
+	}
+	if (NULL != table_ptr) {
+		*table_ptr = rv_table;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetLocalVariableTable);
 }
 
@@ -457,6 +509,8 @@ jvmtiGetBytecodes(jvmtiEnv* env,
 	jvmtiError rc;
 	jvmtiGcp_translation translation;
 	PORT_ACCESS_FROM_JVMTI(env);
+	jint rv_bytecode_count = 0;
+	unsigned char *rv_bytecodes = NULL;
 	
 	Trc_JVMTI_jvmtiGetBytecodes_Entry(env);
 
@@ -757,14 +811,20 @@ readdWide:
 			index += bytecodeSize;
 		}
 
-		*bytecodes_ptr = bytecodes;
-		*bytecode_count_ptr = size;
+		rv_bytecodes = bytecodes;
+		rv_bytecode_count = size;
 	}
 
 done:
 	jvmtiGetConstantPool_free(PORTLIB, &translation);
 	if (rc != JVMTI_ERROR_NONE) {
 		j9mem_free_memory(bytecodes);
+	}
+	if (NULL != bytecode_count_ptr) {
+		*bytecode_count_ptr = rv_bytecode_count;
+	}
+	if (NULL != bytecodes_ptr) {
+		*bytecodes_ptr = rv_bytecodes;
 	}
 	TRACE_JVMTI_RETURN(jvmtiGetBytecodes);
 }
@@ -777,6 +837,7 @@ jvmtiIsMethodNative(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9ROMMethod * romMethod;
+	jboolean rv_is_native = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsMethodNative_Entry(env);
 
@@ -786,10 +847,13 @@ jvmtiIsMethodNative(jvmtiEnv* env,
 	ENSURE_NON_NULL(is_native_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
-	*is_native_ptr = (romMethod->modifiers & J9AccNative) ? JNI_TRUE : JNI_FALSE;
+	rv_is_native = (romMethod->modifiers & J9AccNative) ? JNI_TRUE : JNI_FALSE;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != is_native_ptr) {
+		*is_native_ptr = rv_is_native;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsMethodNative);
 }
 
@@ -801,6 +865,7 @@ jvmtiIsMethodSynthetic(jvmtiEnv* env,
 {
 	jvmtiError rc;
 	J9ROMMethod * romMethod;
+	jboolean rv_is_synthetic = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsMethodSynthetic_Entry(env);
 
@@ -811,10 +876,13 @@ jvmtiIsMethodSynthetic(jvmtiEnv* env,
 	ENSURE_NON_NULL(is_synthetic_ptr);
 
 	romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(((J9JNIMethodID *) method)->method);
-	*is_synthetic_ptr = (romMethod->modifiers & J9AccSynthetic) ? JNI_TRUE : JNI_FALSE;
+	rv_is_synthetic = (romMethod->modifiers & J9AccSynthetic) ? JNI_TRUE : JNI_FALSE;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != is_synthetic_ptr) {
+		*is_synthetic_ptr = rv_is_synthetic;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsMethodSynthetic);
 }
 
@@ -825,6 +893,7 @@ jvmtiIsMethodObsolete(jvmtiEnv* env,
 	jboolean* is_obsolete_ptr)
 {
 	jvmtiError rc;
+	jboolean rv_is_obsolete = JNI_FALSE;
 
 	Trc_JVMTI_jvmtiIsMethodObsolete_Entry(env);
 
@@ -834,10 +903,13 @@ jvmtiIsMethodObsolete(jvmtiEnv* env,
 	ENSURE_JMETHODID_NON_NULL(method);
 	ENSURE_NON_NULL(is_obsolete_ptr);
 
-	*is_obsolete_ptr = (J9CLASS_FLAGS(J9_CLASS_FROM_METHOD(((J9JNIMethodID *) method)->method)) & J9_JAVA_CLASS_HOT_SWAPPED_OUT) ? JNI_TRUE : JNI_FALSE;
+	rv_is_obsolete = (J9CLASS_FLAGS(J9_CLASS_FROM_METHOD(((J9JNIMethodID *) method)->method)) & J9_JAVA_CLASS_HOT_SWAPPED_OUT) ? JNI_TRUE : JNI_FALSE;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != is_obsolete_ptr) {
+		*is_obsolete_ptr = rv_is_obsolete;
+	}
 	TRACE_JVMTI_RETURN(jvmtiIsMethodObsolete);
 }
 

--- a/runtime/jvmti/jvmtiRawMonitor.c
+++ b/runtime/jvmti/jvmtiRawMonitor.c
@@ -32,6 +32,7 @@ jvmtiCreateRawMonitor(jvmtiEnv* env,
 	jrawMonitorID* monitor_ptr)
 {
 	jvmtiError rc;
+	jrawMonitorID rv_monitor = NULL;
 
 	Trc_JVMTI_jvmtiCreateRawMonitor_Entry(env, name);
 
@@ -40,14 +41,17 @@ jvmtiCreateRawMonitor(jvmtiEnv* env,
 	ENSURE_NON_NULL(name);
 	ENSURE_NON_NULL(monitor_ptr);
 
-	if (omrthread_monitor_init_with_name((omrthread_monitor_t *) monitor_ptr, J9THREAD_MONITOR_NAME_COPY, (char *)name) != 0) {
+	if (omrthread_monitor_init_with_name((omrthread_monitor_t *) &rv_monitor, J9THREAD_MONITOR_NAME_COPY, (char *)name) != 0) {
 		JVMTI_ERROR(JVMTI_ERROR_OUT_OF_MEMORY);
 	}
 	rc = JVMTI_ERROR_NONE;
 
-	Trc_JVMTI_rawMonitorCreated(*monitor_ptr);
+	Trc_JVMTI_rawMonitorCreated(rv_monitor);
 
 done:
+	if (NULL != monitor_ptr) {
+		*monitor_ptr = rv_monitor;
+	}
 	TRACE_JVMTI_RETURN(jvmtiCreateRawMonitor);
 }
 

--- a/runtime/jvmti/jvmtiSystemProperties.c
+++ b/runtime/jvmti/jvmtiSystemProperties.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,8 @@ jvmtiGetSystemProperties(jvmtiEnv* env,
 	char ** propertyList;
 	UDATA propertyCount;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_count = 0;
+	char **rv_property = NULL;
 
 	Trc_JVMTI_jvmtiGetSystemProperties_Entry(env);
 
@@ -70,11 +72,17 @@ jvmtiGetSystemProperties(jvmtiEnv* env,
 			property = pool_nextDo(&walkState);
 		}
 
-		*count_ptr = (jint) propertyCount;
-		*property_ptr = propertyList;
+		rv_count = (jint) propertyCount;
+		rv_property = propertyList;
 	}
 
 done:
+	if (NULL != count_ptr) {
+		*count_ptr = rv_count;
+	}
+	if (NULL != property_ptr) {
+		*property_ptr = rv_property;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetSystemProperties);
 }
 
@@ -89,6 +97,7 @@ jvmtiGetSystemProperty(jvmtiEnv* env,
 	jvmtiError rc = JVMTI_ERROR_NONE;
 	char * value;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	char *rv_value = NULL;
 
 	Trc_JVMTI_jvmtiGetSystemProperty_Entry(env);
 
@@ -106,10 +115,13 @@ jvmtiGetSystemProperty(jvmtiEnv* env,
 		rc = JVMTI_ERROR_OUT_OF_MEMORY;
 	} else {
 		strcpy(value, systemProperty->value);
-		*value_ptr = value;
+		rv_value = value;
 	}
 
 done:
+	if (NULL != value_ptr) {
+		*value_ptr = rv_value;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetSystemProperty);
 }
 

--- a/runtime/jvmti/jvmtiThread.c
+++ b/runtime/jvmti/jvmtiThread.c
@@ -44,6 +44,7 @@ jvmtiGetThreadState(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jint rv_thread_state = 0;
 
 	Trc_JVMTI_jvmtiGetThreadState_Entry(env);
 
@@ -98,15 +99,15 @@ jvmtiGetThreadState(jvmtiEnv* env,
 				 * unsuspended thread.
 				 */
 				if (threadStartedFlag) {
-					*thread_state_ptr = JVMTI_THREAD_STATE_TERMINATED;
+					rv_thread_state = JVMTI_THREAD_STATE_TERMINATED;
 				} else {
 					/* thread is new */
-					*thread_state_ptr = 0;
+					rv_thread_state = 0;
 				}
 			} else {
 				vm->internalVMFunctions->haltThreadForInspection(currentThread, targetThread);
 				/* The vmthread can't be recycled because getVMThread() prevented it from exiting. */
-				*thread_state_ptr = getThreadState(currentThread, targetThread->threadObject);
+				rv_thread_state = getThreadState(currentThread, targetThread->threadObject);
 				vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
 			}
 			releaseVMThread(currentThread, targetThread);
@@ -115,6 +116,9 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != thread_state_ptr) {
+		*thread_state_ptr = rv_thread_state; 
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetThreadState);
 }
 
@@ -128,6 +132,8 @@ jvmtiGetAllThreads(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_threads_count = 0;
+	jthread *rv_threads = NULL;
 
 	Trc_JVMTI_jvmtiGetAllThreads_Entry(env);
 
@@ -166,8 +172,8 @@ jvmtiGetAllThreads(jvmtiEnv* env,
 				}
 			} while ((targetThread = targetThread->linkNext) != vm->mainThread);
 
-			*threads_ptr = threads;
-			*threads_count_ptr = threadCount;
+			rv_threads = threads;
+			rv_threads_count = threadCount;
 		}
 
 		vm->internalVMFunctions->releaseExclusiveVMAccess(currentThread);
@@ -176,6 +182,12 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != threads_count_ptr) {
+		*threads_count_ptr = rv_threads_count;
+	}
+	if (NULL != threads_ptr) {
+		*threads_ptr = rv_threads;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetAllThreads);
 }
 
@@ -417,6 +429,11 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	char *rv_name = NULL;
+	jint rv_priority = 0;
+	jboolean rv_is_daemon = JNI_FALSE;
+	jthreadGroup rv_thread_group = NULL;
+	jobject rv_context_class_loader = NULL;
 
 	Trc_JVMTI_jvmtiGetThreadInfo_Entry(env);
 
@@ -482,20 +499,27 @@ jvmtiGetThreadInfo(jvmtiEnv* env,
 
 			contextClassLoader = vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, J9VMJAVALANGTHREAD_CONTEXTCLASSLOADER(currentThread, threadObject));
 
-			info_ptr->name = name;
+			rv_name = name;
 			{
-				info_ptr->priority = J9VMJAVALANGTHREAD_PRIORITY(currentThread, threadObject);
+				rv_priority = J9VMJAVALANGTHREAD_PRIORITY(currentThread, threadObject);
 			}
 
-			info_ptr->is_daemon = J9VMJAVALANGTHREAD_ISDAEMON(currentThread, threadObject) ? JNI_TRUE : JNI_FALSE;
-			info_ptr->thread_group = (jthreadGroup) threadGroup;
-			info_ptr->context_class_loader = contextClassLoader;
+			rv_is_daemon = J9VMJAVALANGTHREAD_ISDAEMON(currentThread, threadObject) ? JNI_TRUE : JNI_FALSE;
+			rv_thread_group = (jthreadGroup) threadGroup;
+			rv_context_class_loader = contextClassLoader;
 		}
 done:
 		releaseVMThread(currentThread, targetThread);
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != info_ptr) {
+		info_ptr->name = rv_name;
+		info_ptr->priority = rv_priority;
+		info_ptr->is_daemon = rv_is_daemon;
+		info_ptr->thread_group = rv_thread_group;
+		info_ptr->context_class_loader = rv_context_class_loader;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetThreadInfo);
 }
 
@@ -510,6 +534,8 @@ jvmtiGetOwnedMonitorInfo(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_owned_monitor_count = 0;
+	jobject *rv_owned_monitors = NULL;
 
 	Trc_JVMTI_jvmtiGetOwnedMonitorInfo_Entry(env);
 
@@ -544,8 +570,8 @@ jvmtiGetOwnedMonitorInfo(jvmtiEnv* env,
 				 */
 				count = walkLocalMonitorRefs(currentThread, locks, targetThread, count);
 			}
-			*owned_monitors_ptr = locks;
-			*owned_monitor_count_ptr = count;
+			rv_owned_monitors = locks;
+			rv_owned_monitor_count = count;
 			releaseVMThread(currentThread, targetThread);
 		}
 
@@ -555,6 +581,12 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != owned_monitor_count_ptr) {
+		*owned_monitor_count_ptr = rv_owned_monitor_count;
+	}
+	if (NULL != owned_monitors_ptr) {
+		*owned_monitors_ptr = rv_owned_monitors;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetOwnedMonitorInfo);
 }
 
@@ -569,6 +601,8 @@ jvmtiGetOwnedMonitorStackDepthInfo(jvmtiEnv* env,
 	jvmtiError rc;
 	J9VMThread * currentThread;
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jint rv_monitor_info_count = 0;
+	jvmtiMonitorStackDepthInfo *rv_monitor_info = NULL;
 
 	Trc_JVMTI_jvmtiGetOwnedMonitorStackDepthInfo_Entry(env);
 
@@ -589,7 +623,7 @@ jvmtiGetOwnedMonitorStackDepthInfo(jvmtiEnv* env,
 			ENSURE_JTHREAD(currentThread, thread);
 		}
 		
-		*monitor_info_count_ptr = 0;
+		rv_monitor_info_count = 0;
 		
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
@@ -654,8 +688,8 @@ jvmtiGetOwnedMonitorStackDepthInfo(jvmtiEnv* env,
 			}
 
 
-			*monitor_info_count_ptr = (jint)maxRecords;
-			*monitor_info_ptr = resultArray; 
+			rv_monitor_info_count = (jint)maxRecords;
+			rv_monitor_info = resultArray; 
 
 doneRelease:
 			if (monitorEnterRecords) {
@@ -669,6 +703,12 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != monitor_info_count_ptr) {
+		*monitor_info_count_ptr = rv_monitor_info_count;
+	}
+	if (NULL != monitor_info_ptr) {
+		*monitor_info_ptr = rv_monitor_info;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetOwnedMonitorStackDepthInfo);
 }
 
@@ -680,6 +720,7 @@ jvmtiGetCurrentContendedMonitor(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	jvmtiError rc;
 	J9VMThread * currentThread;
+	jobject rv_monitor = NULL;
 
 	Trc_JVMTI_jvmtiGetCurrentContendedMonitor_Entry(env);
 
@@ -704,9 +745,9 @@ jvmtiGetCurrentContendedMonitor(jvmtiEnv* env,
 			vmstate = getVMThreadObjectStatesAll(targetThread, &lockObject, NULL, NULL);
 
 			if (lockObject && (0 == (vmstate & (J9VMTHREAD_STATE_PARKED | J9VMTHREAD_STATE_PARKED_TIMED)))) { 
-				*monitor_ptr = (jobject) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, lockObject);
+				rv_monitor = (jobject) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, lockObject);
 			} else {
-				*monitor_ptr = NULL;
+				rv_monitor = NULL;
 			}
 
 			vm->internalVMFunctions->resumeThreadForInspection(currentThread, targetThread);
@@ -716,6 +757,9 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != monitor_ptr) {
+		*monitor_ptr = rv_monitor;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetCurrentContendedMonitor);
 }
 
@@ -822,6 +866,7 @@ jvmtiGetThreadLocalStorage(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	J9VMThread * currentThread;
 	jvmtiError rc;
+	void *rv_data = NULL;
 
 	Trc_JVMTI_jvmtiGetThreadLocalStorage_Entry(env);
 
@@ -837,13 +882,16 @@ jvmtiGetThreadLocalStorage(jvmtiEnv* env,
 
 		rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 		if (rc == JVMTI_ERROR_NONE) {
-			*data_ptr = THREAD_DATA_FOR_VMTHREAD((J9JVMTIEnv *) env, targetThread)->tls;
+			rv_data = THREAD_DATA_FOR_VMTHREAD((J9JVMTIEnv *) env, targetThread)->tls;
 			releaseVMThread(currentThread, targetThread);
 		}
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != data_ptr) {
+		*data_ptr = rv_data;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetThreadLocalStorage);
 }
 
@@ -1013,6 +1061,7 @@ jvmtiGetCurrentThread(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	J9VMThread * currentThread;
 	jvmtiError rc;
+	jthread rv_thread = NULL;
 
 	Trc_JVMTI_jvmtiGetCurrentThread_Entry(env);
 
@@ -1024,11 +1073,14 @@ jvmtiGetCurrentThread(jvmtiEnv* env,
 
 		ENSURE_NON_NULL(thread_ptr);
 
-		*thread_ptr = (jthread) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t) currentThread->threadObject);
+		rv_thread = (jthread) vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *) currentThread, (j9object_t) currentThread->threadObject);
 done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != thread_ptr) {
+		*thread_ptr = rv_thread;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetCurrentThread);
 }
 

--- a/runtime/jvmti/jvmtiTimers.c
+++ b/runtime/jvmti/jvmtiTimers.c
@@ -30,6 +30,7 @@ jvmtiGetCurrentThreadCpuTimerInfo(jvmtiEnv* env,
 	jvmtiTimerInfo* info_ptr)
 {
 	jvmtiError rc;
+	jvmtiTimerInfo rv_info = {0};
 
 	Trc_JVMTI_jvmtiGetCurrentThreadCpuTimerInfo_Entry(env);
 
@@ -38,15 +39,16 @@ jvmtiGetCurrentThreadCpuTimerInfo(jvmtiEnv* env,
 
 	ENSURE_NON_NULL(info_ptr);
 
-	memset(info_ptr, 0, sizeof(jvmtiTimerInfo));
-
-	info_ptr->max_value = (jlong)-1;							/* according to JVMTI spec an unsigned value held as a jlong */
-	info_ptr->may_skip_forward = JNI_FALSE;
-	info_ptr->may_skip_backward = JNI_FALSE;
-	info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;
+	rv_info.max_value = (jlong)-1;							/* according to JVMTI spec an unsigned value held as a jlong */
+	rv_info.may_skip_forward = JNI_FALSE;
+	rv_info.may_skip_backward = JNI_FALSE;
+	rv_info.kind = JVMTI_TIMER_TOTAL_CPU;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != info_ptr) {
+		*info_ptr = rv_info;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetCurrentThreadCpuTimerInfo);
 }
 
@@ -56,6 +58,7 @@ jvmtiGetCurrentThreadCpuTime(jvmtiEnv* env,
 	jlong* nanos_ptr)
 {
 	jvmtiError rc;
+	jlong rv_nanos = 0;
 
 	Trc_JVMTI_jvmtiGetCurrentThreadCpuTime_Entry(env);
 
@@ -64,10 +67,13 @@ jvmtiGetCurrentThreadCpuTime(jvmtiEnv* env,
 
 	ENSURE_NON_NULL(nanos_ptr);
 
-	*nanos_ptr = (jlong)omrthread_get_self_cpu_time(omrthread_self());
+	rv_nanos = (jlong)omrthread_get_self_cpu_time(omrthread_self());
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != nanos_ptr) {
+		*nanos_ptr = rv_nanos;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetCurrentThreadCpuTime);
 }
 
@@ -77,6 +83,7 @@ jvmtiGetThreadCpuTimerInfo(jvmtiEnv* env,
 	jvmtiTimerInfo* info_ptr)
 {
 	jvmtiError rc;
+	jvmtiTimerInfo rv_info = {0};
 
 	Trc_JVMTI_jvmtiGetThreadCpuTimerInfo_Entry(env);
 
@@ -85,15 +92,16 @@ jvmtiGetThreadCpuTimerInfo(jvmtiEnv* env,
 
 	ENSURE_NON_NULL(info_ptr);
 
-	memset(info_ptr, 0, sizeof(jvmtiTimerInfo));
-
-	info_ptr->max_value = (jlong)-1;							/* according to JVMTI spec an unsigned value held as a jlong */
-	info_ptr->may_skip_forward = JNI_FALSE;
-	info_ptr->may_skip_backward = JNI_FALSE;
-	info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;
+	rv_info.max_value = (jlong)-1;							/* according to JVMTI spec an unsigned value held as a jlong */
+	rv_info.may_skip_forward = JNI_FALSE;
+	rv_info.may_skip_backward = JNI_FALSE;
+	rv_info.kind = JVMTI_TIMER_TOTAL_CPU;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != info_ptr) {
+		*info_ptr = rv_info;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetThreadCpuTimerInfo);
 }
 
@@ -106,6 +114,7 @@ jvmtiGetThreadCpuTime(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	J9VMThread * currentThread;
 	jvmtiError rc;
+	jlong rv_nanos = 0;
 
 	Trc_JVMTI_jvmtiGetThreadCpuTime_Entry(env);
 
@@ -120,14 +129,14 @@ jvmtiGetThreadCpuTime(jvmtiEnv* env,
 
 		if (thread == NULL) {
 			ENSURE_NON_NULL(nanos_ptr);
-			*nanos_ptr = (jlong)omrthread_get_cpu_time(omrthread_self());
+			rv_nanos = (jlong)omrthread_get_cpu_time(omrthread_self());
 		} else {
 			rc = getVMThread(currentThread, thread, &targetThread, TRUE, TRUE);
 			if (rc == JVMTI_ERROR_NONE) {
 				if (nanos_ptr == NULL) {
 					rc = JVMTI_ERROR_NULL_POINTER;
 				} else {
-					*nanos_ptr = (jlong)omrthread_get_cpu_time(targetThread->osThread);
+					rv_nanos = (jlong)omrthread_get_cpu_time(targetThread->osThread);
 				}
 				releaseVMThread(currentThread, targetThread);
 			}
@@ -136,6 +145,9 @@ done:
 		vm->internalVMFunctions->internalExitVMToJNI(currentThread);
 	}
 
+	if (NULL != nanos_ptr) {
+		*nanos_ptr = rv_nanos;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetThreadCpuTime);
 }
 
@@ -145,20 +157,22 @@ jvmtiGetTimerInfo(jvmtiEnv* env,
 	jvmtiTimerInfo* info_ptr)
 {
 	jvmtiError rc;
+	jvmtiTimerInfo rv_info = {0};
 
 	Trc_JVMTI_jvmtiGetTimerInfo_Entry(env);
 
 	ENSURE_NON_NULL(info_ptr);
 
-	memset(info_ptr, 0, sizeof(jvmtiTimerInfo));
-
-	info_ptr->max_value = (jlong)-1;							/* according to JVMTI spec an unsigned value held as a jlong */
-	info_ptr->may_skip_forward = JNI_TRUE;
-	info_ptr->may_skip_backward = JNI_TRUE;
-	info_ptr->kind = JVMTI_TIMER_ELAPSED;
+	rv_info.max_value = (jlong)-1;							/* according to JVMTI spec an unsigned value held as a jlong */
+	rv_info.may_skip_forward = JNI_TRUE;
+	rv_info.may_skip_backward = JNI_TRUE;
+	rv_info.kind = JVMTI_TIMER_ELAPSED;
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != info_ptr) {
+		*info_ptr = rv_info;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetTimerInfo);
 }
 
@@ -172,6 +186,7 @@ jvmtiGetTime(jvmtiEnv* env,
 	jvmtiError rc;
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	jlong rv_nanos = 0;
 
 	Trc_JVMTI_jvmtiGetTime_Entry(env);
 
@@ -182,15 +197,18 @@ jvmtiGetTime(jvmtiEnv* env,
 
 	/* freq is "ticks per s" */
 	if ( freq == J9JVMTI_NANO_TICKS ) {
-		*nanos_ptr = ticks;
+		rv_nanos = ticks;
 	} else if ( freq < J9JVMTI_NANO_TICKS ) {
-		*nanos_ptr = ticks * (J9JVMTI_NANO_TICKS / freq);
+		rv_nanos = ticks * (J9JVMTI_NANO_TICKS / freq);
 	} else {
-		*nanos_ptr = ticks / (freq / J9JVMTI_NANO_TICKS);
+		rv_nanos = ticks / (freq / J9JVMTI_NANO_TICKS);
 	}
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != nanos_ptr) {
+		*nanos_ptr = rv_nanos;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetTime);
 }
 
@@ -203,6 +221,7 @@ jvmtiGetAvailableProcessors(jvmtiEnv* env,
 	J9JavaVM * vm = JAVAVM_FROM_ENV(env);
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	UDATA cpuCount;
+	jint rv_processor_count = 0;
 
 	Trc_JVMTI_jvmtiGetAvailableProcessors_Entry(env);
 
@@ -210,10 +229,13 @@ jvmtiGetAvailableProcessors(jvmtiEnv* env,
 
 	/* This implementation should be kept consistent with JVM_ActiveProcessorCount */
 	cpuCount = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET);
-	*processor_count_ptr = ((cpuCount < 1) ? 1 : (jint) cpuCount);
+	rv_processor_count = ((cpuCount < 1) ? 1 : (jint) cpuCount);
 	rc = JVMTI_ERROR_NONE;
 
 done:
+	if (NULL != processor_count_ptr) {
+		*processor_count_ptr = rv_processor_count;
+	}
 	TRACE_JVMTI_RETURN(jvmtiGetAvailableProcessors);
 }
 


### PR DESCRIPTION
Fix all appropriate JVMTI calls to store return value information in
local variables which are initialized to consistent values, and assign
those values at the end of the function unconditionally to any return
pointer which is not NULL.

This does introduce some extra NULL checks for return pointers, but
should have no noticeable performance impact.

Notably not included in this are parameters which describe a
user-allocated buffer (the buffers may or may not be fully or partially
filled in in error situations).

Fixes: #3398

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>