### PR TITLE
Properly find machine base pointer from C stack on X86

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1156,7 +1156,6 @@ UDATA TR_J9VMBase::thisThreadGetSystemSPOffset()
 UDATA TR_J9VMBase::thisThreadGetJavaLiteralsOffset()                {return offsetof(J9VMThread, literals);}
 UDATA TR_J9VMBase::thisThreadGetJavaFrameFlagsOffset()              {return offsetof(J9VMThread, jitStackFrameFlags);}
 UDATA TR_J9VMBase::thisThreadGetMachineSPOffset()                   {return sizeof(J9VMThread);}
-UDATA TR_J9VMBase::thisThreadGetMachineBPOffset(TR::Compilation * comp) {return TR::Compiler->om.sizeofReferenceAddress();}  // DANGER: this is offset from *(machineSP)
 UDATA TR_J9VMBase::thisThreadGetCurrentThreadOffset()               {return offsetof(J9VMThread, threadObject);}
 UDATA TR_J9VMBase::thisThreadGetFloatTemp1Offset()                  {return offsetof(J9VMThread, floatTemp1);}
 UDATA TR_J9VMBase::thisThreadGetFloatTemp2Offset()                  {return offsetof(J9VMThread, floatTemp2);}

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -452,7 +452,6 @@ public:
    virtual uintptrj_t         thisThreadGetSystemSPOffset();
 
    virtual uintptrj_t         thisThreadGetMachineSPOffset();
-   virtual uintptrj_t         thisThreadGetMachineBPOffset( TR::Compilation *);
    virtual uintptrj_t         thisThreadGetJavaFrameFlagsOffset();
    virtual uintptrj_t         thisThreadGetCurrentThreadOffset();
    virtual uintptrj_t         thisThreadGetFloatTemp1Offset();

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -827,12 +827,12 @@ TR::AMD64JNILinkage::generateMethodDispatch(
       fej9->reserveTrampolineIfNecessary(comp(), methodSymRef, false);
       }
 
-   // Load machine bp esp + thisThreadGetMachineBPOffset() + argSize
+   // Load machine bp esp + offsetof(J9CInterpreterStackFrame, machineBP) + argSize
    //
    generateRegMemInstruction(LRegMem(),
                              callNode,
                              vmThreadReg,
-                             generateX86MemoryReference(espReal, fej9->thisThreadGetMachineBPOffset(comp()) + argSize, cg()),
+                             generateX86MemoryReference(espReal, offsetof(J9CInterpreterStackFrame, machineBP) + argSize, cg()),
                              cg());
 
    // Dispatch JNI method directly.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5659,7 +5659,7 @@ typedef struct J9CInterpreterStackFrame {
 #endif /* J9VM_ENV_DATA64 */
 #elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_ARM */
 	UDATA vmStruct;
-	UDATA machineBP; /* JIT has this offset hard-coded - do not move this field */
+	UDATA machineBP;
 #if defined(J9VM_ENV_DATA64)
 	union {
 		UDATA numbered[16];


### PR DESCRIPTION
The previous approach is improper and dangerous, fixing.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>