### PR TITLE
Revert "Turn on Compress Build logs"

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -658,7 +658,6 @@ def set_job_properties(JOB_TYPE) {
         ********************/
 
         properties([
-            compressBuildLog(),
             buildDiscarder(logRotator(
                 artifactDaysToKeepStr: '',
                 artifactNumToKeepStr: NUM_ARTIFACTS,


### PR DESCRIPTION
This reverts commit 9010f8a7055b1cfa447849da8b21120d4f8b7383.
- This plugin isn't working at the moment.
- Compressed logs are not being uncompressed/rendered on the UI
  which makes it near impossible to navigate a pipeline build.
- Opened [Jenkins-54680](https://issues.jenkins-ci.org/browse/JENKINS-54680).

[skip ci]
Related #3644 #3573

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>