### PR TITLE
Require interface in resolveInterfaceMethodRefInto

### DIFF
--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1043,8 +1043,8 @@ resolveInterfaceMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(interfaceClass->romClass);
 			j9object_t detailMessage = vm->memoryManagerFunctions->j9gc_createJavaLangString(vmStruct, J9UTF8_DATA(className), J9UTF8_LENGTH(className), J9_STR_XLAT);
 			setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, (UDATA *)detailMessage);
-			goto done;
 		}
+		goto done;
 	}
 	
 	nameAndSig = J9ROMFIELDREF_NAMEANDSIGNATURE(romMethodRef);


### PR DESCRIPTION
This function should fail whenever interfaceClass is not an interface,
even if no exception is to be thrown. Currently it can continue on with
a non-interface class and find a method that belongs neither to an
interface nor to Object, which is supposed to be impossible for
interface method references.

Fixes #3916