### PR TITLE
Updated bootJDK location for JDK11 and next on windows

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -316,8 +316,8 @@ win_x86-64_cmprssptrs:
     8: '/cygdrive/c/openjdk/jdk7'
     9: '/cygdrive/c/openjdk/jdk8'
     10: '/cygdrive/c/openjdk/jdk9'
-    11: '/cygdrive/c/openjdk/jdk10'
-    next: '/cygdrive/c/openjdk/jdk10'
+    11: '/cygdrive/c/openjdk/jdk11'
+    next: '/cygdrive/c/openjdk/jdk11'
   release:
     8: 'windows-x86_64-normal-server-release'
     9: 'windows-x86_64-normal-server-release'


### PR DESCRIPTION
JDK11 will now be built from bootJDK11, which will allow JDK12 to
also be built. The variable file is being changed to reflect this.
[skip ci]

Signed-off-by: Colton Mills <millscolt3@gmail.com>