### PR TITLE
Fix sigxfszHandlingTests on OSX

### DIFF
--- a/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
@@ -36,6 +36,7 @@
 		<copy todir="${DEST}">
 			<fileset dir="${src}" includes="*.xml"/>
 			<fileset dir="${src}" includes="*.mk"/>
+			<fileset dir="${src}" includes="*.sh"/>
 		</copy>
 	</target>
 

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/playlist.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/playlist.xml
@@ -29,10 +29,14 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
-	ulimit -f 4000 && \
-	ulimit && \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
+	-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' \
+	-DRESJAR=$(CMDLINETESTER_RESJAR) \
+	-DTESTDIR=$(TEST_RESROOT) \
+	-DPATHSEP=$(Q)$(D)$(Q) \
+	-DRUN_SCRIPT=$(RUN_SCRIPT) \
+	-DSCRIPT_SUFFIX=$(SCRIPT_SUFFIX) \
+	-jar $(CMDLINETESTER_JAR) \
 	-config $(Q)$(TEST_RESROOT)$(D)sigxfszHandlingTest.xml$(Q) \
 	-plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError  ; \
 	${TEST_STATUS}</command>

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/runSIGXFSZTest.sh
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/runSIGXFSZTest.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#
+
+# Get the test command
+TEST_CMD=$1
+
+# Set the file size limit to raise SIGXFSZ signal
+ulimit -f 4000
+
+# Print the value of the file size limit
+ulimit -f
+
+echo Running: $TEST_CMD
+$TEST_CMD

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/sigxfszHandlingTest.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/sigxfszHandlingTest.xml
@@ -32,7 +32,7 @@
 <!-- Add -Xshareclasses:none to the command lines of this test suite to ensure that signal SIGXFSZ is triggered on test.txt creation rather than 
 	on shared cache file creation (if shared classes is enabled by default). See issue: https://github.com/eclipse/openj9/issues/3333 -->
  <test id="Default">
-	<command>$EXE$ -Xshareclasses:none $CP$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -45,7 +45,7 @@
  </test>
 
  <test id="-XX:+HandleSIGXFSZ">
-	<command>$EXE$ -Xshareclasses:none $CP$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -58,7 +58,7 @@
  </test>
 
 <test id="-XX:-HandleSIGXFSZ -XX:+HandleSIGXFSZ">
-	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ $HANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -71,7 +71,7 @@
  </test>
 
 <test id=" -Xrs">
-	<command>$EXE$ -Xshareclasses:none $CP$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -84,7 +84,7 @@
  </test>
 
  <test id="-XX:+HandleSIGXFSZ -Xrs">
-	<command>$EXE$ -Xshareclasses:none $CP$ $HANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $HANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="required">java.io.IOException</output>
@@ -98,7 +98,7 @@
 
  <!-- Linux can not handle sigxfsz without special handling in VM. JVM should exit with exit code 153 -->
  <test id="-XX:-HandleSIGXFSZ (Linux)" platforms="linux.*">
-	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">Failed to write the file:</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>
@@ -111,7 +111,7 @@
 
 <!-- Linux can not handle sigxfsz without special handling in VM. JVM should exit with exit code 153 -->
  <test id="-XX:+HandleSIGXFSZ -XX:-HandleSIGXFSZ (Linux)" platforms="linux.*">
-	<command>$EXE$ -Xshareclasses:none $CP$ $HANDLE$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $HANDLE$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">Failed to write the file:</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>
@@ -124,7 +124,7 @@
 
 <!-- Linux can not handle sigxfsz without special handling in VM. JVM should exit with exit code 153 -->
  <test id="-XX:-HandleSIGXFSZ -Xrs (Linux)" platforms="linux.*">
-	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ -Xrs j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">Failed to write the file:</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>
@@ -137,7 +137,7 @@
 
  <!-- AIX and ZOS handles this by default. No need for special handling in JVM -->
  <test id="-XX:-HandleSIGXFSZ (AIX)" platforms="aix.*">
-	<command>$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt</command>
+	<command>$RUN_SCRIPT$ $TESTDIR$$PATHSEP$runSIGXFSZTest$SCRIPT_SUFFIX$ "$EXE$ -Xshareclasses:none $CP$ $NOHANDLE$ j9vm.test.sigxfsz.SignalXfszTest test.txt"</command>
 	<output regex="no" type="required">Starting SignalXfszTest</output>
 	<output regex="no" type="success">Failed to write the file</output>
 	<output regex="no" type="failure" caseSensitive="no" regex="no">File is written successfully</output>


### PR DESCRIPTION
For the `SIGXFSZ` tests to successfully work, file size limit (`ulimit -f 4000`) 
needs to be set. Restricting file size limit causes `SIGXFSZ` to be
raised. On OSX, `ulimit -f 4000` is not persistent. `ulimit -f 4000` is
invoked only once before running the `SIGXFSZ` tests. After the first
`SIGXFSZ` test is run, file size limit automatically changes from `4000` to
`unlimited` on OSX. This causes the remaining `SIGXFSZ` tests to fail.

Instead of setting file size limit once before running all `SIGXFSZ` tests,
file size limit (`ulimit -f 4000`) will be set before running each `SIGXFSZ`
test in order to fix `SIGXFSZ` test failures on OSX.

On Linux, file size limit (`ulimit -f 4000`) is persistent. This can cause
`non-SIGXFSZ` tests to fail. Now onwards, each `SIGXFSZ` test will be
run in a new shell. Thus, `non-SIGXFSZ` tests won't be impacted by 
`ulimit -f 4000`. `runSIGXFSZTest.sh` has been added to run `SIGXFSZ`
tests in a new shell.

`SIGXFSZ` tests are not run on Windows since `SIGXFSZ` is not supported on
Windows. So, `*.bat` variant of `runSIGXFSZTest.sh` is not needed.

Fixes: https://github.com/eclipse/openj9/issues/3342
Fixes: https://github.com/eclipse/openj9/issues/3779

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>