### PR TITLE
Enable bootstrap class sharing by default on OpenJ9 Java 11

### DIFF
--- a/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/Shared.java
+++ b/jcl/src/openj9.sharedclasses/share/classes/com/ibm/oti/shared/Shared.java
@@ -2,7 +2,7 @@
 package com.ibm.oti.shared;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ public class Shared {
 	private static Object monitor;
 	private static SharedClassHelperFactory shcHelperFactory;
 	private static SharedDataHelperFactory shdHelperFactory;
-	private static boolean sharingEnabled;
+	private static boolean nonBootSharingEnabled;
 
 	/*[PR 122459] LIR646 - Remove use of generic object for synchronization */
 	private static final class Monitor {
@@ -44,10 +44,11 @@ public class Shared {
 
 	static {
 		monitor = new Monitor();
-		sharingEnabled = isSharingEnabledImpl();
+		/* Bootstrap class sharing is enabled by default in OpenJ9 Java 11 and up */
+		nonBootSharingEnabled = isNonBootSharingEnabledImpl();
 	}
 	
-	private static native boolean isSharingEnabledImpl();
+	private static native boolean isNonBootSharingEnabledImpl();
 
 	/**
 	 * Checks if sharing is enabled for this JVM.
@@ -55,7 +56,7 @@ public class Shared {
 	 * @return true if using -Xshareclasses on the command-line, false otherwise.
 	 */
 	public static boolean isSharingEnabled() {
-		return sharingEnabled;
+		return nonBootSharingEnabled;
 	}
 
 	/**

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -520,7 +520,7 @@ internalLoadROMClass(J9VMThread * vmThread, J9LoadROMClassData *loadData, J9Tran
 		/* Disable static verification for the bootstrap loader if Xfuture not present */
 		if ((vm->systemClassLoader == loadData->classLoader)
 		&& ((NULL == vm->bytecodeVerificationData) || (0 == (vm->bytecodeVerificationData->verificationFlags & J9_VERIFY_BOOTCLASSPATH_STATIC)))
-		&& ((NULL == vm->sharedCacheAPI) || (0 == (vm->sharedCacheAPI->xShareClassesPresent)))
+		&& (NULL == vm->sharedClassConfig)
 		) {
 			translationFlags &= ~BCT_StaticVerification;
 		}

--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -2303,7 +2303,7 @@ exit:
 }
 
 jboolean JNICALL
-Java_com_ibm_oti_shared_Shared_isSharingEnabledImpl(JNIEnv* env, jclass clazz)
+Java_com_ibm_oti_shared_Shared_isNonBootSharingEnabledImpl(JNIEnv* env, jclass clazz)
 {
 	jboolean ret = JNI_FALSE;
 #if defined(J9VM_OPT_SHARED_CLASSES)

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -220,7 +220,7 @@
 	<export name="Java_com_ibm_oti_shared_SharedClassUtilities_destroySharedCacheImpl" />
 	<export name="Java_com_ibm_oti_shared_SharedClassURLHelperImpl_init" />
 	<export name="Java_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_init" />
-	<export name="Java_com_ibm_oti_shared_Shared_isSharingEnabledImpl" />
+	<export name="Java_com_ibm_oti_shared_Shared_isNonBootSharingEnabledImpl" />
 	<export name="Java_com_ibm_oti_vm_VM_allInstances" />
 	<export name="Java_com_ibm_oti_vm_VM_getClassPathCount" />
 	<export name="Java_com_ibm_oti_vm_VM_getPathFromClassPath" />

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -326,4 +326,7 @@ static const struct { \
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+
+#define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) (J2SE_VERSION(vm) >= J2SE_V11)
+
 #endif /* J9_H */

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -327,6 +327,11 @@ static const struct { \
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
+#if defined(OSX)
+/* Temporarily disable default class sharing on OSX due to https://github.com/eclipse/openj9/issues/3333 */
+#define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) FALSE
+#else /* defined(OSX) */
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) (J2SE_VERSION(vm) >= J2SE_V11)
+#endif /* defined(OSX) */
 
 #endif /* J9_H */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1367,6 +1367,8 @@ typedef struct J9SharedCacheAPI {
 	I_32 maxAOT;
 	I_32 minJIT;
 	I_32 maxJIT;
+	U_8 sharedCacheEnabled;
+	U_8 inContainer; /* It is TRUE only when xShareClassesPresent is FALSE and J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) is TRUE and the JVM is running in container */
 } J9SharedCacheAPI;
 
 typedef struct J9SharedClassConfig {

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -88,7 +88,7 @@ Java_com_ibm_oti_shared_SharedClassURLHelperImpl_init(JNIEnv *env, jclass clazz)
 void JNICALL
 Java_com_ibm_oti_shared_SharedClassURLClasspathHelperImpl_init(JNIEnv *env, jclass clazz);
 jboolean JNICALL
-Java_com_ibm_oti_shared_Shared_isSharingEnabledImpl(JNIEnv* env, jclass clazz);
+Java_com_ibm_oti_shared_Shared_isNonBootSharingEnabledImpl(JNIEnv* env, jclass clazz);
 jlong JNICALL
 Java_com_ibm_oti_shared_SharedClassStatistics_softMaxBytesImpl (JNIEnv* env, jobject thisObj);
 /* J9SourceJclExtremeInit*/

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -2914,3 +2914,8 @@ TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_StatFileSystemFailed NoEnv Overhe
 TraceException=Trc_SHR_INIT_isFreeDiskSpaceLow_SetMaxSize NoEnv Overhead=1 Level=1 Template="INIT::isFreeDiskSpaceLow returning true, the maximum shared cache size allowed is %llu bytes"
 
 TraceEvent=Trc_SHR_CC_startup_Event_InitializingNewCache Overhead=1 Level=1 Template="CC startup: initializing a new cache"
+
+TraceEvent=Trc_SHR_INIT_j9shr_init_Entry Overhead=1 Level=6 Template="INIT entering j9shr_init"
+TraceEvent=Trc_SHR_INIT_j9shr_init_BootClassSharingEnabledByDefault Overhead=1 Level=1 Template="INIT j9shr_init: Bootstrap class sharing enabled by default"
+TraceException=Trc_SHR_INIT_j9shr_init_ExitOnNonFatal Overhead=1 Level=1 Template="INIT j9shr_init: exit on non-fatal error"
+TraceEvent=Trc_SHR_VMInitStages_Event_RunningInContainer Overhead=1 Level=1 Template="The JVM is running in container, class sharing is not enabled by default"

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -3083,6 +3083,17 @@ j9shr_init(J9JavaVM *vm, UDATA loadFlags, UDATA* nonfatal)
 	UnitTest::unitTest = UnitTest::NO_TEST;
 	vm->sharedClassConfig = NULL;
 
+	Trc_SHR_INIT_j9shr_init_Entry(currentThread);
+
+	if (FALSE == vm->sharedCacheAPI->xShareClassesPresent) {
+		Trc_SHR_Assert_True(vm->sharedCacheAPI->sharedCacheEnabled);
+		Trc_SHR_Assert_True(J9_ARE_ALL_BITS_SET(runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_NONFATAL));
+		Trc_SHR_Assert_True(J9_ARE_ALL_BITS_SET(runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHEBOOTCLASSES));
+		Trc_SHR_Assert_True(J9_ARE_NO_BITS_SET(runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_CACHE_NON_BOOT_CLASSES));
+		Trc_SHR_Assert_True(0 == vm->sharedCacheAPI->verboseFlags);
+		Trc_SHR_INIT_j9shr_init_BootClassSharingEnabledByDefault(currentThread);
+	}
+
 	if (((0 != (runtimeFlags & J9SHR_RUNTIMEFLAG_CHECK_STRINGTABLE_RESET_READONLY)) ||
 		(0 != (runtimeFlags & J9SHR_RUNTIMEFLAG_CHECK_STRINGTABLE_RESET_READWRITE))) &&
 		(0 == (runtimeFlags & J9SHR_RUNTIMEFLAG_ENABLE_ROUND_TO_PAGE_SIZE)))
@@ -3614,6 +3625,7 @@ _error:
 			 */
 			vm->sharedClassConfig->runtimeFlags |= J9SHR_RUNTIMEFLAG_DO_DESTROY_CONFIG;
 			j9shr_sharedClassesFinishInitialization(vm);
+			Trc_SHR_INIT_j9shr_init_ExitOnNonFatal(currentThread);
 		} else {
 			if (vm->sharedClassConfig->sharedAPIObject != NULL) {
 				j9mem_free_memory(vm->sharedClassConfig->sharedAPIObject);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1661,7 +1661,9 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				argIndex8 = FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, VMOPT_XSCMAXJITDATA, NULL);
 				argIndex9 = FIND_AND_CONSUME_ARG(EXACT_MEMORY_MATCH, VMOPT_XXSHARED_CACHE_HARD_LIMIT_EQUALS, NULL);
 
-				if (argIndex < 0) {
+				if ((!J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm))
+					&& (argIndex < 0)
+				) {
 					if (argIndex2>=0) {
 						/* If -Xscmx used without -Xshareclasses, don't bomb out with "unrecognised option" */
 						j9nls_printf(PORTLIB, J9NLS_INFO, J9NLS_VM_XSCMX_IGNORED);

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright (c) 2018, 2018 IBM Corp. and others
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+<suite id="Shared Classes CommandLineOptionTests Suite ">
+	<!-- Our test modes for this suite -->
+	<variable name="mode204" value="-Xshareclasses:name=ShareClassesCMLTests"/>
+	<!-- Set variables up -->
+	<variable name="currentMode" value="$mode204$"/>
+	<variable name="CP_HANOI" value="-cp $UTILSJAR$" />
+	<variable name="PROGRAM_HANOI" value="org.openj9.test.ivj.Hanoi 2" />
+	<if testVariable="SCMODE" testValue="204" resultVariable="currentMode" resultValue="$mode204$"/>
+	
+	<echo value=" "/>
+	<echo value="#######################################################"/>
+	<echo value="Running tests in mode $SCMODE$ with command line options: $currentMode$"/>
+	<echo value="#######################################################"/>
+	<echo value=" "/>
+		
+	<!--
+	Note:
+	Most tests check for strings 'corrupt', 'JVM requested Java dump', and 'JVM requested Snap dump' in the output.
+	These checks are present because a cache may be found to be corrupt, and the test could otherwise pass.
+	
+	The string 'corrupt' is checked because it can appear several messages like below.
+		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
+		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
+	-->
+	<exec command="$JAVA_EXE$ -Xshareclasses:destroy" quiet="false"/>
+	<!--Do not check the result of -Xshareclasses:destroy. It is possible another java process is holding the default shared cache open. In this case -Xshareclasses:destroy will fail on Windows -->
+	
+	<test id="Test 1: Test that only bootstrap class sharing is enabled by default" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -Xtrace:print={j9shr.1297,j9shr.1514,j9shr.2272,j9shr.2273,j9shr.2264,j9jcl.104,j9jcl.97} $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<!-- Enable j9shr.2272 Trc_SHR_INIT_j9shr_init_ExitOnNonFatal and j9shr.2264 Trc_SHR_OSC_getCacheDir_j9shmem_getDir_failed1 for debugging purpose when failed -->
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.1514\s+ - CM commitROMClass : Data was stored in the cache for J9ROMClass</output>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.1297\s+ - CM findROMClass: class .* found at address</output>
+		<!--Let this test pass if someone is running in container-->
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">j9shr.2273\s+ - The JVM is running in container, class sharing is not enabled by default</output>
+		<output type="required" caseSensitive="yes" regex="no">Puzzle solved!</output>
+		<!-- j9jcl.104, j9jcl.97 SharedClassURLClasspathHelperImpl.storeSharedClassImpl()/findSharedClassImpl() is not triggered, non-bootstrap class sharing is not enabled.  -->
+		<output type="failure" caseSensitive="no" regex="no">SharedClassURLClasspathHelperImpl</output>	
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<exec command="$JAVA_EXE$ -Xshareclasses:destroy" quiet="false"/>
+	<!--
+	***** IMPORTANT NOTE *****
+	The last test in this file is normally a call to -Xshareclasses:destroy. When the test passes no files should ever be left behind. 
+	-->
+</suite>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -933,16 +933,20 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<test id="Test 52: JAZZ 85641: Test setting -Dcom.ibm.oti.shared.enabled=true without using -Xshareclasses option" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ -XshowSettings:properties -Dcom.ibm.oti.shared.enabled=true $CP_HANOI$ $PROGRAM_HANOI$</command>
+	<test id="Test 52: JAZZ 85641: Test setting -Dcom.ibm.oti.shared.enabled=true incorrectly in the CML won't overwrite this property. And -Xshare:none turns off class sharing" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ -Xshareclasses:none -Xtrace:print={j9shr.1297,j9shr.1514,j9shr.2270} -XshowSettings:properties -Dcom.ibm.oti.shared.enabled=true $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" caseSensitive="yes" regex="no">com.ibm.oti.shared.enabled = false</output>
 		<output type="required" caseSensitive="yes" regex="no">Puzzle solved!</output>
 		
+		<output type="failure" caseSensitive="yes" regex="no">CM commitROMClass : Data was stored in the cache for J9ROMClass</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">CM findROMClass: class .* found at address</output>
 		<output type="failure" caseSensitive="yes" regex="no">com.ibm.oti.shared.enabled = true</output>
+		<output type="failure" caseSensitive="no" regex="no">INIT entering j9shr_init</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
-	</test>
+ 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+ 	</test>
+</test>
 	
 	<test id="Test 53: Make sure classes are being stored to the shared cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,verboseIO $CP_HANOI$ $PROGRAM_HANOI$</command>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -379,4 +379,34 @@
 			<subset>11</subset>
 		</subsets>
 	</test>
+	<test>
+		<testCaseName>ShareClassesCMLOpenJ9</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>$(MKTREE) $(REPORTDIR); \
+	$(CD) $(REPORTDIR); \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-DPATHSEP=$(Q)$(D)$(Q) -DCPDL=$(Q)$(P)$(Q) -DRUN_SCRIPT=$(RUN_SCRIPT) -DPROPS_DIR=$(PROPS_DIR) -DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) -DEXECUTABLE_SUFFIX=$(EXECUTABLE_SUFFIX) \
+	-DJAVA_EXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DJAVA_HOME='$(JDK_HOME)' -DSCMODE=204 -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
+	-DUTILSJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)ShareClassesCMLOpenJ9.xml$(Q) -xids all,$(PLATFORM),$(VARIATION),$(JAVA_VERSION) -plats all,$(PLATFORM),$(VARIATION) \
+	-nonZeroExitWhenError \
+	-outputLimit 300; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>SE110</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -396,6 +396,8 @@
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>
+	<!-- temporarily disable this test on OSX, see https://github.com/eclipse/openj9/issues/3333 -->
+	<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/verbosetest/verbosetests.xml
+++ b/test/functional/cmdLineTests/verbosetest/verbosetests.xml
@@ -490,7 +490,8 @@
 	<variable name="VERBOSE" value="-verbose:dynload,sizes,stack,debug" />
   	<test id="$VERBOSE$">
  		<command>$EXE$ $VERBOSE$ $PROGRAM$</command>
-  		<output regex="no" type="required">Loaded java/lang/Object from</output>
+ 		<!-- check for -verbose:dynload message on a non-bootstrap class. When shared cache is enabled by default, -verbose:dynload won't show bootstrap classes loaded from the share cache-->
+  		<output regex="no" type="required">Loaded jit/test/vich/Allocation</output>
  		<output regex="no" type="required">RAM class segment increment</output>
  		<output regex="no" type="required">JVMVERB000I Verbose stack</output>
  		<output regex="no" type="required"></output>
@@ -501,7 +502,7 @@
 	<variable name="VERBOSE" value="-verbose:dynload -verbose:sizes -verbose:stack -verbose:debug" />
   	<test id="$VERBOSE$">
  		<command>$EXE$ $VERBOSE$ $PROGRAM$</command>
-  		<output regex="no" type="required">Loaded java/lang/Object from</output>
+  		<output regex="no" type="required">Loaded jit/test/vich/Allocation</output>
  		<output regex="no" type="required">RAM class segment increment</output>
  		<output regex="no" type="required">JVMVERB000I Verbose stack</output>
  		<output regex="no" type="success">$EXP_OP$</output>
@@ -510,7 +511,7 @@
 	<variable name="VERBOSE" value="-verbose:dynload -verbose:sizes -verbose:stack -verbose:debug -verbose:none" />
   	<test id="$VERBOSE$">
  		<command>$EXE$ $VERBOSE$ $PROGRAM$</command>
-  		<output regex="no" type="failure">Loaded java/lang/Object from</output>
+  		<output regex="no" type="failure">Loaded jit/test/vich/Allocation</output>
  		<output regex="no" type="failure">RAM class segment increment</output>
  		<output regex="no" type="failure">JVMVERB000I Verbose stack</output>
  		<output regex="no" type="success">$EXP_OP$</output>
@@ -519,7 +520,7 @@
 	<variable name="VERBOSE" value="-verbose:dynload -verbose:sizes -verbose:stack -verbose:debug,none" />
   	<test id="$VERBOSE$">
  		<command>$EXE$ $VERBOSE$ $PROGRAM$</command>
-  		<output regex="no" type="failure">Loaded java/lang/Object from</output>
+  		<output regex="no" type="failure">Loaded jit/test/vich/Allocation</output>
  		<output regex="no" type="failure">RAM class segment increment</output>
  		<output regex="no" type="failure">JVMVERB000I Verbose stack</output>
  		<output regex="no" type="success">$EXP_OP$</output>


### PR DESCRIPTION
1.Enable bootstrap class sharing by default on OpenJ9 Java 11+.
2.Shared.isSharingEnabled() returns false if -Xshareclass is
not used in CML, so that non-bootstrap class sharing is disabled by
default.
3. When bootstrap class sharing is enabled by default, set flags
J9SHR_RUNTIMEFLAG_ENABLE_NONFATAL and clear
J9SHR_RUNTIMEFLAG_ENABLE_CACHE_NON_BOOT_CLASSES and verboseFlags.
4. Add a test that ensures only bootstrap class sharing is enabled by
default.
5.Change verbosetests to check for a non-bootstrap class, as
-verbose:dynload won't show bootstrap classes loaded from the share
cache.

Doc issue eclipse/openj9-docs#110
Fixes #1646

Signed-off-by: hangshao <hangshao@ca.ibm.com>