### PR TITLE
Disable IProfiler thread at the JITaaS server

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2286,6 +2286,10 @@ J9::Options::fePostProcessJIT(void * base)
          // The server can compile with VM access in hand because GC is not a factor here
          // For the same reason we don't have to use TR_EnableYieldVMAccess
          self()->setOption(TR_DisableNoVMAccess); 
+
+         // IProfiler thread is not needed at JITaaS server because
+         // no IProfiler info is collected at the server itself
+         self()->setOption(TR_DisableIProfilerThread);
          }
       }
 


### PR DESCRIPTION
The JITaaS server does not collect interpreter profiling information
so the IProfiler thread is useless in this environment.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>