### PR TITLE
Increase the number of compilation threads on the JITaaS server

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1449,9 +1449,11 @@ onLoadInternal(
       if (TR::Options::_numUsableCompilationThreads > maxNumberOfCodeCaches)
          TR::Options::_numUsableCompilationThreads =  maxNumberOfCodeCaches;
 
-      if (TR::Options::_numUsableCompilationThreads > MAX_USABLE_COMP_THREADS)
+      compInfo->updateNumUsableCompThreads(TR::Options::_numUsableCompilationThreads);
+
+      if (!compInfo->allocateCompilationThreads(TR::Options::_numUsableCompilationThreads))
          {
-         fprintf(stderr, "Too many compilation threads. Only up to %d supported\n", MAX_USABLE_COMP_THREADS);
+         fprintf(stderr, "onLoadInternal: Failed to set up %d compilation threads\n", TR::Options::_numUsableCompilationThreads);
          return -1;
          }
 
@@ -1467,6 +1469,7 @@ onLoadInternal(
             }
          }
 
+      // If more than one diagnostic compilation thread is created, MAX_DIAGNOSTIC_COMP_THREADS needs to be updated
       // create diagnostic compilation thread
       if (compInfo->startCompilationThread(-1, highestThreadID, /* isDiagnosticThread */ true) != 0)
          {

--- a/runtime/compiler/infra/J9MonitorTable.cpp
+++ b/runtime/compiler/infra/J9MonitorTable.cpp
@@ -51,6 +51,9 @@ J9::MonitorTable::init(
    table->_portLib = portLib;
    table->_monitors.setFirst(0);
 
+   table->_numCompThreads = 0;
+   table->_classUnloadMonitorHolders = NULL;
+
    // Initialize the Monitors
    if (!table->_tableMonitor.init      ("JIT-MonitorTableMonitor")) return 0;
    if (!table->_j9MemoryAllocMonitor.init("JIT-MemoryAllocMonitor")) return 0;
@@ -68,17 +71,25 @@ J9::MonitorTable::init(
    memoryAllocMonitor = table->_memoryAllocMonitor = &table->_j9MemoryAllocMonitor;
    table->_scratchMemoryPoolMonitor = &table->_j9ScratchMemoryPoolMonitor; // export this value
 
-   // Allocate and initialize the array of classUnloadMonitorHolders
-   table->_classUnloadMonitorHolders = (int32_t*)j9mem_allocate_memory(sizeof(*(table->_classUnloadMonitorHolders))*MAX_TOTAL_COMP_THREADS, J9MEM_CATEGORY_JIT);
-   if (!table->_classUnloadMonitorHolders)
-      return 0;
-   for (int32_t i = 0; i < MAX_TOTAL_COMP_THREADS; i++)
-      table->_classUnloadMonitorHolders[i] = 0;
-
    OMR::MonitorTable::_instance = table;
    return table;
    }
 
+bool
+J9::MonitorTable::allocInitClassUnloadMonitorHolders(uint32_t allowedTotalCompThreads)
+   {
+   PORT_ACCESS_FROM_PORT(_portLib);
+
+   _numCompThreads = allowedTotalCompThreads;
+   // Allocate and initialize the array of classUnloadMonitorHolders
+   _classUnloadMonitorHolders = (int32_t*)j9mem_allocate_memory(sizeof(*(_classUnloadMonitorHolders)) * _numCompThreads, J9MEM_CATEGORY_JIT);
+   if (!_classUnloadMonitorHolders)
+      return false;
+   for (int32_t i = 0; i < _numCompThreads; i++)
+      _classUnloadMonitorHolders[i] = 0;
+
+   return true;
+   }
 
 TR::Monitor *
 J9::MonitorTable::create(char *name)
@@ -228,7 +239,7 @@ J9::MonitorTable::readAcquireClassUnloadMonitor(int32_t compThreadIndex)
    {
    _classUnloadMonitor.enter_read();
    // Need to determine the identity of the compilation thread
-   TR_ASSERT(compThreadIndex < MAX_TOTAL_COMP_THREADS, "compThreadIndex is too high");
+   TR_ASSERT(compThreadIndex < _numCompThreads, "compThreadIndex is too high");
    return ++(_classUnloadMonitorHolders[compThreadIndex]);
    }
 
@@ -236,7 +247,7 @@ J9::MonitorTable::readAcquireClassUnloadMonitor(int32_t compThreadIndex)
 int32_t
 J9::MonitorTable::readReleaseClassUnloadMonitor(int32_t compThreadIndex)
    {
-   TR_ASSERT(compThreadIndex < MAX_TOTAL_COMP_THREADS, "compThreadIndex is too high");
+   TR_ASSERT(compThreadIndex < _numCompThreads, "compThreadIndex is too high");
    if (_classUnloadMonitorHolders[compThreadIndex] > 0)
       {
       _classUnloadMonitorHolders[compThreadIndex]--;

--- a/runtime/compiler/infra/J9MonitorTable.hpp
+++ b/runtime/compiler/infra/J9MonitorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,7 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    int32_t readReleaseClassUnloadMonitor(int32_t compThreadIndex);
    int32_t getClassUnloadMonitorHoldCount(int32_t i) const { return _classUnloadMonitorHolders[i]; }
 
+   bool allocInitClassUnloadMonitorHolders(uint32_t allowedTotalCompThreads);
 
    private:
 
@@ -94,6 +95,7 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    // the classUnloadmonitor. Normally it should not be more than 1
    //
    int32_t *_classUnloadMonitorHolders;
+   uint32_t _numCompThreads;
    };
 
 }

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -300,10 +300,10 @@ TR_DebugExt::compInfosPerThreadAvailable()
    {
    if (_localCompInfosPT == NULL)
       {
-      _localCompInfosPT = (TR::CompilationInfoPerThread **) dxMalloc(sizeof(TR::CompilationInfoPerThread *) * MAX_TOTAL_COMP_THREADS, NULL);
+      _localCompInfosPT = (TR::CompilationInfoPerThread **) dxMalloc(sizeof(TR::CompilationInfoPerThread *) * _localCompInfo->getNumTotalCompilationThreads(), NULL);
       if (_localCompInfosPT)
          {
-         for (size_t i = 0; i < MAX_TOTAL_COMP_THREADS; ++i)
+         for (size_t i = 0; i < _localCompInfo->getNumTotalCompilationThreads(); ++i)
             {
             _localCompInfosPT[i] = _localCompInfo->_arrayOfCompilationInfoPerThread[i] != NULL ?
                (TR::CompilationInfoPerThread *) dxMallocAndRead(sizeof(TR::CompilationInfoPerThread), _localCompInfo->_arrayOfCompilationInfoPerThread[i], true) :
@@ -320,10 +320,10 @@ TR_DebugExt::activeMethodsToBeCompiledAvailable()
    if (!compInfosPerThreadAvailable()) return false;
    if (_localActiveMethodsToBeCompiled == NULL)
       {
-      _localActiveMethodsToBeCompiled = (TR_MethodToBeCompiled **) dxMalloc(sizeof(TR_MethodToBeCompiled *) * MAX_TOTAL_COMP_THREADS, NULL);
+      _localActiveMethodsToBeCompiled = (TR_MethodToBeCompiled **) dxMalloc(sizeof(TR_MethodToBeCompiled *) * _localCompInfo->getNumTotalCompilationThreads(), NULL);
       if (_localActiveMethodsToBeCompiled)
          {
-         for (size_t i = 0; i < MAX_TOTAL_COMP_THREADS; ++i)
+         for (size_t i = 0; i < _localCompInfo->getNumTotalCompilationThreads(); ++i)
             {
             _localActiveMethodsToBeCompiled[i] = _localCompInfosPT[i] && _localCompInfosPT[i]->_methodBeingCompiled ?
                (TR_MethodToBeCompiled *) dxMallocAndRead(sizeof(TR_MethodToBeCompiled), _localCompInfosPT[i]->_methodBeingCompiled, true) :
@@ -340,7 +340,7 @@ TR_DebugExt::isAOTCompileRequested(TR::Compilation * remoteCompilation)
    if (!compInfosPerThreadAvailable()) return false;
    if (!activeMethodsToBeCompiledAvailable()) return false;
 
-   for (size_t i = 0; i < MAX_TOTAL_COMP_THREADS; ++i)
+   for (size_t i = 0; i < _localCompInfo->getNumTotalCompilationThreads(); ++i)
       {
       if (
          _localCompInfosPT[i]
@@ -1265,7 +1265,7 @@ TR_DebugExt::dxTrPrint(const char* name1, void* addr2, uintptrj_t argCount, cons
    else if (stricmp_ignore_locale(className, "arrayofcompilationinfoperthread") == 0)
       {
       TR::CompilationInfoPerThread ** arrayOfCompInfoPT = NULL;
-      uint8_t numThreads = MAX_TOTAL_COMP_THREADS;
+      uint8_t numThreads = _localCompInfo->getNumTotalCompilationThreads();
       bool allocated = false;
 
       if (argCount == 2 && addr != 0)
@@ -2173,7 +2173,7 @@ TR_DebugExt::dxPrintMethodsBeingCompiled(TR::CompilationInfo *remoteCompInfo)
       }
 
    TR::CompilationInfoPerThread ** arrayOfCompInfoPT = NULL;
-   uint8_t numThreads = MAX_TOTAL_COMP_THREADS;
+   uint8_t numThreads = remoteCompInfo->getNumTotalCompilationThreads();
 
    arrayOfCompInfoPT = dxMallocAndGetArrayOfCompilationInfoPerThread(numThreads, remoteCompInfo->_arrayOfCompilationInfoPerThread);
 
@@ -2265,7 +2265,7 @@ void TR_DebugExt::dxPrintCompilationInfo(TR::CompilationInfo *remoteCompInfo)
       _dbgPrintf("int32_t                               _samplingThreadLifetimeState     = %d\n", localCompInfo->_samplingThreadLifetimeState);
       _dbgPrintf("int32_t                               _numMethodsFoundInSharedCache    = %d\n", localCompInfo->_numMethodsFoundInSharedCache);
       _dbgPrintf("int32_t                               _numInvRequestsInCompQueue       = %d\n", localCompInfo->_numInvRequestsInCompQueue);
-      _dbgPrintf("int32_t                               _compThreadIndex                 = %d\n", localCompInfo->_compThreadIndex);
+      _dbgPrintf("int32_t                               _numCompThreads                  = %d\n", localCompInfo->_numCompThreads);
       _dbgPrintf("int32_t                               _numDiagnosticThreads            = %d\n", localCompInfo->_numDiagnosticThreads);
       _dbgPrintf("int32_t                               _numSeriousFailures              = %d\n", localCompInfo->_numSeriousFailures);
       _dbgPrintf("int32_t[numHotnessLevels]             _statsOptLevels                  = 0x%p\n", localCompInfo->_statsOptLevels);


### PR DESCRIPTION
Currently the JIT allows a maximum of 8 compilation threads due to
the size of uint8_t TR_PersistentClassInfo::_shouldNotBeNewlyExtended.
The JITaaS server uses a different mechanism to track newly extended
classes and it does not set the bit in _shouldNotBeNewlyExtended.
This change increases the max number of compilation threads
on the JIT server to 64.

Issue: #3526

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>