### PR TITLE
Concurrent Scavenger yield critera

### DIFF
--- a/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.cpp
+++ b/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.cpp
@@ -669,6 +669,11 @@ MM_CollectorLanguageInterfaceImpl::private_scavenger_shouldPercolateGarbageColle
 }
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
+bool
+MM_CollectorLanguageInterfaceImpl::scavenger_shouldYield() {
+	return (J9_XACCESS_PENDING == ((J9JavaVM*)_omrVM->_language_vm)->exclusiveAccessState);
+}
+
 void
 MM_CollectorLanguageInterfaceImpl::scavenger_switchConcurrentForThread(MM_EnvironmentBase *env)
 {

--- a/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.hpp
+++ b/runtime/gc_glue_java/CollectorLanguageInterfaceImpl.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -131,6 +131,7 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	virtual void scavenger_switchConcurrentForThread(MM_EnvironmentBase *env);
 	virtual void scavenger_fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
+	virtual bool scavenger_shouldYield();
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 


### PR DESCRIPTION
Introduce a criteria to yield during concurrent phase of a CS cycle:
obey exclusive VM acceess request.

This will clearly cover explicit requests from thread party (like JVMTI
or System GC).

But also this will cover an indirect request to complete concurrent
phase if hybrid allocate/survivor space is (in rare and unfortunat case)
exhausted -> AF is raised by a mutator, which will request exclusive VM
access. It is indeed prefered to complete cycle in STW mode in this
case, because we have more GC threads at disposal than in concurrent
phase.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>