### PR TITLE
Enable class sharing by default on OSX

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -327,11 +327,10 @@ static const struct { \
 #define J9_IS_J9CLASS_VALUETYPE(clazz) FALSE
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
-#if defined(OPENJ9_BUILD) && !defined(OSX)
+#if defined(OPENJ9_BUILD)
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) TRUE
-#else /* defined(OPENJ9_BUILD) && !defined(OSX) */
-/* Temporarily disable default class sharing on OSX due to https://github.com/eclipse/openj9/issues/3333 */
+#else /* defined(OPENJ9_BUILD) */
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) FALSE
-#endif /* defined(OPENJ9_BUILD) && !defined(OSX) */
+#endif /* defined(OPENJ9_BUILD) */
 
 #endif /* J9_H */

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -396,8 +396,6 @@
 	-nonZeroExitWhenError \
 	-outputLimit 300; \
 	$(TEST_STATUS)</command>
-	<!-- temporarily disable this test on OSX, see https://github.com/eclipse/openj9/issues/3333 -->
-	<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Closes #3333

Doc issue https://github.com/eclipse/openj9-docs/issues/149

Signed-off-by: hangshao <hangshao@ca.ibm.com>