### PR TITLE
Remove redundant export groups

### DIFF
--- a/runtime/redirector/module.xml
+++ b/runtime/redirector/module.xml
@@ -23,17 +23,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 <module xmlns:xi="http://www.w3.org/2001/XInclude">
 	<xi:include href="../j9vm/j9vmnatives.xml"><xi:fallback/></xi:include>
 
-	<exports group="jdk11">
-		<export name="_JVM_GetCallerClass@4"/>
-		<export name="JVM_BeforeHalt"/>
-		<export name="JVM_GetNestHost"/>
-		<export name="JVM_GetNestMembers"/>
-		<export name="JVM_AreNestMates"/>
-	</exports>
-	<exports group="jdk12">
-		<export name="JVM_InitializeFromArchive"/>
-	</exports>
-
 	<artifact type="target" name="generated.c" all="false">
 		<dependencies>
 			<dependency name="generated.c.m4"/>


### PR DESCRIPTION
* jdk11 and jdk12 are already defined in j9vmnatives.xml