### PR TITLE
Validate class chain for defining class of static

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -153,19 +153,14 @@ TR::SymbolValidationManager::getBaseComponentClass(TR_OpaqueClassBlock *clazz, i
 
 
 void *
-TR::SymbolValidationManager::storeClassChain(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz, bool isStatic)
+TR::SymbolValidationManager::storeClassChain(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz)
    {
    void *classChain = NULL;
    bool validated = false;
 
    classChain = fej9->sharedCache()->rememberClass(clazz);
    if (classChain)
-      {
-      if (isStatic)
-         validated = addRomClassRecord(clazz);
-      else
-         validated = addClassChainRecord(clazz, classChain);
-      }
+      validated = addClassChainRecord(clazz, classChain);
 
    if (validated)
       return classChain;
@@ -192,7 +187,6 @@ bool
 TR::SymbolValidationManager::storeClassRecord(TR_OpaqueClassBlock *clazz,
                                               TR::ClassValidationRecord *record,
                                               int32_t arrayDimsToValidate,
-                                              bool isStatic,
                                               bool storeCurrentRecord)
    {
    bool validated = false;
@@ -218,7 +212,7 @@ TR::SymbolValidationManager::storeClassRecord(TR_OpaqueClassBlock *clazz,
          }
       else
          {
-         record->_classChain = storeClassChain(fej9, clazz, isStatic);
+         record->_classChain = storeClassChain(fej9, clazz);
          validated = (record->_classChain != NULL);
          }
 
@@ -259,8 +253,7 @@ TR::SymbolValidationManager::storeClassRecord(TR_OpaqueClassBlock *clazz,
 bool
 TR::SymbolValidationManager::storeValidationRecordIfNecessary(void *symbol,
                                                               TR::SymbolValidationRecord *record,
-                                                              int32_t arrayDimsToValidate,
-                                                              bool isStatic)
+                                                              int32_t arrayDimsToValidate)
    {
    bool existsInList = false;
    bool validated = false;
@@ -281,7 +274,6 @@ TR::SymbolValidationManager::storeValidationRecordIfNecessary(void *symbol,
          validated = storeClassRecord(static_cast<TR_OpaqueClassBlock *>(symbol),
                                       reinterpret_cast<TR::ClassValidationRecord *>(record),
                                       arrayDimsToValidate,
-                                      isStatic,
                                       !existsInList);
          }
       else
@@ -417,7 +409,7 @@ TR::SymbolValidationManager::addDefiningClassFromCPRecord(TR_OpaqueClassBlock *c
       }
 
    SymbolValidationRecord *record = new (_region) DefiningClassFromCPRecord(clazz, beholder, cpIndex, isStatic);
-   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims, isStatic);
+   return storeValidationRecordIfNecessary(static_cast<void *>(clazz), record, arrayDims);
    }
 
 bool

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1301,10 +1301,9 @@ private:
    bool storeClassRecord(TR_OpaqueClassBlock *clazz,
                          ClassValidationRecord *record,
                          int32_t arrayDimsToValidate,
-                         bool isStatic,
                          bool storeCurrentRecord);
-   bool storeValidationRecordIfNecessary(void *symbol, SymbolValidationRecord *record, int32_t arrayDimsToValidate = 0, bool isStatic = false);
-   void *storeClassChain(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz, bool isStatic);
+   bool storeValidationRecordIfNecessary(void *symbol, SymbolValidationRecord *record, int32_t arrayDimsToValidate = 0);
+   void *storeClassChain(TR_J9VMBase *fej9, TR_OpaqueClassBlock *clazz);
 
    bool validateSymbol(uint16_t idToBeValidated, void *validSymbol);
 


### PR DESCRIPTION
Since the defining class of a static doesn't escape from the point at
which we request the validation, we're able to get away with checking
only the ROM class, rather than the entire class chain. However, there
are a few issues with this:

- It's different from every other class validation.

- We may need to validate the class chain anyway, if the same class is
  encountered in any other way during compilation, in which case the ROM
  class validation is redundant.

Furthermore, it's unlikely that validating the class chain will cause
many additional load failures.

As such, queries for the defining class of a static will now request a
class chain validation for that class.