### PR TITLE
Select the correct native library suffix

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
@@ -24,7 +24,7 @@ package org.openj9.test.attachAPI;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.openj9.test.util.FileUtilities.deleteRecursive;
 import static org.openj9.test.util.PlatformInfo.isWindows;
-import static org.openj9.test.util.PlatformInfo.isMacOS;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
+import org.openj9.test.util.PlatformInfo;
 import org.openj9.test.util.StringPrintStream;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterMethod;
@@ -215,15 +216,8 @@ public class TestAttachAPI extends AttachApiTest {
 		String lipPath = System.getProperty("java.library.path");
 		String[] libDirs = lipPath.split(File.pathSeparator);
 		char fs = File.separatorChar;
-		String decoration = "lib";
-		String suffix = ".so"; // default for Linux, AIX, and z/OS
-		if (isWindows()) {
-			/* kludgy test if we are on MS Windows */
-			decoration = "";
-			suffix = ".dll";
-		} else if (isMacOS()) {
-			suffix = ".dylib";
-		}
+		String decoration = isWindows()? "": "lib";
+		String librarySuffix = PlatformInfo.getLibrarySuffix();
 		int pIndex = 0;
 		String outOutput = null;
 		TargetManager target = launchTarget();
@@ -241,7 +235,7 @@ public class TestAttachAPI extends AttachApiTest {
 		do {
 			try {
 				String libPath = libDirs[pIndex] + fs + decoration + JVMTITST
-						+ suffix;
+						+ librarySuffix;
 				++pIndex;
 				logger.debug("trying to load " + libPath);
 				File lib = new File(libPath);

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestSunAttachClasses.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestSunAttachClasses.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Properties;
 
 import static org.testng.Assert.fail;
+
+import static org.openj9.test.util.PlatformInfo.getLibrarySuffix;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -80,7 +82,7 @@ public class TestSunAttachClasses extends AttachApiTest {
 		String[] libDirs = lipPath.split(File.pathSeparator);
 		char fs = File.separatorChar;
 		String decoration = "lib";
-		String suffix = ".so";
+		String librarySuffix = getLibrarySuffix();
 		String errOutput = "";
 		String outOutput = "";
 		TargetManager target = new TargetManager(TestConstants.TARGET_VM_CLASS, null, vmArgs, null);
@@ -101,7 +103,7 @@ public class TestSunAttachClasses extends AttachApiTest {
 		}
 		for (String libElement: libDirs) {
 			try {
-				String libPath = libElement+fs+decoration+TestUtil.JVMTITST+suffix;
+				String libPath = libElement+fs+decoration+TestUtil.JVMTITST+librarySuffix;
 				logger.debug("trying to load "+ libPath);
 				File lib = new File(libPath);
 				if (!lib.exists()) {

--- a/test/functional/TestUtilities/src/org/openj9/test/util/PlatformInfo.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/PlatformInfo.java
@@ -33,4 +33,13 @@ public class PlatformInfo {
 		return ((null != osName) && osName.startsWith("Mac OS"));
 	}
 
+	public static String getLibrarySuffix() {
+		String librarySuffix = ".so"; // default for Linux, AIX, and z/OS
+		if (isWindows()) {
+			librarySuffix = ".dll";
+		} else if (isMacOS()) {
+			librarySuffix = ".dylib";
+		}
+		return librarySuffix;
+	}
 }


### PR DESCRIPTION
Move common code to select the suffix to a utility class.  Update
TestSunAttachClasses to use same.

Fixes https://github.com/eclipse/openj9/issues/3842 FYI @llxia 

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>