### PR TITLE
Fix the issue with carriage return removal

### DIFF
--- a/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
+++ b/test/TestConfig/scripts/testKitGen/resultsSummary/resultsSum.pl
@@ -74,9 +74,9 @@ sub resultReporter {
 				my $startTime = 0;
 				my $endTime = 0;
 				while ( $result = <$fhIn> ) {
-					$output .= '        ' . $result;
 					# remove extra carriage return
-					$output =~ s/\r//g;
+					$result =~ s/\r//g;
+					$output .= '        ' . $result;
 					if ($result =~ /Running test (.*) \.\.\.\n/) {
 						$testName = $1;
 					} elsif ($result =~ /^\Q$testName\E Start Time: .* Epoch Time \(ms\): (.*)\n/) {


### PR DESCRIPTION
- remove \t in each line instead of the entire output

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>