### PR TITLE
Fix Windows DDR issues

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/IDATAPointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/IDATAPointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,6 +93,21 @@ public class IDATAPointer extends Pointer {
 	public IDATAPointer sub(Scalar count)
 	{
 		return sub(count.longValue());
+	}
+
+	public IDATA sub(IDATAPointer pointer) {
+		long baseSize = sizeOfBaseType();
+
+		if (baseSize != pointer.sizeOfBaseType()) {
+			throw new UnsupportedOperationException(
+				"Cannot subtract pointers to types of different sizes; "
+					+ "this type = " + getClass()
+					+ ", parameter type = " + pointer.getClass());
+		}
+
+		IDATA diff = new IDATA(this.address).sub(new IDATA(pointer.address));
+
+		return new IDATA(diff.longValue() / baseSize);
 	}
 
 	@Override

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/UDATAPointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/UDATAPointer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 package com.ibm.j9ddr.vm29.pointer;
 
 import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.types.IDATA;
 import com.ibm.j9ddr.vm29.types.Scalar;
 import com.ibm.j9ddr.vm29.types.UDATA;
 
@@ -94,6 +95,21 @@ public class UDATAPointer extends Pointer {
 	public UDATAPointer sub(Scalar count)
 	{
 		return sub(count.longValue());
+	}
+
+	public IDATA sub(UDATAPointer pointer) {
+		long baseSize = sizeOfBaseType();
+
+		if (baseSize != pointer.sizeOfBaseType()) {
+			throw new UnsupportedOperationException(
+				"Cannot subtract pointers to types of different sizes; "
+					+ "this type = " + getClass()
+					+ ", parameter type = " + pointer.getClass());
+		}
+
+		IDATA diff = new IDATA(this.address).sub(new IDATA(pointer.address));
+
+		return new IDATA(diff.longValue() / baseSize);
 	}
 
 	@Override

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U64.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/U64.java
@@ -205,9 +205,9 @@ public class U64 extends UDATA {
 	
 	public boolean gt(Scalar parameter) {
 		checkComparisonValid(parameter);
-		
-		//If sign bit is set, result it reversed
-		if (((data ^ parameter.data) & 0x8000000000000000L) != 0) {
+
+		// if sign bits are different, result is reversed
+		if ((data ^ parameter.data) < 0) {
 			return data < parameter.data;
 		} else {
 			return data > parameter.data;
@@ -216,9 +216,9 @@ public class U64 extends UDATA {
 	
 	public boolean lt(Scalar parameter) {
 		checkComparisonValid(parameter);
-		
-		//If sign bit is set, result it reversed
-		if (((data ^ parameter.data) & 0x8000000000000000L) != 0) {
+
+		// if sign bits are different, result is reversed
+		if ((data ^ parameter.data) < 0) {
 			return data > parameter.data;
 		} else {
 			return data < parameter.data;
@@ -246,6 +246,11 @@ public class U64 extends UDATA {
 
 	public U64 mult(long parameter) {
 		return new U64(data * parameter);
+	}
+
+	@Override
+	public boolean eq(long parameter) {
+		return parameter == data;
 	}
 
 	@Override


### PR DESCRIPTION
* Add U64.eq(long) to override implementation from Scalar
  - implementation in Scalar calls longValue() which may needlessly throw exceptions
  - fix comments in gt() and lt() and simplify
* Add new methods: IDATAPointer.sub(), UDATAPointer.sub()
  - allow subtracting pointers with the same target size (e.g. UDATAPointer/U64Pointer for 64-bit core files)

Fixes #3652: with these changes, the core file behind #3652 can be handled without error by `!gccheck`.

