### PR TITLE
Allow executables to allocate memory below 4GB

### DIFF
--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -48,6 +48,9 @@ $(UMA_EXETARGET): $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 UMA_BEGIN_DASH_L =
 UMA_END_DASH_L =
 
+<#-- Reduce __PAGEZERO segment size from 4GB to 4KB to allocate memory below 4 GB. -->
+UMA_EXE_PREFIX_FLAGS += -pagezero_size 0x1000
+
 UMA_EXE_POSTFIX_FLAGS += -lm -liconv -lc -ldl -lutil -Wl,-rpath,@loader_path
 
 <#if uma.spec.processor.amd64>


### PR DESCRIPTION
Native executables, that invoke OpenJ9 in compressedrefs mode, should be
able to allocate memory below 4GB. But, __PAGEZERO segment takes the
first 4GB by default on OSX 64-bit architectures.

With -pagezero_size 0x1000, __PAGEZERO segment size is reduced to 4KB.
This allows OpenJ9 in compressedrefs mode to allocate memory below 4GB.

-pagezero_size 0x1000 can be used for both compressedrefs and
non-compressedrefs variants. This will allow executables to work with
both compressedrefs and non-compressedrefs OpenJ9 librarires.

Fixes: https://github.com/eclipse/openj9/issues/3795

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>