### PR TITLE
Remove deprecated related to ArrayCopy on X86

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1055,11 +1055,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_MTUnresolvedDoubleStore,    (void *)MTUnresolvedDoubleStore,   TR_Helper);
    SET(TR_MTUnresolvedAddressStore,   (void *)MTUnresolvedAddressStore,  TR_Helper);
 #if defined(TR_HOST_X86)
-   static bool UseOldReferenceArrayCopy = (bool)feGetEnv("TR_UseOldReferenceArrayCopy");
-   if (UseOldReferenceArrayCopy)
-      SET(TR_referenceArrayCopy, (void *)jitConfig->javaVM->memoryManagerFunctions->referenceArrayCopy, TR_System);
-   else
-      SET(TR_referenceArrayCopy,         (void *)jitReferenceArrayCopy,     TR_Helper);
+   SET(TR_referenceArrayCopy,         (void *)jitReferenceArrayCopy,     TR_Helper);
 #endif
 
 #if !defined(TR_HOST_64BIT)

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -84,8 +84,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static void generateVFTMaskInstruction(TR::Node *node, TR::Register *reg, TR::CodeGenerator *cg);
-   static void generateWrtbarForArrayCopy(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *VMarrayStoreCheckArrayCopyEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static bool VMinlineCallEvaluator(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg);
    static TR::Register *VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *VMmonexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Deprecated ArrayCopy implementation and its related helpers are deleted.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>