### PR TITLE
Catch StreamCancel exceptions

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -3425,6 +3425,13 @@ TR::CompilationInfoPerThreadRemote::processEntry(TR_MethodToBeCompiled &entry, J
       stream->cancel(); // This does nothing for raw sockets
       abortCompilation = true;
       }
+   catch (const JITaaS::StreamCancel &e)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "Stream cancelled by client while compThreadID=%d was reading the compilation request: %s",
+            getCompThreadId(), e.what());
+      abortCompilation = true;
+      }
    catch (const JITaaS::StreamOOO &e)
       {
       // Error message was printed when the exception was thrown


### PR DESCRIPTION
While the server is reading the initial compilation request the client
could still cancel the stream resulting in a StreamCancel exception
which needs to be caught at the server, or the server terminates.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>