### PR TITLE
Provide CPU time when no user time at OSX like zOS & Linux

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -969,14 +969,14 @@ getThreadUserTime(omrthread_t thread)
 	
 	userTime = omrthread_get_user_time(thread);
 	
-#if defined(J9ZOS390) || defined(LINUX)
+#if defined(J9ZOS390) || defined(LINUX) || defined(OSX)
 	if (-1 == userTime) {
-		/* For z/OS and Linux, user time is not available from the OS.
+		/* For z/OS, Linux and OSX, user time is not available from the OS.
 		 * So provide cpu time in its place.
 		 */
 		userTime = omrthread_get_cpu_time(thread);
 	}
-#endif /* ZOS or LINUX */
+#endif /* ZOS, LINUX or OSX */
 		
 	return userTime;
 }


### PR DESCRIPTION
Provide CPU time when no user time at `OSX` like `zOS` & `Linux`

Adding `defined(OSX)` after `defined(J9ZOS390) || defined(LINUX)` to invoke `omrthread_get_cpu_time` when `omrthread_get_user_time` returns `-1`.

Manually verified that `Mac OpenJ9 JDK11` with this PR passes the test `threadMXBeanTestSuite2`.
closes: #3778 

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>