### PR TITLE
CMake: allow use of ccache

### DIFF
--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -95,6 +95,7 @@ fi
 
 
 if test "x$RUN_BUILD" = "xyes"; then
+  export CCACHE=ccache
   if [ ! `wget https://ci.eclipse.org/openj9/userContent/freemarker-2.3.8.jar -O freemarker.jar` ]; then
       wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz;
       tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2;

--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -35,6 +35,37 @@ BUILD_ID      ?= 000000
 OS            := $(shell uname)
 TRC_THRESHOLD ?= 1
 FREEMARKER_JAR ?= $(CURDIR)/buildtools/freemarker.jar
+CMAKE_ARGS :=
+
+# We grab the C/C++ compilers detected by autoconf or provided by user, not
+# the CC/CXX variables defined by the makefiles, which potentitally include
+# the ccache command which will throw off cmake
+ifneq (,$(OPENJ9_CC))
+  CMAKE_ARGS += "-DCMAKE_C_COMPILER=$(OPENJ9_CC)"
+else
+  CMAKE_ARGS += "-DCMAKE_C_COMPILER=$(ac_cv_prog_CC)"
+endif
+
+ifneq (,$(OPENJ9_CXX))
+  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER=$(OPENJ9_CXX)"
+else
+  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER=$(ac_cv_prog_CXX)"
+endif
+
+ifneq (,$(CCACHE))
+  # Open jdk makefiles add a  bunch of environemnt variables to the ccache command
+  # cmake will not parse this properly, so we wrap the whole thing in the env command
+  # We also need to add semicolons between arguments or else cmake will treat the whole
+  # thing as one long command name
+
+  # Note: we remove the CCACHE_COMPRESS option that openjdk adds, because it significantly
+  # slows down the build (to the point of erasing any gains from using ccache)
+  CCACHE_NOCOMPRESS := $(filter-out CCACHE_COMPRESS=1,$(CCACHE))
+  ESCAPED_CCACHE :=env$(shell printf ";%s" $(CCACHE_NOCOMPRESS))
+
+  CMAKE_ARGS += "-DCMAKE_CXX_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
+  CMAKE_ARGS += "-DCMAKE_C_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
+endif
 
 ifneq (,$(or $(findstring Windows,$(OS)),$(findstring CYGWIN,$(OS))))
 	PATHSEP := ;
@@ -50,7 +81,7 @@ else
 endif
 
 ifneq (,$(VERSION_MAJOR))
-	EXTRA_CMAKE_ARGS += -DJAVA_SPEC_VERSION=$(VERSION_MAJOR)
+	CMAKE_ARGS += -DJAVA_SPEC_VERSION=$(VERSION_MAJOR)
 endif
 
 default : all
@@ -156,7 +187,7 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 # If we are doing a cmake build, configure won't depend on UMA.
 # However we need to run constantpool and nls tools before invoking cmake.
 configure : constantpool nls
-	mkdir -p build && cd build && $(CMAKE) -C ../cmake/caches/$(SPEC).cmake $(EXTRA_CMAKE_ARGS) ..
+	mkdir -p build && cd build && $(CMAKE) -C ../cmake/caches/$(SPEC).cmake  $(CMAKE_ARGS) $(EXTRA_CMAKE_ARGS) ..
 else
 configure : uma
 	$(MAKE) -C omr -f run_configure.mk 'SPEC=$(SPEC)' 'OMRGLUE=$(OMRGLUE)' 'CONFIG_INCL_DIR=$(CONFIG_INCL_DIR)' 'OMRGLUE_INCLUDES=$(OMRGLUE_INCLUDES)' 'EXTRA_CONFIGURE_ARGS=$(EXTRA_CONFIGURE_ARGS)'


### PR DESCRIPTION
Modify the buildtools.mk file to work properly with the way that openjdk
makefiles utilize ccache

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>