### PR TITLE
Add -Xshareclasses:none to SignalXfszTest.

### DIFF
--- a/test/functional/cmdLineTests/sigxfszHandlingTest/sigxfszHandlingTest.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/sigxfszHandlingTest.xml
@@ -29,8 +29,10 @@
 <variable name="HANDLE" value="-XX:+HandleSIGXFSZ" />
 <variable name="NOHANDLE" value="-XX:-HandleSIGXFSZ" />
 
+<!-- Add -Xshareclasses:none to the command lines of this test suite to ensure that signal SIGXFSZ is triggered on test.txt creation rather than 
+	on shared cache file creation (if shared classes is enable by default). See issue: https://github.com/eclipse/openj9/issues/3333 -->
  <test id="Default">
-	<command>$EXE$ $CP$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -43,7 +45,7 @@
  </test>
 
  <test id="-XX:+HandleSIGXFSZ">
-	<command>$EXE$ $CP$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -56,7 +58,7 @@
  </test>
 
 <test id="-XX:-HandleSIGXFSZ -XX:+HandleSIGXFSZ">
-	<command>$EXE$ $CP$ $NOHANDLE$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -69,7 +71,7 @@
  </test>
 
 <test id=" -Xrs">
-	<command>$EXE$ $CP$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -82,7 +84,7 @@
  </test>
 
  <test id="-XX:+HandleSIGXFSZ -Xrs">
-	<command>$EXE$ $CP$ $HANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $HANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -96,7 +98,7 @@
 
  <!-- Linux can not handle sigxfsz without special handling in VM. JVM should exit with exit code 153 -->
  <test id="-XX:-HandleSIGXFSZ (Linux)" platforms="linux.*">
-	<command>$EXE$ $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">Failed to write the file:</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>
@@ -109,7 +111,7 @@
 
 <!-- Linux can not handle sigxfsz without special handling in VM. JVM should exit with exit code 153 -->
  <test id="-XX:+HandleSIGXFSZ -XX:-HandleSIGXFSZ (Linux)" platforms="linux.*">
-	<command>$EXE$ $CP$ $HANDLE$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $HANDLE$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">Failed to write the file:</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>
@@ -122,7 +124,7 @@
 
 <!-- Linux can not handle sigxfsz without special handling in VM. JVM should exit with exit code 153 -->
  <test id="-XX:-HandleSIGXFSZ -Xrs (Linux)" platforms="linux.*">
-	<command>$EXE$ $CP$ $NOHANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">Failed to write the file:</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>
@@ -135,7 +137,7 @@
 
  <!-- AIX and ZOS handles this by default. No need for special handling in JVM -->
  <test id="-XX:-HandleSIGXFSZ (AIX)" platforms="aix.*">
-	<command>$EXE$ $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>


### PR DESCRIPTION
Add -Xshareclasses:none to the command lines of SignalXfszTest so that
signal SIGXFSZ is always triggered on test.txt creation rather than
shared cache file creation after shared classes is enabled by default. 

[ci skip]

Issue #3333

Signed-off-by: hangshao <hangshao@ca.ibm.com>