### PR TITLE
Enable thrstatetest on OSX

### DIFF
--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -347,8 +347,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	'$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest' $(JVM_OPTIONS) -Djava.home='$(JAVA_BIN)$(D)..$(D)' -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
 	$(TEST_STATUS)
 	</command>
-		<!-- Temporarily exclude until the issue is fixed on osx https://github.com/eclipse/openj9/issues/3878 -->
-		<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Reverts eclipse/openj9#4082. eclipse/openj9#3878 is fixed by eclipse/omr#3356.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>