### PR TITLE
Enable gcc-7 on Linux x86-64 platforms

### DIFF
--- a/buildspecs/linux_x86-64.spec
+++ b/buildspecs/linux_x86-64.spec
@@ -41,7 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.unixBin$}/platform/linux_hammer/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxa6424"/>
 		<property name="graph_label.java6" value="pxa6460"/>
@@ -101,7 +101,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
-		<property name="uma_make_cmd_interp_gcc" value="gcc-4.6"/>
 		<property name="uma_make_cmd_ranlib" value="ranlib"/>
 		<property name="uma_processor" value="amd64"/>
 		<property name="uma_type" value="unix,linux"/>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -42,7 +42,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.unixBin$}/platform/linux_hammer/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxa64cmprssptrs24"/>
 		<property name="graph_label.java6" value="pxa64cmprssptrs60"/>
@@ -97,7 +97,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
-		<property name="uma_make_cmd_interp_gcc" value="gcc-4.6"/>
 		<property name="uma_make_cmd_ranlib" value="ranlib"/>
 		<property name="uma_processor" value="amd64"/>
 		<property name="uma_type" value="unix,linux"/>

--- a/buildspecs/linux_x86-64_codecov.spec
+++ b/buildspecs/linux_x86-64_codecov.spec
@@ -41,7 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.unixBin$}/platform/linux_hammer/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxa6424_codecov"/>
 		<property name="graph_label.java6" value="pxa6460_codecov"/>
@@ -98,7 +98,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="uma_make_cmd_cxx_exe_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_dll_ld" value="$(CC)"/>
 		<property name="uma_make_cmd_exe_ld" value="$(CC)"/>
-		<property name="uma_make_cmd_interp_gcc" value="gcc-4.6"/>
 		<property name="uma_make_cmd_ranlib" value="ranlib"/>
 		<property name="uma_optimization_cflags" value="-O0 -g"/>
 		<property name="uma_optimization_cxxflags" value="-O0 -g"/>

--- a/runtime/makelib/mkconstants.mk.ftl
+++ b/runtime/makelib/mkconstants.mk.ftl
@@ -41,25 +41,6 @@ ifndef UMA_TARGET_PATH
 endif
 
 # Define all the tool used for compilation and linking.
-<#if uma.spec.tools.interp_gcc.needed>
-ifneq (default,$(origin CC))
-  ifndef INTERP_GCC
-    # If the user has overridden CC we'll want to let them know that INTERP_GCC exists.
-    ifndef PRINT_ONCE_INTERP_GCC
-      $(info ****************)
-      $(info *)
-      $(info * CC=$(CC) (overridden), note that this build will also invoke another compiler that can be overridden: INTERP_GCC=${uma.spec.tools.interp_gcc.name})
-      $(info *)
-      $(info ****************)
-      export PRINT_ONCE_INTERP_GCC=1
-    endif
-  endif
-endif
-INTERP_GCC?=${uma.spec.tools.interp_gcc.name}
-<#else>
-#INTERP_GCC not used
-</#if>
-
 <#if uma.spec.type.windows>
 <#if uma.spec.flags.build_VS12AndHigher.enabled>
 VS12AndHigher:=1

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -512,16 +512,6 @@ MHInterpreter$(UMA_DOT_O) : MHInterpreter.cpp
 endif
 </#if>
 <#if uma.spec.processor.amd64>
-# special handling BytecodeInterpreter.cpp and DebugBytecodeInterpreter.cpp
-BytecodeInterpreter$(UMA_DOT_O) : BytecodeInterpreter.cpp
-	$(INTERP_GCC) $(CXXFLAGS) -c $<
-
-DebugBytecodeInterpreter$(UMA_DOT_O) : DebugBytecodeInterpreter.cpp
-	$(INTERP_GCC) $(CXXFLAGS) -c $<
-
-MHInterpreter$(UMA_DOT_O) : MHInterpreter.cpp
-	$(INTERP_GCC) $(CXXFLAGS) -c $<
-
 # Special handling for unused result warnings.
 closures$(UMA_DOT_O) : closures.c
 	$(CC) $(CFLAGS) -Wno-unused-result -c -o $@ $<


### PR DESCRIPTION
- update graph_enable_gcc7_cmd property to enable gcc-7 environment
- remove uma_make_cmd_interp_gcc property and clean up its references

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>