### PR TITLE
Add JNICALL decoration to `nativeFuncAddrJNU` function pointer

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -415,7 +415,7 @@ jstring getEncoding(JNIEnv *env, jint encodingType)
 			PORT_ACCESS_FROM_ENV(env);
 			/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
 			if (0 == j9sl_open_shared_library("../java", &handle, J9PORT_SLOPEN_DECORATE)) {
-				void (*nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
+				void (JNICALL *nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
 				if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
 					/* invoke JCL native to initialize platform encoding explicitly */
 					nativeFuncAddrJNU(env, encoding);


### PR DESCRIPTION
The function pointer definition needs to be decorated with JNICALL
for win 32 (the only platform where the decoration matters).

fixes: #3614

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>