### PR TITLE
Deprecate use of `generate(RXY|RSY|SIY)Instruction` API

### DIFF
--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -1505,7 +1505,7 @@ J9::Z::TreeEvaluator::zonedToPackedHelper(TR::Node *node, TR_PseudoRegister *tar
    processSign->setStartInternalControlFlow();
 
    // Load the sign byte of the Packed Decimal from memory
-   generateRXYInstruction(cg, TR::InstOpCode::LLC, node, signCode, generateS390LeftAlignedMemoryReference(*destMR, node, 0, cg, 1));
+   generateRXInstruction(cg, TR::InstOpCode::LLC, node, signCode, generateS390LeftAlignedMemoryReference(*destMR, node, 0, cg, 1));
 
    generateRRInstruction(cg, TR::InstOpCode::LR, node, signCode4Bit, signCode);
 
@@ -1650,7 +1650,7 @@ J9::Z::TreeEvaluator::pd2zdSignFixup(TR::Node *node,
    processSign->setStartInternalControlFlow();
 
    // Load the sign byte of the Zoned Decimal from memory
-   generateRXYInstruction(cg, TR::InstOpCode::LLC, node, signCode, generateS390LeftAlignedMemoryReference(*destMR, node, 0, cg, 1));
+   generateRXInstruction(cg, TR::InstOpCode::LLC, node, signCode, generateS390LeftAlignedMemoryReference(*destMR, node, 0, cg, 1));
 
    generateRRInstruction(cg, TR::InstOpCode::LR, node, signCode4Bit, signCode);
 
@@ -3033,27 +3033,27 @@ J9::Z::TreeEvaluator::pd2ddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       switch (partialSize)
          {
          case 1:
-            generateRXYInstruction(cg, TR::InstOpCode::LLGC, srcNode, gpr64Partial, sourceMR);
+            generateRXInstruction(cg, TR::InstOpCode::LLGC, srcNode, gpr64Partial, sourceMR);
             break;
          case 2:
-            generateRXYInstruction(cg, TR::InstOpCode::LLGH, srcNode, gpr64Partial, sourceMR);
+            generateRXInstruction(cg, TR::InstOpCode::LLGH, srcNode, gpr64Partial, sourceMR);
             break;
          case 3:
             generateRRInstruction(cg, TR::InstOpCode::XGR, srcNode, gpr64Partial, gpr64Partial);
             generateRSInstruction(cg, TR::InstOpCode::ICM, srcNode, gpr64Partial, (uint32_t) 0x7, sourceMR);
             break;
          case 4:
-            generateRXYInstruction(cg, TR::InstOpCode::LLGF, srcNode, gpr64Partial, sourceMR);
+            generateRXInstruction(cg, TR::InstOpCode::LLGF, srcNode, gpr64Partial, sourceMR);
             break;
          case 5:
          case 6:
          case 7:
             generateRRInstruction(cg, TR::InstOpCode::XGR, srcNode, gpr64Partial, gpr64Partial);
-            generateRSYInstruction(cg, TR::InstOpCode::ICMH, node, gpr64Partial, (uint32_t)((1 << (partialSize-4)) - 1), sourceMR);  // 5->mask=1, 6->mask=3, 7->mask=7
-            generateRXYInstruction(cg, TR::InstOpCode::L, srcNode, gpr64Partial, generateS390LeftAlignedMemoryReference(*sourceMR, srcNode, partialSize-4, cg, sourceMR->getLeftMostByte(), enforceSSLimits));
+            generateRSInstruction(cg, TR::InstOpCode::ICMH, node, gpr64Partial, (uint32_t)((1 << (partialSize-4)) - 1), sourceMR);  // 5->mask=1, 6->mask=3, 7->mask=7
+            generateRXInstruction(cg, TR::InstOpCode::L, srcNode, gpr64Partial, generateS390LeftAlignedMemoryReference(*sourceMR, srcNode, partialSize-4, cg, sourceMR->getLeftMostByte(), enforceSSLimits));
             break;
          case 8:
-            generateRXYInstruction(cg, TR::InstOpCode::LG, srcNode, gpr64Partial, sourceMR);
+            generateRXInstruction(cg, TR::InstOpCode::LG, srcNode, gpr64Partial, sourceMR);
             break;
          default:
             TR_ASSERT(false,"unexpected partialSize %d\n",partialSize);
@@ -3062,7 +3062,7 @@ J9::Z::TreeEvaluator::pd2ddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       if (isLongDouble)
          {
          if (srcRegSize > 8)
-            generateRXYInstruction(cg, TR::InstOpCode::LG, srcNode, gpr64Lo, generateS390LeftAlignedMemoryReference(*sourceMR, srcNode, partialSize, cg, sourceMR->getLeftMostByte(), enforceSSLimits));
+            generateRXInstruction(cg, TR::InstOpCode::LG, srcNode, gpr64Lo, generateS390LeftAlignedMemoryReference(*sourceMR, srcNode, partialSize, cg, sourceMR->getLeftMostByte(), enforceSSLimits));
          else
             generateRRInstruction(cg, TR::InstOpCode::XGR, srcNode, gpr64Hi, gpr64Hi);
          }
@@ -3620,7 +3620,7 @@ J9::Z::TreeEvaluator::df2pdEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          case 5:
          case 6:
          case 7:
-            generateRSYInstruction(cg, TR::InstOpCode::STCMH, node, gpr64Partial, (uint32_t)((1 << (partialSize-4)) - 1), destMR);
+            generateRSInstruction(cg, TR::InstOpCode::STCMH, node, gpr64Partial, (uint32_t)((1 << (partialSize-4)) - 1), destMR);
             generateRXInstruction(cg, TR::InstOpCode::ST, node, gpr64Partial, generateS390LeftAlignedMemoryReference(*destMR, node, partialSize-4, cg, destMR->getLeftMostByte(), enforceSSLimits));
             break;
          case 8:
@@ -3631,7 +3631,7 @@ J9::Z::TreeEvaluator::df2pdEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
 
       if (isLongDouble && remainingTargetBytes > 8)
-         generateRXYInstruction(cg, TR::InstOpCode::STG, node, gpr64Lo, generateS390LeftAlignedMemoryReference(*destMR, node, partialSize, cg, destMR->getLeftMostByte(), enforceSSLimits));
+         generateRXInstruction(cg, TR::InstOpCode::STG, node, gpr64Lo, generateS390LeftAlignedMemoryReference(*destMR, node, partialSize, cg, destMR->getLeftMostByte(), enforceSSLimits));
 
       if (deps)
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, generateLabelSymbol(cg), deps);
@@ -3917,7 +3917,7 @@ J9::Z::TreeEvaluator::pd2lVariableEvaluator(TR::Node* node, TR::CodeGenerator* c
          }
       else
          {
-         generateRXYInstruction(cg, TR::InstOpCode::CVBG, node, returnReg, generateS390MemoryReference(*ZAPtargetMR, 0, cg));
+         generateRXInstruction(cg, TR::InstOpCode::CVBG, node, returnReg, generateS390MemoryReference(*ZAPtargetMR, 0, cg));
          }
 
       tempSR->setTemporaryReferenceCount(0);
@@ -4032,7 +4032,7 @@ J9::Z::TreeEvaluator::generatePackedToBinaryConversion(TR::Node * node, TR::Inst
    if (op == TR::InstOpCode::CVB)
       inst = generateRXInstruction(cg, op, node, targetReg, sourceMR);
    else
-      inst = generateRXYInstruction(cg, op, node, targetReg, sourceMR);
+      inst = generateRXInstruction(cg, op, node, targetReg, sourceMR);
 
    if (sourceMR->getStorageReference() == firstStorageReference)
       firstReg->setHasKnownValidSignAndData();
@@ -4139,10 +4139,7 @@ J9::Z::TreeEvaluator::generateBinaryToPackedConversion(TR::Node * node,
       firstReg = tempReg;
       }
 
-   if (isI2PD)
-      generateRXInstruction(cg, op, node, firstReg, targetMR);
-   else
-      generateRXYInstruction(cg, op, node, firstReg, targetMR);
+   generateRXInstruction(cg, op, node, firstReg, targetMR);
 
    targetReg->setIsInitialized();
 

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -1990,11 +1990,11 @@ J9::Z::CodeGenerator::evaluateAggregateToGPR(size_t destSize, TR::Node *srcNode,
       case 2:
          if (targetReg->getKind() == TR_GPR64)
             {
-            generateRXYInstruction(cg, loadSize == 1 ? TR::InstOpCode::LLGC : TR::InstOpCode::LLGH, srcNode, targetReg, srcMR);
+            generateRXInstruction(cg, loadSize == 1 ? TR::InstOpCode::LLGC : TR::InstOpCode::LLGH, srcNode, targetReg, srcMR);
             }
          else
             {
-            generateRXYInstruction(cg, loadSize == 1 ? TR::InstOpCode::LLC : TR::InstOpCode::LLH, srcNode, targetReg, srcMR);
+            generateRXInstruction(cg, loadSize == 1 ? TR::InstOpCode::LLC : TR::InstOpCode::LLH, srcNode, targetReg, srcMR);
             }
          break;
       case 3:
@@ -2002,7 +2002,7 @@ J9::Z::CodeGenerator::evaluateAggregateToGPR(size_t destSize, TR::Node *srcNode,
          break;
       case 4:
          if (targetReg->getKind() == TR_GPR64)
-            generateRXYInstruction(cg, TR::InstOpCode::LLGF, srcNode, targetReg, srcMR);
+            generateRXInstruction(cg, TR::InstOpCode::LLGF, srcNode, targetReg, srcMR);
          else
             generateRXInstruction(cg, TR::InstOpCode::L, srcNode, targetReg, srcMR);
          break;
@@ -2022,8 +2022,8 @@ J9::Z::CodeGenerator::evaluateAggregateToGPR(size_t destSize, TR::Node *srcNode,
             {
             TR_ASSERT(targetReg->getKind() == TR_GPR64,"targetReg should be 64 bit on node %p\n",srcNode);
             generateRRInstruction(cg, TR::InstOpCode::XGR, srcNode, targetReg, targetReg);
-            generateRSYInstruction(cg, TR::InstOpCode::ICMH, srcNode, targetReg, mask, srcMR);
-            generateRXYInstruction(cg, TR::InstOpCode::L, srcNode, targetReg, generateS390MemoryReference(*srcMR, mrOffset, cg));
+            generateRSInstruction(cg, TR::InstOpCode::ICMH, srcNode, targetReg, mask, srcMR);
+            generateRXInstruction(cg, TR::InstOpCode::L, srcNode, targetReg, generateS390MemoryReference(*srcMR, mrOffset, cg));
             }
          }
          break;
@@ -2035,7 +2035,7 @@ J9::Z::CodeGenerator::evaluateAggregateToGPR(size_t destSize, TR::Node *srcNode,
             }
          else
             {
-            generateRXYInstruction(cg, TR::InstOpCode::LG, srcNode, targetReg, srcMR);
+            generateRXInstruction(cg, TR::InstOpCode::LG, srcNode, targetReg, srcMR);
             }
          break;
       case 9:

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -1208,7 +1208,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
       {
       int32_t offset = cg()->machine()->getGPRSize() * -1;
       retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
-      cursor = generateRXYInstruction(cg(), TR::InstOpCode::getExtendedStoreOpCode(), firstNode, getS390RealRegister(getReturnAddressRegister()),
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::getExtendedStoreOpCode(), firstNode, getS390RealRegister(getReturnAddressRegister()),
          retAddrMemRef, cursor);
       }
 
@@ -1221,7 +1221,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
    else
       {
       // Adjust stack pointer with LA (reduce AGI delay)
-      cursor = generateRXYInstruction(cg(), TR::InstOpCode::LAY, firstNode, spReg, generateS390MemoryReference(spReg,(size) * -1, cg()),cursor);
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::LAY, firstNode, spReg, generateS390MemoryReference(spReg,(size) * -1, cg()),cursor);
       }
 
    if (!comp()->isDLT())
@@ -1418,7 +1418,7 @@ TR::S390PrivateLinkage::createPrologue(TR::Instruction * cursor)
 
       if (cg()->isPrefetchNextStackCacheLine() && prefetchStack)
          {
-         cursor = generateRXYbInstruction(cg(), TR::InstOpCode::PFD, firstNode, 2, generateS390MemoryReference(spReg, -256, cg()), cursor);
+         cursor = generateRXInstruction(cg(), TR::InstOpCode::PFD, firstNode, 2, generateS390MemoryReference(spReg, -256, cg()), cursor);
          }
       }
 
@@ -1480,7 +1480,7 @@ TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
 
    if (getRaContextRestoreNeeded())
       {
-      cursor = generateRXYInstruction(cg(), TR::InstOpCode::getExtendedLoadOpCode(), nextNode,
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::getExtendedLoadOpCode(), nextNode,
                                       getS390RealRegister(getReturnAddressRegister()),
                                       generateS390MemoryReference(spReg, frameSize, cg()), cursor);
       }
@@ -1555,7 +1555,7 @@ TR::S390PrivateLinkage::createEpilogue(TR::Instruction * cursor)
       }
    else if (adjustSize<MAXLONGDISP)
       {
-      cursor = generateRXYInstruction(cg(), TR::InstOpCode::LAY, nextNode, spReg, generateS390MemoryReference(spReg,adjustSize,cg()),cursor);
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::LAY, nextNode, spReg, generateS390MemoryReference(spReg,adjustSize,cg()),cursor);
       }
    else
       {
@@ -1967,7 +1967,7 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
       else
          {
          cursor =
-            generateRXYInstruction(cg(), TR::InstOpCode::getExtendedLoadOpCode(), callNode, RegRA,
+            generateRXInstruction(cg(), TR::InstOpCode::getExtendedLoadOpCode(), callNode, RegRA,
                                    generateS390MemoryReference(classReg, offset, cg()));
 
          if (unresolvedSnippet)
@@ -2186,7 +2186,7 @@ TR::S390PrivateLinkage::buildVirtualDispatch(TR::Node * callNode, TR::RegisterDe
             cursor = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::LARL, callNode, RegRA, returnLocationLabel, cursor, cg());
 
             if (TR::Compiler->target.is64Bit())
-               cursor = generateRXYInstruction(cg(), TR::InstOpCode::LPQ, callNode, classMethodEPPairRegister,
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::LPQ, callNode, classMethodEPPairRegister,
                         generateS390MemoryReference(snippetReg, ifcSnippet->getDataConstantSnippet()->getSingleDynamicSlotOffset(), cg()), cursor);
             else
                cursor = generateRSInstruction(cg(), TR::InstOpCode::LM, callNode, classMethodEPPairRegister,
@@ -2544,7 +2544,7 @@ TR::S390PrivateLinkage::setupJNICallOutFrame(TR::Node * callNode,
 
    int32_t stackAdjust = (-5 * (int32_t)sizeof(intptrj_t));
 
-   cursor = generateRXYInstruction(codeGen, TR::InstOpCode::LAY, callNode, javaStackPointerRealRegister, generateS390MemoryReference(javaStackPointerRealRegister, stackAdjust, codeGen), cursor);
+   cursor = generateRXInstruction(codeGen, TR::InstOpCode::LAY, callNode, javaStackPointerRealRegister, generateS390MemoryReference(javaStackPointerRealRegister, stackAdjust, codeGen), cursor);
 
    setOffsetToLongDispSlot( getOffsetToLongDispSlot() - stackAdjust );
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -1030,7 +1030,7 @@ J9::Z::TreeEvaluator::genLoadForObjectHeadersMasked(TR::CodeGenerator *cg, TR::N
 #if defined(J9VM_INTERP_COMPRESSED_OBJECT_HEADER)
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z13) && !disabled)
       {
-      iCursor = generateRXYInstruction(cg, TR::InstOpCode::LLZRGF, node, reg, tempMR, iCursor);
+      iCursor = generateRXInstruction(cg, TR::InstOpCode::LLZRGF, node, reg, tempMR, iCursor);
       cg->generateDebugCounter("z13/LoadAndMask", 1, TR::DebugCounter::Free);
       }
    else
@@ -1044,7 +1044,7 @@ J9::Z::TreeEvaluator::genLoadForObjectHeadersMasked(TR::CodeGenerator *cg, TR::N
 #else
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z13))
       {
-      iCursor = generateRXYInstruction(cg, TR::InstOpCode::getLoadAndMaskOpCode(), node, reg, tempMR, iCursor);
+      iCursor = generateRXInstruction(cg, TR::InstOpCode::getLoadAndMaskOpCode(), node, reg, tempMR, iCursor);
       cg->generateDebugCounter("z13/LoadAndMask", 1, TR::DebugCounter::Free);
       }
    else
@@ -3088,7 +3088,7 @@ J9::Z::TreeEvaluator::BNDCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
          TR::InstOpCode::Mnemonic opCode = (regChild->getDataType()==TR::Int64) ? TR::InstOpCode::CLGT :
                                                                                   TR::InstOpCode::CLT;
-         cursor = generateRSYInstruction(cg, opCode,
+         cursor = generateRSInstruction(cg, opCode,
                                          node, regChild->getRegister(),
                                          getMaskForBranchCondition(compareCondition),
                                          generateS390MemoryReference(memChild, cg));
@@ -4184,7 +4184,7 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
          {
             srcReg = cg->allocateCollectedReferenceRegister();
 
-            generateRXYInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), sourceChild, srcReg, generateS390MemoryReference(sourceChild, cg));
+            generateRXInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), sourceChild, srcReg, generateS390MemoryReference(sourceChild, cg));
 
             sourceChild->setRegister(srcReg);
          }
@@ -6776,7 +6776,7 @@ J9::Z::TreeEvaluator::VMcheckcastEvaluator(TR::Node * node, TR::CodeGenerator * 
 
          tempMR = generateS390MemoryReference(objNode, cg);
 
-         generateRXYInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), objNode, objReg, tempMR);
+         generateRXInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), objNode, objReg, tempMR);
 
          objNode->setRegister(objReg);
          nullCCSet = true;
@@ -7112,7 +7112,7 @@ J9::Z::TreeEvaluator::VMmonentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       if (comp->getOption(TR_EnableMonitorCacheLookup))
          targetLabel = monitorLookupCacheLabel;
 
-      generateRXYInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, tempMR);
+      generateRXInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, tempMR);
 
       if (disableOOL)
          {
@@ -7191,7 +7191,7 @@ J9::Z::TreeEvaluator::VMmonentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          generateRXInstruction(cg, TR::InstOpCode::LLGF, node, tempRegister, temp2MR, NULL);
          startICF = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, tempRegister, NULLVALUE, TR::InstOpCode::COND_BE, helperCallLabel, false, true);
 #else
-         generateRXYInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, temp2MR);
+         generateRXInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, temp2MR);
 
          startICF = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, helperCallLabel);
 #endif
@@ -7542,7 +7542,7 @@ J9::Z::TreeEvaluator::VMmonexitEvaluator(TR::Node * node, TR::CodeGenerator * cg
       if (comp->getOption(TR_EnableMonitorCacheLookup))
          targetLabel = monitorLookupCacheLabel;
 
-      generateRXYInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, tempMR);
+      generateRXInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, tempMR);
 
       if (disableOOL)
          {
@@ -7624,7 +7624,7 @@ J9::Z::TreeEvaluator::VMmonexitEvaluator(TR::Node * node, TR::CodeGenerator * cg
          generateRXInstruction(cg, TR::InstOpCode::LLGF, node, tempRegister, temp2MR, NULL);
          startICF = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, tempRegister, NULLVALUE, TR::InstOpCode::COND_BE, helperCallLabel, false, true);
 #else
-         generateRXYInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, temp2MR);
+         generateRXInstruction(cg, TR::InstOpCode::getLoadTestOpCode(), node, tempRegister, temp2MR);
          startICF = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, helperCallLabel);
 #endif
 
@@ -10082,7 +10082,7 @@ VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mn
       // reads the existing value to be compared with a provided compare value, before the store itself), hence needs
       // a read barrier
       generateS390IEInstruction(cg, TR::InstOpCode::NIAI, 1, 0, node);
-      generateRXYInstruction(cg, guardedLoadMnemonic, node, tempReadBarrier, generateS390MemoryReference(*casMemRef, 0, cg));
+      generateRXInstruction(cg, guardedLoadMnemonic, node, tempReadBarrier, generateS390MemoryReference(*casMemRef, 0, cg));
 
       cg->stopUsingRegister(tempReadBarrier);
       }
@@ -10333,10 +10333,10 @@ extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::No
       if (TR::Compiler->target.isZOS())
          {
          // Load FFCVT(R0)
-         generateRXYInstruction(cg, TR::InstOpCode::LLGT, node, tempRegister, generateS390MemoryReference(offsets[0], cg));
+         generateRXInstruction(cg, TR::InstOpCode::LLGT, node, tempRegister, generateS390MemoryReference(offsets[0], cg));
 
          // Load CVTEXT2 - CVT
-         generateRXYInstruction(cg, TR::InstOpCode::LLGT, node, tempRegister, generateS390MemoryReference(tempRegister, offsets[1], cg));
+         generateRXInstruction(cg, TR::InstOpCode::LLGT, node, tempRegister, generateS390MemoryReference(tempRegister, offsets[1], cg));
          }
 #endif
 
@@ -10349,7 +10349,7 @@ extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::No
       if (TR::Compiler->target.isZOS())
          {
          // Subtract the LSO offset
-         generateRXYInstruction(cg, TR::InstOpCode::SLG, node, targetRegister, generateS390MemoryReference(tempRegister, offsets[2],cg));
+         generateRXInstruction(cg, TR::InstOpCode::SLG, node, targetRegister, generateS390MemoryReference(tempRegister, offsets[2],cg));
          }
 
       cg->stopUsingRegister(tempRegister);
@@ -10374,10 +10374,10 @@ extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::No
       if (TR::Compiler->target.isZOS())
          {
          // Load FFCVT(r0)
-         generateRXYInstruction(cg, TR::InstOpCode::L, node, tempRegister1, generateS390MemoryReference(offsets[0], cg));
+         generateRXInstruction(cg, TR::InstOpCode::L, node, tempRegister1, generateS390MemoryReference(offsets[0], cg));
 
          // Load CVTEXT2 - CVT
-         generateRXYInstruction(cg, TR::InstOpCode::L, node, tempRegister1, generateS390MemoryReference(tempRegister1, offsets[1],cg));
+         generateRXInstruction(cg, TR::InstOpCode::L, node, tempRegister1, generateS390MemoryReference(tempRegister1, offsets[1],cg));
          }
 #endif
 
@@ -10394,8 +10394,8 @@ extern TR::Register* inlineCurrentTimeMaxPrecision(TR::CodeGenerator* cg, TR::No
       if (TR::Compiler->target.isZOS())
          {
          // Subtract the LSO offset
-         generateRXYInstruction(cg, TR::InstOpCode::SL, node, targetRegister->getLowOrder(), generateS390MemoryReference(tempRegister1, offsets[2] + 4, cg));
-         generateRXYInstruction(cg, TR::InstOpCode::SLB, node, targetRegister->getHighOrder(), generateS390MemoryReference(tempRegister1, offsets[2], cg));
+         generateRXInstruction(cg, TR::InstOpCode::SL, node, targetRegister->getLowOrder(), generateS390MemoryReference(tempRegister1, offsets[2] + 4, cg));
+         generateRXInstruction(cg, TR::InstOpCode::SLB, node, targetRegister->getHighOrder(), generateS390MemoryReference(tempRegister1, offsets[2], cg));
          }
 #endif
 
@@ -11190,7 +11190,7 @@ inlineConcurrentLinkedQueueTMOffer(
 
       if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
          {
-         cursor = generateRXYInstruction(cg, guardedLoadMnemonic, node, rP, generateS390MemoryReference(rThis, offsetTail, cg));
+         cursor = generateRXInstruction(cg, guardedLoadMnemonic, node, rP, generateS390MemoryReference(rThis, offsetTail, cg));
          }
       else
          {
@@ -11214,7 +11214,7 @@ inlineConcurrentLinkedQueueTMOffer(
 
       if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
          {
-         cursor = generateRXYInstruction(cg, guardedLoadMnemonic, node, rQ, generateS390MemoryReference(rP, offsetNext, cg));
+         cursor = generateRXInstruction(cg, guardedLoadMnemonic, node, rQ, generateS390MemoryReference(rP, offsetNext, cg));
 
          cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CLG, node, rQ, 0, TR::InstOpCode::COND_CC0, insertLabel, false, false);
          }
@@ -11245,7 +11245,7 @@ inlineConcurrentLinkedQueueTMOffer(
 
       if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
          {
-         cursor = generateRXYInstruction(cg, guardedLoadMnemonic, node, rQ, generateS390MemoryReference(rP, offsetNext, cg));
+         cursor = generateRXInstruction(cg, guardedLoadMnemonic, node, rQ, generateS390MemoryReference(rP, offsetNext, cg));
 
          cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CLG, node, rQ, 0, TR::InstOpCode::COND_CC0, insertLabel, false, false);
          }
@@ -11414,7 +11414,7 @@ inlineConcurrentLinkedQueueTMPoll(
 
       if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
          {
-         cursor = generateRXYInstruction(cg, guardedLoadMnemonic, node, rP, generateS390MemoryReference(rThis, offsetHead, cg));
+         cursor = generateRXInstruction(cg, guardedLoadMnemonic, node, rP, generateS390MemoryReference(rThis, offsetHead, cg));
          }
       else
          {
@@ -11438,7 +11438,7 @@ inlineConcurrentLinkedQueueTMPoll(
 
       if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
          {
-         cursor = generateRXYInstruction(cg, guardedLoadMnemonic, node, rE, generateS390MemoryReference(rP, offsetItem, cg));
+         cursor = generateRXInstruction(cg, guardedLoadMnemonic, node, rE, generateS390MemoryReference(rP, offsetItem, cg));
          }
       else
          {
@@ -11462,7 +11462,7 @@ inlineConcurrentLinkedQueueTMPoll(
 
       if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
          {
-         cursor = generateRXYInstruction(cg, guardedLoadMnemonic, node, rQ, generateS390MemoryReference(rP, offsetNext, cg));
+         cursor = generateRXInstruction(cg, guardedLoadMnemonic, node, rQ, generateS390MemoryReference(rP, offsetNext, cg));
 
          if (usesCompressedrefs)
             {
@@ -11582,7 +11582,7 @@ VMgenerateCatchBlockBBStartPrologue(
       if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z10))
          {
          TR::MemoryReference * recompMR = generateS390MemoryReference(biAddrReg, 0, cg);
-         generateSIYInstruction(cg, TR::InstOpCode::ASI, node, recompMR, -1);
+         generateSIInstruction(cg, TR::InstOpCode::ASI, node, recompMR, -1);
          recompMR->stopUsingMemRefRegister(cg);
          }
       else
@@ -11817,15 +11817,15 @@ J9::Z::TreeEvaluator::countDigitsEvaluator(TR::Node * node, TR::CodeGenerator * 
          label[i] = generateLabelSymbol(cg);
          }
 
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[7]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[7]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[11]);
 
       // LABEL 3
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[3]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[3]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[5]);
 
       // LABEL 1
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[1]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[1]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[2]);
 
       countDigitsHelper(node, cg, 0, work[0], inputReg, countReg, cFlowRegionEnd, isLong);           // 0 and 1
@@ -11835,7 +11835,7 @@ J9::Z::TreeEvaluator::countDigitsEvaluator(TR::Node * node, TR::CodeGenerator * 
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, label[5]);       // LABEL 5
 
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[5]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[5]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[6]);
 
       countDigitsHelper(node, cg, 4, work[4], inputReg, countReg, cFlowRegionEnd, isLong);           // 4 and 5
@@ -11845,11 +11845,11 @@ J9::Z::TreeEvaluator::countDigitsEvaluator(TR::Node * node, TR::CodeGenerator * 
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, label[11]);      // LABEL 11
 
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[11]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[11]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[14]);
 
       // LABEL 9
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[9]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[9]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[10]);
 
       countDigitsHelper(node, cg, 8, work[8], inputReg, countReg, cFlowRegionEnd, isLong);           // 8 and 9
@@ -11859,11 +11859,11 @@ J9::Z::TreeEvaluator::countDigitsEvaluator(TR::Node * node, TR::CodeGenerator * 
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, label[14]);      // LABEL 14
 
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[14]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[14]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[16]);
 
       // LABEL 12
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[12]); // 12
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[12]); // 12
       generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, countReg, 12+1);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, node, cFlowRegionEnd);
 
@@ -11872,7 +11872,7 @@ J9::Z::TreeEvaluator::countDigitsEvaluator(TR::Node * node, TR::CodeGenerator * 
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, label[16]);      // LABEL 16
 
-      generateRXYInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[16]);
+      generateRXInstruction(cg, TR::InstOpCode::CG, node, inputReg, work[16]);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, label[17]);
       // LABEL 15
       countDigitsHelper(node, cg, 15, work[15], inputReg, countReg, cFlowRegionEnd, isLong);  // 15 and 16


### PR DESCRIPTION
Now that eclipse/omr#3113 has been merged we can safely deprecate the
use of long displacement APIs in favor or RX,RS,SI APIs since the long
displacement versions map right down to the non-long displacement APIs.

This eliminates all uses of such long displacement APIs in all
downstream projects so that we can fold the API away entirely at the
OMR level and simplify the generation of many instructions in the Z
code generator without having the user worry whether they need long
displacement support or not.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>