### PR TITLE
Reload evacuated object in the hardware read barrier helper

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -404,6 +404,17 @@ public:
    */
    void setSupportsInlineStringHashCode() { return _j9Flags.set(SupportsInlineStringHashCode); }
 
+   /** \brief
+   *    Determines whether the code generator supports inlining of java_util_concurrent_ConcurrentLinkedQueue_tm*
+   *    methods
+   */
+   bool getSupportsInlineConcurrentLinkedQueue() { return _j9Flags.testAny(SupportsInlineConcurrentLinkedQueue); }
+
+   /** \brief
+   *    The code generator supports inlining of java_util_concurrent_ConcurrentLinkedQueue_tm* methods
+   */
+   void setSupportsInlineConcurrentLinkedQueue() { return _j9Flags.set(SupportsInlineConcurrentLinkedQueue); }
+
    /**
     * \brief
     *    The number of nodes between a monext and the next monent before
@@ -420,6 +431,7 @@ private:
       SupportsInlineStringCaseConversion  = 0x00000004, /*! codegen inlining of Java string case conversion */
       SupportsInlineStringIndexOf         = 0x00000008, /*! codegen inlining of Java string index of */
       SupportsInlineStringHashCode        = 0x00000010, /*! codegen inlining of Java string hash code */
+      SupportsInlineConcurrentLinkedQueue = 0x00000020,
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4994,7 +4994,7 @@ break
 #endif
        }
 
-    if (comp()->cg()->getSupportsTMHashMapAndLinkedQueue() && (comp()->getOptions()->getGcMode() != TR_WrtbarRealTime) &&
+    if (comp()->cg()->getSupportsInlineConcurrentLinkedQueue() && (comp()->getOptions()->getGcMode() != TR_WrtbarRealTime) &&
          (symbol->getRecognizedMethod() == TR::java_util_concurrent_ConcurrentLinkedQueue_tmEnabled))
        {
        loadConstant(TR::iconst, 1);

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -59,6 +59,11 @@ J9::Power::CodeGenerator::CodeGenerator() :
       cg->setSupportsBigDecimalLongLookasideVersioning();
       }
 
+   if (cg->getSupportsTM())
+      {
+      cg->setSupportsInlineConcurrentLinkedQueue();
+      }
+
    cg->setSupportsNewInstanceImplOpt();
 
    static char *disableMonitorCacheLookup = feGetEnv("TR_disableMonitorCacheLookup");
@@ -352,7 +357,7 @@ bool J9::Power::CodeGenerator::suppressInliningOfRecognizedMethod(TR::Recognized
       }
 
    // Transactional Memory
-   if (self()->getSupportsTM())
+   if (self()->getSupportsInlineConcurrentLinkedQueue())
       {
       if (method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer ||
           method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmPoll ||

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11688,7 +11688,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          {
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer:
          {
-         if (cg->getSupportsTM())
+         if (cg->getSupportsInlineConcurrentLinkedQueue())
             {
             resultReg = inlineConcurrentLinkedQueueTMOffer(node, cg);
             return true;
@@ -11698,7 +11698,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmPoll:
          {
-         if (cg->getSupportsTM())
+         if (cg->getSupportsInlineConcurrentLinkedQueue())
             {
             resultReg = inlineConcurrentLinkedQueueTMPoll(node, cg);
             return true;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -121,6 +121,12 @@ J9::Z::CodeGenerator::CodeGenerator() :
       cg->setSupportsInlineStringHashCode();
       }
 
+   // See comment in `handleHardwareReadBarrier` implementation as to why we cannot support CTX under CS
+   if (cg->getSupportsTM() && !TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
+      {
+      cg->setSupportsInlineConcurrentLinkedQueue();
+      }
+
    // Let's turn this on.  There is more work needed in the opt
    // to catch the case where the BNDSCHK is inserted after
    //
@@ -3892,7 +3898,7 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
       }
 
    // Transactional Memory
-   if (self()->getSupportsTM())
+   if (self()->getSupportsInlineConcurrentLinkedQueue())
       {
       if (method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer ||
           method == TR::java_util_concurrent_ConcurrentLinkedQueue_tmPoll ||
@@ -4115,7 +4121,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
          return true;
 
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer:
-         if (cg->getSupportsTM())
+         if (cg->getSupportsInlineConcurrentLinkedQueue())
             {
             resultReg = inlineConcurrentLinkedQueueTMOffer(node, cg);
             return true;
@@ -4123,7 +4129,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
          break;
 
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmPoll:
-         if (cg->getSupportsTM())
+         if (cg->getSupportsInlineConcurrentLinkedQueue())
             {
             resultReg = inlineConcurrentLinkedQueueTMPoll(node, cg);
             return true;

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -404,6 +404,9 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #if defined(J9VM_INTERP_SMALL_MONITOR_SLOT)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_INTERP_SMALL_MONITOR_SLOT", 1) |
 #endif /* J9VM_INTERP_SMALL_MONITOR_SLOT */
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
+			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_GC_COMPRESSED_POINTERS", 1) |
+#endif /* J9VM_GC_COMPRESSED_POINTERS */
 #if defined(J9VM_GC_TLH_PREFETCH_FTA)
 			writeConstant(OMRPORTLIB, fd, "ASM_J9VM_GC_TLH_PREFETCH_FTA", 1) |
 #endif /* J9VM_GC_TLH_PREFETCH_FTA */
@@ -558,6 +561,8 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_stackWalkState", offsetof(J9VMThread, stackWalkState)) |
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_gsParameters_GSECI", offsetof(J9VMThread, gsParameters) + 2) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_gsParameters_instructionAddr", offsetof(J9VMThread, gsParameters.instructionAddr)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_gsParameters_operandAddr", offsetof(J9VMThread, gsParameters.operandAddr)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_VMThread_gsParameters_returnAddr", offsetof(J9VMThread, gsParameters.returnAddr)) |
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
@@ -578,6 +583,9 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 #if defined(J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_jitTOC", offsetof(J9JavaVM, jitTOC)) |
 #endif /* J9VM_ENV_SHARED_LIBS_USE_GLOBAL_TABLE */
+#if defined(J9VM_GC_COMPRESSED_POINTERS)
+			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_compressedPointersShift", offsetof(J9JavaVM, compressedPointersShift)) |
+#endif /* J9VM_GC_COMPRESSED_POINTERS */
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9MemoryManagerFunctions_J9ReadBarrier", offsetof(J9MemoryManagerFunctions, J9ReadBarrier)) |
 			/* J9VMEntryLocalStorage */
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_jitGlobalStorageBase", offsetof(J9VMEntryLocalStorage, jitGlobalStorageBase)) |

--- a/runtime/oti/zhelpers.m4
+++ b/runtime/oti/zhelpers.m4
@@ -435,13 +435,53 @@ dnl M1 = $1
 dnl D2 = $2
 dnl X2 = $3
 dnl B2 = $4
-define({BRANCH_INDIRECT_ON_CONDITION},{
+define({ENCODE_BIC},{
     BYTE(227)
     BYTE(eval((($1 % 16) * 16) + ($3 % 16)))
     BYTE(eval((($4 % 16) * 16) + (($2 / 256) % 16)))
     BYTE(eval($2 % 256))
     BYTE(eval(($2 / 4096) % 256))
     BYTE(71)
+})
+
+dnl Encodes the Add Immediate (AGSI) instruction with the following
+dnl format:
+dnl 
+dnl AGSI D1(B2),I2
+dnl
+dnl Where:
+dnl
+dnl D1 = $1
+dnl B1 = $2
+dnl I2 = $3
+define({ENCODE_AGSI},{
+    BYTE(235)
+    BYTE($3)
+    BYTE(eval((($2 % 16) * 16) + (($1 / 256) % 16)))
+    BYTE(eval($1 % 256))
+    BYTE(eval(($1 / 4096) % 256))
+    BYTE(122)
+})
+
+dnl Encodes the Rotate Then Insert Selected Bits (RISBGN) instruction
+dnl with the following format:
+dnl 
+dnl RISBGN R1,R2,I3,I4,I5
+dnl
+dnl Where:
+dnl
+dnl R1 = $1
+dnl R2 = $2
+dnl I3 = $3
+dnl I4 = $4
+dnl I5 = $5
+define({ENCODE_RISBGN},{
+    BYTE(236)
+    BYTE(eval((($1 % 16) * 16) + ($2 % 16)))
+    BYTE($3)
+    BYTE($4)
+    BYTE($5)
+    BYTE(89)
 })
 
 define({JIT_GPR_SAVE_OFFSET},{eval(STACK_BIAS+J9TR_cframe_jitGPRs+(($1)*J9TR_pointerSize))})

--- a/runtime/vm/guardedstorage.c
+++ b/runtime/vm/guardedstorage.c
@@ -28,8 +28,8 @@
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 
-J9_EXTERN_BUILDER_SYMBOL(handleReadBarrier);
-J9_EXTERN_BUILDER_SYMBOL(handleGuardedStorageEvent);
+J9_EXTERN_BUILDER_SYMBOL(handleSoftwareReadBarrier);
+J9_EXTERN_BUILDER_SYMBOL(handleHardwareReadBarrier);
 
 void
 invokeJ9ReadBarrier(J9VMThread *currentThread)
@@ -73,9 +73,9 @@ j9gs_initializeThread(J9VMThread *vmThread)
 			gsControlBlock->sectionMask = 0;
 			gsControlBlock->paramListAddr = (uint64_t) &vmThread->gsParameters;
 			if (1 == supportsGuardedStorageFacility) {
-				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleGuardedStorageEvent);
+				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleHardwareReadBarrier);
 			} else {
-				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleReadBarrier);
+				vmThread->gsParameters.handlerAddr = (uint64_t)(uintptr_t)J9_BUILDER_SYMBOL(handleSoftwareReadBarrier);
 			}
 
 			/* Initialize the parameters */

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -375,11 +375,11 @@ checkModuleAccess(J9VMThread *currentThread, J9JavaVM* vm, J9ROMClass* srcRomCla
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 /**
- * Guarded Storage Trap Handler
+ * Hardware Read Barrier Handler
  *
  * The trap handler that gets invoked when a H/W Read Barrier is triggered
  */
-J9_EXTERN_BUILDER_SYMBOL(handleGuardedStorageEvent);
+J9_EXTERN_BUILDER_SYMBOL(handleHardwareReadBarrier);
 
 /**
  * Software Read Barrier Handler
@@ -387,7 +387,7 @@ J9_EXTERN_BUILDER_SYMBOL(handleGuardedStorageEvent);
  * The handler that gets invoked by JIT before loads when running concurrent scavenger on hardware
  * that doesn't support guarded storage facility for object that are being evacuated
  */
-J9_EXTERN_BUILDER_SYMBOL(handleReadBarrier);
+J9_EXTERN_BUILDER_SYMBOL(handleSoftwareReadBarrier);
 
 /**
  * Handle a Guarded Storage Event


### PR DESCRIPTION
In the case of the unlikely event that the call to J9ReadBarrier fails
to evacuate the object we may end up in an infinite loop because the
hardware read barrier helper currently returns back into the JIT
mainline to re-execute the guarded load instruction.

The JIT was under the assumption that J9ReadBarrier will always succeed
which may not be the case if we completely run out of space on the heap
to evacuate the object. In such a scenario the GC must reach a
synchronization point and issue a full global collection, but to do
that we must be able to return to the JIT mainline and load the
non-evacuated object. This means we cannot re-execute the guarded load
instruction in the JIT mainline.

To avoid this issue we reload the evacuated object in the hardware read
barrier helper and jump past the guarded load instruction upon exiting
the helper.

As a side-effect of this change we can no longer do constrained TX with
hardware concurrent scavenge because the J9ReadBarrier can fail and we
cannot get out of the CTX loop if that happens because the execution
will resume at the beginning of the transaction.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>