### PR TITLE
Reduce number of getOSRFrameSizeInBytes messages

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1441,12 +1441,6 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(TR_J9MethodBase::isBigDecimalConvertersMethod(j9method));
          }
          break;
-      case J9ServerMessageType::ResolvedMethod_osrFrameSize:
-         {
-         J9Method *j9method = std::get<0>(client->getRecvData<J9Method*>());
-         client->write(TR_J9MethodBase::osrFrameSize(j9method));
-         }
-         break;
       case J9ServerMessageType::ResolvedMethod_isInlineable:
          {
          TR_ResolvedJ9Method *mirror = std::get<0>(client->getRecvData<TR_ResolvedJ9Method *>());

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -19,7 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
+#include "oti/jitprotos.h"
 #include "rpc/J9Server.hpp"
 #include "VMJ9Server.hpp"
 #include "j9methodServer.hpp"
@@ -519,6 +519,15 @@ TR_J9ServerVM::isClassInitialized(TR_OpaqueClassBlock * clazz)
 UDATA
 TR_J9ServerVM::getOSRFrameSizeInBytes(TR_OpaqueMethodBlock * method)
    {
+      {
+      ClientSessionData *clientSessionData = _compInfoPT->getClientData();
+      OMR::CriticalSection getRemoteROMClass(clientSessionData->getROMMapMonitor());
+      auto it = clientSessionData->getJ9MethodMap().find((J9Method*) method);
+      if (it != clientSessionData->getJ9MethodMap().end())
+         {
+         return osrFrameSizeRomMethod(it->second._romMethod);
+         }
+      }
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITaaS::J9ServerMessageType::VM_getOSRFrameSizeInBytes, method);
    return std::get<0>(stream->read<UDATA>());


### PR DESCRIPTION
ROMMethod are already cached so acquire the ROMMethod for the J9Method from the J9MethodMap.
New method osrFrameSizeRomMethod takes ROMMethod as input and return the frame size.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>