### PR TITLE
Refactor code related to method fanin

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5797,55 +5797,6 @@ TR_J9VMBase::getMaxCallGraphCallCount()
    return profiler->getMaxCallCount();
    }
 
-void
-TR_J9VMBase::getNumberofCallersAndTotalWeight(TR_OpaqueMethodBlock *method, uint32_t *count, uint32_t *weight)
-   {
-   TR_IProfiler *profiler = getIProfiler();
-
-   if (!profiler)
-      {
-      return;
-      }
-
-   profiler->getNumberofCallersAndTotalWeight(method,count,weight);
-   return;
-   }
-
-uint32_t
-TR_J9VMBase::getOtherBucketWeight(TR_OpaqueMethodBlock *method)
-   {
-   TR_IProfiler *profiler = getIProfiler();
-
-   if (!profiler)
-      {
-      return 0;
-      }
-
-   return profiler->getOtherBucketWeight(method);
-   }
-
-bool
-TR_J9VMBase::getCallerWeight(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *callerMethod , uint32_t *weight)
-   {
-   TR_IProfiler *profiler = getIProfiler();
-
-   if (!profiler)
-      return 0;
-
-   return profiler->getCallerWeight(calleeMethod,callerMethod, weight);
-   }
-bool
-TR_J9VMBase::getCallerWeight(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *callerMethod , uint32_t *weight, uint32_t pcIndex)
-   {
-   TR_IProfiler *profiler = getIProfiler();
-
-   if (!profiler)
-      return 0;
-
-   return profiler->getCallerWeight(calleeMethod,callerMethod, weight, pcIndex);
-   }
-
-
 int32_t
 TR_J9VMBase::getIProfilerCallCount(TR_OpaqueMethodBlock *caller, int32_t bcIndex, TR::Compilation * comp)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -845,11 +845,6 @@ public:
    virtual bool    isClassLibraryClass(TR_OpaqueClassBlock *clazz);
    virtual int32_t getMaxCallGraphCallCount();
 
-   virtual void getNumberofCallersAndTotalWeight(TR_OpaqueMethodBlock *method, uint32_t *count, uint32_t *weight);
-   virtual uint32_t getOtherBucketWeight(TR_OpaqueMethodBlock *method);
-   virtual bool getCallerWeight(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *callerMethod , uint32_t *weight);
-   virtual bool getCallerWeight(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *callerMethod , uint32_t *weight, uint32_t pcIndex);
-
    virtual bool    getSupportsRecognizedMethods();
 
    // Hardware profiling support

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5350,6 +5350,29 @@ void TR_ResolvedJ9Method::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilati
       fej9()->getIProfiler()->setWarmCallGraphTooBig((TR_OpaqueMethodBlock *)ramMethod(), bcIndex, comp, true);
    }
 
+void
+TR_ResolvedJ9Method::getFaninInfo(uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight)
+   {
+   TR_IProfiler *profiler = fej9()->getIProfiler();
+
+   if (!profiler)
+      return;
+
+   TR_OpaqueMethodBlock *method = getPersistentIdentifier();
+   profiler->getFaninInfo(method, count, weight, otherBucketWeight);
+   }
+
+bool
+TR_ResolvedJ9Method::getCallerWeight(TR_ResolvedJ9Method *caller, uint32_t *weight, uint32_t pcIndex)
+   {
+   TR_IProfiler *profiler = fej9()->getIProfiler();
+
+   if (!profiler)
+      return false;
+
+   return profiler->getCallerWeight(getPersistentIdentifier(), caller->getPersistentIdentifier(), weight, pcIndex);
+   }
+
 void *
 TR_ResolvedJ9Method::startAddressForInterpreterOfJittedMethod()
    {

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -304,6 +304,9 @@ public:
    virtual void *                startAddressForInterpreterOfJittedMethod();
    virtual bool                  isWarmCallGraphTooBig(uint32_t bcIndex,  TR::Compilation *);
    virtual void                  setWarmCallGraphTooBig(uint32_t bcIndex,  TR::Compilation *);
+   virtual void                  getFaninInfo(uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight=nullptr);
+   virtual bool                  getCallerWeight(TR_ResolvedJ9Method *caller, uint32_t *weight, uint32_t pcIndex=~0);
+
 
    virtual intptrj_t             getInvocationCount();
    virtual bool                  setInvocationCount(intptrj_t oldCount, intptrj_t newCount);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2216,15 +2216,17 @@ TR_J9InlinerPolicy::adjustFanInSizeInWeighCallSite(int32_t& weight,
       static const float otherBucketThreshold = (qqq) ? (float)  (atoi (qqq) /100.0) : FANIN_OTHER_BUCKET_THRESHOLD ;
 
       //convenience
-      TR_OpaqueMethodBlock* j9methodCallee = callee->getPersistentIdentifier();
+      TR_ResolvedJ9Method *resolvedJ9Callee = (TR_ResolvedJ9Method *) callee;
+      TR_ResolvedJ9Method *resolvedJ9Caller = (TR_ResolvedJ9Method *) caller;
 
-      uint32_t numCallers = 0, totalWeight = 0, fanInWeight = 0;
-      comp()->fej9()->getNumberofCallersAndTotalWeight(j9methodCallee,&numCallers,&totalWeight);
 
-      if (numCallers < MIN_NUM_CALLERS || (totalWeight > 0 && comp()->fej9()->getOtherBucketWeight(j9methodCallee)*1.0 / totalWeight < otherBucketThreshold))
+      uint32_t numCallers = 0, totalWeight = 0, fanInWeight = 0, otherBucketWeight = 0;
+      resolvedJ9Callee->getFaninInfo(&numCallers, &totalWeight, &otherBucketWeight);
+
+      if (numCallers < MIN_NUM_CALLERS || (totalWeight > 0 && otherBucketWeight * 1.0 / totalWeight < otherBucketThreshold))
          return;
 
-      bool hasCaller = comp()->fej9()->getCallerWeight(j9methodCallee,caller->getPersistentIdentifier(), &fanInWeight, bcIndex);
+      bool hasCaller = resolvedJ9Callee->getCallerWeight(resolvedJ9Caller, &fanInWeight, bcIndex); 
 
       if (size >= 0 && totalWeight && fanInWeight)
          {
@@ -2329,19 +2331,20 @@ TR_J9InlinerPolicy::adjustFanInSizeInExceedsSizeThreshold(int bytecodeSize,
       return false;
       }
 
-   TR_OpaqueMethodBlock* j9methodCallee = callee->getPersistentIdentifier();
+   TR_ResolvedJ9Method *resolvedJ9Callee = (TR_ResolvedJ9Method *) callee;
+   TR_ResolvedJ9Method *resolvedJ9Caller = (TR_ResolvedJ9Method *) caller;
 
-   uint32_t numCallers = 0, totalWeight = 0;
+   uint32_t numCallers = 0, totalWeight = 0, otherBucketWeight = 0;
    float dynamicFanInRatio = 0.0;
-   comp()->fej9()->getNumberofCallersAndTotalWeight(j9methodCallee,&numCallers,&totalWeight);
+   resolvedJ9Callee->getFaninInfo(&numCallers, &totalWeight, &otherBucketWeight);
 
-   if (numCallers < MIN_NUM_CALLERS || (totalWeight > 0 && comp()->fej9()->getOtherBucketWeight(j9methodCallee)*1.0 / totalWeight < otherBucketThreshold))
+   if (numCallers < MIN_NUM_CALLERS || (totalWeight > 0 && otherBucketWeight * 1.0 / totalWeight < otherBucketThreshold))
      return false;
 
 
 
    uint32_t weight = 0;
-   bool hasCaller = comp()->fej9()->getCallerWeight(j9methodCallee,caller->getPersistentIdentifier(), &weight, bcIndex);
+   bool hasCaller = resolvedJ9Callee->getCallerWeight(resolvedJ9Caller, &weight, bcIndex);
 
    /*
     * We assume that if the caller lands in the other bucket it is not worth trouble inlining
@@ -4139,7 +4142,7 @@ int32_t TR_MultipleCallTargetInliner::scaleSizeBasedOnBlockFrequency(int32_t byt
 bool TR_MultipleCallTargetInliner::isLargeCompiledMethod(TR_ResolvedMethod *calleeResolvedMethod, int32_t bytecodeSize, int32_t callerBlockFrequency)
    {
    TR_OpaqueMethodBlock* methodCallee = calleeResolvedMethod->getPersistentIdentifier();
-   if (TR::Compiler->mtd.isCompiledMethod(methodCallee))
+   if (!calleeResolvedMethod->isInterpreted())
       {
       void * methodAddress = calleeResolvedMethod->startAddressForInterpreterOfJittedMethod();
       TR_PersistentJittedBodyInfo * bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(methodAddress);
@@ -4171,7 +4174,7 @@ bool TR_MultipleCallTargetInliner::isLargeCompiledMethod(TR_ResolvedMethod *call
                }
 
             uint32_t numCallers = 0, totalWeight = 0;
-            comp()->fej9()->getNumberofCallersAndTotalWeight(methodCallee, &numCallers, &totalWeight);
+            ((TR_ResolvedJ9Method *) calleeResolvedMethod)->getFaninInfo(&numCallers, &totalWeight);
             if ((numCallers > veryLargeCompiledMethodFaninThreshold) &&
                 (bytecodeSize > veryLargeCompiledMethodThreshold))
                {

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3488,17 +3488,20 @@ void TR_IProfiler::checkMethodHashTable()
       }
    }
 
-void TR_IProfiler::getNumberofCallersAndTotalWeight(TR_OpaqueMethodBlock *calleeMethod, uint32_t *count, uint32_t *weight)
+void
+TR_IProfiler::getFaninInfo(TR_OpaqueMethodBlock *calleeMethod, uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight)
    {
    uint32_t i = 0;
    uint32_t w = 0;
+   uint32_t other = 0;
 
    // Search for the callee in the hashtable
-   int32_t bucket = methodHash((uintptrj_t)calleeMethod);
-   TR_IPMethodHashTableEntry *entry = searchForMethodSample((TR_OpaqueMethodBlock*)calleeMethod, bucket);
+   int32_t bucket = methodHash((uintptrj_t) calleeMethod);
+   TR_IPMethodHashTableEntry *entry = searchForMethodSample((TR_OpaqueMethodBlock*) calleeMethod, bucket);
    if (entry)
       {
-      w = entry->_otherBucket.getWeight();
+      other = entry->_otherBucket.getWeight();
+      w = other;
       // Iterate through all the callers and add their weight
       for (TR_IPMethodData* it = &entry->_caller; it; it = it->next)
          {
@@ -3508,22 +3511,10 @@ void TR_IProfiler::getNumberofCallersAndTotalWeight(TR_OpaqueMethodBlock *callee
       }
    *weight = w;
    *count = i;
+   if (otherBucketWeight)
+      *otherBucketWeight = other;
+   return;
    }
-
-uint32_t TR_IProfiler::getOtherBucketWeight(TR_OpaqueMethodBlock *calleeMethod)
-   {
-   int32_t bucket = methodHash((uintptrj_t)calleeMethod);
-
-   TR_IPMethodHashTableEntry *entry = searchForMethodSample((TR_OpaqueMethodBlock*)calleeMethod, bucket);
-
-   if(!entry)   // if there are no entries, we have no callers!
-      return 0;
-
-   return entry->_otherBucket.getWeight();
-
-
-   }
-
 
 bool TR_IProfiler::getCallerWeight(TR_OpaqueMethodBlock *calleeMethod,TR_OpaqueMethodBlock *callerMethod, uint32_t *weight, uint32_t pcIndex, TR::Compilation *comp)
 {

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -507,11 +507,11 @@ public:
 
    int32_t getMaxCallCount();
 
-   //VMJ9.cpp
-   void getNumberofCallersAndTotalWeight(TR_OpaqueMethodBlock *calleeMethod,uint32_t *count, uint32_t *weight);
-   uint32_t getOtherBucketWeight(TR_OpaqueMethodBlock *calleeMethod);
+   //j9method.cpp
+   void getFaninInfo(TR_OpaqueMethodBlock *calleeMethod, uint32_t *count, uint32_t *weight, uint32_t *otherBucketWeight = nullptr);
    bool getCallerWeight(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *callerMethod , uint32_t *weight, uint32_t pcIndex = ~0, TR::Compilation *comp = 0);
 
+   //VMJ9.cpp
    int32_t getCallCount(TR_OpaqueMethodBlock *calleeMethod, TR_OpaqueMethodBlock *method, int32_t bcIndex, TR::Compilation *);
    int32_t getCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, TR::Compilation *);
    int32_t getCallCount(TR_ByteCodeInfo &bcInfo, TR::Compilation *comp);


### PR DESCRIPTION
- Refactor interpreter profiling methods `getNumberofCallersAndTotalWeight`
and `getOtherBucketWeight` into one method - `getFaninInfo`.
These 2 methods are usually called together, so it makes sense
to make them one method. This also reduces the number of times
a hashtable of method samples is searched.

- Move calls that access fanin info from the front-end to resolved method.
This information is only accessed from the inliner, where we always have
a resolved method. This also makes fanin info more easily accessible for
a downstream project.

Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>