### PR TITLE
J9UNIX support on OSX

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2367,13 +2367,13 @@ JVM_SocketShutdown(jint fd, jint howto)
 {
 	jint retVal = JNI_FALSE;
 
-#if defined(J9UNIX) || defined(OSX)
+#if defined(J9UNIX)
 	retVal = shutdown(fd, howto);
-#elif defined(WIN32) /* defined(J9UNIX) || defined(OSX) */
+#elif defined(WIN32) /* defined(J9UNIX) */
 	retVal = closesocket(fd);
-#else /* defined(J9UNIX) || defined(OSX) */
+#else /* defined(J9UNIX) */
 	assert(!"JVM_SocketShutdown() stubbed!");
-#endif /* defined(J9UNIX) || defined(OSX) */
+#endif /* defined(J9UNIX) */
 	
 	return retVal;
 }

--- a/runtime/j9vm/j9vm_internal.h
+++ b/runtime/j9vm/j9vm_internal.h
@@ -56,7 +56,7 @@
 #define LAUNCHERS
 #include "jvm.h"
 
-#if defined(J9UNIX) || defined(OSX)
+#if defined(J9UNIX)
 #include <sys/socket.h>
 #include <dlfcn.h>
 #include <sys/ioctl.h>
@@ -67,7 +67,7 @@
 #else /* defined(J9ZTPF) */
 #define J9FSTAT fstat64
 #endif /* !defined(J9ZTPF) */
-#endif /* J9UNIX */
+#endif /* defined(J9UNIX) */
 
 
 /* required for poll support on some Unix platforms (called in JVM_Available) */

--- a/runtime/j9vm/j9vm_internal.h
+++ b/runtime/j9vm/j9vm_internal.h
@@ -62,11 +62,13 @@
 #include <sys/ioctl.h>
 #include <setjmp.h>
 #include <sys/time.h>
+
+/* On OSX, fstat64 is deprecated. So, fstat is used on OSX. */
 #if defined(J9ZTPF) || defined(OSX)
 #define J9FSTAT fstat
-#else /* defined(J9ZTPF) */
+#else /* defined(J9ZTPF) || defined(OSX) */
 #define J9FSTAT fstat64
-#endif /* !defined(J9ZTPF) */
+#endif /* defined(J9ZTPF) || defined(OSX) */
 #endif /* defined(J9UNIX) */
 
 

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -581,7 +581,7 @@ jint JNICALL DestroyJavaVM(JavaVM * javaVM)
 #if defined(J9UNIX) || defined(J9ZOS390)
 		j9vm_dllHandle = 0;
 		java_dllHandle = 0;
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 		BFUjavaVM = NULL;
 	} else {
@@ -1010,7 +1010,7 @@ removeSuffix(char *string, const char *suffix)
 }
 #endif /* J9VM_JAVA9_BUILD < 150 */
 
-#if defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#if defined(J9UNIX) || defined(J9ZOS390)
 static BOOLEAN 
 preloadLibraries(void)
 {
@@ -1221,7 +1221,7 @@ preloadLibraries(void)
 #endif /* J9VM_OPT_HARMONY */
 	return TRUE;
 }
-#endif  /* defined(J9UNIX) || defined(J9ZOS390) */
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 
 
@@ -1886,7 +1886,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		libpathValue = envTemp;
 	}
 #endif
-#if defined(J9UNIX) || defined(OSX)
+#if defined(J9UNIX)
 	ldLibraryPathValue = getenv(ENV_LD_LIB_PATH);
 	if (NULL != ldLibraryPathValue) {
 		size_t pathLength = strlen(ldLibraryPathValue) +1;
@@ -1898,7 +1898,7 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		strcpy(envTemp, ldLibraryPathValue);
 		ldLibraryPathValue = envTemp;
 	}
-#endif
+#endif /* defined(J9UNIX) */
 
 	if (BFUjavaVM != NULL) {
 		result = JNI_ERR;
@@ -2076,11 +2076,11 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 		ibmMallocTraceSet = TRUE;
 	altJavaHomeSpecified = (GetEnvironmentVariableW(ALT_JAVA_HOME_DIR_STR, NULL, 0) > 0);
 #endif
-#if defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#if defined(J9UNIX) || defined(J9ZOS390)
 	if (getenv(IBM_MALLOCTRACE_STR)) {
 		ibmMallocTraceSet = TRUE;
 	}
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	args = (JavaVMInitArgs *)vm_args;
 	launcherArgumentsSize = initialArgumentScan(args, &specialArgs);
@@ -2661,7 +2661,7 @@ preloadLibrary(char* dllName, BOOLEAN inJVMDir)
 		fprintf(stderr,"jvm.dll preloadLibrary: LoadLibrary(%s) error: %x\n", buffer->data, GetLastError());
 	}
 #endif
-#if defined(J9UNIX) || defined(OSX)
+#if defined(J9UNIX)
 	buffer = jvmBufferCat(buffer, "/lib");
 	buffer = jvmBufferCat(buffer, dllName);
 	buffer = jvmBufferCat(buffer, J9PORT_LIBRARY_SUFFIX);
@@ -2688,7 +2688,7 @@ preloadLibrary(char* dllName, BOOLEAN inJVMDir)
 	if (handle == NULL) {
 		fprintf(stderr,"libjvm.so preloadLibrary(%s): %s\n", buffer->data, dlerror());
 	}
-#endif /* J9UNIX || OSX */
+#endif /* defined(J9UNIX) */
 #ifdef J9ZOS390
 	buffer = jvmBufferCat(buffer, "/lib");
 	buffer = jvmBufferCat(buffer, dllName);
@@ -3718,7 +3718,7 @@ JVM_LoadSystemLibrary(const char *libName)
 
 #endif
 
-#if defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#if defined(J9UNIX) || defined(J9ZOS390)
 	void *dllHandle;
 
 	Trc_SC_LoadSystemLibrary_Entry(libName);
@@ -3742,7 +3742,7 @@ JVM_LoadSystemLibrary(const char *libName)
 		return dllHandle;
 	}
 
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	/* We are here means we failed to load library. Throw java.lang.UnsatisfiedLinkError */
 	Trc_SC_LoadSystemLibrary_LoadFailed(libName);
@@ -3828,7 +3828,7 @@ _end:
 		Trc_SC_LoadLibrary_Exit(dllHandle);
 		return dllHandle;
 	}
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	/* We are here means we failed to load library. Throw java.lang.UnsatisfiedLinkError */
  	(*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_2);
@@ -3866,11 +3866,11 @@ JVM_FindLibraryEntry(void* handle, const char *functionName)
 
 #if defined(WIN32)
 	result = GetProcAddress ((HINSTANCE)handle, (LPCSTR)functionName);
-#elif defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
 	result = (void*)dlsym( (void*)handle, (char *)functionName );
-#else
+#else /* defined(WIN32) */
 #error "Please implemente jvm.c:JVM_FindLibraryEntry(void* handle, const char *functionName)"
-#endif
+#endif /* defined(WIN32) */
 
 	Trc_SC_FindLibraryEntry_Exit(result);
 
@@ -4159,13 +4159,13 @@ JVM_Lseek(jint descriptor, jlong bytesToSeek, jint origin)
 		return JVM_IO_ERR;
 	}
 
-#ifdef WIN32
+#if defined(WIN32)
 #ifdef __IBMC__
 	result = lseek(descriptor, (long) bytesToSeek, origin);
 #else
 	result = _lseeki64(descriptor, bytesToSeek, origin);
 #endif
-#elif defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
 #if defined(LINUX) && !defined(J9VM_ENV_DATA64)
 
 #if __GLIBC_PREREQ(2,4)
@@ -4180,12 +4180,12 @@ JVM_Lseek(jint descriptor, jlong bytesToSeek, jint origin)
 	}
 #endif
 
-#else	/* defined(LINUX) && !defined(J9VM_ENV_DATA64) */
+#else /* defined(LINUX) && !defined(J9VM_ENV_DATA64) */
 	result = lseek(descriptor, (off_t) bytesToSeek, origin);
 #endif /* !defined(LINUX) ||defined(J9VM_ENV_DATA64) */
-#else
+#else /* defined(WIN32) */
 #error No JVM_Lseek provided
-#endif
+#endif /* defined(WIN32) */
 
 	Trc_SC_Lseek_Exit(result);
 
@@ -4262,7 +4262,7 @@ JVM_Open(const char* filename, jint flags, jint mode)
 #endif
 #endif
 
-#if defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#if defined(J9UNIX) || defined(J9ZOS390)
 #if defined(OSX)
 #define EXTRA_OPEN_FLAGS 0
 #else
@@ -4278,8 +4278,8 @@ JVM_Open(const char* filename, jint flags, jint mode)
     flags &= (O_CREAT | O_APPEND | O_RDONLY | O_RDWR | O_TRUNC | O_WRONLY | O_EXCL | O_NOCTTY | O_NONBLOCK | O_NDELAY | O_SYNC | O_DSYNC);
 #else /* !defined(J9ZTPF) */
     flags &= (O_CREAT | O_APPEND | O_RDONLY | O_RDWR | O_TRUNC | O_WRONLY | O_EXCL | O_NOCTTY | O_NONBLOCK | O_SYNC | O_DSYNC);
-#endif /* defined(J9ZTPF) */
-#endif /* defined(J9UNIX) || defined(J9ZOS390) || defined(OSX) */
+#endif /* !defined(J9ZTPF) */
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	/* For some reason, although JVM_NativePath is called on the filenames, some of them seem to
 		get mangled between JVM_NativePath being called and JVM_open being called */
@@ -4288,7 +4288,7 @@ JVM_Open(const char* filename, jint flags, jint mode)
 #if defined(J9UNIX) || defined(J9ZOS390)
 	do {
 		errorVal = 0;
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 #ifdef J9OS_I5
 	returnVal = Xj9Open_JDK6((char *)filename, (flags | EXTRA_OPEN_FLAGS), mode);
@@ -4325,7 +4325,7 @@ JVM_Open(const char* filename, jint flags, jint mode)
 	/* Unix does not have an O_TEMPORARY flag. Unlink if Sovereign O_TEMPORARY flag passed in. */
 	if ((returnVal>=0) && doUnlink)
 		unlink(filename);
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	if (returnVal<0) {
 		Trc_SC_Open_error(filename, errorVal);
@@ -4357,18 +4357,18 @@ JVM_Sync(jint descriptor)
 		return -1;
 	}
 
-#ifdef WIN32
+#if defined(WIN32)
 #ifdef WIN32_IBMC
 	printf("_JVM_Sync@4 called but not yet implemented. Exiting.\n");
 	exit(44);
 #else
 	result = _commit(descriptor);
 #endif
-#elif defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
 	result = fsync(descriptor);
-#else
+#else /* defined(WIN32) */
 #error No JVM_Sync implementation
-#endif
+#endif /* defined(WIN32) */
 
 	Trc_SC_Sync_Exit(result);
 
@@ -5324,7 +5324,7 @@ JVM_SocketAvailable(jint descriptor, jint* result)
 	/* Windows JCL native doesn't invoke this JVM method */
 	Assert_SC_unreachable();
 #endif
-#if defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#if defined(J9UNIX) || defined(J9ZOS390)
 	if (0 <= descriptor) {
 		do {
 			retVal = ioctl(descriptor, FIONREAD, result);
@@ -5338,7 +5338,7 @@ JVM_SocketAvailable(jint descriptor, jint* result)
 			retVal = 0;
 		}
 	}
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	Trc_SC_SocketAvailable_Exit(retVal, *result);
 
@@ -5389,11 +5389,11 @@ JVM_Timeout(jint descriptor, jint timeout)
 	struct fd_set fdset;
 #endif
 
-#if defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#if defined(J9UNIX) || defined(J9ZOS390)
 	jint returnVal = 0; 
 	jint crazyCntr = 10;
 	fd_set fdset;
-#endif
+#endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 	Trc_SC_Timeout_Entry(descriptor, timeout);
 
@@ -5401,15 +5401,15 @@ JVM_Timeout(jint descriptor, jint timeout)
 	tval.tv_usec = (timeout % 1000) * 1000;
 	FD_ZERO(&fdset);
 	FD_SET((u_int)descriptor, &fdset);
-#ifdef WIN32
+#if defined(WIN32)
 	result = select(0, &fdset, 0, 0, &tval);
-#elif defined(J9ZTPF)
+#elif defined(J9ZTPF) /* defined(WIN32) */
         if (-1 == timeout)  {
                 result = select(0, &fdset, 0, 0, NULL);
         } else  {
                 result = select(0, &fdset, 0, 0, &tval);
         }
-#elif defined(J9UNIX) || defined(J9ZOS390) || defined(OSX)
+#elif defined(J9UNIX) || defined(J9ZOS390) /* defined(WIN32) */
 	do {
 		crazyCntr--;
 		returnVal = select(descriptor+1, &fdset, 0, 0, &tval);
@@ -5422,7 +5422,7 @@ JVM_Timeout(jint descriptor, jint timeout)
 			break;
 		}
 	} while (crazyCntr);
-#endif
+#endif /* defined(WIN32) */
 
 	Trc_SC_Timeout_Exit(result);
 

--- a/runtime/j9vm/jvm.h
+++ b/runtime/j9vm/jvm.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2016 IBM Corp. and others
+ * Copyright (c) 2002, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,14 +61,14 @@ extern "C" {
 
 #endif /* WIN32 */
 
-#ifdef J9UNIX
+#if defined(J9UNIX)
 #ifndef __USE_LARGEFILE64
 #define __USE_LARGEFILE64
 #endif
 #include <unistd.h>
 #include <sys/param.h>
 #include <dirent.h>
-#endif /* J9UNIX */
+#endif /* defined(J9UNIX) */
 
 #ifdef J9ZOS390
 #include <ctype.h>
@@ -128,11 +128,11 @@ extern "C" {
 #define JVM_ZIP_HOOK_STATE_CLOSED 2
 #define JVM_ZIP_HOOK_STATE_RESET 3
 	
-#ifdef J9UNIX
+#if defined(J9UNIX)
 typedef sigjmp_buf* pre_block_t;
-#else
+#else /* defined(J9UNIX) */
 typedef void* pre_block_t;
-#endif
+#endif /* defined(J9UNIX) */
 
 struct sockaddr;                                                                               /* suppress warning messages */
 

--- a/runtime/j9vm/jvm.h
+++ b/runtime/j9vm/jvm.h
@@ -28,9 +28,6 @@
 extern "C" {
 #endif
 
-#if defined(RS6000) || defined(LINUX)
-#define J9UNIX
-#endif
 #if defined(IBM_MVS)
 /* J2SE class libraries include jvm.h but don't define J9ZOS390. We do that here on their behalf. */
 #ifndef J9ZOS390
@@ -61,15 +58,6 @@ extern "C" {
 
 #endif /* WIN32 */
 
-#if defined(J9UNIX)
-#ifndef __USE_LARGEFILE64
-#define __USE_LARGEFILE64
-#endif
-#include <unistd.h>
-#include <sys/param.h>
-#include <dirent.h>
-#endif /* defined(J9UNIX) */
-
 #ifdef J9ZOS390
 #include <ctype.h>
 #include <unistd.h>
@@ -88,6 +76,15 @@ extern "C" {
 
 #include <jni.h>
 #include "j9comp.h"		/* for definition */
+
+#if defined(J9UNIX)
+#ifndef __USE_LARGEFILE64
+#define __USE_LARGEFILE64
+#endif
+#include <unistd.h>
+#include <sys/param.h>
+#include <dirent.h>
+#endif /* defined(J9UNIX) */
 
 /* AIX has a #define for MAXPATHLEN in /usr/include/param.h which defines MAXPATHLEN as PATH_MAX+1 */
 #ifndef MAXPATHLEN

--- a/runtime/oti/j9comp.h
+++ b/runtime/oti/j9comp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,5 +29,9 @@
 #define J9_ARE_ANY_BITS_SET(value, bits) OMR_ARE_ANY_BITS_SET((value), (bits))
 #define J9_ARE_ALL_BITS_SET(value, bits) OMR_ARE_ALL_BITS_SET((value), (bits))
 #define J9_ARE_NO_BITS_SET(value, bits) OMR_ARE_NO_BITS_SET((value), (bits))
+
+#if defined(RS6000) || defined(LINUX) || defined(OSX)
+#define J9UNIX
+#endif /* defined(RS6000) || defined(LINUX) || defined(OSX) */
 
 #endif /* j9comp_h */

--- a/runtime/oti/vmargs_api.h
+++ b/runtime/oti/vmargs_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,12 @@
 #define ARG_ENCODING_LATIN 3
 
 #define ENV_LIBPATH "LIBPATH"
+
+#if defined(OSX)
+#define ENV_LD_LIB_PATH "DYLD_LIBRARY_PATH"
+#else /* defined(OSX) */
 #define ENV_LD_LIB_PATH "LD_LIBRARY_PATH"
+#endif /* defined(OSX) */
 
 /**
  * Walks the j9vm_args to find the entry for a given argument. optionValue can be

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -905,14 +905,15 @@ addJavaLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 #endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
 #if defined(J9UNIX)
-#if defined(J9VM_ENV_DATA64)
+	/* On OSX, /usr/lib64 doesn't exist. Only /usr/lib needs to be appended on OSX. */
+#if defined(J9VM_ENV_DATA64) && !defined(OSX)
 	/* JAZZ103 117105: 64-bit JDKs on Linux and AIX should add /usr/lib64 to java.library.path ahead of /usr/lib. */
 #define USRLIB64 ":/usr/lib64"
 	substringBuffer[substringIndex] = USRLIB64;
 	substringIndex += 1;
 	substringLength += (sizeof(USRLIB64) - 1) ;
 #undef USRLIB64
-#endif /* defined(J9VM_ENV_DATA64) */
+#endif /* defined(J9VM_ENV_DATA64) && !defined(OSX) */
 
 	substringBuffer[substringIndex] = ":/usr/lib";
 	substringIndex += 1;

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -766,9 +766,6 @@ addJavaLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 		UDATA argEncoding, BOOLEAN jvmInSubdir, char *j9binPath, char *jrebinPath,
 		const char *libpathValue, const char *ldLibraryPathValue)
 {
-#if defined(J9UNIX) || defined(J9ZOS390)
-	IDATA envVarSize = 0;
-#endif
 	char *substringBuffer[MAX_LIBPATH_SUBSTRINGS];
 	BOOLEAN allocated[MAX_LIBPATH_SUBSTRINGS] = {FALSE};
 	char *pathBuffer = NULL;

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -51,9 +51,6 @@
 #if defined(J9ZOS390)
 #include "atoe.h"
 #endif
-#if defined(RS6000) || defined(LINUX)
-#define J9UNIX
-#endif
 
 #define MAP_TWO_COLONS_TO_ONE 8
 #define EXACT_MAP_NO_OPTIONS 16

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -907,7 +907,7 @@ addJavaLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 	}
 #endif /* defined(J9UNIX) || defined(J9ZOS390) */
 
-#ifdef J9UNIX
+#if defined(J9UNIX)
 #if defined(J9VM_ENV_DATA64)
 	/* JAZZ103 117105: 64-bit JDKs on Linux and AIX should add /usr/lib64 to java.library.path ahead of /usr/lib. */
 #define USRLIB64 ":/usr/lib64"
@@ -920,7 +920,7 @@ addJavaLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 	substringBuffer[substringIndex] = ":/usr/lib";
 	substringIndex += 1;
 	substringLength += strlen(":/usr/lib");
-#endif
+#endif /* defined(J9UNIX) */
 #ifdef WIN32
 	/* CMVC 177267, RTC 87362 : On windows, current directory is added at the end */
 	substringBuffer[substringIndex] = ";.";


### PR DESCRIPTION
**1) Remove dead code - unused variable: `envVarSize`**

**2) Update `(J9UNIX || OSX)` ifdefs**

- `J9UNIX` flag will be enabled for `OSX`. Thus, replacing ifdefs: `(J9UNIX
|| OSX)` -> `(J9UNIX)`.
- Also, formatted `J9UNIX` ifdefs according to coding standards.

**3) Handle outliers where `J9UNIX` code doesn't apply to `OSX`**

`J9UNIX` flag is going to be enabled on `OSX`. 

In `jvm.c::JVM_Available` and `jvm.c::JVM_Open`, `stat` and `fstat` are used on 
OSX because `stat64` and `fstat64` are deprecated on `OSX`. `J9UNIX` code uses 
`stat64` and `fstat64`, which needs to be disabled on `OSX`.

In `jvm.c::JVM_SetLength`, `ftruncate` is used on `OSX` and `ftruncate64` is used
on `J9UNIX`. `ftruncate64` is unsupported on `OSX`. So, `J9UNIX` code related to
`ftruncate64` needs to be disabled on `OSX`.

**4) Avoid multiple `J9UNIX` definitions and enable `J9UNIX` flag on `OSX`**

Two definitions of `J9UNIX`, in `jvm.h` and `vmargs.c`, have been removed.

A `J9UNIX` definition has been added in `j9comp.h`.

In `jvm.h`, code dependent on `J9UNIX` has been moved after `j9comp.h` is
included.

At the end, `J9UNIX` flag is enabled on `OSX`.

**5) Use `DYLD_LIBRARY_PATH` on `OSX`**

On `OSX`, environment variable, `DYLD_LIBRARY_PATH`, contains library search
paths. So, `ENV_LD_LIB_PATH` macro should refer to `DYLD_LIBRARY_PATH` on
`OSX`.

**6) Don't append `/usr/lib64` to `java.library.path` on `OSX`**

`/usr/lib64` doesn't exist on `OSX`. So, it shouldn't be appended to
`java.library.path` on `OSX`.

More details about `J9UNIX` usage available here: https://github.com/eclipse/openj9/issues/3452.

Closes: https://github.com/eclipse/openj9/issues/3452

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>