### PR TITLE
Revert to loading `../java` now that OMR is updated

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -412,15 +412,9 @@ jstring getEncoding(JNIEnv *env, jint encodingType)
 #if defined(J9VM_JCL_SE11)
 		{
 			UDATA handle = 0;
-			J9JavaVM * const vm = ((J9VMThread*)env)->javaVM;
-			char dllPath[EsMaxPath];
-			UDATA written = 0;
 			PORT_ACCESS_FROM_ENV(env);
 			/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
-			written = j9str_printf(PORTLIB, dllPath, sizeof(dllPath), "%s/../java", vm->j9libvmDirectory);
-			/* Assert the number of characters written (not including the null) fit within the dllPath buffer */
-			Assert_JCL_true(written < (sizeof(dllPath) - 1));
-			if (0 == j9sl_open_shared_library(dllPath, &handle, J9PORT_SLOPEN_DECORATE)) {
+			if (0 == j9sl_open_shared_library("../java", &handle, J9PORT_SLOPEN_DECORATE)) {
 				void (*nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
 				if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
 					/* invoke JCL native to initialize platform encoding explicitly */


### PR DESCRIPTION
Current behaviour of using the full path is causing odd
behaviour on windows.  This worked before so reverting.

fixes: #3565

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>