### PR TITLE
DDR updates for examining thread stacks

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
@@ -109,10 +109,6 @@ public class StructureStubGenerator {
 	}
 
 	private void generateClass(StructureDescriptor structure) throws IOException {
-		String superClassName = structure.getSuperName();
-		if (superClassName == null || superClassName.isEmpty()) {
-			superClassName = "StructurePointer";
-		}
 		File javaFile = new File(outputDir, structure.getName() + ".java");
 		byte[] original = null;
 		int length = 0;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ConfigFlags.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ConfigFlags.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.j9ddr.vm29.j9;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+
+/**
+ * This class deals with an oversight in the migration to new DDR tools.
+ *
+ * The DDR tooling from OMR, normally generates constants with names as they appear in
+ * the source code. Field overrides can be used to adjust those names. Unfortunately,
+ * overrides were only specified for fields that were actually used in DDR_VM code and
+ * it was later discovered that the host_XXX fields from TRBuildFlags were not properly
+ * captured in the blob. The arch_XXX fields in J9BuildFlags are reliable, but some
+ * interim builds don't include the overrides for all flags we need to use. This class
+ * adapts to core files from those builds.
+ */
+public final class J9ConfigFlags {
+
+	public static final boolean arch_arm;
+	public static final boolean arch_power;
+	public static final boolean arch_s390;
+	public static final boolean arch_x86;
+
+	static {
+		Class<?> flagsClass = J9BuildFlags.class;
+
+		arch_arm = getFlag(flagsClass, "arch_arm", "J9VM_ARCH_ARM");
+		arch_power = getFlag(flagsClass, "arch_power", "J9VM_ARCH_POWER");
+		arch_s390 = getFlag(flagsClass, "arch_s390", "J9VM_ARCH_S390");
+		arch_x86 = getFlag(flagsClass, "arch_x86", "J9VM_ARCH_X86");
+	}
+
+	private static boolean getFlag(Class<?> flagsClass, String... fieldNames) {
+		Boolean value = null;
+
+		for (String fieldName : fieldNames) {
+			try {
+				Field field = flagsClass.getField(fieldName);
+				int modifiers = field.getModifiers();
+
+				if (!Modifier.isPublic(modifiers) || !Modifier.isStatic(modifiers) || !Modifier.isFinal(modifiers)) {
+					// ignore fields with unexpected modifiers
+					continue;
+				}
+
+				if (field.getType() != boolean.class) {
+					// ignore non-boolean fields
+					continue;
+				}
+
+				if (value != null) {
+					// only one of the expected field names should match
+					throw new InternalError("ambiguous flag");
+				}
+
+				value = Boolean.valueOf(field.getBoolean(null));
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				// this should not happen - the field is public static final boolean
+				throw new InternalError("unexpected exception", e);
+			} catch (NoSuchFieldException e) {
+				// ignore: check below that exactly one field is found
+			} catch (SecurityException e) {
+				throw new InternalError("unexpected exception", e);
+			}
+		}
+
+		if (value == null) {
+			// exactly one of the expected field names should match
+			throw new InternalError("missing flag");
+		}
+
+		return value.booleanValue();
+	}
+
+}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corp. and others
+ * Copyright (c) 2009, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.j9.stackwalker;
 
-import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 
 /**
  * JIT register map.
@@ -29,234 +29,85 @@ import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
  * Per-platform register information reproduced here rather than embedded in blob.
  * 
  * @author andhall
- *
  */
-public class JITRegMap
-{
+public class JITRegMap {
 
 	static final String jitRegisterNames[];
-	
+
 	static final int jitCalleeDestroyedRegisterList[];
-	
+
 	static final int jitCalleeSavedRegisterList[];
-	
-	static
-	{
-		
-		if (TRBuildFlags.host_X86 && TRBuildFlags.host_32BIT) {
-			jitRegisterNames = new String[]{
-				"jit_eax",
-				"jit_ebx",
-				"jit_ecx",
-				"jit_edx",
-				"jit_edi",
-				"jit_esi",
-				"jit_ebp"
-			};
-			
-			jitCalleeDestroyedRegisterList = new int[] {
-				0x00,   /* jit_eax */
-				0x03,   /* jit_edx */
-				0x04,   /* jit_edi */
-				0x06    /* jit_ebp */
-			};
-			
-			jitCalleeSavedRegisterList = new int[] {
-				0x05,   /* jit_esi */
-				0x02,   /* jit_ecx */
-				0x01    /* jit_ebx */
-			};
-		} else if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
-			jitRegisterNames = new String[]{
-					"jit_rax",
-					"jit_rbx",
-					"jit_rcx",
-					"jit_rdx",
-					"jit_rdi",
-					"jit_rsi",
-					"jit_rbp",
-					"jit_rsp",
-					"jit_r8",
-					"jit_r9",
-					"jit_r10",
-					"jit_r11",
-					"jit_r12",
-					"jit_r13",
-					"jit_r14",
-					"jit_r15"
+
+	static {
+		if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (!J9BuildFlags.env_data64) {
+				jitRegisterNames = new String[] {
+						"jit_eax",
+						"jit_ebx",
+						"jit_ecx",
+						"jit_edx",
+						"jit_edi",
+						"jit_esi",
+						"jit_ebp"
 				};
-				
-			jitCalleeDestroyedRegisterList = new int[] {
-					0x00,   /* jit_rax */
-					0x02,   /* jit_rcx */
-					0x03,   /* jit_rdx */
-					0x04,   /* jit_rdi */
-					0x05,   /* jit_rsi */
-					0x06,   /* jit_rbp */
-					0x07,   /* jit_rsp */
-					0x08    /* jit_r8 */
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_eax */
+						0x03,   /* jit_edx */
+						0x04,   /* jit_edi */
+						0x06    /* jit_ebp */
 				};
-				
-			jitCalleeSavedRegisterList = new int[] {
-					0x01,   /* jit_rbx */
-					0x0F,   /* jit_r15 */
-					0x0E,   /* jit_r14 */
-					0x0D,   /* jit_r13 */
-					0x0C,   /* jit_r12 */
-					0x0B,   /* jit_r11 */
-					0x0A,   /* jit_r10 */
-					0x09    /* jit_r9 */
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x05,   /* jit_esi */
+						0x02,   /* jit_ecx */
+						0x01    /* jit_ebx */
 				};
-		} else if (TRBuildFlags.host_POWER && TRBuildFlags.host_32BIT) {
-			jitRegisterNames = new String[]{
-					"jit_r0",
-					"jit_r1",
-					"jit_r2",
-					"jit_r3",
-					"jit_r4",
-					"jit_r5",
-					"jit_r6",
-					"jit_r7",
-					"jit_r8",
-					"jit_r9",
-					"jit_r10",
-					"jit_r11",
-					"jit_r12",
-					"jit_r13",
-					"jit_r14",
-					"jit_r15",
-					"jit_r16",
-					"jit_r17",
-					"jit_r18",
-					"jit_r19",
-					"jit_r20",
-					"jit_r21",
-					"jit_r22",
-					"jit_r23",
-					"jit_r24",
-					"jit_r25",
-					"jit_r26",
-					"jit_r27",
-					"jit_r28",
-					"jit_r29",
-					"jit_r30",
-					"jit_r31"
+			} else {
+				jitRegisterNames = new String[] {
+						"jit_rax",
+						"jit_rbx",
+						"jit_rcx",
+						"jit_rdx",
+						"jit_rdi",
+						"jit_rsi",
+						"jit_rbp",
+						"jit_rsp",
+						"jit_r8",
+						"jit_r9",
+						"jit_r10",
+						"jit_r11",
+						"jit_r12",
+						"jit_r13",
+						"jit_r14",
+						"jit_r15"
 				};
-				
-			jitCalleeDestroyedRegisterList = new int[] {
-					0x00,   /* jit_r0 */
-					0x01,   /* jit_r1 */
-					0x02,   /* jit_r2 */
-					0x03,   /* jit_r3 */
-					0x04,   /* jit_r4 */
-					0x05,   /* jit_r5 */
-					0x06,   /* jit_r6 */
-					0x07,   /* jit_r7 */
-					0x08,   /* jit_r8 */
-					0x09,   /* jit_r9 */
-					0x0A,   /* jit_r10 */
-					0x0B,   /* jit_r11 */
-					0x0C,   /* jit_r12 */
-					0x0D,   /* jit_r13 */
-					0x0E    /* jit_r14 */
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_rax */
+						0x02,   /* jit_rcx */
+						0x03,   /* jit_rdx */
+						0x04,   /* jit_rdi */
+						0x05,   /* jit_rsi */
+						0x06,   /* jit_rbp */
+						0x07,   /* jit_rsp */
+						0x08    /* jit_r8 */
 				};
-				
-			jitCalleeSavedRegisterList = new int[] {
-					0x1F,   /* jit_r31 */
-					0x1E,   /* jit_r30 */
-					0x1D,   /* jit_r29 */
-					0x1C,   /* jit_r28 */
-					0x1B,   /* jit_r27 */
-					0x1A,   /* jit_r26 */
-					0x19,   /* jit_r25 */
-					0x18,   /* jit_r24 */
-					0x17,   /* jit_r23 */
-					0x16,   /* jit_r22 */
-					0x15,   /* jit_r21 */
-					0x14,   /* jit_r20 */
-					0x13,   /* jit_r19 */
-					0x12,   /* jit_r18 */
-					0x11,   /* jit_r17 */
-					0x10,   /* jit_r16 */
-					0x0F    /* jit_r15 */
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x01,   /* jit_rbx */
+						0x0F,   /* jit_r15 */
+						0x0E,   /* jit_r14 */
+						0x0D,   /* jit_r13 */
+						0x0C,   /* jit_r12 */
+						0x0B,   /* jit_r11 */
+						0x0A,   /* jit_r10 */
+						0x09    /* jit_r9 */
 				};
-		} else if (TRBuildFlags.host_POWER && TRBuildFlags.host_64BIT) {
-			jitRegisterNames = new String[]{
-					"jit_r0",
-					"jit_r1",
-					"jit_r2",
-					"jit_r3",
-					"jit_r4",
-					"jit_r5",
-					"jit_r6",
-					"jit_r7",
-					"jit_r8",
-					"jit_r9",
-					"jit_r10",
-					"jit_r11",
-					"jit_r12",
-					"jit_r13",
-					"jit_r14",
-					"jit_r15",
-					"jit_r16",
-					"jit_r17",
-					"jit_r18",
-					"jit_r19",
-					"jit_r20",
-					"jit_r21",
-					"jit_r22",
-					"jit_r23",
-					"jit_r24",
-					"jit_r25",
-					"jit_r26",
-					"jit_r27",
-					"jit_r28",
-					"jit_r29",
-					"jit_r30",
-					"jit_r31"
-				};
-				
-			jitCalleeDestroyedRegisterList = new int[] {
-					0x00,   /* jit_r0 */
-					0x01,   /* jit_r1 */
-					0x02,   /* jit_r2 */
-					0x03,   /* jit_r3 */
-					0x04,   /* jit_r4 */
-					0x05,   /* jit_r5 */
-					0x06,   /* jit_r6 */
-					0x07,   /* jit_r7 */
-					0x08,   /* jit_r8 */
-					0x09,   /* jit_r9 */
-					0x0A,   /* jit_r10 */
-					0x0B,   /* jit_r11 */
-					0x0C,   /* jit_r12 */
-					0x0D,   /* jit_r13 */
-					0x0E,   /* jit_r14 */
-					0x0F    /* jit_r15 */
-				};
-				
-			jitCalleeSavedRegisterList = new int[] {
-					0x1F,   /* jit_r31 */
-					0x1E,   /* jit_r30 */
-					0x1D,   /* jit_r29 */
-					0x1C,   /* jit_r28 */
-					0x1B,   /* jit_r27 */
-					0x1A,   /* jit_r26 */
-					0x19,   /* jit_r25 */
-					0x18,   /* jit_r24 */
-					0x17,   /* jit_r23 */
-					0x16,   /* jit_r22 */
-					0x15,   /* jit_r21 */
-					0x14,   /* jit_r20 */
-					0x13,   /* jit_r19 */
-					0x12,   /* jit_r18 */
-					0x11,   /* jit_r17 */
-					0x10    /* jit_r16 */
-				};
-		} else {
-			//390 32 & 64
-			if (TRBuildFlags.host_32BIT) {
-				jitRegisterNames = new String[]{
+			}
+		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			if (!J9BuildFlags.env_data64) {
+				jitRegisterNames = new String[] {
 						"jit_r0",
 						"jit_r1",
 						"jit_r2",
@@ -289,8 +140,156 @@ public class JITRegMap
 						"jit_r29",
 						"jit_r30",
 						"jit_r31"
-					};
-					
+				};
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_r0 */
+						0x01,   /* jit_r1 */
+						0x02,   /* jit_r2 */
+						0x03,   /* jit_r3 */
+						0x04,   /* jit_r4 */
+						0x05,   /* jit_r5 */
+						0x06,   /* jit_r6 */
+						0x07,   /* jit_r7 */
+						0x08,   /* jit_r8 */
+						0x09,   /* jit_r9 */
+						0x0A,   /* jit_r10 */
+						0x0B,   /* jit_r11 */
+						0x0C,   /* jit_r12 */
+						0x0D,   /* jit_r13 */
+						0x0E    /* jit_r14 */
+				};
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x1F,   /* jit_r31 */
+						0x1E,   /* jit_r30 */
+						0x1D,   /* jit_r29 */
+						0x1C,   /* jit_r28 */
+						0x1B,   /* jit_r27 */
+						0x1A,   /* jit_r26 */
+						0x19,   /* jit_r25 */
+						0x18,   /* jit_r24 */
+						0x17,   /* jit_r23 */
+						0x16,   /* jit_r22 */
+						0x15,   /* jit_r21 */
+						0x14,   /* jit_r20 */
+						0x13,   /* jit_r19 */
+						0x12,   /* jit_r18 */
+						0x11,   /* jit_r17 */
+						0x10,   /* jit_r16 */
+						0x0F    /* jit_r15 */
+				};
+			} else {
+				jitRegisterNames = new String[] {
+						"jit_r0",
+						"jit_r1",
+						"jit_r2",
+						"jit_r3",
+						"jit_r4",
+						"jit_r5",
+						"jit_r6",
+						"jit_r7",
+						"jit_r8",
+						"jit_r9",
+						"jit_r10",
+						"jit_r11",
+						"jit_r12",
+						"jit_r13",
+						"jit_r14",
+						"jit_r15",
+						"jit_r16",
+						"jit_r17",
+						"jit_r18",
+						"jit_r19",
+						"jit_r20",
+						"jit_r21",
+						"jit_r22",
+						"jit_r23",
+						"jit_r24",
+						"jit_r25",
+						"jit_r26",
+						"jit_r27",
+						"jit_r28",
+						"jit_r29",
+						"jit_r30",
+						"jit_r31"
+				};
+
+				jitCalleeDestroyedRegisterList = new int[] {
+						0x00,   /* jit_r0 */
+						0x01,   /* jit_r1 */
+						0x02,   /* jit_r2 */
+						0x03,   /* jit_r3 */
+						0x04,   /* jit_r4 */
+						0x05,   /* jit_r5 */
+						0x06,   /* jit_r6 */
+						0x07,   /* jit_r7 */
+						0x08,   /* jit_r8 */
+						0x09,   /* jit_r9 */
+						0x0A,   /* jit_r10 */
+						0x0B,   /* jit_r11 */
+						0x0C,   /* jit_r12 */
+						0x0D,   /* jit_r13 */
+						0x0E,   /* jit_r14 */
+						0x0F    /* jit_r15 */
+				};
+
+				jitCalleeSavedRegisterList = new int[] {
+						0x1F,   /* jit_r31 */
+						0x1E,   /* jit_r30 */
+						0x1D,   /* jit_r29 */
+						0x1C,   /* jit_r28 */
+						0x1B,   /* jit_r27 */
+						0x1A,   /* jit_r26 */
+						0x19,   /* jit_r25 */
+						0x18,   /* jit_r24 */
+						0x17,   /* jit_r23 */
+						0x16,   /* jit_r22 */
+						0x15,   /* jit_r21 */
+						0x14,   /* jit_r20 */
+						0x13,   /* jit_r19 */
+						0x12,   /* jit_r18 */
+						0x11,   /* jit_r17 */
+						0x10    /* jit_r16 */
+				};
+			}
+		} else if (J9BuildFlags.arch_s390) {
+			if (!J9BuildFlags.env_data64) {
+				jitRegisterNames = new String[] {
+						"jit_r0",
+						"jit_r1",
+						"jit_r2",
+						"jit_r3",
+						"jit_r4",
+						"jit_r5",
+						"jit_r6",
+						"jit_r7",
+						"jit_r8",
+						"jit_r9",
+						"jit_r10",
+						"jit_r11",
+						"jit_r12",
+						"jit_r13",
+						"jit_r14",
+						"jit_r15",
+						"jit_r16",
+						"jit_r17",
+						"jit_r18",
+						"jit_r19",
+						"jit_r20",
+						"jit_r21",
+						"jit_r22",
+						"jit_r23",
+						"jit_r24",
+						"jit_r25",
+						"jit_r26",
+						"jit_r27",
+						"jit_r28",
+						"jit_r29",
+						"jit_r30",
+						"jit_r31"
+				};
+
 				jitCalleeDestroyedRegisterList = new int[] {
 						0x00,	/* jit_r0 */
 						0x01,	/* jit_r1 */
@@ -311,7 +310,7 @@ public class JITRegMap
 						0x1E,	/* jit_r30 */
 						0x1F	/* jit_r31 */
 				};
-					
+
 				jitCalleeSavedRegisterList = new int[] {
 						0x1C,	/* jit_r28 */
 						0x1B,	/* jit_r27 */
@@ -330,7 +329,7 @@ public class JITRegMap
 				};
 			} else {
 				/* 390 64 bit */
-				jitRegisterNames = new String[]{
+				jitRegisterNames = new String[] {
 						"jit_r0",
 						"jit_r1",
 						"jit_r2",
@@ -347,8 +346,8 @@ public class JITRegMap
 						"jit_r13",
 						"jit_r14",
 						"jit_r15",
-					};
-					
+				};
+
 				jitCalleeDestroyedRegisterList = new int[] {
 						0x00,	/* jit_r0 */
 						0x01,	/* jit_r1 */
@@ -360,7 +359,7 @@ public class JITRegMap
 						0x0E,	/* jit_r14 */
 						0x0F,	/* jit_r15 */
 				};
-					
+
 				jitCalleeSavedRegisterList = new int[] {
 						0x0C,	/* jit_r12 */
 						0x0B,	/* jit_r11 */
@@ -371,8 +370,9 @@ public class JITRegMap
 						0x06	/* jit_r6 */
 				};
 			}
+		} else {
+			throw new InternalError("Unsupported platform");
 		}
-		
 	}
-	
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITRegMap.java
@@ -21,6 +21,7 @@
  *******************************************************************************/
 package com.ibm.j9ddr.vm29.j9.stackwalker;
 
+import com.ibm.j9ddr.vm29.j9.J9ConfigFlags;
 import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 
 /**
@@ -39,7 +40,7 @@ public class JITRegMap {
 	static final int jitCalleeSavedRegisterList[];
 
 	static {
-		if (J9BuildFlags.J9VM_ARCH_X86) {
+		if (J9ConfigFlags.arch_x86) {
 			if (!J9BuildFlags.env_data64) {
 				jitRegisterNames = new String[] {
 						"jit_eax",
@@ -105,7 +106,7 @@ public class JITRegMap {
 						0x09    /* jit_r9 */
 				};
 			}
-		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+		} else if (J9ConfigFlags.arch_power) {
 			if (!J9BuildFlags.env_data64) {
 				jitRegisterNames = new String[] {
 						"jit_r0",
@@ -253,7 +254,7 @@ public class JITRegMap {
 						0x10    /* jit_r16 */
 				};
 			}
-		} else if (J9BuildFlags.arch_s390) {
+		} else if (J9ConfigFlags.arch_s390) {
 			if (!J9BuildFlags.env_data64) {
 				jitRegisterNames = new String[] {
 						"jit_r0",

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -159,7 +159,7 @@ public class JITStackWalker
 		
 		private static U8Pointer MASK_PC(AbstractPointer ptr)
 		{
-			if (TRBuildFlags.host_S390 && TRBuildFlags.host_32BIT) {
+			if (J9BuildFlags.arch_s390 && !J9BuildFlags.env_data64) {
 				return U8Pointer.cast(UDATA.cast(ptr).bitAnd(0x7FFFFFFF));
 			} else {
 				return U8Pointer.cast(ptr);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -32,6 +32,7 @@ import com.ibm.j9ddr.vm29.j9.AlgorithmPicker;
 import com.ibm.j9ddr.vm29.j9.AlgorithmVersion;
 import com.ibm.j9ddr.vm29.j9.BaseAlgorithm;
 import com.ibm.j9ddr.vm29.j9.IAlgorithm;
+import com.ibm.j9ddr.vm29.j9.J9ConfigFlags;
 import com.ibm.j9ddr.vm29.pointer.AbstractPointer;
 import com.ibm.j9ddr.vm29.pointer.ObjectReferencePointer;
 import com.ibm.j9ddr.vm29.pointer.PointerPointer;
@@ -159,7 +160,7 @@ public class JITStackWalker
 		
 		private static U8Pointer MASK_PC(AbstractPointer ptr)
 		{
-			if (J9BuildFlags.arch_s390 && !J9BuildFlags.env_data64) {
+			if (J9ConfigFlags.arch_s390 && !J9BuildFlags.env_data64) {
 				return U8Pointer.cast(UDATA.cast(ptr).bitAnd(0x7FFFFFFF));
 			} else {
 				return U8Pointer.cast(ptr);
@@ -646,7 +647,7 @@ public class JITStackWalker
 		{
 			U64Pointer base = U64Pointer.cast(walkState.walkedEntryLocalStorage.jitFPRegisterStorageBase());
 
-			if (J9BuildFlags.arch_s390) {
+			if (J9ConfigFlags.arch_s390) {
 				/* 390 uses FPR0/2/4/6 for arguments, so double fpParmNumber to get the right register */
 				fpParmNumber = fpParmNumber.add(fpParmNumber);
 				/* On 390, either vector or floating point registers are preserved in the ELS, not both.

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -394,26 +394,28 @@ public class MethodMetaData
 		
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 data resolve shape
-				 16 slots of XMM registers
-				 16 slots of scalar registers
-				 1 slot flags
-				 1 slot call from snippet
-				 1 slot call from codecache to snippet
-				 */
-				return new UDATA(16);
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 data resolve shape
-				 20 slots FP saves
-				 7 slots integer registers
-				 1 slot saved flags
-				 1 slot return address in snippet
-				 1 slot literals
-				 1 slot cpIndex
-				 1 slot call from codecache to snippet
-				 */
-				return new UDATA(20);
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 data resolve shape
+					 16 slots of XMM registers
+					 16 slots of scalar registers
+					 1 slot flags
+					 1 slot call from snippet
+					 1 slot call from codecache to snippet
+					 */
+					return new UDATA(16);
+				} else {
+					/* IA32 data resolve shape
+					 20 slots FP saves
+					 7 slots integer registers
+					 1 slot saved flags
+					 1 slot return address in snippet
+					 1 slot literals
+					 1 slot cpIndex
+					 1 slot call from codecache to snippet
+					 */
+					return new UDATA(20);
+				}
 			} else {
 				return new UDATA(0);
 			}
@@ -548,62 +550,62 @@ public class MethodMetaData
 			return md.objectTempSlots(); 
 		}
 		
-		public UDATA getJitDataResolvePushes() throws CorruptDataException
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-			/* AMD64 data resolve shape
-			   16 slots of XMM registers
-			   16 slots of integer registers
-			   1 slot flags
-			   1 slot call from snippet
-			   1 slot call from codecache to snippet
-			*/
-				return new UDATA(35);
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-			/* IA32 data resolve shape
-			   20 slots FP saves
-			   7 slots integer registers
-			   1 slot saved flags
-			   1 slot return address in snippet
-			   1 slot literals
-			   1 slot cpIndex
-			   1 slot call from codecache to snippet
-			*/
-				return new UDATA(32);
+		public UDATA getJitDataResolvePushes() throws CorruptDataException {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 data resolve shape
+					   16 slots of XMM registers
+					   16 slots of integer registers
+					   1 slot flags
+					   1 slot call from snippet
+					   1 slot call from codecache to snippet
+					*/
+					return new UDATA(35);
+				} else {
+					/* IA32 data resolve shape
+					   20 slots FP saves
+					   7 slots integer registers
+					   1 slot saved flags
+					   1 slot return address in snippet
+					   1 slot literals
+					   1 slot cpIndex
+					   1 slot call from codecache to snippet
+					*/
+					return new UDATA(32);
+				}
 			} else if (J9BuildFlags.J9VM_ARCH_ARM) {
-			/* ARM data resolve shape
-			   12 slots saved integer registers
-			*/
+				/* ARM data resolve shape
+				   12 slots saved integer registers
+				*/
 				return new UDATA(12);
 			} else if (J9BuildFlags.arch_s390) {
-			/* 390 data resolve shape
-			   16 integer registers
-			*/
+				/* 390 data resolve shape
+				   16 integer registers
+				*/
 				if (J9BuildFlags.jit_32bitUses64bitRegisters) {
 					return new UDATA(32);
 				} else {
 					return new UDATA(16);
 				}
 			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
-			/* PPC data resolve shape
-			   32 integer registers
-			   CR
-			*/
+				/* PPC data resolve shape
+				   32 integer registers
+				   CR
+				*/
 				return new UDATA(33);
 			} else if (TRBuildFlags.host_MIPS) {
-			/* MIPS data resolve shape
-			   32 integer registers
-			*/
+				/* MIPS data resolve shape
+				   32 integer registers
+				*/
 				return new UDATA(32);
 			} else if (TRBuildFlags.host_SH4) {
-			/* SH4 data resolve shape
-			   16 integer registers 
-			*/
+				/* SH4 data resolve shape
+				   16 integer registers 
+				*/
 				return new UDATA(16);
 			} else {
 				return new UDATA(0);
 			}
-
 		}
 
 		public VoidPointer getStackMapFromJitPC(J9JavaVMPointer javaVM,
@@ -1007,31 +1009,32 @@ public class MethodMetaData
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
-		public int getJitRecompilationResolvePushes()
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 recompilation resolve shape
-				0: rcx (arg register)
-				1: rdx (arg register)
-				2: rsi (arg register)
-				3: rax (arg register)
-				4: 8 XMMs (1 8-byte slot each)				<== unwindSP points here
-				12: return PC (caller of recompiled method)
-				13: <last argument to method>				<== unwindSP should point here"
-				 */
-				return 9;
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 recompilation resolve shape
-				0: return address (picbuilder)
-				1: return PC (caller of recompiled method)
-				2: old start address
-				3: method
-				4: EAX (contains receiver for virtual)	<== unwindSP points here
-				5: EDX
-				6: return PC (caller of recompiled method)
-				7: <last argument to method>				<== unwindSP should point here"
-				 */
-				return 3;
+		public int getJitRecompilationResolvePushes() {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 recompilation resolve shape
+					0: rcx (arg register)
+					1: rdx (arg register)
+					2: rsi (arg register)
+					3: rax (arg register)
+					4: 8 XMMs (1 8-byte slot each)				<== unwindSP points here
+					12: return PC (caller of recompiled method)
+					13: <last argument to method>				<== unwindSP should point here"
+					*/
+					return 9;
+				} else {
+					/* IA32 recompilation resolve shape
+					0: return address (picbuilder)
+					1: return PC (caller of recompiled method)
+					2: old start address
+					3: method
+					4: EAX (contains receiver for virtual)	<== unwindSP points here
+					5: EDX
+					6: return PC (caller of recompiled method)
+					7: <last argument to method>				<== unwindSP should point here"
+					*/
+					return 3;
+				}
 			} else if (J9BuildFlags.arch_s390) {
 				/* 390 recompilation resolve shape
 				0:		r3 (arg register)
@@ -1045,7 +1048,7 @@ public class MethodMetaData
 				8:		temp2
 				9:		temp3
 				XX:	<linkage area>							<== unwindSP should point here
-				 */
+				*/
 				return 7 + (64 / UDATA.SIZEOF);
 			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC recompilation resolve shape
@@ -1061,7 +1064,7 @@ public class MethodMetaData
 				9:	r12
 				10:	r12
 				XX:	<linkage area>						<== unwindSP should point here
-				 */
+				*/
 				return 3;
 			} else {
 				return 0;
@@ -1073,32 +1076,33 @@ public class MethodMetaData
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
-		public int getJitVirtualMethodResolvePushes()
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 virtual resolve shape
-				0: ret addr to picbuilder
-				1: arg3
-				2: arg2
-				3: arg1
-				4: arg0
-				5: saved RDI								<==== unwindSP points here
-				6: code cache return address
-				7: last arg									<==== unwindSP should point here
-				 */
-				return 2;
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 virtual resolve shape
-				0: return address (picbuilder)
-				1: indexAndLiteralsEA
-				2: jitEIP
-				3: saved eax									<== unwindSP points here
-				4: saved esi
-				5: saved edi
-				6: return address (code cache)
-				7: <last argument to method>			<== unwindSP should point here
-				 */
-				return 4;
+		public int getJitVirtualMethodResolvePushes() {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 virtual resolve shape
+					0: ret addr to picbuilder
+					1: arg3
+					2: arg2
+					3: arg1
+					4: arg0
+					5: saved RDI								<==== unwindSP points here
+					6: code cache return address
+					7: last arg									<==== unwindSP should point here
+					*/
+					return 2;
+				} else {
+					/* IA32 virtual resolve shape
+					0: return address (picbuilder)
+					1: indexAndLiteralsEA
+					2: jitEIP
+					3: saved eax									<== unwindSP points here
+					4: saved esi
+					5: saved edi
+					6: return address (code cache)
+					7: <last argument to method>			<== unwindSP should point here
+					 */
+					return 4;
+				}
 			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC doesn't save anything extra */
 				return 0;
@@ -1111,7 +1115,7 @@ public class MethodMetaData
 				4: return address                <== unwindSP points here    
 				5: saved resolved data
 				6: <last argument to method>     <== unwindSP should point here
-				 */
+				*/
 				return 2;
 			} else {
 				return 0;
@@ -1123,30 +1127,30 @@ public class MethodMetaData
 		   Include the slot for the pushed return address (if any) for the call from the codecache to the picbuilder.
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
-		public int getJitStaticMethodResolvePushes()
-		{
-			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-				/* AMD64 static resolve shape
-				0: ret addr to picbuilder
-				1: code cache return address		<==== unwindSP points here
-				2: last arg									<==== unwindSP should point here
-				 */
-				return 1;
-			} else if (J9BuildFlags.J9VM_ARCH_X86) {
-				/* IA32 static resolve shape
-				0: return address (picbuilder)
-				1: jitEIP
-				2: constant pool
-				3: cpIndex
-				4: return address (code cache)		<== unwindSP points here
-				5: <last argument to method>			<== unwindSP should point here
-				 */
-				return 1;
+		public int getJitStaticMethodResolvePushes() {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
+				if (J9BuildFlags.env_data64) {
+					/* AMD64 static resolve shape
+					0: ret addr to picbuilder
+					1: code cache return address		<==== unwindSP points here
+					2: last arg									<==== unwindSP should point here
+					 */
+					return 1;
+				} else {
+					/* IA32 static resolve shape
+					0: return address (picbuilder)
+					1: jitEIP
+					2: constant pool
+					3: cpIndex
+					4: return address (code cache)		<== unwindSP points here
+					5: <last argument to method>			<== unwindSP should point here
+					 */
+					return 1;
+				}
 			} else {
 				return 0;
 			}
 		}
-
 
 		public void walkJITFrameSlotsForInternalPointers(WalkState walkState,  U8Pointer jitDescriptionCursor, UDATAPointer scanCursor, VoidPointer stackMap, J9JITStackAtlasPointer gcStackAtlas) throws CorruptDataException
 		{

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -356,8 +356,8 @@ public class MethodMetaData
 	private static class MethodMetaData_29_V0 extends com.ibm.j9ddr.vm29.j9.BaseAlgorithm implements MethodMetaDataImpl
 	{
 
-		private static boolean alignStackMaps = TRBuildFlags.host_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;
-		
+		private static boolean alignStackMaps = J9BuildFlags.J9VM_ARCH_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;
+
 		protected MethodMetaData_29_V0() {
 			super(90,0);
 		}
@@ -394,7 +394,7 @@ public class MethodMetaData
 		
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 data resolve shape
 				 16 slots of XMM registers
 				 16 slots of scalar registers
@@ -403,7 +403,7 @@ public class MethodMetaData
 				 1 slot call from codecache to snippet
 				 */
 				return new UDATA(16);
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 data resolve shape
 				 20 slots FP saves
 				 7 slots integer registers
@@ -433,7 +433,7 @@ public class MethodMetaData
 			J9JITExceptionTablePointer md = walkState.jitInfo;
 			UDATA registerSaveDescription = walkState.jitInfo.registerSaveDescription();
 
-			if (TRBuildFlags.host_X86) {
+			if (J9BuildFlags.J9VM_ARCH_X86) {
 				UDATA prologuePushes = new UDATA(getJitProloguePushes(walkState.jitInfo));
 				U8 i = new U8(1); 
 
@@ -454,8 +454,8 @@ public class MethodMetaData
 					}
 					while (! registerSaveDescription.eq(0));
 				}
-			} else if (TRBuildFlags.host_POWER || TRBuildFlags.host_MIPS) {
-				if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER || TRBuildFlags.host_MIPS) {
+				if (J9BuildFlags.J9VM_ARCH_POWER) {
 					/*
 					 * see PPCLinkage for a description of the RSD 
 					 * the save offset is located from bits 18-32 
@@ -473,7 +473,7 @@ public class MethodMetaData
 				}
 				saveCursor = walkState.bp.subOffset(saveOffset);
 
-				if (TRBuildFlags.host_POWER) {
+				if (J9BuildFlags.J9VM_ARCH_POWER) {
 					mapCursor += lowestRegister.intValue(); /* access gpr15 in the vm register state */
 					U8 i = new U8(lowestRegister.add(1));
 					do 
@@ -497,7 +497,7 @@ public class MethodMetaData
 						savedGPRs = savedGPRs.sub(1);
 					}
 				}
-			} else if (TRBuildFlags.host_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_S390) {
+			} else if (J9BuildFlags.J9VM_ARCH_ARM || TRBuildFlags.host_SH4 || J9BuildFlags.arch_s390) {
 				savedGPRs = registerSaveDescription.bitAnd(new UDATA(0xFFFF));
 
 				if (! savedGPRs.eq(0))
@@ -526,7 +526,7 @@ public class MethodMetaData
 		
 		private U8Pointer GET_REGISTER_SAVE_DESCRIPTION_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF * 2);
 			} else {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF);
@@ -550,7 +550,7 @@ public class MethodMetaData
 		
 		public UDATA getJitDataResolvePushes() throws CorruptDataException
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 			/* AMD64 data resolve shape
 			   16 slots of XMM registers
 			   16 slots of integer registers
@@ -559,7 +559,7 @@ public class MethodMetaData
 			   1 slot call from codecache to snippet
 			*/
 				return new UDATA(35);
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 			/* IA32 data resolve shape
 			   20 slots FP saves
 			   7 slots integer registers
@@ -570,12 +570,12 @@ public class MethodMetaData
 			   1 slot call from codecache to snippet
 			*/
 				return new UDATA(32);
-			} else if (TRBuildFlags.host_ARM) {
+			} else if (J9BuildFlags.J9VM_ARCH_ARM) {
 			/* ARM data resolve shape
 			   12 slots saved integer registers
 			*/
 				return new UDATA(12);
-			} else if (TRBuildFlags.host_S390) {
+			} else if (J9BuildFlags.arch_s390) {
 			/* 390 data resolve shape
 			   16 integer registers
 			*/
@@ -584,7 +584,7 @@ public class MethodMetaData
 				} else {
 					return new UDATA(16);
 				}
-			} else if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 			/* PPC data resolve shape
 			   32 integer registers
 			   CR
@@ -727,7 +727,7 @@ public class MethodMetaData
 		@SuppressWarnings("unused")
 		private static U8Pointer ADDRESS_OF_REGISTERMAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(3 * U32.SIZEOF);
 			} else {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(2 * U32.SIZEOF);
@@ -763,7 +763,7 @@ public class MethodMetaData
 		//#define GET_REGISTER_MAP_CURSOR(fourByteOffset, stackMap) ((U_8 *)stackMap + SIZEOF_MAP_OFFSET(fourByteOffset) + 2*sizeof(U_32))
 		private static U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, U8Pointer stackMap)
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(3 * U32.SIZEOF));
 			} else {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(2 * U32.SIZEOF));
@@ -968,7 +968,7 @@ public class MethodMetaData
 
 		public U32 getJitHighWordRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return U32Pointer.cast(GET_HIGHWORD_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(methodMetaData), stackMap)).at(0);
 			} else {
 				return new U32(0);	
@@ -1009,7 +1009,7 @@ public class MethodMetaData
 		*/
 		public int getJitRecompilationResolvePushes()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 recompilation resolve shape
 				0: rcx (arg register)
 				1: rdx (arg register)
@@ -1020,7 +1020,7 @@ public class MethodMetaData
 				13: <last argument to method>				<== unwindSP should point here"
 				 */
 				return 9;
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 recompilation resolve shape
 				0: return address (picbuilder)
 				1: return PC (caller of recompiled method)
@@ -1032,7 +1032,7 @@ public class MethodMetaData
 				7: <last argument to method>				<== unwindSP should point here"
 				 */
 				return 3;
-			} else if (TRBuildFlags.host_S390) {
+			} else if (J9BuildFlags.arch_s390) {
 				/* 390 recompilation resolve shape
 				0:		r3 (arg register)
 				1:		r2 (arg register)
@@ -1047,7 +1047,7 @@ public class MethodMetaData
 				XX:	<linkage area>							<== unwindSP should point here
 				 */
 				return 7 + (64 / UDATA.SIZEOF);
-			} else if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC recompilation resolve shape
 				0:		r10 (arg register)
 				1:		r9 (arg register)
@@ -1075,7 +1075,7 @@ public class MethodMetaData
 		*/
 		public int getJitVirtualMethodResolvePushes()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 virtual resolve shape
 				0: ret addr to picbuilder
 				1: arg3
@@ -1087,7 +1087,7 @@ public class MethodMetaData
 				7: last arg									<==== unwindSP should point here
 				 */
 				return 2;
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 virtual resolve shape
 				0: return address (picbuilder)
 				1: indexAndLiteralsEA
@@ -1099,7 +1099,7 @@ public class MethodMetaData
 				7: <last argument to method>			<== unwindSP should point here
 				 */
 				return 4;
-			} else if (TRBuildFlags.host_POWER) {
+			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 				/* PPC doesn't save anything extra */
 				return 0;
 			} else if (TRBuildFlags.host_SH4) {
@@ -1125,14 +1125,14 @@ public class MethodMetaData
 		*/
 		public int getJitStaticMethodResolvePushes()
 		{
-			if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+			if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 				/* AMD64 static resolve shape
 				0: ret addr to picbuilder
 				1: code cache return address		<==== unwindSP points here
 				2: last arg									<==== unwindSP should point here
 				 */
 				return 1;
-			} else if (TRBuildFlags.host_X86) {
+			} else if (J9BuildFlags.J9VM_ARCH_X86) {
 				/* IA32 static resolve shape
 				0: return address (picbuilder)
 				1: jitEIP
@@ -1297,7 +1297,7 @@ public class MethodMetaData
 						swPrintf(walkState, 6, "\tJIT-RegisterMap = {0}", registerMap);
 						tempJitDescriptionCursorForRegs = U8Pointer.cast(stackMap);
 
-						if (TRBuildFlags.host_S390) {
+						if (J9BuildFlags.arch_s390) {
 							tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(12); /*skip register map, register save description word and high word register map*/
 						} else {						
 							tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(8); /*skip register map and register save description word */
@@ -1429,7 +1429,7 @@ public class MethodMetaData
 		
 		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap) 
 		{
-			if (TRBuildFlags.host_S390) {
+			if (J9BuildFlags.arch_s390) {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 3));
 			} else {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 2));
@@ -1466,7 +1466,7 @@ public class MethodMetaData
 		
 		private boolean isPatchedValue(J9MethodPointer m)
 		{
-			if ((TRBuildFlags.host_POWER && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
+			if ((J9BuildFlags.J9VM_ARCH_POWER && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
 				return true;
 			}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/MethodMetaData.java
@@ -35,6 +35,7 @@ import java.util.List;
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.j9.AlgorithmPicker;
 import com.ibm.j9ddr.vm29.j9.AlgorithmVersion;
+import com.ibm.j9ddr.vm29.j9.J9ConfigFlags;
 import com.ibm.j9ddr.vm29.pointer.PointerPointer;
 import com.ibm.j9ddr.vm29.pointer.U16Pointer;
 import com.ibm.j9ddr.vm29.pointer.U32Pointer;
@@ -356,7 +357,7 @@ public class MethodMetaData
 	private static class MethodMetaData_29_V0 extends com.ibm.j9ddr.vm29.j9.BaseAlgorithm implements MethodMetaDataImpl
 	{
 
-		private static boolean alignStackMaps = J9BuildFlags.J9VM_ARCH_ARM || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;
+		private static boolean alignStackMaps = J9ConfigFlags.arch_arm || TRBuildFlags.host_SH4 || TRBuildFlags.host_MIPS;
 
 		protected MethodMetaData_29_V0() {
 			super(90,0);
@@ -394,7 +395,7 @@ public class MethodMetaData
 		
 		private static UDATA getJitSlotsBeforeSavesInDataResolve()
 		{
-			if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9ConfigFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
 					/* AMD64 data resolve shape
 					 16 slots of XMM registers
@@ -435,7 +436,7 @@ public class MethodMetaData
 			J9JITExceptionTablePointer md = walkState.jitInfo;
 			UDATA registerSaveDescription = walkState.jitInfo.registerSaveDescription();
 
-			if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9ConfigFlags.arch_x86) {
 				UDATA prologuePushes = new UDATA(getJitProloguePushes(walkState.jitInfo));
 				U8 i = new U8(1); 
 
@@ -456,8 +457,8 @@ public class MethodMetaData
 					}
 					while (! registerSaveDescription.eq(0));
 				}
-			} else if (J9BuildFlags.J9VM_ARCH_POWER || TRBuildFlags.host_MIPS) {
-				if (J9BuildFlags.J9VM_ARCH_POWER) {
+			} else if (J9ConfigFlags.arch_power || TRBuildFlags.host_MIPS) {
+				if (J9ConfigFlags.arch_power) {
 					/*
 					 * see PPCLinkage for a description of the RSD 
 					 * the save offset is located from bits 18-32 
@@ -475,7 +476,7 @@ public class MethodMetaData
 				}
 				saveCursor = walkState.bp.subOffset(saveOffset);
 
-				if (J9BuildFlags.J9VM_ARCH_POWER) {
+				if (J9ConfigFlags.arch_power) {
 					mapCursor += lowestRegister.intValue(); /* access gpr15 in the vm register state */
 					U8 i = new U8(lowestRegister.add(1));
 					do 
@@ -499,7 +500,7 @@ public class MethodMetaData
 						savedGPRs = savedGPRs.sub(1);
 					}
 				}
-			} else if (J9BuildFlags.J9VM_ARCH_ARM || TRBuildFlags.host_SH4 || J9BuildFlags.arch_s390) {
+			} else if (J9ConfigFlags.arch_arm || TRBuildFlags.host_SH4 || J9ConfigFlags.arch_s390) {
 				savedGPRs = registerSaveDescription.bitAnd(new UDATA(0xFFFF));
 
 				if (! savedGPRs.eq(0))
@@ -528,7 +529,7 @@ public class MethodMetaData
 		
 		private U8Pointer GET_REGISTER_SAVE_DESCRIPTION_CURSOR(boolean fourByteOffset, VoidPointer stackMap)
 		{
-			if (J9BuildFlags.arch_s390) {
+			if (J9ConfigFlags.arch_s390) {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF * 2);
 			} else {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(U32.SIZEOF);
@@ -551,7 +552,7 @@ public class MethodMetaData
 		}
 		
 		public UDATA getJitDataResolvePushes() throws CorruptDataException {
-			if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9ConfigFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
 					/* AMD64 data resolve shape
 					   16 slots of XMM registers
@@ -573,12 +574,12 @@ public class MethodMetaData
 					*/
 					return new UDATA(32);
 				}
-			} else if (J9BuildFlags.J9VM_ARCH_ARM) {
+			} else if (J9ConfigFlags.arch_arm) {
 				/* ARM data resolve shape
 				   12 slots saved integer registers
 				*/
 				return new UDATA(12);
-			} else if (J9BuildFlags.arch_s390) {
+			} else if (J9ConfigFlags.arch_s390) {
 				/* 390 data resolve shape
 				   16 integer registers
 				*/
@@ -587,7 +588,7 @@ public class MethodMetaData
 				} else {
 					return new UDATA(16);
 				}
-			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			} else if (J9ConfigFlags.arch_power) {
 				/* PPC data resolve shape
 				   32 integer registers
 				   CR
@@ -729,7 +730,7 @@ public class MethodMetaData
 		@SuppressWarnings("unused")
 		private static U8Pointer ADDRESS_OF_REGISTERMAP(boolean fourByteOffset, U8Pointer stackMap)
 		{
-			if (J9BuildFlags.arch_s390) {
+			if (J9ConfigFlags.arch_s390) {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(3 * U32.SIZEOF);
 			} else {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset)).add(2 * U32.SIZEOF);
@@ -765,7 +766,7 @@ public class MethodMetaData
 		//#define GET_REGISTER_MAP_CURSOR(fourByteOffset, stackMap) ((U_8 *)stackMap + SIZEOF_MAP_OFFSET(fourByteOffset) + 2*sizeof(U_32))
 		private static U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, U8Pointer stackMap)
 		{
-			if (J9BuildFlags.arch_s390) {
+			if (J9ConfigFlags.arch_s390) {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(3 * U32.SIZEOF));
 			} else {
 				return stackMap.add(SIZEOF_MAP_OFFSET(fourByteOffset).add(2 * U32.SIZEOF));
@@ -970,7 +971,7 @@ public class MethodMetaData
 
 		public U32 getJitHighWordRegisterMap(J9JITExceptionTablePointer methodMetaData, VoidPointer stackMap) throws CorruptDataException
 		{
-			if (J9BuildFlags.arch_s390) {
+			if (J9ConfigFlags.arch_s390) {
 				return U32Pointer.cast(GET_HIGHWORD_REGISTER_MAP_CURSOR(HAS_FOUR_BYTE_OFFSET(methodMetaData), stackMap)).at(0);
 			} else {
 				return new U32(0);	
@@ -1010,7 +1011,7 @@ public class MethodMetaData
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
 		public int getJitRecompilationResolvePushes() {
-			if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9ConfigFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
 					/* AMD64 recompilation resolve shape
 					0: rcx (arg register)
@@ -1035,7 +1036,7 @@ public class MethodMetaData
 					*/
 					return 3;
 				}
-			} else if (J9BuildFlags.arch_s390) {
+			} else if (J9ConfigFlags.arch_s390) {
 				/* 390 recompilation resolve shape
 				0:		r3 (arg register)
 				1:		r2 (arg register)
@@ -1050,7 +1051,7 @@ public class MethodMetaData
 				XX:	<linkage area>							<== unwindSP should point here
 				*/
 				return 7 + (64 / UDATA.SIZEOF);
-			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			} else if (J9ConfigFlags.arch_power) {
 				/* PPC recompilation resolve shape
 				0:		r10 (arg register)
 				1:		r9 (arg register)
@@ -1077,7 +1078,7 @@ public class MethodMetaData
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
 		public int getJitVirtualMethodResolvePushes() {
-			if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9ConfigFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
 					/* AMD64 virtual resolve shape
 					0: ret addr to picbuilder
@@ -1103,7 +1104,7 @@ public class MethodMetaData
 					 */
 					return 4;
 				}
-			} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			} else if (J9ConfigFlags.arch_power) {
 				/* PPC doesn't save anything extra */
 				return 0;
 			} else if (TRBuildFlags.host_SH4) {
@@ -1128,7 +1129,7 @@ public class MethodMetaData
 		   Do not include the slot for return address for call from picbuilder to resolve helper.
 		*/
 		public int getJitStaticMethodResolvePushes() {
-			if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9ConfigFlags.arch_x86) {
 				if (J9BuildFlags.env_data64) {
 					/* AMD64 static resolve shape
 					0: ret addr to picbuilder
@@ -1301,7 +1302,7 @@ public class MethodMetaData
 						swPrintf(walkState, 6, "\tJIT-RegisterMap = {0}", registerMap);
 						tempJitDescriptionCursorForRegs = U8Pointer.cast(stackMap);
 
-						if (J9BuildFlags.arch_s390) {
+						if (J9ConfigFlags.arch_s390) {
 							tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(12); /*skip register map, register save description word and high word register map*/
 						} else {						
 							tempJitDescriptionCursorForRegs = tempJitDescriptionCursorForRegs.add(8); /*skip register map and register save description word */
@@ -1433,7 +1434,7 @@ public class MethodMetaData
 		
 		private U8Pointer GET_REGISTER_MAP_CURSOR(boolean fourByteOffset, VoidPointer stackMap) 
 		{
-			if (J9BuildFlags.arch_s390) {
+			if (J9ConfigFlags.arch_s390) {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 3));
 			} else {
 				return U8Pointer.cast(stackMap).add(SIZEOF_MAP_OFFSET(fourByteOffset).add(U32.SIZEOF * 2));
@@ -1470,7 +1471,7 @@ public class MethodMetaData
 		
 		private boolean isPatchedValue(J9MethodPointer m)
 		{
-			if ((J9BuildFlags.J9VM_ARCH_POWER && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
+			if ((J9ConfigFlags.arch_power && m.anyBitsIn(0x1))   ||  UDATA.cast(m).bitNot().eq(0)) {
 				return true;
 			}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -262,16 +262,18 @@ public class StackWalker
 						} else if (J9BuildFlags.arch_s390) {
 							/* r5 */
 							javaSPName = "r5";
-						} else if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-							/* esp */
-							javaSPName = "rsp";
 						} else if (J9BuildFlags.J9VM_ARCH_X86) {
-							/* rsp */
-							javaSPName = "esp";
+							if (J9BuildFlags.env_data64) {
+								/* rsp */
+								javaSPName = "rsp";
+							} else {
+								/* esp */
+								javaSPName = "esp";
+							}
 						} else {
 							throw new IllegalArgumentException("Unsupported platform");
 						}
-						
+
 						for (IRegister reg : nativeThread.getRegisters()) {
 							if (reg.getName().equalsIgnoreCase(javaSPName)) {
 								javaSp = UDATAPointer.cast(reg.getValue().longValue());

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -34,6 +34,7 @@ import com.ibm.j9ddr.vm29.j9.AlgorithmPicker;
 import com.ibm.j9ddr.vm29.j9.AlgorithmVersion;
 import com.ibm.j9ddr.vm29.j9.BaseAlgorithm;
 import com.ibm.j9ddr.vm29.j9.IAlgorithm;
+import com.ibm.j9ddr.vm29.j9.J9ConfigFlags;
 import com.ibm.j9ddr.vm29.pointer.PointerPointer;
 import com.ibm.j9ddr.vm29.pointer.U32Pointer;
 import com.ibm.j9ddr.vm29.pointer.U8Pointer;
@@ -255,14 +256,14 @@ public class StackWalker
 
 						/* fetch the Java stack for the platform directly from the register file */
 						String javaSPName = "";
-						if (J9BuildFlags.J9VM_ARCH_POWER) {
+						if (J9ConfigFlags.arch_power) {
 							/* AIX shows as POWER not PPC */
 							/* gpr14 */
 							javaSPName = "gpr14";
-						} else if (J9BuildFlags.arch_s390) {
+						} else if (J9ConfigFlags.arch_s390) {
 							/* r5 */
 							javaSPName = "r5";
-						} else if (J9BuildFlags.J9VM_ARCH_X86) {
+						} else if (J9ConfigFlags.arch_x86) {
 							if (J9BuildFlags.env_data64) {
 								/* rsp */
 								javaSPName = "rsp";

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -55,7 +55,6 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9SFMethodTypeFramePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9SFSpecialFramePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9SFStackFramePointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9VMEntryLocalStoragePointer;
-import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ROMMethodHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ThreadHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
@@ -256,17 +255,17 @@ public class StackWalker
 
 						/* fetch the Java stack for the platform directly from the register file */
 						String javaSPName = "";
-						if (TRBuildFlags.host_POWER) {
+						if (J9BuildFlags.J9VM_ARCH_POWER) {
 							/* AIX shows as POWER not PPC */
 							/* gpr14 */
 							javaSPName = "gpr14";
-						} else if (TRBuildFlags.host_S390) {
+						} else if (J9BuildFlags.arch_s390) {
 							/* r5 */
 							javaSPName = "r5";
-						} else if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
+						} else if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
 							/* esp */
 							javaSPName = "rsp";
-						} else if (TRBuildFlags.host_X86 && TRBuildFlags.host_32BIT) {
+						} else if (J9BuildFlags.J9VM_ARCH_X86) {
 							/* rsp */
 							javaSPName = "esp";
 						} else {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -38,6 +38,7 @@ import java.io.PrintStream;
 import java.text.MessageFormat;
 
 import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.j9.J9ConfigFlags;
 import com.ibm.j9ddr.vm29.pointer.PointerPointer;
 import com.ibm.j9ddr.vm29.pointer.UDATAPointer;
 import com.ibm.j9ddr.vm29.pointer.VoidPointer;
@@ -87,16 +88,16 @@ public class StackWalkerUtils
 	static final int jitArgumentRegisterNumbers[];
 	
 	static {
-		if (J9BuildFlags.J9VM_ARCH_X86) {
+		if (J9ConfigFlags.arch_x86) {
 			if (J9BuildFlags.env_data64) {
 				jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
 			} else {
 				// 32 bit X86 doesn't use jitArgumentRegisterNumbers
 				jitArgumentRegisterNumbers = new int[0];
 			}
-		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+		} else if (J9ConfigFlags.arch_power) {
 			jitArgumentRegisterNumbers = new int[] { 3, 4, 5, 6, 7, 8, 9, 10 };
-		} else if (J9BuildFlags.arch_s390) {
+		} else if (J9ConfigFlags.arch_s390) {
 			jitArgumentRegisterNumbers = new int[] { 1, 2, 3 };
 		} else {
 			throw new IllegalArgumentException("Unsupported platform");
@@ -263,7 +264,7 @@ public class StackWalkerUtils
 	
 	public static UDATA JIT_RESOLVE_PARM(WalkState walkState, int parmNumber) throws CorruptDataException
 	{
-		if (J9BuildFlags.J9VM_ARCH_X86 && !J9BuildFlags.env_data64) {
+		if (J9ConfigFlags.arch_x86 && !J9BuildFlags.env_data64) {
 			return walkState.bp.at(parmNumber);
 		} else {
 			return walkState.walkedEntryLocalStorage.jitGlobalStorageBase().at(jitArgumentRegisterNumbers[parmNumber - 1]);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -46,7 +46,6 @@ import com.ibm.j9ddr.vm29.pointer.generated.J9ConstantPoolPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9MethodPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMMethodPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9UTF8Pointer;
-import com.ibm.j9ddr.vm29.pointer.generated.TRBuildFlags;
 import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.structure.J9Consts;
 import com.ibm.j9ddr.vm29.types.UDATA;
@@ -88,12 +87,12 @@ public class StackWalkerUtils
 	static final int jitArgumentRegisterNumbers[];
 	
 	static {
-		if (TRBuildFlags.host_X86 && TRBuildFlags.host_64BIT) {
-			jitArgumentRegisterNumbers = new int[]{ 0, 5, 3, 2};
-		} else if (TRBuildFlags.host_POWER) {
-			jitArgumentRegisterNumbers = new int[]{ 3, 4, 5, 6, 7, 8, 9, 10 };
-		} else if (TRBuildFlags.host_S390) {
-			jitArgumentRegisterNumbers = new int[]{ 1, 2, 3 };
+		if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
+			jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
+		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
+			jitArgumentRegisterNumbers = new int[] { 3, 4, 5, 6, 7, 8, 9, 10 };
+		} else if (J9BuildFlags.arch_s390) {
+			jitArgumentRegisterNumbers = new int[] { 1, 2, 3 };
 		} else {
 			//32 bit X86 doesn't use jitArgumentRegisterNumbers
 			jitArgumentRegisterNumbers = new int[0];
@@ -260,7 +259,7 @@ public class StackWalkerUtils
 	
 	public static UDATA JIT_RESOLVE_PARM(WalkState walkState, int parmNumber) throws CorruptDataException
 	{
-		if (TRBuildFlags.host_X86 && TRBuildFlags.host_32BIT) {
+		if (J9BuildFlags.J9VM_ARCH_X86 && !J9BuildFlags.env_data64) {
 			return walkState.bp.at(parmNumber);
 		} else {
 			return walkState.walkedEntryLocalStorage.jitGlobalStorageBase().at(jitArgumentRegisterNumbers[parmNumber - 1]);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalkerUtils.java
@@ -87,15 +87,19 @@ public class StackWalkerUtils
 	static final int jitArgumentRegisterNumbers[];
 	
 	static {
-		if (J9BuildFlags.J9VM_ARCH_X86 && J9BuildFlags.env_data64) {
-			jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
+		if (J9BuildFlags.J9VM_ARCH_X86) {
+			if (J9BuildFlags.env_data64) {
+				jitArgumentRegisterNumbers = new int[] { 0, 5, 3, 2 };
+			} else {
+				// 32 bit X86 doesn't use jitArgumentRegisterNumbers
+				jitArgumentRegisterNumbers = new int[0];
+			}
 		} else if (J9BuildFlags.J9VM_ARCH_POWER) {
 			jitArgumentRegisterNumbers = new int[] { 3, 4, 5, 6, 7, 8, 9, 10 };
 		} else if (J9BuildFlags.arch_s390) {
 			jitArgumentRegisterNumbers = new int[] { 1, 2, 3 };
 		} else {
-			//32 bit X86 doesn't use jitArgumentRegisterNumbers
-			jitArgumentRegisterNumbers = new int[0];
+			throw new IllegalArgumentException("Unsupported platform");
 		}
 	}
 	

--- a/runtime/ddr/jitflagsddr.c
+++ b/runtime/ddr/jitflagsddr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #include <limits.h>
 #include "j9ddr.h"
 #include "ddrtable.h"
+#include "env/defines.h" /* for TR_HOST_XXX */
 
 /* @ddr_namespace: map_to_type=TRBuildFlags */
 
@@ -34,13 +35,13 @@ J9DDRConstantTableBegin(TRBuildFlags)
 	#define host_ARM 0
 #endif
 J9DDRConstantTableEntryWithValue("host_ARM", host_ARM)
-	
+
 #if defined(TR_HOST_IA32)
 	#define host_IA32 1
 #else
 	#define host_IA32 0
 #endif
-J9DDRConstantTableEntryWithValue("host_IA32", host_IA32) 
+J9DDRConstantTableEntryWithValue("host_IA32", host_IA32)
 
 #if defined(TR_HOST_POWER)
 	#define host_POWER 1
@@ -83,6 +84,7 @@ J9DDRConstantTableEntryWithValue("host_32BIT", host_32BIT)
 	#define host_64BIT 0
 #endif
 J9DDRConstantTableEntryWithValue("host_64BIT", host_64BIT)
+
 J9DDRConstantTableEnd
 
 J9DDRConstantTableBegin(CLimits)
@@ -107,9 +109,8 @@ J9DDRStructTableBegin(JIT)
 	J9DDREmptyStruct(CLimits, NULL)
 J9DDRStructTableEnd
 
-const J9DDRStructDefinition* getJITStructTable()
+const J9DDRStructDefinition *
+getJITStructTable()
 {
 	return J9DDR_JIT_structs;
 }
-
-

--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -388,6 +388,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			</include>
 			<include path="j9gcvlhgc"/>
 			<include path="$(OMR_DIR)/include_core" type="relativepath"/>
+			<include path="$(OMR_DIR)/compiler" type="relativepath">
+				<include-if condition="spec.flags.J9VM_INTERP_NATIVE_SUPPORT"/>
+			</include>
 		</includes>
 		<makefilestubs>
 			<makefilestub data="CFLAGS += -femit-class-debug-always">


### PR DESCRIPTION
This is a replay of https://github.com/eclipse/openj9/pull/3518 with a couple of additions. 

- an adapter is added to bridge the differences between OMR's ddrgen and the legacy DDR tools used in IBM builds
- some useless code is removed from `StructureStubGenerator`