### PR TITLE
Eliminate Recompilation_getExistingMethodInfo messages

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -178,6 +178,9 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
       CompilationInfoPerThreadRemote(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread)
          :CompilationInfoPerThread(compInfo, jitConfig, id, isDiagnosticThread) {}
       void processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider) override;
+      TR_PersistentMethodInfo *getRecompilationMethodInfo() { return _recompilationMethodInfo; }
+   private:
+      TR_PersistentMethodInfo *_recompilationMethodInfo;
    };
 }
 


### PR DESCRIPTION
Persistent method info is initialized in Recompilation
object, which is created for every compilation
that can be recompiled. Thus, it makes sense to send this
method info as a part of compile request.
Once server receives it, method info is allocated and stashed in
`TR::CompilationInfoPerThreadRemote`, until it is time to create a recompilation object.

Addresses:#3504