### PR TITLE
Update usage thresholds to prevent notification misstrigger case

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/nogc/TestGCPolicyNogc.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/nogc/TestGCPolicyNogc.java
@@ -226,7 +226,7 @@ public class TestGCPolicyNogc {
 		for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
 			if (MemoryType.HEAP == pool.getType()) {
 				long usagemax = pool.getUsage().getMax();
-				long threshold = (long) (usagemax * 0.5);
+				long threshold = (long) (usagemax * 0.3);
 				if (pool.isCollectionUsageThresholdSupported()) {
 					 pool.setCollectionUsageThreshold(threshold);
 				}


### PR DESCRIPTION
  - change usage thresholds from 50% of heapsize to 30% to 
  guarantee triggering the usage notifications.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>