### PR TITLE
Add extra assertions for atomic non-helpers on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12482,6 +12482,17 @@ TR::Register *J9::Power::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::
 
    if (!cg->inlineDirectCall(node, returnRegister))
       {
+      TR::SymbolReference *symRef = node->getSymbolReference();
+      TR::SymbolReferenceTable *symRefTab = cg->comp()->getSymRefTab();
+
+      // Non-helpers supported by code gen. are expected to be inlined
+      if (symRefTab->isNonHelper(symRef))
+         {
+         TR_ASSERT(!cg->supportsNonHelper(symRefTab->getNonHelperSymbol(symRef)),
+                   "Non-helper %d was not inlined, but was expected to be.\n",
+                   symRefTab->getNonHelperSymbol(symRef));
+         }
+
       linkage = cg->getLinkage(callee->getLinkageConvention());
       returnRegister = linkage->buildDirectDispatch(node);
       }


### PR DESCRIPTION
If a call to codegen inlineDirectCall from directCallEvaluator does not inline a call, added an assertion that the symbol is not one of the atomic non-helpers.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>