### PR TITLE
Fix typo: USE_COMPUTED_GOTO for gcc 7 on zLinux

### DIFF
--- a/runtime/vm/BytecodeInterpreter.cpp
+++ b/runtime/vm/BytecodeInterpreter.cpp
@@ -43,7 +43,7 @@
 #define USE_COMPUTED_GOTO
 #elif (defined(LINUX) && defined(J9HAMMER))
 #define USE_COMPUTED_GOTO
-#elif (defined(LINUX) && defined(S390) && (__GNUC__ > 7))
+#elif (defined(LINUX) && defined(S390) && (__GNUC__ >= 7))
 #define USE_COMPUTED_GOTO
 #elif defined(OSX)
 #define USE_COMPUTED_GOTO


### PR DESCRIPTION
I expect the intent of #3761 was to enable computed goto for gcc 7 on zLinux (not require gcc 8+).