### PR TITLE
Remove unnecessary type cast on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -2400,13 +2400,11 @@ bool isConditionCodeSetForCompare(TR::Node *node, bool *jumpOnOppositeCondition)
    // (and that hopefully does both)
    //
    TR::Instruction     *prevInstr;
-   TR::X86RegInstruction  *prevRegInstr;
    for (prevInstr = comp->cg()->getAppendInstruction();
         prevInstr;
         prevInstr = prevInstr->getPrev())
       {
-      prevRegInstr = prevInstr->getIA32RegInstruction();
-      if (prevRegInstr && (prevInstr->getOpCodeValue() == CMP4RegReg))
+      if (prevInstr->getOpCodeValue() == CMP4RegReg)
          {
          TR::Register *prevInstrTargetRegister = prevInstr->getTargetRegister();
          TR::Register *prevInstrSourceRegister = prevInstr->getSourceRegister();


### PR DESCRIPTION
In this case, casting TR::Instruction* to TR::X86RegInstruction*
is unnecessary, removing.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>