### PR TITLE
Preventing out-of-order updates in JITaaS

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -951,6 +951,9 @@ public:
    void setClientSessionHT(ClientSessionHT *ht) { _clientSessionHT = ht; }
    PersistentVector<TR_OpaqueClassBlock*> *getUnloadedClassesTempList() { return _unloadedClassesTempList; }
    void setUnloadedClassesTempList(PersistentVector<TR_OpaqueClassBlock*> *it) { _unloadedClassesTempList = it; }
+   TR::Monitor *getSequencingMonitor() { return _sequencingMonitor; }
+   uint32_t getCompReqSeqNo() const { return _compReqSeqNo; }
+   uint32_t incCompReqSeqNo() { return ++_compReqSeqNo; }
    PersistentUnorderedMap<TR_OpaqueClassBlock*, uint8_t> *getNewlyExtendedClasses() { return _newlyExtendedClasses; }
    void classGotNewlyExtended(TR_OpaqueClassBlock* clazz)
       {
@@ -1150,6 +1153,8 @@ private:
    ClientSessionHT *_clientSessionHT;
    // JITaaS list of classes unloaded 
    PersistentVector<TR_OpaqueClassBlock*> *_unloadedClassesTempList;
+   TR::Monitor *_sequencingMonitor; // used for ordering outgoing messages at the client
+   uint32_t _compReqSeqNo; // seqNo for outgoing messages at the client
    // JITaaS table of newly extended classes
    PersistentUnorderedMap<TR_OpaqueClassBlock*, uint8_t> *_newlyExtendedClasses;
    uint8_t _chTableUpdateFlags;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -200,6 +200,7 @@ char *compilationErrorNames[]={
    "compilationEnforceProfiling", //49
    "compilationSymbolValidationManagerFailure", //50
    "compilationStreamFailure", //51
+   "compilationStreamLostMessage", // 52
    "compilationMaxError"
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -75,6 +75,7 @@ typedef enum {
    compilationEnforceProfiling                     = 49,
    compilationSymbolValidationManagerFailure       = 50,
    compilationStreamFailure                        = 51,
+   compilationStreamLostMessage                    = 52,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/env/JITaaSPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.hpp
@@ -45,8 +45,9 @@ public:
 
    TR_JITaaSServerPersistentCHTable(TR_PersistentMemory *);
 
-   void initializeIfNeeded();
-   void doUpdate(TR::Compilation *comp);
+   bool isInitialized() { return !getData().empty(); } // needs CHTable mutex in hand
+   bool initializeIfNeeded(TR_J9VMBase *fej9);
+   void doUpdate(TR_J9VMBase *fej9);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId) override;
    virtual TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false, bool validate = true) override;

--- a/runtime/compiler/rpc/StreamTypes.hpp
+++ b/runtime/compiler/rpc/StreamTypes.hpp
@@ -50,6 +50,12 @@ namespace JITaaS
       virtual const char* what() const throw() { return "compilation canceled by client"; }
       };
 
+   class StreamOOO : public virtual std::exception
+      {
+      public:
+         virtual const char* what() const throw() { return "Messages arriving out-of-order"; }
+      };
+
    class StreamTypeMismatch: public virtual StreamFailure
       {
    public:


### PR DESCRIPTION
The client sends class unloading and CHTable updates with each compilation
request and the JITaaS server needs to apply those updates in the order
they were generated. Unfortunatelly, the updates can arrive out-of-order
at the server and this can lead to functional problems. The solution
implemented by this commit uses a sequencing scheme based on ticket numbers.

The client obtains a sequence number (a ticket) that defines the update
and attaches it to the compilation request.
The server obtains a pointer to the clientSession and then enters a
critical section protected by the "sequencingMonitor" where compilation
requests are reordered. The clientSession maintains an "expectedSeqNo"
variable and only a request with a matching sequence number can pass
through. Any request with a larger sequence number is put onto a
waiting list (we say that handling threads are parked). Waiting is done
on a monitor associated with the entry (this scheme allows us to pick
which threads to wake up).
Any request with a smaller sequence number is cancelled (this can happen
at the very beginning when a later compilation request arrives first and
creates the clientSession).
The thread that goes through applies its updates to the CHTable and the
hashtable with ramClass-->romClass mappings and then increments
expectedSeqNo to allow the next thread to pass. Also, it needs to notify
any potential thread that is parked waiting for its turn.
The first thread that goes through the sequencing critical section and
finds an empty CHTable is responsible for fetching the entire CHTable
from the client (this is done only once).

A big complication is introduced by messages that are lost. If a message
never arrives, the threads that are parked are going to time-out, but
since the lost message could carry crucial information, these threads
cannot continue safely. In order to avoid cancelling these compilation
requests, when the thread at the front of the waiting list times-out,
it waits for any active threads (threads that actually perform
compilations) to drain out, it clears the caches for this clientSession
and then it changes the expectedSeqNo to allow itself to go through the
sequencing critical section. Parked threads are notified as before.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>