### PR TITLE
Fix incorrect map argument

### DIFF
--- a/runtime/codert_vm/CodertVMHelpers.cpp
+++ b/runtime/codert_vm/CodertVMHelpers.cpp
@@ -332,16 +332,14 @@ jitGetExceptionCatcher(J9VMThread *currentThread, void *handlerPC, J9JITExceptio
 	 * the start address of the compiled exception handler.
 	 */
 	jitGetMapsFromPC(currentThread->javaVM, metaData, (UDATA)handlerPC + 1, &stackMap, &inlineMap);
-	Assert_CodertVM_false(NULL == stackMap);
+	Assert_CodertVM_false(NULL == inlineMap);
 	if (NULL != getJitInlinedCallInfo(metaData)) {
-		if (NULL != inlineMap) {
-			inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
-			if (NULL != inlinedCallSite) {
-				method = (J9Method*)getInlinedMethod(inlinedCallSite);
-			}
+		inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
+		if (NULL != inlinedCallSite) {
+			method = (J9Method*)getInlinedMethod(inlinedCallSite);
 		}
 	}
-	*location = (IDATA)getCurrentByteCodeIndexAndIsSameReceiver(metaData, stackMap, inlinedCallSite, NULL);
+	*location = (IDATA)getCurrentByteCodeIndexAndIsSameReceiver(metaData, inlineMap, inlinedCallSite, NULL);
 	return method;
 }
 

--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1228,13 +1228,11 @@ c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 	 * decomp record is the start address of the compiled exception handler.
 	 */
 	jitGetMapsFromPC(vm, metaData, (UDATA)jitPC + 1, &stackMap, &inlineMap);
-	Assert_CodertVM_false(NULL == stackMap);
+	Assert_CodertVM_false(NULL == inlineMap);
 	if (NULL != getJitInlinedCallInfo(metaData)) {
-		if (NULL != inlineMap) {
-			inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
-			if (inlinedCallSite != NULL) {
-				newNumberOfFrames = getJitInlineDepthFromCallSite(metaData, inlinedCallSite) + 1;
-			}
+		inlinedCallSite = getFirstInlinedCallSite(metaData, inlineMap);
+		if (inlinedCallSite != NULL) {
+			newNumberOfFrames = getJitInlineDepthFromCallSite(metaData, inlinedCallSite) + 1;
 		}
 	}
 	Assert_CodertVM_true(numberOfFrames >= newNumberOfFrames);
@@ -1255,7 +1253,7 @@ c_jitDecompileAtExceptionCatch(J9VMThread * currentThread)
 	/* Fix the OSR frame to resume at the catch point with an empty pending stack (the caught exception
 	 * is pushed after decompilation completes).
 	 */
-	osrFrame->bytecodePCOffset = getCurrentByteCodeIndexAndIsSameReceiver(metaData, stackMap, inlinedCallSite, NULL);
+	osrFrame->bytecodePCOffset = getCurrentByteCodeIndexAndIsSameReceiver(metaData, inlineMap, inlinedCallSite, NULL);
 	Trc_Decomp_jitInterpreterPCFromWalkState_Entry(jitPC);
 	Trc_Decomp_jitInterpreterPCFromWalkState_exHandler(osrFrame->bytecodePCOffset);
 	osrFrame->pendingStackHeight = 0;

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -285,15 +285,15 @@ iterateStackTrace(J9VMThread * vmThread, j9object_t* exception, callback_func_t 
 			J9JITExceptionTable * metaData = NULL;
 			UDATA inlineDepth = 0;
 			void * inlinedCallSite = NULL;
-			void * stackMap = NULL;
+			void * inlineMap = NULL;
 			J9JITConfig * jitConfig = vm->jitConfig;
 
 			if (jitConfig) {
 				metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, methodPC);
 				if (metaData) {
-					stackMap = jitConfig->jitGetInlinerMapFromPC(vm, metaData, methodPC);
-					if (stackMap) {
-						inlinedCallSite = jitConfig->getFirstInlinedCallSite(metaData, stackMap);
+					inlineMap = jitConfig->jitGetInlinerMapFromPC(vm, metaData, methodPC);
+					if (inlineMap) {
+						inlinedCallSite = jitConfig->getFirstInlinedCallSite(metaData, inlineMap);
 						if (inlinedCallSite) {
 							inlineDepth = jitConfig->getJitInlineDepthFromCallSite(metaData, inlinedCallSite);
 							totalEntries += inlineDepth;
@@ -318,15 +318,15 @@ inlinedEntry:
 						goto done;
 					}
 					if (inlineDepth == 0) {
-						if (stackMap == NULL) {
+						if (inlineMap == NULL) {
 							methodPC = -1;
 							isSameReceiver = FALSE;
 						} else {
-							methodPC = jitConfig->getCurrentByteCodeIndexAndIsSameReceiver(metaData, stackMap, NULL, &isSameReceiver);
+							methodPC = jitConfig->getCurrentByteCodeIndexAndIsSameReceiver(metaData, inlineMap, NULL, &isSameReceiver);
 						}
 						ramMethod = metaData->ramMethod;
 					} else {
-						methodPC = jitConfig->getCurrentByteCodeIndexAndIsSameReceiver(metaData, stackMap , inlinedCallSite, &isSameReceiver);
+						methodPC = jitConfig->getCurrentByteCodeIndexAndIsSameReceiver(metaData, inlineMap , inlinedCallSite, &isSameReceiver);
 						ramMethod = jitConfig->getInlinedMethod(inlinedCallSite);
 					}
 					if (pruneConstructors) {


### PR DESCRIPTION
For accurate bytecode information,
getCurrentByteCodeIndexAndIsSameReceiver needs the inline map, not the
stack map. Fix exception event and decompilation to use the proper map,
and update the variable name in other code to be consistent.

Closes: #3373

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>