### PR TITLE
Make CH table updates more granular

### DIFF
--- a/runtime/compiler/env/JITaaSPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.hpp
@@ -89,6 +89,8 @@ public:
    virtual bool classGotExtended(TR_FrontEnd *vm, TR_PersistentMemory *, TR_OpaqueClassBlock *superClassId, TR_OpaqueClassBlock *subClassId) override;
 
   
+   void markForRemoval(TR_OpaqueClassBlock *clazz);
+   void markDirty(TR_OpaqueClassBlock *clazz);
 #ifdef COLLECT_CHTABLE_STATS
    uint32_t _numUpdates; // aka numCompilations
    uint32_t _numCommitFailures;
@@ -99,9 +101,6 @@ public:
 #endif
 
 private:
-   void markSuperClassesAsDirty(TR_FrontEnd *fe, TR_OpaqueClassBlock *classId);
-   void markForRemoval(TR_OpaqueClassBlock *clazz);
-   void markDirty(TR_OpaqueClassBlock *clazz);
 
    std::string serializeRemoves();
    std::string serializeModifications();
@@ -134,6 +133,36 @@ public:
 
    uint32_t                            _numSubClasses;
    TR_OpaqueClassBlock                *_subClasses[0];
+   };
+
+class TR_JITaaSPersistentClassInfo : public TR_PersistentClassInfo
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::PersistentInfo);
+   TR_JITaaSPersistentClassInfo(TR_OpaqueClassBlock *id, TR_JITaaSClientPersistentCHTable *chTable);
+
+   // All of these methods mark the classInfo as dirty/removed and call a parent method
+   virtual void setInitialized(TR_PersistentMemory *) override;
+   virtual void setClassId(TR_OpaqueClassBlock *newClass) override;
+   virtual void setFirstSubClass(TR_SubClass *sc) override;
+   virtual void setFieldInfo(TR_PersistentClassInfoForFields *i) override;
+   virtual TR_SubClass *addSubClass(TR_PersistentClassInfo *subClass) override;
+   virtual void removeSubClasses() override;
+   virtual void removeASubClass(TR_PersistentClassInfo *subClass) override;
+   virtual void removeUnloadedSubClasses() override;
+   virtual void setUnloaded() override;
+   virtual void incNumPrexAssumptions() override;
+   virtual void setReservable(bool v = true) override;
+   virtual void setShouldNotBeNewlyExtended(int32_t ID) override;
+   virtual void resetShouldNotBeNewlyExtended(int32_t ID) override;
+   virtual void clearShouldNotBeNewlyExtended() override;
+   virtual void setHasRecognizedAnnotations(bool v = true) override;
+   virtual void setAlreadyCheckedForAnnotations(bool v = true) override;
+   virtual void setCannotTrustStaticFinal(bool v = true) override;
+   virtual void setClassHasBeenRedefined(bool v = true) override;
+   virtual void setNameLength(int32_t length) override;
+private:
+   static TR_JITaaSClientPersistentCHTable *_chTable;
    };
 
 #endif // JITaaS_PERSISTENT_CHTABLE_H

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -90,6 +90,7 @@ class TR_PersistentCHTable
 
    protected:
    void removeAssumptionFromList(OMR::RuntimeAssumption **list, OMR::RuntimeAssumption *assumption, OMR::RuntimeAssumption *prev);
+   TR_LinkHead<TR_PersistentClassInfo> *getClasses() { return _classes; }
 
    private:
    uint8_t _buffer[sizeof(TR_LinkHead<TR_PersistentClassInfo>) * (CLASSHASHTABLE_SIZE + 1)];

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -69,17 +69,17 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
 
    TR_OpaqueClassBlock *getClassId() { return (TR_OpaqueClassBlock *) (((uintptr_t) _classId) & ~(uintptr_t)1); }
    bool isInitialized()  { return ((((uintptr_t) _classId) & 1) == 0); }
-   void setInitialized(TR_PersistentMemory *);
+   virtual void setInitialized(TR_PersistentMemory *);
 
    // HCR
-   void setClassId(TR_OpaqueClassBlock *newClass)
+   virtual void setClassId(TR_OpaqueClassBlock *newClass)
       {
       _classId = (TR_OpaqueClassBlock *) (((uintptrj_t)newClass) | (uintptrj_t)isInitialized());
       setClassHasBeenRedefined(true);
       }
 
    TR_SubClass *getFirstSubclass() { return _subClasses.getFirst(); }
-   void setFirstSubClass(TR_SubClass *sc) { _subClasses.setFirst(sc); }
+   virtual void setFirstSubClass(TR_SubClass *sc) { _subClasses.setFirst(sc); }
 
    void setVisited() {_visitedStatus |= 1; }
    void resetVisited() { _visitedStatus = _visitedStatus & ~(uintptrj_t)1; }
@@ -96,7 +96,7 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
       fieldInfo = fieldInfo & ~(uintptrj_t)3;
       return (TR_PersistentClassInfoForFields *) fieldInfo;
       }
-   void setFieldInfo(TR_PersistentClassInfoForFields *i)
+   virtual void setFieldInfo(TR_PersistentClassInfoForFields *i)
       {
       uintptrj_t fieldInfo = (uintptrj_t) i;
       fieldInfo |= (((uintptrj_t) _fieldInfo) & (uintptrj_t)3);
@@ -105,11 +105,11 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
 
    int32_t getSubClassesCount() { return _subClasses.getSize(); }
 
-   TR_SubClass *addSubClass(TR_PersistentClassInfo *subClass);
-   void removeSubClasses();
-   void removeASubClass(TR_PersistentClassInfo *subClass);
-   void removeUnloadedSubClasses();
-   void setUnloaded(){_visitedStatus |= 0x2;}
+   virtual TR_SubClass *addSubClass(TR_PersistentClassInfo *subClass);
+   virtual void removeSubClasses();
+   virtual void removeASubClass(TR_PersistentClassInfo *subClass);
+   virtual void removeUnloadedSubClasses();
+   virtual void setUnloaded(){_visitedStatus |= 0x2;}
    bool getUnloaded()
     {
     if (_visitedStatus & 0x2)
@@ -118,32 +118,32 @@ class TR_PersistentClassInfo : public TR_Link0<TR_PersistentClassInfo>
    }
    uint16_t getTimeStamp() { return _timeStamp; }
    int16_t getNumPrexAssumptions() { return _prexAssumptions; }
-   void incNumPrexAssumptions() { _prexAssumptions++; }
+   virtual void incNumPrexAssumptions() { _prexAssumptions++; }
 
-   void setReservable(bool v = true)              { _flags.set(_isReservable, v); }
+   virtual void setReservable(bool v = true)              { _flags.set(_isReservable, v); }
    bool isReservable()                            { return _flags.testAny(_isReservable); }
 
-   void setShouldNotBeNewlyExtended(int32_t ID);
-   void resetShouldNotBeNewlyExtended(int32_t ID){ _shouldNotBeNewlyExtended.reset(1 << ID); }
-   void clearShouldNotBeNewlyExtended()          { _shouldNotBeNewlyExtended.clear(); }
+   virtual void setShouldNotBeNewlyExtended(int32_t ID);
+   virtual void resetShouldNotBeNewlyExtended(int32_t ID){ _shouldNotBeNewlyExtended.reset(1 << ID); }
+   virtual void clearShouldNotBeNewlyExtended()          { _shouldNotBeNewlyExtended.clear(); }
    bool shouldNotBeNewlyExtended()               { return _shouldNotBeNewlyExtended.testAny(0xff); }
    bool shouldNotBeNewlyExtended(int32_t ID)     { return _shouldNotBeNewlyExtended.testAny(1 << ID); }
    flags8_t getShouldNotBeNewlyExtendedMask() const { return _shouldNotBeNewlyExtended; }
 
-   void setHasRecognizedAnnotations(bool v = true){ _flags.set(_containsRecognizedAnnotations, v); }
+   virtual void setHasRecognizedAnnotations(bool v = true){ _flags.set(_containsRecognizedAnnotations, v); }
    bool hasRecognizedAnnotations()                { return _flags.testAny(_containsRecognizedAnnotations); }
-   void setAlreadyCheckedForAnnotations(bool v = true){ _flags.set(_alreadyScannedForAnnotations, v); }
+   virtual void setAlreadyCheckedForAnnotations(bool v = true){ _flags.set(_alreadyScannedForAnnotations, v); }
    bool alreadyCheckedForAnnotations()            { return _flags.testAny(_alreadyScannedForAnnotations); }
 
-   void setCannotTrustStaticFinal(bool v = true)  { _flags.set(_cannotTrustStaticFinal, v); }
+   virtual void setCannotTrustStaticFinal(bool v = true)  { _flags.set(_cannotTrustStaticFinal, v); }
    bool cannotTrustStaticFinal()                  { return _flags.testAny(_cannotTrustStaticFinal); }
 
    // HCR
-   void setClassHasBeenRedefined(bool v = true)  { _flags.set(_classHasBeenRedefined, v); }
+   virtual void setClassHasBeenRedefined(bool v = true)  { _flags.set(_classHasBeenRedefined, v); }
    bool classHasBeenRedefined()                  { return _flags.testAny(_classHasBeenRedefined); }
 
    int32_t getNameLength()                       { return _nameLength; }
-   void setNameLength(int32_t length)            { _nameLength = length; }
+   virtual void setNameLength(int32_t length)            { _nameLength = length; }
 
    private:
 


### PR DESCRIPTION
Create a subclass of `TR_PersistentClassInfo` for the client.
Override every method that modifies class info so that it is marked
as dirty/for removal before calling base method.

This enables us to detect changes to persistent CH table at a finer
granularity. We used to mark class as dirty every time class info
is accessed, whether or not it was modified. This is too conservative
and makes CH table updates larger than necessary.

It also makes code cleaner and less prone to bugs, because we don't need
to think about class hierarchy anymore. Since dirty/removed set gets
updated every time a class info is modified, cases like unloading a subclass of
a loaded class are handled automatically, so we don't need
`markSuperClasesAsDirty` method.

Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>