### PR TITLE
Methods and tests for jep334 String

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -8298,14 +8298,6 @@ written authorization of the copyright holder.
 /*[ENDIF] Sidecar19-SE*/
 
 /*[IF Java12]*/
-	public Optional<String> describeConstable() {
-		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
-	}
-
-	public String resolveConstantDesc(MethodHandles.Lookup lookup) {
-		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
-	}
-	
 	/**
 	 * Apply a function to this string. The function expects a single String input and returns an R.
 	 * 
@@ -8314,6 +8306,27 @@ written authorization of the copyright holder.
 	 */
 	public <R> R transform(Function<? super String, ? extends R> f) {
 		return f.apply(this);
+	}
+
+	/**
+	 * Returns the nominal descriptor of this String instance, or an empty optional 
+	 * if construction is not possible.
+	 * 
+	 * @return Optional with nominal descriptor of String instance
+	 */
+	public Optional<String> describeConstable() {
+		return Optional.of(this);
+	}
+
+	/**
+	 * Resolves this ConstantDesc instance
+	 * 
+	 * @param lookup parameter is ignored
+	 * 
+	 * @return the resolved Constable value
+	 */
+	public String resolveConstantDesc(MethodHandles.Lookup lookup) {
+		return this;
 	}
 /*[ENDIF] Java12 */
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -140,7 +140,7 @@ typical use case for OpenJ9 developers, there are also many cases
 where developers need to verify features for a specific version or
 compare behaviour against a particular implementation.
 
-JDK_VERSION=[8|9|10|11|Panama|Valhalla] (8 default value)
+JDK_VERSION=[8|9|10|11|12|Panama|Valhalla] (8 default value)
 
 JDK_IMPL=[openj9|ibm|hotspot|sap] (openj9 default value)
 

--- a/test/docs/OpenJ9TestUserGuide.md
+++ b/test/docs/OpenJ9TestUserGuide.md
@@ -47,7 +47,7 @@ tools should be installed on your test machine to run tests.
     ```
     JAVA_BIN=<path to JDK bin directory that you wish to test>
     SPEC=[linux_x86-64|linux_x86-64_cmprssptrs|...] (platform on which to test)
-    JDK_VERSION=[8|9|10|11|Panama|Valhalla] (8 default value)
+    JDK_VERSION=[8|9|10|11|12|Panama|Valhalla] (8 default value)
     JDK_IMPL=[openj9|ibm|hotspot|sap] (openj9 default value)
     BUILD_LIST=<comma separated projects to be compiled and executed> (default to all projects)
     NATIVE_TEST_LIBS=<path to native test libraries> (default to native-test-libs folder at same level as JDK_HOME)

--- a/test/functional/Java12andUp/build.xml
+++ b/test/functional/Java12andUp/build.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2018, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="Java12AndUp" default="build" basedir=".">
+	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+	<description>
+		Tests for Java 12 and up
+	</description>
+	<import file="${TEST_ROOT}/functional/build.xml"/>
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/Java12andUp" />
+		
+	<!--Properties for this particular build-->
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}"/>
+	</target>
+	
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source" >
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:		${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:			${DEST}</echo>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}"/>
+			<classpath>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/testng.jar"/>
+				<pathelement location="${TEST_ROOT}/TestConfig/lib/jcommander.jar"/>
+				<pathelement location="${build}" />
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile,dist_functional" description="generate the distribution" >
+		<mkdir dir="${DEST}"/>
+		<jar jarfile="${DEST}/GeneralTest.jar" filesonly="true">
+			<fileset dir="${build}"/>
+			<fileset dir="${src}/../" includes="*.properties,*.xml"/>
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.mk" />
+		</copy>
+	</target>
+	
+	<target name="build" >
+		<if>
+			<not>
+				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11)$$" />
+			</not>
+			<then>
+				<antcall target="clean" inheritall="true" />
+			</then>
+		</if>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up" >
+		<delete dir="${build}"/>
+	</target>
+</project>

--- a/test/functional/Java12andUp/playlist.xml
+++ b/test/functional/Java12andUp/playlist.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2018, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+  <test>
+          <testCaseName>Jep334Tests</testCaseName>
+          <variations>
+                  <variation>NoOptions</variation>
+          </variations>
+          <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+                  -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+                  org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames Jep334Tests \
+                  -groups $(TEST_GROUP) \
+                  -excludegroups $(DEFAULT_EXCLUDE); \
+                  $(TEST_STATUS)
+          </command>
+          <levels>
+                  <level>sanity</level>
+          </levels>
+          <groups>
+                  <group>functional</group>
+          </groups>
+          <subsets>
+                  <subset>12+</subset>
+          </subsets>
+  </test>
+</playlist>

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_String.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang/Test_String.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.util.Optional;
+
+/**
+ * This test Java.lang.String API added in Java 12 and later version.
+ *
+ */
+public class Test_String {
+	public static Logger logger = Logger.getLogger(Test_String.class);
+
+	private String empty = "";
+	private String latin1 = "abc123";
+	private String nonLatin1 = "abc\u0153";
+	private String emptyWithTerm = "\n";
+
+	/*
+	 * Test Java 12 API String.describeConstable()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testStringDescribeConstable() throws Throwable {
+		testStringDescribeConstable_sub(empty);
+		testStringDescribeConstable_sub(latin1);
+		testStringDescribeConstable_sub(nonLatin1);
+		testStringDescribeConstable_sub(emptyWithTerm);
+	}
+
+	private void testStringDescribeConstable_sub(String test) throws Throwable {
+		logger.debug("testStringDescribeConstable: test with string: " + test);
+		Optional<String> optionalTest = test.describeConstable();
+		String describedTestString = optionalTest.orElseThrow();
+		Assert.assertTrue(test.equals(describedTestString));
+	}
+
+	/*
+	 * Test Java 12 API String.resolveConstantDesc()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testStringResolveConstantDesc() {
+		testStringResolveConstantDesc_sub(empty);
+		testStringResolveConstantDesc_sub(latin1);
+		testStringResolveConstantDesc_sub(nonLatin1);
+		testStringResolveConstantDesc_sub(emptyWithTerm);
+	}
+
+	private void testStringResolveConstantDesc_sub(String test) {
+		logger.debug("testStringDescribeConstable: test with string: " + test);
+
+		/* run test with a valid lookup */
+		MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+		String resolvedTest = test.resolveConstantDesc(lookup);
+		Assert.assertTrue(test.equals(resolvedTest));
+
+		/* run tests with a null lookup (should be ignored) */
+		String resolvedTest2 = test.resolveConstantDesc(null);
+		Assert.assertTrue(test.equals(resolvedTest2));
+	}
+	 
+}

--- a/test/functional/Java12andUp/testng.xml
+++ b/test/functional/Java12andUp/testng.xml
@@ -27,7 +27,7 @@
 
 	<test name="Jep334Tests">
 		<classes>
-			<!-- empty for now -->
+			<class name="org.openj9.test.java_lang.Test_String" />
 		</classes>
 	</test>
 

--- a/test/functional/Java12andUp/testng.xml
+++ b/test/functional/Java12andUp/testng.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2018, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Java12andUp suite" parallel="none" verbose="2">
+
+	<test name="Jep334Tests">
+		<classes>
+			<!-- empty for now -->
+		</classes>
+	</test>
+
+</suite>


### PR DESCRIPTION
- Java12andUp test framework
- String.describeConstable & tests
- String.resolveConstantDesc & tests

Depends on (see https://github.com/eclipse/openj9/issues/4195): 
- Fix Java 12 build failures: https://github.com/eclipse/openj9/pull/3980
- Constants API stubs: https://github.com/eclipse/openj9/pull/4030
- Java12andUp test setup: https://github.com/eclipse/openj9/pull/4104

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>