### PR TITLE
Store Client's isIProfilerEnabled info at Server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -414,6 +414,7 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          vmInfo._canMethodEnterEventBeHooked = fe->canMethodEnterEventBeHooked();
          vmInfo._canMethodExitEventBeHooked = fe->canMethodExitEventBeHooked();
          vmInfo._usesDiscontiguousArraylets = TR::Compiler->om.usesDiscontiguousArraylets();
+         vmInfo._isIProfilerEnabled = fe->getIProfiler();
          vmInfo._arrayletLeafLogSize = TR::Compiler->om.arrayletLeafLogSize();
          vmInfo._arrayletLeafSize = TR::Compiler->om.arrayletLeafSize();
          vmInfo._overflowSafeAllocSize = static_cast<uint64_t>(fe->getOverflowSafeAllocSize());

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -81,6 +81,7 @@ class ClientSessionData
       bool _canMethodEnterEventBeHooked;
       bool _canMethodExitEventBeHooked;
       bool _usesDiscontiguousArraylets;
+      bool _isIProfilerEnabled;
       int32_t _arrayletLeafLogSize;
       int32_t _arrayletLeafSize;
       uint64_t _overflowSafeAllocSize;

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1364,3 +1364,19 @@ TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
 
    return (J9_ARE_ALL_BITS_SET(extraModifiers, J9AccClassAnonClass));
    }
+
+TR_IProfiler *
+TR_J9ServerVM::getIProfiler()
+   {
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   auto * vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   if (!vmInfo->_isIProfilerEnabled)
+      return NULL;
+
+   if (!_iProfiler)
+      {
+      // This used to use a global variable called 'jitConfig' instead of the local object's '_jitConfig'.  In early out of memory scenarios, the global jitConfig may be NULL.
+      _iProfiler = ((TR_JitPrivateConfig*)(_jitConfig->privateConfig))->iProfiler;
+      }
+   return _iProfiler;
+   }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -162,6 +162,7 @@ public:
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
    using TR_J9VM :: isAnonymousClass;
    virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;
+   virtual TR_IProfiler *getIProfiler() override;
    };
 
 #endif // VMJ9SERVER_H


### PR DESCRIPTION
There are cases where a client disables its IProfiler. Server needs to keep track of this information for each client so that it only uses it for client that has IProfiler enabled.
[skip ci]

Closes: #3736

Signed-off-by: Harry Yu <harryyu1994@gmail.com>