### PR TITLE
Force testjep178 to initialize libpthread

### DIFF
--- a/runtime/tests/redirector/jep178/testjep178.c
+++ b/runtime/tests/redirector/jep178/testjep178.c
@@ -28,6 +28,20 @@
  */
 
 #include "testjep178.h"
+#ifdef LINUX
+/* kludge to work around known issue in glibc pre 2.25
+ * https://sourceware.org/bugzilla/show_bug.cgi?id=16628
+ * https://github.com/eclipse/openj9/issues/3672
+ * Add a dummy pthread call to force libpthread to initialize.
+ */
+#include <pthread.h>
+
+static  pthread_key_t key;
+void unused_function()
+{
+    pthread_key_create(&key, NULL);
+}
+#endif
 
 /* The JVM launcher. */
 int main(int argc, char ** argv, char ** envp)


### PR DESCRIPTION
Add a dummy reference to a pthread function to work around a known issue in
glibc pre 2.25 https://sourceware.org/bugzilla/show_bug.cgi?id=16628

Fixes https://github.com/eclipse/openj9/issues/3672

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>