### PR TITLE
Update comment for a no-op implementation

### DIFF
--- a/runtime/j9vm/javanextvmi.c
+++ b/runtime/j9vm/javanextvmi.c
@@ -27,6 +27,6 @@
 JNIEXPORT void JNICALL
 JVM_InitializeFromArchive(JNIEnv *env, jclass clz)
 {
-	/* To be implemented via https://github.com/eclipse/openj9/issues/2452 */
+	/* A no-op implementation is ok. */
 }
 #endif /* JAVA_SPEC_VERSION >= 12 */


### PR DESCRIPTION
Update comment for a no-op implementation

It has been determined a no-op implementation is enough. Closed #2452 .
[skip ci]

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>