### PR TITLE
Fix and use withfield in value type tests

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -418,7 +418,7 @@ public class ValueTypeGenerator {
 	
 	private static void generateWither(ClassWriter cw, String[] nameAndSigValue, String className) {
 		/* generate setter */
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "set" + nameAndSigValue[0], "(" + nameAndSigValue[1] + ")L" + className + ";", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "with" + nameAndSigValue[0], "(" + nameAndSigValue[1] + ")L" + className + ";", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ALOAD, 0);
 		switch (nameAndSigValue[1]) {
@@ -443,7 +443,49 @@ public class ValueTypeGenerator {
 			break;
 		}
 		mv.visitFieldInsn(WITHFIELD, className, nameAndSigValue[0], nameAndSigValue[1]);
-		mv.visitInsn(RETURN);
+		mv.visitInsn(ARETURN);
+		mv.visitMaxs(2, 2);
+		mv.visitEnd();
+		
+		mv = cw.visitMethod(ACC_PUBLIC, "withGeneric" + nameAndSigValue[0], "(Ljava/lang/Object;)L" + className + ";", null, null);
+		mv.visitCode();
+		mv.visitVarInsn(ALOAD, 0);
+		mv.visitVarInsn(ALOAD, 1);
+		switch (nameAndSigValue[1]) {
+		case "D":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Double");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()D", false);
+			break;
+		case "I":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Interger");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Interger", "intValue", "()I", false);
+		case "Z":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Boolean");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z", false);
+		case "B":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Byte");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Byte", "byteValue", "()B", false);
+		case "C":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Character");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Character", "charValue", "()C", false);
+		case "S":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Short");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Short", "shortValue", "()S", false);
+			break;
+		case "F":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Float");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Float", "floatValue", "()F", false);
+			break;
+		case "J":
+			mv.visitTypeInsn(CHECKCAST, "java/lang/Double");
+			mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()J", false);
+			break;
+		default:
+			break;
+		}
+		
+		mv.visitMethodInsn(INVOKEVIRTUAL, className, "with" + nameAndSigValue[0], "(" + nameAndSigValue[1] + ")L" + className + ";", false);
+		mv.visitInsn(ARETURN);
 		mv.visitMaxs(2, 2);
 		mv.visitEnd();
 	}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -71,9 +71,9 @@ public class ValueTypeTests {
 		makePoint2D = lookup.findStatic(point2DClass, "makeValue", MethodType.methodType(point2DClass, int.class, int.class));
 		
 		getX = generateGetter(point2DClass, "x", int.class);
-		MethodHandle setX = generateSetter(point2DClass, "x", int.class);
+		MethodHandle withX = generateWither(point2DClass, "x", int.class, point2DClass);
 		getY = generateGetter(point2DClass, "y", int.class);
-		MethodHandle setY = generateSetter(point2DClass, "y", int.class);
+		MethodHandle withY = generateWither(point2DClass, "y", int.class, point2DClass);
 
 		int x = 0xFFEEFFEE;
 		int y = 0xAABBAABB;
@@ -85,8 +85,8 @@ public class ValueTypeTests {
 		assertEquals(getX.invoke(point2D), x);
 		assertEquals(getY.invoke(point2D), y);
 		
-		setX.invoke(point2D, xNew);
-		setY.invoke(point2D, yNew);
+		point2D = withX.invoke(point2D, xNew);
+		point2D = withY.invoke(point2D, yNew);
 		
 		assertEquals(getX.invoke(point2D), xNew);
 		assertEquals(getY.invoke(point2D), yNew);
@@ -109,9 +109,9 @@ public class ValueTypeTests {
 		makeLine2D = lookup.findStatic(line2DClass, "makeValue", MethodType.methodType(line2DClass, point2DClass, point2DClass));
 		
 		MethodHandle getSt = generateGetter(line2DClass, "st", point2DClass);
- 		MethodHandle setSt = generateSetter(line2DClass, "st", point2DClass);
+ 		MethodHandle withSt = generateWither(line2DClass, "st", point2DClass, line2DClass);
  		MethodHandle getEn = generateGetter(line2DClass, "en", point2DClass);
- 		MethodHandle setEn = generateSetter(line2DClass, "en", point2DClass);
+ 		MethodHandle withEn = generateWither(line2DClass, "en", point2DClass, line2DClass);
  		
 		int x = 0xFFEEFFEE;
 		int y = 0xAABBAABB;
@@ -140,8 +140,8 @@ public class ValueTypeTests {
 		Object stNew = makePoint2D.invoke(xNew, yNew);
 		Object enNew = makePoint2D.invoke(x2New, y2New);
 		
-		setSt.invoke(line2D, stNew);
-		setEn.invoke(line2D, enNew);
+		line2D = withSt.invoke(line2D, stNew);
+		line2D = withEn.invoke(line2D, enNew);
 		
 		assertEquals(getX.invoke(getSt.invoke(line2D)), xNew);
 		assertEquals(getY.invoke(getSt.invoke(line2D)), yNew);
@@ -165,14 +165,10 @@ public class ValueTypeTests {
 				
 		MethodHandle makeFlattenedLine2D = lookup.findStatic(flattenedLine2DClass, "makeValueGeneric", MethodType.methodType(flattenedLine2DClass, Object.class, Object.class));
 		
-		
-		/*
- 		TODO need q signature support to do anything else with FalttenedLine2D
-		
 		MethodHandle getSt = generateGenericGetter(flattenedLine2DClass, "st");
- 		MethodHandle setSt = generateGenericSetter(flattenedLine2DClass, "st");
+ 		MethodHandle withSt = generateGenericWither(flattenedLine2DClass, "st", flattenedLine2DClass);
  		MethodHandle getEn = generateGenericGetter(flattenedLine2DClass, "en");
- 		MethodHandle setEn = generateGenericSetter(flattenedLine2DClass, "en");
+ 		MethodHandle withEn = generateGenericWither(flattenedLine2DClass, "en", flattenedLine2DClass);
  		
 		int x = 0xFFEEFFEE;
 		int y = 0xAABBAABB;
@@ -200,17 +196,14 @@ public class ValueTypeTests {
 		
 		Object stNew = makePoint2D.invoke(xNew, yNew);
 		Object enNew = makePoint2D.invoke(x2New, y2New);
-				
-		setSt.invoke(line2D, stNew);
-		setEn.invoke(line2D, enNew);
+		
+		line2D = withSt.invoke(line2D, stNew);
+		line2D = withEn.invoke(line2D, enNew);
 		
 		assertEquals(getX.invoke(getSt.invoke(line2D)), xNew);
 		assertEquals(getY.invoke(getSt.invoke(line2D)), yNew);
 		assertEquals(getX.invoke(getEn.invoke(line2D)), x2New);
 		assertEquals(getY.invoke(getEn.invoke(line2D)), y2New);
-		
-		*/
-
 	}
 
 	/*
@@ -355,6 +348,24 @@ public class ValueTypeTests {
 	static MethodHandle generateGenericSetter(Class clazz, String fieldName) {
 		try {
 			return lookup.findVirtual(clazz, "setGeneric"+fieldName, MethodType.methodType(void.class, Object.class));
+		} catch (IllegalAccessException | SecurityException | NullPointerException | NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+	
+	static MethodHandle generateWither(Class clazz, String fieldName, Class fieldType, Class returnType) {
+		try {
+			return lookup.findVirtual(clazz, "with"+fieldName, MethodType.methodType(returnType, fieldType));
+		} catch (IllegalAccessException | SecurityException | NullPointerException | NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	static MethodHandle generateGenericWither(Class clazz, String fieldName, Class returnType) {
+		try {
+			return lookup.findVirtual(clazz, "withGeneric"+fieldName, MethodType.methodType(returnType, Object.class));
 		} catch (IllegalAccessException | SecurityException | NullPointerException | NoSuchMethodException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Previously, withfield was not correctly implemented due to an incorrect
return type and naming convention. Support was also added for a
`withGeneric` method for testing.

In addition, value type tests used setters instead of withers, causing
errors as `putfield` was used to overwrite final variables.

Previously unused value type testing was re-enabled due to now being
supported.

Signed-off-by: Andrew Crowther <acrowthe3388@gmail.com>