### PR TITLE
Track unloaded classes on the server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -38,6 +38,8 @@
 #include "env/j9methodServer.hpp"
 #include "exceptions/AOTFailure.hpp" // for AOTFailure
 
+extern TR::Monitor *assumptionTableMutex;
+
 uint32_t serverMsgTypeCount[JITaaS::J9ServerMessageType_ARRAYSIZE] = {};
 
 size_t methodStringsLength(J9ROMMethod *method)
@@ -201,6 +203,18 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
       case J9ServerMessageType::compilationCode:
          done = true;
          break;
+
+      case J9ServerMessageType::getUnloadedClassRanges:
+         {
+         auto unloadedClasses = comp->getPersistentInfo()->getUnloadedClassAddresses();
+         std::vector<TR_AddressRange> ranges(unloadedClasses->getNumberOfRanges());
+            {
+            OMR::CriticalSection getAddressSetRanges(assumptionTableMutex);
+            unloadedClasses->getRanges(ranges);
+            }
+         client->write(ranges, unloadedClasses->getMaxRanges());
+         break;
+         }
 
       case J9ServerMessageType::VM_isClassLibraryClass:
          {
@@ -2397,7 +2411,9 @@ ClientSessionData::ClientSessionData(uint64_t clientUID, uint32_t seqNo) :
    _chTableClassMap(decltype(_chTableClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _romClassMap(decltype(_romClassMap)::allocator_type(TR::Compiler->persistentAllocator())),
    _J9MethodMap(decltype(_J9MethodMap)::allocator_type(TR::Compiler->persistentAllocator())),
-   _systemClassByNameMap(decltype(_systemClassByNameMap)::allocator_type(TR::Compiler->persistentAllocator()))
+   _systemClassByNameMap(decltype(_systemClassByNameMap)::allocator_type(TR::Compiler->persistentAllocator())),
+   _unloadedClassAddresses(NULL),
+   _requestUnloadedClasses(true)
    {
    updateTimeOfLastAccess();
    _javaLangClassPtr = nullptr;
@@ -2415,20 +2431,52 @@ ClientSessionData::~ClientSessionData()
    _romMapMonitor->destroy();
    _systemClassMapMonitor->destroy();
    _sequencingMonitor->destroy();
+   if (_unloadedClassAddresses)
+      {
+      _unloadedClassAddresses->destroy();
+      jitPersistentFree(_unloadedClassAddresses);
+      }
    jitPersistentFree(_vmInfo);
    }
 
 void
-ClientSessionData::processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*> &classes)
+ClientSessionData::processUnloadedClasses(JITaaS::J9ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes)
    {
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Server will process a list of %u unloaded classes for clientUID %llu", (unsigned)classes.size(), (unsigned long long)_clientUID);
-   OMR::CriticalSection processUnloadedClasses(getROMMapMonitor());
-   for (TR_OpaqueClassBlock *clazz : classes)
+
+   bool updateUnloadedClasses = true;
+   if (_requestUnloadedClasses)
       {
+      stream->write(JITaaS::J9ServerMessageType::getUnloadedClassRanges, JITaaS::Void());
+
+      auto response = stream->read<std::vector<TR_AddressRange>, int32_t>();
+      auto unloadedClassRanges = std::get<0>(response);
+      auto maxRanges = std::get<1>(response);
+
+         {
+         OMR::CriticalSection getUnloadedClasses(getROMMapMonitor());
+
+         if (!_unloadedClassAddresses)
+            _unloadedClassAddresses = new (PERSISTENT_NEW) TR_AddressSet(trPersistentMemory, maxRanges);
+         _unloadedClassAddresses->setRanges(unloadedClassRanges);
+         _requestUnloadedClasses = false;
+         }
+
+      updateUnloadedClasses = false;
+      }
+
+   OMR::CriticalSection processUnloadedClasses(getROMMapMonitor());
+
+   for (auto clazz : classes)
+      {
+      if (updateUnloadedClasses)
+         _unloadedClassAddresses->add((uintptrj_t)clazz);
+
       auto it = _romClassMap.find((J9Class*) clazz);
       if (it == _romClassMap.end())
          continue; // unloaded class was never cached
+
       J9ROMClass *romClass = it->second.romClass;
       J9Method *methods = it->second.methodsOfClass;
       // delete all the cached J9Methods belonging to this unloaded class
@@ -2629,6 +2677,7 @@ ClientSessionData::clearCaches()
       jitPersistentFree(classInfo);
       }
    _chTableClassMap.clear();
+   _requestUnloadedClasses = true;
    }
 
 void 
@@ -3275,8 +3324,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       // Free data for all classes that were unloaded for this sequence number
       // Redefined classes are marked as unloaded, since they need to be cleared
       // from the ROM class cache.
-      if (unloadedClasses.size() != 0)
-         clientSession->processUnloadedClasses(unloadedClasses); // this locks getROMMapMonitor()
+      clientSession->processUnloadedClasses(stream, unloadedClasses); // this locks getROMMapMonitor()
 
       auto chTable = (TR_JITaaSServerPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
       // TODO: is chTable always non-null?

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -99,13 +99,18 @@ class ClientSessionData
    PersistentUnorderedMap<J9Class*, ClassInfo> & getROMClassMap() { return _romClassMap; }
    PersistentUnorderedMap<J9Method*, J9MethodInfo> & getJ9MethodMap() { return _J9MethodMap; }
    PersistentUnorderedMap<std::string, TR_OpaqueClassBlock*> & getSystemClassByNameMap() { return _systemClassByNameMap; }
-   void processUnloadedClasses(const std::vector<TR_OpaqueClassBlock*> &classes);
+   void processUnloadedClasses(JITaaS::J9ServerStream *stream, const std::vector<TR_OpaqueClassBlock*> &classes);
    TR::Monitor *getROMMapMonitor() { return _romMapMonitor; }
    TR::Monitor *getSystemClassMapMonitor() { return _systemClassMapMonitor; }
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
    VMInfo *getOrCacheVMInfo(JITaaS::J9ServerStream *stream);
    void clearCaches(); // destroys _chTableClassMap, _romClassMap and _J9MethodMap
+   TR_AddressSet& getUnloadedClassAddresses()
+      {
+      TR_ASSERT(_unloadedClassAddresses, "Unloaded classes address set should exist by now");
+      return *_unloadedClassAddresses;
+      }
 
    void incInUse() { _inUse++; }
    void decInUse() { _inUse--; TR_ASSERT(_inUse >= 0, "_inUse=%d must be positive\n", _inUse); }
@@ -158,6 +163,9 @@ class ClientSessionData
                              // This is smaller or equal to _inUse because some threads
                              // could be just starting or waiting in _OOSequenceEntryList
    VMInfo *_vmInfo; // info specific to a client VM that does not change, nullptr means not set
+
+   TR_AddressSet *_unloadedClassAddresses; // Per-client versions of the unloaded class and method addresses kept in J9PersistentInfo
+   bool           _requestUnloadedClasses; // If true we need to request the current state of unloaded classes from the client
    }; // ClientSessionData
 
 // Hashtable that maps clientUID to a pointer that points to ClientSessionData

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -159,6 +159,7 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    bool isUnloadedClass(void *v, bool yesIReallyDontCareAboutHCR); // You probably want isObsoleteClass
    bool isInUnloadedMethod(uintptrj_t address);
    int32_t getNumUnloadedClasses() const { return _numUnloadedClasses; }
+   TR_AddressSet* getUnloadedClassAddresses() { return _unloadedClassAddresses; }
 
    void incNumLoadedClasses() {_numLoadedClasses++;}
 

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -49,6 +49,7 @@ enum J9ServerMessageType
    compilationCode = 0;
    mirrorResolvedJ9Method = 1;
    get_params_to_construct_TR_j9method = 2;
+   getUnloadedClassRanges = 3;
 
    // For TR_ResolvedJ9JITaaSServerMethod methods
    ResolvedMethod_isJNINative = 100;
@@ -222,7 +223,7 @@ enum J9ServerMessageType
    CompInfo_isClassSpecial = 409;
    CompInfo_getJ9MethodStartPC = 410;
 
-   // For J109::ClassEnv Methods
+   // For J9::ClassEnv Methods
    ClassEnv_classFlagsValue = 500;
    ClassEnv_classDepthOf = 501;
    ClassEnv_classInstanceSize = 502;

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -593,7 +593,7 @@ protected:
    bool isCompact(U_8 byteCode);
    bool isSwitch(U_8 byteCode);
    bool isNewOpCode(U_8 byteCode);
-   bool invalidateEntryIfInconsistent(TR_IPBytecodeHashTableEntry *entry);
+   virtual bool invalidateEntryIfInconsistent(TR_IPBytecodeHashTableEntry *entry);
    TR::CompilationInfo *getCompInfo() { return _compInfo; }
 
 private:

--- a/runtime/compiler/runtime/JITaaSIProfiler.cpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.cpp
@@ -352,6 +352,12 @@ TR_JITaaSIProfiler::printStats()
       }
    }
 
+bool
+TR_JITaaSIProfiler::invalidateEntryIfInconsistent(TR_IPBytecodeHashTableEntry *entry)
+   {
+   // Invalid entries are purged early in the compilation for JITaaS, we don't need to do anything here.
+   }
+
 TR_JITaaSClientIProfiler *
 TR_JITaaSClientIProfiler::allocate(J9JITConfig *jitConfig)
    {

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -68,10 +68,12 @@ public:
    virtual int32_t getMaxCallCount() override;
    virtual void setCallCount(TR_OpaqueMethodBlock *method, int32_t bcIndex, int32_t count, TR::Compilation *) override;
 
-
    TR_IPBytecodeHashTableEntry *ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptrj_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
    TR_IPMethodHashTableEntry *deserializeMethodEntry(TR_ContiguousIPMethodHashTableEntry *serialEntry, TR_Memory *trMemory);
    void printStats();
+
+protected:
+   virtual bool invalidateEntryIfInconsistent(TR_IPBytecodeHashTableEntry *entry) override;
 
 private:
    void validateCachedIPEntry(TR_IPBytecodeHashTableEntry *entry, TR_IPBCDataStorageHeader *clientData, uintptrj_t methodStart, bool isMethodBeingCompiled, TR_OpaqueMethodBlock *method);

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -229,6 +229,12 @@ class TR_AddressSet
       _maxAddressRanges(maxAddressRanges)
       {}
 
+   void destroy();
+   void getRanges(std::vector<TR_AddressRange> &ranges);
+   void setRanges(const std::vector<TR_AddressRange> &ranges);
+   int32_t getNumberOfRanges() { return _numAddressRanges; }
+   int32_t getMaxRanges() { return _maxAddressRanges; }
+
    void add        (uintptrj_t address){ add(address, address); }
    void add        (uintptrj_t start, uintptrj_t end);
    bool mayContain (uintptrj_t address)


### PR DESCRIPTION
When sending a list of unloaded classes to the server,
the client will also send the range of memory the
methods of each class occupy. This info will be used
to maintain per-client `TR_AddressSet`s of unloaded
classes and methods on the server.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>