### PR TITLE
avoid out of memory during generating dump for testing OOM Case

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/nogc/TestNogcDieWithOOM.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/nogc/TestNogcDieWithOOM.java
@@ -60,9 +60,11 @@ public class TestNogcDieWithOOM {
 		Random random = new Random();
 		String message = "Caught expected java/lang/OutOfMemoryError: Java heap space";
 		byte[] data = null;
+		data = allocateMemory(3 * 1024*1024);
 		try {
 			for (int cnt=0; cnt<1024; cnt++) {
-				data = allocateMemory(random.nextInt(10) * 1024*1024 + 9*1024*1024);
+				int multi = random.nextInt(10);
+				data = allocateMemory(((0 == multi)?1:multi) * 10 * 1024*1024);
 			}
 		} catch (OutOfMemoryError error) {
 			logger.info(message);


### PR DESCRIPTION
 - catch expected OOM error with dump for confirming the OOM 
 test case via testNG assert check.
 - update allocation pattern to save some heap memory for preventing
 background threads and dump process crash.
 
fix: #3653 
 
Signed-off-by: Lin Hu <linhu@ca.ibm.com>