### PR TITLE
Remove obsolete jcl MAX link

### DIFF
--- a/buildspecs/aix_ppc-64.spec
+++ b/buildspecs/aix_ppc-64.spec
@@ -77,7 +77,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="aix_ppc-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/aix_ppc-64_cmprssptrs.spec
+++ b/buildspecs/aix_ppc-64_cmprssptrs.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="aix_ppc-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/aix_ppc.spec
+++ b/buildspecs/aix_ppc.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="aix_ppc-32"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jdiTestsSupported" value="true"/>

--- a/buildspecs/core.feature
+++ b/buildspecs/core.feature
@@ -29,7 +29,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<requiredProperty name="j9dt.compileTarget"/>
 		<requiredProperty name="j9dt.make"/>
 		<requiredProperty name="j9dt.toolsTarget"/>
-		<requiredProperty name="jclMaxSecurityPolicyDefine"/>
 		<requiredProperty name="jclMemoryMax"/>
 		<requiredProperty name="jclOSStackSizeMax"/>
 		<requiredProperty name="jitTestingOptLevel"/>

--- a/buildspecs/linux_390-64.spec
+++ b/buildspecs/linux_390-64.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_390-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_390-64_cmprssptrs.spec
+++ b/buildspecs/linux_390-64_cmprssptrs.spec
@@ -77,7 +77,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_390-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_390.spec
+++ b/buildspecs/linux_390.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_390-31"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_arm.spec
+++ b/buildspecs/linux_arm.spec
@@ -90,7 +90,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_arm-32"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jdiTestsSupported" value="true"/>

--- a/buildspecs/linux_arm_linaro.spec
+++ b/buildspecs/linux_arm_linaro.spec
@@ -90,7 +90,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_arm-32"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jdiTestsSupported" value="true"/>

--- a/buildspecs/linux_ppc-64.spec
+++ b/buildspecs/linux_ppc-64.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-64_le_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_cmprssptrs_le_gcc.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-64_le_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_ppc-64_le.spec
+++ b/buildspecs/linux_ppc-64_le.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-64_le"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_ppc-64_le_gcc.spec
+++ b/buildspecs/linux_ppc-64_le_gcc.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-64_le"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_ppc.spec
+++ b/buildspecs/linux_ppc.spec
@@ -76,7 +76,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ppc-32"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_x86-64.spec
+++ b/buildspecs/linux_x86-64.spec
@@ -79,7 +79,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_x86-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_x86-64_cmprssptrs.spec
+++ b/buildspecs/linux_x86-64_cmprssptrs.spec
@@ -77,7 +77,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_x86-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/linux_x86.spec
+++ b/buildspecs/linux_x86.spec
@@ -90,7 +90,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_x86-32"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jdiTestsSupported" value="true"/>

--- a/buildspecs/linux_ztpf_390-64.spec
+++ b/buildspecs/linux_ztpf_390-64.spec
@@ -75,7 +75,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_ztpf_390-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/osx_x86-64.spec
+++ b/buildspecs/osx_x86-64.spec
@@ -79,7 +79,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_x86-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/osx_x86-64_cmprssptrs.spec
+++ b/buildspecs/osx_x86-64_cmprssptrs.spec
@@ -77,7 +77,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="linux_x86-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/win_x86-64.spec
+++ b/buildspecs/win_x86-64.spec
@@ -83,7 +83,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.shellPrefix" value="cmd.exe /C"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="win_x86-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/win_x86-64_cmprssptrs.spec
+++ b/buildspecs/win_x86-64_cmprssptrs.spec
@@ -81,7 +81,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.shellPrefix" value="cmd.exe /C"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="win_x86-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/win_x86.spec
+++ b/buildspecs/win_x86.spec
@@ -83,7 +83,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.shellPrefix" value="cmd.exe /C"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="win_x86-32"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=http://jcl1.ottawa.ibm.com/testres/java.policy&quot;"/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jdiTestsSupported" value="true"/>

--- a/buildspecs/zos_390-64.spec
+++ b/buildspecs/zos_390-64.spec
@@ -74,7 +74,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="zos_390-64"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/zos_390-64_cmprssptrs.spec
+++ b/buildspecs/zos_390-64_cmprssptrs.spec
@@ -75,7 +75,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="zos_390-64_cr"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx64m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/buildspecs/zos_390.spec
+++ b/buildspecs/zos_390.spec
@@ -74,7 +74,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<property name="j9dt.make" value="gmake"/>
 		<property name="j9dt.toolsTarget" value="buildtools.mk"/>
 		<property name="javatestPlatform" value="zos_390"/>
-		<property name="jclMaxSecurityPolicyDefine" value=" &quot;-Djava.security.policy=file://$(J9_L390_ROOT)/testing/java.policy&quot; "/>
 		<property name="jclMemoryMax" value="-Xmx32m"/>
 		<property name="jclOSStackSizeMax" value=""/>
 		<property name="jgrinderTestingSupported" value="true"/>

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -901,9 +901,19 @@ private:
 			 * (i.e., number of dimensions of the array - 1)
 			 * in the next 2 bytes in Big Endian (since we are maintaining Sun StackMapTable format).
 			 *
-			 * See: https://jtcjazz.ottawa.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/18860
-			 * for explanation of why arity -1 is encoded instead of arity.
-			 *  */
+			 * The reason for encoding arity - 1 in verification type info in Stack maps for primitive array special cases are:
+			 * The newarray and anewarray bytecodes assume that the array has only a single dimension.
+			 * To create a multidimension array, multianewarray must be used.
+			 * The primitive array access bytecodes (ie: iaload) can only be used on single dimension arrays.
+			 * aaload must be used to access every dimension prior to the base dimension in a multi-arity primitive array.
+			 * The constants in vrfytbl.c are based off the constants for the primitive types, and can't have the arity of 1 encoded if the constant is to be used for both purposes.
+			 * (See rtverify.c verifyBytecodes() - the RTV_ARRAY_FETCH_PUSH & RTV_ARRAY_STORE cases of the switch)
+			 * In addition, the code all through the verifier assumes this condition.
+			 * Notes:
+			 * See util/vrfytbl.c for bytecode tables.
+			 * See constant definitions in cfreader.h and oti/bytecodewalk.h.
+			 * bcverify/bcverify.c simulateStack() is the other place that creates stack maps.
+			 */
 			_cursor->writeBigEndianU16(nameLength - 2, Cursor::GENERIC);
 		} else {
 			/*

--- a/runtime/jvmti/jvmtiHeap.c
+++ b/runtime/jvmti/jvmtiHeap.c
@@ -474,8 +474,6 @@ countObjectTags(J9JVMTIObjectTag * entry, J9JVMTIObjectTagMatch * results)
  * @param callbacks       callbacks to be invoked for each reference type
  * @param user_data       user data to be passed back via the callbacks
  * @return                a jvmtiError value
- * 
- *	Full spec is available here: http://j9.ottawa.ibm.com/j9dt/specs/jvmti.html#FollowReferences
  */
 jvmtiError JNICALL
 jvmtiFollowReferences(jvmtiEnv* env, jint heap_filter, jclass klass, jobject initial_object, const jvmtiHeapCallbacks* callbacks,
@@ -1276,9 +1274,6 @@ mapEventType(J9JVMTIHeapData * data, IDATA type, jint index, j9object_t referrer
  * @param callbacks       callbacks to be invoked for each reference type
  * @param user_data       user data to be passed back via the callbacks
  * @return                a jvmtiError value
- * 
- *	Full spec is available here: http://j9.ottawa.ibm.com/j9dt/specs/jvmti.html#IterateThroughHeap
- *
  */
 jvmtiError JNICALL jvmtiIterateThroughHeap(jvmtiEnv* env,
 					   jint heap_filter,
@@ -1680,8 +1675,7 @@ wrap_primitiveFieldCallback(J9JavaVM * vm, J9JVMTIHeapData * iteratorData, IDATA
 			goto nextField; 
 		}
 
-		/* The field index must reflect the index order returned by jvmtiGetClassFields in addition to being offset
-		 * as per the details in http://j9.ottawa.ibm.com/j9dt/specs/jvmti.html#jvmtiHeapReferenceInfoField */
+		/* The field index must reflect the index order returned by jvmtiGetClassFields in addition to being offset */
 		fieldInfo.field.index = (jint)(state.fieldOffsetWalkState.result.index + state.classIndexAdjust + state.referenceIndexOffset - 1);
 
 		primitiveValue.j = (jlong) 0;


### PR DESCRIPTION
Remove obsolete `jcl MAX` link

`jcl Max` configuration is obsoleted and the link is invalid.
Also removed a few other internal links.
Note: this was discovered while eyeballing JVM flags.

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>