### PR TITLE
Enable gcc-7 on Linux x86-32 platforms

### DIFF
--- a/buildspecs/linux_x86.spec
+++ b/buildspecs/linux_x86.spec
@@ -42,7 +42,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="graph_commands.chroot" value=""/>
 		<property name="graph_commands.unix.remote_host" value=""/>
 		<property name="graph_datamines" value="commands.unix.datamine,site-ottawa.datamine,use.local.datamine"/>
-		<property name="graph_enable_gcc7_cmd" value=""/>
+		<property name="graph_enable_gcc7_cmd" value="source {$buildinfo.fsroot.unixBin$}/platform/linux386/set_gcc7_env &amp;&amp;"/>
 		<property name="graph_flags.linux_2.4" value="graph_tck"/>
 		<property name="graph_label.classlib" value="150"/>
 		<property name="graph_label.java5" value="j9vmxi3224"/>


### PR DESCRIPTION
Set graph_enable_gcc7_cmd property to enable gcc-7 environment

[ci skip]

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>