### PR TITLE
Change how compilation dispatch works in JITaaS

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -620,8 +620,8 @@ public:
    TR_MethodToBeCompiled *requestExistsInCompilationQueue(TR::IlGeneratorMethodDetails & details, TR_FrontEnd *fe);
 
    TR_MethodToBeCompiled *addMethodToBeCompiled(TR::IlGeneratorMethodDetails &details, void *pc, CompilationPriority priority,
-      bool async, TR_OptimizationPlan *optPlan, bool *queued, TR_YesNoMaybe methodIsInSharedCache, void *extra = nullptr, char *clientOptions = nullptr, size_t clientOptionsSize = 0);
-
+      bool async, TR_OptimizationPlan *optPlan, bool *queued, TR_YesNoMaybe methodIsInSharedCache);
+   TR_MethodToBeCompiled *addRemoteMethodToBeCompiled(JITaaS::J9ServerStream *stream);
    void                   queueEntry(TR_MethodToBeCompiled *entry);
    void                   recycleCompilationEntry(TR_MethodToBeCompiled *cur);
    TR_MethodToBeCompiled *adjustCompilationEntryAndRequeue(TR::IlGeneratorMethodDetails &details,
@@ -650,10 +650,6 @@ public:
    void purgeMethodQueue(TR_CompilationErrorCode errorCode);
    void *compileMethod(J9VMThread * context, TR::IlGeneratorMethodDetails &details, void *oldStartPC,
       TR_YesNoMaybe async, TR_CompilationErrorCode *, bool *queued, TR_OptimizationPlan *optPlan);
-   void *compileRemoteMethod(J9VMThread * vmThread, TR::IlGeneratorMethodDetails & details,
-                             const J9ROMMethod *romMethod, const J9ROMClass* romClass,
-                             void *oldStartPC, TR_CompilationErrorCode *compErrCode,
-                             bool *queued, TR_OptimizationPlan * optimizationPlan, void *extra, char *clientOptions, size_t clientOptionsSize);
    void *compileOnApplicationThread(J9VMThread * context, TR::IlGeneratorMethodDetails &details, void *oldStartPC,
                                     TR_CompilationErrorCode *,
                                     TR_OptimizationPlan *optPlan);

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -371,7 +371,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    TR::Monitor *getCompThreadMonitor() { return _compThreadMonitor; }
    void                   run();
    void                   processEntries();
-   void                   processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider);
+   virtual void           processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider);
    bool                   shouldPerformCompilation(TR_MethodToBeCompiled &entry);
    void                   waitForWork();
    void                   doSuspend();
@@ -405,7 +405,7 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    uint32_t               getLastLocalGCCounter() { return _lastLocalGCCounter; }
    void                   updateLastLocalGCCounter(); 
 
-   private:
+   protected:
    J9::J9SegmentCache initializeSegmentCache(J9::J9SegmentProvider &segmentProvider);
 
    TR_J9ServerVM         *_serverVM;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2836,7 +2836,7 @@ J9::Options::unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Mem
    bool rtResolve = (bool) *((uint8_t *) options + clientOptionsSize - sizeof(bool));
    J9JITConfig *jitConfig = (J9JITConfig *) _feBase;
    if (rtResolve)
-      jitConfig->runtimeFlags |= J9JIT_RUNTIME_RESOLVE;
+      jitConfig->runtimeFlags |= J9JIT_RUNTIME_RESOLVE; // JITaaS FIXME: don't change global flags
 
    // disable caching of resolved methods if env variable TR_DisableResolvedMethodsCaching is set
    TR_ResolvedJ9JITaaSServerMethod::_useCaching = !feGetEnv("TR_DisableResolvedMethodsCaching");

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -168,6 +168,19 @@ void printJITaaSMsgStats(J9JITConfig *);
 void printJITaaSCHTableStats(J9JITConfig *, TR::CompilationInfo *);
 void printJITaaSCacheStats(J9JITConfig *, TR::CompilationInfo *);
 
+namespace TR
+{
+// Objects of this type are instantiated at JITaaS server
+class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
+   {
+   public:
+      friend class TR::CompilationInfo;
+      CompilationInfoPerThreadRemote(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread)
+         :CompilationInfoPerThread(compInfo, jitConfig, id, isDiagnosticThread) {}
+      void processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider) override;
+   };
+}
+
 class JITaaSHelpers
    {
    public:

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -68,7 +68,8 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
    _tryCompilingAgain = false;
    _compInfoPT = NULL;
    _aotCodeToBeRelocated = NULL;
-   _optimizationPlan->setIsAotLoad(false);
+   if (_optimizationPlan)
+      _optimizationPlan->setIsAotLoad(false); // FIXME: this should be done by the caller
    _async = false;
    _reqFromSecondaryQueue = TR_MethodToBeCompiled::REASON_NONE;
    _reqFromJProfilingQueue = false;

--- a/runtime/compiler/runtime/CompileService.cpp
+++ b/runtime/compiler/runtime/CompileService.cpp
@@ -21,214 +21,29 @@
  *******************************************************************************/
 
 #include "runtime/CompileService.hpp"
-#include "j9.h"
 #include "control/CompilationRuntime.hpp"
 #include "control/JITaaSCompilationThread.hpp"
-#include "env/j9methodServer.hpp"
-#include "env/PersistentCollections.hpp"
+#include "control/MethodToBeCompiled.hpp"
 
-static J9Method *ramMethodFromRomMethod(J9JITConfig *jitConfig, J9VMThread *vmThread,
-                                       const J9ROMClass* romClass, const J9ROMMethod* romMethod,
-                                       void* classChainC, void* classChainCL)
-   {
-   // Acquire vm access within this scope, variable is intentionally unused
-   VMAccessHolder access(vmThread);
 
-   TR_J9VMBase *fej9 = TR_J9VMBase::get(jitConfig, vmThread);
-   TR_J9SharedCache *cache = fej9->sharedCache();
-   J9ClassLoader *CL = (J9ClassLoader*)cache->persistentClassLoaderTable()->lookupClassLoaderAssociatedWithClassChain(classChainCL);
-   if (CL)
-      {
-      J9Class *ramClass = (J9Class*)cache->lookupClassFromChainAndLoader((uintptrj_t *)classChainC, CL);
-      if (ramClass)
-         {
-         J9Method *ramMethods = ramClass->ramMethods;
-         for (int32_t i = 0; i < romClass->romMethodCount; i++)
-            {
-            J9Method *curMethod = ramMethods + i;
-            J9ROMMethod *curROMMethod = J9_ROM_METHOD_FROM_RAM_METHOD(curMethod);
-            if (curROMMethod == romMethod)
-               return curMethod;
-            }
-         }
-      }
-   return NULL;
-   }
-
-static void doRemoteCompile(J9JITConfig* jitConfig, J9VMThread* vmThread,
-   J9ROMClass* romClass, const J9ROMMethod* romMethod,
-   J9Method* ramMethod, J9Class *clazz, JITaaS::J9ServerStream *rpc, TR_Hotness optLevel,
-   TR::IlGeneratorMethodDetails *clientDetails,
-   J9::IlGeneratorMethodDetailsType methodDetailsType,
-   J9Method *methodsOfClass,
-   char *clientOptions, size_t clientOptionsSize)
-   {
-   J9UTF8 *methodNameUTF = J9ROMNAMEANDSIGNATURE_NAME(&romMethod->nameAndSignature);
-   std::string methodNameStr((const char*)methodNameUTF->data, (size_t)methodNameUTF->length);
-   const char *methodName = methodNameStr.c_str();
-   J9UTF8 *classNameUTF = J9ROMCLASS_CLASSNAME(romClass);
-   std::string classNameStr((const char*)classNameUTF->data, (size_t)classNameUTF->length);
-   const char *className = classNameStr.c_str();
-
-   // Acquire vm access within this scope, variable is intentionally unused
-   VMAccessHolder access(vmThread);
-
-   PORT_ACCESS_FROM_JITCONFIG(jitConfig);
-
-   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-         "Server received request to compile %s.%s @ %s", className, methodName, TR::Compilation::getHotnessName(optLevel));
-
-   TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
-   TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, vmThread);
-   if (ramMethod)
-      {
-      bool queued = false;
-      TR_CompilationErrorCode compErrCode = compilationFailure;
-      TR_MethodEvent event;
-      event._eventType = TR_MethodEvent::RemoteCompilationRequest;
-      event._j9method = ramMethod;
-      event._oldStartPC = 0;
-      event._vmThread = vmThread;
-      event._classNeedingThunk = 0;
-      event._JITaaSClientOptLevel = optLevel;
-      bool newPlanCreated;
-      IDATA result = 0;
-      TR_OptimizationPlan *plan = TR::CompilationController::getCompilationStrategy()->processEvent(&event, &newPlanCreated);
-
-      // if the controller decides to compile this method, trigger the compilation
-      if (plan)
-         {
-         TR::IlGeneratorMethodDetails details;
-         *(uintptr_t*)clientDetails = 0; // smash remote vtable pointer to catch bugs early
-         TR::IlGeneratorMethodDetails &remoteDetails = details.createRemoteMethodDetails(*clientDetails, methodDetailsType, ramMethod, romClass, romMethod, clazz, methodsOfClass);
-         result = (IDATA)compInfo->compileRemoteMethod(vmThread, remoteDetails, romMethod, romClass, 0, &compErrCode, &queued, plan, rpc, clientOptions, clientOptionsSize);
-
-         if (newPlanCreated)
-            {
-            if (!queued)
-               TR_OptimizationPlan::freeOptimizationPlan(plan);
-
-            // If the responder has been handed over to the compilation thread, the compErrCode should be compilationInProgress
-            if (compErrCode == compilationInProgress)
-               {
-               // This should be the only path in which we do not call finish (the compilation thread will do that instead)
-               if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-                     "Server queued compilation for %s.%s", className, methodName);
-               }
-            else
-               {
-               if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-                     "Server failed to queue compilation for %s.%s", className, methodName);
-               fe->jitPersistentFree(romClass);
-               rpc->finishCompilation(compErrCode);
-               }
-            }
-         else
-            {
-            if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-               TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-                  "Server failed to compile %s.%s because a new plan could not be created.", className, methodName);
-            fe->jitPersistentFree(romClass);
-            rpc->finishCompilation(compilationFailure);
-            }
-         }
-      else
-         {
-         if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-            TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-               "Server failed to compile %s.%s because no memory was available to create an optimization plan.", className, methodName);
-         fe->jitPersistentFree(romClass);
-         rpc->finishCompilation(compilationFailure);
-         }
-      }
-   else // !method
-      {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS,
-            "Server couldn't find ramMethod for romMethod %s.%s .", className, methodName);
-      fe->jitPersistentFree(romClass);
-      rpc->finishCompilation(compilationFailure);
-      }
-   }
-
+// Routine called when a new connection request has been received at the server
+// Executed by the dispatcher thread
 void J9CompileDispatcher::compile(JITaaS::J9ServerStream *stream)
    {
-   char * clientOptions = nullptr;
-   try
+   TR::CompilationInfo * compInfo = getCompilationInfo(_jitConfig);
+   TR_MethodToBeCompiled *entry = NULL;
+   if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server received request for stream %p", stream);
       {
-      auto req = stream->read<uint64_t, uint32_t, J9Method *, J9Class*, TR_Hotness, std::string, 
-                              J9::IlGeneratorMethodDetailsType, std::vector<TR_OpaqueClassBlock*>,
-                              JITaaSHelpers::ClassInfoTuple, std::string>();
-
-      PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
-      TR_J9VMBase *fej9 = TR_J9VMBase::get(_jitConfig, _vmThread);
-      TR_J9SharedCache *cache = fej9->sharedCache();
-      uint64_t clientId = std::get<0>(req);
-      stream->setClientId(clientId);
-      uint32_t romMethodOffset = std::get<1>(req);
-      J9Method *ramMethod = std::get<2>(req);
-      J9Class *clazz = std::get<3>(req);
-      TR_Hotness opt = std::get<4>(req);
-      std::string detailsStr = std::get<5>(req);
-      TR::IlGeneratorMethodDetails *details = (TR::IlGeneratorMethodDetails*) &detailsStr[0];
-      auto detailsType = std::get<6>(req);
-      TR::CompilationInfo * compInfo = getCompilationInfo(jitConfig);
-      auto &unloadedClasses = std::get<7>(req);
-      auto &classInfoTuple = std::get<8>(req);
-      std::string clientOptionsStr = std::get<9>(req);
-      
-      size_t clientOptionsSize = clientOptionsStr.size();
-      clientOptions = new (PERSISTENT_NEW) char[clientOptionsSize];
-      memcpy(clientOptions, clientOptionsStr.data(), clientOptionsSize);
-
-      J9ROMClass *romClass = nullptr;
+      // Grab the compilation monitor to queue this entry and notify a compilation thread
+      OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
+      if (compInfo->addRemoteMethodToBeCompiled(stream))
          {
-         OMR::CriticalSection compilationMonitorLock(compInfo->getCompilationMonitor());
-         auto clientSession = compInfo->getClientSessionHT()->findOrCreateClientSession(clientId);
-         if (!clientSession)
-            throw std::bad_alloc();
-         
-         // If new classes have been unloaded at the client, 
-         // delete relevant entries from the persistent caches we hold per client
-         // This could be an expensive operation and we are holding the compilation monitor
-         // Maybe we should create another monitor.
-         // 
-         // Redefined classes are marked as unloaded, since they need to be cleared
-         // from the ROM class cache.
-         if (unloadedClasses.size() != 0)
-            clientSession->processUnloadedClasses(unloadedClasses);
-         // Get the ROMClass for the method to be compiled if it is already cached
-         // Or read it from the compilation request and cache it otherwise
-         if (!(romClass = JITaaSHelpers::getRemoteROMClassIfCached(clientSession, clazz)))
-            {
-            romClass = JITaaSHelpers::romClassFromString(std::get<0>(classInfoTuple), fej9->_compInfo->persistentMemory());
-            JITaaSHelpers::cacheRemoteROMClass(clientSession, clazz, romClass, &classInfoTuple);
-            }
-
-         clientSession->decInUse();
+         // successfully queued the new entry, so notify a thread
+         compInfo->getCompilationMonitor()->notifyAll();
+         return;
          }
-      J9ROMMethod *romMethod = (J9ROMMethod*)((uint8_t*) romClass + romMethodOffset);
-      J9Method *methodsOfClass = std::get<1>(classInfoTuple);
-
-      doRemoteCompile(_jitConfig, _vmThread, romClass, romMethod, ramMethod, clazz, stream, opt, details, detailsType, methodsOfClass, clientOptions, clientOptionsSize);
-      }
-   catch (const JITaaS::StreamFailure &e)
-      {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream failed in server compilation dispatcher thread: %s", e.what());
-      stream->cancel();
-      if (clientOptions)
-         TR_Memory::jitPersistentFree(clientOptions);
-      }
-   catch (const std::bad_alloc &e)
-      {
-      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
-         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server out of memory in compilation dispatcher thread: %s", e.what());
-      stream->finishCompilation(compilationLowPhysicalMemory);
-      if (clientOptions)
-         TR_Memory::jitPersistentFree(clientOptions);
-      }
+      } // end critical section
+   // If we reached this point there was a memory allocation failure
+   stream->finishCompilation(compilationLowPhysicalMemory);
    }


### PR DESCRIPTION
Currently, the dispatcher thread at the JITaaS server performs too much
work which could hinder connections from other clients. One of the main
problems is that the listener thread, which accepts incoming connection
requests, also perform a blocking read to determine the parameters for
the incoming compilation request. Thus, while waiting for this request
to come, no new connections can be established.
Another problem is that processing the unloaded classes could take some
time (also done under a monitor) which again could delay new connections.

The proposal is to queue just the stream that is created as a consequence
of the connection being accepted. Then, the reading of the compilation
request sent by the client could be handled by a dedicated compilation
thread. This way, the job of the dispatcher thread is much simplified.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>