### PR TITLE
Remove the attach library in test

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/Test_ClassLoader.java
@@ -468,7 +468,7 @@ public class Test_ClassLoader {
 			 * not already loaded by another classloader. If it starts failing,
 			 * find another library to load.
 			 */
-			loader2.loadLibrary("attach");
+			loader2.loadLibrary("unpack");
 		} catch (UnsatisfiedLinkError e) {
 			e.printStackTrace();
 			Assert.fail("expected to find library");


### PR DESCRIPTION
The test change is to replace the attach
library with another native library as
attach library has been removed.

Related to eclipse/openj9#3441

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>