### PR TITLE
Enable TGC root scan times for Metronome

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -286,6 +286,8 @@ MM_RootScanner::scanClasses(MM_EnvironmentBase *env)
 		}
 	}
 
+	condYield();
+
 	reportScanningEnded(RootScannerEntity_Classes);
 }
 
@@ -395,6 +397,8 @@ MM_RootScanner::scanPermanentClasses(MM_EnvironmentBase *env)
 			}
 		}
 	}
+
+	condYield();
 
 	reportScanningEnded(RootScannerEntity_PermanentClasses);
 }

--- a/runtime/gc_realtime/EnvironmentRealtime.cpp
+++ b/runtime/gc_realtime/EnvironmentRealtime.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,7 @@
 #include "Metronome.hpp"
 #include "OSInterface.hpp"
 #include "RealtimeGC.hpp"
+#include "RealtimeRootScanner.hpp"
 #include "SegregatedAllocationTracker.hpp"
 #include "Timer.hpp"
 
@@ -115,4 +116,18 @@ void MM_EnvironmentRealtime::enableYield()
 {
 	_yieldDisableDepth--;
 	assert1(_yieldDisableDepth >= 0);
+}
+
+void
+MM_EnvironmentRealtime::reportScanningSuspended() {
+	if (NULL != _rootScanner) {
+		_rootScanner->reportScanningSuspended();
+	}
+}
+
+void
+MM_EnvironmentRealtime::reportScanningResumed() {
+	if (NULL != _rootScanner) {
+		_rootScanner->reportScanningResumed();
+	}
 }

--- a/runtime/gc_realtime/EnvironmentRealtime.hpp
+++ b/runtime/gc_realtime/EnvironmentRealtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,6 +39,7 @@
 
 class MM_AllocationContextRealtime;
 class MM_HeapRegionDescriptorRealtime;
+class MM_RealtimeRootScanner;
 class MM_Timer;
 
 class MM_EnvironmentRealtime : public MM_EnvironmentBase
@@ -49,7 +50,8 @@ public:
 
 protected:
 private:
-	MM_Scheduler *_scheduler;	
+	MM_Scheduler *_scheduler;
+	MM_RealtimeRootScanner *_rootScanner;
 	
 	MM_OSInterface *_osInterface;
 	
@@ -107,6 +109,11 @@ public:
 		return shouldSkipTimeCheck;
 	}
 	
+	void reportScanningSuspended();
+	void reportScanningResumed();
+	
+	void setRootScanner(MM_RealtimeRootScanner *rootScanner) { _rootScanner = rootScanner; }
+	
 	UDATA getScannedBytes() const { return 	_scannedBytes; }
 	void addScannedBytes(UDATA scannedBytes) { _scannedBytes += scannedBytes; }
 	UDATA getScannedObjects() const { return _scannedObjects; }
@@ -129,6 +136,7 @@ public:
 	MM_EnvironmentRealtime(OMR_VMThread *omrVMThread) :
 		MM_EnvironmentBase(omrVMThread),
 		_scheduler((MM_Scheduler *)MM_GCExtensions::getExtensions(omrVMThread)->dispatcher),
+		_rootScanner(NULL),
 		_osInterface(_scheduler->_osInterface),
 		_overflowCache(NULL),
 		_overflowCacheCount(0),
@@ -142,6 +150,7 @@ public:
 	MM_EnvironmentRealtime(J9JavaVM *vm) :
 		MM_EnvironmentBase(vm->omrVM),
 		_scheduler((MM_Scheduler *)MM_GCExtensions::getExtensions(vm)->dispatcher),
+		_rootScanner(NULL),
 		_osInterface(_scheduler->_osInterface),
 		_overflowCache(NULL),
 		_overflowCacheCount(0),

--- a/runtime/gc_realtime/IncrementalParallelTask.cpp
+++ b/runtime/gc_realtime/IncrementalParallelTask.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,9 @@
 #include "ModronAssertions.h"
 
 void
-MM_IncrementalParallelTask::synchronizeGCThreads(MM_EnvironmentBase *env, const char *id)
+MM_IncrementalParallelTask::synchronizeGCThreads(MM_EnvironmentBase *envBase, const char *id)
 {
+	MM_EnvironmentRealtime *env = MM_EnvironmentRealtime::getEnvironment(envBase);
 	if(1 < _totalThreadCount) {
 		
 		if (env->isMasterThread()) {
@@ -74,8 +75,10 @@ MM_IncrementalParallelTask::synchronizeGCThreads(MM_EnvironmentBase *env, const 
 				 * (We may be overly cautious here, since we are not that sure that overlap between iterations may even happen)
 				 */				
 				do {
+					env->reportScanningSuspended();
 					omrthread_monitor_wait(_synchronizeMutex);
-				} while ((index == _synchronizeIndex) && !env->isMasterThread() && (_yieldCollaborator.getResumeEvent() != MM_YieldCollaborator::synchedThreads));				
+					env->reportScanningResumed();
+				} while ((index == _synchronizeIndex) && !env->isMasterThread() && (_yieldCollaborator.getResumeEvent() != MM_YieldCollaborator::synchedThreads));
 
 			} while(index == _synchronizeIndex);
 		}
@@ -146,7 +149,9 @@ MM_IncrementalParallelTask::synchronizeGCThreadsAndReleaseMaster(MM_EnvironmentB
 			 * (We may be overly cautious here, since we are not that sure that overlap between iterations may even happen)
 			 */
 			do {
+				env->reportScanningSuspended();
 				omrthread_monitor_wait(_synchronizeMutex);
+				env->reportScanningResumed();
 			} while ((index == _synchronizeIndex) && !env->isMasterThread() && (_yieldCollaborator.getResumeEvent() != MM_YieldCollaborator::synchedThreads));
 		}
 		omrthread_monitor_exit(_synchronizeMutex);

--- a/runtime/gc_realtime/RealtimeMarkingScheme.hpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
 #include "SegregatedMarkingScheme.hpp"
 
 class MM_RealtimeMarkingSchemeRootMarker;
+class MM_RealtimeRootScanner;
 class MM_Scheduler;
 
 #define REFERENCE_OBJECT_YIELD_CHECK_INTERVAL 200

--- a/runtime/gc_realtime/Scheduler.cpp
+++ b/runtime/gc_realtime/Scheduler.cpp
@@ -712,7 +712,11 @@ MM_Scheduler::condYieldFromGC(MM_EnvironmentBase *envBase, U_64 timeSlack)
 	if (!internalShouldGCYield(env, timeSlack)) {
 		return false;
 	}
+
+	env->reportScanningSuspended();
 	yieldFromGC(env, true);
+	env->reportScanningResumed();
+
 	env->resetCurrentDistanceToYieldTimeCheck();
 
 	return true;

--- a/runtime/gc_trace/Tgc.cpp
+++ b/runtime/gc_trace/Tgc.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -295,6 +295,10 @@ tgcInitializeRequestedOptions(J9JavaVM *javaVM)
 		if (tgcExtensions->_heapRequested) {
 			result = result && tgcHeapInitialize(javaVM);
 		}
+
+		if (tgcExtensions->_rootScannerRequested) {
+			result = result && tgcRootScannerInitialize(javaVM);
+		}
 	}
 
 	/* StandardGC and VLHGC both options*/
@@ -321,10 +325,6 @@ tgcInitializeRequestedOptions(J9JavaVM *javaVM)
 
 		if (tgcExtensions->_parallelRequested) {
 			result = result && tgcParallelInitialize(javaVM);
-		}
-
-		if (tgcExtensions->_rootScannerRequested) {
-			result = result && tgcRootScannerInitialize(javaVM);
 		}
 
 		if (tgcExtensions->_terseRequested) {


### PR DESCRIPTION
Reduce the prints to only threads/increments that really have non-0
values to report (note that most of increments in Metronome do not deal
with roots)

Since scan time for one entity can span over several increments, new API
is introduced for suspending/resuming within one entity, to properly
include only GC increment time (and exclude mutator times in between).

Each time GC yields to mutator or blocks a thread on synchronization
barrier, suspend API is invoked, and conversely after awakening on any
of those two points resume API is invoked.

The API will maintain start/end event of the increment, and add the diff
(duration of increment) to the total time of entity scan time. Also
maximum increment of any entity for each threads is maintained and
reported by TGC.

A yield point in incremental roots is moved up to scan class entity(s).
Now, all explicit yield points are within a root scan entity, which
makes life simpler for reporting purposes.

An example of TGC report with two new max increment fields (expectedly,
time is around or bellow 3ms):

```
<scan timestamp="Dec 12 21:17:40 2018">
        <thread id="0" ownablesynchronizerobjects="2.240"
stringtable="0.109" maxincrementtime="2.240"
maxincremententity="ownablesynchronizerobjects"/>
        <thread id="1" ownablesynchronizerobjects="2.151"
stringtable="0.094" maxincrementtime="2.150"
maxincremententity="ownablesynchronizerobjects"/>
        <thread id="2" ownablesynchronizerobjects="2.154"
stringtable="0.090" monitorrefs="6.525"
monitorreferenceobjectscomplete="0.001" maxincrementtime="2.964"
maxincremententity="monitorrefs"/>
        <total ownablesynchronizerobjects="6.545" stringtable="0.293"
monitorrefs="6.525" monitorreferenceobjectscomplete="0.001"/>
</scan>
```

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>