### PR TITLE
z/TPF Compilation Failure on a2e translation wrapper

### DIFF
--- a/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
+++ b/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
@@ -20,6 +20,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#ifdef J9ZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
+
 #include "optimizer/BoolArrayStoreTransformer.hpp"
 #include "compiler/il/OMRTreeTop_inlines.hpp"
 #include "il/Block.hpp"


### PR DESCRIPTION
The BoolArrayStoreTransformer segment fails to compile
because of an unnecessary pre-processor redefinition
of the remove member function to atoe_remove for the
z/TPF platform only.  The redefinition occurs because
of the ascii to ebcdic translation wrapper library
required for z/TPF.  The fix is to turn on a guard
macro to prevent this translation just for this
segment.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>