### PR TITLE
Add test for 64-bit OOL spill on 31-bit

### DIFF
--- a/test/functional/JIT_Test/playlist.xml
+++ b/test/functional/JIT_Test/playlist.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+	Copyright (c) 2016, 2018 IBM Corp. and others
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+	This program and the accompanying materials are made available under
+	the terms of the Eclipse Public License 2.0 which accompanies this
+	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+	or the Apache License, Version 2.0 which accompanies this distribution and
+	is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+	This Source Code may also be made available under the following
+	Secondary Licenses when the conditions for such availability set
+	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+	General Public License, version 2 with the GNU Classpath
+	Exception [1] and GNU General Public License, version 2 with the
+	OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] http://openjdk.java.net/legal/assembly-exception.html
+	[1] https://www.gnu.org/software/classpath/license.html
+	[2] http://openjdk.java.net/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
@@ -333,6 +333,35 @@
 			<subset>10</subset>
 			<subset>11</subset>
 		</subsets>
+	</test>
+
+	<!-- jit.test.ra tests start here -->
+	<test>
+		<testCaseName>jit_ra</testCaseName>
+		<variations>
+			<variation>-Xmn1M -Xjit:'{*powerOfTenBI*}(count=7),disableasynccompilation,tryToInline={java/lang/String.<init>([C)V|java/lang/String.<init>([CII)V|java/lang/Object.<init>()V|java/math/BigInteger.<init>(Ljava/lang/String;)V|java/math/BigInteger.<init>(Ljava/lang/String;I)V|java/lang/Object.<init>()V|java/lang/String.length()I|java/lang/String.lengthInternal()I},dontInline={java/util/Arrays.fill([CC)V}'</variation>
+		</variations>
+		<command>
+			$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)jitt.jar$(Q) \
+			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+			-testnames \
+			raTest \
+			-groups $(TEST_GROUP) \
+			-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)
+		</command>
+		<platformRequirements>^arch.arm</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 
 	<!-- jit.test.vich tests start here -->

--- a/test/functional/JIT_Test/src/jit/test/ra/TestOOLSpill31Bit.java
+++ b/test/functional/JIT_Test/src/jit/test/ra/TestOOLSpill31Bit.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package jit.test.ra;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import org.testng.annotations.Test;
+
+@Test(groups = { "level.sanity", "component.jit" })
+public class TestOOLSpill31Bit {
+
+	// public volatile prevents JIT optimizer from eliminating stores
+	public static volatile BigInteger bi;
+
+	public static final BigInteger powerOfTenBI(long i) {
+		char[] ten = new char[(int)i + 1];
+		Arrays.fill(ten,'0');
+		ten[0] = '1';
+		return new BigInteger(new String(ten));
+	}
+
+	/**
+	 * The following test is articulated such that the {@code powerOfTenBI} method gets deterministically JIT compiled and
+	 * eventually has to call the VM JIT helper to allocate memory as we run out of TLH space.
+	 *
+	 * On 31-bit platforms when using 64-bit registers we can encounter problems in this path if the register allocator
+	 * fails to properly spill 64-bit values across an OOL code section.
+	 *
+	 * @see eclipse/omr#3337
+	 */
+	@Test
+	public static void testOOLSpill31Bit() {
+		for (int i = 0; i < 100000; ++i) {
+			bi = powerOfTenBI(0x15);
+		}
+	}
+}

--- a/test/functional/JIT_Test/testng.xml
+++ b/test/functional/JIT_Test/testng.xml
@@ -448,6 +448,13 @@
     </classes>
   </test>
 
+  <!-- jit.test.ra tests start here -->
+  <test name="raTest">
+    <classes>
+      <class name="jit.test.ra.TestOOLSpill31Bit" />
+    </classes>
+  </test>
+
   <!-- jit.test.vich tests start here -->
   <test name="AllocationTest">
     <classes>


### PR DESCRIPTION
Add targetted test coverage for several bugs which were recently
exposed when 64-bit values get spilled on 31-bit.

Related: eclipse/omr#3337

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>