### PR TITLE
Fix the access check in findSpecial

### DIFF
--- a/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Find.java
+++ b/test/functional/Jsr292/src/com/ibm/j9/jsr292/LookupAPITests_Find.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,7 @@ import com.ibm.j9.jsr292.SamePackageExample.SamePackageInnerClass;
 import com.ibm.j9.jsr292.SamePackageExample.SamePackageInnerClass.SamePackageInnerClass_Nested_Level2;
 
 import examples.PackageExamples;
+import examples.CrossPackageDefaultMethodInterface;
 import examples.PackageExamples.CrossPackageInnerClass;
 
 /**
@@ -2096,6 +2097,33 @@ public class LookupAPITests_Find {
 		System.out.println(example);
 		int out = ( int )example.invokeExact( g, 1, 2 ); 
 		AssertJUnit.assertEquals( 3, out );
+	}
+	
+	/**
+	 * findSpecial test using a default method of an interface where the class (the resultant 
+	 * method handle will be bound to) is in a different package.
+	 * @throws Throwable
+	 */
+	@Test(groups = { "level.extended" })
+	public void test_FindSpecial_Default_CrossPackage_Interface() throws Throwable {
+		MethodHandle example = MethodHandles.lookup().findSpecial(CrossPackageDefaultMethodInterface.class, "addDefault", MethodType.methodType(int.class, int.class, int.class), CrossPackageDefaultMethodInterface.class);
+	}
+	
+	/**
+	 * Negative findSpecial test using a public method of a class where the class (the resultant 
+	 * method handle will be bound to) is in a different package.
+	 * Note: when the lookup class is not equal to the caller class, the declaring class
+	 * must be an interface which the caller class can be assigned to.
+	 * @throws Throwable
+	 */
+	@Test(groups = { "level.extended" })
+	public void test_FindSpecial_Public_CrossPackage_Not_Interface() throws Throwable {
+		try {
+			MethodHandles.lookup().findSpecial(PackageExamples.class, "addPublic", MethodType.methodType(int.class, int.class, int.class), PackageExamples.class);
+			Assert.fail("No exception thrown finding a public method of a class in a different package");
+		} catch(IllegalAccessException e) {
+			// Exception expected, test passed
+		}
 	}
 	
 	/**

--- a/test/functional/Jsr292/src/examples/CrossPackageDefaultMethodInterface.java
+++ b/test/functional/Jsr292/src/examples/CrossPackageDefaultMethodInterface.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package examples;
+
+/**
+ * Cross-package default method interface example used by LookupAPITests_Find 
+ * @author jincheng
+ *
+ */
+public interface CrossPackageDefaultMethodInterface {
+
+	default int addDefault(int a, int b) {
+		return (a + b);
+	}
+	
+}


### PR DESCRIPTION
The change is to add the access check
in invoking interface's methods via
findSpecial.

Fix: #3851

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>