### PR TITLE
Travis: Increase ccache size to 1 GB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ addons:
 before_install:
   - jdk_switcher use oraclejdk8
 before_script:
-  - ccache -s -z
+  - ccache -s -z --max-size=1G
 script:
   - bash ./buildenv/travis/build-on-travis.sh
 after_script:


### PR DESCRIPTION
Current size is 512MB, which is almost completely filled (possibly
overfilled) by a single build. By increasing cache size we should
see improvements in build times

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>