### PR TITLE
Defer acquiring heap walk capability until necessary

### DIFF
--- a/runtime/include/ibmjvmti.h
+++ b/runtime/include/ibmjvmti.h
@@ -339,26 +339,6 @@ typedef struct jvmtiObjectRenameInfo {
     jlong newAutoTag;
 } jvmtiObjectRenameInfo;
 
-/**
- * Signature of callback function which may be provided to the jvmtiAutotaggedObjectAlloc callback.
- * This function is callback-safe and it has the same parameters as VMObjectAlloc, plus a pointer to userData.
- * 
- * JNIEnv - the JNI environment of the event (current) thread.
- * thread - thread allocating the object.
- * object - JNI local reference to the object that was allocated.
- * object_klass	- JNI local reference to the class of the object.
- * size	- size of the object (in bytes).
- * userData - pointer received in the jvmtiAutotaggedObjectAlloc callback
- */ 
-typedef void (JNICALL *jvmtiAutotaggedObjectAllocCallbackSafeFunction)(
-	jvmtiEnv *jvmti_env,
-	JNIEnv* jni_env,
-	jthread thread,
-	jobject object,
-	jclass object_klass,
-	jlong size,
-	void *userData);
-
 /*
  * Trace subscriber callback function. This function will be passed records containing trace
  * data as they are processed. This provides a mechanism for a user defined transport and is

--- a/runtime/jvmti/jvmtiHeap10.c
+++ b/runtime/jvmti/jvmtiHeap10.c
@@ -91,6 +91,7 @@ jvmtiIterateOverHeap(jvmtiEnv* env,
 		ENSURE_NON_NULL(heap_object_callback);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
+		ensureHeapWalkable(currentThread);
 
 		iteratorData.env = (J9JVMTIEnv *)env;
 		iteratorData.filter = object_filter;
@@ -137,6 +138,7 @@ jvmtiIterateOverInstancesOfClass(jvmtiEnv* env,
 		ENSURE_NON_NULL(heap_object_callback);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
+		ensureHeapWalkable(currentThread);
 
 		iteratorData.env = (J9JVMTIEnv *)env;
 		iteratorData.filter = object_filter;
@@ -186,6 +188,7 @@ jvmtiIterateOverObjectsReachableFromObject(jvmtiEnv* env,
 		ENSURE_NON_NULL(object_reference_callback);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
+		ensureHeapWalkable(currentThread);
 
 		slot = *(j9object_t*)object;
 
@@ -235,6 +238,7 @@ jvmtiIterateOverReachableObjects(jvmtiEnv* env,
 		ENSURE_CAPABILITY(env, can_tag_objects);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
+		ensureHeapWalkable(currentThread);
 
 		iteratorData.env = (J9JVMTIEnv *)env;
 		iteratorData.heapRootCallback = (jvmtiHeapRootCallback) J9_COMPATIBLE_FUNCTION_POINTER( heap_root_callback );
@@ -500,12 +504,7 @@ processStackRoot(J9JVMTIObjectIteratorData * data, J9JVMTIObjectTag * entry, jlo
 	/* Find thread tag */
 
 	search.ref = (j9object_t) walkState->walkThread->threadObject;
-	if (!AUTOTAGGING_OBJECTS(data->env)) {
-		result = hashTableFind(data->env->objectTagTable, &search);
-	} else {
-		search.tag = (jlong)(UDATA)search.ref;
-		result = &search;
-	}
+	result = hashTableFind(data->env->objectTagTable, &search);
 	
 	/* Call the callback */
 
@@ -538,12 +537,7 @@ wrapHeapIterationCallback(J9JavaVM * vm, J9MM_IterateObjectDescriptor *objectDes
 		}
 
 		entry.ref = object;
-		if ( OBJECT_IS_TAGGABLE(iteratorData->env, vm, object) ) {
-			objectTag = hashTableFind(iteratorData->env->objectTagTable, &entry);
-		} else {
-			entry.tag = (jlong)(UDATA)entry.ref;
-			objectTag = &entry;
-		}
+		objectTag = hashTableFind(iteratorData->env->objectTagTable, &entry);
 
 		if ( (iteratorData->filter == JVMTI_HEAP_OBJECT_EITHER) ||
 		     (iteratorData->filter == JVMTI_HEAP_OBJECT_TAGGED && objectTag != NULL) ||
@@ -567,29 +561,26 @@ wrapHeapIterationCallback(J9JavaVM * vm, J9MM_IterateObjectDescriptor *objectDes
 					&tag,
 					iteratorData->userData);
 
-			/* Update the tag only if not autotagging or if it is a class, i.e., if the object is taggable */
-			if ( OBJECT_IS_TAGGABLE(iteratorData->env, vm, object) ) {
-				if (objectTag) {
-					/* object was tagged before callback */
-					if (tag) {
-						/* still tagged, update the tag */
-						objectTag->tag = tag;
-					} else {
-						/* no longer tagged, remove the table entry */
-						entry.ref = object;
-						hashTableRemove(iteratorData->env->objectTagTable, &entry);
-					}
+			if (objectTag) {
+				/* object was tagged before callback */
+				if (tag) {
+					/* still tagged, update the tag */
+					objectTag->tag = tag;
 				} else {
-					/* object was untagged before callback */
-					if (tag) {
-						/* now tagged, add table entry */
-						entry.ref = object;
-						entry.tag = tag;
-						hashTableAdd(iteratorData->env->objectTagTable, &entry);
-					}
+					/* no longer tagged, remove the table entry */
+					entry.ref = object;
+					hashTableRemove(iteratorData->env->objectTagTable, &entry);
+				}
+			} else {
+				/* object was untagged before callback */
+				if (tag) {
+					/* now tagged, add table entry */
+					entry.ref = object;
+					entry.tag = tag;
+					hashTableAdd(iteratorData->env->objectTagTable, &entry);
 				}
 			}
-			
+		
 			return rc;
 		}
 	}
@@ -628,12 +619,7 @@ wrapObjectIterationCallback(j9object_t *slotPtr, j9object_t referrer, void *user
 
 		if ( referrer && (event.type != J9JVMTI_HEAP_EVENT_STACK)) {
 			entry.ref = referrer;
-			if ( OBJECT_IS_TAGGABLE(iteratorData->env, vm, referrer) ) {
-				result = hashTableFind(iteratorData->env->objectTagTable, &entry);
-			} else {
-				entry.tag = (jlong)(UDATA)entry.ref;
-				result = &entry;
-			}
+			result = hashTableFind(iteratorData->env->objectTagTable, &entry);
 			referrerTag = result ? result->tag : 0;
 		}
 
@@ -641,14 +627,8 @@ wrapObjectIterationCallback(j9object_t *slotPtr, j9object_t referrer, void *user
 
 		entry.ref = object;
 		entry.tag = 0;
-
-		if ( OBJECT_IS_TAGGABLE(iteratorData->env, vm, object) ) {
-			result = hashTableFind(iteratorData->env->objectTagTable, &entry);
-			if ( result == NULL ) {
-				result = &entry;
-			}
-		} else {
-			entry.tag = (jlong)(UDATA)entry.ref;
+		result = hashTableFind(iteratorData->env->objectTagTable, &entry);
+		if ( result == NULL ) {
 			result = &entry;
 		}
 
@@ -666,19 +646,15 @@ wrapObjectIterationCallback(j9object_t *slotPtr, j9object_t referrer, void *user
 				break;
 		}
 
-		/* Update the tag only if not autotagging or if it is a class, i.e., if the object is taggable */
-
-		if ( OBJECT_IS_TAGGABLE(iteratorData->env, vm, object) ) {
-			if ( &entry == result ) {
-				/* Tag wasn't set, but now is... */
-				if (result->tag != 0) {
-					hashTableAdd(iteratorData->env->objectTagTable, result);
-				}
-			} else {
-				/* Tag was set, but now isn't... */
-				if (result->tag == 0) {
-					hashTableRemove(iteratorData->env->objectTagTable, result);
-				}
+		if ( &entry == result ) {
+			/* Tag wasn't set, but now is... */
+			if (result->tag != 0) {
+				hashTableAdd(iteratorData->env->objectTagTable, result);
+			}
+		} else {
+			/* Tag was set, but now isn't... */
+			if (result->tag == 0) {
+				hashTableRemove(iteratorData->env->objectTagTable, result);
 			}
 		}
 	} else if (J9JVMTI_HEAP_EVENT_NONE_NOFOLLOW == event.type) {

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -1699,3 +1699,25 @@ findDecompileInfo(J9VMThread *currentThread, J9VMThread *targetThread, UDATA dep
 	currentThread->javaVM->walkStackFrames(currentThread, walkState);
 	return (UDATA)walkState->userData1;
 }
+
+void
+ensureHeapWalkable(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	/* Must be called while holding exclusive */
+	Assert_JVMTI_true(currentThread->omrVMThread->exclusiveCount > 0);
+	/* If heap walk is already enabled, nothing need be done */
+	if (J9_ARE_NO_BITS_SET(vm->requiredDebugAttributes, J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK)) {
+		J9MemoryManagerFunctions const * const mmFuncs = vm->memoryManagerFunctions;
+		vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK;
+		/* J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT allows the GC to run while the current thread is holding
+		 * exclusive VM access.
+		 */
+		mmFuncs->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT);
+		if (J9_GC_POLICY_METRONOME == vm->gcPolicy) {
+			/* In metronome, the previous GC call may have only finished the current cycle.
+			 * Call again to ensure a full GC takes place.					 */
+			mmFuncs->j9gc_modron_global_collect_with_overrides(currentThread, J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT);
+		}
+	}
+}

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -789,12 +789,6 @@ hookNonEventCapabilities(J9JVMTIEnv * j9env, jvmtiCapabilities * capabilities)
 	}
 
 	if (capabilities->can_tag_objects) {
-		/* Heap iteration functions require the can_tag_objects capability, so use the capability to tell the GC to maintain heap walkability */
-
-		if (enableDebugAttribute(j9env, J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK)) {
-			return 1;
-		}
-
 		if (hookRegister(gcOmrHook, J9HOOK_MM_OMR_GLOBAL_GC_END, jvmtiHookGCEnd, OMR_GET_CALLSITE(), j9env)) {
 			return 1;
 		}

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -902,6 +902,15 @@ jvmtiIterateOverReachableObjects(jvmtiEnv* env,
 /* ---------------- jvmtiHelpers.c ---------------- */
 
 /**
+* @brief Make the heap walkable, assume exclusive VM access is held
+* @param currentThread The current J9VMThread
+* @return void
+*/
+void
+ensureHeapWalkable(J9VMThread *currentThread);
+
+
+/**
 * @brief
 * @param state
 * @return J9JVMTIAgentBreakpoint *

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -178,7 +178,6 @@ typedef struct J9JVMTIEnv {
 #define J9JVMTIENV_FLAG_UNUSED_2 2
 #define J9JVMTIENV_FLAG_CLASS_LOAD_HOOK_EVER_ENABLED 4
 #define J9JVMTIENV_FLAG_RETRANSFORM_CAPABLE 8
-#define J9JVMTIENV_FLAG_AUTOTAG_OBJECTS 16
 
 
 typedef struct J9JVMTIData {
@@ -337,9 +336,6 @@ typedef struct jvmtiGcp_translation {
 		Trc_JVMTI_##func##_Exit(rc, param, param2, param3, param4); \
 		return rc; \
 	} while(0)
-
-#define AUTOTAGGING_OBJECTS(env) (((J9JVMTIEnv *) (env))->flags & J9JVMTIENV_FLAG_AUTOTAG_OBJECTS)
-#define OBJECT_IS_TAGGABLE(env, vm, object) ( !AUTOTAGGING_OBJECTS((env)) || J9VM_IS_INITIALIZED_HEAPCLASS_VM((vm), (object)) )
 
 /*
  * True if the given JLClass instance is a JLClass instance but is not fully initialized.


### PR DESCRIPTION
Rather than enabling the heap walk GC capability when can_tag_objects is
acquired, defer it until the first use of the heap walk APIs. This
allows object tags to be used without the GC time penalty if the heap
walk APIs are avoided.

Also remove the last vestiges of autotagging (GC and most JVMTI support
was removed some time ago).

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>