### PR TITLE
Turn on Compress Build logs

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -657,6 +657,7 @@ def set_job_properties(JOB_TYPE) {
         ********************/
 
         properties([
+            compressBuildLog(),
             buildDiscarder(logRotator(
                 artifactDaysToKeepStr: '',
                 artifactNumToKeepStr: NUM_ARTIFACTS,


### PR DESCRIPTION
- Jenkins jobs store console logs in plain text on the Jenkins Master.
- The [Compress Build Log Plugin](https://wiki.jenkins.io/display/JENKINS/Compress+Build+Log+Plugin) allows the log to be compressed
  once the build is complete.
- This will save disk space on the master.
- This will be enabled for all Build and Pipeline jobs.

[skip ci]
Issue #3573 

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>