### PR TITLE
Provide ordering to CHTable updates

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7825,14 +7825,6 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             {
             uint64_t proposedScratchMemoryLimit = (uint64_t)TR::Options::getScratchSpaceLimit();
 
-            // update our cached CHTable
-            if (details.isRemoteMethod() && !compiler->getOption(TR_DisableCHOpts))
-               {
-               auto table = (TR_JITaaSServerPersistentCHTable*)compiler->getPersistentInfo()->getPersistentCHTable();
-               table->doUpdate((TR_J9VMBase*)compiler->fe());
-               }
-
-
             bool isJSR292 = TR::CompilationInfo::isJSR292(details.getRomMethod());
 
             // Check if the the method to be compiled is a JSR292 method

--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2103,14 +2103,13 @@ remoteCompile(
 
    
    compInfo->getSequencingMonitor()->enter();
+   // Collect the list of unloaded classes
    std::vector<TR_OpaqueClassBlock*> unloadedClasses(compInfo->getUnloadedClassesTempList()->begin(), compInfo->getUnloadedClassesTempList()->end());
    compInfo->getUnloadedClassesTempList()->clear();
-   // Here we would need to collect the CHTable updates
-   // This will acquire CHTable mutex
-   // Must test disableCHTableOpts
-   //auto table = (TR_JITaaSClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
-   //auto encoded = table->serializeUpdates();
-   //client->write(encoded.first, encoded.second);
+   // Collect and encode the CHTable updates; this will acquire CHTable mutex
+   auto table = (TR_JITaaSClientPersistentCHTable*)compInfo->getPersistentInfo()->getPersistentCHTable();
+   std::pair<std::string, std::string> chtableUpdates = table->serializeUpdates();
+   // Update the sequence number for these updates
    uint32_t seqNo = compInfo->getCompReqSeqNo();
    compInfo->incCompReqSeqNo();
    compInfo->getSequencingMonitor()->exit();
@@ -2138,7 +2137,8 @@ remoteCompile(
          }
       client.buildCompileRequest(TR::comp()->getPersistentInfo()->getJITaaSId(), romMethodOffset, 
                                  method, clazz, compiler->getMethodHotness(), detailsStr, details.getType(), 
-                                 unloadedClasses, classInfoTuple, optionsStr, recompMethodInfoStr, seqNo);
+                                 unloadedClasses, classInfoTuple, optionsStr, recompMethodInfoStr, seqNo, 
+                                 chtableUpdates.first, chtableUpdates.second);
       // re-acquire VM access and check for possible class unloading
       acquireVMAccessNoSuspend(vmThread);
       if (compInfoPT->compilationShouldBeInterrupted())
@@ -3203,7 +3203,7 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       {
       auto req = stream->read<uint64_t, uint32_t, J9Method *, J9Class*, TR_Hotness, std::string,
          J9::IlGeneratorMethodDetailsType, std::vector<TR_OpaqueClassBlock*>,
-         JITaaSHelpers::ClassInfoTuple, std::string, std::string, uint32_t>();
+         JITaaSHelpers::ClassInfoTuple, std::string, std::string, uint32_t, std::string, std::string>();
 
       uint64_t clientId         = std::get<0>(req);
       uint32_t romMethodOffset  = std::get<1>(req);
@@ -3217,6 +3217,8 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       std::string clientOptStr  = std::get<9>(req);
       std::string recompInfoStr = std::get<10>(req);
       uint32_t seqNo            = std::get<11>(req); // sequence number at the client
+      std::string chtableUnloads= std::get<12>(req);
+      std::string chtableMods   = std::get<13>(req);
 
       //if (seqNo == 100)
       //   throw JITaaS::StreamFailure(); // stress testing
@@ -3284,15 +3286,12 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       // The following will acquire CHTable monitor and VMAccess, send a message and then release them
       bool initialized = chTable->initializeIfNeeded(_vm);
 
-      // Any thread with a sequence number lower or equal to the seqNo that created
-      // the session and initialized the CHTable does not have to apply CHTable updates
+      // A thread that initialized the CHTable does not have to apply the incremental update
       if (!initialized)
          {
-         // TODO: move the CHTable updates here
+         // Process the CHTable updates in order
          // Note that applying the updates will acquire the CHTable monitor and VMAccess
-         // Apply the CHTable updates in sequence
-         //auto table = (TR_JITaaSServerPersistentCHTable*)getPersistentInfo()->getPersistentCHTable();
-         //table->doUpdate(_vm);
+         chTable->doUpdate(_vm, chtableUnloads, chtableMods);
          }
 
       clientSession->getSequencingMonitor()->enter();

--- a/runtime/compiler/env/JITaaSPersistentCHTable.cpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.cpp
@@ -75,17 +75,13 @@ TR_JITaaSServerPersistentCHTable::initializeIfNeeded(TR_J9VMBase *fej9)
    }
 
 void 
-TR_JITaaSServerPersistentCHTable::doUpdate(TR_J9VMBase *fej9)
+TR_JITaaSServerPersistentCHTable::doUpdate(TR_J9VMBase *fej9, const std::string &removeStr, const std::string &modifyStr)
    {
-   auto stream = TR::CompilationInfo::getStream();
-   stream->write(JITaaS::J9ServerMessageType::CHTable_getClassInfoUpdates, JITaaS::Void());
-   auto recv = stream->read<std::string, std::string>();
-   std::string &removeStr = std::get<0>(recv);
-   std::string &modifyStr = std::get<1>(recv);
-
    TR::ClassTableCriticalSection doUpdate(fej9);
-   commitModifications(modifyStr);
-   commitRemoves(removeStr);
+   if (!modifyStr.empty())
+      commitModifications(modifyStr);
+   if (!removeStr.empty())
+      commitRemoves(removeStr);
 
 #ifdef COLLECT_CHTABLE_STATS
    uint32_t nBytes = removeStr.size() + modifyStr.size();
@@ -99,7 +95,7 @@ TR_JITaaSServerPersistentCHTable::doUpdate(TR_J9VMBase *fej9)
    }
 
 void 
-TR_JITaaSServerPersistentCHTable::commitRemoves(std::string &rawData)
+TR_JITaaSServerPersistentCHTable::commitRemoves(const std::string &rawData)
    {
    auto &data = getData();
    TR_OpaqueClassBlock **ptr = (TR_OpaqueClassBlock**)&rawData[0];
@@ -115,7 +111,7 @@ TR_JITaaSServerPersistentCHTable::commitRemoves(std::string &rawData)
    }
 
 void 
-TR_JITaaSServerPersistentCHTable::commitModifications(std::string &rawData)
+TR_JITaaSServerPersistentCHTable::commitModifications(const std::string &rawData)
    {
    auto &data = getData();
    std::unordered_map<TR_OpaqueClassBlock*, std::pair<FlatPersistentClassInfo*, TR_PersistentClassInfo*>> infoMap;

--- a/runtime/compiler/env/JITaaSPersistentCHTable.hpp
+++ b/runtime/compiler/env/JITaaSPersistentCHTable.hpp
@@ -47,7 +47,7 @@ public:
 
    bool isInitialized() { return !getData().empty(); } // needs CHTable mutex in hand
    bool initializeIfNeeded(TR_J9VMBase *fej9);
-   void doUpdate(TR_J9VMBase *fej9);
+   void doUpdate(TR_J9VMBase *fej9, const std::string &removeStr, const std::string &modifyStr);
 
    virtual TR_PersistentClassInfo * findClassInfo(TR_OpaqueClassBlock * classId) override;
    virtual TR_PersistentClassInfo * findClassInfoAfterLocking(TR_OpaqueClassBlock * classId, TR::Compilation *, bool returnClassInfoForAOT = false, bool validate = true) override;
@@ -63,8 +63,8 @@ public:
 #endif
 
 private:
-   void commitRemoves(std::string &data);
-   void commitModifications(std::string &data);
+   void commitRemoves(const std::string &data);
+   void commitModifications(const std::string &data);
 
    PersistentUnorderedMap<TR_OpaqueClassBlock*, TR_PersistentClassInfo*> &getData();
    };


### PR DESCRIPTION
The client will send CHTable updates to the JItaaS server, but these
updates need to be applied in the order they were generated at the
client. This commit moves these CHTable updates in the sequencing
region ensuring they are applied in the correct order. More
specifically, each CHTable update encoded at the client will be tagged
with a sequence number which is communicated to the server. The server
logic is reponsible for applying these updates in the order given by
the client sequence number.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>