### PR TITLE
Software Concurrent Scavenge Support on Power

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1920,11 +1920,11 @@ UDATA TR_J9VMBase::thisThreadGetConcurrentScavengeActiveByteAddressOffset()
 UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-#if defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86)
+#if defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390)
    return offsetof(J9VMThread, readBarrierRangeCheckBaseCompressed);
 #else
    return offsetof(J9VMThread, readBarrierRangeCheckBase);
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86) */
+#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    TR_ASSERT(0,"Field readBarrierRangeCheckBase does not exists in J9VMThread.");
    return 0;
@@ -1937,11 +1937,11 @@ UDATA TR_J9VMBase::thisThreadGetEvacuateBaseAddressOffset()
 UDATA TR_J9VMBase::thisThreadGetEvacuateTopAddressOffset()
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-#if defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86)
+#if defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390)
    return offsetof(J9VMThread, readBarrierRangeCheckTopCompressed);
 #else
    return offsetof(J9VMThread, readBarrierRangeCheckTop);
-#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && defined(TR_TARGET_X86) */
+#endif /* defined(J9VM_GC_COMPRESSED_POINTERS) && !defined(TR_TARGET_S390) */
 #else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    TR_ASSERT(0,"Field readBarrierRangeCheckTop does not exists in J9VMThread.");
    return 0;

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -619,7 +619,10 @@ J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register
       }
 
    if (node->getOpCodeValue() == TR::aloadi ||
-      (TR::Compiler->target.is64Bit() && comp()->useCompressedPointers() && node->getOpCodeValue() == TR::iloadi && comp()->getMethodHotness() >= hot))
+         (TR::Compiler->target.is64Bit() &&
+          comp()->useCompressedPointers() &&
+          (node->getOpCodeValue() == TR::iloadi || node->getOpCodeValue() == TR::irdbari) &&
+          comp()->getMethodHotness() >= hot))
       {
       TR::Node *firstChild = node->getFirstChild();
       optDisabled = disableIteratorPrefetch;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,6 +79,9 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *ardbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    
    static void restoreTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);
    static void buildArgsProcessFEDependencies(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies);

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -999,7 +999,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_flushGPU,                   (void *)flushGPU,                  TR_Helper);
    SET(TR_callGPU,                    (void *)callGPU,                   TR_Helper);
 
-#if defined(TR_HOST_X86)
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER)
    SET(TR_referenceArrayCopy,         (void *)jitReferenceArrayCopy,     TR_Helper);
 #endif
 
@@ -1048,7 +1048,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_typeCheckArrayStore,        (void *)jitTypeCheckArrayStoreWithNullCheck,   TR_Helper);
 #endif
 
-#if defined (TR_HOST_X86)
+#if defined(TR_HOST_X86) || defined(TR_HOST_POWER)
    SET(TR_readBarrier,                                      (void *)jitReadBarrier,                                    TR_Helper);
 #endif
    SET(TR_writeBarrierStore,                                (void *)jitWriteBarrierStore,                              TR_Helper);

--- a/runtime/gc_glue_java/configure_includes/configure_aix_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_aix_ppc.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@ ifeq (aix_ppc-64_cmprssptrs, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
@@ -73,6 +74,7 @@ ifeq (aix_ppc-64, $(SPEC))
 		--enable-OMRTHREAD_LIB_AIX \
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 endif
 

--- a/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
+++ b/runtime/gc_glue_java/configure_includes/configure_linux_ppc.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ ifeq (linux_ppc-64_cmprssptrs_le, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
@@ -49,6 +50,7 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
 		--enable-OMR_ENV_GCC \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
 		--enable-OMR_GC_COMPRESSED_POINTERS \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
 		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
@@ -127,6 +129,7 @@ ifeq (linux_ppc-64_le, $(SPEC))
 		--enable-OMR_ARCH_POWER \
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		--enable-OMR_PORT_NUMA_SUPPORT
@@ -139,6 +142,7 @@ ifeq (linux_ppc-64_le_gcc, $(SPEC))
 		--enable-OMR_ENV_DATA64 \
 		--enable-OMR_ENV_GCC \
 		--enable-OMR_ENV_LITTLE_ENDIAN \
+		--enable-OMR_GC_CONCURRENT_SCAVENGER \
 		--enable-OMR_GC_IDLE_HEAP_MANAGER \
 		--enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
 		--enable-OMR_PORT_NUMA_SUPPORT

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2952,9 +2952,9 @@ gcInitializeDefaults(J9JavaVM* vm)
 	if (gc_policy_gencon == extensions->configurationOptions._gcPolicy) {
 		/* after we parsed cmd line options, check if we can obey the request to run CS (valid for Gencon only) */
 		if (extensions->concurrentScavengerForced) {
-#if defined(J9VM_ARCH_X86)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER)
 			extensions->softwareRangeCheckReadBarrier = true;
-#endif /* J9VM_ARCH_X86 */
+#endif /* J9VM_ARCH_X86 || J9VM_ARCH_POWER */
 			if (LOADED == (FIND_DLL_TABLE_ENTRY(J9_JIT_DLL_NAME)->loadFlags & LOADED)) {
 				/* If running jitted, it must be on supported h/w */
 				J9ProcessorDesc  processorDesc;

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -480,6 +480,7 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			writeConstant(OMRPORTLIB, fd, "J9TR_JavaVM_compressedPointersShift", offsetof(J9JavaVM, compressedPointersShift)) |
 #endif /* J9VM_GC_COMPRESSED_POINTERS */
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9MemoryManagerFunctions_J9ReadBarrier", offsetof(J9MemoryManagerFunctions, J9ReadBarrier)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_J9MemoryManagerFunctions_referenceArrayCopy", offsetof(J9MemoryManagerFunctions, referenceArrayCopy)) |
 			/* J9VMEntryLocalStorage */
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_jitGlobalStorageBase", offsetof(J9VMEntryLocalStorage, jitGlobalStorageBase)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_ELS_jitFPRegisterStorageBase", offsetof(J9VMEntryLocalStorage, jitFPRegisterStorageBase)) |


### PR DESCRIPTION
Sets OMR_GC_CONCURRENT_SCAVENGER in the configure files to enable
concurrent scavenge.

Modifies mminit.cpp to be able to set softwareRangeCheckReadBarrier to
true to enable software based concurrent scavenge.

Implemented irdbarEvaluator and ardbarEvaluator which are used to handle
loads that might need to call out to the readbarrier under Concurrent
Scavenge GC policy.

Updated VMinlineCompareAndSwapObject to be aware of the possibility of
calling out to the read barrier under Concurrent Scavenge GC policy.

Implemented a new version of arraycopyEvaluator for reference array copies
that calls out to the referenceArrayCopy if current scavenge is currently
happening.

Added jitReadBarrier and jitReferenceArrayCopy as helpers to call out to
J9ReadBarrier and referenceArrayCopy.

Updated thisThreadGetConcurrentScavengeActiveByteAddressOffset and
thisThreadGetEvacuateBaseAddressOffset to recognize Power as well as X86.

Updated insertPrefetchIfNecessary to recognize the irdbari opcode.

TM is currently not compatible with read barriers. This change will disable
TM if read barriers are needed.

Issue: #3421
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>