### PR TITLE
Remove last bit of CS checks in `tmPoll`

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -11457,7 +11457,7 @@ inlineConcurrentLinkedQueueTMPoll(
    if (useNonConstrainedTM || disableTMPoll)
       cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, failLabel, deps);
 
-   if (!TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() && usesCompressedrefs)
+   if (usesCompressedrefs)
       {
       generateRRInstruction(cg, TR::InstOpCode::LLGFR, node, rQ, rQ);
 


### PR DESCRIPTION
In #3763 we disabled the use of TM CLQ optimizations under concurrent
scavenge (CS). Hence checking for whether it is enabled within the
evaluators for `tmPoll` will always return false, so the query can be
folded away.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>