### PR TITLE
Truncate boolean writes in JNI and Unsafe

### DIFF
--- a/runtime/oti/UnsafeAPI.hpp
+++ b/runtime/oti/UnsafeAPI.hpp
@@ -421,7 +421,7 @@ public:
 	static VMINLINE void
 	putBoolean(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, bool isVolatile, U_8 value)
 	{
-		put32(currentThread, objectAccessBarrier, object, offset, isVolatile, 0, false, (I_32)value);
+		put32(currentThread, objectAccessBarrier, object, offset, isVolatile, 0, false, (I_32)(value & 1));
 	}
 
 	static VMINLINE I_16

--- a/runtime/vm/jnifield.cpp
+++ b/runtime/vm/jnifield.cpp
@@ -384,7 +384,7 @@ setBooleanField(JNIEnv *env, jobject obj, jfieldID fieldID, jboolean value)
 
 	j9object_t object = J9_JNI_UNWRAP_REFERENCE(obj);
 	valueOffset += J9_OBJECT_HEADER_SIZE;
-	J9OBJECT_U32_STORE(currentThread, object, valueOffset, (U_32)value);
+	J9OBJECT_U32_STORE(currentThread, object, valueOffset, (U_32) (value & 1));
 
 	if (isVolatile) {
 		VM_AtomicSupport::readWriteBarrier();


### PR DESCRIPTION
Truncate boolean writes in JNI and Unsafe

Signed-off-by: tajila <atobia@ca.ibm.com>