### PR TITLE
Remove unnecessary gcc-specific optimization flags

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -178,8 +178,6 @@ endif
 
 ifeq ($(C_COMPILER),clang)
     CX_FLAGS+=-Wno-parentheses -Werror=header-guard
-else
-    CX_FLAGS+=-fno-rounding-math -fno-signaling-nans
 endif
 
 ifeq ($(BUILD_CONFIG),debug)


### PR DESCRIPTION
Using -fno-rounding-math and -fno-signalling-nans flags on OSX
results in Clang warning about these unsupported options for
every use of this option.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

Edit: Also removed these options for GCC due to them being defaults.

Edit2: Since #4118 addressed the clang warning issues, this PR has been modified to address just removing the options on GCC.