### PR TITLE
Enable COMPUTED_GOTO on Windows

### DIFF
--- a/runtime/vm/BytecodeInterpreter.cpp
+++ b/runtime/vm/BytecodeInterpreter.cpp
@@ -39,7 +39,7 @@
  * USE_COMPUTED_GOTO is enabled on Linux s390 when compiling with gcc7+.
  * USE_COMPUTED_GOTO improves startup performance by ~10% on Linux s390.
  */
-#if (defined(WIN32) && defined(__GNUC__))
+#if (defined(WIN32) && defined(__clang__))
 #define USE_COMPUTED_GOTO
 #elif (defined(LINUX) && defined(J9HAMMER))
 #define USE_COMPUTED_GOTO

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8249,7 +8249,7 @@ protected:
 
 public:
 
-#if (defined(J9VM_ARCH_X86) || defined(S390)) && defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))
+#if ((defined(WIN32) && defined(__clang__)) || ((defined(J9VM_ARCH_X86) || defined(S390)) && defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))))
 	/*
 	 * This method can't be 'VMINLINE' because it declares local static data
 	 * triggering a warning with GCC compilers newer than 4.6.


### PR DESCRIPTION
The change is to turn on this flag while
disabling VMINLINE to see how much percentage
we can improve in terms of performance on Windows.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>