### PR TITLE
Store and use client's compressedRefShift at server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -417,6 +417,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._arrayletLeafLogSize = TR::Compiler->om.arrayletLeafLogSize();
          vmInfo._arrayletLeafSize = TR::Compiler->om.arrayletLeafSize();
          vmInfo._overflowSafeAllocSize = static_cast<uint64_t>(fe->getOverflowSafeAllocSize());
+         vmInfo._compressedReferenceShift = TR::Compiler->om.compressedReferenceShift();
 
          client->write(vmInfo);
          }

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -84,6 +84,7 @@ class ClientSessionData
       int32_t _arrayletLeafLogSize;
       int32_t _arrayletLeafSize;
       uint64_t _overflowSafeAllocSize;
+      int32_t _compressedReferenceShift;
       };
 
    TR_PERSISTENT_ALLOC(TR_Memory::ClientSessionData)

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -302,6 +302,12 @@ J9::ObjectModel::compressedReferenceShiftOffset()
 int32_t
 J9::ObjectModel::compressedReferenceShift()
    {
+   if (auto stream = TR::CompilationInfo::getStream())
+      {
+      auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      return vmInfo->_compressedReferenceShift;
+      }
+
 #if defined(J9VM_GC_COMPRESSED_POINTERS)
    J9JavaVM *javaVM = TR::Compiler->javaVM;
    if (!javaVM)


### PR DESCRIPTION
- Server should be using client's compressedRefShift for compilation
- previously using server's own compressedRefShift
[skip ci]
Issue: #3762

Signed-off-by: Harry Yu <harryyu1994@gmail.com>