### PR TITLE
XXgc option for OMR/GC Scavenger aliasing

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -785,6 +785,20 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 
 			continue;
 		}
+		if (try_scan(&scan_start, "aliasInhibitingThresholdPercentage=")) {
+			UDATA percentage = 0;
+			if(!scan_udata_helper(vm, &scan_start, &percentage, "aliasInhibitingThresholdPercentage=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			if(percentage > 100) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->aliasInhibitingThresholdPercentage = ((double)percentage) / 100.0;
+
+			continue ;
+		}
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		if (try_scan(&scan_start, "debugConcurrentScavengerPageAlignment")) {


### PR DESCRIPTION
Option to override percentage of GC threads that can be blocked before copy cache aliasing is inhibited  (set through aliasInhibitingThresholdPercentage=)

See https://github.com/eclipse/omr/issues/3089.

Changes depend on https://github.com/eclipse/omr/pull/3194

Signed-off-by: Salman Rana salman.rana@ibm.com