### PR TITLE
Use potentialOSRPointHelper call as OSR point marker

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -550,6 +550,7 @@ TR_J9ByteCodeIlGenerator::genILFromByteCodes()
       else if (_invokeSpecialInterfaceCalls != NULL
                && currNode->getNumChildren() >= 1
                && currNode->getFirstChild()->getOpCode().isCallDirect()
+               && !currNode->getFirstChild()->isPotentialOSRPointHelperCall()
                && _invokeSpecialInterfaceCalls->isSet(
                      currNode->getFirstChild()->getByteCodeIndex())
                && !evaluatedInvokeSpecialCalls.contains(currNode->getFirstChild()))

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -130,6 +130,9 @@ public:
    static void createTempsForCall(TR::Optimization* opt, TR::TreeTop *callTree);
    static void createDiamondForCall(TR::Optimization* opt, TR::TreeTop *callTree, TR::TreeTop *compareTree, TR::TreeTop *ifTree, TR::TreeTop *elseTree, bool changeBlockExtensions = false, bool markCold = false);
 
+   static void prohibitOSROverRange(TR::Compilation* comp, TR::TreeTop* start, TR::TreeTop* end);
+   static void removePotentialOSRPointHelperCalls(TR::Compilation* comp, TR::TreeTop* start, TR::TreeTop* end);
+
 protected:
    /**
     * \brief
@@ -145,6 +148,7 @@ protected:
     *    True if the field is folded
     */
    static bool foldStaticFinalFieldImpl(TR::Compilation *, TR::Node *node);
+
    };
 
 }

--- a/runtime/compiler/optimizer/OSRGuardInsertion.hpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.hpp
@@ -26,6 +26,7 @@
 #include "optimizer/Optimization.hpp"         // for Optimization
 #include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
 #include "control/RecompilationInfo.hpp"
+#include "optimizer/HCRGuardAnalysis.hpp"
 
 namespace TR { class Block; }
 
@@ -46,7 +47,9 @@ class TR_OSRGuardInsertion : public TR::Optimization
    private:
    static const uint32_t defaultRematBlockLimit = 3;
 
-   void removeHCRGuards(TR_BitVector &fearGeneratingNodes);
+   void removeHCRGuards(TR_BitVector &fearGeneratingNodes, TR_HCRGuardAnalysis* guardAnalysis);
+   void removeRedundantPotentialOSRPointHelperCalls(TR_HCRGuardAnalysis* guardAnalysis);
+   void cleanUpPotentialOSRPointHelperCalls();
    int32_t insertOSRGuards(TR_BitVector &fearGeneratingNodes);
    void performRemat(TR::TreeTop *osrPoint, TR::TreeTop *osrGuard, TR::TreeTop *rematDest);
    void generateTriggeringRecompilationTrees(TR::TreeTop *osrGuard, TR_PersistentMethodInfo::InfoBits reason);

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -205,9 +205,6 @@ int32_t TR_VarHandleTransformer::perform()
                comp()->failCompilation<J9::FSDHasInvokeHandle>("A call to a VarHandle access method is not supported in FSD. Failing ilgen.");
                }
 
-            if (comp()->getOption(TR_EnableOSR) && !comp()->isPeekingMethod())
-               methodSymbol->setCannotAttemptOSR(node->getByteCodeInfo().getByteCodeIndex());
-
             // Anchoring all the children for varhandle
             anchorAllChildren(node, tt);
             performTransformation(comp(), "%sVarHandle access methods found, working on node %p\n", optDetailString(), node);


### PR DESCRIPTION
This pull request contains three commits to use potentialOSRPointHelper
call as OSR point marker.

 - Insert a helper call right after each OSR point.
 - Remove the helper calls where OSR is not possible due to
    StringPeepHoles transformations.
 - Remove redundant helper calls in OSRGuardInsertion.

Details can be found in the commit message of each commit.

Closes: #3531 