### PR TITLE
Temporarily disable DDR test on osx

### DIFF
--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -99,14 +99,16 @@
 	</target>
 
 	<!-- Temporarily disable compilation on zos and aix until ddr is supported; github.com/eclipse/openj9/issues/1511 -->
+	<!-- Temporarily disable compilation osx until ddr is supported; github.com/eclipse/openj9/issues/3366 -->
 	<target name="build" >
+		<echo>os.name:	${os.name}</echo>
 		<if>
 			<and>
 				<not>
 					<equals arg1="${os.name}" arg2="z/OS" />
 				</not>
 				<not>
-					<matches string="${os.name}" pattern="AIX" />
+					<matches string="${os.name}" pattern="AIX|(Mac OS X)" />
 				</not>
 			</and>
 			<then>

--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -54,7 +54,8 @@
 	-Dtest.list=$(Q)TestDDRExtensionGeneral$(Q) -DADDITIONALEXPORTS=-showversion -f $(Q)$(TEST_RESROOT)$(D)tck_ddrext.xml$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.aix,^os.zos,^os.win</platformRequirements>
+		<!-- temporarily disable this test on osx; github.com/eclipse/openj9/issues/3366 -->
+		<platformRequirements>^os.aix,^os.zos,^os.win,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Temporarily disable DDR test compilation and execution on osx until it
is enabled on osx

Issue: #3366
[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>