### PR TITLE
Remove inconsistant DDR !dumppackage test requirement

### DIFF
--- a/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/modularityddrtests.xml
@@ -969,7 +969,6 @@
 		<output regex="no" type="required">Exported to:</output>
 		<output regex="no" type="success">openj9.gpu</output>
 		<output regex="no" type="required">!j9module </output>
-		<output regex="no" type="required">ALL-UNNAMED</output>
 		<output regex="no" type="failure">DDRInteractiveCommandException</output>
 	</test>
 


### PR DESCRIPTION
The package `com/ibm/gpu/spi` is not always exported to all unnamed
modules. As a result, one of the DDR `!dumppackage` tests was
inconsistent. This lack of being exported seemed to occur on windows
machines.

The requirement for said package to be exported to all unnamed
modules has been removed as this was not an important part of the test.

This solves #4028.

Signed-off-by: Andrew Crowther <acrowthe3388@gmail.com>