### PR TITLE
Fix for incorrect kind of AllocPrefetchSnippet on X86

### DIFF
--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.hpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,8 +94,6 @@ class X86AllocPrefetchSnippet  : public TR::X86RestartSnippet
       _prefetchSize = prefetchSize;
       _nonZeroTLH = nonZeroTLH;
       }
-
-   virtual Kind getKind() { return IsJNIPause; }
 
    virtual uint8_t *emitSnippetBody();
 


### PR DESCRIPTION
X86AllocPrefetchSnippet incorrectly reports itself as IsJNIPause,
fixing.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>