### PR TITLE
Free client specific data on VM shutdown

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3210,6 +3210,26 @@ void TR::CompilationInfo::stopCompilationThreads()
 #endif
 
    releaseCompMonitor(vmThread);
+   if (getPersistentInfo()->getJITaaSMode() == CLIENT_MODE)
+      {
+      getSequencingMonitor()->enter();
+      uint32_t seqNo = getCompReqSeqNo();
+      incCompReqSeqNo();
+      getSequencingMonitor()->exit();
+      JITaaSHelpers::ClassInfoTuple classTuple;
+      std::vector<TR_OpaqueClassBlock*> unloadedClasses;
+      std::string optionsStr;
+      std::string recompMethodInfoStr;
+      std::string detailsStr;
+      J9Class *clazz = NULL;
+      J9Method *ramMethod = NULL;
+      uint32_t romMethodOffset = 0;
+      JITaaS::J9ClientStream client(getPersistentInfo());
+      client.buildCompileRequest(getPersistentInfo()->getJITaaSId(), romMethodOffset,
+                     ramMethod, clazz, cold, detailsStr, J9::EMPTY,
+                     unloadedClasses, classTuple, optionsStr, recompMethodInfoStr, seqNo);
+
+      }
    }
 
 IDATA J9THREAD_PROC compilationThreadProc(void *entryarg)

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -135,6 +135,9 @@ class ClientSessionData
    void decNumActiveThreads() { --_numActiveThreads;  }
    void printStats();
 
+   void markForDeletion() { _markedForDeletion = true;}
+   bool isMarkedForDeletion() const { return _markedForDeletion; }
+
    TR::Monitor *getStaticMapMonitor() { return _staticMapMonitor; }
    PersistentUnorderedMap<void *, TR_StaticFinalData> &getStaticFinalDataMap() { return _staticFinalDataMap; }
 
@@ -168,7 +171,7 @@ class ClientSessionData
                              // This is smaller or equal to _inUse because some threads
                              // could be just starting or waiting in _OOSequenceEntryList
    VMInfo *_vmInfo; // info specific to a client VM that does not change, nullptr means not set
-
+   bool _markedForDeletion; //Client Session is marked for deletion. When the inUse count will become zero this will be deleted.
    TR_AddressSet *_unloadedClassAddresses; // Per-client versions of the unloaded class and method addresses kept in J9PersistentInfo
    bool           _requestUnloadedClasses; // If true we need to request the current state of unloaded classes from the client
    TR::Monitor *_staticMapMonitor;
@@ -188,6 +191,7 @@ class ClientSessionHT
    ~ClientSessionHT();
    static ClientSessionHT* allocate(); // allocates a new instance of this class
    ClientSessionData * findOrCreateClientSession(uint64_t clientUID, uint32_t seqNo, bool *newSessionWasCreated);
+   bool deleteClientSession(uint64_t clientUID, bool forDeletion);
    ClientSessionData * findClientSession(uint64_t clientUID);
    void purgeOldDataIfNeeded();
    void printStats();


### PR DESCRIPTION
JITaaS server caches the information for the JITaaS client
in an internal hash map per client.This data is purged if
not used for sometime(1000 minutes) but this can grow very
large if the number of client increases to large number.
To fix this issue the client data needs to be deleted when
the client compilation thread teminates.

On VM shutdown, stopCompilationThreads get called which terminate
the client thread.On thread temination a dummy remote compilation
request is build with NULL J9Method. On seeing this request the server
check if the inUse for the client session is 0 and removes the client
session data from the hash map. If the inUse is not zero then the
the client data is marked to be deleted and the onus of deleting
the client data lies with whoever make the inUse 0.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>