### PR TITLE
Disable OMR_THR_YIELD_ALG on MacOS

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_osx.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_osx.mk
@@ -24,7 +24,6 @@ include $(CONFIG_INCL_DIR)/configure_common.mk
 CONFIGURE_ARGS += \
 	--enable-debug \
 	--enable-OMR_THR_THREE_TIER_LOCKING \
-	--enable-OMR_THR_YIELD_ALG \
 	--enable-OMR_THR_SPIN_WAKE_CONTROL \
 	--enable-OMRTHREAD_LIB_UNIX \
 	--enable-OMR_ARCH_X86 \


### PR DESCRIPTION
OMR_THR_YIELD_ALG enables support for -Xthr:[cfsYield|noCfsYield].
[cfsYield|noCfsYield] should only be used with Completely Fair Scheduler
(CFS).

MacOS schedulers can be classified as multilevel feedback queue
schedulers. MacOS doesn't use CFS. Thus, disabling OMR_THR_YIELD_ALG on
MacOS.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>