### PR TITLE
Stop prepending includes with "omr/" where unnecessary

### DIFF
--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -20,19 +20,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "infra/Cfg.hpp"
-#include "codegen/CodeGenerator.hpp"
-#include "ilgen/J9ByteCodeIlGenerator.hpp"
-#include "ilgen/J9ByteCodeIterator.hpp"
 #include "ilgen/ClassLookahead.hpp"
-#include "env/PersistentCHTable.hpp"
-#include "env/ClassTableCriticalSection.hpp"
+#include "codegen/CodeGenerator.hpp"
 #include "compile/ResolvedMethod.hpp"
+#include "compiler/il/OMRTreeTop_inlines.hpp"
+#include "env/ClassTableCriticalSection.hpp"
+#include "env/IO.hpp"
+#include "env/PersistentCHTable.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "il/TreeTop.hpp"
-#include "omr/compiler/il/OMRTreeTop_inlines.hpp"
-#include "env/IO.hpp"
+#include "ilgen/J9ByteCodeIlGenerator.hpp"
+#include "ilgen/J9ByteCodeIterator.hpp"
+#include "infra/Cfg.hpp"
 
 TR_ClassLookahead::TR_ClassLookahead(
    TR_PersistentClassInfo * classInfo, TR_FrontEnd * fe, TR::Compilation * comp,

--- a/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
+++ b/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
@@ -21,16 +21,16 @@
  *******************************************************************************/
 
 #include "optimizer/BoolArrayStoreTransformer.hpp"
-#include "infra/Cfg.hpp"
-#include "il/Node.hpp"
+#include "compiler/il/OMRTreeTop_inlines.hpp"
 #include "il/Block.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "il/TreeTop.hpp"
-#include "omr/compiler/il/OMRTreeTop_inlines.hpp"
 #include "il/symbol/AutomaticSymbol.hpp"
+#include "infra/Cfg.hpp"
 #include "infra/ILWalk.hpp"
-#include <stack>
 #include <deque>
+#include <stack>
 
 /*
  * This transformer is used to make sure the behavior of bastore in JIT code


### PR DESCRIPTION
For files which have an "OMR" prefix we are guaranteed not to have file
name conflicts in OpenJ9 and as such we can omit the "omr/" prefix in
the include path.

Issue #3725

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>