### PR TITLE
Fix unsafe and JNI bool writes and returns

### DIFF
--- a/runtime/oti/UnsafeAPI.hpp
+++ b/runtime/oti/UnsafeAPI.hpp
@@ -421,7 +421,7 @@ public:
 	static VMINLINE void
 	putBoolean(J9VMThread *currentThread, MM_ObjectAccessBarrierAPI *objectAccessBarrier, j9object_t object, UDATA offset, bool isVolatile, U_8 value)
 	{
-		put32(currentThread, objectAccessBarrier, object, offset, isVolatile, 0, false, (I_32)(value & 1));
+		put32(currentThread, objectAccessBarrier, object, offset, isVolatile, 0, false, (I_32)(0 != value));
 	}
 
 	static VMINLINE I_16

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1389,7 +1389,7 @@ exit:
 			}
 			break;
 		case J9NtcBoolean:
-			*returnStorage = ((UDATA)(U_8)*returnStorage) & 1;
+			*returnStorage = ((UDATA)(U_8)(0 != *returnStorage));
 			break;
 		case J9NtcByte:
 			*returnStorage = (UDATA)(IDATA)(I_8)*returnStorage;

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -373,7 +373,7 @@ JNICALL throwNew(JNIEnv *env, jclass clazz, const char *message)
 
 static void JNICALL setStaticBooleanField(JNIEnv *env, jclass cls, jfieldID fieldID, jboolean value)
 {
-	setStaticIntField(env, cls, fieldID, (jint)(value != 0));
+	setStaticIntField(env, cls, fieldID, (jint)(value & 1));
 }
 
 


### PR DESCRIPTION
Fix unsafe and JNI bool writes and returns

The spec rules on bool's `the int value is narrowed by taking the
bitwise AND of value and 1, resulting in value` only apply to JVM
bytecodes. The Unsafe behaviour in the RI writes `(0 != value)`. 
JNI returns behave the same way.

Signed-off-by: tajila <atobia@ca.ibm.com>