### PR TITLE
Temporarily disable DDR cmdLineTests on osx

### DIFF
--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -93,8 +93,8 @@
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)callsiteddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.aix,^os.zos</platformRequirements>
+		<!-- temporarily disable this test on AIX, z/OS and osx; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.aix,^os.zos,^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/playlist.xml
@@ -71,8 +71,8 @@
 	-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
 	-xlist $(Q)$(TEST_RESROOT)$(D)dbgextddrtests_excludes.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- j9ddr.jar is not supported on AIX or z/OS; OpenJ9 issue 1511 -->
-		<platformRequirements>^os.aix,^os.zos</platformRequirements>
+		<!-- j9ddr.jar is not supported on AIX, z/OS and osx; OpenJ9 issue 1511 -->
+		<platformRequirements>^os.aix,^os.zos,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/modularityddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/playlist.xml
@@ -40,8 +40,8 @@
 	-config $(Q)$(TEST_RESROOT)$(D)modularityddrtests.xml$(Q) \
 	-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- Tests excluded on zos and aix because neither platform supports DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
-		<platformRequirements>^os.zos,^os.aix</platformRequirements>
+		<!-- Tests excluded on zos, aix and osx because they do not support DDR yet. Please see https://github.com/eclipse/openj9/issues/1511 for updates -->
+		<platformRequirements>^os.zos,^os.aix,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/playlist.xml
@@ -41,8 +41,8 @@
 	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)shrcdbgextddrtests.xml$(Q) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on AIX, z/OS; github.com/eclipse/openj9/issues/1511 -->
-		<platformRequirements>^os.aix,^os.zos</platformRequirements>
+		<!-- temporarily disable this test on AIX, z/OS and osx; github.com/eclipse/openj9/issues/1511 -->
+		<platformRequirements>^os.aix,^os.zos,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Temporarily disable DDR cmdLineTests on osx until it is supported on osx

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>