### PR TITLE
Remove unused metaDataStats debug facility

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2252,8 +2252,7 @@ TR_J9VMBase::allocateRelocationData(TR::Compilation * comp, uint32_t numBytes)
          }
       comp->failCompilation<J9::DataCacheError>("Failed to allocate relocation data");
       }
-   if (debug("metaDataStats"))
-      metaDataStats._relocationSize += size;
+
    return relocationData;
    }
 
@@ -2334,12 +2333,6 @@ TR_J9VMBase::resizeCodeMemory(TR::Compilation * comp, U_8 *bufferStart, uint32_t
    TR::VMAccessCriticalSection resizeCodeMemory(this);
    TR::CodeCache * codeCache = comp->getCurrentCodeCache();
    codeCache->resizeCodeMemory(bufferStart, numBytes);
-
-   if (debug("metaDataStats"))
-      {
-      metaDataStats._codeSize += numBytes;
-      if (numBytes > metaDataStats._maxCodeSize) metaDataStats._maxCodeSize = numBytes;
-      }
    }
 
 bool
@@ -3860,7 +3853,7 @@ TR_J9VMBase::lowerMultiANewArray(TR::Compilation * comp, TR::Node * root, TR::Tr
    TR::Node * tempRef = TR::Node::createWithSymRef(root, TR::loadaddr,0,new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), temp));
    root->setAndIncChild(0,tempRef);
    root->setNumChildren(3);
-   
+
    static bool recreateRoot = feGetEnv("TR_LowerMultiANewArrayRecreateRoot") ? true : false;
    if (!TR::Compiler->target.is64Bit() || recreateRoot || dims > 2 || secondDimConstNonZero)
       TR::Node::recreate(root, TR::acall);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1219,25 +1219,6 @@ TR_MethodMetaData * createMethodMetaData(TR_J9VMBase &, TR_ResolvedMethod *, TR:
 
 extern J9JITConfig * jitConfig;
 
-struct TR_MetaDataStats
-   {
-#if defined(DEBUG)
-   ~TR_MetaDataStats();
-#endif
-
-   uint32_t _counter;
-   uint32_t _codeSize;
-   uint32_t _maxCodeSize;
-   uint32_t _exceptionDataSize;
-   uint32_t _tableSize;
-   uint32_t _inlinedCallDataSize;
-   uint32_t _gcDataSize;
-   uint32_t _relocationSize;
-
-   };
-
-extern struct TR_MetaDataStats metaDataStats;
-
 static inline char * utf8Data(J9UTF8 * name)
    {
    return (char *)J9UTF8_DATA(name);

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -69,8 +69,6 @@
 #include "control/CompilationRuntime.hpp"
 #include "runtime/HWProfiler.hpp"
 
-TR_MetaDataStats metaDataStats;
-
 typedef std::set<TR_GCStackMap*, std::less<TR_GCStackMap*>, TR::typed_allocator<TR_GCStackMap*, TR::Region&>> GCStackMapSet;
 
 struct TR_StackAtlasStats
@@ -101,8 +99,6 @@ static uint8_t * allocateGCData(TR_J9VMBase * vm, uint32_t numBytes, TR::Compila
          }
       comp->failCompilation<J9::DataCacheError>("Failed to allocate GC Data");
       }
-   if (debug("metaDataStats"))
-      metaDataStats._gcDataSize += size;
 
    return gcData;
    }
@@ -110,31 +106,6 @@ static uint8_t * allocateGCData(TR_J9VMBase * vm, uint32_t numBytes, TR::Compila
 ///////////////////////////////////////////////////////////////////////////
 //  Meta Data Creation
 ///////////////////////////////////////////////////////////////////////////
-
-#if defined(DEBUG)
-   // HACK 1GAN1V9 :: OSE Runtime cannot link with destructors defined
-TR_MetaDataStats::~TR_MetaDataStats()
-   {
-   if (!debug("metaDataStats"))
-      return;
-
-   uint32_t totalMetaData = _exceptionDataSize + _tableSize + _inlinedCallDataSize + _gcDataSize + _relocationSize;
-
-   printf("\nMetaDataStats\n");
-   printf("number of methods jitted:      %10d\n", _counter);
-   printf("tot code size:                 %10d\n", _codeSize);
-   printf("av. code size:                 %10d\n", _codeSize / _counter);
-   printf("max code size:                 %10d\n", _maxCodeSize);
-   printf("tot meta size:                 %10d\n", totalMetaData);
-   printf("av. meta data size:            %10d\n", totalMetaData / _counter);
-   printf("   av. exception data size:    %10d\n", _exceptionDataSize / _counter);
-   printf("   av. table size:             %10d\n", _tableSize / _counter);
-   printf("   av. inlined call data size: %10d\n", _inlinedCallDataSize / _counter);
-   printf("   av. gc data size:           %10d\n", _gcDataSize / _counter);
-   printf("   av. relocation size:        %10d\n", _relocationSize / _counter);
-   fflush(stdout);
-   }
-#endif
 
 #if defined(DEBUG)
 TR_StackAtlasStats::~TR_StackAtlasStats()
@@ -1378,14 +1349,6 @@ createMethodMetaData(
    //
    uint32_t inlinedCallSize = comp->getNumInlinedCallSites() * (sizeof(TR_InlinedCallSite) + numberOfMapBytes);
    tableSize += inlinedCallSize;
-
-   if (debug("metaDataStats"))
-      {
-      ++metaDataStats._counter;
-      metaDataStats._exceptionDataSize += exceptionsSize;
-      metaDataStats._tableSize += sizeof(TR_MethodMetaData);
-      metaDataStats._inlinedCallDataSize += inlinedCallSize;
-      }
 
    // Add size of stack atlas to allocate
    //


### PR DESCRIPTION
The debug MetaDataStats facility in the JIT compiler has not been used
for some time, is only available in a debug build, and provides limited
value with its global aggregation of certain metadata statistics.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>