### PR TITLE
macOS: Use Clang for JDK8 JIT builds

### DIFF
--- a/runtime/compiler/makefile.ftl
+++ b/runtime/compiler/makefile.ftl
@@ -88,11 +88,7 @@ export BUILD_CONFIG?=prod
   export PLATFORM=arm-linux-gcc-cross
 </#if>
 <#if uma.spec.id?starts_with("osx_x86-64")>
-  ifeq ($(VERSION_MAJOR),8)
-    export PLATFORM=amd64-osx-gcc
-  else
-    export PLATFORM=amd64-osx-clang
-  endif
+  export PLATFORM=amd64-osx-clang
 </#if>
 
 <#if uma.spec.flags.uma_codeCoverage.enabled>


### PR DESCRIPTION
Necessary for removing the JIT's dependency on
libstdc++.6.0.9.dylib that results in failing to load libj9jit on
newer macOS versions not having the right version of the library.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

Fixes: #3496
Depends on: ibmruntimes/openj9-openjdk-jdk8#206
Issue: #36 