### PR TITLE
[WIP]Move unused OMR properties to openj9

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -1498,6 +1498,9 @@ J9::Z::CodeGenerator::getAddressOneToAddressTwoOffset(bool *canGetOffset,
 TR::list<TR::Node*> *
 J9::Z::CodeGenerator::_nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator()))
 
+TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> *
+_jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(TR::comp()->allocator()))
+
 TR::Node *
 J9::Z::CodeGenerator::getAddressLoadVar(TR::Node *node, bool trace)
    {

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -1511,6 +1511,8 @@ J9::Z::CodeGenerator::getAddressLoadVar(TR::Node *node, bool trace)
       return NULL;
    }
 
+J9::Z::CodeGenerator::_dummyTempStorageRefNode(NULL)
+
 void
 J9::Z::CodeGenerator::addStorageReferenceHints(TR::Node *node)
    {

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -1495,6 +1495,9 @@ J9::Z::CodeGenerator::getAddressOneToAddressTwoOffset(bool *canGetOffset,
    return;
    }
 
+TR::list<TR::Node*> *
+J9::Z::CodeGenerator::_nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator()))
+
 TR::Node *
 J9::Z::CodeGenerator::getAddressLoadVar(TR::Node *node, bool trace)
    {

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -167,6 +167,7 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
                                          bool mustCheckAllNodes);
 
    TR::Node *getAddressLoadVar(TR::Node *node, bool trace);
+   TR::Node *_dummyTempStorageRefNode;
 
    void markStoreAsAnAccumulator(TR::Node *node);
    void addStorageReferenceHints(TR::Node *node);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -169,6 +169,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
    TR::Node *getAddressLoadVar(TR::Node *node, bool trace);
    TR::Node *_dummyTempStorageRefNode;
 
+   TR::list<TR::Node*> _nodesSpineCheckedList;
+
    void markStoreAsAnAccumulator(TR::Node *node);
    void addStorageReferenceHints(TR::Node *node);
    void examineNode(TR::Node *parent, TR::Node *node, TR::Node *&bestNode, int32_t &storeSize, TR::list<TR::Node*> &leftMostNodesList);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -171,6 +171,8 @@ class OMR_EXTENSIBLE CodeGenerator : public J9::CodeGenerator
 
    TR::list<TR::Node*> _nodesSpineCheckedList;
 
+   TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> _jniCallSites;
+
    void markStoreAsAnAccumulator(TR::Node *node);
    void addStorageReferenceHints(TR::Node *node);
    void examineNode(TR::Node *parent, TR::Node *node, TR::Node *&bestNode, int32_t &storeSize, TR::list<TR::Node*> &leftMostNodesList);


### PR DESCRIPTION
This is a work in progress to remove unused OMR functions and properties to openj9.

This closes these [issues:](https://github.com/eclipse/omr/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Abeginner+move+to+openj9+)