### PR TITLE
Fix stack smashing bug

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -114,7 +114,7 @@ J9::ClassEnv::classInstanceSize(TR_OpaqueClassBlock * clazzPointer)
    {
    if (auto stream = TR::CompilationInfo::getStream())
       {
-      uint32_t totalInstanceSize = 0;
+      uintptrj_t totalInstanceSize = 0;
       JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazzPointer, TR::compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_TOTAL_INSTANCE_SIZE, (void *)&totalInstanceSize);
       return totalInstanceSize;
       }

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -603,12 +603,11 @@ TR_J9ServerVM::isPrimitiveArray(TR_OpaqueClassBlock *clazz)
 uint32_t
 TR_J9ServerVM::getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz)
    {
-   uint32_t totalInstanceSize = 0;
-   uint32_t objectSize = sizeof(J9Object);
+   uintptrj_t totalInstanceSize = 0;
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITaaSHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITaaSHelpers::CLASSINFO_TOTAL_INSTANCE_SIZE, (void *)&totalInstanceSize);
 
-   objectSize += totalInstanceSize;
+   uint32_t objectSize = sizeof(J9Object) + (uint32_t)totalInstanceSize;
    return ((objectSize >= J9_GC_MINIMUM_OBJECT_SIZE) ? objectSize : J9_GC_MINIMUM_OBJECT_SIZE);
    }
 


### PR DESCRIPTION
In a couple of places the code was writing a 64-bit value
to a 32-bit local variable corrupting the stack.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>