### PR TITLE
Check that SVM symbol <-> ID lookups succeed

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2231,7 +2231,10 @@ TR_RelocationRecordInlinedMethod::inlinedSiteValid(TR_RelocationRuntime *reloRun
 
          // currentMethod is guaranteed to not be NULL because of the SVM
          currentMethod = (J9Method *)reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(methodID);
-         reloPrivateData->_receiverClass = (TR_OpaqueClassBlock *)reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(receiverClassID);
+         if (needsReceiverClassFromID())
+            reloPrivateData->_receiverClass = (TR_OpaqueClassBlock *)reloRuntime->comp()->getSymbolValidationManager()->getSymbolFromID(receiverClassID);
+         else
+            reloPrivateData->_receiverClass = NULL;
 
          if (reloFlags(reloTarget) != inlinedMethodIsStatic && reloFlags(reloTarget) != inlinedMethodIsSpecial)
             {

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1076,6 +1076,7 @@ class TR_RelocationRecordInlinedMethod : public TR_RelocationRecordConstantPoolW
 
    protected:
       virtual void fixInlinedSiteInfo(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_OpaqueMethodBlock *inlinedMethod);
+      virtual bool needsReceiverClassFromID() { return false; }
 
    private:
       virtual bool inlinedSiteValid(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_OpaqueMethodBlock **theMethod);
@@ -1169,6 +1170,8 @@ class TR_RelocationRecordInlinedInterfaceMethodWithNopGuard : public TR_Relocati
       TR_RelocationRecordInlinedInterfaceMethodWithNopGuard() {}
       TR_RelocationRecordInlinedInterfaceMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
       virtual char *name();
+   protected:
+      virtual bool needsReceiverClassFromID() { return true; }
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
       virtual void updateFailedStats(TR_AOTStats *aotStats);
@@ -1194,6 +1197,8 @@ class TR_RelocationRecordInlinedAbstractMethodWithNopGuard : public TR_Relocatio
       TR_RelocationRecordInlinedAbstractMethodWithNopGuard() {}
       TR_RelocationRecordInlinedAbstractMethodWithNopGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecordNopGuard(reloRuntime, record) {}
       virtual char *name();
+   protected:
+      virtual bool needsReceiverClassFromID() { return true; }
    private:
       virtual TR_OpaqueMethodBlock *getMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpindex, TR_OpaqueMethodBlock *callerMethod);
       virtual void updateFailedStats(TR_AOTStats *aotStats);

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -119,13 +119,21 @@ TR::SymbolValidationManager::getSymbolFromID(uint16_t id)
    }
 
 uint16_t
-TR::SymbolValidationManager::getIDFromSymbol(void *symbol)
+TR::SymbolValidationManager::tryGetIDFromSymbol(void *symbol)
    {
    SymbolToIdMap::iterator it = _symbolToIdMap.find(symbol);
    if (it == _symbolToIdMap.end())
       return NO_ID;
    else
       return it->second;
+   }
+
+uint16_t
+TR::SymbolValidationManager::getIDFromSymbol(void *symbol)
+   {
+   uint16_t id = tryGetIDFromSymbol(symbol);
+   SVM_ASSERT(id != NO_ID, "Unknown symbol %p\n", symbol);
+   return id;
    }
 
 TR_OpaqueClassBlock *

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -112,10 +112,8 @@ void *
 TR::SymbolValidationManager::getSymbolFromID(uint16_t id)
    {
    IdToSymbolMap::iterator it = _idToSymbolsMap.find(id);
-   if (it == _idToSymbolsMap.end())
-      return NULL;
-   else
-      return it->second;
+   SVM_ASSERT(it != _idToSymbolsMap.end(), "Unknown ID %d", id);
+   return it->second;
    }
 
 uint16_t
@@ -900,11 +898,11 @@ bool
 TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *validSymbol)
    {
    bool valid = false;
-   void *symbol = getSymbolFromID(idToBeValidated);
+   IdToSymbolMap::iterator it = _idToSymbolsMap.find(idToBeValidated);
 
    if (validSymbol)
       {
-      if (symbol == NULL)
+      if (it == _idToSymbolsMap.end())
          {
          if (_seenSymbolsSet.find(validSymbol) == _seenSymbolsSet.end())
             {
@@ -915,7 +913,7 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
          }
       else
          {
-         valid = (symbol == validSymbol);
+         valid = (it->second == validSymbol);
          }
       }
 
@@ -925,12 +923,6 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
 bool
 TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_t beholderID, J9ROMClass *romClass, char primitiveType)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -940,11 +932,7 @@ TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_
 
    if (primitiveType != '\0')
       {
-      if (getSymbolFromID(classID) == NULL)
-         {
-         TR_ASSERT(false, "primitive classID %u should exist\n", classID);
-         return false;
-         }
+      getSymbolFromID(classID); // just to assert that it exists
       return true;
       }
 
@@ -970,11 +958,7 @@ TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, char 
 
    if (primitiveType != '\0')
       {
-      if (getSymbolFromID(classID) == NULL)
-         {
-         TR_ASSERT(false, "primitive classID %u should exist\n", classID);
-         return false;
-         }
+      getSymbolFromID(classID); // just to assert that it exists
       return true;
       }
 
@@ -999,12 +983,6 @@ TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, char 
 bool
 TR::SymbolValidationManager::validateClassFromCPRecord(uint16_t classID,  uint16_t beholderID, uint32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1022,12 +1000,6 @@ TR::SymbolValidationManager::validateClassFromCPRecord(uint16_t classID,  uint16
 bool
 TR::SymbolValidationManager::validateDefiningClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex, bool isStatic)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1053,12 +1025,6 @@ TR::SymbolValidationManager::validateDefiningClassFromCPRecord(uint16_t classID,
 bool
 TR::SymbolValidationManager::validateStaticClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1076,12 +1042,6 @@ TR::SymbolValidationManager::validateStaticClassFromCPRecord(uint16_t classID, u
 bool
 TR::SymbolValidationManager::validateClassFromMethodRecord(uint16_t classID, uint16_t methodID)
    {
-   if (getSymbolFromID(methodID) == NULL)
-      {
-      TR_ASSERT(false, "methodID %u should exist\n", methodID);
-      return false;
-      }
-
    J9Method *method = static_cast<J9Method *>(getSymbolFromID(methodID));
    TR_OpaqueClassBlock *classFromMethod = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_METHOD(method));
 
@@ -1094,12 +1054,6 @@ TR::SymbolValidationManager::validateClassFromMethodRecord(uint16_t classID, uin
 bool
 TR::SymbolValidationManager::validateComponentClassFromArrayClassRecord(uint16_t componentClassID, uint16_t arrayClassID)
    {
-   if (getSymbolFromID(arrayClassID) == NULL)
-      {
-      TR_ASSERT(false, "arrayClassID %u should exist\n", arrayClassID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1113,12 +1067,6 @@ TR::SymbolValidationManager::validateComponentClassFromArrayClassRecord(uint16_t
 bool
 TR::SymbolValidationManager::validateArrayClassFromComponentClassRecord(uint16_t arrayClassID, uint16_t componentClassID)
    {
-   if (getSymbolFromID(componentClassID) == NULL)
-      {
-      TR_ASSERT(false, "componentClassID %u should exist\n", componentClassID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1132,12 +1080,6 @@ TR::SymbolValidationManager::validateArrayClassFromComponentClassRecord(uint16_t
 bool
 TR::SymbolValidationManager::validateSuperClassFromClassRecord(uint16_t superClassID, uint16_t childClassID)
    {
-   if (getSymbolFromID(childClassID) == NULL)
-      {
-      TR_ASSERT(false, "childClassID %u should exist\n", childClassID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1154,13 +1096,6 @@ TR::SymbolValidationManager::validateSuperClassFromClassRecord(uint16_t superCla
 bool
 TR::SymbolValidationManager::validateClassInstanceOfClassRecord(uint16_t classOneID, uint16_t classTwoID, bool objectTypeIsFixed, bool castTypeIsFixed, bool wasInstanceOf)
    {
-   if (getSymbolFromID(classOneID) == NULL || getSymbolFromID(classTwoID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(classOneID) != 0, "classOneID %u should exist\n", classOneID);
-      TR_ASSERT(getSymbolFromID(classTwoID) != 0, "classTwoID %u should exist\n", classTwoID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1193,12 +1128,6 @@ TR::SymbolValidationManager::validateSystemClassByNameRecord(uint16_t systemClas
 bool
 TR::SymbolValidationManager::validateClassFromITableIndexCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1217,12 +1146,6 @@ TR::SymbolValidationManager::validateClassFromITableIndexCPRecord(uint16_t class
 bool
 TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1274,12 +1197,6 @@ TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint1
 bool
 TR::SymbolValidationManager::validateClassClassRecord(uint16_t classClassID, uint16_t objectClassID)
    {
-   if (getSymbolFromID(objectClassID) == NULL)
-      {
-      TR_ASSERT(false, "objectClassID %u should exist\n", objectClassID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = (TR_J9VM *)TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1293,12 +1210,6 @@ TR::SymbolValidationManager::validateClassClassRecord(uint16_t classClassID, uin
 bool
 TR::SymbolValidationManager::validateConcreteSubClassFromClassRecord(uint16_t childClassID, uint16_t superClassID)
    {
-   if (getSymbolFromID(superClassID) == NULL)
-      {
-      TR_ASSERT(false, "superClassID %u should exist\n", superClassID);
-      return false;
-      }
-
    TR_OpaqueClassBlock *superClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(superClassID));
 
    TR_PersistentCHTable * chTable = comp()->getPersistentInfo()->getPersistentCHTable();
@@ -1313,12 +1224,6 @@ TR::SymbolValidationManager::validateConcreteSubClassFromClassRecord(uint16_t ch
 bool
 TR::SymbolValidationManager::validateClassChainRecord(uint16_t classID, void *classChain)
    {
-   if (getSymbolFromID(classID) == NULL)
-      {
-      TR_ASSERT(false, "classID %u should exist\n", classID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    TR_OpaqueClassBlock *definingClass = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classID));
 
@@ -1328,12 +1233,6 @@ TR::SymbolValidationManager::validateClassChainRecord(uint16_t classID, void *cl
 bool
 TR::SymbolValidationManager::validateMethodByNameRecord(uint16_t methodID, uint16_t beholderID, J9ROMClass *romClass, J9ROMMethod *romMethod)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VM *fej9 = reinterpret_cast<TR_J9VM *>(TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread));
@@ -1364,12 +1263,6 @@ TR::SymbolValidationManager::validateMethodByNameRecord(uint16_t methodID, uint1
 bool
 TR::SymbolValidationManager::validateMethodFromClassRecord(uint16_t methodID, uint16_t beholderID, uint32_t index)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1391,12 +1284,6 @@ TR::SymbolValidationManager::validateMethodFromClassRecord(uint16_t methodID, ui
 bool
 TR::SymbolValidationManager::validateStaticMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1416,12 +1303,6 @@ TR::SymbolValidationManager::validateStaticMethodFromCPRecord(uint16_t methodID,
 bool
 TR::SymbolValidationManager::validateSpecialMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1441,12 +1322,6 @@ TR::SymbolValidationManager::validateSpecialMethodFromCPRecord(uint16_t methodID
 bool
 TR::SymbolValidationManager::validateVirtualMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1464,12 +1339,6 @@ TR::SymbolValidationManager::validateVirtualMethodFromCPRecord(uint16_t methodID
 bool
 TR::SymbolValidationManager::validateVirtualMethodFromOffsetRecord(uint16_t methodID, uint16_t beholderID, int32_t virtualCallOffset, bool ignoreRtResolve)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1484,13 +1353,6 @@ TR::SymbolValidationManager::validateVirtualMethodFromOffsetRecord(uint16_t meth
 bool
 TR::SymbolValidationManager::validateInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, uint16_t lookupID, int32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL || getSymbolFromID(lookupID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
-      TR_ASSERT(getSymbolFromID(lookupID) != 0, "lookupID %u should exist\n", lookupID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1508,12 +1370,6 @@ TR::SymbolValidationManager::validateInterfaceMethodFromCPRecord(uint16_t method
 bool
 TR::SymbolValidationManager::validateImproperInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex)
    {
-   if (getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(false, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1533,13 +1389,6 @@ TR::SymbolValidationManager::validateImproperInterfaceMethodFromCPRecord(uint16_
 bool
 TR::SymbolValidationManager::validateMethodFromClassAndSignatureRecord(uint16_t methodID, uint16_t methodClassID, uint16_t beholderID, J9ROMMethod *romMethod)
    {
-   if (getSymbolFromID(methodClassID) == NULL || getSymbolFromID(beholderID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(methodClassID) != 0, "methodClassID %u should exist\n", methodClassID);
-      TR_ASSERT(getSymbolFromID(beholderID) != 0, "beholderID %u should exist\n", beholderID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1569,13 +1418,6 @@ TR::SymbolValidationManager::validateMethodFromSingleImplementerRecord(uint16_t 
                                                                        uint16_t callerMethodID,
                                                                        TR_YesNoMaybe useGetResolvedInterfaceMethod)
    {
-   if (getSymbolFromID(thisClassID) == NULL || getSymbolFromID(callerMethodID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(thisClassID) != 0, "thisClassID %u should exist\n", thisClassID);
-      TR_ASSERT(getSymbolFromID(callerMethodID) != 0, "callerMethodID %u should exist\n", callerMethodID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1602,13 +1444,6 @@ TR::SymbolValidationManager::validateMethodFromSingleInterfaceImplementerRecord(
                                                                                 int32_t cpIndex,
                                                                                 uint16_t callerMethodID)
    {
-   if (getSymbolFromID(thisClassID) == NULL || getSymbolFromID(callerMethodID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(thisClassID) != 0, "thisClassID %u should exist\n", thisClassID);
-      TR_ASSERT(getSymbolFromID(callerMethodID) != 0, "callerMethodID %u should exist\n", callerMethodID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1635,13 +1470,6 @@ TR::SymbolValidationManager::validateMethodFromSingleAbstractImplementerRecord(u
                                                                                int32_t vftSlot,
                                                                                uint16_t callerMethodID)
    {
-   if (getSymbolFromID(thisClassID) == NULL || getSymbolFromID(callerMethodID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(thisClassID) != 0, "thisClassID %u should exist\n", thisClassID);
-      TR_ASSERT(getSymbolFromID(callerMethodID) != 0, "callerMethodID %u should exist\n", callerMethodID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1665,13 +1493,6 @@ TR::SymbolValidationManager::validateMethodFromSingleAbstractImplementerRecord(u
 bool
 TR::SymbolValidationManager::validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames)
    {
-   if (getSymbolFromID(methodID) == NULL || getSymbolFromID(methodClassID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(methodID) != 0, "methodID %u should exist\n", methodID);
-      TR_ASSERT(getSymbolFromID(methodClassID) != 0, "methodClassID %u should exist\n", methodClassID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    J9VMThread *vmThread = comp->j9VMThread();
    TR_J9VMBase *fej9 = TR_J9VMBase::get(vmThread->javaVM->jitConfig, vmThread);
@@ -1687,12 +1508,6 @@ TR::SymbolValidationManager::validateStackWalkerMaySkipFramesRecord(uint16_t met
 bool
 TR::SymbolValidationManager::validateClassInfoIsInitializedRecord(uint16_t classID, bool wasInitialized)
    {
-   if (getSymbolFromID(classID) == NULL)
-      {
-      TR_ASSERT(getSymbolFromID(classID) != 0, "classID %u should exist\n", classID);
-      return false;
-      }
-
    TR::Compilation* comp = TR::comp();
    TR_OpaqueClassBlock *clazz = static_cast<TR_OpaqueClassBlock *>(getSymbolFromID(classID));
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1075,11 +1075,12 @@ public:
    SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee);
 
    void* getSymbolFromID(uint16_t id);
+   uint16_t tryGetIDFromSymbol(void *symbol);
    uint16_t getIDFromSymbol(void *symbol);
 
    bool isAlreadyValidated(void *symbol)
       {
-      return inHeuristicRegion() || getIDFromSymbol(symbol) != NO_ID;
+      return inHeuristicRegion() || tryGetIDFromSymbol(symbol) != NO_ID;
       }
 
    bool addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder);

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -266,7 +266,12 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
             TR_OpaqueMethodBlock *method = resolvedMethod->getPersistentIdentifier();
             TR_OpaqueClassBlock *thisClass = guard->getThisClass();
             uint16_t methodID = symValManager->getIDFromSymbol(static_cast<void *>(method));
-            uint16_t receiverClassID = symValManager->getIDFromSymbol(static_cast<void *>(thisClass));
+            uint16_t receiverClassID = 0;
+            if (relocation->getTargetKind() == TR_InlinedInterfaceMethodWithNopGuard ||
+                relocation->getTargetKind() == TR_InlinedAbstractMethodWithNopGuard)
+               {
+               receiverClassID = symValManager->getIDFromSymbol(static_cast<void *>(thisClass));
+               }
 
             uintptrj_t data = 0;
             data = (((uintptrj_t)receiverClassID << 16) | (uintptrj_t)methodID);


### PR DESCRIPTION
This series changes `getIDFromSymbol()` and `getSymbolFromID()` so that they require as a precondition that the requested key exists. Looking up an unknown symbol or ID results in an assertion failure (`SVM_ASSERT`). Explicit checks are removed from callers, since they're now redundant.