### PR TITLE
Updated x86 cent6 Dockerfile for JDK12. Build jdk11 with jdk11

### DIFF
--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -32,8 +32,8 @@ FROM centos:centos6.9
 
 ENV USER="jenkins"
 
-RUN yum -y install \
-    JSON \
+RUN yum -y update \
+  && yum -y install \
     alsa-lib-devel \
     bind-utils \
     bison \
@@ -58,6 +58,7 @@ RUN yum -y install \
     java-1.8.0-openjdk-devel \
     lbzip2 \
     libdwarf \
+    libstdc++-static \
     libX11-devel \
     libXext-devel \
     libXrender-devel \
@@ -66,6 +67,7 @@ RUN yum -y install \
     make \
     mesa-libGL-devel \
     mpfr-devel \
+    nasm \
     numactl-devel \
     ntp \
     openssl-devel \
@@ -82,9 +84,12 @@ RUN yum -y install \
     wget\
     xz \
     zip \
-    https://$(rpm -E '%{?centos:centos}%{!?centos:rhel}%{rhel}').iuscommunity.org/ius-release.rpm \
-    libdwarf-devel \
-  && rm -rf /var/lib/apt/lists/*
+  && yum clean all
+
+RUN yum -y update \
+  && yum -y install https://$(rpm -E '%{?centos:centos}%{!?centos:rhel}%{rhel}').iuscommunity.org/ius-release.rpm \
+  && yum -y install libdwarf-devel \
+  && yum clean all
 
 # Install autoconf version 2.69
 RUN cd /usr/src/ \
@@ -94,34 +99,53 @@ RUN cd /usr/src/ \
   && cd autoconf-2.69 \
   && ./configure \
   && make \
-  && make install
+  && make install \
+  && cd .. \
+  && rm -rf /usr/src/autoconf-2.69
 
 # Dependency required by test framework
-RUN /usr/bin/perl -MCPAN -e'install Text::CSV' \
-  && /usr/bin/perl -MCPAN -e'install JSON'
+RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
+  && cpanm Text::CSV \
+  && cpanm JSON
 
-# install GCC-4.8
+# install GCC-4.8 and GCC-7.3
 RUN cd /etc/yum.repos.d \
   && wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo \
+  && yum -y update \
   && yum -y install devtoolset-2-gcc devtoolset-2-binutils \
   && yum -y install devtoolset-2-gcc-c++ devtoolset-2-gcc-gfortran \
+  && yum clean all \
   && scl enable devtoolset-2 bash \
   && mv /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 \
   && mv /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8 \
   && ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 /usr/bin/gcc \
   && ln -s /opt/rh/devtoolset-2/root/usr/bin/g++-4.8 /usr/bin/g++ \
-  && ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 /usr/bin/cc
+  && ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 /usr/bin/cc \
+  && yum -y update \
+  && yum -y install centos-release-scl \
+  && yum -y install devtoolset-7-gcc devtoolset-7-binutils \
+  && yum -y install devtoolset-7-gcc-c++ devtoolset-2-gcc-gfortran \
+  && yum clean all
 
 #Building and setting up git version 2.5.3
-RUN yum -y install curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker \
+RUN yum -y update \
+  && yum -y install \
+    curl-devel \
+    expat-devel \
+    gettext-devel \
+    openssl-devel \
+    perl-ExtUtils-MakeMaker \
+    zlib-devel \
+  && yum clean all \
   && cd /usr/src \
   && wget https://www.kernel.org/pub/software/scm/git/git-2.5.3.tar.gz \
   && tar xzf git-2.5.3.tar.gz \
   && rm git-2.5.3.tar.gz \
   && cd git-2.5.3 \
-  && make prefix=/usr/local/git all \
-  && make prefix=/usr/local/git install \
-  && ln -s /usr/local/git/bin/git /usr/bin/git
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && cd .. \
+  && rm -rf /usr/src/git-2.5.3
 
 # Install ant version 1.10.5.
 RUN wget http://www.us.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz \
@@ -142,7 +166,8 @@ RUN wget http://www.us.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz
 RUN cd /usr/src/ \
   && wget http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run \
   && chmod +x cuda_7.5.18_linux.run \
-  && /usr/src/cuda_7.5.18_linux.run --silent --toolkit --override
+  && /usr/src/cuda_7.5.18_linux.run --silent --toolkit --override \
+  && rm -f /usr/src/cuda_7.5.18_linux.run
 
 # add user home/jenkins
 RUN useradd -ms /bin/bash ${USER} \
@@ -150,7 +175,8 @@ RUN useradd -ms /bin/bash ${USER} \
 COPY authorized_keys /home/${USER}/.ssh/authorized_keys
 COPY known_hosts /home/${USER}/.ssh/known_hosts
 RUN chown -R ${USER}:${USER} /home/${USER} \
-  && chmod 644 /home/${USER}/.ssh/authorized_keys
+  && chmod 644 /home/${USER}/.ssh/authorized_keys \
+  && chmod 644 /home/${USER}/.ssh/known_hosts
 
 # set up sshd config
 RUN mkdir /var/run/sshd \
@@ -162,34 +188,17 @@ RUN mkdir /var/run/sshd \
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 # Setup boot JDK for building Java 8
-RUN ln -s java-1.7.0 /usr/lib/jvm/java-7-openjdk-amd64
-
-# Setup boot JDK for building Java 9
-RUN mkdir /usr/lib/jvm/adoptojdk-java-80 \
-  && cd /usr/lib/jvm/adoptojdk-java-80 \
-  && wget -O bootjdk8.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk" \
-  && tar -xzf bootjdk8.tar.gz \
-  && rm -f bootjdk8.tar.gz \
-  && mv $(ls | grep -i jdk) bootjdk8 \
-  && mv bootjdk8/* /usr/lib/jvm/adoptojdk-java-80
-
-# Setup boot JDK for building Java 10
-RUN mkdir /usr/lib/jvm/adoptojdk-java-90 \
-  && cd /usr/lib/jvm/adoptojdk-java-90 \
-  && wget -O bootjdk9.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk" \
-  && tar -xzf bootjdk9.tar.gz \
-  && rm -f bootjdk9.tar.gz \
-  && mv $(ls | grep -i jdk) bootjdk9 \
-  && mv bootjdk9/* /usr/lib/jvm/adoptojdk-java-90
+RUN ln -s java-1.7.0 /usr/lib/jvm/java-1.7.0-openjdk
 
 # Setup boot JDK for building Java 11
-RUN mkdir /usr/lib/jvm/adoptojdk-java-10 \
+RUN mkdir -p /usr/lib/jvm/adoptojdk-java-10 \
   && cd /usr/lib/jvm/adoptojdk-java-10 \
   && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk" \
   && tar -xzf bootjdk10.tar.gz \
   && rm -f bootjdk10.tar.gz \
   && mv $(ls | grep -i jdk) bootjdk10 \
-  && mv bootjdk10/* /usr/lib/jvm/adoptojdk-java-10
+  && mv bootjdk10/* /usr/lib/jvm/adoptojdk-java-10 \
+  && rm -rf bootjdk10
 
 # Install Freemaker for building OpenJ9. Used in bash ./configure --with-freemarker-jar=<path-to-freemaker-jar>
 RUN cd /home/${USER} \
@@ -203,17 +212,17 @@ RUN cd /usr/src \
   && tar xfj curl-7.24.0.tar.bz2 \
   && rm -f curl-7.24.0.tar.bz2 \
   && cd curl-7.24.0 \
-  && ./configure --prefix=/usr \
+  && ./configure --prefix=/usr/local \
   && make \
-  && make install 
+  && make install \
+  && cd .. \
+  && rm -rf /usr/src/curl-7.24.0
 
 # Setup a reference repository cache for faster clones in the container
 RUN mkdir /home/${USER}/openjdk_cache \
   && cd /home/${USER}/openjdk_cache \
   && git init --bare \
   && git remote add jdk8 https://github.com/ibmruntimes/openj9-openjdk-jdk8.git \
-  && git remote add jdk9 https://github.com/ibmruntimes/openj9-openjdk-jdk9.git \
-  && git remote add jdk10 https://github.com/ibmruntimes/openj9-openjdk-jdk10.git \
   && git remote add jdk11 https://github.com/ibmruntimes/openj9-openjdk-jdk11.git \
   && git remote add jdk https://github.com/ibmruntimes/openj9-openjdk-jdk.git \
   && git remote add openj9 https://github.com/eclipse/openj9.git \
@@ -227,5 +236,10 @@ EXPOSE 22
 RUN mkdir -p /var/run/sshd \
   && service sshd start \
   && service sshd stop
+
+# Adding bash profile so jenkins max user processes will be unlimited
+RUN echo >> /home/jenkins/.bashrc \
+  && echo "# Change max user processes in jenkins" >> /home/jenkins/.bashrc \
+  && echo "ulimit -u unlimited" >> /home/jenkins/.bashrc
 
 CMD ["/usr/sbin/sshd","-D"]

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -191,14 +191,14 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 RUN ln -s java-1.7.0 /usr/lib/jvm/java-1.7.0-openjdk
 
 # Setup boot JDK for building Java 11
-RUN mkdir -p /usr/lib/jvm/adoptojdk-java-10 \
-  && cd /usr/lib/jvm/adoptojdk-java-10 \
-  && wget -O bootjdk10.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk" \
-  && tar -xzf bootjdk10.tar.gz \
-  && rm -f bootjdk10.tar.gz \
-  && mv $(ls | grep -i jdk) bootjdk10 \
-  && mv bootjdk10/* /usr/lib/jvm/adoptojdk-java-10 \
-  && rm -rf bootjdk10
+RUN mkdir -p /usr/lib/jvm/adoptojdk-java-11 \
+  && cd /usr/lib/jvm/adoptojdk-java-11 \
+  && wget -O bootjdk11.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal" \
+  && tar -xzf bootjdk11.tar.gz \
+  && rm -f bootjdk11.tar.gz \
+  && mv $(ls | grep -i jdk-11) bootjdk11 \
+  && mv bootjdk11/* /usr/lib/jvm/adoptojdk-java-11 \
+  && rm -rf bootjdk11
 
 # Install Freemaker for building OpenJ9. Used in bash ./configure --with-freemarker-jar=<path-to-freemaker-jar>
 RUN cd /home/${USER} \

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
@@ -1,0 +1,114 @@
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+# To use this docker file:
+# First copy your public ssh key into a file named authorized_keys next to the Dockerfile
+# Then include a known_hosts file next to the Dockerfile, with github as a saved host
+# This can be done with "ssh-keyscan github.com >> path_to_dockerfile/known_hosts"
+# Make sure you are in the directory contianing the Dockerfile, authorized_keys file, and known_hosts file
+# Then run:
+#   docker build -t openj9 -f Dockerfile .
+#   docker run -it openj9
+
+FROM ubuntu:16.04
+
+# Install required OS tools
+
+ENV USER="jenkins"
+
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+  && add-apt-repository ppa:ubuntu-toolchain-r/test \
+  && apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    ant \
+    ant-contrib \
+    autoconf \
+    build-essential \
+    ca-certificates \
+    cmake \
+    cpio \
+    curl \
+    file \
+    g++-4.8 \
+    g++-7 \
+    gcc-4.8 \
+    gcc-7 \
+    gdb \
+    git \
+    git-core \
+    libasound2-dev \
+    libcups2-dev \
+    libdwarf-dev \
+    libelf-dev \
+    libfontconfig \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libnuma-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    libxt-dev \
+    libxtst-dev \
+    make \
+    openjdk-8-jdk \
+    openssh-client \
+    openssh-server \
+    perl \
+    pkg-config \
+    realpath \
+    ssh \
+    unzip \
+    wget \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Docker module to run test framework
+RUN echo yes | cpan install JSON Text::CSV
+
+# Create links for c++,g++,cc,gcc
+RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
+  && ln -s g++ /usr/bin/c++ \
+  && ln -s g++-4.8 /usr/bin/g++ \
+  && ln -s gcc /usr/bin/cc \
+  && ln -s gcc-4.8 /usr/bin/gcc
+
+# Add user home/USER and copy authorized_keys and known_hosts
+RUN useradd -ms /bin/bash ${USER} \
+  && mkdir /home/${USER}/.ssh/
+COPY authorized_keys /home/${USER}/.ssh/authorized_keys
+COPY known_hosts /home/${USER}/.ssh/known_hosts
+RUN chown -R ${USER}:${USER} /home/${USER} \
+  && chmod 644 /home/${USER}/.ssh/authorized_keys \
+  && chmod 644 /home/${USER}/.ssh/known_hosts
+
+# Set up sshd config
+RUN mkdir /var/run/sshd \
+  && sed -i 's/#PermitRootLogin/PermitRootLogin/' /etc/ssh/sshd_config \
+  && sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config \
+  && sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+# Expose SSH port and run SSH
+EXPOSE 22

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -191,8 +191,8 @@ linux_x86-64_cmprssptrs:
     8: '/usr/lib/jvm/java-7-openjdk-amd64'
     9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-90'
-    11: '/usr/lib/jvm/adoptojdk-java-10'
-    next: '/usr/lib/jvm/adoptojdk-java-10'
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+    next: '/usr/lib/jvm/adoptojdk-java-11'
   release:
     8: 'linux-x86_64-normal-server-release'
     9: 'linux-x86_64-normal-server-release'
@@ -228,8 +228,8 @@ linux_x86-64_cmprssptrs_cmake:
     8: '/usr/lib/jvm/java-7-openjdk-amd64'
     9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-90'
-    11: '/usr/lib/jvm/adoptojdk-java-10'
-    next: '/usr/lib/jvm/adoptojdk-java-10'
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+    next: '/usr/lib/jvm/adoptojdk-java-11'
   release:
     8: 'linux-x86_64-normal-server-release'
     9: 'linux-x86_64-normal-server-release'
@@ -275,8 +275,8 @@ linux_x86-64:
     8: '/usr/lib/jvm/java-7-openjdk-amd64'
     9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-90'
-    11: '/usr/lib/jvm/adoptojdk-java-10'
-    next: '/usr/lib/jvm/adoptojdk-java-10'
+    11: '/usr/lib/jvm/adoptojdk-java-11'
+    next: '/usr/lib/jvm/adoptojdk-java-11'
   release:
     8: 'linux-x86_64-normal-server-release'
     9: 'linux-x86_64-normal-server-release'


### PR DESCRIPTION
JDK11 will now be built using bootJDK11. This allows JDK12 to be built using the same bootJDK. The x86 cent6 Dockerfile, and the default variable file have been updated to reflect this change.

Depends on #3482, and should be merged afterward