### PR TITLE
Temporarily exclude libpathTestRtf and libpathTestRtfChild tests on OSX

### DIFF
--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -33,7 +33,8 @@
 	-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
-		<platformRequirements>bits.64,vm.cmprssptrs</platformRequirements>
+		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3787 -->
+		<platformRequirements>bits.64,vm.cmprssptrs,^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -56,6 +57,8 @@
 	-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude_rtfchild.xml$(Q) \
 	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
+		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3787 -->
+		<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
libpathTestRtf and libpathTestRtfChild tests pass locally on OSX. But,
they hang in Jenkins builds due to a pop-up requiring user-action. This
causes a Jenkins build to halt for 4 hrs. Temporarily excluding
libpathTestRtf and libpathTestRtfChild tests on OSX to avoid the halt
for 4 hrs. The tests will be added back once the issue is resolved.

Issue: https://github.com/eclipse/openj9/issues/3787

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>