### PR TITLE
Set KEEP_REPORTDIR false for tests archiving

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions
+++ b/buildenv/jenkins/common/pipeline-functions
@@ -181,7 +181,8 @@ def build_with_one_upstream(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, VA
             string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),
             string(name: 'USER_CREDENTIALS_ID', value: USER_CREDENTIALS_ID),
             string(name: 'BUILD_LIST', value: BUILD_LIST),
-            string(name: 'TEST_FLAG', value: TEST_FLAG)])
+            string(name: 'TEST_FLAG', value: TEST_FLAG),
+            string(name: 'KEEP_REPORTDIR', value: 'false')])
 
     }
 }
@@ -206,7 +207,8 @@ def build_with_artifactory(JOB_NAME, VARIABLE_FILE, VENDOR_REPO, VENDOR_BRANCH, 
             string(name: 'CUSTOMIZED_SDK_URL', value: CUSTOMIZED_SDK_URL),
             string(name: 'ARTIFACTORY_SERVER', value: ARTIFACTORY_SERVER),
             string(name: 'CUSTOMIZED_SDK_URL_CREDENTIAL_ID', value: ARTIFACTORY_CREDS),
-            string(name: 'TEST_FLAG', value: TEST_FLAG)])
+            string(name: 'TEST_FLAG', value: TEST_FLAG),
+            string(name: 'KEEP_REPORTDIR', value: 'false')])
     }
 }
 


### PR DESCRIPTION
- KEEP_REPORTDIR is a flag in the test jobs that controls
  whether or not we delete the successful test reports before
  we archive the reports.
- By default the setting is true (don't delete).
- Setting it to false will delete successful repots.
- This will reduce the size of the test artifact.
- Set to false for both Test jobs that archive to Artifactory and Master.

[skip ci]
Related #3589

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>