### PR TITLE
WIP: Add correctness checks for certain validations/relocations

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1241,6 +1241,16 @@ TR_RelocationRecordConstantPoolWithIndex::getAbstractMethodFromCP(TR_RelocationR
 
       {
       TR::VMAccessCriticalSection getAbstractlMethodFromCP(reloRuntime->fej9());
+
+      J9ROMClass *romClass = cp->ramClass->romClass;
+      uint32_t constantPoolCount = romClass->romConstantPoolCount;
+      uint32_t * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
+      if (cpIndex >= constantPoolCount)
+         return NULL;
+      if ((J9CPTYPE_INSTANCE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex)) &&
+          (J9CPTYPE_INTERFACE_INSTANCE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex)))
+         return NULL;
+
       abstractClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(reloRuntime->currentThread(),
                                                                                             cp,
                                                                                             romMethodRef->classRefCPIndex,

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1142,10 +1142,20 @@ TR_RelocationRecordConstantPoolWithIndex::getVirtualMethodFromCP(TR_RelocationRu
 TR_OpaqueMethodBlock *
 TR_RelocationRecordConstantPoolWithIndex::getStaticMethodFromCP(TR_RelocationRuntime *reloRuntime, void *void_cp, int32_t cpIndex)
    {
-   TR::VMAccessCriticalSection getStaticMethodFromCP(reloRuntime->fej9());
    J9JavaVM *javaVM = reloRuntime->javaVM();
-   J9ConstantPool *cp = (J9ConstantPool *) void_cp;
    TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
+
+   TR::VMAccessCriticalSection getStaticMethodFromCP(reloRuntime->fej9());
+
+   J9ConstantPool *cp = (J9ConstantPool *) void_cp;
+   J9ROMClass *romClass = cp->ramClass->romClass;
+   uint32_t constantPoolCount = romClass->romConstantPoolCount;
+   uint32_t * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
+   if (cpIndex >= constantPoolCount)
+      return NULL;
+   if ((J9CPTYPE_STATIC_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex)) &&
+       (J9CPTYPE_INTERFACE_STATIC_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex)))
+      return NULL;
 
    TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *) jitResolveStaticMethodRef(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                                      cp,

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1181,6 +1181,15 @@ TR_RelocationRecordConstantPoolWithIndex::getInterfaceMethodFromCP(TR_Relocation
 
       {
       TR::VMAccessCriticalSection getInterfaceMethodFromCP(reloRuntime->fej9());
+
+      J9ROMClass *romClass = cp->ramClass->romClass;
+      uint32_t constantPoolCount = romClass->romConstantPoolCount;
+      uint32_t * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
+      if (cpIndex >= constantPoolCount)
+         return NULL;
+      if (J9CPTYPE_INTERFACE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex))
+         return NULL;
+
       interfaceClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(reloRuntime->currentThread(),
                                                                                             cp,
                                                                                             romMethodRef->classRefCPIndex,

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1105,6 +1105,16 @@ TR_RelocationRecordConstantPoolWithIndex::getVirtualMethodFromCP(TR_RelocationRu
 
       {
       TR::VMAccessCriticalSection getVirtualMethodFromCP(reloRuntime->fej9());
+
+      J9ROMClass *romClass = cp->ramClass->romClass;
+      uint32_t constantPoolCount = romClass->romConstantPoolCount;
+      uint32_t * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
+      if (cpIndex >= constantPoolCount)
+         return NULL;
+      if ((J9CPTYPE_INSTANCE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex)) &&
+          (J9CPTYPE_INTERFACE_INSTANCE_METHOD != J9_CP_TYPE(cpShapeDescription, cpIndex)))
+         return NULL;
+
       UDATA vTableOffset = javaVM->internalVMFunctions->resolveVirtualMethodRefInto(javaVM->internalVMFunctions->currentVMThread(javaVM),
                                                                                    cp,
                                                                                    cpIndex,

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3090,10 +3090,21 @@ TR_RelocationRecordValidateClass::getClassFromCP(TR_RelocationRuntime *reloRunti
    if (void_cp)
       {
       TR::VMAccessCriticalSection getClassFromCP(reloRuntime->fej9());
+
+      uint32_t constPoolIndex = cpIndex(reloTarget);
+      J9ConstantPool *cp = (J9ConstantPool *)void_cp;
+      J9ROMClass *romClass = cp->ramClass->romClass;
+      uint32_t constantPoolCount = romClass->romConstantPoolCount;
+      uint32_t * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
+      if (constPoolIndex >= constantPoolCount)
+         return NULL;
+      if (J9CPTYPE_CLASS != J9_CP_TYPE(cpShapeDescription, constPoolIndex))
+         return NULL;
+
       J9JavaVM *javaVM = reloRuntime->javaVM();
       definingClass = (TR_OpaqueClassBlock *) javaVM->internalVMFunctions->resolveClassRef(javaVM->internalVMFunctions->currentVMThread(javaVM),
-                                                                                           (J9ConstantPool *) void_cp,
-                                                                                           cpIndex(reloTarget),
+                                                                                           cp,
+                                                                                           constPoolIndex,
                                                                                            J9_RESOLVE_FLAG_AOT_LOAD_TIME);
       }
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1196,6 +1196,16 @@ TR_SharedCacheRelocationRuntime::getClassFromCP(J9VMThread *vmThread, J9JavaVM *
    J9JITConfig *jitConfig = vmThread->javaVM->jitConfig;
    TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, vmThread);
    TR::VMAccessCriticalSection getClassFromCP(fe);
+
+   J9ROMClass *romClass = constantPool->ramClass->romClass;
+   uint32_t constantPoolCount = romClass->romConstantPoolCount;
+   uint32_t * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(romClass);
+   if (cpIndex >= constantPoolCount)
+      return NULL;
+   if ((J9CPTYPE_FIELD != J9_CP_TYPE(cpShapeDescription, cpIndex)) &&
+       (J9CPTYPE_CLASS != J9_CP_TYPE(cpShapeDescription, cpIndex)))
+      return NULL;
+
    /* Get the class.  Stop immediately if an exception occurs. */
    J9ROMFieldRef *romFieldRef = (J9ROMFieldRef *)&constantPool->romConstantPool[cpIndex];
 


### PR DESCRIPTION
To fix a fundamental issue with the way the AOT relocations/validations are performed (see https://github.com/eclipse/openj9/issues/4135#issuecomment-449504268 for more detail), this PR adds

1. cpIndex bounds checks
2. constant type checks

to
1. inlined special method relocations
2. inlined static method relocations
3. inlined virtual method relocations
4. inlined abstract method relocations
5. inlined interface method relocations
6. class validations
7. field validations

Fixes https://github.com/eclipse/openj9/issues/4135