### PR TITLE
Add -XX:DebugLocalMapper to force using the debug stack mapper

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -328,6 +328,7 @@ enum INIT_STAGE {
 #define VMOPT_XXHANDLESIGXFSZ "-XX:+HandleSIGXFSZ"
 #define VMOPT_XXHEAPDUMPONOOM "-XX:+HeapDumpOnOutOfMemoryError"
 #define VMOPT_XXNOHEAPDUMPONOOM "-XX:-HeapDumpOnOutOfMemoryError"
+#define VMOPT_XXDEBUGLOCALMAPPER "-XX:DebugLocalMapper"
 
 #define VMOPT_XSOFTREFTHRESHOLD "-XSoftRefThreshold"
 #define VMOPT_XAGGRESSIVE "-Xaggressive"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -81,6 +81,7 @@
 #include "bcnames.h"
 #include "jimagereader.h"
 #include "vendor_version.h"
+#include "stackmap_api.h"
 
 #ifdef J9VM_OPT_ZIP_SUPPORT
 #include "zip_api.h"
@@ -2960,6 +2961,12 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 			vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_POSITIVE_HASHCODE;
 		} else if (0 == strcmp(testString, VMOPT_XXDISABLEPOSITIVEHASHCODE)) {
 			vm->extendedRuntimeFlags &= ~(UDATA)J9_EXTENDED_RUNTIME_POSITIVE_HASHCODE;
+		} else if (0 == strcmp(testString, VMOPT_XXDEBUGLOCALMAPPER)) {
+			/* There is no option to revert to the non-debug local mapper as using such
+			 * an option when in debug mode would result in issues where the debugger
+			 * may have the wrong view of data
+			 */
+			installDebugLocalMapper(vm);
 		}
 		/* -Xbootclasspath and -Xbootclasspath/p are not supported from Java 9 onwards */
 		if (J2SE_VERSION(vm) >= J2SE_19) {


### PR DESCRIPTION
The debugLocalMapper (debuglocalmapper.c) is much more conservative
about object lifetimes than the regular local mapper.

The regular mapper walks from the current pc to the end of the method
and only reports locals containing objects as alive if they will be
used as objects again.

The debug local mapper walks from the start of the method to the current
pc and determines if the slot previously contained a live object.  This
is the behaviour typically wanted when debugging to ensure that the
debugger can show you the current object values in locals.

Occasionally, we want to force the use of the debug mapper to test
whether the shortened object lifetimes are affecting poorly written user
code, usually due to the use of finalizers.

This PR adds a new option `-XX:DebugLocalMapper` which uses the debug
local mapper to help diagnose and debug these kinds of issues.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>