### PR TITLE
Getting OSR frame size from ROMMethod

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1765,6 +1765,20 @@ UDATA
 osrFrameSize(J9Method *method)
 {
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+	return osrFrameSizeRomMethod(romMethod);
+}
+
+
+/**
+ * Compute the number of bytes required for a single OSR frame.
+ *
+ * @param[in] *romMethod the J9ROMMethod for which to compute the OSR frame size
+ *
+ * @return byte size of the OSR frame
+ */
+UDATA
+osrFrameSizeRomMethod(J9ROMMethod *romMethod)
+{
 	U_32 numberOfLocals = J9_ARG_COUNT_FROM_ROM_METHOD(romMethod) + J9_TEMP_COUNT_FROM_ROM_METHOD(romMethod);
 	U_32 maxStack = J9_MAX_STACK_FROM_ROM_METHOD(romMethod);
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -787,18 +787,6 @@ TR_J9MethodBase::isBigDecimalConvertersMethod(TR::Compilation * comp)
    }
 
 
-uintptr_t
-TR_J9MethodBase::osrFrameSize(J9Method* j9Method)
-   {
-   if (auto stream = TR::compInfoPT->getStream())
-      {
-      stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_osrFrameSize, j9Method);
-      return std::get<0>(stream->read<uintptr_t>());
-      }
-   return ::osrFrameSize(j9Method);
-   }
-
-
 J9ROMConstantPoolItem *
 TR_ResolvedJ9MethodBase::romLiterals()
    {

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -138,7 +138,6 @@ public:
 
    virtual bool                  isUnsafeWithObjectArg( TR::Compilation * comp = NULL);
    virtual bool                  isUnsafeCAS(TR::Compilation * = NULL);
-   static uintptr_t              osrFrameSize(J9Method* j9Method);
    virtual uint32_t              numberOfExplicitParameters();
    virtual TR::DataType         parmType(uint32_t parmNumber); // returns the type of the parmNumber'th parameter (0-based)
 

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -41,6 +41,7 @@ void * setUpForDLT(J9VMThread * currentThread, J9StackWalkState * walkState);
 
 extern J9_CFUNC void   induceOSROnCurrentThread(J9VMThread * currentThread);
 extern J9_CFUNC UDATA osrFrameSize(J9Method *method);
+extern J9_CFUNC UDATA osrFrameSizeRomMethod(J9ROMMethod *romMethod);
 extern J9_CFUNC UDATA ensureOSRBufferSize(J9JavaVM *vm, UDATA osrFramesByteSize, UDATA osrScratchBufferByteSize, UDATA osrStackFrameByteSize);
 extern J9_CFUNC void jitStackLocalsModified (J9VMThread * currentThread, J9StackWalkState * walkState);
 #if (defined(J9VM_INTERP_HOT_CODE_REPLACEMENT)) /* priv. proto (autogen) */


### PR DESCRIPTION
osrFrameSizeRomMethod is introduced to return the OSR frame size
for the ROMMethod.
This is needed to reduce the messages in the JITaaS.

Also removed the unused function "TR_J9MethodBase::osrFrameSize".

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>