### PR TITLE
Only include oit/clang/stddef.h on windows

### DIFF
--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -20,9 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 #include "clang_comp.h"
-#if defined(__clang__)
+
+#if defined(WIN32) && defined(__clang__)
 #include "../oti/clang/stddef.h"
-#endif /* defined(__clang__) */
+#endif /* defined(WIN32) && defined(__clang__) */
 #include "j9cfg.h"
 #include "VM_MethodHandleKinds.h"
 


### PR DESCRIPTION
fixes: #3810

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>