### PR TITLE
WIP: Virtualizing MemoryReference Hierarchy

### DIFF
--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -292,7 +292,7 @@ J9::Z::MemoryReference::createUnresolvedDataSnippetForiaload(TR::Node * node, TR
       isStore = true;
       }
    
-   TR::UnresolvedDataSnippet * uds = self()->createUnresolvedDataSnippet(node, cg, symRef, tempReg, isStore);
+   TR::UnresolvedDataSnippet * uds = createUnresolvedDataSnippet(node, cg, symRef, tempReg, isStore);
    self()->getUnresolvedSnippet()->createUnresolvedData(cg, _baseNode);
    self()->getUnresolvedSnippet()->getUnresolvedData()->setUnresolvedDataSnippet(self()->getUnresolvedSnippet());
    return uds;
@@ -321,7 +321,7 @@ J9::Z::MemoryReference::createUnresolvedSnippetWithNodeRegister(TR::Node * node,
       tempReg = cg->allocateRegister(TR_VRF);
       }
 
-   self()->createUnresolvedDataSnippet(node, cg, symRef, tempReg, false);
+   createUnresolvedDataSnippet(node, cg, symRef, tempReg, false);
 
    if (node->getOpCodeValue() == TR::loadaddr)
       {

--- a/runtime/compiler/z/codegen/J9MemoryReference.hpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/z/codegen/J9MemoryReference.hpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.hpp
@@ -45,7 +45,7 @@ namespace J9
 namespace Z
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReferenceConnector
    {
 public:
    MemoryReference(TR::CodeGenerator *cg) : OMR::MemoryReferenceConnector(cg) {}


### PR DESCRIPTION
* Commented out OMR_EXTENSIBLE from CodeGenerator class declarations
* Removed self() from function calls of CodeGenerator

Since virtualizing the MemoryReference hierarchy requires changes from both, the OMR and OpenJ9, projects this PR is linked to [a similar one in omr](https://github.com/eclipse/omr/pull/3162) achieving the same purpose.

Signed-off-by: Samer AL Masri <almasri@ualberta.ca>