### PR TITLE
Fix anewarray AOT bug

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -7692,7 +7692,9 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
    // --------------------------------------------------------------------------------
    // Initialize the header
    // --------------------------------------------------------------------------------
-   if (fej9->inlinedAllocationsMustBeVerified() && node->getOpCodeValue() == TR::anewarray)
+   if (fej9->inlinedAllocationsMustBeVerified()
+       && !comp->getOption(TR_UseSymbolValidationManager)
+       && node->getOpCodeValue() == TR::anewarray)
       {
       genInitArrayHeader(
             node,


### PR DESCRIPTION
When the compiler encounters the TR::anewarray op code, it will ignore
the class register when calling genInitArrayHeader in favour of
determining the array class itself. However, during an AOT compile, it
does use the class register; this is because when not using the SVM, the
compiler would generate code to acquire the array class from the
component class. It did so because prior to the SVM, there wasn't a way
to materialize the array class without creating a specialized relocation
record.

With the SVM, the compiler does not need to generate the code to acquire
the array class from the component class, and thus needs to also go
through the code path that ignores the class register.

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>