### PR TITLE
Add new test for blocking static field access during class init

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/clinit/GetStaticTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/clinit/GetStaticTest.java
@@ -65,5 +65,7 @@ public class GetStaticTest {
 		}
 	}
 
-	public static void main(String[] args) { GetStaticTest.test(); }
+	public static void main(String[] args) {
+		GetStaticTest.test();
+	}
 }


### PR DESCRIPTION
The existing test isn't rigorous enough - static field accesses were
invalidly allowed during certain class initialization patterns.

See: #2794

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>