### PR TITLE
Return the same helper index on method symbol

### DIFF
--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -299,7 +299,7 @@ TR_RuntimeHelper TR::PPCCallSnippet::getInterpretedDispatchHelper(
       return TR_PPCnativeStaticHelper;
       }
    else if (isJitInduceOSRCall)
-      return TR_induceOSRAtCurrentPC;
+      return (TR_RuntimeHelper) methodSymRef->getReferenceNumber();
    else
       {
       switch (type)


### PR DESCRIPTION
Fix getInterpretedDispatchHelper on PPC to return the same
helper index on method symbol reference since now
induceOSR helper can be either TR_induceOSRAtCurrentPC or
TR_induceOSRAtCurrentPCAndRecompile.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>