### PR TITLE
Newly extended bit should not be set at the JITaaS server

### DIFF
--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -508,8 +508,14 @@ TR_PersistentCHTable::removeAssumptionFromList(
 void
 TR_PersistentClassInfo::setShouldNotBeNewlyExtended(int32_t ID)
    {
-   auto classesThatShouldNotBeNewlyExtended = TR::compInfoPT->getClassesThatShouldNotBeNewlyExtended();
-   if (classesThatShouldNotBeNewlyExtended)
-      classesThatShouldNotBeNewlyExtended->insert(_classId);
-   _shouldNotBeNewlyExtended.set(1 << ID);
+   if (TR::compInfoPT->getStream())
+      {
+      auto classesThatShouldNotBeNewlyExtended = TR::compInfoPT->getClassesThatShouldNotBeNewlyExtended();
+      if (classesThatShouldNotBeNewlyExtended)
+         classesThatShouldNotBeNewlyExtended->insert(_classId);
+      }
+   else
+      {
+      _shouldNotBeNewlyExtended.set(1 << ID);
+      }
    }


### PR DESCRIPTION
The JIT compiler may use optimizations based on the current state of class
hierarchy. To prevent problems that may arise from hierarchy extensions during
the compilation, for each class that should not be further extended the
JIT compiler sets a bit in TR_PersistentClassInfo::_shouldNotBeNewlyExtended
corresponding to the compilation thread ID that performs that compilation.
This introduces a limitation to the number of compilation threads (8) because
TR_PersistentClassInfo::_shouldNotBeNewlyExtended is a uint8_t in order to
conserve footprint. However, the JITaaS server uses a different mechanism to
track newly extended classes and it should not set this newlyExtended bit.
This change will allow the usage of more than 8 compilation threads at the
server.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>