### PR TITLE
CMake: Don't append version suffix for jextractnatives

### DIFF
--- a/runtime/jextractnatives/CMakeLists.txt
+++ b/runtime/jextractnatives/CMakeLists.txt
@@ -20,6 +20,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ################################################################################
 
+# Don't append version suffix to j9jextract
+set(CMAKE_SHARED_LIBRARY_SUFFIX ${J9VM_OLD_SHARED_SUFFIX})
+
 add_library(j9jextract SHARED
 	jextractglue.c
 	jextractnatives.c


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>