### PR TITLE
DDR updates for examining thread stacks

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.j9.stackwalker;
 
-import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 
 /**
  * JIT register map.
@@ -29,234 +29,85 @@ import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
  * Per-platform register information reproduced here rather than embedded in blob.
  * 
  * @author andhall
- *
  */
-public class JITRegMap
-{
+public class JITRegMap {
 
 	static final String jitRegisterNames[];
-	
+
 	static final int jitCalleeDestroyedRegisterList[];
-	
+
 	static final int jitCalleeSavedRegisterList[];
-	
-	static
-	{
-		
-		if (TRBuildFlags.host_X86 && TRBuildFlags.host_32BIT) {
-			jitRegisterNames = new String[]{
-				"jit_eax",
-				"jit_ebx",
-				"jit_ecx",
-				"jit_edx",
-				"jit_edi",
-				"jit_esi",
-				"jit_ebp"
-			};
-			
-			jitCalleeDestroyedRegisterList = new int[] {
-				0x00,   /* jit_eax */
-				0x03,   /* jit_edx */
-				0x04,   /* jit_edi */
-				0x06    /* jit_ebp */
-			};
-			
-			jitCalleeSavedRegisterList = new int[] {
-				0x05,   /* jit_esi */
-				0x02,   /* jit_ecx */
-				0x01    /* jit_ebx */
-			};
-		} else if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
-			jitRegisterNames = new String[]{
-					"jit_rax",
-					"jit_rbx",
-					"jit_rcx",
-					"jit_rdx",
-					"jit_rdi",
-					"jit_rsi",
-					"jit_rbp",
-					"jit_rsp",
-					"jit_r8",
-					"jit_r9",
-					"jit_r10",
-					"jit_r11",
-					"jit_r12",
-					"jit_r13",
-					"jit_r14",
-					"jit_r15"
+
+	static {
+		if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (!J9BuildFlags.env_data64) {
+				jitRegisterNames = new String[] {
+						"jit_eax",
+						"jit_ebx",
+						"jit_ecx",
+						"jit_edx",
+						"jit_edi",
+						"jit_esi",
+						"jit_ebp"
 				};
-				
-			jitCalleeDestroyedRegisterList = new int[] {
-					0x00,   /* jit_rax */
-					0x02,   /* jit_rcx */
-					0x03,   /* jit_rdx */
-					0x04,   /* jit_rdi */
-					0x05,   /* jit_rsi */
-					0x06,   /* jit_rbp */
-					0x07,   /* jit_rsp */
-					0x08    /* jit_r8 */
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_eax */
+						0x03,   /* jit_edx */
+						0x04,   /* jit_edi */
+						0x06    /* jit_ebp */
 				};
-				
-			jitCalleeSavedRegisterList = new int[] {
-					0x01,   /* jit_rbx */
-					0x0F,   /* jit_r15 */
-					0x0E,   /* jit_r14 */
-					0x0D,   /* jit_r13 */
-					0x0C,   /* jit_r12 */
-					0x0B,   /* jit_r11 */
-					0x0A,   /* jit_r10 */
-					0x09    /* jit_r9 */
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x05,   /* jit_esi */
+						0x02,   /* jit_ecx */
+						0x01    /* jit_ebx */
 				};
-		} else if (TRBuildFlags.host_POWER && TRBuildFlags.host_32BIT) {
-			jitRegisterNames = new String[]{
-					"jit_r0",
-					"jit_r1",
-					"jit_r2",
-					"jit_r3",
-					"jit_r4",
-					"jit_r5",
-					"jit_r6",
-					"jit_r7",
-					"jit_r8",
-					"jit_r9",
-					"jit_r10",
-					"jit_r11",
-					"jit_r12",
-					"jit_r13",
-					"jit_r14",
-					"jit_r15",
-					"jit_r16",
-					"jit_r17",
-					"jit_r18",
-					"jit_r19",
-					"jit_r20",
-					"jit_r21",
-					"jit_r22",
-					"jit_r23",
-					"jit_r24",
-					"jit_r25",
-					"jit_r26",
-					"jit_r27",
-					"jit_r28",
-					"jit_r29",
-					"jit_r30",
-					"jit_r31"
+			} else {
+				jitRegisterNames = new String[] {
+						"jit_rax",
+						"jit_rbx",
+						"jit_rcx",
+						"jit_rdx",
+						"jit_rdi",
+						"jit_rsi",
+						"jit_rbp",
+						"jit_rsp",
+						"jit_r8",
+						"jit_r9",
+						"jit_r10",
+						"jit_r11",
+						"jit_r12",
+						"jit_r13",
+						"jit_r14",
+						"jit_r15"
 				};
-				
-			jitCalleeDestroyedRegisterList = new int[] {
-					0x00,   /* jit_r0 */
-					0x01,   /* jit_r1 */
-					0x02,   /* jit_r2 */
-					0x03,   /* jit_r3 */
-					0x04,   /* jit_r4 */
-					0x05,   /* jit_r5 */
-					0x06,   /* jit_r6 */
-					0x07,   /* jit_r7 */
-					0x08,   /* jit_r8 */
-					0x09,   /* jit_r9 */
-					0x0A,   /* jit_r10 */
-					0x0B,   /* jit_r11 */
-					0x0C,   /* jit_r12 */
-					0x0D,   /* jit_r13 */
-					0x0E    /* jit_r14 */
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_rax */
+						0x02,   /* jit_rcx */
+						0x03,   /* jit_rdx */
+						0x04,   /* jit_rdi */
+						0x05,   /* jit_rsi */
+						0x06,   /* jit_rbp */
+						0x07,   /* jit_rsp */
+						0x08    /* jit_r8 */
 				};
-				
-			jitCalleeSavedRegisterList = new int[] {
-					0x1F,   /* jit_r31 */
-					0x1E,   /* jit_r30 */
-					0x1D,   /* jit_r29 */
-					0x1C,   /* jit_r28 */
-					0x1B,   /* jit_r27 */
-					0x1A,   /* jit_r26 */
-					0x19,   /* jit_r25 */
-					0x18,   /* jit_r24 */
-					0x17,   /* jit_r23 */
-					0x16,   /* jit_r22 */
-					0x15,   /* jit_r21 */
-					0x14,   /* jit_r20 */
-					0x13,   /* jit_r19 */
-					0x12,   /* jit_r18 */
-					0x11,   /* jit_r17 */
-					0x10,   /* jit_r16 */
-					0x0F    /* jit_r15 */
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x01,   /* jit_rbx */
+						0x0F,   /* jit_r15 */
+						0x0E,   /* jit_r14 */
+						0x0D,   /* jit_r13 */
+						0x0C,   /* jit_r12 */
+						0x0B,   /* jit_r11 */
+						0x0A,   /* jit_r10 */
+						0x09    /* jit_r9 */
 				};
-		} else if (TRBuildFlags.host_POWER && TRBuildFlags.host_64BIT) {
-			jitRegisterNames = new String[]{
-					"jit_r0",
-					"jit_r1",
-					"jit_r2",
-					"jit_r3",
-					"jit_r4",
-					"jit_r5",
-					"jit_r6",
-					"jit_r7",
-					"jit_r8",
-					"jit_r9",
-					"jit_r10",
-					"jit_r11",
-					"jit_r12",
-					"jit_r13",
-					"jit_r14",
-					"jit_r15",
-					"jit_r16",
-					"jit_r17",
-					"jit_r18",
-					"jit_r19",
-					"jit_r20",
-					"jit_r21",
-					"jit_r22",
-					"jit_r23",
-					"jit_r24",
-					"jit_r25",
-					"jit_r26",
-					"jit_r27",
-					"jit_r28",
-					"jit_r29",
-					"jit_r30",
-					"jit_r31"
-				};
-				
-			jitCalleeDestroyedRegisterList = new int[] {
-					0x00,   /* jit_r0 */
-					0x01,   /* jit_r1 */
-					0x02,   /* jit_r2 */
-					0x03,   /* jit_r3 */
-					0x04,   /* jit_r4 */
-					0x05,   /* jit_r5 */
-					0x06,   /* jit_r6 */
-					0x07,   /* jit_r7 */
-					0x08,   /* jit_r8 */
-					0x09,   /* jit_r9 */
-					0x0A,   /* jit_r10 */
-					0x0B,   /* jit_r11 */
-					0x0C,   /* jit_r12 */
-					0x0D,   /* jit_r13 */
-					0x0E,   /* jit_r14 */
-					0x0F    /* jit_r15 */
-				};
-				
-			jitCalleeSavedRegisterList = new int[] {
-					0x1F,   /* jit_r31 */
-					0x1E,   /* jit_r30 */
-					0x1D,   /* jit_r29 */
-					0x1C,   /* jit_r28 */
-					0x1B,   /* jit_r27 */
-					0x1A,   /* jit_r26 */
-					0x19,   /* jit_r25 */
-					0x18,   /* jit_r24 */
-					0x17,   /* jit_r23 */
-					0x16,   /* jit_r22 */
-					0x15,   /* jit_r21 */
-					0x14,   /* jit_r20 */
-					0x13,   /* jit_r19 */
-					0x12,   /* jit_r18 */
-					0x11,   /* jit_r17 */
-					0x10    /* jit_r16 */
-				};
-		} else {
-			//390 32 & 64
-			if (TRBuildFlags.host_32BIT) {
-				jitRegisterNames = new String[]{
+			}
+		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			if (!J9BuildFlags.env_data64) {
+				jitRegisterNames = new String[] {
 						"jit_r0",
 						"jit_r1",
 						"jit_r2",
@@ -289,8 +140,156 @@ public class JITRegMap
 						"jit_r29",
 						"jit_r30",
 						"jit_r31"
-					};
-					
+				};
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_r0 */
+						0x01,   /* jit_r1 */
+						0x02,   /* jit_r2 */
+						0x03,   /* jit_r3 */
+						0x04,   /* jit_r4 */
+						0x05,   /* jit_r5 */
+						0x06,   /* jit_r6 */
+						0x07,   /* jit_r7 */
+						0x08,   /* jit_r8 */
+						0x09,   /* jit_r9 */
+						0x0A,   /* jit_r10 */
+						0x0B,   /* jit_r11 */
+						0x0C,   /* jit_r12 */
+						0x0D,   /* jit_r13 */
+						0x0E    /* jit_r14 */
+				};
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x1F,   /* jit_r31 */
+						0x1E,   /* jit_r30 */
+						0x1D,   /* jit_r29 */
+						0x1C,   /* jit_r28 */
+						0x1B,   /* jit_r27 */
+						0x1A,   /* jit_r26 */
+						0x19,   /* jit_r25 */
+						0x18,   /* jit_r24 */
+						0x17,   /* jit_r23 */
+						0x16,   /* jit_r22 */
+						0x15,   /* jit_r21 */
+						0x14,   /* jit_r20 */
+						0x13,   /* jit_r19 */
+						0x12,   /* jit_r18 */
+						0x11,   /* jit_r17 */
+						0x10,   /* jit_r16 */
+						0x0F    /* jit_r15 */
+				};
+			} else {
+				jitRegisterNames = new String[] {
+						"jit_r0",
+						"jit_r1",
+						"jit_r2",
+						"jit_r3",
+						"jit_r4",
+						"jit_r5",
+						"jit_r6",
+						"jit_r7",
+						"jit_r8",
+						"jit_r9",
+						"jit_r10",
+						"jit_r11",
+						"jit_r12",
+						"jit_r13",
+						"jit_r14",
+						"jit_r15",
+						"jit_r16",
+						"jit_r17",
+						"jit_r18",
+						"jit_r19",
+						"jit_r20",
+						"jit_r21",
+						"jit_r22",
+						"jit_r23",
+						"jit_r24",
+						"jit_r25",
+						"jit_r26",
+						"jit_r27",
+						"jit_r28",
+						"jit_r29",
+						"jit_r30",
+						"jit_r31"
+				};
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_r0 */
+						0x01,   /* jit_r1 */
+						0x02,   /* jit_r2 */
+						0x03,   /* jit_r3 */
+						0x04,   /* jit_r4 */
+						0x05,   /* jit_r5 */
+						0x06,   /* jit_r6 */
+						0x07,   /* jit_r7 */
+						0x08,   /* jit_r8 */
+						0x09,   /* jit_r9 */
+						0x0A,   /* jit_r10 */
+						0x0B,   /* jit_r11 */
+						0x0C,   /* jit_r12 */
+						0x0D,   /* jit_r13 */
+						0x0E,   /* jit_r14 */
+						0x0F    /* jit_r15 */
+				};
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x1F,   /* jit_r31 */
+						0x1E,   /* jit_r30 */
+						0x1D,   /* jit_r29 */
+						0x1C,   /* jit_r28 */
+						0x1B,   /* jit_r27 */
+						0x1A,   /* jit_r26 */
+						0x19,   /* jit_r25 */
+						0x18,   /* jit_r24 */
+						0x17,   /* jit_r23 */
+						0x16,   /* jit_r22 */
+						0x15,   /* jit_r21 */
+						0x14,   /* jit_r20 */
+						0x13,   /* jit_r19 */
+						0x12,   /* jit_r18 */
+						0x11,   /* jit_r17 */
+						0x10    /* jit_r16 */
+				};
+			}
+		} else if (J9BuildFlags.arch_s390) {
+			if (!J9BuildFlags.env_data64) {
+				jitRegisterNames = new String[] {
+						"jit_r0",
+						"jit_r1",
+						"jit_r2",
+						"jit_r3",
+						"jit_r4",
+						"jit_r5",
+						"jit_r6",
+						"jit_r7",
+						"jit_r8",
+						"jit_r9",
+						"jit_r10",
+						"jit_r11",
+						"jit_r12",
+						"jit_r13",
+						"jit_r14",
+						"jit_r15",
+						"jit_r16",
+						"jit_r17",
+						"jit_r18",
+						"jit_r19",
+						"jit_r20",
+						"jit_r21",
+						"jit_r22",
+						"jit_r23",
+						"jit_r24",
+						"jit_r25",
+						"jit_r26",
+						"jit_r27",
+						"jit_r28",
+						"jit_r29",
+						"jit_r30",
+						"jit_r31"
+				};
+
 				jitCalleeDestroyedRegisterList = new int[] {
 						0x00,	/* jit_r0 */
 						0x01,	/* jit_r1 */
@@ -311,7 +310,7 @@ public class JITRegMap
 						0x1E,	/* jit_r30 */
 						0x1F	/* jit_r31 */
 				};
-					
+
 				jitCalleeSavedRegisterList = new int[] {
 						0x1C,	/* jit_r28 */
 						0x1B,	/* jit_r27 */
@@ -330,7 +329,7 @@ public class JITRegMap
 				};
 			} else {
 				/* 390 64 bit */
-				jitRegisterNames = new String[]{
+				jitRegisterNames = new String[] {
 						"jit_r0",
 						"jit_r1",
 						"jit_r2",
@@ -347,8 +346,8 @@ public class JITRegMap
 						"jit_r13",
 						"jit_r14",
 						"jit_r15",
-					};
-					
+				};
+
 				jitCalleeDestroyedRegisterList = new int[] {
 						0x00,	/* jit_r0 */
 						0x01,	/* jit_r1 */
@@ -360,7 +359,7 @@ public class JITRegMap
 						0x0E,	/* jit_r14 */
 						0x0F,	/* jit_r15 */
 				};
-					
+
 				jitCalleeSavedRegisterList = new int[] {
 						0x0C,	/* jit_r12 */
 						0x0B,	/* jit_r11 */
@@ -371,8 +370,9 @@ public class JITRegMap
 						0x06	/* jit_r6 */
 				};
 			}
+		} else {
+			throw new InternalError("Unsupported platform");
 		}
-		
 	}
-	
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -159,7 +159,7 @@ public class JITStackWalker
 		
 		private static U8Pointer MASK_PC(AbstractPointer ptr)
 		{
-			if (TRBuildFlags.host_S390 && TRBuildFlags.host_32BIT) {
+			if (J9BuildFlags.arch_s390 && !J9BuildFlags.env_data64) {
 				return U8Pointer.cast(UDATA.cast(ptr).bitAnd(0x7FFFFFFF));
 			} else {
 				return U8Pointer.cast(ptr);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -394,26 +394,28 @@ public class MethodMetaData
 		
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 data resolve shape
-				 16 slots of XMM registers
-				 16 slots of scalar registers
-				 1 slot flags
-				 1 slot call from snippet
-				 1 slot call from codecache to snippet
-				 */
-				return new UDATA(16);
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 data resolve shape
-				 20 slots FP saves
-				 7 slots integer registers
-				 1 slot saved flags
-				 1 slot return address in snippet
-				 1 slot literals
-				 1 slot cpIndex
-				 1 slot call from codecache to snippet
-				 */
-				return new UDATA(20);
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 data resolve shape
+					 16 slots of XMM registers
+					 16 slots of scalar registers
+					 1 slot flags
+					 1 slot call from snippet
+					 1 slot call from codecache to snippet
+					 */
+					return new UDATA(16);
+				} else {
+					/* IA32 data resolve shape
+					 20 slots FP saves
+					 7 slots integer registers
+					 1 slot saved flags
+					 1 slot return address in snippet
+					 1 slot literals
+					 1 slot cpIndex
+					 1 slot call from codecache to snippet
+					 */
+					return new UDATA(20);
+				}
 			} else {
 				return new UDATA(0);
 			}
@@ -548,62 +550,62 @@ public class MethodMetaData
 			return md.objectTempSlots(); 
 		}
 		
-		public UDATA getJitDataResolvePushes() throws CorruptDataException
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-			/* AMD64 data resolve shape
-			   16 slots of XMM registers
-			   16 slots of integer registers
-			   1 slot flags
-			   1 slot call from snippet
-			   1 slot call from codecache to snippet
-			*/
-				return new UDATA(35);
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-			/* IA32 data resolve shape
-			   20 slots FP saves
-			   7 slots integer registers
-			   1 slot saved flags
-			   1 slot return address in snippet
-			   1 slot literals
-			   1 slot cpIndex
-			   1 slot call from codecache to snippet
-			*/
-				return new UDATA(32);
+		public UDATA getJitDataResolvePushes() throws CorruptDataException {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 data resolve shape
+					   16 slots of XMM registers
+					   16 slots of integer registers
+					   1 slot flags
+					   1 slot call from snippet
+					   1 slot call from codecache to snippet
+					*/
+					return new UDATA(35);
+				} else {
+					/* IA32 data resolve shape
+					   20 slots FP saves
+					   7 slots integer registers
+					   1 slot saved flags
+					   1 slot return address in snippet
+					   1 slot literals
+					   1 slot cpIndex
+					   1 slot call from codecache to snippet
+					*/
+					return new UDATA(32);
+				}
 			} else if (J9BuildFlags.J9VM_ARCH_ARM) {
-			/* ARM data resolve shape
-			   12 slots saved integer registers
-			*/
+				/* ARM data resolve shape
+				   12 slots saved integer registers
+				*/
 				return new UDATA(12);
 			} else if (J9BuildFlags.arch_s390) {
-			/* 390 data resolve shape
-			   16 integer registers
-			*/
+				/* 390 data resolve shape
+				   16 integer registers
+				*/
 				if (J9BuildFlags.jit_32bitUses64bitRegisters) {
 					return new UDATA(32);
 				} else {
 					return new UDATA(16);
 				}
 			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
-			/* PPC data resolve shape
-			   32 integer registers
-			   CR
-			*/
+				/* PPC data resolve shape
+				   32 integer registers
+				   CR
+				*/
 				return new UDATA(33);
 			} else if (TRBuildFlags.host_MIPS) {
-			/* MIPS data resolve shape
-			   32 integer registers
-			*/
+				/* MIPS data resolve shape
+				   32 integer registers
+				*/
 				return new UDATA(32);
 			} else if (TRBuildFlags.host_SH4) {
-			/* SH4 data resolve shape
-			   16 integer registers 
-			*/
+				/* SH4 data resolve shape
+				   16 integer registers 
+				*/
 				return new UDATA(16);
 			} else {
 				return new UDATA(0);
 			}
-
 		}
 
 		public VoidPointer getStackMapFromJitPC(J9JavaVMPointer javaVM,
@@ -1007,31 +1009,32 @@ public class MethodMetaData
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
-		public int getJitRecompilationResolvePushes()
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 recompilation resolve shape
-				0: rcx (arg register)
-				1: rdx (arg register)
-				2: rsi (arg register)
-				3: rax (arg register)
-				4: 8 XMMs (1 8-byte slot each)				<== unwindSP points here
-				12: return PC (caller of recompiled method)
-				13: <last argument to method>				<== unwindSP should point here"
-				 */
-				return 9;
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 recompilation resolve shape
-				0: return address (picbuilder)
-				1: return PC (caller of recompiled method)
-				2: old start address
-				3: method
-				4: EAX (contains receiver for virtual)	<== unwindSP points here
-				5: EDX
-				6: return PC (caller of recompiled method)
-				7: <last argument to method>				<== unwindSP should point here"
-				 */
-				return 3;
+		public int getJitRecompilationResolvePushes() {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 recompilation resolve shape
+					0: rcx (arg register)
+					1: rdx (arg register)
+					2: rsi (arg register)
+					3: rax (arg register)
+					4: 8 XMMs (1 8-byte slot each)				<== unwindSP points here
+					12: return PC (caller of recompiled method)
+					13: <last argument to method>				<== unwindSP should point here"
+					*/
+					return 9;
+				} else {
+					/* IA32 recompilation resolve shape
+					0: return address (picbuilder)
+					1: return PC (caller of recompiled method)
+					2: old start address
+					3: method
+					4: EAX (contains receiver for virtual)	<== unwindSP points here
+					5: EDX
+					6: return PC (caller of recompiled method)
+					7: <last argument to method>				<== unwindSP should point here"
+					*/
+					return 3;
+				}
 			} else if (J9BuildFlags.arch_s390) {
 				/* 390 recompilation resolve shape
 				0:		r3 (arg register)
@@ -1045,7 +1048,7 @@ public class MethodMetaData
 				8:		temp2
 				9:		temp3
 				XX:	<linkage area>							<== unwindSP should point here
-				 */
+				*/
 				return 7 + (64 / UDATA.SIZEOF);
 			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC recompilation resolve shape
@@ -1061,7 +1064,7 @@ public class MethodMetaData
 				9:	r12
 				10:	r12
 				XX:	<linkage area>						<== unwindSP should point here
-				 */
+				*/
 				return 3;
 			} else {
 				return 0;
@@ -1073,32 +1076,33 @@ public class MethodMetaData
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
-		public int getJitVirtualMethodResolvePushes()
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 virtual resolve shape
-				0: ret addr to picbuilder
-				1: arg3
-				2: arg2
-				3: arg1
-				4: arg0
-				5: saved RDI								<==== unwindSP points here
-				6: code cache return address
-				7: last arg									<==== unwindSP should point here
-				 */
-				return 2;
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 virtual resolve shape
-				0: return address (picbuilder)
-				1: indexAndLiteralsEA
-				2: jitEIP
-				3: saved eax									<== unwindSP points here
-				4: saved esi
-				5: saved edi
-				6: return address (code cache)
-				7: <last argument to method>			<== unwindSP should point here
-				 */
-				return 4;
+		public int getJitVirtualMethodResolvePushes() {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 virtual resolve shape
+					0: ret addr to picbuilder
+					1: arg3
+					2: arg2
+					3: arg1
+					4: arg0
+					5: saved RDI								<==== unwindSP points here
+					6: code cache return address
+					7: last arg									<==== unwindSP should point here
+					*/
+					return 2;
+				} else {
+					/* IA32 virtual resolve shape
+					0: return address (picbuilder)
+					1: indexAndLiteralsEA
+					2: jitEIP
+					3: saved eax									<== unwindSP points here
+					4: saved esi
+					5: saved edi
+					6: return address (code cache)
+					7: <last argument to method>			<== unwindSP should point here
+					 */
+					return 4;
+				}
 			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC doesn't save anything extra */
 				return 0;
@@ -1111,7 +1115,7 @@ public class MethodMetaData
 				4: return address                <== unwindSP points here    
 				5: saved resolved data
 				6: <last argument to method>     <== unwindSP should point here
-				 */
+				*/
 				return 2;
 			} else {
 				return 0;
@@ -1123,30 +1127,30 @@ public class MethodMetaData
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
-		public int getJitStaticMethodResolvePushes()
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 static resolve shape
-				0: ret addr to picbuilder
-				1: code cache return address		<==== unwindSP points here
-				2: last arg									<==== unwindSP should point here
-				 */
-				return 1;
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 static resolve shape
-				0: return address (picbuilder)
-				1: jitEIP
-				2: constant pool
-				3: cpIndex
-				4: return address (code cache)		<== unwindSP points here
-				5: <last argument to method>			<== unwindSP should point here
-				 */
-				return 1;
+		public int getJitStaticMethodResolvePushes() {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 static resolve shape
+					0: ret addr to picbuilder
+					1: code cache return address		<==== unwindSP points here
+					2: last arg									<==== unwindSP should point here
+					 */
+					return 1;
+				} else {
+					/* IA32 static resolve shape
+					0: return address (picbuilder)
+					1: jitEIP
+					2: constant pool
+					3: cpIndex
+					4: return address (code cache)		<== unwindSP points here
+					5: <last argument to method>			<== unwindSP should point here
+					 */
+					return 1;
+				}
 			} else {
 				return 0;
 			}
 		}
-
 
 		public void walkJITFrameSlotsForInternalPointers(WalkState walkState,  U8Pointer jitDescriptionCursor, UDATAPointer scanCursor, VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException
 		{

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -356,8 +356,8 @@ public class MethodMetaData
 	private static class MethodMetaData_29_V0 extends com.ibm.j9ddr.vm29.j9.BaseAlgorithm implements MethodMetaDataImpl
 	{
 
-		private static boolean alignStackMaps = TRBuildFlags.host_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;
-		
+		private static boolean alignStackMaps = J9BuildFlags.J9VM_ARCH_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;
+
 		protected MethodMetaData_29_V0() {
 			super(90,0);
 		}
@@ -394,7 +394,7 @@ public class MethodMetaData
 		
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 data resolve shape
 				 16 slots of XMM registers
 				 16 slots of scalar registers
@@ -403,7 +403,7 @@ public class MethodMetaData
 				 1 slot call from codecache to snippet
 				 */
 				return new UDATA(16);
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 data resolve shape
 				 20 slots FP saves
 				 7 slots integer registers
@@ -433,7 +433,7 @@ public class MethodMetaData
 			J9JITExceptionTablePointer md = walkState.jitInfo;
 			UDATA registerSaveDescription = walkState.jitInfo.registerSaveDescription();
 
-			if (TRBuildFlags.host_X86) {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
 				UDATA prologuePushes = new UDATA(getJitProloguePushes(walkState.jitInfo));
 				U8 i = new U8(1); 
 
@@ -454,8 +454,8 @@ public class MethodMetaData
 					}
 					while (! registerSaveDescription.eq(0));
 				}
-			} else if (TRBuildFlags.host_POWER || TRBuildFlags.host_MIPS) {
-				if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER || TRBuildFlags.host_MIPS) {
+				if (J9BuildFlags.J9VM_ARCH_POWER) {
 					/*
 					 * see PPCLinkage for a description of the RSD 
 					 * the save offset is located from bits 18-32 
@@ -473,7 +473,7 @@ public class MethodMetaData
 				}
 				saveCursor = walkState.bp.subOffset(saveOffset);
 
-				if (TRBuildFlags.host_POWER) {
+				if (J9BuildFlags.J9VM_ARCH_POWER) {
 					mapCursor += lowestRegister.intValue(); /* access gpr15 in the vm register state */
 					U8 i = new U8(lowestRegister.add(1));
 					do 
@@ -497,7 +497,7 @@ public class MethodMetaData
 						savedGPRs = savedGPRs.sub(1);
 					}
 				}
-			} else if (TRBuildFlags.host_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_S390) {
+			} else if (J9BuildFlags.J9VM_ARCH_ARM || TRBuildFlags.host_SH4 || J9BuildFlags.arch_s390) {
 				savedGPRs = registerSaveDescription.bitAnd(new UDATA(0xFFFF));
 
 				if (! savedGPRs.eq(0))
@@ -526,7 +526,7 @@ public class MethodMetaData
 		
 		private U8Pointer GET_REGISTER_SAVE_DESCRIPTION_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF * 2);
 			} else {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF);
@@ -550,7 +550,7 @@ public class MethodMetaData
 		
 		public UDATA getJitDataResolvePushes() throws CorruptDataException
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 			/* AMD64 data resolve shape
 			   16 slots of XMM registers
 			   16 slots of integer registers
@@ -559,7 +559,7 @@ public class MethodMetaData
 			   1 slot call from codecache to snippet
 			*/
 				return new UDATA(35);
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 			/* IA32 data resolve shape
 			   20 slots FP saves
 			   7 slots integer registers
@@ -570,12 +570,12 @@ public class MethodMetaData
 			   1 slot call from codecache to snippet
 			*/
 				return new UDATA(32);
-			} else if (TRBuildFlags.host_ARM) {
+			} else if (J9BuildFlags.J9VM_ARCH_ARM) {
 			/* ARM data resolve shape
 			   12 slots saved integer registers
 			*/
 				return new UDATA(12);
-			} else if (TRBuildFlags.host_S390) {
+			} else if (J9BuildFlags.arch_s390) {
 			/* 390 data resolve shape
 			   16 integer registers
 			*/
@@ -584,7 +584,7 @@ public class MethodMetaData
 				} else {
 					return new UDATA(16);
 				}
-			} else if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 			/* PPC data resolve shape
 			   32 integer registers
 			   CR
@@ -727,7 +727,7 @@ public class MethodMetaData
 		@SuppressWarnings("unused")
 		private static U8Pointer ADDRESS_OF_REGISTERMAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(3 * U32.SIZEOF);
 			} else {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(2 * U32.SIZEOF);
@@ -763,7 +763,7 @@ public class MethodMetaData
 		//#define GET_REGISTER_MAP_CURSOR(fourByteOffset, stackMap) ((U_8 *)stackMap + SIZEOF_MAP_OFFSET(fourByteOffset) + 2*sizeof(U_32))
 		private static U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, U8Pointer stackMap)
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(3 * U32.SIZEOF));
 			} else {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(2 * U32.SIZEOF));
@@ -968,7 +968,7 @@ public class MethodMetaData
 
 		public U32 getJitHighWordRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return U32Pointer.cast(GET_HIGHWORD_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(methodMetaData), stackMap)).at(0);
 			} else {
 				return new U32(0);	
@@ -1009,7 +1009,7 @@ public class MethodMetaData
 		*/
 		public int getJitRecompilationResolvePushes()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 recompilation resolve shape
 				0: rcx (arg register)
 				1: rdx (arg register)
@@ -1020,7 +1020,7 @@ public class MethodMetaData
 				13: <last argument to method>				<== unwindSP should point here"
 				 */
 				return 9;
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 recompilation resolve shape
 				0: return address (picbuilder)
 				1: return PC (caller of recompiled method)
@@ -1032,7 +1032,7 @@ public class MethodMetaData
 				7: <last argument to method>				<== unwindSP should point here"
 				 */
 				return 3;
-			} else if (TRBuildFlags.host_S390) {
+			} else if (J9BuildFlags.arch_s390) {
 				/* 390 recompilation resolve shape
 				0:		r3 (arg register)
 				1:		r2 (arg register)
@@ -1047,7 +1047,7 @@ public class MethodMetaData
 				XX:	<linkage area>							<== unwindSP should point here
 				 */
 				return 7 + (64 / UDATA.SIZEOF);
-			} else if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC recompilation resolve shape
 				0:		r10 (arg register)
 				1:		r9 (arg register)
@@ -1075,7 +1075,7 @@ public class MethodMetaData
 		*/
 		public int getJitVirtualMethodResolvePushes()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 virtual resolve shape
 				0: ret addr to picbuilder
 				1: arg3
@@ -1087,7 +1087,7 @@ public class MethodMetaData
 				7: last arg									<==== unwindSP should point here
 				 */
 				return 2;
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 virtual resolve shape
 				0: return address (picbuilder)
 				1: indexAndLiteralsEA
@@ -1099,7 +1099,7 @@ public class MethodMetaData
 				7: <last argument to method>			<== unwindSP should point here
 				 */
 				return 4;
-			} else if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC doesn't save anything extra */
 				return 0;
 			} else if (TRBuildFlags.host_SH4) {
@@ -1125,14 +1125,14 @@ public class MethodMetaData
 		*/
 		public int getJitStaticMethodResolvePushes()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 static resolve shape
 				0: ret addr to picbuilder
 				1: code cache return address		<==== unwindSP points here
 				2: last arg									<==== unwindSP should point here
 				 */
 				return 1;
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 static resolve shape
 				0: return address (picbuilder)
 				1: jitEIP
@@ -1297,7 +1297,7 @@ public class MethodMetaData
 						swPrintf(walkState, 6, "\tJIT-RegisterMap = {0}", registerMap);
 						tempJitDescriptionCursorForRegs = U8Pointer.cast(stackMap);
 
-						if (TRBuildFlags.host_S390) {
+						if (J9BuildFlags.arch_s390) {
 							tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(12); /*skip register map, register save description word and high word register map*/
 						} else {						
 							tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(8); /*skip register map and register save description word */
@@ -1429,7 +1429,7 @@ public class MethodMetaData
 		
 		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap) 
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 3));
 			} else {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 2));
@@ -1466,7 +1466,7 @@ public class MethodMetaData
 		
 		private boolean isPatchedValue(J9MethodPointer m)
 		{
-			if ((TRBuildFlags.host_POWER && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
+			if ((J9BuildFlags.J9VM_ARCH_POWER && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
 				return true;
 			}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -262,16 +262,18 @@ public class StackWalker
 						} else if (J9BuildFlags.arch_s390) {
 							/* r5 */
 							javaSPName = "r5";
-						} else if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-							/* esp */
-							javaSPName = "rsp";
 						} else if (J9BuildFlags.J9VM_ARCH_X86) {
-							/* rsp */
-							javaSPName = "esp";
+							if (J9BuildFlags.env_data64) {
+								/* rsp */
+								javaSPName = "rsp";
+							} else {
+								/* esp */
+								javaSPName = "esp";
+							}
 						} else {
 							throw new IllegalArgumentException("Unsupported platform");
 						}
-						
+
 						for (IRegister reg : nativeThread.getRegisters()) {
 							if (reg.getName().equalsIgnoreCase(javaSPName)) {
 								javaSp = UDATAPointer.cast(reg.getValue().longValue());

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -55,7 +55,6 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9SFMethodTypeFramePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9SFSpecialFramePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9SFStackFramePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9VMEntryLocalStoragePointer;
-import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ROMMethodHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ThreadHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
@@ -256,17 +255,17 @@ public class StackWalker
 
 						/* fetch the Java stack for the platform directly from the register file */
 						String javaSPName = "";
-						if (TRBuildFlags.host_POWER) {
+						if (J9BuildFlags.J9VM_ARCH_POWER) {
 							/* AIX shows as POWER not PPC */
 							/* gpr14 */
 							javaSPName = "gpr14";
-						} else if (TRBuildFlags.host_S390) {
+						} else if (J9BuildFlags.arch_s390) {
 							/* r5 */
 							javaSPName = "r5";
-						} else if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+						} else if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 							/* esp */
 							javaSPName = "rsp";
-						} else if (TRBuildFlags.host_X86 && TRBuildFlags.host_32BIT) {
+						} else if (J9BuildFlags.J9VM_ARCH_X86) {
 							/* rsp */
 							javaSPName = "esp";
 						} else {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -46,7 +46,6 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9ConstantPoolPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9MethodPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMMethodPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
-import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.structure.J9Consts;
 import com.ibm.j9ddr.vm29.types.UDATA;
@@ -88,12 +87,12 @@ public class StackWalkerUtils
 	static final int jitArgumentRegisterNumbers[];
 	
 	static {
-		if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
-			jitArgumentRegisterNumbers = new int[]{ 0, 5, 3, 2};
-		} else if (TRBuildFlags.host_POWER) {
-			jitArgumentRegisterNumbers = new int[]{ 3, 4, 5, 6, 7, 8, 9, 10 };
-		} else if (TRBuildFlags.host_S390) {
-			jitArgumentRegisterNumbers = new int[]{ 1, 2, 3 };
+		if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
+			jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
+		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			jitArgumentRegisterNumbers = new int[] { 3, 4, 5, 6, 7, 8, 9, 10 };
+		} else if (J9BuildFlags.arch_s390) {
+			jitArgumentRegisterNumbers = new int[] { 1, 2, 3 };
 		} else {
 			//32 bit X86 doesn't use jitArgumentRegisterNumbers
 			jitArgumentRegisterNumbers = new int[0];
@@ -260,7 +259,7 @@ public class StackWalkerUtils
 	
 	public static UDATA JIT_RESOLVE_PARM(WalkState walkState, int parmNumber) throws CorruptDataException
 	{
-		if (TRBuildFlags.host_X86 && TRBuildFlags.host_32BIT) {
+		if (J9BuildFlags.J9VM_ARCH_X86 && !J9BuildFlags.env_data64) {
 			return walkState.bp.at(parmNumber);
 		} else {
 			return walkState.walkedEntryLocalStorage.jitGlobalStorageBase().at(jitArgumentRegisterNumbers[parmNumber - 1]);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -87,15 +87,19 @@ public class StackWalkerUtils
 	static final int jitArgumentRegisterNumbers[];
 	
 	static {
-		if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-			jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
+		if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9BuildFlags.env_data64) {
+				jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
+			} else {
+				// 32 bit X86 doesn't use jitArgumentRegisterNumbers
+				jitArgumentRegisterNumbers = new int[0];
+			}
 		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 			jitArgumentRegisterNumbers = new int[] { 3, 4, 5, 6, 7, 8, 9, 10 };
 		} else if (J9BuildFlags.arch_s390) {
 			jitArgumentRegisterNumbers = new int[] { 1, 2, 3 };
 		} else {
-			//32 bit X86 doesn't use jitArgumentRegisterNumbers
-			jitArgumentRegisterNumbers = new int[0];
+			throw new IllegalArgumentException("Unsupported platform");
 		}
 	}
 	

--- a/runtime/ddr/jitflagsddr.c
+++ b/runtime/ddr/jitflagsddr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #include <limits.h>
 #include "j9ddr.h"
 #include "ddrtable.h"
+#include "env/defines.h" /* for TR_HOST_XXX */
 
 /* @ddr_namespace: map_to_type=TRBuildFlags */
 
@@ -34,13 +35,13 @@ J9DDRConstantTableBegin(TRBuildFlags)
 	#define host_ARM 0
 #endif
 J9DDRConstantTableEntryWithValue("host_ARM", host_ARM)
-	
+
 #if defined(TR_HOST_IA32)
 	#define host_IA32 1
 #else
 	#define host_IA32 0
 #endif
-J9DDRConstantTableEntryWithValue("host_IA32", host_IA32) 
+J9DDRConstantTableEntryWithValue("host_IA32", host_IA32)
 
 #if defined(TR_HOST_POWER)
 	#define host_POWER 1
@@ -83,6 +84,7 @@ J9DDRConstantTableEntryWithValue("host_32BIT", host_32BIT)
 	#define host_64BIT 0
 #endif
 J9DDRConstantTableEntryWithValue("host_64BIT", host_64BIT)
+
 J9DDRConstantTableEnd
 
 J9DDRConstantTableBegin(CLimits)
@@ -107,9 +109,8 @@ J9DDRStructTableBegin(JIT)
 	J9DDREmptyStruct(CLimits, NULL)
 J9DDRStructTableEnd
 
-const J9DDRStructDefinition* getJITStructTable()
+const J9DDRStructDefinition *
+getJITStructTable()
 {
 	return J9DDR_JIT_structs;
 }
-
-

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -388,6 +388,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</include>
 			<include path="j9gcvlhgc"/>
 			<include path="$(OMR_DIR)/include_core" type="relativepath"/>
+			<include path="$(OMR_DIR)/compiler" type="relativepath">
+				<include-if condition="spec.flags.J9VM_INTERP_NATIVE_SUPPORT"/>
+			</include>
 		</includes>
 		<makefilestubs>
 			<makefilestub data="CFLAGS += -femit-class-debug-always">


### PR DESCRIPTION
DDR code was using `TRBuildFlags` which weren't accurately captured in the blob included in core files. This fixes those flags for future core files and updates the DDR code so older core files can be properly interpreted (using equivalent flags in `J9BuildFlags`).

* fix host_XXX macro definitions for DDR
Use "env/defines.h" to get TR_HOST_XXX definitions rather than relying on command-line options.

* use more reliable constants from blob

Updating references as listed below allows DDR to operate on core files that predate the fix to TRBuildFlags.
```
TRBuildFlags.host_32BIT -> J9BuildFlags.!env_data64
TRBuildFlags.host_64BIT -> J9BuildFlags.env_data64
TRBuildFlags.host_ARM   -> J9BuildFlags.J9VM_ARCH_ARM
TRBuildFlags.host_POWER -> J9BuildFlags.J9VM_ARCH_POWER
TRBuildFlags.host_S390  -> J9BuildFlags.arch_s390
TRBuildFlags.host_X86   -> J9BuildFlags.J9VM_ARCH_X86
```

* avoid redundant conditions

Fixes #3472.