### PR TITLE
Fix check for resolved method in ClassLookAhead

### DIFF
--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -771,7 +771,7 @@ TR_ClassLookahead::examineNode(TR::TreeTop *nextTree, TR::Node *grandParent, TR:
                char *sig = getFieldSignature(comp(), sym, storedSymRef, length);
 
                if (rhsOfStoreNode->getOpCode().isCall() &&
-                   !rhsOfStoreNode->getSymbolReference()->isUnresolved())
+                   rhsOfStoreNode->getSymbol()->getResolvedMethodSymbol())
                   {
                   if (rhsOfStoreNode->getSymbol()->getResolvedMethodSymbol()->getRecognizedMethod() == TR::java_math_BigDecimal_valueOf)
                      {


### PR DESCRIPTION
The original code assumed a MethodSymbol that is not unresolved is a
ResolvedMethodSymbol which is not correct. All the helper method symbols
are not unresolved but they are not ResolvedMethodSymbol either.
ResolvedMethodSymbol is more of a concept for Java methods.

Fix the condition to check for ResolvedMethodSymbol directly.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>