### PR TITLE
FFI: fix bug on z/os

### DIFF
--- a/runtime/libffi/z/ffi.c
+++ b/runtime/libffi/z/ffi.c
@@ -1,7 +1,7 @@
 /* -----------------------------------------------------------------------
    ffi.c - Copyright (c) 2000, 2007 Software AG
            Copyright (c) 2008 Red Hat, Inc
-           Copyright (c) 2016, 2017 IBM Corp.
+           Copyright (c) 2016, 2018 IBM Corp.
  
    S390 Foreign Function Interface
  
@@ -68,7 +68,7 @@
  
 /*Making it extern to call this from sysvz.S*/
 #pragma map(ffi_prep_args, "PREPARGS")
-char* ffi_prep_args (unsigned char *, extended_cif *);
+void ffi_prep_args (unsigned char *, extended_cif *);
 void ffi_closure_helper_SYSV (ffi_closure *, unsigned long *, 
 			 unsigned long long *, unsigned long *);
 
@@ -146,7 +146,7 @@ ffi_check_struct_type (ffi_type *arg)
 /*                                                                    */
 /*====================================================================*/
  
-char*
+void
 ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 {
   /* The stack space will be filled with these areas:
@@ -180,11 +180,10 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
      ------------------------------------ <- High Addresses
   */
 
-  int i, idx;
+  int i;
   ffi_type **type_ptr;
   void **p_argv = ecif->avalue;
   unsigned char* arg_ptr = stack;
-  unsigned char  _t[256]; 
   
 #ifdef FFI_DEBUG
   printf("prep_args: stack=%x, extended_cif=%x\n",stack,ecif);
@@ -200,9 +199,9 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 
    /*Now for the arguments.  */
  
-  for (type_ptr = ecif->cif->arg_types, i = ecif->cif->nargs, idx=0;
+  for (type_ptr = ecif->cif->arg_types, i = ecif->cif->nargs;
        i > 0;
-       i--, type_ptr++, p_argv++, idx++)
+       i--, type_ptr++, p_argv++)
     {
       void *arg = *p_argv;
       int type = (*type_ptr)->type;
@@ -221,68 +220,56 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE 
 	  case FFI_TYPE_LONGDOUBLE: 
 	    *(long double *) arg_ptr = * (long double *) (*p_argv);
-	    _t[idx] = FFI_TYPE_LONGDOUBLE; 
 	    break;
 #endif
 
 	  case FFI_TYPE_DOUBLE:
 	  case FFI_TYPE_COMPLEX:
 	    *(double *) arg_ptr = * (double *) (*p_argv);
-	    _t[idx] = FFI_TYPE_DOUBLE;
 	    break;
 	
 	  case FFI_TYPE_FLOAT:
 	    *(float *) arg_ptr = * (float *) (*p_argv);
-	    _t[idx] = FFI_TYPE_FLOAT;
 	    break;
 
 	  case FFI_TYPE_POINTER:
 	    *(unsigned long *) arg_ptr = * (unsigned long *) (* p_argv); 
-	    _t[idx] = FFI_TYPE_POINTER;
 	    break;
  
 	  case FFI_TYPE_SINT64:
 	    *(signed long long *) arg_ptr = * (signed long long *) (* p_argv);
-	    _t[idx] = FFI_TYPE_SINT64;
 	    break;
 
 	  case FFI_TYPE_UINT64:
 	    *(unsigned long long *) arg_ptr = * (unsigned long long *) (* p_argv);
-	    _t[idx] = FFI_TYPE_UINT64;
 	    break;
  
 	  case FFI_TYPE_UINT32:
 	    *(unsigned int *) arg_ptr = * (unsigned int *) (*p_argv);
-	    _t[idx] = FFI_TYPE_UINT32;
 	    break;
  
 	  case FFI_TYPE_SINT32:
 	  case FFI_TYPE_INT:
 	    *(signed int *) arg_ptr = * (signed int *) (*p_argv);
-	    _t[idx] = FFI_TYPE_INT;
 	    break;
  
 	  case FFI_TYPE_UINT16:
 	    *(unsigned short *) arg_ptr = * (unsigned short *) (* p_argv);
-	    _t[idx] = FFI_TYPE_UINT16;
 			arg_ptr += 2;
 	    break;
  
 	  case FFI_TYPE_SINT16:
 	    *(signed short *) arg_ptr = * (signed short *) (* p_argv);
-	    _t[idx] = FFI_TYPE_SINT16;
 			arg_ptr += 2;
 	    break;
 
 	  case FFI_TYPE_UINT8:
 	    *(unsigned char *) arg_ptr = * (unsigned char *) (* p_argv);
-	    _t[idx] = FFI_TYPE_UINT8;
 					arg_ptr += 3;
 	    break;
  
 	  case FFI_TYPE_SINT8:
 	    *(signed char *) arg_ptr = * (signed char*) (* p_argv);
-	    _t[idx] = FFI_TYPE_SINT8;
 			arg_ptr += 3;
 	    break;
  
@@ -292,8 +279,6 @@ ffi_prep_args (unsigned char *stack, extended_cif *ecif)
         }
       arg_ptr += size;
     }
-
-  return _t;
   
 }
 

--- a/runtime/libffi/z/sysvz.S
+++ b/runtime/libffi/z/sysvz.S
@@ -1,4 +1,4 @@
-* Copyright (c) 2016, 2017 IBM Corp. and others
+* Copyright (c) 2016, 2018 IBM Corp. and others
 
       ACONTROL AFPR,FLAG(CONT)
 
@@ -16,20 +16,19 @@ FFISYS EDCXPRLG DSASIZE=DSASZ,PSECT=ASP
 *What: Storing arguments in this routine's
 *      local storage for future use
           USING  CEEDSAHP,4
-
+         L  14,0(,2)          ecif->cif
+         L  14,8(,14)         cif->arg_types
 *Name:    ffi_prep_args_call
 *Input:   stack, extended_cif
 *Output:  void
 *Action:  Is an external call to C-XPLINK routine
 *         It saves function's arguments in this 
 *         routine's local storage
-*Returns: The parameter types in a array
-*         r3 points to the start of the array
          LA 1,LSTOR
          LR 13,1
          EDCXCALL  PREPARGS,WORKREG=10
 
-         LR 5,3               Copy of parameter types
+         LR 5,14              Copy of parameter types
 *Reset registers used in code gen
          SR  0,0              GPR counter
          SR  14,14            FPR counter
@@ -41,8 +40,8 @@ FFISYS EDCXPRLG DSASIZE=DSASZ,PSECT=ASP
          L   9,(2112+(((DSASZ+31)/32)*32)+20)(,4) 
 
 *Place arguments passed to the foreign function based on type
-ARGLOOP  SR  11,11
-         LLC 11,0(10,5)       Get the next parameter type
+ARGLOOP  L   11,0(10,5)       Get pointer to current ffi_type
+         LLC 11,7(11)         ffi_type->type
          SLL 11,2             Find offset in branch tabel
          LA  15,ATABLE
          L   15,0(11,15)
@@ -480,7 +479,7 @@ BYTE12   DS 0H
          B CONT
 
 CONT     DS 0H                End of processing curr_param
-         AHI 10,1             Next parameter type
+         AHI 10,4             Next parameter type
          AHI 6,4              Next parameter value stored
          BCT 9,ARGLOOP
   
@@ -565,6 +564,9 @@ ATABLE DC A(I)                Labels for parm types
  DC A(UI64)
  DC A(FLT)
  DC A(STRCT)
+ DC A(0)
+ DC A(I)
+ DC A(D)
 I32 DC A(IGPR1)               Labels for passing INT in gpr
  DC A(IGPR2)
  DC A(IGPR3)

--- a/runtime/libffi/z/sysvz64.S
+++ b/runtime/libffi/z/sysvz64.S
@@ -1,3 +1,4 @@
+* Copyright (c) 2016, 2018 IBM Corp. and others
       ACONTROL AFPR,FLAG(CONT)
 
 FFISYS CELQPRLG DSASIZE=DSASZ,PSECT=ASP
@@ -11,23 +12,22 @@ FFISYS CELQPRLG DSASIZE=DSASZ,PSECT=ASP
 *@2132(,4) <- cif->nargs (+44)?
 *@2136(,4) <- cif->arg_types->size (+52)?
 
+         USING  CEEDSAHP,4
+         LG 14,0(,2)           ecif->cif
+         LG 14,8(,14)          cif->arg_types
 *What: Storing arguments in this routine's
 *      local storage for future use
-          USING  CEEDSAHP,4
-
 *Name:    ffi_prep_args_call
 *Input:   stack, extended_cif
 *Output:  void
 *Action:  Is an external call to C-XPLINK routine
 *         It saves function's arguments in this 
 *         routine's local storage
-*Returns: The parameter types in a array
-*         r3 points to the start of the array
          LA 1,LSTOR          
          LGR 13,1 
          CELQCALL   PREPARGS,WORKREG=10
 
-         LGR 5,3               Copy of parameter types
+         LGR 5,14              Copy of parameter types
 *Reset registers used in code gen
 *         SR  0,0              GPR counter
           LA  0,0
@@ -44,8 +44,8 @@ FFISYS CELQPRLG DSASIZE=DSASZ,PSECT=ASP
          L   9,(2176+(((DSASZ+31)/32)*32)+44)(,4) 
 
 *Place arguments passed to the foreign function based on type
-ARGLOOP  LA  11,0
-         LLC 11,0(10,5)       Get the next parameter type
+ARGLOOP  LG  11,0(10,5)       Get pointer to current ffi_type
+         LLGC 11,11(11)       ffi_type->type
          SLL 11,2             Find offset in branch tabel
          LA  15,ATABLE        
          L   15,0(11,15)      
@@ -469,7 +469,7 @@ BYTE12   DS 0H
          B CONT
 
 CONT     DS 0H                End of processing curr_param
-         AHI 10,1             Next parameter type 
+         AHI 10,8             Next parameter type
          AHI 6,4              Next parameter value stored 
          BCT 9,ARGLOOP        
   
@@ -546,6 +546,9 @@ ATABLE DC A(I)                Labels for parm types
  DC A(UI64)
  DC A(FLT)
  DC A(STRCT)
+ DC A(0)
+ DC A(I)
+ DC A(D)
 I32 DC A(IGPR1)               Labels for passing INT in gpr
  DC A(IGPR2)
  DC A(IGPR3)


### PR DESCRIPTION
FFISYS was calling ffi_prep_args to perform some special handling of the
argument types. As part of this ffi_prep_args was returning a list of
argument types  which was store in an array inside the ffi_prep_args stack
frame

However on z/os, it is possible that child stack frames can be reclaimed
after the child returns. Solution is to make FFISYS process the arg types
itself, and the data is no longer returned from ffi_prep_args

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>