### PR TITLE
Pass isOptServer value to the server

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2115,6 +2115,8 @@ remoteCompile(
    TR::CompilationInfo *compInfo = compInfoPT->getCompilationInfo();
 
 
+   if (compiler->isOptServer())
+      compiler->setOption(TR_Server);
    auto classInfoTuple = JITaaSHelpers::packRemoteROMClassInfo(clazz, compiler->fej9vm(), compiler->trMemory());
    std::string optionsStr = TR::Options::packOptions(compiler->getOptions());
    std::string recompMethodInfoStr = compiler->isRecompilationEnabled() ? std::string((char *) compiler->getRecompilationInfo()->getMethodInfo(), sizeof(TR_PersistentMethodInfo)) : std::string();


### PR DESCRIPTION
`_isOptServer` can be set either by `TR_Server` option, or it
is set automatically, when the number of loaded classes exceeds
a certain threshold. However, for JITaaS client, automatic set
will not happen because it doesn't know the number of classes loaded
on the client.
To fix this limitation, check whether `_isOptServer` is set on the client,
before sending compilation request, and if it is set, set `TR_Server` option,
so that it gets passed to a server.