### PR TITLE
Changed ppc64le bootJDK locations

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -75,8 +75,8 @@ restart_timeout:
 #========================================#
 linux_ppc-64_cmprssptrs_le:
   boot_jdk:
-    8: '/usr/lib/jvm/java-7-openjdk-ppc64el'
-    9: '/usr/lib/jvm/adoptojdk-java-ppc64le-80'
+    8: '/usr/lib/jvm/adoptojdk-java-80'
+    9: '/usr/lib/jvm/adoptojdk-java-80'
     10: '/usr/lib/jvm/adoptojdk-java-ppc64le-90'
     11: '/usr/lib/jvm/adoptojdk-java-10'
     next: '/usr/lib/jvm/adoptojdk-java-10'


### PR DESCRIPTION
Changed the location of bootJDKs for JDK8/9 on ppc64le
to be /usr/lib/jvm/adoptojdk-java-80.

Signed-off-by: Colton Mills <millscolt3@gmail.com>