### PR TITLE
Ensure boolean JNI methods on x86 produce a result of zero or one

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1269,6 +1269,13 @@ static bool isSignatureTypeBool(const char *fieldSignature, int32_t len)
    return len == 1 && fieldSignature[0] == 'Z';
    }
 
+static bool isSignatureReturnTypeBool(const char *methodSignature, int32_t len)
+   {
+   TR_ASSERT(len > 1, "Method signature is unexpectedly short %d", len);
+   // Method signature must end with ")Z" to have a boolean result type
+   return len > 1 && (')' == methodSignature[len-2]) && ('Z' == methodSignature[len-1]);
+   }
+
 bool
 J9::SymbolReferenceTable::isFieldTypeBool(TR::SymbolReference *symRef)
    {
@@ -1285,6 +1292,16 @@ J9::SymbolReferenceTable::isStaticTypeBool(TR::SymbolReference *symRef)
    const char *fieldSignature = symRef->getOwningMethod(comp())->staticSignatureChars(symRef->getCPIndex(), len);
    dumpOptDetails(comp(), "got static signature as %s\n", fieldSignature);
    return isSignatureTypeBool(fieldSignature, len);
+   }
+
+bool
+J9::SymbolReferenceTable::isReturnTypeBool(TR::SymbolReference *symRef)
+   {
+   TR_Method *method = symRef->getSymbol()->castToResolvedMethodSymbol()->getMethod();
+   char *methodSignature = method->signatureChars();
+   const int32_t len = method->signatureLength();
+   dumpOptDetails(comp(), "got method signature as %.*s\n", len, methodSignature);
+   return isSignatureReturnTypeBool(methodSignature, len);
    }
 
 static bool parmSlotCameFromExpandingAnArchetypeArgPlaceholder(int32_t slot, TR::ResolvedMethodSymbol *sym, TR_Memory *mem)

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -263,6 +263,7 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    bool isFieldClassObject(TR::SymbolReference *symRef);
    bool isFieldTypeBool(TR::SymbolReference *symRef);
    bool isStaticTypeBool(TR::SymbolReference *symRef);
+   bool isReturnTypeBool(TR::SymbolReference *symRef);
    void addParameters(TR::ResolvedMethodSymbol * owningMethodSymbol);
 
    // NO LONGER NEEDED?  Disabled since inception (2009)

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -335,10 +335,20 @@ TR::Register *TR::IA32JNILinkage::buildJNIDispatch(TR::Node *callNode)
    // type so that we sign and zero extend the narrower integer return types properly.
    //
    bool isUnsigned = resolvedMethod->returnTypeIsUnsigned();
+   bool isBoolean;
    switch (resolvedMethod->returnType())
       {
       case TR::Int8:
-         generateRegRegInstruction(isUnsigned ? MOVZXReg4Reg1 : MOVSXReg4Reg1,
+         isBoolean = comp()->getSymRefTab()->isReturnTypeBool(callSymRef);
+         if (isBoolean)
+            {
+            // For bool return type, must check whether value returned by
+            // JNI is zero (false) or non-zero (true) to yield Java result
+            generateRegRegInstruction(TEST1RegReg, callNode, eaxReal, eaxReal, cg());
+            generateRegInstruction(SETNE1Reg, callNode, eaxReal, cg());
+            }
+         generateRegRegInstruction((isUnsigned || isBoolean)
+                                         ? MOVZXReg4Reg1 : MOVSXReg4Reg1,
                                    callNode, ecxReal, eaxReal, cg());
          break;
       case TR::Int16:


### PR DESCRIPTION
In calling a JNI boolean method, if the native implementation returns
zero, the result is false; if it returns a non-zero value, the result
is true.

This behaviour is consistent with the reference implementation.

Progresses issue #2049

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>