### PR TITLE
Disable Vector Facility for z/TPF

### DIFF
--- a/runtime/port/unix/j9sysinfo.c
+++ b/runtime/port/unix/j9sysinfo.c
@@ -269,7 +269,7 @@ static intptr_t getAIXPPCDescription(struct J9PortLibrary *portLibrary, J9Proces
 #elif (defined(S390) || defined(J9ZOS390) || defined(J9ZTPF))
 static BOOLEAN testSTFLE(struct J9PortLibrary *portLibrary, uint64_t stfleBit);
 static intptr_t getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc);
-#endif
+#endif /* defined(S390) || defined(J9ZOS390) || defined(J9ZTPF) */
 
 #if (defined(LINUXPPC) || defined(AIXPPC))
 static J9ProcessorArchitecture mapPPCProcessor(const char *processorName);
@@ -838,24 +838,33 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	if (J9_ARE_NO_BITS_SET(*(int*) 200, S390_STFLE_BIT)) {
 		return -1;
 	}
-#elif defined(LINUX) && !defined(J9ZTPF) /* LINUX S390*/
+#elif defined(J9ZTPF)  /* defined(J9ZOS390) */
+	/*
+	 * z/TPF requires OS support for some of the Hardware Capabilities.
+	 * Setting the auxvFeatures capabilities flag directly to mimic the query_auxv call in Linux.
+	 */
+	unsigned long auxvFeatures = J9PORT_HWCAP_S390_HIGH_GPRS|J9PORT_S390_FEATURE_ESAN3|J9PORT_HWCAP_S390_ZARCH|
+			J9PORT_HWCAP_S390_STFLE|J9PORT_HWCAP_S390_MSA|J9PORT_HWCAP_S390_DFP|
+			J9PORT_HWCAP_S390_LDISP|J9PORT_HWCAP_S390_EIMM|J9PORT_HWCAP_S390_ETF3EH;
+
+#elif defined(LINUX) /* defined(J9ZTPF) */
 	/* Some s390 features require OS support on Linux, querying auxv for AT_HWCAP bit-mask of processor capabilities. */
 	unsigned long auxvFeatures = query_auxv(AT_HWCAP);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(LINUX) */
 
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support of HPAGE on Linux on Z */
 	if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_HPAGE)){
 		setFeature(desc, J9PORT_S390_FEATURE_HPAGE);
 	}
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX) */
 
 	/* HIGH_GPRS support */
 #if defined(OMR_ENV_DATA64)
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 	if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_HIGH_GPRS))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX)*/
 	{
 		setFeature(desc, J9PORT_S390_FEATURE_HIGH_GPRS);
 	}
@@ -864,50 +873,50 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	/* Miscellaneous facility detection */
 
 	if (testSTFLE(portLibrary, 0)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_ESAN3))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX)*/
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_ESAN3);
 		}
 	}
 
 	if (testSTFLE(portLibrary, 2)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_ZARCH))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX)*/
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_ZARCH);
 		}
 	}
 
 	if (testSTFLE(portLibrary, 7)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_STFLE))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX)*/
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_STFLE);
 		}
 	}
 
 	if (testSTFLE(portLibrary, 17)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_MSA))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX)*/
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_MSA);
 		}
 	}
 
 	if (testSTFLE(portLibrary, 42) && testSTFLE(portLibrary, 44)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_DFP))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_DFP);
 		}
@@ -951,10 +960,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	/* z990 facility and processor detection */
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_LONG_DISPLACEMENT)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_LDISP))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_LONG_DISPLACEMENT);
 
@@ -965,10 +974,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	/* z9 facility and processor detection */
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_EXTENDED_IMMEDIATE)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_EIMM))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF)) */
+#endif /* defined(S390) && defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_EXTENDED_IMMEDIATE);
 		}
@@ -979,10 +988,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	}
 
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_ETF3_ENHANCEMENT)) {
-#if (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#if (defined(S390) && defined(LINUX))
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_ETF3EH))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_ETF3_ENHANCEMENT);
 		}
@@ -1016,7 +1025,7 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	if (testSTFLE(portLibrary, 50) && testSTFLE(portLibrary, 73)) {
 #if defined(J9ZOS390)
 		if (getS390zOS_supportsTransactionalExecutionFacility())
-#elif defined(LINUX) && !defined(J9ZTPF) /* LINUX S390 */
+#elif defined(LINUX) /* LINUX S390 */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_TE))
 #endif /* defined(J9ZOS390) */
 		{
@@ -1048,13 +1057,12 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 #if defined(J9ZOS390)
 		/* Vector facility requires hardware and OS support */
 		if (getS390zOS_supportsVectorExtensionFacility())
-#elif !defined(J9ZTPF)
+#elif defined(LINUX) /* LINUX S390 */
 		/* Vector facility requires hardware and OS support */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS))
 #endif
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_FACILITY);
-
 			desc->processor = PROCESSOR_S390_GP11;
 		}
 	}
@@ -1077,9 +1085,9 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 	if (testSTFLE(portLibrary, J9PORT_S390_FEATURE_GUARDED_STORAGE)) {
 #if defined(J9ZOS390)
 		if (getS390zOS_supportsGuardedStorageFacility())
-#elif defined(LINUX) && !defined(J9ZTPF) /* LINUX S390*/
+#elif defined(LINUX) /* defined(J9ZOS390) */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_GS))
-#endif /* defined(J9ZOS390) */
+#endif /* defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_GUARDED_STORAGE);
 
@@ -1103,10 +1111,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 #if defined(J9ZOS390)
 		/* Vector packed decimal requires hardware and OS support (for OS, checking for VEF is sufficient) */
 		if (getS390zOS_supportsVectorExtensionFacility())
-#elif (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#elif (defined(S390) && defined(LINUX)) /* defined(J9ZOS390) */
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS_BCD))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_PACKED_DECIMAL);
 
@@ -1118,10 +1126,10 @@ getS390Description(struct J9PortLibrary *portLibrary, J9ProcessorDesc *desc)
 #if defined(J9ZOS390)
 		/* Vector facility enhancement 1 requires hardware and OS support (for OS, checking for VEF is sufficient) */
 		if (getS390zOS_supportsVectorExtensionFacility())
-#elif (defined(S390) && defined(LINUX) && !defined(J9ZTPF))
+#elif (defined(S390) && defined(LINUX)) /* defined(J9ZOS390) */
 	/* OS Support for Linux on Z */
 		if (J9_ARE_ALL_BITS_SET(auxvFeatures, J9PORT_HWCAP_S390_VXRS_EXT))
-#endif /* defined(S390) && defined(LINUX) && !defined(J9ZTPF) */
+#endif /* defined(S390) && defined(LINUX) */
 		{
 			setFeature(desc, J9PORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1);
 


### PR DESCRIPTION
z/TPF does not currently support Vector Instructions and JVM
initializaiton will fail if enabled for z/TPF.  This PR configures zTPF
not to use it.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>