### PR TITLE
Add libXi libXrandr to ppc64le & s390x Dockerfiles for jdk12+

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -62,6 +62,8 @@ RUN yum -y update \
     libstdc++-static \
     libX11-devel \
     libXext-devel \
+    libXi-devel \
+    libXrandr-devel \
     libXrender-devel \
     libXt-devel \
     libXtst-devel \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update \
     libfreetype6-dev \
     libx11-dev \
     libxext-dev \
+    libxrandr-dev \
     libxrender-dev \
     libxt-dev \
     libxtst-dev \


### PR DESCRIPTION
- Cent7 ppc64le
- Ubuntu16 s390x
- Note: libXi-devel not needed on s390x

[skip ci]
Related #4048

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>