### PR TITLE
Expand MethodHandle invoke calls after walker

### DIFF
--- a/runtime/compiler/env/JSR292Methods.h
+++ b/runtime/compiler/env/JSR292Methods.h
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JSR292Methods_h
+#define JSR292Methods_h
+
+#define JSR292_ILGenMacros    "java/lang/invoke/ILGenMacros"
+#define JSR292_placeholder    "placeholder"
+#define JSR292_placeholderSig "(I)I"
+
+#define JSR292_MethodHandle   "java/lang/invoke/MethodHandle"
+#define JSR292_invokeExactTargetAddress    "invokeExactTargetAddress"
+#define JSR292_invokeExactTargetAddressSig "()J"
+#define JSR292_getType                     "type"
+#define JSR292_getTypeSig                  "()Ljava/lang/invoke/MethodType;"
+
+#define JSR292_invokeExact    "invokeExact"
+#define JSR292_invokeExactSig "([Ljava/lang/Object;)Ljava/lang/Object;"
+
+#define JSR292_ComputedCalls  "java/lang/invoke/ComputedCalls"
+#define JSR292_dispatchDirectPrefix "dispatchDirect_"
+#define JSR292_dispatchDirectArgSig "(JI)"
+
+#define JSR292_asType              "asType"
+#define JSR292_asTypeSig           "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;"
+#define JSR292_forGenericInvoke    "forGenericInvoke"
+#define JSR292_forGenericInvokeSig "(Ljava/lang/invoke/MethodType;Z)Ljava/lang/invoke/MethodHandle;"
+
+#define JSR292_ArgumentMoverHandle  "java/lang/invoke/ArgumentMoverHandle"
+
+#endif

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -126,9 +126,8 @@ private:
    void         genHandleTypeCheck();
    void         genHandleTypeCheck(TR::Node *handle, TR::Node *expectedType) { push(handle); push(expectedType); genHandleTypeCheck(); }
 
-   // These expect receiver MethodHandle on top of stack, with method arguments (including the receiver MethodHandle) underneath
    TR::Node *    genInvokeHandle(TR::SymbolReference *invokeExactSymRef, TR::Node *invokedynamicReceiver = NULL);
-   TR::Node *    genInvokeHandleGeneric(TR::SymbolReference *invokeGenericSymRef, TR::SymbolReference *methodTypeSymRef);
+   TR::Node *    genILGenMacroInvokeExact(TR::SymbolReference *invokeExactSymRef);
 
    bool         runMacro(TR::SymbolReference *);
    bool         runFEMacro(TR::SymbolReference *);
@@ -169,7 +168,6 @@ private:
    void         loadConstant(TR::ILOpCodes, void *);
    void         loadFromCP(TR::DataType, int32_t);
    void         loadFromCallSiteTable(int32_t);
-   void         loadFromMethodTypeTable(int32_t);
 
    void         loadClassObjectAndIndirect(int32_t cpIndex);
 
@@ -300,6 +298,17 @@ private:
    void expandInvokeSpecialInterface(TR::TreeTop *tree);
    void separateNullCheck(TR::TreeTop *tree);
 
+   // Expand MethodHandle invoke
+   void expandInvokeHandle(TR::TreeTop *tree);
+   void expandInvokeExact(TR::TreeTop *tree);
+   void expandInvokeDynamic(TR::TreeTop *tree);
+   void expandInvokeHandleGeneric(TR::TreeTop *tree);
+   void expandMethodHandleInvokeCall(TR::TreeTop *tree);
+   void insertCustomizationLogicTreeIfEnabled(TR::TreeTop *tree, TR::Node* methodHandle);
+   TR::Node* loadCallSiteMethodTypeFromCP(TR::Node* methodHandleInvokeCall);
+   TR::Node* loadFromMethodTypeTable(TR::Node* methodHandleInvokeCall);
+   TR::Node* loadCallSiteMethodType(TR::Node* methodHandleInvokeCall);
+
    // inline functions
    //
    TR::SymbolReferenceTable * symRefTab()                      { return _symRefTab; }
@@ -379,6 +388,11 @@ private:
    // JSR292
    int32_t                           _argPlaceholderSlot;
    int32_t                           _argPlaceholderSignatureOffset;
+   TR_BitVector                     *_methodHandleInvokeCalls;
+   TR_BitVector                     *_invokeHandleCalls;
+   TR_BitVector                     *_invokeHandleGenericCalls;
+   TR_BitVector                     *_invokeDynamicCalls;
+   TR_BitVector                     *_ilGenMacroInvokeExactCalls;
 
    // TenantScope field support, set to 'true' if a get/put static is encountered
    // when option TR_DisableMultiTenancy is on and current method contains static

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -51,6 +51,7 @@
 #include "optimizer/Optimization.hpp"          // for Optimization
 #include "optimizer/Optimization_inlines.hpp"  // for trace()
 #include "optimizer/J9TransformUtil.hpp"       // for calculateElementAddress
+#include "env/JSR292Methods.h"
 
 // All VarHandle Access methods
 /*
@@ -76,13 +77,6 @@ addAndGet
 */
 #define VarHandleParmLength 28
 #define VarHandleParam "Ljava/lang/invoke/VarHandle;"
-#define JSR292_MethodHandle   "java/lang/invoke/MethodHandle"
-#define JSR292_asType              "asType"
-#define JSR292_asTypeSig           "(Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;"
-#define JSR292_invokeExactTargetAddress    "invokeExactTargetAddress"
-#define JSR292_invokeExactTargetAddressSig "()J"
-#define JSR292_invokeExact    "invokeExact"
-#define JSR292_invokeExactSig "([Ljava/lang/Object;)Ljava/lang/Object;"
 
 
 struct X


### PR DESCRIPTION
One or more extra calls are generated for MethodHandle invoke in walker,
adding the difficulty to do OSR bookkeeping. This commit will move the
extra call creations to post-walker.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>