### PR TITLE
Reduce size of *.i files

### DIFF
--- a/runtime/makelib/targets.mk.ftl
+++ b/runtime/makelib/targets.mk.ftl
@@ -353,7 +353,7 @@ LIBCDEFS := $(word 1,$(wildcard $(foreach d,$(TPF_ROOT),$d/base/lib/libCDEFSFORA
 # over 1GB and reduces the workload of getmacros as it reads them.
 
 DDR_SED_COMMAND := \
-    sed -n -e '/^DDRFILE_BEGIN /,/^DDRFILE_END /s/^/@/p'
+	sed -n -e '/^DDRFILE_BEGIN /,/^DDRFILE_END /s/^/@/' -e '/^@./p'
 
 %.i : %.c
 	$(CC) $(CFLAGS) -E $< | $(DDR_SED_COMMAND) > $@


### PR DESCRIPTION
Omit useless lines with only '@'.

See also eclipse/omr#3330.