### PR TITLE
Optimize GetOwnedMonitorInfo

### DIFF
--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -63,6 +63,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "gomsdi001", gomsdi001, "com.ibm.jvmti.tests.getOwnedMonitorStackDepthInfo.gomsdi001", "GetOwnedMonitorStackDepthInfo" },
 	{ "gomsdi002", gomsdi002, "com.ibm.jvmti.tests.getOwnedMonitorStackDepthInfo.gomsdi002", "GetOwnedMonitorStackDepthInfo" },
 	{ "gomi001", gomi001, "com.ibm.jvmti.tests.getOwnedMonitorInfo.gomi001", "GetOwnedMonitorInfo" },
+	{ "gomi002", gomi002, "com.ibm.jvmti.tests.getOwnedMonitorInfo.gomi002", "GetOwnedMonitorInfo" },
 	{ "abcl001", abcl001, "com.ibm.jvmti.tests.addToBootstrapClassLoaderSearch.abcl001", "AddToBootstrapClassLoaderSearch during OnLoad" },
 	{ "abcl002", abcl002, "com.ibm.jvmti.tests.addToBootstrapClassLoaderSearch.abcl002", "AddToBootstrapClassLoaderSearch during live" },
 	{ "abcl003", abcl003, "com.ibm.jvmti.tests.addToBootstrapClassLoaderSearch.abcl003", "AddToBootstrapClassLoaderSearch reject bad jar during live" },

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -210,6 +210,7 @@ jint JNICALL gtgc002(agentEnv * env, char * args);
 jint JNICALL gomsdi001(agentEnv * env, char * args);
 jint JNICALL gomsdi002(agentEnv * env, char * args);
 jint JNICALL gomi001(agentEnv * env, char * args);
+jint JNICALL gomi002(agentEnv * env, char * args);
 jint JNICALL gts001(agentEnv * env, char * args);
 jint JNICALL ghftm001(agentEnv * env, char * args);
 jint JNICALL rat001(agentEnv * env, char * args);

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -123,6 +123,7 @@
 		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_gomsdi002_callGet"/>
 		<export name="Java_com_ibm_jvmti_tests_getThreadState_gts001_getThreadStates"/>
 		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorInfo_ThreadMonitorInfoTest_verifyMonitors"/>
+		<export name="Java_com_ibm_jvmti_tests_getOwnedMonitorInfo_gomi002_callGet"/>
 		<export name="Java_com_ibm_jvmti_tests_getHeapFreeTotalMemory_ghftm001_getHeapFreeMemory"/>
 		<export name="Java_com_ibm_jvmti_tests_getHeapFreeTotalMemory_ghftm001_getHeapTotalMemory"/>
 		<export name="Java_com_ibm_jvmti_tests_getHeapFreeTotalMemory_ghftm001_getCycleStartCount"/>

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/getOrSetLocal/gosl001.c
 
 	com/ibm/jvmti/tests/getOwnedMonitorInfo/gomi001.c
+	com/ibm/jvmti/tests/getOwnedMonitorInfo/gomi002.c
 
 	com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi001.c
 	com/ibm/jvmti/tests/getOwnedMonitorStackDepthInfo/gomsdi002.c

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getOwnedMonitorInfo/gomi002.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getOwnedMonitorInfo/gomi002.c
@@ -28,7 +28,7 @@
 static agentEnv * env;                                                    
 
 jint JNICALL
-gomsdi002(agentEnv * agent_env, char * args)
+gomi002(agentEnv * agent_env, char * args)
 {
 	JVMTI_ACCESS_FROM_AGENT(agent_env);                                
 	jvmtiCapabilities capabilities;
@@ -37,7 +37,7 @@ gomsdi002(agentEnv * agent_env, char * args)
 	env = agent_env;
 
 	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
-	capabilities.can_get_owned_monitor_stack_depth_info = 1;
+	capabilities.can_get_owned_monitor_info = 1;
 	err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
 	if (err != JVMTI_ERROR_NONE) {
 		error(env, err, "Failed to add capabilities");
@@ -48,14 +48,14 @@ gomsdi002(agentEnv * agent_env, char * args)
 }
 
 void JNICALL
-Java_com_ibm_jvmti_tests_getOwnedMonitorStackDepthInfo_gomsdi002_callGet(
+Java_com_ibm_jvmti_tests_getOwnedMonitorInfo_gomi002_callGet(
 		JNIEnv *jni_env, 
 		jclass klass, 
 		jthread thread) 
 {
 	JVMTI_ACCESS_FROM_AGENT(env);
 	jint infoCount = 0;
-	jvmtiMonitorStackDepthInfo *info = NULL;
-	(*jvmti_env)->GetOwnedMonitorStackDepthInfo(jvmti_env, thread, &infoCount, &info);
+	jobject *info = NULL;
+	(*jvmti_env)->GetOwnedMonitorInfo(jvmti_env, thread, &infoCount, &info);
 	(*jvmti_env)->Deallocate(jvmti_env, (unsigned char*)info);
 }

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -234,6 +234,11 @@
 		<return type="success" value="0"/>
 	</test>
 
+ 	<test id="gomi002">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:gomi002 -Xint -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<return type="success" value="0"/>
+	</test>
+
 	<test id="Destroy shared class cache created by previous test.">
  		<command>$EXE$ $JVM_OPTS$ -Xshareclasses:destroyAll</command>
 		<return type="success" value="1"/>


### PR DESCRIPTION
Use haltThreadForInspection instead of exclusive VM access to halt the
target thread.

Add a test to call GetOwnedMonitorInfo repeatedly on a running foreign
thread.

Fixes: #3500

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>