### PR TITLE
Improve SymbolValidationManager compatibility with JITaaS

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2842,20 +2842,23 @@ J9::CodeGenerator::processRelocations()
             }
          }
 
-      TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
-      if (!validationRecords.empty() && self()->comp()->getOption(TR_UseSymbolValidationManager))
+      if (self()->comp()->getOption(TR_UseSymbolValidationManager))
          {
-         // Add the flags in TR_AOTMethodHeader on the compile run
-         J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)self()->comp()->getAotMethodDataStart();
-         TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
-         aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesSymbolValidationManager;
-
-         for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
+         TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
+         if (!validationRecords.empty())
             {
-            self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                             (uint8_t *)(*it),
-                                                                             (*it)->_kind, self()),
-                                                                             __FILE__, __LINE__, NULL);
+            // Add the flags in TR_AOTMethodHeader on the compile run
+            J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)self()->comp()->getAotMethodDataStart();
+            TR_AOTMethodHeader *aotMethodHeaderEntry = (TR_AOTMethodHeader *)(aotMethodHeader + 1);
+            aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_UsesSymbolValidationManager;
+
+            for (auto it = validationRecords.begin(); it != validationRecords.end(); it++)
+               {
+               self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(NULL,
+                                                                                (uint8_t *)(*it),
+                                                                                (*it)->_kind, self()),
+                                                                                __FILE__, __LINE__, NULL);
+               }
             }
          }
 

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -171,7 +171,10 @@ J9::Compilation::Compilation(int32_t id,
    _skippedJProfilingBlock(false),
    _reloRuntime(reloRuntime)
    {
-   _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
+   if (((TR_J9VMBase *)fe)->canUseSymbolValidationManager() || optimizationPlan->getIsAotLoad())
+      _symbolValidationManager = new (self()->region()) TR::SymbolValidationManager(self()->region(), compilee);
+   else
+      _symbolValidationManager = NULL;
 
    _aotClassClassPointer = NULL;
    _aotClassClassPointerInitialized = false;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -72,11 +72,10 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
 
-   struct J9Class ** arrayClasses = &fej9->getJ9JITConfig()->javaVM->booleanArrayClass;
    uint16_t id;
    for (int32_t i = 4; i <= 11; i++)
       {
-      TR_OpaqueClassBlock *arrayClass = reinterpret_cast<TR_OpaqueClassBlock *>(arrayClasses[i - 4]);
+      TR_OpaqueClassBlock *arrayClass = fej9->getClassFromNewArrayType(i);
       TR_OpaqueClassBlock *component = fej9->getComponentClassFromArrayClass(arrayClass);
 
       id = getNewSymbolID();
@@ -1537,8 +1536,7 @@ TR::SymbolValidationManager::validateArrayClassFromJavaVM(uint16_t arrayClassID,
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
 
-   struct J9Class ** arrayClasses = &fej9->getJ9JITConfig()->javaVM->booleanArrayClass;
-   TR_OpaqueClassBlock *arrayClass = reinterpret_cast<TR_OpaqueClassBlock *>(arrayClasses[arrayClassIndex - 4]);
+   TR_OpaqueClassBlock *arrayClass = fej9->getClassFromNewArrayType(arrayClassIndex);
 
    int32_t arrayDims = 0;
    arrayClass = getBaseComponentClass(arrayClass, arrayDims);


### PR DESCRIPTION
Compiler code should avoid using attributes of javaVM,
and use front-end instead, because it makes code compatible with JITaaS.
In this case, accessing javaVM->booleanArrayClass will lead to bugs on
JITaaS server, because classes from the server VM will be accessed, but
for compilation we need classes from the client.
On the other hand, using front-end call is fine, because JITaaS subclasses `TR_J9VM`,
and will fetch classes from the client.

Also add a guard to only initialize SVM when doing an AOT compile or load.

Related to: #3845 