### PR TITLE
Fix rare VM shutdown assertion

### DIFF
--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -226,6 +226,10 @@ error:
 
 #ifdef J9VM_PROF_EVENT_REPORTING
 	if (env) {
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+		enterVMFromJNI(env);
+		releaseVMAccess(env);
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		TRIGGER_J9HOOK_VM_SHUTTING_DOWN(vm->hookInterface, env, result);
 	}
 #endif /* J9VM_PROF_EVENT_REPORTING */


### PR DESCRIPTION
If VM startup fails to complete, but gets far enough to have reported VM
start, then VM shutdown must be reported. The hook caller for this case
was calling the hook in the JNI context, whereas the other two callers
have entered the VM and released VM access. Make the startup failure
case consistent with the other callers.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>