### PR TITLE
Fix RegisterIterator build break

### DIFF
--- a/runtime/compiler/build/files/common.mk
+++ b/runtime/compiler/build/files/common.mk
@@ -90,6 +90,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/codegen/OMRUnresolvedDataSnippet.cpp \
     omr/compiler/codegen/OutOfLineCodeSection.cpp \
     omr/compiler/codegen/PreInstructionSelection.cpp \
+    omr/compiler/codegen/RegisterIterator.cpp \
     omr/compiler/codegen/Relocation.cpp \
     omr/compiler/codegen/ScratchRegisterManager.cpp \
     omr/compiler/codegen/StorageInfo.cpp \

--- a/runtime/compiler/build/files/target/arm.mk
+++ b/runtime/compiler/build/files/target/arm.mk
@@ -36,7 +36,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/arm/codegen/OMRMemoryReference.cpp \
     omr/compiler/arm/codegen/OMRRealRegister.cpp \
     omr/compiler/arm/codegen/OMRRegisterDependency.cpp \
-    omr/compiler/arm/codegen/OMRRegisterIterator.cpp \
     omr/compiler/arm/codegen/OMRSnippet.cpp \
     omr/compiler/arm/codegen/OMRTreeEvaluator.cpp \
     omr/compiler/arm/codegen/OpBinary.cpp \

--- a/runtime/compiler/build/files/target/p.mk
+++ b/runtime/compiler/build/files/target/p.mk
@@ -31,7 +31,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/p/codegen/OMRMemoryReference.cpp \
     omr/compiler/p/codegen/OMRRealRegister.cpp \
     omr/compiler/p/codegen/OMRRegisterDependency.cpp \
-    omr/compiler/p/codegen/OMRRegisterIterator.cpp \
     omr/compiler/p/codegen/OMRSnippet.cpp \
     omr/compiler/p/codegen/OMRTreeEvaluator.cpp \
     omr/compiler/p/codegen/OpBinary.cpp \

--- a/runtime/compiler/build/files/target/x.mk
+++ b/runtime/compiler/build/files/target/x.mk
@@ -39,7 +39,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/OMRRealRegister.cpp \
     omr/compiler/x/codegen/OMRRegister.cpp \
     omr/compiler/x/codegen/OMRRegisterDependency.cpp \
-    omr/compiler/x/codegen/OMRRegisterIterator.cpp \
     omr/compiler/x/codegen/OMRSnippet.cpp \
     omr/compiler/x/codegen/OMRTreeEvaluator.cpp \
     omr/compiler/x/codegen/OMRX86Instruction.cpp \

--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -37,7 +37,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/OMRRealRegister.cpp \
     omr/compiler/z/codegen/OMRRegister.cpp \
     omr/compiler/z/codegen/OMRRegisterDependency.cpp \
-    omr/compiler/z/codegen/OMRRegisterIterator.cpp \
     omr/compiler/z/codegen/OMRRegisterPair.cpp \
     omr/compiler/z/codegen/OMRSnippet.cpp \
     omr/compiler/z/codegen/OMRTreeEvaluator.cpp \


### PR DESCRIPTION
* Remove build references to obsolete OMRRegisterIterator.cpp files
* Add new OMR RegisterIterator.cpp dependence

Signed-off-by: Daryl Maier <maier@ca.ibm.com>