### PR TITLE
Set job variables for PR builds based on PR case not build case

### DIFF
--- a/buildenv/jenkins/common/variables-functions
+++ b/buildenv/jenkins/common/variables-functions
@@ -729,17 +729,11 @@ def set_job_variables(job_type) {
     switch (job_type) {
         case "build":
             // set the node the Jenkins build would run on
-            set_node('build')
+            set_node(job_type)
             // set variables for a build job
             set_build_variables()
             set_sdk_variables()
             set_artifactory_config()
-            break
-        case "test":
-            // set the node the tests would run on
-            set_node('test')
-            // set variables for a test job
-            set_test_variables()
             break
         case "pullRequest":
             // set the node the pull request job would run on

--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -35,29 +35,16 @@ timeout(time: 10, unit: 'HOURS') {
 
                 variableFile = load 'buildenv/jenkins/common/variables-functions'
 
-                // identify the pipeline type: build, test or pull request and
-                // initialize required variables
-                if (run_tests()) {
-                    if (!params.ghprbPullId) {
-                        // test pipeline
-                        variableFile.set_job_variables('test')
-                    } else {
-                        // pull request pipeline
-                        variableFile.set_job_variables('pullRequest')
-                    }
+                // identify the pipeline type: build or pull request and initialize required variables
+                if (params.ghprbPullId) {
+                    variableFile.set_job_variables('pullRequest')
                 } else {
-                    // build or pull request compile only pipeline 
                     variableFile.set_job_variables('build')
                 }
 
-                if (!params.UPSTREAM_JOB_NAME && !params.UPSTREAM_JOB_NUMBER) {
-                    // the test pipeline requires resources(e.g. a jdk) from an
-                    // upstream build pipeline identified by the UPSTREAM_JOB_NAME,
-                    // UPSTREAM_JOB_NAME parameters
-                    // if they are not set then it is not a test pipeline, could be
-                    // a build or a pull request pipeline, thus load resource here
-                    // to avoid another source checkout on the slave
-                    buildFile = load 'buildenv/jenkins/common/build'
+                buildFile = load 'buildenv/jenkins/common/build'
+                if (run_tests()) {
+                    testFile = load 'buildenv/jenkins/common/test'
                 }
             } finally {
                 // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
@@ -72,19 +59,8 @@ timeout(time: 10, unit: 'HOURS') {
                 // clean up
                 buildFile.build_all()
             } else {
-                checkout scm
-                testFile = load 'buildenv/jenkins/common/test'
-                cleanWs()
-                if (params.UPSTREAM_JOB_NAME && params.UPSTREAM_JOB_NUMBER) {
-                    // test pipeline: fetch resources from upstream job, run tests,
-                    // archive results, clean up
-                    testFile.test_all_with_fetch()
-                } else {
-                    // pull request pipeline: compile, run tests, archive results,
-                    // clean up
-                    buildFile.build_pr()
-                    testFile.test_all()
-                }
+                buildFile.build_pr()
+                testFile.test_all()
             }
         }
     }

--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -104,13 +104,6 @@ linux_ppc-64_cmprssptrs_le:
       11: 'ci.role.build && hw.arch.ppc64le && sw.os.ubuntu'
       12: 'ci.role.build && hw.arch.ppc64le && sw.os.ubuntu'
       next: 'ci.role.build && hw.arch.ppc64le && sw.os.ubuntu'
-    test:
-      8: 'hw.arch.ppc64le && sw.os.ubuntu'
-      9: 'hw.arch.ppc64le && sw.os.ubuntu'
-      10: 'hw.arch.ppc64le && sw.os.ubuntu'
-      11: 'hw.arch.ppc64le && sw.os.ubuntu'
-      12: 'hw.arch.ppc64le && sw.os.ubuntu'
-      next: 'hw.arch.ppc64le && sw.os.ubuntu'
   extra_configure_options:
     8: '--with-openssl=fetched --enable-openssl-bundling'
     11: '--with-openssl=fetched --enable-openssl-bundling'
@@ -149,13 +142,6 @@ linux_390-64_cmprssptrs:
       11: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
       12: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
       next: 'ci.role.build && hw.arch.s390x && sw.os.ubuntu'
-    test:
-      8: 'hw.arch.s390x && sw.os.ubuntu'
-      9: 'hw.arch.s390x && sw.os.ubuntu'
-      10: 'hw.arch.s390x && sw.os.ubuntu'
-      11: 'hw.arch.s390x && sw.os.ubuntu'
-      12: 'hw.arch.s390x && sw.os.ubuntu'
-      next: 'hw.arch.s390x && sw.os.ubuntu'
   build_env:
     vars:
       11: 'CC=gcc-7 CXX=g++-7'
@@ -192,13 +178,6 @@ aix_ppc-64_cmprssptrs:
       11: 'ci.role.build && hw.arch.ppc64 && sw.os.aix'
       12: 'ci.role.build && hw.arch.ppc64 && sw.os.aix'
       next: 'ci.role.build && hw.arch.ppc64 && sw.os.aix'
-    test:
-      8: 'hw.arch.ppc64 && sw.os.aix'
-      9: 'hw.arch.ppc64 && sw.os.aix'
-      10: 'hw.arch.ppc64 && sw.os.aix'
-      11: 'hw.arch.ppc64 && sw.os.aix'
-      12: 'hw.arch.ppc64 && sw.os.aix'
-      next: 'hw.arch.ppc64 && sw.os.aix'
   extra_configure_options:
     8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8'
     9: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
@@ -234,13 +213,6 @@ linux_x86-64_cmprssptrs:
       11: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
       12: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
       next: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-    test:
-      8: 'hw.arch.x86 && sw.os.ubuntu'
-      9: 'hw.arch.x86 && sw.os.ubuntu'
-      10: 'hw.arch.x86 && sw.os.ubuntu'
-      11: 'hw.arch.x86 && sw.os.ubuntu'
-      12: 'hw.arch.x86 && sw.os.ubuntu'
-      next: 'hw.arch.x86 && sw.os.ubuntu'
   extra_configure_options:
     8: '--with-openssl=fetched --enable-openssl-bundling'
     11: '--with-openssl=fetched --enable-openssl-bundling'
@@ -277,13 +249,6 @@ linux_x86-64_cmprssptrs_cmake:
       11: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
       12: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
       next: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-    test:
-      8: 'hw.arch.x86 && sw.os.ubuntu'
-      9: 'hw.arch.x86 && sw.os.ubuntu'
-      10: 'hw.arch.x86 && sw.os.ubuntu'
-      11: 'hw.arch.x86 && sw.os.ubuntu'
-      12: 'hw.arch.x86 && sw.os.ubuntu'
-      next: 'hw.arch.x86 && sw.os.ubuntu'
   extra_configure_options:
     8: '--with-cmake --disable-ddr --with-openssl=fetched --enable-openssl-bundling'
     9: '--with-cmake --disable-ddr'
@@ -331,13 +296,6 @@ linux_x86-64:
       11: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
       12: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
       next: 'ci.role.build && hw.arch.x86 && sw.os.ubuntu'
-    test:
-      8: 'hw.arch.x86 && sw.os.ubuntu'
-      9: 'hw.arch.x86 && sw.os.ubuntu'
-      10: 'hw.arch.x86 && sw.os.ubuntu'
-      11: 'hw.arch.x86 && sw.os.ubuntu'
-      12: 'hw.arch.x86 && sw.os.ubuntu'
-      next: 'hw.arch.x86 && sw.os.ubuntu'
   extra_configure_options:
     8: '--with-noncompressedrefs --with-openssl=fetched --enable-openssl-bundling'
     9: '--with-noncompressedrefs'
@@ -385,13 +343,6 @@ win_x86-64_cmprssptrs:
       11: 'ci.role.build && hw.arch.x86 && sw.os.windows'
       12: 'ci.role.build && hw.arch.x86 && sw.os.windows'
       next: 'ci.role.build && hw.arch.x86 && sw.os.windows'
-    test:
-      8: 'hw.arch.x86 && sw.os.windows'
-      9: 'hw.arch.x86 && sw.os.windows'
-      10: 'hw.arch.x86 && sw.os.windows'
-      11: 'hw.arch.x86 && sw.os.windows'
-      12: 'hw.arch.x86 && sw.os.windows'
-      next: 'hw.arch.x86 && sw.os.windows'
   build_env:
     vars:
       8: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM64/bin:/cygdrive/c/openjdk/nasm-2.13.03'
@@ -413,8 +364,6 @@ win_x86:
   node_labels:
     build:
       8: 'ci.role.build && hw.arch.x86 && sw.os.windows'
-    test:
-      8: 'hw.arch.x86 && sw.os.windows'
   build_env:
     vars:
       8: 'PATH+TOOLS=/cygdrive/c/openjdk/LLVM32/bin:/cygdrive/c/openjdk/nasm-2.13.03'
@@ -443,11 +392,6 @@ osx_x86-64_cmprssptrs:
       11: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
       12: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
       next: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
-    test:
-      8: 'hw.arch.x86 && sw.os.osx'
-      11: 'hw.arch.x86 && sw.os.osx'
-      12: 'hw.arch.x86 && sw.os.osx'
-      next: 'hw.arch.x86 && sw.os.osx'
   build_env:
     vars:
       8: 'MACOSX_DEPLOYMENT_TARGET=10.9.0 SDKPATH=/Users/jenkins/Xcode4/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk'
@@ -477,10 +421,6 @@ osx_x86-64:
       11: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
       12: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
       next: 'ci.role.build && hw.arch.x86 && sw.os.osx.10_13'
-    test:
-      8: 'hw.arch.x86 && sw.os.osx'
-      11: 'hw.arch.x86 && sw.os.osx'
-      12: 'hw.arch.x86 && sw.os.osx'
   build_env:
     vars:
       8: 'MACOSX_DEPLOYMENT_TARGET=10.9.0 SDKPATH=/Users/jenkins/Xcode4/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk'


### PR DESCRIPTION
- Remove support for test cases since we no longer
  use our test pipelines (#1450)
- Set job variables for PullRequest builds based on PR case
  not build case. This avoids setting job properties for PR builds
  which removes the GH trigger configuration
- Remove test node labels as these are no longer in use

[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>