### PR TITLE
Fix checking method handle access

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF]*/
 #
-# Copyright (c) 1998, 2018 IBM Corp. and others
+# Copyright (c) 1998, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1038,6 +1038,7 @@ K0584="The target is not a direct handle"
 
 K0585="{0} could not access {1} - private access required"
 K0586="Lookup class ({0}) must be the same as or subclass of the current class ({1})"
+K0587= '{0}' no access to: '{1}'
 K0588="Illegal Lookup object - originated from java.lang.invoke: {0}"
 K0589="Caller-sensitive method cannot be looked up using a restricted lookup object"
 K0590="Can't unreflect @SignaturePolymorphic method: {0}"

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -383,8 +383,8 @@ public class MethodHandles {
 				throw new IllegalAccessException(this.toString());
 			}
 			
-			final Class<?> definingClass = handle.getDefiningClass();
-			checkAccess(definingClass, definingClass, handle.getFieldName(), handle.getModifiers(), null, skipAccessCheckPara);
+			/* VarHandles have no reference class */
+			checkAccess(handle.getDefiningClass(), null, handle.getFieldName(), handle.getModifiers(), null, skipAccessCheckPara);
 		}
 		
 		void checkAccess(Class<?> clazz) throws IllegalAccessException {
@@ -406,7 +406,8 @@ public class MethodHandles {
 		 * Equivalent of visible.c checkVisibility();
 		 * 
 		 * @param definingClass The {@link Class} that defines the member being accessed.
-		 * @param referenceClass The {@link Class} class through which the the member is accessed, which may be a subtype of the defining class.
+		 * @param referenceClass The {@link Class} class through which the the member is accessed, 
+		 * which must be the defining class or a subtype.  May be null.
 		 * @param name The name of member being accessed.
 		 * @param memberModifiers The modifiers of the member being accessed.
 		 * @param handle A handle object (e.g. {@link MethodHandle} or {@link VarHandle}), if applicable.
@@ -418,6 +419,9 @@ public class MethodHandles {
 		 * @throws IllegalAccessError If a handle argument or return type is not accessible.
 		 */
 		private void checkAccess(Class<?> definingClass, Class<?> referenceClass, String name, int memberModifiers, MethodHandle handle, boolean skipAccessCheckPara) throws IllegalAccessException {
+			if (null == referenceClass) {
+				referenceClass = definingClass;
+			}
 			checkClassAccess(referenceClass);
 
 			/*[IF Sidecar19-SE]*/


### PR DESCRIPTION
Use the defining class of a class member or the target class of the lookup as
appropriate.  Also reinstate missing external message definition and replace duplicated
code with a common method.

Fixes https://github.com/eclipse/openj9/issues/3301

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>