### PR TITLE
CMake: Disable building DDR

### DIFF
--- a/runtime/cmake/omr_config.cmake
+++ b/runtime/cmake/omr_config.cmake
@@ -21,7 +21,7 @@
 ################################################################################
 
 # Various config options we apply to OMR
-
+set(OMR_DDR OFF CACHE INTERNAL "")
 set(OMR_EXAMPLE OFF CACHE INTERNAL "")
 set(OMR_FVTEST OFF CACHE INTERNAL "")
 set(OMR_GC ON CACHE INTERNAL "")


### PR DESCRIPTION
The openj9 cmake build system does nto currently support ddr

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>