### PR TITLE
Re-enable ppc64le tests

### DIFF
--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -1,29 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2018 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
-
 	<test>
 		<testCaseName>algotest2</testCaseName>
 		<variations>
@@ -32,8 +29,6 @@
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)algotest' -avltest:$(TEST_RESROOT)$(D)..$(D)algotest$(D)avltest.lst -Xcheck:memory:ignoreUnfreedCallsite=zip/:dbgwrapper:unknown:wrapper; \
 	$(TEST_STATUS)</command>
-		<!-- Disable for issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -54,8 +49,6 @@
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)ctest' ; \
 	$(TEST_STATUS)</command>
-		<!-- Disable for issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -95,10 +88,8 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)vmtest'  ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)vmtest' ; \
 	$(TEST_STATUS)</command>
-		<!-- Disable for issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -120,8 +111,8 @@
 	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)jsigjnitest' \
 	'$(J9VM_PATH)' $(JVM_OPTIONS) ; \
 	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
-		<platformRequirements>^os.win,^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
+		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
+		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -143,8 +134,7 @@
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)gc_rwlocktest' -verbose; \
 	$(TEST_STATUS)</command>
-		<!-- Disable for ppc64le issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>^os.win,^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
+		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -185,7 +175,7 @@
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)'  '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.linux</platformRequirements>
@@ -207,7 +197,7 @@
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)'  '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.zos</platformRequirements>
@@ -229,7 +219,7 @@
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all aix ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)'  '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -250,7 +240,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)'  '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' '-Xbootclasspath/a:"dummy1$(P)dummy2$(P)dummy3"' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.win</platformRequirements>
@@ -272,11 +262,10 @@
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)' ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' ; \
 	$(TEST_STATUS)
 	</command>
-		<!-- Disable for issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>os.linux,^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
+		<platformRequirements>os.linux</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -294,7 +283,7 @@
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all zos ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)' ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.zos</platformRequirements>
@@ -315,7 +304,7 @@
 		</variations>
 		<command>perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all aix ; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)'  ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -335,7 +324,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)'  ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)shrtest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' ; \
 	$(TEST_STATUS)
 	</command>
 		<platformRequirements>os.win</platformRequirements>
@@ -355,11 +344,9 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest' $(JVM_OPTIONS)  -Djava.home='$(JAVA_BIN)$(D)..$(D)' -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
+	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
 	$(TEST_STATUS)
 	</command>
-		<!-- Disable for issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -1,27 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2018 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>cmdLineTester_jep178_staticLinking_SE80</testCaseName>
@@ -43,9 +41,8 @@
 	-config $(Q)$(TEST_RESROOT)$(D)jep178.xml$(Q) \
 	-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-	<!-- Disable for issue https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-	<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
-		<platformRequirements>^os.win,^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
+		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
+		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -76,9 +73,9 @@
 	-config $(Q)$(TEST_RESROOT)$(D)jep178.xml$(Q) \
 	-verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	${TEST_STATUS}</command>
-		<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
+		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
 		<platformRequirements>^os.win</platformRequirements>
- 		<levels>
+		<levels>
 			<level>extended</level>
 		</levels>
 		<groups>

--- a/test/functional/cmdLineTests/pltest/playlist.xml
+++ b/test/functional/cmdLineTests/pltest/playlist.xml
@@ -1,27 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2018 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>cmdLineTester_pltest</testCaseName>
@@ -33,9 +31,8 @@
 	-DEXE='$(JAVA_SHARED_LIBRARIES_DIR)$(D)pltest $(_JVM_OPTIONS)' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)pltest.xml$(Q) -verbose -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
-		<!-- temporarily disable this test on ppc64le; https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>^os.aix,^os.win,^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
+		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
+		<platformRequirements>^os.aix,^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -68,7 +65,7 @@
 		<subsets>
 			<subset>8</subset>
 			<subset>9</subset>
-			<!--temporarily disabled for 11,  https://github.com/eclipse/openj9/issues/3221 -->
+			<!--temporarily disabled for 11, https://github.com/eclipse/openj9/issues/3221 -->
 		</subsets>
 	</test>
 	<test>
@@ -116,7 +113,7 @@
 			<subset>9</subset>
 			<subset>11</subset>
 		</subsets>
-	<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
+	<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
 	<disabled>github.com/eclipse/openj9/issues/1511</disabled>
 	</test>
 	<test>
@@ -141,7 +138,7 @@
 			<subset>9</subset>
 			<subset>11</subset>
 		</subsets>
-	<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
+	<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
 	<disabled>github.com/eclipse/openj9/issues/1511</disabled>
 	</test>
 	<test>
@@ -156,8 +153,7 @@
 	-config $(Q)$(TEST_RESROOT)$(D)pltest_numcpus_bound.xml$(Q) -verbose -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<!-- disable on ppc64le https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/190 -->
-		<platformRequirements>os.linux,^spec.linux_ppc-64_cmprssptrs_le</platformRequirements>
+		<platformRequirements>os.linux</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -178,7 +174,7 @@
 		<command>echo $(Q)$(JAVA_SHARED_LIBRARIES_DIR)$(D)pltest -include:j9numcpus -boundcpus:1$(Q) > run_pltest.bat ; \
 	echo exit 0 >> run_pltest.bat; \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
-	-DEXE='cmd /C start /B /wait /affinity 1 run_pltest.bat  > j9numcpus.txt 2>&1' -jar $(CMDLINETESTER_JAR) \
+	-DEXE='cmd /C start /B /wait /affinity 1 run_pltest.bat > j9numcpus.txt 2>&1' -jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)pltest_numcpus_bound.xml$(Q) -verbose -explainExcludes \
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
@@ -194,7 +190,7 @@
 			<subset>9</subset>
 			<subset>11</subset>
 		</subsets>
-		<!-- temporarily disable this test on win; https://github.com/eclipse/openj9/issues/3212 -->
+		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
 		<disabled>github.com/eclipse/openj9/issues/1511</disabled>
 	</test>
 	<test>


### PR DESCRIPTION
Re-enable tests that were disabled for ibmruntimes/openj9-openjdk-jdk8#190.