### PR TITLE
Add stub method Java_sun_management_FileSystemImpl_init0

### DIFF
--- a/runtime/mgmt/mgmtinit.c
+++ b/runtime/mgmt/mgmtinit.c
@@ -123,3 +123,11 @@ Java_sun_management_FileSystemImpl_isAccessUserOnly0(JNIEnv *env, jclass c, jstr
 
 	return result;
 }
+
+#if defined(WIN32) || defined(WIN64)
+JNIEXPORT void JNICALL 
+Java_sun_management_FileSystemImpl_init0(JNIEnv *env, jclass c)
+{
+	/* stub method, no implementation required */ 
+}
+#endif /* defined(WIN32) || defined(WIN64) */

--- a/runtime/mgmt/module.xml
+++ b/runtime/mgmt/module.xml
@@ -25,6 +25,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	<exports group="all">
 		<export name="JNI_OnLoad" />
 		<export name="Java_sun_management_FileSystemImpl_isAccessUserOnly0" />
+		<export name="Java_sun_management_FileSystemImpl_init0">
+			<include-if condition="spec.win_x86.*" />
+		</export>
 	</exports>
 
 	<artifact type="shared" name="management" loadgroup="" appendrelease="false">


### PR DESCRIPTION
Add stub method `Java_sun_management_FileSystemImpl_init0` for `Windows`

No actual implementation required.
Note: this is a native method only required by `Windows` platform.
Manually verified that `java/lang/UnsatisfiedLinkError: sun/management/FileSystemImpl.init0()V` doesn't occur with this PR.

closes: #3909 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>