### PR TITLE
Add workaround for clone on Windows

### DIFF
--- a/buildenv/jenkins/common/build
+++ b/buildenv/jenkins/common/build
@@ -61,28 +61,41 @@ def get_sources_with_authentication() {
 }
 
 def get_sources() {
-    // use credentials ID for all platforms except zOS
-    // for zOS use ssh key
+    // Temp workaround for Windows clones
+    // See #3633 and JENKINS-54612
+    if (NODE_LABELS.contains("windows")) {
+        cleanWs()
+        CLONE_CMD = "git clone --reference ${OPENJDK_REFERENCE_REPO} -b ${OPENJDK_BRANCH} ${OPENJDK_REPO} ."
+        if (USER_CREDENTIALS_ID != '') {
+            sshagent(credentials:["${USER_CREDENTIALS_ID}"]) {
+                sh "${CLONE_CMD}"
+            }
+        } else {
+            sh "${CLONE_CMD}"
+        }
+    } else {
+        // use credentials ID for all platforms except zOS
+        // for zOS use ssh key
+        def remote_config_parameters = [url: "${OPENJDK_REPO}"]
+        if (!SPEC.startsWith('zos') && USER_CREDENTIALS_ID) {
+            remote_config_parameters.put('credentialsId', "${USER_CREDENTIALS_ID}")
+        }
 
-    def remote_config_parameters = [url: "${OPENJDK_REPO}"]
-    if (!SPEC.startsWith('zos') && USER_CREDENTIALS_ID) {
-        remote_config_parameters.put('credentialsId', "${USER_CREDENTIALS_ID}")
+        checkout changelog: false,
+                poll: false,
+                scm: [$class: 'GitSCM',
+                    branches: [[name: "${OPENJDK_BRANCH}"]],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[$class: 'CheckoutOption', timeout: 30],
+                                [$class: 'CloneOption',
+                                    depth: 0,
+                                    noTags: false,
+                                    reference: "${OPENJDK_REFERENCE_REPO}",
+                                    shallow: false,
+                                    timeout: 30]],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [remote_config_parameters]]
     }
-
-    checkout changelog: false,
-            poll: false,
-            scm: [$class: 'GitSCM',
-                branches: [[name: "${OPENJDK_BRANCH}"]],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [[$class: 'CheckoutOption', timeout: 30],
-                            [$class: 'CloneOption',
-                                depth: 0,
-                                noTags: false,
-                                reference: "${OPENJDK_REFERENCE_REPO}",
-                                shallow: false,
-                                timeout: 30]],
-                submoduleCfg: [],
-                userRemoteConfigs: [remote_config_parameters]]
 
     // Check if this build is a PR
     if (params.ghprbGhRepository) {

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -325,7 +325,7 @@ win_x86-64_cmprssptrs:
     11: 'windows-x86_64-normal-server-release'
     next: 'windows-x86_64-normal-server-release'
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
-  openjdk_reference_repo: 'C:\openjdk\openjdk_cache'
+  openjdk_reference_repo: '/cygdrive/c/openjdk/openjdk_cache'
   extra_configure_options:
     8: '--with-freetype-include=/cygdrive/c/openjdk/freetype-2.5.3/include --with-freetype-lib=/cygdrive/c/openjdk/freetype-2.5.3/lib64 --disable-ccache --with-openssl=/cygdrive/c/OpenSSL-1.1.1-x86_64 --enable-openssl-bundling'
     9: '--with-freetype-src=/cygdrive/c/openjdk/freetype-2.5.3 --with-toolchain-version=2013 --disable-ccache'
@@ -361,7 +361,7 @@ win_x86:
   extra_configure_options:
     8: '--with-freetype-include=/cygdrive/c/openjdk/freetype-2.5.3/include --with-freetype-lib=/cygdrive/c/openjdk/freetype-2.5.3/lib32 --with-target-bits=32 --disable-ccache --with-openssl=/cygdrive/c/OpenSSL-1.1.1-x86_32 --enable-openssl-bundling'
   freemarker: '/cygdrive/c/openjdk/freemarker.jar'
-  openjdk_reference_repo: 'C:\openjdk\openjdk_cache'
+  openjdk_reference_repo: '/cygdrive/c/openjdk/openjdk_cache'
   node_labels:
     build:
       8: 'ci.role.build && hw.arch.x86 && sw.os.windows'


### PR DESCRIPTION
- Temporarily clone on Windows using sh instead of scm:git
- Open Jenkins Issue 54612
- This allows us to properly use the ref repo to get
  faster clone times

Related #3633
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>