### PR TITLE
Reduce number of getOSRFrameSizeInBytes messages

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1765,6 +1765,20 @@ UDATA
 osrFrameSize(J9Method *method)
 {
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+	return osrFrameSizeRomMethod(romMethod);
+}
+
+
+/**
+ * Compute the number of bytes required for a single OSR frame.
+ *
+ * @param[in] *romMethod the J9ROMMethod for which to compute the OSR frame size
+ *
+ * @return byte size of the OSR frame
+ */
+UDATA
+osrFrameSizeRomMethod(J9ROMMethod *romMethod)
+{
 	U_32 numberOfLocals = J9_ARG_COUNT_FROM_ROM_METHOD(romMethod) + J9_TEMP_COUNT_FROM_ROM_METHOD(romMethod);
 	U_32 maxStack = J9_MAX_STACK_FROM_ROM_METHOD(romMethod);
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -19,7 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
+#include "oti/jitprotos.h"
 #include "rpc/J9Server.hpp"
 #include "VMJ9Server.hpp"
 #include "j9methodServer.hpp"
@@ -519,6 +519,15 @@ TR_J9ServerVM::isClassInitialized(TR_OpaqueClassBlock * clazz)
 UDATA
 TR_J9ServerVM::getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method)
    {
+      {
+      ClientSessionData *clientSessionData = _compInfoPT->getClientData();
+      OMR::CriticalSection cacheRemoteROMClass(clientSessionData->getROMMapMonitor());
+      auto it = clientSessionData->getJ9MethodMap().find((J9Method*) method);
+      if (it != clientSessionData->getJ9MethodMap().end())
+         {
+         return osrFrameSizeRomMethod(it->second._romMethod);
+         }
+      }
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::J9ServerMessageType::VM_getOSRFrameSizeInBytes, method);
    return std::get<0>(stream->read<UDATA>());

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -41,6 +41,7 @@ void * setUpForDLT(J9VMThread * currentThread, J9StackWalkState * walkState);
 
 extern J9_CFUNC void   induceOSROnCurrentThread(J9VMThread * currentThread);
 extern J9_CFUNC UDATA osrFrameSize(J9Method *method);
+extern J9_CFUNC UDATA osrFrameSizeRomMethod(J9ROMMethod *romMethod);
 extern J9_CFUNC UDATA ensureOSRBufferSize(J9JavaVM *vm, UDATA osrFramesByteSize, UDATA osrScratchBufferByteSize, UDATA osrStackFrameByteSize);
 extern J9_CFUNC void jitStackLocalsModified (J9VMThread * currentThread, J9StackWalkState * walkState);
 #if (defined(J9VM_INTERP_HOT_CODE_REPLACEMENT)) /* priv. proto (autogen) */


### PR DESCRIPTION
ROMMethod are already cached so acquire the ROMMethod for the J9Method from the J9MethodMap.
New method osrFrameSizeRomMethod takes ROMMethod as input and return the frame size.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>