### PR TITLE
Add Infrastructure to retry AOT loads

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -880,6 +880,9 @@ public:
    bool getSuspendThreadDueToLowPhysicalMemory() const { return _suspendThreadDueToLowPhysicalMemory; }
    void setSuspendThreadDueToLowPhysicalMemory(bool b) { _suspendThreadDueToLowPhysicalMemory = b; }
 
+   bool shouldRetryAOTLoad(void *j9method);
+   bool retryAOTLoadIfPossible(void *j9method, Compilation *comp);
+
    static int32_t         VERY_SMALL_QUEUE;
    static int32_t         SMALL_QUEUE;
    static int32_t         MEDIUM_LARGE_QUEUE;
@@ -1006,6 +1009,12 @@ private:
    int32_t                _numSeriousFailures; // count failures where method needs to continue interpreted
 
    TR::Monitor           *_gpuInitMonitor;
+
+
+   typedef TR::typed_allocator<std::pair<void* const, uint32_t>, TR_TypedPersistentAllocatorBase&> AOTLoadRetryAllocator;
+   typedef std::less<void*> AOTLoadRetryComparator;
+   typedef std::map<void*, uint32_t, AOTLoadRetryComparator, AOTLoadRetryAllocator> AOTLoadRetryMap;
+   AOTLoadRetryMap        _aotLoadRetryMap;
 
    enum // flags
       {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -601,7 +601,7 @@ void TR::CompilationInfo::freeCompilationInfo(J9JITConfig *jitConfig)
    TR::CompilationInfo * compilationRuntime = _compilationRuntime;
    _compilationRuntime = NULL;
    TR::RawAllocator rawAllocator(jitConfig->javaVM);
-   _compilationRuntime->~CompilationInfo();
+   compilationRuntime->~CompilationInfo();
    rawAllocator.deallocate(compilationRuntime);
    }
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -246,6 +246,8 @@ int32_t J9::Options::_jProfilingEnablementSampleThreshold = 10000;
 
 bool J9::Options::_aggressiveLockReservation = false;
 
+int32_t J9::Options::_retryAOTLoadInitialInvocationCount = -1;
+
 //************************************************************************
 //
 // Options handling - the following code implements the VM-specific
@@ -908,6 +910,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_relaxedCompilationLimitsSampleThreshold, 0, " %d", NOT_IN_SUBSET },
    {"resetCountThreshold=", "R<nnn>\tThe number of global samples which if exceed during a method's sampling interval will cause the method's sampling counter to be incremented by the number of samples in a sampling interval",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_resetCountThreshold, 0, " %d", NOT_IN_SUBSET},
+   {"retryAOTLoadInitialInvocationCount=", "M<nnn>\tInvocation count for an AOT load that will be retried",
+        TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_retryAOTLoadInitialInvocationCount, 0, "F%d", NOT_IN_SUBSET},
    {"rtlog=",             "L<filename>\twrite verbose run-time output to filename",
         TR::Options::setStringForPrivateBase,  offsetof(TR_JitPrivateConfig,rtLogFileName), 0, "P%s"},
    {"rtResolve",          "D\ttreat all data references as unresolved", SET_JITCONFIG_RUNTIME_FLAG(J9JIT_RUNTIME_RESOLVE) },

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -298,6 +298,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static bool _aggressiveLockReservation;
 
+   static int32_t _retryAOTLoadInitialInvocationCount;
+
    static void  printPID();
 
 


### PR DESCRIPTION
Currently, when an AOT load fails, the compiler will perform a JIT
compilation. An AOT compilation is generally performed with count=1000,
bcount=250, but an AOT load is generally performed with scount=20. This
means that there will likely be AOT load failures caused by validation
failures which occur because what's being validated isn't resolved yet.
This PR provides the infrastructure to postpone the AOT load (that
fail under specific conditions likely caused by the low scount) and
retry the load some time later.

The general design is as follows. The first time an AOT load fails,
the J9Method is added to a map. The key is the J9Method pointer itself,
and the value is the new invocation count. The extra field of the
J9Method is then updated with the new invocation count, and the
compilation ends. On each subsequent load failure, the invocation count
doubles, up to half of the initial default count/bcount for that
method; the value in the map is used for this purpose and updated
accordingly. The purpose of this is to ensure that the total invocation
count set for this method does not exceed its default count/bcount. If
the count cannot be increased anymore, the method is JIT compiled.

In order to minimize the cost of querying the map (since the map is
only required for AOT load failures), a method is only removed
from the map when the compiler is unable to increase the invocation
count. This is ok because the map is only checked during an AOT load
failure.