### PR TITLE
WIP: Virtualizing Symbol Hierarchy

### DIFF
--- a/runtime/compiler/il/Symbol.hpp
+++ b/runtime/compiler/il/Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/Symbol.hpp
+++ b/runtime/compiler/il/Symbol.hpp
@@ -31,7 +31,7 @@
 namespace TR 
 {
 
-class OMR_EXTENSIBLE Symbol : public J9::SymbolConnector
+class /*OMR_EXTENSIBLE*/ Symbol : public J9::SymbolConnector
    {
 
 public:

--- a/runtime/compiler/il/symbol/J9MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/symbol/J9MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.hpp
@@ -48,7 +48,7 @@ namespace J9
 /**
  * Symbol for methods, along with information about the method
  */
-class OMR_EXTENSIBLE MethodSymbol : public OMR::MethodSymbolConnector
+class /*OMR_EXTENSIBLE*/ MethodSymbol : public OMR::MethodSymbolConnector
    {
 
 protected:

--- a/runtime/compiler/il/symbol/J9StaticSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9StaticSymbol.hpp
@@ -46,7 +46,7 @@ namespace J9
 /**
  * A symbol with an adress
  */
-class OMR_EXTENSIBLE StaticSymbol : public OMR::StaticSymbolConnector
+class /*OMR_EXTENSIBLE*/ StaticSymbol : public OMR::StaticSymbolConnector
    {
 
 protected:

--- a/runtime/compiler/il/symbol/J9Symbol.hpp
+++ b/runtime/compiler/il/symbol/J9Symbol.hpp
@@ -171,7 +171,7 @@ public:
       };
 
    static RecognizedField searchRecognizedField(TR::Compilation *, TR_ResolvedMethod * owningMethodSymbol, int32_t cpIndex, bool isStatic);
-   RecognizedField  getRecognizedField();
+   virtual RecognizedField  getRecognizedField();
 
    /**
     * TR_RecognizedShadowSymbol

--- a/runtime/compiler/il/symbol/J9Symbol.hpp
+++ b/runtime/compiler/il/symbol/J9Symbol.hpp
@@ -55,7 +55,7 @@ namespace TR { class Symbol; }
 
 namespace J9 {
 
-class OMR_EXTENSIBLE Symbol : public OMR::SymbolConnector
+class /*OMR_EXTENSIBLE*/ Symbol : public OMR::SymbolConnector
    {
 
 public:

--- a/runtime/compiler/il/symbol/J9Symbol_inlines.hpp
+++ b/runtime/compiler/il/symbol/J9Symbol_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/symbol/MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/MethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/symbol/MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/MethodSymbol.hpp
@@ -33,7 +33,7 @@ class TR_Method;
 namespace TR
 {
 
-class OMR_EXTENSIBLE MethodSymbol : public J9::MethodSymbolConnector
+class /*OMR_EXTENSIBLE*/ MethodSymbol : public J9::MethodSymbolConnector
    {
 
 protected:

--- a/runtime/compiler/il/symbol/StaticSymbol.hpp
+++ b/runtime/compiler/il/symbol/StaticSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/runtime/compiler/il/symbol/StaticSymbol.hpp
+++ b/runtime/compiler/il/symbol/StaticSymbol.hpp
@@ -34,7 +34,7 @@
 namespace TR
 {
 
-class OMR_EXTENSIBLE StaticSymbol : public J9::StaticSymbolConnector
+class /*OMR_EXTENSIBLE*/ StaticSymbol : public J9::StaticSymbolConnector
    {
 
 protected:


### PR DESCRIPTION
* Commented out `OMR_EXTENSIBLE` from `Symbol` class declarations
* Removed `self()` from function calls of `Symbol` classes

Since virtualizing the `Symbol` hierarchy requires changes from both, the OMR and OpenJ9, projects this PR is linked to [a related one in omr](https://github.com/eclipse/omr/pull/3215) achieving the same purpose.

Signed-off-by: Samer AL Masri <almasri@ualberta.ca>