### PR TITLE
Fix MethodHandle related bugs

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1233,6 +1233,24 @@ TR_J9ServerVM::setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp)
    stream->read<JITaaS::Void>();
    }
 
+bool
+TR_J9ServerVM::needsInvokeExactJ2IThunk(TR::Node *callNode, TR::Compilation *comp)
+   {
+   TR_ASSERT(callNode->getOpCode().isCall(), "needsInvokeExactJ2IThunk expects call node; found %s", callNode->getOpCode().getName());
+
+   TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
+   TR_Method       *method       = methodSymbol->getMethod();
+   if (  methodSymbol->isComputed()
+      && (  method->getMandatoryRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact
+         || method->isArchetypeSpecimen()))
+      {
+      // for JITaaS always need to regenerate a thunk, when it's needed
+      return true;
+      }
+   else
+      return false;
+   }
+
 TR_ResolvedMethod *
 TR_J9ServerVM::createMethodHandleArchetypeSpecimen(TR_Memory *trMemory, uintptrj_t *methodHandleLocation, TR_ResolvedMethod *owningMethod)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -153,6 +153,7 @@ public:
    virtual uintptrj_t getBytecodePC(TR_OpaqueMethodBlock *method, TR_ByteCodeInfo &bcInfo) override;
    virtual bool isClassLoadedBySystemClassLoader(TR_OpaqueClassBlock *clazz) override;
    virtual void setInvokeExactJ2IThunk(void *thunkptr, TR::Compilation *comp) override;
+   virtual bool needsInvokeExactJ2IThunk(TR::Node *node,  TR::Compilation *comp) override;
    virtual TR_ResolvedMethod *createMethodHandleArchetypeSpecimen(TR_Memory *, uintptrj_t *methodHandleLocation, TR_ResolvedMethod *owningMethod = 0) override;
    virtual bool getArrayLengthOfStaticAddress(void *ptr, int32_t &length) override;
    virtual intptrj_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset) override;

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1752,7 +1752,7 @@ TR::Register *TR::X86PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
                break;
             default:
                // in server mode, we always need to regenerate the thunk inside the code cache for this compilation
-               if (fej9->needsInvokeExactJ2IThunk(callNode, comp()) || comp()->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+               if (fej9->needsInvokeExactJ2IThunk(callNode, comp()))
                   {
                   TR_J2IThunk *thunk = generateInvokeExactJ2IThunk(callNode, methodSymbol->getMethod()->signatureChars());
                   fej9->setInvokeExactJ2IThunk(thunk, comp());


### PR DESCRIPTION
- fix `filterArguments`, server tried to get and use filter indices
from the known object table, which is not support in JITaaS.
Use pointers to filters instead.

- `FoldHandle_argIndices` would put indices in the reverse order on
the client, and then reverse them again on the server, resulting
in the non-reversed order, which is incorrect. Fix by not reversing on
the client.

- `X86PrivateLinkage::buildIndirectDispatch` recreates thunks every time
we try to get one in JITaaS. It's not clear to me why it's done, because
these thunks are already allocated in code memory, and they do not seem
to be persistent.
I don't think this behavior is entirely correct, because recreating
`invokeExactJ2IThunk` leads to errors in method handle tests.

JITaaS part of: #3780 