### PR TITLE
Fix for JITaaS sequencer code

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -205,15 +205,19 @@ class CompilationInfoPerThreadRemote : public TR::CompilationInfoPerThread
    public:
       friend class TR::CompilationInfo;
       CompilationInfoPerThreadRemote(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool isDiagnosticThread)
-         :CompilationInfoPerThread(compInfo, jitConfig, id, isDiagnosticThread), _seqNo(0) {}
+         :CompilationInfoPerThread(compInfo, jitConfig, id, isDiagnosticThread), 
+         _recompilationMethodInfo(NULL), _seqNo(0), _waitToBeNotified(false) {}
       virtual void processEntry(TR_MethodToBeCompiled &entry, J9::J9SegmentProvider &scratchSegmentProvider) override;
       TR_PersistentMethodInfo *getRecompilationMethodInfo() { return _recompilationMethodInfo; }
       uint32_t getSeqNo() const { return _seqNo; }; // for ordering requests at the server
       void setSeqNo(uint32_t seqNo) { _seqNo = seqNo; }
       void waitForMyTurn(ClientSessionData *clientSession, TR_MethodToBeCompiled &entry); // return false if timeout
+      bool getWaitToBeNotified() const { return _waitToBeNotified; }
+      void setWaitToBeNotified(bool b) { _waitToBeNotified = b; }
    private:
       TR_PersistentMethodInfo *_recompilationMethodInfo;
       uint32_t _seqNo;
+      bool _waitToBeNotified; // accessed with clientSession->_sequencingMonitor in hand
    };
 }
 


### PR DESCRIPTION
Previous sequencer code had a problem described here:
1. One thread times-out and clears the caches from the server
2. Another waiting thread times-out very soon after and is now
waiting to enter the critical section
3. The first thread proceeds through the critical section and
at some point it unlocks the monitor to do a remote read.
4. The second thread enters the critical section and thinks it
needs to clear the caches as well because it is a thread that
timed-out.

The solution is for the first thread to flag the next in line
thread that everything is ok and it should go and wait again
on the monitor until it gets notified.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>