### PR TITLE
Fix typo in Memory Documentation

### DIFF
--- a/doc/compiler/memory/MemoryManager.md
+++ b/doc/compiler/memory/MemoryManager.md
@@ -70,11 +70,11 @@ provider of memory.
 --------------------------------------------------------------------
 
 
-                +---------------------+
-                |                     |
-                | J9::SegmentProvider |
-                |                     |
-                +-----+-----------+---+
+                +-----------------------+
+                |                       |
+                | J9::J9SegmentProvider |
+                |                       |
+                +-----+-----------+-----+
                       ^           ^
                       |           |
                       |           |
@@ -89,7 +89,7 @@ provider of memory.
 
 #### J9::SystemSegmentProvider
 `J9::SystemSegmentProvider` implements `TR::SegmentAllocator`. 
-It uses `J9::SegmentProvider` (see below) in order to allocate 
+It uses `J9::J9SegmentProvider` (see below) in order to allocate 
 `TR::MemorySegment`s and uses `TR::RawAllocator` for all its 
 internal memory management requirements. As part of its initialization, it
 preallocates a segment of memory. This is the default Low 
@@ -102,8 +102,8 @@ when the `TR_EnableScratchMemoryDebugging` option is enabled.
 This object exists specifically for the Debugger Extensions. It
 uses `dbgMalloc`/`dbgFree` to allocate and free memory.
 
-#### J9::SegmentProvider
-`J9::SegmentProvider` is a pure virtual class which provides
+#### J9::J9SegmentProvider
+`J9::J9SegmentProvider` is a pure virtual class which provides
 APIs to
 * Request Memory
 * Release Memory
@@ -116,17 +116,17 @@ segments show up in the `Internal Memory` section of a javacore. They
 allow the Compiler to minimize the number of times it needs to request
 memory from the Port Library (an expensive operation for the allocation
 patterns exhibited by the Compiler). Therefore, in some sense, 
-`J9::SegmentProvider` is the truest allocator of segments as defined by
+`J9::J9SegmentProvider` is the truest allocator of segments as defined by
 the Port Library. It should only be used as the backing provider of
 other Allocators.
 
 #### J9::SegmentAllocator
-`J9::SegmentAllocator` implements `J9::SegmentProvider`. It uses the
+`J9::SegmentAllocator` implements `J9::J9SegmentProvider`. It uses the
 `allocateMemorySegment` and `freeMemorySegment` APIs accessed via
 `javaVM->internalVMFunctions`.
 
 #### J9::SegmentCache
-`J9::SegmentCache` implements `J9::SegmentProvider`. It requires a
+`J9::SegmentCache` implements `J9::J9SegmentProvider`. It requires a
 `J9::SegmentAllocator` instantiated to use as its backing provider. As part
 of its initialization, it preallocates a segment. This class exists
 as an optimization to minimize the churn of memory allocation and
@@ -167,7 +167,7 @@ be compiled, it initializes a `J9::SegmentCache` local object. As stated
 above, this will preallocate a segment. Then, it goes through the list. 
 At the start of a compilation, it initializes a `J9::SystemSegmentProvider`, 
 passing in the `J9::SegmentCache` as the backing provider (technically it is 
-passed a reference to a `J9::SegmentProvider`, the reason for which is described
+passed a reference to a `J9::J9SegmentProvider`, the reason for which is described
 below). As stated above, `J9::SystemSegmentProvider` will allocate a
 segment as part of its initialization. However, the size of the segment it
 allocates is the same as the size of the segment preallocated by
@@ -191,7 +191,7 @@ instantiated in, causing it to be destroyed and finally releasing all of its
 memory.
 
 The reason why `J9::SystemSegmentProvider` is passed in a reference to
-`J9::SegmentProvider` and not `J9::SegmentCache` is because the code that
+`J9::J9SegmentProvider` and not `J9::SegmentCache` is because the code that
 instantiates `J9::SystemSegmentProvider` is common for both compilations on 
 Compilation Threads AND compilations on Application Threads. When a compilation 
 occurs on an Application Thread, `J9::SegmentAllocator` is instantiated instead.


### PR DESCRIPTION
The existing documentation refers to a "J9::SegmentProvider", which
doesn't exist; what it was referring to was a "J9::J9SegmentProvider".
This commit updates the documentation to be correct.