### PR TITLE
set javac encoding

### DIFF
--- a/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
@@ -34,6 +34,14 @@
 	<property name="src" location="."/>
 	<property name="build.dir" location="./bin"/>
 	
+	<!-- on zos, ant <copy> does not keep file tag. Therefore, ant copied files 
+	cannot be read by javac. Preset javac with encoding="ISO-8859-1" so that files 
+	without proper tagging can be read.
+	-->
+	<presetdef name="javac">
+		<javac encoding="ISO-8859-1" />
+	</presetdef>
+	
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build.dir}" />

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/build.xml
@@ -36,6 +36,14 @@
 	
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/shareClassTests/testClasses" />
 
+	<!-- on zos, ant <copy> does not keep file tag. Therefore, ant copied files 
+	cannot be read by javac. Preset javac with encoding="ISO-8859-1" so that files 
+	without proper tagging can be read.
+	-->
+	<presetdef name="javac">
+		<javac encoding="ISO-8859-1" />
+	</presetdef>
+
 	<target name="AddTestClassesToPackage">
 		<!-- create the folders -->
 		<mkdir dir="${build}/Alphabet" />


### PR DESCRIPTION
This is only needed for compile ant copied files on zos. On zos, ant <copy>
does not keep file tag. Therefore, ant copied files cannot be read by
javac. Preset javac with encoding="ISO-8859-1" so that files without
proper tag can be read

[ci skip]

Signed-off-by: lanxia <lan_xia@ca.ibm.com>