### PR TITLE
Reorder interpreter jump targets for performance

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -9993,6 +9993,9 @@ executeBytecodeFromLocal:
 		JUMP_TARGET(JBmultianewarray):
 			SINGLE_STEP();
 			PERFORM_ACTION(multianewarray(REGISTER_ARGS));
+		JUMP_TARGET(JBiincw):
+			SINGLE_STEP();
+			PERFORM_ACTION(iinc(REGISTER_ARGS, 2));
 		JUMP_TARGET(JBaloadw):
 		JUMP_TARGET(JBiloadw):
 		JUMP_TARGET(JBfloadw):
@@ -10011,9 +10014,6 @@ executeBytecodeFromLocal:
 		JUMP_TARGET(JBdstorew):
 			SINGLE_STEP();
 			PERFORM_ACTION(lstorew(REGISTER_ARGS));
-		JUMP_TARGET(JBiincw):
-			SINGLE_STEP();
-			PERFORM_ACTION(iinc(REGISTER_ARGS, 2));
 		JUMP_TARGET(JBreturnFromConstructor):
 			SINGLE_STEP();
 			PERFORM_ACTION(returnFromConstructor(REGISTER_ARGS));


### PR DESCRIPTION
Make the order of the JUMP_TARGETs match the bytecode numbers
better.

This causes an approximately 2% improvement in Liberty startup time with -Xint
on Linux PPC.

Signed-off-by: Peter Bain peter_bain@ca.ibm.com