### PR TITLE
Fix incorrect JVMTI capability check

### DIFF
--- a/runtime/jvmti/jvmtiMethod.c
+++ b/runtime/jvmti/jvmtiMethod.c
@@ -898,7 +898,6 @@ jvmtiIsMethodObsolete(jvmtiEnv* env,
 	Trc_JVMTI_jvmtiIsMethodObsolete_Entry(env);
 
 	ENSURE_PHASE_START_OR_LIVE(env);
-	ENSURE_CAPABILITY(env, can_redefine_classes);
 
 	ENSURE_JMETHODID_NON_NULL(method);
 	ENSURE_NON_NULL(is_obsolete_ptr);


### PR DESCRIPTION
IsObsoleteMethod incorrectly required that the can_redefine_classes
capability be acquired in the envrionment. No such restriction exists in
the specification.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>