### PR TITLE
Use correct `generate*Instruction` APIs

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -9445,7 +9445,7 @@ inlineMathSQRT(TR::Node * node, TR::CodeGenerator * cg)
       if (firstChild->isSingleRefUnevaluated() && firstChild->getOpCodeValue() == TR::dloadi)
          {
          targetRegister = cg->allocateRegister(TR_FPR);
-         generateRXInstruction(cg, TR::InstOpCode::SQDB, node, targetRegister, generateS390MemoryReference(firstChild, cg));
+         generateRXEInstruction(cg, TR::InstOpCode::SQDB, node, targetRegister, generateS390MemoryReference(firstChild, cg), 0);
          }
       else
          {

--- a/runtime/compiler/z/codegen/S390Recompilation.cpp
+++ b/runtime/compiler/z/codegen/S390Recompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -396,7 +396,7 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    TR::MemoryReference* endOfPrologueSlotMemRef = generateS390MemoryReference(cg->getStackPointerRealRegister(), 0, cg);
 
    // Store GPR2 off to the stack so countingRecompileMethod can access it
-   cursor = generateRSInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), endOfPrologueSlotMemRef, cursor);
+   cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), endOfPrologueSlotMemRef, cursor);
 
    // Adjust GPR2 to point to the countingRecompileMethod address
    cursor = generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR2), 0, cursor);
@@ -457,7 +457,7 @@ TR_S390Recompilation::generatePrologue(TR::Instruction* cursor)
    TR::MemoryReference* epRegisterSlotMemRef = generateS390MemoryReference(cg->getStackPointerRealRegister(), 0, cg);
 
    // Save EP register
-   cursor = generateRSInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->getEntryPointRealRegister(), epRegisterSlotMemRef, cursor);
+   cursor = generateRXInstruction(cg, TR::InstOpCode::getStoreOpCode(), node, cg->getEntryPointRealRegister(), epRegisterSlotMemRef, cursor);
 
    // Save the return address in GPR0 so the patching assembly stub can access it
    cursor = generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), cg->getReturnAddressRealRegister(), cursor);


### PR DESCRIPTION
In some instances we are not using the correct `generate*` APIs.
Asserts are being added at the OMR level to make sure we don't do this
in the future.

Issue: https://github.com/eclipse/omr/issues/2848

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>