### PR TITLE
Enable gcc-7 on zLinux 64bits platforms

### DIFF
--- a/buildspecs/linux_390-64.spec
+++ b/buildspecs/linux_390-64.spec
@@ -41,7 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-zLinux.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.linux390Bin$}/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxz6424"/>
 		<property name="graph_label.java6" value="pxz6460"/>

--- a/buildspecs/linux_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_390-64_cmprssptrs.spec
@@ -42,7 +42,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-zLinux.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.linux390Bin$}/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxz64cmprssptrs24"/>
 		<property name="graph_label.java6" value="pxz64cmprssptrs60"/>

--- a/buildspecs/linux_390.spec
+++ b/buildspecs/linux_390.spec
@@ -41,7 +41,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-zLinux.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.linux390Bin$}/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxz3124"/>
 		<property name="graph_label.java6" value="pxz3160"/>


### PR DESCRIPTION
Update graph_enable_gcc7_cmd property to enable gcc-7 environment

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>