### PR TITLE
Improve performance of ClassSummaryHelper

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ClassSummaryHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ClassSummaryHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,27 +32,29 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.LinearDumper.J9ClassRegion;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.LinearDumper.J9ClassRegionNode;
 
 public class ClassSummaryHelper {
+
 	private final Map<String, Long> sizeStat;
-	private int numberOfClasses = 0;
-	private String[] preferredOrder;
+	private int numberOfClasses;
+	private final String[] preferredOrder;
 
 	public ClassSummaryHelper(String[] preferredOrder) {
-		sizeStat = new HashMap<String, Long>();
+		super();
+		this.sizeStat = new HashMap<>();
+		this.numberOfClasses = 0;
 		this.preferredOrder = preferredOrder;
 	}
 
 	public void addRegionsForClass(J9ClassRegionNode allRegionsNode) {
-		numberOfClasses++;
+		numberOfClasses += 1;
 		appendSizeStat(sizeStat, allRegionsNode, "");
 	}
 
 	public void printStatistics(PrintStream out) {
 		/*
-		 * This will sort the data, sizeStat should not be a TreeMap, because it
-		 * will sort the key on every access to the map
+		 * This will sort the data, sizeStat should not be a TreeMap,
+		 * otherwise it would sort on every addition to the map.
 		 */
-		Map<String, Long> data = new TreeMap<String, Long>(new StringCompare(
-				preferredOrder));
+		Map<String, Long> data = new TreeMap<>(new StringCompare(preferredOrder));
 		data.putAll(sizeStat);
 
 		long totalSize = 0;
@@ -67,14 +69,14 @@ public class ClassSummaryHelper {
 				numberOfClasses, totalSize, totalSize / 1024));
 
 		// Print the sections
-		out.println(String.format("%-40s%-8s %-8s %-6s", "Section", "Byte",
-				"kB", "%"));
+		out.println(String.format("%-39s %-8s %-8s %-6s",
+				"Section", "Byte", "kB", "%"));
 		for (Map.Entry<String, Long> entry : data.entrySet()) {
 			out.println(printSize(entry.getKey(), entry.getValue(), totalSize));
 		}
 	}
 
-	private void appendSizeStat(Map<String, Long> sizeStat,
+	private static void appendSizeStat(Map<String, Long> sizeStat,
 			J9ClassRegionNode regionNode, String parentName) {
 		String section = parentName;
 		final J9ClassRegion nodeValue = regionNode.getNodeValue();
@@ -82,11 +84,11 @@ public class ClassSummaryHelper {
 			if (nodeValue.getType() == SlotType.J9_SECTION_START
 					|| nodeValue.getType() == SlotType.J9_Padding) {
 				section = section + "/" + nodeValue.getName();
-				if (sizeStat.containsKey(section)) {
-					sizeStat.put(section, new Long(sizeStat.get(section)
-							+ nodeValue.getLength()));
+				Long length = sizeStat.get(section);
+				if (length != null) {
+					sizeStat.put(section, Long.valueOf(length.longValue() + nodeValue.getLength()));
 				} else {
-					sizeStat.put(section, new Long(nodeValue.getLength()));
+					sizeStat.put(section, Long.valueOf(nodeValue.getLength()));
 				}
 			}
 		}
@@ -95,28 +97,36 @@ public class ClassSummaryHelper {
 		}
 	}
 
-	private String printSize(String key, Long size, Long totalSize) {
-		long sizeByte = size.longValue();
-		double sizekB = sizeByte / 1024.0;
-
+	private static String printSize(String key, Long size, long totalSize) {
 		/*
 		 * Get the tab indent, the sections are separated by "/" like
 		 * /methods/method/stackMap
 		 */
-		String[] parts = key.split("/");
-		String section = parts[parts.length - 1];
-		for (int i = 0; i < getLevel(key); i++) {
-			section = "  " + section;
+		StringBuilder section = new StringBuilder();
+		for (int i = 0, level = getLevel(key); i < level; ++i) {
+			section.append("  ");
 		}
+		section.append(key.substring(key.lastIndexOf('/') + 1));
 
-		double percent = ((double) sizeByte / totalSize) * 100;
+		long sizeByte = size.longValue();
+		double sizekB = sizeByte / 1024.0;
+		double percent = sizeByte * 100.0 / totalSize;
 
-		return String.format("%-40s%-8d %-8.2f %-6.2f", section, sizeByte,
-				sizekB, percent);
+		return String.format("%-39s %-8d %-8.2f %-6.2f",
+				section, sizeByte, sizekB, percent);
 	}
 
-	private int getLevel(String key) {
-		return key.split("/").length - 1;
+	/* count the '/' separators to determine the nesting level */
+	private static int getLevel(String key) {
+		for (int index = -1, level = 0;;) {
+			index = key.indexOf('/', index + 1);
+
+			if (index < 0) {
+				return level;
+			}
+
+			level += 1;
+		}
 	}
 
 	/**
@@ -125,36 +135,59 @@ public class ClassSummaryHelper {
 	 * alphabetically.
 	 * 
 	 * @author jeanpb
-	 * 
 	 */
-	private class StringCompare implements Comparator<String> {
+	private static class StringCompare implements Comparator<String> {
+
 		private final Map<String, Integer> preferredOrderMap;
 
 		public StringCompare(String[] preferredOrder) {
-			preferredOrderMap = new HashMap<String, Integer>();
+			preferredOrderMap = new HashMap<>();
 
 			for (int i = 0; i < preferredOrder.length; i++) {
-				preferredOrderMap.put(preferredOrder[i], i);
+				preferredOrderMap.put(preferredOrder[i], Integer.valueOf(i));
 			}
 		}
 
 		private int find(String key) {
-			if (preferredOrderMap.containsKey(key.trim())) {
-				return preferredOrderMap.get(key.trim());
+			Integer order = preferredOrderMap.get(key.trim());
+			if (order != null) {
+				return order.intValue();
 			}
 			return Integer.MAX_VALUE;
 		}
 
+		private static String firstSegment(String key) {
+			int start = key.indexOf('/') + 1;
+
+			if (start <= 0) {
+				/* all the keys used here should have at least one slash */
+				throw new IllegalArgumentException();
+			}
+
+			int end = key.indexOf('/', start);
+			String segment;
+
+			if (end < 0) {
+				segment = key.substring(start);
+			} else {
+				segment = key.substring(start, end);
+			}
+
+			return segment;
+		}
+
+		@Override
 		public int compare(String o1, String o2) {
-			String[] partso1 = o1.split("/");
-			String[] partso2 = o2.split("/");
-			int ordero1 = find(partso1[1]);
-			int ordero2 = find(partso2[1]);
+			String segment1 = firstSegment(o1);
+			String segment2 = firstSegment(o2);
+			int ordero1 = find(segment1);
+			int ordero2 = find(segment2);
 			if (ordero1 != ordero2) {
-				return ordero1 - ordero2;
+				return Integer.compare(ordero1, ordero2);
 			} else {
 				return o1.compareTo(o2);
 			}
 		}
 	}
+
 }


### PR DESCRIPTION
Noticeably improves `!ramclasssummary` and `!romclasssummary` commands by avoiding (repeated) unnecessary use of `String.split()`.

Discovered while investigating #3673.