### PR TITLE
Enable Concurrent Scavenge on Windows X86-64

### DIFF
--- a/runtime/gc_glue_java/configure_includes/configure_win_x86.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_win_x86.mk
@@ -35,6 +35,7 @@ ifeq (win_x86-64_cmprssptrs, $(SPEC))
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
@@ -76,6 +77,7 @@ ifeq (win_x86-64, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_TLH_PREFETCH_FTA \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_ALLOCATE_TOP_DOWN \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 endif


### PR DESCRIPTION
win_x86-64.spec and win_x86-64_cmprssptrs.spec now supports concurrent scavenge.

Part of Issue #4108

Doc issue eclipse/openj9-docs#172

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>