### PR TITLE
Fix tap result parsing issue on windows

### DIFF
--- a/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
+++ b/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
@@ -75,6 +75,8 @@ sub resultReporter {
 				my $endTime = 0;
 				while ( $result = <$fhIn> ) {
 					$output .= '        ' . $result;
+					# remove extra carriage return
+					$output =~ s/\r//g;
 					if ($result =~ /Running test (.*) \.\.\.\n/) {
 						$testName = $1;
 					} elsif ($result =~ /^\Q$testName\E Start Time: .* Epoch Time \(ms\): (.*)\n/) {


### PR DESCRIPTION
- extra carriage return caused output to violate the yaml format
- remove extra carriage return when writing tap output

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>