### PR TITLE
Replace deprecated VM option

### DIFF
--- a/test/TestConfig/resources/modes.xml
+++ b/test/TestConfig/resources/modes.xml
@@ -3,7 +3,7 @@
 <modes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="ModeSchema.xsd">
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2018 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,16 +52,16 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT off, optthruput GC (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 				<clArg>-Xgcpolicy:optthruput</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -69,16 +69,16 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, optthruput GC (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 				<clArg>-Xgcpolicy:optthruput</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -87,19 +87,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -108,15 +108,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -125,15 +125,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -142,19 +142,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -163,19 +163,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -184,23 +184,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -209,23 +209,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -234,15 +234,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -251,19 +251,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:concurrentScavenge</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
 			</setting>
 		</settings>
 	</mode>
@@ -271,16 +271,16 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -288,20 +288,20 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc (J9), Concurrent Scavenger</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:concurrentScavenge</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
 			</setting>
 		</settings>
 	</mode>
@@ -310,19 +310,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -331,15 +331,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -348,19 +348,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -369,23 +369,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -394,19 +394,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -416,23 +416,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -442,15 +442,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=1,gcOnResolve,rtResolve,enableFastHotRecompilation,enableFastScorchingRecompilation,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=1,gcOnResolve,rtResolve,enableFastHotRecompilation,enableFastScorchingRecompilation,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=1,gcOnResolve,rtResolve,enableFastHotRecompilation,enableFastScorchingRecompilation,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 		</settings>
 	</mode>
@@ -460,15 +460,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -477,15 +477,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -494,19 +494,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -515,15 +515,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -532,15 +532,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 						<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -549,19 +549,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -570,19 +570,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -591,15 +591,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:subpool</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
     </mode>
@@ -608,15 +608,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:subpool</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -625,15 +625,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:subpool</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -642,20 +642,20 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>Split heap, JIT on, gencon gc (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:splitheap"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:splitheap"/>
 				<clArg>-Xgc:splitheap</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -665,18 +665,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 				<clArg>-Xgcpolicy:optthruput</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
 				<clArg>-Xgc:maxContractPercent=50</clArg>
 			</setting>
 		</settings>
@@ -685,20 +685,20 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc (J9), 50% Heap Contraction</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
 				<clArg>-Xgc:maxContractPercent=50</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -707,18 +707,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
 				<clArg>-Xgc:maxContractPercent=50</clArg>
 			</setting>
 		</settings>
@@ -727,20 +727,20 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, VLHGC GC (J9), 50% Heap Contraction</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 				<clArg>-Xgcpolicy:balanced</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:maxContractPercent=50"/>
 				<clArg>-Xgc:maxContractPercent=50</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -750,19 +750,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -771,23 +771,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xaot:forceAoT,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -796,27 +796,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:maximal=all,buffers=64k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:fatalassert</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:fatalassert"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:fatalassert"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -825,19 +825,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses:nonpersistent</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -846,23 +846,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xzero</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xzero"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xzero"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -871,69 +871,45 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
-	<mode number="145-NoBCI">
-		<description>JIT on with shared classes and BCI off, gencon GC</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xshareclasses:disableBCI</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:disableBCI"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-		</settings>
-	</mode>
+	
 	<mode number="146">
 		<description>Same as mode 140, but adds -XXnosuballoc32bitmem, which is used on z/OS to disable the suballocator and use __malloc31 instead.</description>
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXnosuballoc32bitmem"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXnosuballoc32bitmem"/>
 				<clArg>-XXnosuballoc32bitmem</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -942,23 +918,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXnosuballoc32bitmem"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXnosuballoc32bitmem"/>
 				<clArg>-XXnosuballoc32bitmem</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -966,21 +942,21 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:name=bcienabled,enableBCI"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:name=bcienabled,enableBCI"/>
 				<clArg>-Xshareclasses:name=bcienabled,enableBCI</clArg>
 				<modeHints>HINT_SHARECLASSES</modeHints>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -988,21 +964,21 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:cacheRetransformed,name=retransformenabled"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:cacheRetransformed,name=retransformenabled"/>
 				<clArg>-Xshareclasses:cacheRetransformed,name=retransformenabled</clArg>
 				<modeHints>HINT_SHARECLASSES</modeHints>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1012,15 +988,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1029,19 +1005,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:concurrentScavenge</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1050,18 +1026,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -1071,18 +1047,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -1092,23 +1068,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1117,23 +1093,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1142,18 +1118,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -1163,19 +1139,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:fvtest=verifyHeapBelow=4294967296</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=4294967296"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=4294967296"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1184,19 +1160,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:fvtest=verifyHeapBelow=8589934592</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=8589934592"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=8589934592"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1205,19 +1181,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="both">
 				<clArg>-Xmx9216M</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmx9216M"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmx9216M"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1226,15 +1202,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1243,19 +1219,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:concurrentScavenge</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:concurrentScavenge"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1265,15 +1241,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,disableTrex</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,disableTrex"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,disableTrex"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1282,15 +1258,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,disableGoldenEagle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,disableGoldenEagle"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,disableGoldenEagle"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1299,15 +1275,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,disableTrex</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,disableTrex"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,disableTrex"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1316,15 +1292,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,disableGoldenEagle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,disableGoldenEagle"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,disableGoldenEagle"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1333,15 +1309,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,disableTrex</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,disableTrex"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,disableTrex"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1350,15 +1326,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,disableGoldenEagle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,disableGoldenEagle"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,disableGoldenEagle"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1367,19 +1343,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XCEEHDLR</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XCEEHDLR"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XCEEHDLR"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1388,19 +1364,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xsignal:userConditionHandler=percolate</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xsignal:userConditionHandler=percolate"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xsignal:userConditionHandler=percolate"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1409,19 +1385,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xsignal:posixSignalHandler=cooperativeShutdown</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xsignal:posixSignalHandler=cooperativeShutdown"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xsignal:posixSignalHandler=cooperativeShutdown"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1430,16 +1406,16 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>(LIR644) JIT on, gencon GC (J9), invoke performance v2.4 J9 VM</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 				<clArg>-Xgcpolicy:gencon</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 				<clArg>-Xjvm:perf</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1448,27 +1424,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 				<clArg>-Xjvm:perf</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XtlhPrefetch"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XtlhPrefetch"/>
 				<clArg>-XtlhPrefetch</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoloa"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoloa"/>
 				<clArg>-Xnoloa</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1477,27 +1453,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 				<clArg>-Xjvm:perf</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XtlhPrefetch"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XtlhPrefetch"/>
 				<clArg>-XtlhPrefetch</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1506,19 +1482,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 				<clArg>-Xjvm:perf</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1527,27 +1503,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve,reserveAllLocks</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve,reserveAllLocks"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve,reserveAllLocks"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1556,19 +1532,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet -Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet -Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet -Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1577,19 +1553,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 				<clArg>-Xjvm:perf</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1598,19 +1574,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 				<clArg>-Xjvm:perf</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1619,19 +1595,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1640,23 +1616,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1665,23 +1641,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:reserveAllLocks"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:reserveAllLocks"/>
 				<clArg>-Xjit:reserveAllLocks</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1690,19 +1666,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1711,23 +1687,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1736,23 +1712,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:reserveAllLocks</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:reserveAllLocks"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:reserveAllLocks"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1761,19 +1737,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1782,23 +1758,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1807,23 +1783,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjvm:perf</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjvm:perf"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjvm:perf"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XlockReservation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XlockReservation"/>
 				<clArg>-XlockReservation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:reserveAllLocks</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:reserveAllLocks"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:reserveAllLocks"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1833,19 +1809,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xaggressive</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1854,23 +1830,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xaggressive</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xconcurrentlevel0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xconcurrentlevel0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xconcurrentlevel0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1879,20 +1855,20 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc, large pages</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 				<clArg>-Xgcpolicy:gencon</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xlp</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xlp"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xlp"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1901,19 +1877,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 				<clArg>-Xgcpolicy:gencon</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xlp</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xlp"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xlp"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1922,23 +1898,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:fvtest=verifyHeapBelow=4294967296</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=4294967296"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=4294967296"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xlp</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xlp"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xlp"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1947,23 +1923,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:fvtest=verifyHeapBelow=8589934592</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=8589934592"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:fvtest=verifyHeapBelow=8589934592"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xlp</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xlp"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xlp"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1972,23 +1948,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmx9216M</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmx9216M"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmx9216M"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xlp</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xlp"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xlp"/>
 			</setting>
 		</settings>
 	</mode>
@@ -1997,11 +1973,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:RecreateClassfileOnload</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:RecreateClassfileOnload"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:RecreateClassfileOnload"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2011,19 +1987,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xaggressive</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2032,19 +2008,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xaggressive</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2054,15 +2030,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2071,11 +2047,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2084,15 +2060,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnojit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnojit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnojit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2101,15 +2077,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2118,15 +2094,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2135,19 +2111,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2156,23 +2132,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2181,23 +2157,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnojit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnojit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnojit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2206,11 +2182,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime -Xgcthreads${MAX_GC_THREADS}"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime -Xgcthreads${MAX_GC_THREADS}"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2220,15 +2196,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2237,27 +2213,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:maximal=all,buffers=64k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:fatalassert</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:fatalassert"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:fatalassert"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2266,19 +2242,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnojit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnojit"/>
 				<clArg>-Xnojit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2287,19 +2263,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2308,19 +2284,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoaot"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoaot"/>
 				<clArg>-Xnoaot</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2329,15 +2305,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xrealtime</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrealtime"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrealtime"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:none</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:none"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:none"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2347,15 +2323,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2364,11 +2340,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2377,15 +2353,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2394,15 +2370,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2411,15 +2387,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2428,19 +2404,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2449,15 +2425,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2466,23 +2442,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2491,15 +2467,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=1</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=1"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=1"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2508,19 +2484,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2529,27 +2505,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-verbose:gc</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-verbose:gc"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-verbose:gc"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xverbosegclog:gc.log</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xverbosegclog:gc.log"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xverbosegclog:gc.log"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:targetUtilization=75</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetUtilization=75"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetUtilization=75"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XXgc:verboseExtensions,headroom=100m,trigger=1m</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXgc:verboseExtensions,headroom=100m,trigger=1m"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXgc:verboseExtensions,headroom=100m,trigger=1m"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2558,19 +2534,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2579,23 +2555,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xaot:forceAoT,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2604,27 +2580,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:maximal=all,buffers=64k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:fatalassert</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:fatalassert"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:fatalassert"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2633,23 +2609,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses:nonpersistent</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2658,19 +2634,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2679,15 +2655,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:none</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:none"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:none"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2696,15 +2672,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgc:targetPausetime=5</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetPausetime=5"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetPausetime=5"/>
 			</setting>
 		    <setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2713,19 +2689,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgc:targetPausetime=17</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetPausetime=17"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetPausetime=17"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2734,23 +2710,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 		    <setting type="either">
 				<clArg>-Xgc:targetPausetime=26</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetPausetime=26"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetPausetime=26"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2759,15 +2735,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2776,11 +2752,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2789,15 +2765,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2806,15 +2782,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2823,15 +2799,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2840,19 +2816,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2861,15 +2837,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2878,23 +2854,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2903,15 +2879,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=1</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=1"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=1"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2920,19 +2896,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2941,27 +2917,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-verbose:gc</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-verbose:gc"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-verbose:gc"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xverbosegclog:gc.log</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xverbosegclog:gc.log"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xverbosegclog:gc.log"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgc:targetUtilization=75</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetUtilization=75"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetUtilization=75"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XXgc:verboseExtensions,headroom=100m,trigger=1m</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXgc:verboseExtensions,headroom=100m,trigger=1m"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXgc:verboseExtensions,headroom=100m,trigger=1m"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2970,19 +2946,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -2991,23 +2967,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xaot:forceAoT,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3016,27 +2992,27 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:maximal=all,buffers=64k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:fatalassert</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:fatalassert"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:fatalassert"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3045,23 +3021,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses:nonpersistent</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3070,19 +3046,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3091,15 +3067,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:none</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:none"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:none"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3108,15 +3084,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgc:targetPausetime=5</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetPausetime=5"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetPausetime=5"/>
 			</setting>
 		    <setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3125,19 +3101,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgc:targetPausetime=17</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetPausetime=17"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetPausetime=17"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3146,23 +3122,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 		    <setting type="either">
 				<clArg>-Xgc:targetPausetime=26</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:targetPausetime=26"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgc:targetPausetime=26"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:metronome</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:metronome"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3171,15 +3147,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xproxy:auto</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xproxy:auto"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xproxy:auto"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3188,11 +3164,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xproxy:auto</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xproxy:auto"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xproxy:auto"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3201,15 +3177,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xproxy:auto</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xproxy:auto"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xproxy:auto"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3218,11 +3194,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xproxy:auto</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xproxy:auto"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xproxy:auto"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3232,16 +3208,16 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT off, VLHGC GC (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 				<clArg>-Xgcpolicy:balanced</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3249,16 +3225,16 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, VLHGC GC (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 				<clArg>-Xgcpolicy:balanced</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3267,19 +3243,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3288,15 +3264,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3305,19 +3281,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XXgc:tarokEnableExpensiveAssertions,fvtest_tarokPGCRotateCollectors</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXgc:tarokEnableExpensiveAssertions,fvtest_tarokPGCRotateCollectors"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXgc:tarokEnableExpensiveAssertions,fvtest_tarokPGCRotateCollectors"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3326,19 +3302,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3347,19 +3323,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3368,23 +3344,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3393,14 +3369,14 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 				<clArg>-Xgcpolicy:balanced</clArg>
 			</setting>
 		</settings>
@@ -3410,14 +3386,14 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 				<clArg>-Xgcpolicy:balanced</clArg>
 			</setting>
 		</settings>
@@ -3427,18 +3403,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3448,15 +3424,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3465,19 +3441,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XXgc:tarokEnableExpensiveAssertions,fvtest_tarokPGCRotateCollectors</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXgc:tarokEnableExpensiveAssertions,fvtest_tarokPGCRotateCollectors"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXgc:tarokEnableExpensiveAssertions,fvtest_tarokPGCRotateCollectors"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3486,19 +3462,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3507,18 +3483,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3528,23 +3504,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-XX:+UseCompressedOops</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3554,18 +3530,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3575,22 +3551,22 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xaot:forceAoT,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3600,26 +3576,26 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:maximal=all,buffers=64k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:fatalassert</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:fatalassert"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:fatalassert"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3629,18 +3605,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses:nonpersistent</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3650,22 +3626,22 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:balanced</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XXnosuballoc32bitmem"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XXnosuballoc32bitmem"/>
 				<clArg>-XXnosuballoc32bitmem</clArg>
 			</setting>
 		</settings>
@@ -3675,14 +3651,14 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 				<clArg>-Xint</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 				<clArg>-Xgcpolicy:optthruput</clArg>
 			</setting>
 		</settings>
@@ -3692,14 +3668,14 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 				<clArg>-Xgcpolicy:optthruput</clArg>
 			</setting>
 		</settings>
@@ -3709,18 +3685,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3730,15 +3706,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3747,15 +3723,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3764,19 +3740,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3785,18 +3761,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3806,23 +3782,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3831,23 +3807,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3856,15 +3832,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3873,15 +3849,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3890,18 +3866,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3911,15 +3887,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3928,19 +3904,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3949,23 +3925,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xmn512k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 		</settings>
 	</mode>
@@ -3974,18 +3950,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -3995,15 +3971,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4012,14 +3988,14 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4029,18 +4005,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xnoquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4050,15 +4026,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4067,15 +4043,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 						<setting type="either">
 				<clArg>-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4084,19 +4060,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:counts=&quot;- - - - - - 1 1 1 1000 250 250 - - - 10000 100000 10000&quot;,gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xcheck:gc:vmthreads:all:quiet</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcheck:gc:vmthreads:all:quiet"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4105,18 +4081,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xquickstart"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xquickstart"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4126,15 +4102,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:subpool</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xint"/>
 			</setting>
 		</settings>
     </mode>
@@ -4143,14 +4119,14 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:subpool</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4160,15 +4136,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:subpool</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:subpool"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4178,18 +4154,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4199,22 +4175,22 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xaot:forceAoT,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaot:forceAoT,count=0"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4224,26 +4200,26 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xtrace:maximal=all,buffers=64k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xtrace:maximal=all,buffers=64k"/>
 			</setting>
 			<setting type="either">
 				<clArg>-XX:fatalassert</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:fatalassert"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:fatalassert"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4253,18 +4229,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xshareclasses:nonpersistent</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses:nonpersistent"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
 				<clArg>-Xjit</clArg>
 			</setting>
 		</settings>
@@ -4274,22 +4250,22 @@ Removed verbose:stackwalk from anywhere it appeared.
         <settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
             <setting type="either">
                 <clArg>-Xgcpolicy:optthruput</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
             </setting>
             <setting type="either">
                 <clArg>-Xshareclasses</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
             </setting>
             <setting type="either">
                 <clArg>-Xzero</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xzero"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xzero"/>
             </setting>
             <setting type="either">
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
                 <clArg>-Xjit</clArg>
             </setting>
         </settings>
@@ -4299,23 +4275,23 @@ Removed verbose:stackwalk from anywhere it appeared.
         <settings>
             <setting type="either">
                 <clArg>-XX:+UseCompressedOops</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
             </setting>
             <setting type="either">
                 <clArg>-Xjit</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
             </setting>
             <setting type="either">
                 <clArg>-Xgcpolicy:gencon</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
             </setting>
             <setting type="either">
             	<clArg>-Xaggressive</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
             </setting>
             <setting type="either">
             	<clArg>-Xshareclasses</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
             </setting>
         </settings>
     </mode>
@@ -4324,23 +4300,23 @@ Removed verbose:stackwalk from anywhere it appeared.
         <settings>
             <setting type="either">
                 <clArg>-Xcompressedrefs</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
             </setting>
             <setting type="either">
                 <clArg>-Xjit:count=0</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
             </setting>
             <setting type="either">
                 <clArg>-Xgcpolicy:gencon</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
             </setting>
             <setting type="either">
             	<clArg>-Xaggressive</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
             </setting>
             <setting type="either">
             	<clArg>-Xshareclasses</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xshareclasses"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xshareclasses"/>
             </setting>
         </settings>
     </mode>
@@ -4349,19 +4325,19 @@ Removed verbose:stackwalk from anywhere it appeared.
         <settings>
             <setting type="either">
                 <clArg>-XX:+UseCompressedOops</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-XX:+UseCompressedOops"/>
             </setting>
             <setting type="either">
                 <clArg>-Xjit</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
             </setting>
             <setting type="either">
                 <clArg>-Xgcpolicy:gencon</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
             </setting>
             <setting type="either">
             	<clArg>-Xaggressive</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
             </setting>
         </settings>
     </mode>
@@ -4370,23 +4346,23 @@ Removed verbose:stackwalk from anywhere it appeared.
         <settings>
             <setting type="either">
                 <clArg>-Xcompressedrefs</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
             </setting>
             <setting type="either">
                 <clArg>-Xjit:count=0</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:count=0"/>
             </setting>
             <setting type="either">
                 <clArg>-Xgcpolicy:gencon</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
             </setting>
             <setting type="either">
             	<clArg>-Xaggressive</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xaggressive"/>
             </setting>
             <setting type="either">
 				<clArg>-Xconcurrentlevel0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xconcurrentlevel0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xconcurrentlevel0"/>
 			</setting>
         </settings>
     </mode>
@@ -4395,382 +4371,23 @@ Removed verbose:stackwalk from anywhere it appeared.
         <settings>
             <setting type="either">
                 <clArg>-Xcompressedrefs</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs "/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs "/>
             </setting>
             <setting type="either">
                 <clArg>-Xjit</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit"/>
             </setting>
             <setting type="either">
                 <clArg>-Xgcpolicy:gencon</clArg>
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
             </setting>
             <setting type="either">
-                <envVar name="IBM_JAVA_OPTIONS" value="-Xlp"/>
+                <envVar name="OPENJ9_JAVA_OPTIONS" value="-Xlp"/>
                 <clArg>-Xlp</clArg>
             </setting>
         </settings>
     </mode>
-	<mode number="700">
-		<description>JIT on, accurate GC accounting with gencon (J9)</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-				<clArg>-Xgcpolicy:gencon</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:-ReduceCPUMonitorOverhead"/>
-				<clArg>-XX:-ReduceCPUMonitorOverhead</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-				<clArg>-Xnocompressedrefs</clArg>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="701">
-		<description>JIT on, accurate GC accounting with metronome (J9)</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:-ReduceCPUMonitorOverhead"/>
-				<clArg>-XX:-ReduceCPUMonitorOverhead</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-				<clArg>-Xnocompressedrefs</clArg>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="702">
-		<description>JIT on, accurate GC accounting with balanced (J9)</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:balanced"/>
-				<clArg>-Xgcpolicy:balanced</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:-ReduceCPUMonitorOverhead"/>
-				<clArg>-XX:-ReduceCPUMonitorOverhead</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-				<clArg>-Xnocompressedrefs</clArg>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="703">
-		<description>JIT on, accurate GC accounting with optavgpause (J9)</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
-				<clArg>-Xgcpolicy:optavgpause</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:-ReduceCPUMonitorOverhead"/>
-				<clArg>-XX:-ReduceCPUMonitorOverhead</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-				<clArg>-Xnocompressedrefs</clArg>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="705">
-		<description>JIT on, gencon gc (J9) with Idle Tuning on</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:IdleTuningMinIdleWaitTime=180</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:IdleTuningMinIdleWaitTime=180"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="706">
-		<description>JIT on, gencon gc (J9) with GC on Idle in IdleTuning</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+IdleTuningGcOnIdle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+IdleTuningGcOnIdle"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="707">
-		<description>JIT on, gencon gc (J9) with GC and Compaction on Idle in IdleTuning</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+IdleTuningCompactOnIdle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+IdleTuningCompactOnIdle"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="708">
-		<description>JIT on, gencon gc (J9) with Idle Tuning on</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:IdleTuningMinIdleWaitTime=180</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:IdleTuningMinIdleWaitTime=180"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="709">
-		<description>JIT on, gencon gc (J9) with GC on Idle in IdleTuning</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+IdleTuningGcOnIdle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+IdleTuningGcOnIdle"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="710">
-		<description>JIT on, gencon gc (J9) with GC and Compaction on Idle in IdleTuning</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+IdleTuningCompactOnIdle</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+IdleTuningCompactOnIdle"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="901">
-		<description>Ensure alternatve hashing algorithm is used, no other JVM options set</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Djdk.map.althashing.threshold=1</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Djdk.map.althashing.threshold=1"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="902">
-		<description>Ensure alternatve hashing algorithm is used if a HashMap capacity expands from the default, no other JVM options set</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Djdk.map.althashing.threshold=31</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Djdk.map.althashing.threshold=31"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-		</settings>
-	</mode>
-
-	<mode number="903">
-	    <description>Force on DAA behaviour</description>
-	    <settings>
-	        <setting type="either">
-		    <clArg>-Xjit:disableIntrinsics</clArg>
-		    <envVar name="IBM_JAVA_OPTIONS" value="-Xjit:disableIntrinsics"/>
-		</setting>
-	    </settings>
-	</mode>
-	<mode number="904">
-        <description>SVT Cloud Mode interpreted</description>
-        <settings>
-            <setting type="envVar">
-                <envVar name="MT_DAEMON_OPTIONS" value="-Xgcpolicy:balanced"/>
-            </setting>
-            <setting type="envVar">
-                <envVar name="MT_DAEMON_OPTIONS" value="-Xint"/>
-            </setting>
-            <setting type="envVar">
-                <envVar name="MT_DAEMON_OPTIONS" value="-Xcompressedrefs"/>
-            </setting>
-        </settings>
-    </mode>
-    <mode number="905">
-        <description>SVT Cloud Mode with JIT</description>
-        <settings>
-            <setting type="envVar">
-                <envVar name="MT_DAEMON_OPTIONS" value="-Xgcpolicy:balanced"/>
-            </setting>
-            <setting type="envVar">
-                <envVar name="MT_DAEMON_OPTIONS" value="-Xjit"/>
-            </setting>
-            <setting type="envVar">
-                <envVar name="MT_DAEMON_OPTIONS" value="-Xcompressedrefs"/>
-            </setting>
-        </settings>
-    </mode>
-    <mode number="1000">
-        <description>SVT Deterministic JIT mode, number 0</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=0"/>
-				<clArg>-Xjit:deterministic=0</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1001">
-        <description>SVT Deterministic JIT mode, number 1</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=1"/>
-				<clArg>-Xjit:deterministic=1</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1002">
-        <description>SVT Deterministic JIT mode, number 2</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=2"/>
-				<clArg>-Xjit:deterministic=2</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1003">
-        <description>SVT Deterministic JIT mode, number 3</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=3"/>
-				<clArg>-Xjit:deterministic=3</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1004">
-        <description>SVT Deterministic JIT mode, number 4</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=4"/>
-				<clArg>-Xjit:deterministic=4</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1005">
-        <description>SVT Deterministic JIT mode, number 5</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=5"/>
-				<clArg>-Xjit:deterministic=5</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1006">
-        <description>SVT Deterministic JIT mode, number 6</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=6"/>
-				<clArg>-Xjit:deterministic=6</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1007">
-        <description>SVT Deterministic JIT mode, number 7</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=7"/>
-				<clArg>-Xjit:deterministic=7</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1008">
-        <description>SVT Deterministic JIT mode, number 8</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=8"/>
-				<clArg>-Xjit:deterministic=8</clArg>
-			</setting>
-		</settings>
-    </mode>
-    <mode number="1009">
-        <description>SVT Deterministic JIT mode, number 9</description>
-        <settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:deterministic=9"/>
-				<clArg>-Xjit:deterministic=9</clArg>
-			</setting>
-		</settings>
-    </mode>
+	
 	<mode number="Random">
 		<description>Place holder for mode information randomly generated at runtime.</description>
 	</mode>
@@ -4788,19 +4405,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4808,12 +4425,12 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, gencon gc (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR"/>
 				<clArg>-Xjit:enableOSR</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4822,11 +4439,11 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4835,23 +4452,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4860,15 +4477,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR"/>
 				<clArg>-Xjit:enableOSR</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4877,15 +4494,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,count=0"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4894,19 +4511,19 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4914,12 +4531,12 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<description>JIT on, with OSROnGuardFailure gencon gc (J9)</description>
 		<settings>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
 				<clArg>-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4928,23 +4545,23 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xdebug</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xdebug"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xdebug"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4953,15 +4570,15 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
 				<clArg>-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation</clArg>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 		</settings>
 	</mode>
@@ -4970,399 +4587,18 @@ Removed verbose:stackwalk from anywhere it appeared.
 		<settings>
 			<setting type="either">
 				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xcompressedrefs"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
 			</setting>
 			<setting type="either">
 				<clArg>-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
+				<envVar name="OPENJ9_JAVA_OPTIONS" value="-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation"/>
 			</setting>
 		</settings>
 	</mode>
-	<mode number="100-PACK">
-		<description>JIT off, optthruput GC (J9) packed</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
-				<clArg>-Xint</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
-				<clArg>-Xgcpolicy:optthruput</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="101-PACK">
-		<description>JIT on, packed on, optthruput GC (J9)</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
-				<clArg>-Xgcpolicy:optthruput</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-
-	<mode number="103-PACK">
-		<description>JIT on, packed on, optthruput GC, force JIT compilation with jit:count=0 (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="104-PACK">
-		<description>JIT on, packed on, optthruput GC, force JIT compilation with jit:count=0, high opt, aggressive pointer sniffer (-Xsnw) (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:optthruput</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optthruput"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-
-	<mode number="109-PACK">
-		<description>JIT off, gencon GC (J9) packed</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="110-PACK">
-		<description>JIT on, gencon gc (J9) packed</description>
-		<settings>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="112-PACK">
-		<description>JIT on, gencon gc, jit count=0 (J9) packed</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="113-PACK">
-		<description>JIT on, gencon gc, jit count=0, high opt, aggressive pointer sniffer (J9) packed</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xmn512k</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xmn512k"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="118-PACK">
-		<description>JIT off, optavgpause gc (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-		</settings>
-	</mode>
-	<mode number="119-PACK">
-		<description>JIT on, packed on, optavgpause gc (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
-			</setting>
-			<setting type="either">
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-				<clArg>-Xjit</clArg>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="121-PACK">
-		<description>JIT on, packed on, optavgpause gc, force compile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="122-PACK">
-		<description>JIT on, packed on, optavgpause gc, force compile, aggressive pointer sniffer, quickProfile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgcpolicy:optavgpause</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:optavgpause"/>
-			</setting>
-						<setting type="either">
-				<clArg>-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0,optlevel=hot,gcOnResolve,rtResolve"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-XX:+PackedObject</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-XX:+PackedObject"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="109-NUMA">
-		<description>JIT on, packed on, optavgpause gc, force compile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgc:numa</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:numa"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xint</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xint"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="110-NUMA">
-		<description>JIT on, packed on, optavgpause gc, force compile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgc:numa</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:numa"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="112-NUMA">
-		<description>JIT on, packed on, optavgpause gc, force compile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgc:numa</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:numa"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnocompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnocompressedrefs"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="151-NUMA">
-		<description>JIT on, packed on, optavgpause gc, force compile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgc:numa</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:numa"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xnoquickstart</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xnoquickstart"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit"/>
-			</setting>
-
-		</settings>
-	</mode>
-	<mode number="199-NUMA">
-		<description>JIT on, packed on, optavgpause gc, force compile (J9)</description>
-		<settings>
-			<setting type="either">
-				<clArg>-Xgc:numa</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgc:numa"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xaggressive</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xaggressive"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xcompressedrefs</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xcompressedrefs"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xgcpolicy:gencon</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xgcpolicy:gencon"/>
-			</setting>
-			<setting type="either">
-				<clArg>-Xjit:count=0</clArg>
-				<envVar name="IBM_JAVA_OPTIONS" value="-Xjit:count=0"/>
-			</setting>
-
-		</settings>
-	</mode>
+	
+	
 </modes>


### PR DESCRIPTION
Also remove obsolete modes

[ci skip]

Fixes https://github.com/eclipse/openj9/issues/3525

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>