### PR TITLE
Use regular getClassClassPointer() when using SVM

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1187,7 +1187,7 @@ J9::Compilation::addAsMonitorAuto(TR::SymbolReference* symRef, bool dontAddIfDLT
 TR_OpaqueClassBlock *
 J9::Compilation::getClassClassPointer(bool isVettedForAOT)
    {
-   if (!isVettedForAOT)
+   if (!isVettedForAOT || self()->getOption(TR_UseSymbolValidationManager))
       return _ObjectClassPointer ? self()->fe()->getClassClassPointer(_ObjectClassPointer) : 0;
 
    if (_aotClassClassPointerInitialized)


### PR DESCRIPTION
It is not necessary to take the `_aotClassClassPointer` path when the symbol validation manager (SVM) is in use.