### PR TITLE
Optimize copyforward scheme for abort case and hybrid case

### DIFF
--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -406,7 +406,15 @@ MM_VerboseHandlerOutputVLHGC::handleCopyForwardEnd(J9HookInterface** hook, UDATA
 		writer->formatAndOutput(env, 1, "<memory-traced type=\"other\" objects=\"%zu\" bytes=\"%zu\" />",
 					copyForwardStats->_scanObjectsNonEden, copyForwardStats->_scanBytesNonEden);
 	}
-
+	if (0 == copyForwardStats->_nonEvacuateRegionCount) {
+		writer->formatAndOutput(env, 1, "<regions eden=\"%zu\" other=\"%zu\" />",
+				copyForwardStats->_edenEvacuateRegionCount, copyForwardStats->_nonEdenEvacuateRegionCount);
+	} else {
+		writer->formatAndOutput(env, 1, "<regions eden=\"%zu\" other=\"%zu\" evacuated=\"%zu\" marked=\"%zu\" />",
+				copyForwardStats->_edenEvacuateRegionCount, copyForwardStats->_nonEdenEvacuateRegionCount,
+				(copyForwardStats->_edenEvacuateRegionCount + copyForwardStats->_nonEdenEvacuateRegionCount - copyForwardStats->_nonEvacuateRegionCount),
+				copyForwardStats->_nonEvacuateRegionCount);
+	}
 	outputRememberedSetClearedInfo(env, irrsStats);
 
 	outputUnfinalizedInfo(env, 1, copyForwardStats->_unfinalizedCandidates, copyForwardStats->_unfinalizedEnqueued);
@@ -426,9 +434,7 @@ MM_VerboseHandlerOutputVLHGC::handleCopyForwardEnd(J9HookInterface** hook, UDATA
 	if(copyForwardStats->_scanCacheOverflow) {
 		writer->formatAndOutput(env, 1, "<warning details=\"scan cache overflow (storage acquired from heap)\" />");
 	}
-	if (0 != copyForwardStats->_nonEvacuateRegionCount) {
-		writer->formatAndOutput(env, 1, "<warning details=\"running under hybrid mode, JNI Critical region count=%zu\" />", copyForwardStats->_nonEvacuateRegionCount);
-	}
+
 	if(copyForwardStats->_aborted) {
 		writer->formatAndOutput(env, 1, "<warning details=\"operation aborted due to insufficient free space\" />");
 	}

--- a/runtime/gc_vlhgc/CollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/CollectionSetDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,9 +165,9 @@ MM_CollectionSetDelegate::createNurseryCollectionSet(MM_EnvironmentVLHGC *env)
 			bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
 
 			/* For CopyForwardHybrid mode we allow eden regions, which has jniCritical,to be part of nursery collectionSet, those regions would be marked instead of copyforwarded.
-			 * Would not add any non Eden regions with jniCritical to collectionSet for copyforward
 			 * For Non CopyForwardHybrid mode we do not check Eden regions with jniCritical here, because we have already set MarkCompact PGC mode for the case in early. */
-			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && region->isEden()))) {
+			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && (_extensions->tarokEnableCopyForwardHybrid || (0 != _extensions->fvtest_forceCopyForwardHybridRatio)) && region->isEden()))) {
+
 				if(MM_CompactGroupManager::isRegionInNursery(env, region)) {
 					UDATA compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
 					/* on collection phase, mark all non-overflowed regions and those that RSCL is not being rebuilt */

--- a/runtime/gc_vlhgc/CopyForwardCompactGroup.hpp
+++ b/runtime/gc_vlhgc/CopyForwardCompactGroup.hpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,8 +59,8 @@ public:
 		UDATA _copiedBytes; /**< The number of bytes copied into survivor regions for this compact group by the owning thread */
 		UDATA _liveObjects; /**< The number of live objects found in evacuate regions for this compact group by the owning thread (i.e. objects copied FROM or WITHIN this compact group) */
 		UDATA _liveBytes; /**< The number of live bytes found in evacuate regions for this compact group by the owning thread */
-		UDATA _scannedObjects; /**< The number of objects scanned in abort recovery in regions in this compact group */
-		UDATA _scannedBytes; /**< The number of objects scanned in abort recovery in regions in this compact group */
+		UDATA _scannedObjects; /**< The number of objects scanned in abort recovery/nonEvacuated regions in this compact group */
+		UDATA _scannedBytes; /**< The number of objects scanned in abort recovery/nonEvacuated regions in this compact group */
 	};
 	
 	MM_CopyForwardCompactGroupStats _edenStats; /**< Data about objects from Eden regions */

--- a/runtime/gc_vlhgc/CopyForwardDelegate.hpp
+++ b/runtime/gc_vlhgc/CopyForwardDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,6 +115,16 @@ public:
 			ret = _breadthFirstCopyForwardScheme->isHybrid(env);
 		}
 		return ret;
+	}
+
+	/**
+	 * Set the number of regions, which are need to be reserved for Mark/Compact only in CollectionSet due to short of survivor regions for CopyForward
+	 */
+	void setReservedNonEvacuatedRegions(int regionCount)
+	{
+		if (NULL != _breadthFirstCopyForwardScheme) {
+			_breadthFirstCopyForwardScheme->setReservedNonEvacuatedRegions(regionCount);
+		}
 	}
 };
 

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,8 +174,9 @@ MM_ProjectedSurvivalCollectionSetDelegate::createNurseryCollectionSet(MM_Environ
 		if (region->containsObjects()) {
 			bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 			bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
-			/* allow jniCritical regions are part of nursery collectionSet for copyforward */
-			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && region->isEden()))) {
+			/* Allow jniCritical Eden regions are part of Nursery collectionSet in CopyForwardHybrid mode */
+			if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && (_extensions->tarokEnableCopyForwardHybrid || (0 != _extensions->fvtest_forceCopyForwardHybridRatio)) && region->isEden()))) {
+
 				if(MM_CompactGroupManager::isRegionInNursery(env, region)) {
 					/* on collection phase, mark all non-overflowed regions and those that RSCL is not being rebuilt */
 					/* sweep/compact flags are set in ReclaimDelegate */
@@ -265,8 +266,8 @@ MM_ProjectedSurvivalCollectionSetDelegate::createRateOfReturnCollectionSet(MM_En
 			if (MM_CompactGroupManager::isRegionDCSSCandidate(env, region)) {
 				bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 				bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
-				/* allow jniCritical regions are part ofRateOfReturnCollectionSet for copyforward */
-				if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions || (regionHasCriticalRegions && region->isEden()))) {
+
+				if (region->getRememberedSetCardList()->isAccurate() && (!isSelectionForCopyForward || !regionHasCriticalRegions)) {
 					_dynamicSelectionRegionList[sortListSize] = region;
 					sortListSize += 1;
 				}

--- a/runtime/gc_vlhgc/ReclaimDelegate.cpp
+++ b/runtime/gc_vlhgc/ReclaimDelegate.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -745,6 +745,10 @@ MM_ReclaimDelegate::runReclaimForAbortedCopyForward(MM_EnvironmentVLHGC *env, MM
 
 	Trc_MM_ReclaimDelegate_runReclaimForAbortedCopyForward_Entry(env->getLanguageVMThread(), ((MM_GlobalAllocationManagerTarok *)MM_GCExtensions::getExtensions(env)->globalAllocationManager)->getFreeRegionCount());
 	Assert_MM_true(env->_cycleState->_shouldRunCopyForward);
+
+	/* Perform Atomic Sweep on nonEvacuated regions before compacting in order to maintain accurate projectedLiveByte for the regions
+	 * projectedLiveByte will be used in selecting RateOfReturnCollectionSet in future collection */
+	performAtomicSweep(env, allocDescription, activeSubSpace, gcCode);
 
 	UDATA regionsCompacted = tagRegionsBeforeCompact(env, skippedRegionCountRequiringSweep);
 	MM_CompactGroupPersistentStats::updateStatsBeforeCompact(env, persistentStats);

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -373,6 +373,11 @@ public:
 	void firstPGCAfterGMPCompleted();
 
 	/**
+	 * return whether a PGC Abort happens during GMP
+	 */
+	bool isPGCAbortDuringGMP() {return _disableCopyForwardDuringCurrentGlobalMarkPhase;}
+
+	/**
 	 * return whether the following PGC is required to do global sweep (typically, first PGC after GMP completed)
 	 */
 	bool isGlobalSweepRequired() { return _globalSweepRequired; }
@@ -455,6 +460,8 @@ public:
 	 */
 	void heapReconfigured(MM_EnvironmentVLHGC *env);
 	
+	double getAvgEdenSurvivalRateCopyForward(MM_EnvironmentVLHGC *env) { return _edenSurvivalRateCopyForward; }
+
 	MM_SchedulingDelegate(MM_EnvironmentVLHGC *env, MM_HeapRegionManager *manager);
 };
 


### PR DESCRIPTION
In pull request #2855 , we introduced -XXgc:tarokEnableCopyForwardMarkCompactHybrid option to enable copyforward Hybrid mode to minimize MarkCompact PGC due to jniCritical in eden regions( it could reduce  more than 40% gc pause for the case). 
In order to measure the performance of  copyforwardHybrid in various cases, use testing option -XXgc:fvtest_forceCopyForwardMarkCompactHybridRatio can random pick from 1%-100% collectionSet regions to set markCompact, for extreme case -XXgc:fvtest_forceCopyForwardMarkCompactHybridRatio=100%, we expects similar performance as jvm is running with -XXgc:tarokPGCOnlyMarkCompact option.
But we did see performance gap between CopyForwardMarkCompactHybridRatio=100% and PGCOnlyMarkCompact(Hybrid shows 79% more GMP cycles, 25% more PGC pause, 5% throughput drop).
The performance gap are majorly caused by the below 3 issues.
1, mark in copyforward (include abort case) does not aware  leaf objects(there is no reference in leaf object, don't need to add them in scan stack) during scan.  
2, underestimate the remaining after PGC due to overestimate the required survivor regions
3, missed to adjust "live" bytes for mark only regions (both abort and hybrid case), it would cause to pick wrong RateOfReturnCollectionSet for the next collection(lower return rate).

This pull request tries to optimize code to avoid the 3 issues.

	Optimize copyforward scheme for abort case and hybrid case

	- Allow jniCritical eden regions	are part of nursery
	collectionSet in CopyForwardHybrid mode.
	- report the numbers of regions in collection set (for eden,
	nonEden, evacuated, marked) in gc-op-copypforward of verbose gc.
	- Not push leaf Objects into work stack for abort case and
	 CopyforwardHybrid mode.
	- create inline method iterateAndCopyforwardSlotReference()
	for avoiding duplicated logic.
	- Perform Atomic Sweep on nonEvacurated regions before compacting
	for abort case and CopyforwardHybrid mode in order to maintain
	accurate projectedLiveByte for the regions.
	- Correct estimatePartialGCsRemaining if
	_extensions->fvtest_forceCopyForwardHybridRatio is set
	(testing purpose) to avoid underestimating the remaining.
    - avoid any MarkCompactPGC in Hybrid mode to reduce longer gc pause
      1, eliminate MarkCompactPGCs caused by jniCrital(set any
      jniCritial Eden regions to mark only).
      2, eliminate MarkCompactPGCs caused by disabling copyforward
      due to pervious abort during GMP(set number of Eden regions to
      mark only if estimating free regions are not enough for survivor).

Signed-off-by: Lin Hu <linhu@ca.ibm.com>