### PR TITLE
Don't turn off OSR for Quad

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4585,10 +4585,6 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock * aMethod, TR_Fron
                          !strncmp(m->_name, name, nameLen) &&
                          (m->_sigLen == (int16_t)-1 || !strncmp(m->_sig,  sig,  sigLen)))
                         {
-
-                        if ((classNameLen == 30) && !strncmp(className, "com/ibm/Compiler/Internal/Quad", 30))
-                           setQuadClassSeen();
-
                         setRecognizedMethodInfo(m->_enum);
                         break;
                         }
@@ -4984,19 +4980,6 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
          setRecognizedMethod(rm);
          }
       }
-   }
-
-void
-TR_ResolvedJ9Method::setQuadClassSeen()
-   {
-   TR::Compilation* comp = ( fej9()->_compInfoPT ) ? fej9()->_compInfoPT->getCompilation() : NULL;
-   //TODO:
-   //This works but is too drastic because it disable the OSR
-   //for the entire compilation. Further work needs to be done
-   //to not attempt OSR only when the execution entered the code path
-   //that's different from the interpreter.
-   if (comp && comp->supportsQuadOptimization())
-     comp->setSeenClassPreventingInducedOSR();
    }
 
 J9RAMConstantPoolItem *

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -478,7 +478,6 @@ private:
    virtual void                  handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * unresolvedInCP);
 
    void setRecognizedMethodInfo(TR::RecognizedMethod rm);
-   void setQuadClassSeen();
 
    J9Method *              _ramMethod;
    J9ROMMethod *           _romMethod;


### PR DESCRIPTION
Quad optimizations turns a call to Quad method into arithmetic
operations, which is not an OSR point. Therefore no OSR bookkeeping will
be done for Quad and there is no interaction between Quad and OSR. It is
safe to turn OSR on even when Quad is encountered.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>