### PR TITLE
Guarantee functional correctness of rdbar/wrtbar

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1398,3 +1398,9 @@ J9::Compilation::notYetRunMeansCold()
       return true;
    }
 
+bool
+J9::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
+   {
+   return self()->getOption(TR_EnableFieldWatch);
+   }
+

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -311,6 +311,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    TR_RelocationRuntime *reloRuntime() { return _reloRuntime; }
 
+   bool incompleteOptimizerSupportForReadWriteBarriers();
+
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
 
 private:

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -177,6 +177,12 @@ bool TR_EscapeAnalysis::isImmutableObject(Candidate *candidate)
 int32_t TR_EscapeAnalysis::perform()
    {
    if (comp()->isOptServer() && (comp()->getMethodHotness() <= warm))
+      return 0;
+
+   // EA generates direct stores/loads to instance field which is different
+   // from a normal instance field read/write. Field watch would need special handling
+   // for stores/loads genearted by EA.
+   if (comp()->incompleteOptimizerSupportForReadWriteBarriers())
       return 0;
 
    static char *doESCNonQuiet = feGetEnv("TR_ESCAPENONQUIET");

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2302,6 +2302,10 @@ TR_CISCNode *
 TR_CISCTransformer::addAllSubNodes(TR_CISCGraph *const graph, TR::Block *const block, TR::TreeTop *const top,
                                    TR::Node *const parent, TR::Node *const node, const int32_t dagId)
    {
+   //IdiomRecognition doesn't know how to handle rdbar/wrtbar for now
+   if (comp()->incompleteOptimizerSupportForReadWriteBarriers() &&
+       (node->getOpCode().isReadBar() || node->getOpCode().isWrtBar()))
+      return 0;
    int32_t i;
    int32_t numChildren = node->getNumChildren();
    TR_ScratchList<TR_CISCNode> childList(trMemory());

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1077,6 +1077,16 @@ J9::TransformUtil::canFoldStaticFinalField(TR::Compilation *comp, TR::Node* node
    return TR_maybe;
    }
 
+/*
+ * Load const node should have zero children
+ */
+static void prepareNodeToBeLoadConst(TR::Node *node)
+   {
+   for (int i=0; i < node->getNumChildren(); i++)
+      node->getAndDecChild(i);
+   node->setNumChildren(0);
+   }
+
 bool
 J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *node)
    {
@@ -1143,6 +1153,7 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
       if (performTransformation(comp, "O^O foldStaticFinalField: turn [%p] %s %s into load const\n", node, node->getOpCode().getName(), symRef->getName(comp->getDebug())))
          {
          TR::VMAccessCriticalSection isConsitble(comp->fej9());
+         prepareNodeToBeLoadConst(node);
          switch (loadType)
             {
             case TR::Int8:
@@ -1191,6 +1202,7 @@ J9::TransformUtil::foldStaticFinalFieldImpl(TR::Compilation *comp, TR::Node *nod
          default:
             if (performTransformation(comp, "O^O transformDirectLoad: [%p] field is null - change to aconst NULL\n", node))
                {
+               prepareNodeToBeLoadConst(node);
                TR::Node::recreate(node, TR::aconst);
                node->setAddress(0);
                node->setIsNull(true);


### PR DESCRIPTION
This change guarantees the correctness of rdbar/wrtbar from the following
aspects:
1. Consider rdbar/wrtbar as GC points
2. Make optimizations consider shape of rdbar/wrtbar when doing
transformations
3. Disable opts not supporting newly added rdbar/wrtbar when seeing
the opcodes

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>