### PR TITLE
Updated s390x ubuntu16 Dockerfile to support JDK12

### DIFF
--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -117,15 +117,15 @@ RUN mkdir -p /usr/lib/jvm/adoptojdk-java-80 \
   && mv bootjdk8/* /usr/lib/jvm/adoptojdk-java-80 \
   && rm -rf bootjdk8
 
-# Download and install boot JDK from AdoptOpenJDK for java 11
-RUN mkdir -p /usr/lib/jvm/adoptojdk-java-10 \
-  && cd /usr/lib/jvm/adoptojdk-java-10 \
-  && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk" \
-  && tar -xzf bootjdk10.tar.gz \
-  && rm -f bootjdk10.tar.gz \
-  && mv $(ls | grep -i jdk-10) bootjdk10 \
-  && mv bootjdk10/* /usr/lib/jvm/adoptojdk-java-10 \
-  && rm -rf bootjdk10
+# Download and install boot JDK from AdoptOpenJDK for java 11 and 12
+RUN mkdir -p /usr/lib/jvm/adoptojdk-java-11 \
+  && cd /usr/lib/jvm/adoptojdk-java-11 \
+  && wget -O bootjdk11.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk" \
+  && tar -xzf bootjdk11.tar.gz \
+  && rm -f bootjdk11.tar.gz \
+  && mv $(ls | grep -i jdk-11) bootjdk11 \
+  && mv bootjdk11/* /usr/lib/jvm/adoptojdk-java-11 \
+  && rm -rf bootjdk11
 
 # Set up sshd config
 RUN mkdir /var/run/sshd \

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -117,8 +117,8 @@ linux_390-64_cmprssptrs:
     8: '/usr/lib/jvm/adoptojdk-java-s390x-80'
     9: '/usr/lib/jvm/adoptojdk-java-s390x-80'
     10: '/usr/lib/jvm/adoptojdk-java-s390x-90'
-    11: '/usr/lib/jvm/adoptojdk-java-10'
-    next: '/usr/lib/jvm/adoptojdk-java-10'
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+    next: '/usr/lib/jvm/adoptojdk-java-11'
   release:
     8: 'linux-s390x-normal-server-release'
     9: 'linux-s390x-normal-server-release'


### PR DESCRIPTION
Compiling JDK version N requires bootJDK N or N-1. JDK11 compiles will
now boot from JDK11. This will not harm JDK11 compiles but allows
JDK12 to be compiled using the same bootJDK.

Signed-off-by: Colton Mills <millscolt3@gmail.com>