### PR TITLE
Add support for DefaultValue bytecode

### DIFF
--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -1072,6 +1072,7 @@ private:
 	VMINLINE void markClassAsUsedByMultiANewArray(U_16 classCPIndex);
 	VMINLINE void markClassAsUsedByANewArray(U_16 classCPIndex);
 	VMINLINE void markClassAsUsedByNew(U_16 classCPIndex);
+	VMINLINE void markClassAsUsedByDefaultValue(U_16 classCPIndex);
 
 	VMINLINE void markInvokeDynamicInfoAsUsedByInvokeDynamic(U_16 cpIndex);
 

--- a/runtime/bcutil/ConstantPoolMap.hpp
+++ b/runtime/bcutil/ConstantPoolMap.hpp
@@ -273,6 +273,9 @@ public:
 	void markClassAsUsedByMultiANewArray(U_16 classCfrCPIndex) { mark(classCfrCPIndex, MULTI_ANEW_ARRAY); }
 	void markClassAsUsedByANewArray(U_16 classCfrCPIndex)      { mark(classCfrCPIndex, ANEW_ARRAY); }
 	void markClassAsUsedByNew(U_16 classCfrCPIndex)            { mark(classCfrCPIndex, NEW); }
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	void markClassAsUsedByDefaultValue(U_16 classCfrCPIndex)   { mark(classCfrCPIndex, DEFAULT_VALUE); }
+#endif
 
 	void markFieldRefAsUsedByGetStatic(U_16 fieldRefCfrCPIndex) { mark(fieldRefCfrCPIndex, GET_STATIC); }
 	void markFieldRefAsUsedByPutStatic(U_16 fieldRefCfrCPIndex) { mark(fieldRefCfrCPIndex, PUT_STATIC); }
@@ -358,6 +361,9 @@ public:
 		GET_STATIC = SPLIT1,
 		PUT_FIELD = SPLIT1,
 		GET_FIELD = SPLIT1,
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		DEFAULT_VALUE = SPLIT1,
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		NEW = SPLIT1,
 		INVOKE_HANDLEGENERIC = SPLIT5,
 		INVOKE_HANDLEEXACT = SPLIT5,

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1853,3 +1853,12 @@ J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.explanation=The class has a field with a q s
 J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.system_action=The JVM will throw a IncompatibleClassChangeError.
 J9NLS_VM_ERROR_QTYPE_NOT_VALUE_TYPE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_ERROR_BYTECODE_CLASSREF_MUST_BE_VALUE_TYPE=bad class %2$.*1$s: classref is not a value type
+# START NON-TRANSLATABLE
+J9NLS_VM_ERROR_BYTECODE_CLASSREF_MUST_BE_VALUE_TYPE.sample_input_1=3
+J9NLS_VM_ERROR_BYTECODE_CLASSREF_MUST_BE_VALUE_TYPE.sample_input_2=Foo
+J9NLS_VM_ERROR_BYTECODE_CLASSREF_MUST_BE_VALUE_TYPE.explanation=The class has specified a bytecode operation that can only be performed on a value type but the supplied classref is not of a value type.
+J9NLS_VM_ERROR_BYTECODE_CLASSREF_MUST_BE_VALUE_TYPE.system_action=The JVM will throw a IncompatibleClassChangeError.
+J9NLS_VM_ERROR_BYTECODE_CLASSREF_MUST_BE_VALUE_TYPE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -321,9 +321,8 @@ static const struct { \
 	((NULL != (interfaceClass)) && ((J9_ITABLE_INDEX_UNRESOLVED != ((methodIndexAndArgCount) & ~255))))
 
 /* Macros for ValueTypes */
-/* TODO this will have to be updated to look at the ramClass instead when further support is added */
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
-#define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET(clazz->romClass->modifiers, J9AccValueType)
+#define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsValueType)
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -165,6 +165,7 @@
 #define J9ClassIsDerivedValueType 0x80
 #define J9ClassHasWatchedFields 0x100
 #define J9ClassReservableLockWordInit 0x200
+#define J9ClassIsValueType 0x400
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2901,6 +2901,13 @@ retry:
 			}
 			classFlags |= J9ClassIsAnonymous;
 		}
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (J9_ARE_ALL_BITS_SET(romClass->modifiers, J9AccValueType)) {
+			classFlags |= J9ClassIsValueType;
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 		result->classFlags = classFlags;
 	}
 


### PR DESCRIPTION
Add support for DefaultValue bytecode

Adds an initial implementation for defaultValue. This PR does not
update the verifier, that work will be done in a subsequent PR. 
As a result ValueTypes can only used with -Xverify:none for the 
time being. 

A subsequent PR will be added to provide tests for this bytecode.

This based on Eric's work in 
https://github.com/eclipse/openj9/pull/1235.

Signed-off-by: tajila <atobia@ca.ibm.com>