### PR TITLE
Initialize variables

### DIFF
--- a/runtime/rastrace/trctrigger.c
+++ b/runtime/rastrace/trctrigger.c
@@ -453,22 +453,22 @@ processTriggerTpnidClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 {
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(thr);
 	omr_error_t rc = OMR_ERROR_NONE;
-	char *p;
-	int length;
-	const char *ptrName;
-	const char *ptrAction;
-	const char *ptrDelay;
-	const char *ptrMatch;
+	char *p = NULL;
+	int length = 0;
+	const char *ptrName = NULL;
+	const char *ptrAction = NULL;
+	const char *ptrDelay = NULL;
+	const char *ptrMatch = NULL;
 	char *ptrRangeStart = NULL;
 	char *ptrRangeEnd = NULL;
 	int32_t doneFirstParm = FALSE;
 	int tpidRangeStart = 0;
 	int tpidRangeEnd = 0;
-	uint32_t actionIndex;
+	uint32_t actionIndex = 0;
 	int delayCount = 0;
 	int matchCount = -1;
-	RasTriggerTpidRange *newTriggerRangeP;
-	char *compName;
+	RasTriggerTpidRange *newTriggerRangeP = NULL;
+	char *compName = NULL;
 
 	RAS_DBGOUT((stderr, "<RAS> Processing tpnid clause: \"%s\"\n", clause));
 
@@ -635,18 +635,18 @@ processTriggerGroupClause(OMR_VMThread *thr, char *clause, BOOLEAN atRuntime)
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(thr);
 	omr_error_t rc = OMR_ERROR_NONE;
 	int numParms = 0;
-	int length;
+	int length = 0;
 	unsigned int maxLength = 5;
-	const char *ptrGroupName;
-	const char *ptrAction;
-	const char *ptrDelay;
-	const char *ptrMatch;
-	uint32_t actionIndex;
+	const char *ptrGroupName = NULL;
+	const char *ptrAction = NULL;
+	const char *ptrDelay = NULL;
+	const char *ptrMatch = NULL;
+	uint32_t actionIndex = 0;
 	int delay = 0;
 	int match = -1;
-	char *p;
-	RasTriggerGroup *newTriggerGroupP;
-	char *copyOfNameP;
+	char *p = NULL;
+	RasTriggerGroup *newTriggerGroupP = NULL;
+	char *copyOfNameP = NULL;
 
 	RAS_DBGOUT((stderr, "<RAS> Processing GROUP clause: \"%s\"\n", clause));
 

--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -543,8 +543,8 @@ protectedDetachCurrentThread(J9PortLibrary* portLibrary, void * userData)
 jint JNICALL DetachCurrentThread(JavaVM * javaVM)
 {
 	J9JavaVM * vm = ((J9InvocationJavaVM *)javaVM)->j9vm;
-	J9VMThread * vmThread;
-	UDATA result;
+	J9VMThread * vmThread = NULL;
+	UDATA result = 0;
 	PORT_ACCESS_FROM_PORT(vm->portLibrary);
 
 	/* we should return here to avoid the detaching operations after the destroy call to avoid

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -626,7 +626,7 @@ static void walkObjectPushes(J9StackWalkState * walkState)
 static void walkDescribedPushes(J9StackWalkState * walkState, UDATA * highestSlot, UDATA slotCount, U_32 * descriptionSlots, UDATA argCount)
 {
 	UDATA descriptionBitsRemaining = 0;
-	U_32 description;
+	U_32 description = 0;
 
 	while (slotCount) {
 		if (!descriptionBitsRemaining) {
@@ -1198,7 +1198,7 @@ static void walkPushedJNIRefs(J9StackWalkState * walkState)
 static void walkIndirectDescribedPushes(J9StackWalkState * walkState, UDATA * highestIndirectSlot, UDATA slotCount, U_32 * descriptionSlots)
 {
 	UDATA descriptionBitsRemaining = 0;
-	U_32 description;
+	U_32 description = 0;
 
 	while (slotCount) {
 		if (!descriptionBitsRemaining) {


### PR DESCRIPTION
Compiling with `gcc7` + `-Os` yields `-Werror=maybe-uninitialized` on zLinux.

Uninitialized variables have been initialized to fix the above error.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>