### PR TITLE
Print _class for ClassChainRecord in SVM

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -2165,6 +2165,8 @@ void TR::ConcreteSubClassFromClassRecord::printFields()
 void TR::ClassChainRecord::printFields()
    {
    traceMsg(TR::comp(), "ClassChainRecord\n");
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
    traceMsg(TR::comp(), "\t_classChain=0x%p\n", _classChain);
    }
 


### PR DESCRIPTION
The symbol validation manager (SVM) class chain record has a class field
but has not been printing it in its tracing. This field is now shown.