### PR TITLE
Enable COMPUTED_GOTO on zLinux

### DIFF
--- a/runtime/vm/BytecodeInterpreter.cpp
+++ b/runtime/vm/BytecodeInterpreter.cpp
@@ -34,11 +34,16 @@
 #define LOOP_NAME bytecodeLoop
 #endif
 
-/* USE_COMPUTED_GOTO on Windows is a performance improvement of 15% */
-/* USE_COMPUTED_GOTO on Linux amd64 has a performance improvement of 3% */
+/* USE_COMPUTED_GOTO on Windows has a performance improvement of 15%.
+ * USE_COMPUTED_GOTO on Linux amd64 has a performance improvement of 3%.
+ * USE_COMPUTED_GOTO is enabled on Linux s390 when compiling with gcc7+.
+ * USE_COMPUTED_GOTO improves startup performance by ~10% on Linux s390.
+ */
 #if (defined(WIN32) && defined(__GNUC__))
 #define USE_COMPUTED_GOTO
 #elif (defined(LINUX) && defined(J9HAMMER))
+#define USE_COMPUTED_GOTO
+#elif (defined(LINUX) && defined(S390) && (__GNUC__ > 7))
 #define USE_COMPUTED_GOTO
 #elif defined(OSX)
 #define USE_COMPUTED_GOTO

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8124,7 +8124,7 @@ protected:
 
 public:
 
-#if defined(J9VM_ARCH_X86) && defined(__GNUC__) && ((__GNUC__> 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 6))
+#if (defined(J9VM_ARCH_X86) || defined(S390)) && defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))
 	/*
 	 * This method can't be 'VMINLINE' because it declares local static data
 	 * triggering a warning with GCC compilers newer than 4.6.


### PR DESCRIPTION
`USE_COMPUTED_GOTO` is enabled on `zLinux` when compiling with `gcc-7+`. When
OpenJ9 is built using `gcc-7` on zLinux, `USE_COMPUTED_GOTO` improves startup
performance by `~10%` for DayTrader.

When compiling with `USE_COMPUTED_GOTO` enabled and `gcc version > 4.6`,
`VMINLINE` shouldn't be used with `VM_BytecodeInterpreter::run`. Otherwise,
the following compile error is encountered:
```
BytecodeInterpreter.hpp:8136:2: error: function ‘UDATA
VM_BytecodeInterpreter::run(J9VMThread*)’ can never be copied because it
saves address of local label in a static variable
```
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>