### PR TITLE
Ensure GC map is generated at BB entry on all platforms

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4526,8 +4526,17 @@ J9::CodeGenerator::generateCatchBlockBBStartPrologue(
       TR::Node *node,
       TR::Instruction *fenceInstruction)
    {
+   if (self()->comp()->getOptions()->getReportByteCodeInfoAtCatchBlock())
+      {
+      // Note we should not use `fenceInstruction` here because it is not the first instruction in this BB. The first
+      // instruction is a label that incoming branches will target. We will use this label (first instruction in the
+      // block) in `createMethodMetaData` to populate a list of non-mergable GC maps so as to ensure the GC map at the
+      // catch block entry is always present if requested.
+      node->getBlock()->getFirstInstruction()->setNeedsGCMap();
+      }
+
    VMgenerateCatchBlockBBStartPrologue(node, fenceInstruction, self());
-}
+   }
 
 void
 J9::CodeGenerator::registerAssumptions()

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12733,10 +12733,6 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
    {
    TR::Compilation * comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (comp->fe());
-   if (comp->getOption(TR_FullSpeedDebug))
-      {
-      fenceInstruction->setNeedsGCMap(); // a catch entry is a gc point in FSD mode
-      }
 
    TR::Block *block = node->getBlock();
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11506,11 +11506,6 @@ VMgenerateCatchBlockBBStartPrologue(
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
 
-   if (comp->getOption(TR_FullSpeedDebug))
-      {
-      fenceInstruction->setNeedsGCMap(); // a catch entry is a gc point in FSD mode
-      }
-
    if (comp->getJittedMethodSymbol()->usesSinglePrecisionMode() &&
        cg->enableSinglePrecisionMethods())
       {

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -12089,10 +12089,6 @@ VMgenerateCatchBlockBBStartPrologue(
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
-   if (comp->getOption(TR_FullSpeedDebug))
-      {
-      fenceInstruction->setNeedsGCMap(); // a catch entry is a gc point in FSD mode
-      }
 
    TR::Block *block = node->getBlock();
 


### PR DESCRIPTION
Stack maps are required at the entry of exception catch
blocks under FSD mode and when Agent is attached.

Closes #3374
Closes #3375
Closes #3376
Closes #3462

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>