### PR TITLE
Add the j9libvm and j2seRoot directories to the -verbose:init output

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2199,6 +2199,10 @@ jint JNICALL JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *vm_args) {
 	createParams.globalJavaVM = &BFUjavaVM;
 
 	if (VERBOSE_INIT == localVerboseLevel) {
+		fprintf(stderr, "VM known paths\t- j9libvm directory: %s\n\t\t- j2seRoot directory: %s\n",
+			createParams.j9libvmDirectory,
+			createParams.j2seRootDirectory);
+
 		printVmArgumentsList(j9ArgList);
 	}
 	createParams.vm_args = j9ArgList;


### PR DESCRIPTION
Occasionally it's useful to have this info when debugging startup problems.
Add the two paths to the -verbose:init output

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>