### PR TITLE
Fix JITaaS Options deallocation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -5044,6 +5044,7 @@ void TR::CompilationInfo::recycleCompilationEntry(TR_MethodToBeCompiled *entry)
    entry->_freeTag |= ENTRY_IN_POOL_NOT_FREE;
    if (entry->_numThreadsWaiting == 0)
       entry->_freeTag |= ENTRY_IN_POOL_FREE;
+   entry->cleanupJITaaS();
 
    entry->_next = _methodPool;
    _methodPool = entry;

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -94,14 +94,7 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
 void
 TR_MethodToBeCompiled::shutdown()
    {
-   // JITaaS: clean up c-style string client options which was allocated using persistent allocator
-   if (_clientOptions)
-      {
-      _compInfoPT->getCompilationInfo()->persistentMemory()->freePersistentMemory((void *)_clientOptions);
-      _clientOptions = NULL;
-      _clientOptionsSize = 0;
-      }
-
+   cleanupJITaaS();
    TR::MonitorTable *table = TR::MonitorTable::get();
    if (!table) return;
    table->removeAndDestroy(_monitor);
@@ -148,4 +141,15 @@ uint64_t
 TR_MethodToBeCompiled::getClientUID() const
    {
    return _stream->getClientId();
+   }
+
+void
+TR_MethodToBeCompiled::cleanupJITaaS()
+   {
+   // JITaaS: clean up c-style string client options which was allocated using persistent allocator
+   if (_clientOptions)
+      {
+      _compInfoPT->getCompilationInfo()->persistentMemory()->freePersistentMemory((void *)_clientOptions);
+      _clientOptions = NULL;
+      }
    }

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -65,6 +65,7 @@ struct TR_MethodToBeCompiled
    void setRemoteCompReq() { _remoteCompReq = true; }
    bool isOutOfProcessCompReq() const { return _stream != nullptr; } // at the server
    uint64_t getClientUID() const;
+   void cleanupJITaaS();
 
    TR_MethodToBeCompiled *_next;
    TR::IlGeneratorMethodDetails _methodDetailsStorage;


### PR DESCRIPTION
Previously JITaaS Options strings are deallocated in MethodToBeCompiled::shutdown() when entries are destroyed. However, we often recycle MethodToBeCompiled entries for use and that does not call shutdown(). We should therefore deallocate the strings when entries are recycled.

Issue: #3597
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>