### PR TITLE
Cache IProfiler info for interpreted methods

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9298,6 +9298,9 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
    TR_DataCache *dataCache = NULL;
    const J9JITDataCacheHeader *storedCompiledMethod = nullptr;
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+   if (comp->getPersistentInfo()->getJITaaSMode() == SERVER_MODE)
+      // end of compilation, clear per-compilation IProfiler cache
+      ((TR::CompilationInfoPerThreadRemote *) entry->_compInfoPT)->clearIProfilerMap(comp->trMemory());
 
    if (details.isNewInstanceThunk())
       {

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -33,6 +33,8 @@ class TR_IPBytecodeHashTableEntry;
 struct TR_RemoteROMStringKey;
 
 using IPTable_t = PersistentUnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
+using IPTableHeapEntry = UnorderedMap<uint32_t, TR_IPBytecodeHashTableEntry*>;
+using IPTableHeap_t = UnorderedMap<J9Method *, IPTableHeapEntry *>;
 
 class ClientSessionData
    {
@@ -214,10 +216,14 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
       void waitForMyTurn(ClientSessionData *clientSession, TR_MethodToBeCompiled &entry); // return false if timeout
       bool getWaitToBeNotified() const { return _waitToBeNotified; }
       void setWaitToBeNotified(bool b) { _waitToBeNotified = b; }
+      void clearIProfilerMap(TR_Memory *trMemory);
+      bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
+      TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
    private:
       TR_PersistentMethodInfo *_recompilationMethodInfo;
       uint32_t _seqNo;
       bool _waitToBeNotified; // accessed with clientSession->_sequencingMonitor in hand
+      IPTableHeap_t *_methodIPDataPerComp;
    };
 }
 

--- a/runtime/compiler/runtime/JITaaSIProfiler.hpp
+++ b/runtime/compiler/runtime/JITaaSIProfiler.hpp
@@ -99,7 +99,7 @@ class TR_JITaaSClientIProfiler : public TR_IProfiler
       uint32_t walkILTreeForIProfilingEntries(uintptrj_t *pcEntries, uint32_t &numEntries, TR_J9ByteCodeIterator *bcIterator,
                                               TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort, TR::Compilation *comp);
       uintptr_t serializeIProfilerMethodEntries(uintptrj_t *pcEntries, uint32_t numEntries, uintptr_t memChunk, uintptrj_t methodStartAddress);
-      bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::J9ClientStream *client);
+      bool serializeAndSendIProfileInfoForMethod(TR_OpaqueMethodBlock*method, TR::Compilation *comp, JITaaS::J9ClientStream *client, bool usePersistentCache);
       std::string serializeIProfilerMethodEntry(TR_OpaqueMethodBlock *omb);
    };
 


### PR DESCRIPTION
Previously, IProfiler would only cache profiling information
for methods that have already been compiled, and for the method currently being compiled.
This change starts caching info for interpreted methods in a per-compilation cache.
When a server requests info for a particular bytecode, client sends profiling info
for the entire method, which is then cached until the end of the compilation.
Even though IProfiler data might get updated during compilation,
the hope is that the change will be small enough to not affect performance.

Addresses:#3723