### PR TITLE
Updated gcc-7 install for centos7

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -113,7 +113,7 @@ RUN rm /usr/bin/c++ /usr/bin/cc \
 # Install GCC-7.3.1
 RUN cd /usr/local \
   && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.ppc64le.tar.xz" \
-  && tar -xJf gcc-7.tar.xz \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
   && rm -rf gcc-7.tar.xz
 
 #Building and setting up git version 2.5.3


### PR DESCRIPTION
Changed the location of the gcc-7.3 install for centos7 ppc64le docker containers
so gcc-7 will be found on the path.

Signed-off-by: Colton Mills <millscolt3@gmail.com>