### PR TITLE
Exclude SAFESEH on non-Win platforms

### DIFF
--- a/runtime/makelib/targets.mk.win.inc.ftl
+++ b/runtime/makelib/targets.mk.win.inc.ftl
@@ -132,7 +132,7 @@ UMA_EXEFLAGS+=/INCREMENTAL:NO /NOLOGO /LARGEADDRESSAWARE
 #	/Gd Use C calls (i.e. prepend underscored to symbols)
 ASFLAGS+=/c /Cp /W3 /nologo /Zd /Zi -DWIN32 -D_WIN32 -DOMR_OS_WINDOWS
 <#if uma.spec.processor.x86>
-ASFLAGS+=/safeseh /coff /Zm /Gd -DWIN_X86_SEH
+ASFLAGS+=/safeseh /coff /Zm /Gd
 <#elseif uma.spec.processor.amd64>
 ASFLAGS+=-DWIN64 -D_WIN64 -DJ9HAMMER
 </#if>

--- a/runtime/vm/module.xml
+++ b/runtime/vm/module.xml
@@ -93,6 +93,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 			<makefilestub data="UMA_OBJECTS:=$(filter-out inlineleconditionhandler$(UMA_DOT_O),$(UMA_OBJECTS))\n">
 				<exclude-if condition="spec.zos_390.* and not spec.flags.J9VM_ENV_DATA64"/>
 			</makefilestub>
+			<makefilestub data="UMA_OBJECTS:=$(filter-out safeseh$(UMA_DOT_O),$(UMA_OBJECTS))\n">
+				<exclude-if condition="spec.win_x86.* and not spec.flags.J9VM_ENV_DATA64"/>
+			</makefilestub>
 		</makefilestubs>
 		<vpaths>
 			<vpath pattern="stackswap.m4" path="wi32" augmentObjects="true" type="relativepath">

--- a/runtime/vm/safeseh.asm
+++ b/runtime/vm/safeseh.asm
@@ -18,10 +18,8 @@
 ;
 ; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
-ifdef WIN_X86_SEH
 .386
 .model  flat
 win32ExceptionHandler   proto
 .safeseh    win32ExceptionHandler
-endif
 end


### PR DESCRIPTION
The change is to prevent the assembly file
from being compiled on non-Win platforms

Fixes a problem with #2979

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>