### PR TITLE
Remove requirement for 'spec.flags.build_j2se' in jep178 tests

### DIFF
--- a/runtime/tests/redirector/jep178/module.xml
+++ b/runtime/tests/redirector/jep178/module.xml
@@ -1,31 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2014, 2017 IBM Corp. and others
+Copyright (c) 2014, 2018 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-
 	<artifact type="executable" name="testjep178_static">
-		<include-if condition="spec.flags.build_j2se" />
 		<options>
 			<option name="doesNotRequireCMAIN"/>
 		</options>
@@ -35,34 +31,37 @@
 			<include path="j9oti"/>
 		</includes>
 		<makefilestubs>
-			<makefilestub data="CFLAGS+=-Wc,DLL,EXPORTALL">
-				<include-if condition="spec.zos_390.*" />
+			<makefilestub data="CFLAGS += -Wc,DLL,EXPORTALL">
+				<include-if condition="spec.zos_390.*"/>
 			</makefilestub>
-			<makefilestub data="UMA_CC_MODE+=-qpic -brtl -bexpall">
-				<include-if condition="spec.aix_.*" />
+			<makefilestub data="UMA_CC_MODE += -qpic -brtl -bexpall">
+				<include-if condition="spec.aix_.*"/>
 			</makefilestub>
-			<makefilestub data="UMA_LINK_FLAGS+=-Wl,xplink,dll">
-				<include-if condition="spec.zos_390.*" />
+			<makefilestub data="UMA_LINK_FLAGS += -Wl,xplink,dll">
+				<include-if condition="spec.zos_390.*"/>
 			</makefilestub>
-			<makefilestub data="UMA_EXE_POSTFIX_FLAGS+=-rdynamic">
-				<include-if condition="spec.linux_x86.*" />
-				<include-if condition="spec.linux_390.*" />
+			<makefilestub data="UMA_EXE_POSTFIX_FLAGS += -rdynamic">
+				<include-if condition="spec.linux_x86.*"/>
+				<include-if condition="spec.linux_390.*"/>
 			</makefilestub>
-			<makefilestub data="UMA_EXE_POSTFIX_FLAGS+=--export-dynamic">
-				<include-if condition="spec.linux_ppc.*" />
+			<makefilestub data="UMA_EXE_POSTFIX_FLAGS += --export-dynamic">
+				<include-if condition="spec.linux_ppc.*"/>
+				<exclude-if condition="spec.linux_ppc.*_gcc"/>
+			</makefilestub>
+			<makefilestub data="UMA_EXE_POSTFIX_FLAGS += -export-dynamic">
+				<include-if condition="spec.linux_ppc.*_gcc"/>
 			</makefilestub>
 		</makefilestubs>
 		<objects>
-			<object name="static_agents" />
-			<object name="static_libraries" />
-			<object name="testjep178" />
+			<object name="static_agents"/>
+			<object name="static_libraries"/>
+			<object name="testjep178"/>
 			<object name="testjep178_static.res">
 				<include-if condition="spec.win.*"/>
 			</object>
 		</objects>
 	</artifact>
 	<artifact type="executable" name="testjep178_dynamic">
-		<include-if condition="spec.flags.build_j2se" />
 		<options>
 			<option name="doesNotRequireCMAIN"/>
 		</options>

--- a/runtime/tests/redirector/jep178/testjvmtiA/module.xml
+++ b/runtime/tests/redirector/jep178/testjvmtiA/module.xml
@@ -1,36 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2014, 2017 IBM Corp. and others
+Copyright (c) 2014, 2018 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-
 	<exports group="all">
 		<export name="Agent_OnLoad"/>
 		<export name="Agent_OnAttach"/>
 		<export name="Agent_OnUnload"/>
 	</exports>
 	<artifact type="shared" name="testjvmtiA" appendrelease="false">
-		<include-if condition="spec.flags.build_j2se" />
 		<phase>core quick j2se</phase>
 		<exports>
 			<group name="all"/>

--- a/runtime/tests/redirector/jep178/testjvmtiB/module.xml
+++ b/runtime/tests/redirector/jep178/testjvmtiB/module.xml
@@ -1,36 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2014, 2017 IBM Corp. and others
+Copyright (c) 2014, 2018 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-
 	<exports group="all">
 		<export name="Agent_OnLoad"/>
 		<export name="Agent_OnAttach"/>
 		<export name="Agent_OnUnload"/>
 	</exports>
 	<artifact type="shared" name="testjvmtiB" appendrelease="false">
-		<include-if condition="spec.flags.build_j2se" />
 		<phase>core quick j2se</phase>
 		<exports>
 			<group name="all"/>

--- a/runtime/tests/redirector/jep178/testlibA/module.xml
+++ b/runtime/tests/redirector/jep178/testlibA/module.xml
@@ -1,36 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2014, 2017 IBM Corp. and others
+Copyright (c) 2014, 2018 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-
 	<exports group="all">
 		<export name="JNI_OnLoad"/>
 		<export name="JNI_OnUnload"/>
 		<export name="Java_com_ibm_j9_tests_jeptests_StaticLinking_fooImpl"/>
 	</exports>
 	<artifact type="shared" name="testlibA" appendrelease="false">
-		<include-if condition="spec.flags.build_j2se" />
 		<phase>core quick j2se</phase>
 		<exports>
 			<group name="all"/>

--- a/runtime/tests/redirector/jep178/testlibB/module.xml
+++ b/runtime/tests/redirector/jep178/testlibB/module.xml
@@ -1,36 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
-   Copyright (c) 2014, 2017 IBM Corp. and others
+Copyright (c) 2014, 2018 IBM Corp. and others
 
-   This program and the accompanying materials are made available under
-   the terms of the Eclipse Public License 2.0 which accompanies this
-   distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-   or the Apache License, Version 2.0 which accompanies this distribution and
-   is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-   This Source Code may also be made available under the following
-   Secondary Licenses when the conditions for such availability set
-   forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-   General Public License, version 2 with the GNU Classpath
-   Exception [1] and GNU General Public License, version 2 with the
-   OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-   [1] https://www.gnu.org/software/classpath/license.html
-   [2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
-
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
-
 	<exports group="all">
 		<export name="JNI_OnLoad"/>
 		<export name="JNI_OnUnload"/>
 		<export name="Java_com_ibm_j9_tests_jeptests_StaticLinking_barImpl"/>
 	</exports>
 	<artifact type="shared" name="testlibB" appendrelease="false">
-		<include-if condition="spec.flags.build_j2se" />
 		<phase>core quick j2se</phase>
 		<exports>
 			<group name="all"/>


### PR DESCRIPTION
The jep178 tests were failing on Linux ppc64le (using gcc) because the associated build specs specified `build_j2se = false` . The tests don't need to depend on that flag. This change removes the requirement that flag be set and adjusts `UMA_EXE_POSTFIX_FLAGS` to suit gcc.