### PR TITLE
Add test setUp/tearDown to TKG

### DIFF
--- a/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/test/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -443,6 +443,8 @@ sub writeTargets {
 				}
 			}
 
+			print $fhOut "$indent\$(TEST_SETUP);\n";
+
 			print $fhOut "$indent\@echo \"variation: $var\" | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
 			print $fhOut "$indent\@echo \"JVM_OPTIONS: \$(JVM_OPTIONS)\" | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
 
@@ -451,6 +453,8 @@ sub writeTargets {
 			$command =~ s/\s+$//;
 
 			print $fhOut "$indent\{ \$(MKTREE) \$(REPORTDIR); \\\n$indent\$(CD) \$(REPORTDIR); \\\n$indent$command; \} 2>&1 | tee -a \$(Q)\$(TESTOUTPUT)\$(D)TestTargetResult\$(Q);\n";
+
+			print $fhOut "$indent\$(TEST_TEARDOWN);\n";
 
 			if (defined($capabilityReqs)) {
 				foreach my $key (keys %capabilityReqs_Hash) {

--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -218,6 +218,16 @@ endif
 TEST_SKIP_STATUS=$@_SKIPPED
 
 #######################################
+# TEST_SETUP
+#######################################
+TEST_SETUP=$(JAVA_COMMAND) -Xshareclasses:destroyAll || echo "cache cleanup done"
+
+#######################################
+# TEST_TEARDOWN
+#######################################
+TEST_TEARDOWN=$(JAVA_COMMAND) -Xshareclasses:destroyAll || echo "cache cleanup done"
+
+#######################################
 # include configure makefile
 #######################################
 ifndef MACHINE_MK

--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -45,8 +45,7 @@
 	TestMemoryPoolMXBean \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS); \
-	$(JAVA_COMMAND) -Xshareclasses:name=testJLM,destroy || echo "cache cleanup done"</command>
+	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -80,8 +79,7 @@
 	TestMemoryPoolMXBean \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS); \
-	$(JAVA_COMMAND) -Xshareclasses:name=testJLM,destroy || echo "cache cleanup done"</command>
+	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -108,8 +106,7 @@
 	-testnames JLM_Tests_class \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS); \
-	$(JAVA_COMMAND) -Xshareclasses:name=testJLM,destroy || echo "cache cleanup done"</command>
+	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -135,8 +132,7 @@
 	-testnames JLM_Tests_class \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS); \
-	$(JAVA_COMMAND) -Xshareclasses:name=testJLM,destroy || echo "cache cleanup done"</command>
+	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -163,8 +159,7 @@
 	-testnames JLM_Tests_IBMinternal \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS); \
-	$(JAVA_COMMAND) -Xshareclasses:name=testJLM,destroy || echo "cache cleanup done"</command>
+	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -190,8 +185,7 @@
 	-testnames JLM_Tests_IBMinternal \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
-	$(TEST_STATUS); \
-	$(JAVA_COMMAND) -Xshareclasses:name=testJLM,destroy || echo "cache cleanup done"</command>
+	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Clean up shareclasses cache before/after test execution.
- Remove duplicate cleanup from JLM_Test.

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>