### PR TITLE
Remove Xgc:debugLOAResize option

### DIFF
--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -200,11 +200,6 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 		goto _exit;
 	}
 	
-	if(try_scan(scan_start, "debugLOAResize")) {
-		extensions->debugLOAResize = true;
-		goto _exit;
-	}
-	
 	if(try_scan(scan_start, "debugLOAFreelist")) {
 		extensions->debugLOAFreelist = true;
 		goto _exit;


### PR DESCRIPTION
   - remove -Xgc:debugLOAResize option, use trace point for the related debug output

Signed-off-by: Lin Hu <linhu@ca.ibm.com>