### PR TITLE
Apply -Xshareclasses:destroyAll only when JDK_IMPL=openj9 or ibm

### DIFF
--- a/test/TestConfig/settings.mk
+++ b/test/TestConfig/settings.mk
@@ -220,12 +220,18 @@ TEST_SKIP_STATUS=$@_SKIPPED
 #######################################
 # TEST_SETUP
 #######################################
-TEST_SETUP=$(JAVA_COMMAND) -Xshareclasses:destroyAll || echo "cache cleanup done"
+TEST_SETUP=@echo "Nothing to be done for setup."
+ifeq ($(JDK_IMPL), $(filter $(JDK_IMPL),openj9 ibm))
+	TEST_SETUP=$(JAVA_COMMAND) -Xshareclasses:destroyAll; $(JAVA_COMMAND) -Xshareclasses:groupAccess,destroyAll; echo "cache cleanup done"
+endif
 
 #######################################
 # TEST_TEARDOWN
 #######################################
-TEST_TEARDOWN=$(JAVA_COMMAND) -Xshareclasses:destroyAll || echo "cache cleanup done"
+TEST_TEARDOWN=@echo "Nothing to be done for teardown."
+ifeq ($(JDK_IMPL), $(filter $(JDK_IMPL),openj9 ibm))
+	TEST_TEARDOWN=$(JAVA_COMMAND) -Xshareclasses:destroyAll; $(JAVA_COMMAND) -Xshareclasses:groupAccess,destroyAll; echo "cache cleanup done"
+endif
 
 #######################################
 # include configure makefile


### PR DESCRIPTION
- add the conditional check in settings.mk

[ci skip]

Fixes #3975 

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>