### PR TITLE
 Stubs for Constants API (jep334)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -50,6 +50,10 @@ import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.security.PrivilegedAction;
 import java.lang.ref.*;
+/*[IF Java12]*/
+import java.lang.constant.ClassDesc;
+import java.lang.constant.Constable;
+/*[ENDIF]*/
 
 import sun.reflect.generics.repository.ClassRepository;
 import sun.reflect.generics.factory.CoreReflectionFactory;
@@ -130,7 +134,11 @@ import java.security.PrivilegedActionException;
  * @author		OTI
  * @version		initial
  */
-public final class Class<T> implements java.io.Serializable, GenericDeclaration, Type {
+public final class Class<T> implements java.io.Serializable, GenericDeclaration, Type
+/*[IF Java12]*/
+	, Constable, TypeDescriptor, TypeDescriptor.OfField<Class<?>>
+/*[ENDIF]*/
+{
 	private static final long serialVersionUID = 3206093459760846163L;
 	private static ProtectionDomain AllPermissionsPD;
 	private static final int SYNTHETIC = 0x1000;
@@ -4554,11 +4562,19 @@ public Class<?>[] getNestMembers() throws LinkageError, SecurityException {
 
 /*[IF Java12]*/
 	public Class<?> arrayType() {
-		throw new UnsupportedOperationException("Stub for Java 12 compilation");
+		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
+	}
+
+	public Class<?> componentType() {
+		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
 	}
 
 	public Optional<ClassDesc> describeConstable() {
-		throw new UnsupportedOperationException("Stub for Java 12 compilation");
+		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
+	}
+
+	public String descriptorString() {
+		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
 	}
 /*[ENDIF] Java12 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -36,6 +36,9 @@ import java.util.function.IntFunction;
 import java.util.function.IntUnaryOperator;
 import java.util.Iterator;
 import java.nio.charset.Charset;
+/*[IF Java12]*/
+import java.util.Optional;
+/*[ENDIF]*/
 import java.util.Spliterator;
 import java.util.stream.StreamSupport;
 
@@ -50,6 +53,13 @@ import sun.misc.Unsafe;
 import java.util.stream.Stream;
 /*[ENDIF] Java11*/
 
+/*[IF Java12]*/
+import java.lang.constant.Constable;
+import java.lang.constant.ConstantDesc;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+/*[ENDIF]*/
+
 /**
  * Strings are objects which represent immutable arrays of characters.
  *
@@ -58,7 +68,11 @@ import java.util.stream.Stream;
  *
  * @see StringBuffer
  */
-public final class String implements Serializable, Comparable<String>, CharSequence {
+public final class String implements Serializable, Comparable<String>, CharSequence 
+/*[IF Java12]*/
+	, Constable, ConstantDesc
+/*[ENDIF]*/
+{
 	
 	/*
 	 * Last character of String substitute in String.replaceAll(regex, substitute) can't be \ or $.
@@ -8281,4 +8295,14 @@ written authorization of the copyright holder.
 	}
 
 /*[ENDIF] Sidecar19-SE*/
+
+/*[IF Java12]*/
+	public Optional<String> describeConstable() {
+		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
+	}
+
+	public String resolveConstantDesc(MethodHandles.Lookup lookup) {
+		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
+	}
+/*[ENDIF] Java12 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -26,6 +26,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+/*[IF Java12]*/
+import java.lang.constant.Constable;
+import java.lang.constant.MethodHandleDesc;
+/*[ENDIF]*/
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
@@ -35,6 +39,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import java.util.Objects;
+/*[IF Java12]*/
+import java.util.Optional;
+/*[ENDIF]*/
 // {{{ JIT support
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -81,7 +88,11 @@ import com.ibm.oti.vm.VMLangAccess;
  * @since 1.7
  */
 @VMCONSTANTPOOL_CLASS
-public abstract class MethodHandle {
+public abstract class MethodHandle 
+/*[IF Java12]*/
+	implements Constable
+/*[ENDIF]*/
+{
 	/* Ensure that these stay in sync with the MethodHandleInfo constants and VM constants in VM_MethodHandleKinds.h */
 	/* Order matters here - static and special are direct pointers */
 	static final byte KIND_BOUND = 0;
@@ -724,6 +735,13 @@ public abstract class MethodHandle {
 		return this;
 	}
 	
+/*[IF Java12]*/
+	public Optional<MethodHandleDesc> describeConstable() {
+		/* Jep334 */
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF]*/
+
 	public MethodHandle bindTo(Object value) throws IllegalArgumentException, ClassCastException {
 		/*
 		 * Check whether the first parameter has a reference type assignable from value. Note that MethodType.parameterType(0) will

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,10 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.ObjectStreamField;
 import java.io.Serializable;
+/*[IF Java12]*/
+import java.lang.constant.Constable;
+import java.lang.constant.MethodTypeDesc;
+/*[ENDIF]*/
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
@@ -38,6 +42,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+/*[IF Java12]*/
+import java.util.Optional;
+/*[ENDIF]*/
 import java.util.Set;
 import java.util.WeakHashMap;
 
@@ -60,7 +67,11 @@ import java.lang.invoke.MethodTypeForm;
  * @since 1.7
  */
 @VMCONSTANTPOOL_CLASS
-public final class MethodType implements Serializable {
+public final class MethodType implements Serializable 
+/*[IF Java12]*/
+	, Constable, TypeDescriptor.OfMethod<Class<?>, MethodType>
+/*[ENDIF]*/
+{
 	static final Class<?>[] EMTPY_PARAMS = new Class<?>[0];
 	static final Set<Class<?>> WRAPPER_SET;
 	static {
@@ -854,7 +865,7 @@ public final class MethodType implements Serializable {
 	 * 
 	 * @return the parameter types as an array
 	 */
-	public Class<?>[] parameterArray(){
+	public Class<?>[] parameterArray() {
 		return arguments.clone();
 	}
 
@@ -863,7 +874,7 @@ public final class MethodType implements Serializable {
 	 * 
 	 * @return the number of parameters
 	 */
-	public int parameterCount(){
+	public int parameterCount() {
 		return arguments.length;
 	}
 
@@ -885,7 +896,7 @@ public final class MethodType implements Serializable {
 	 * 
 	 * @return the parameter types as a List
 	 */
-	public List<Class<?>> parameterList(){
+	public List<Class<?>> parameterList() {
 		List<Class<?>> list = Arrays.asList(arguments.clone()); 
 		return Collections.unmodifiableList(list);
 	}     
@@ -908,7 +919,7 @@ public final class MethodType implements Serializable {
 	/**
 	 * @return the type of the return
 	 */
-	public Class<?> returnType(){
+	public Class<?> returnType() {
 		return returnType;
 	}
 	
@@ -1257,6 +1268,18 @@ public final class MethodType implements Serializable {
 		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 	}
 /*[ENDIF]*/
+/*[ENDIF]*/
+
+/*[IF Java12]*/
+	public String descriptorString() {
+		/* Jep334 */
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	public Optional<MethodTypeDesc> describeConstable() {
+		/* Jep334 */
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
 /*[ENDIF]*/
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -28,6 +28,9 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+/*[IF Java12]*/
+import java.util.Optional;
+/*[ENDIF]*/
 /*[IF Sidecar19-SE]
 import jdk.internal.misc.Unsafe;
 /*[ELSE]*/
@@ -49,7 +52,11 @@ import java.lang.constant.DynamicConstantDesc;
  * VarHandle instances are created through the MethodHandles factory API.
  * 
  */
-public abstract class VarHandle extends VarHandleInternal {
+public abstract class VarHandle extends VarHandleInternal 
+/*[IF Java12]*/
+	implements Constable
+/*[ENDIF]*/
+{
 	/**
 	 * Access mode identifiers for VarHandle operations.
 	 */
@@ -311,6 +318,29 @@ public abstract class VarHandle extends VarHandleInternal {
 	public final List<Class<?>> coordinateTypes() {
 		return Collections.unmodifiableList(Arrays.<Class<?>>asList(coordinateTypes));
 	}
+
+/*[IF Java12]*/
+	public Optional<VarHandle.VarHandleDesc> describeConstable() {
+		/* Jep334 */
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public final boolean equals(Object obj) {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public final int hashCode() {
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+
+	@Override
+	public final String toString() {
+		/* Jep334 */
+		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+	}
+/*[ENDIF]*/
 	
 	/**
 	 * Each {@link AccessMode}, e.g. get and set, requires different parameters
@@ -931,7 +961,7 @@ public abstract class VarHandle extends VarHandleInternal {
 
 /*[IF Java12]*/
 	/* nominal descriptor of a VarHandle constant */
-	public static final class VarHandleDesc extends DynamicConstantDesc<VarHandle> {
+	public static final class VarHandleDesc extends DynamicConstantDesc<VarHandle> implements ConstantDesc {
 
 		protected VarHandleDesc(DirectMethodHandleDesc bootstrapMethod, String constantName, ClassDesc constantType, ConstantDesc... bootstrapArgs) {
 			super(bootstrapMethod, constantName, constantType, bootstrapArgs);
@@ -939,26 +969,34 @@ public abstract class VarHandle extends VarHandleInternal {
 		}
 
 		public static VarHandleDesc ofArray(ClassDesc arrayClass) {
+			/* Jep334 */
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 
 		public static VarHandleDesc ofField(ClassDesc declaringClass, String name, ClassDesc fieldType) {
+			/* Jep334 */
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 
 		public static VarHandleDesc ofStaticField(ClassDesc declaringClass, String name, ClassDesc fieldType) {
+			/* Jep334 */
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 
-		public VarHandle resolveConstantDesc(MethodHandles.Lookup lookup) {
+		@Override
+		public VarHandle resolveConstantDesc(MethodHandles.Lookup lookup) throws ReflectiveOperationException {
+			/* Jep334 */
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 
+		@Override
 		public String toString() {
+			/* Jep334 */
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 
 		public ClassDesc varType() {
+			/* Jep334 */
 			throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
 		}
 	}


### PR DESCRIPTION
This change adds the remaining method stubs for jep334 that were not directly needed to compile Java12 and adjusts interface implementation dependencies for Constable classes.

Java 12 depends on https://github.com/eclipse/openj9/pull/3980 to compile (also see https://github.com/eclipse/openj9/issues/4195)

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>