### PR TITLE
WIP: [X86] Add AOT support for field watch datablock

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1797,6 +1797,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
             case compilationAotClassChainPersistenceFailure:
             case compilationAotValidateStringCompressionFailure:
             case compilationSymbolValidationManagerFailure:
+            case compilationAOTNoSupportForOldAOTFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotUseAotCodeFromSharedCache = true;
                tryCompilingAgain = true;
@@ -10081,6 +10082,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTSymbolValidationManagerFailure &e)
       {
       _methodBeingCompiled->_compErrCode = compilationSymbolValidationManagerFailure;
+      }
+   catch (const J9::AOTNoSupportForOldAOTFailure &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationAOTNoSupportForOldAOTFailure;
       }
    catch (const J9::ClassChainPersistenceFailure &e)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -196,6 +196,7 @@ char *compilationErrorNames[]={
    "compilationVirtualAddressExhaustion", //48
    "compilationEnforceProfiling", //49
    "compilationSymbolValidationManagerFailure", //50
+   "compilationAOTNoSupportForOldAOTFailure", //51
    "compilationMaxError"
 };
 

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,7 @@ typedef enum {
    compilationVirtualAddressExhaustion             = 48,
    compilationEnforceProfiling                     = 49,
    compilationSymbolValidationManagerFailure       = 50,
+   compilationAOTNoSupportForOldAOTFailure         = 51,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,15 @@ class AOTRelocationFailed : public virtual RuntimeFailure
 class AOTSymbolValidationManagerFailure : public virtual TR::CompilationException
    {
    virtual const char* what() const throw() { return "AOT Symbol Validation Manager Failure"; }
+   };
+
+/**
+ * Thrown when certain code path would have worked under new AOT but not old AOT.
+ * This exception can be deleted when new AOT is completely enabled.
+ */
+class AOTNoSupportForOldAOTFailure : public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "This code only works under new AOT"; }
    };
 
 }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5855,6 +5855,9 @@ TR_J9ByteCodeIlGenerator::loadAuto(TR::DataType type, int32_t slot, bool isAdjun
 void
 TR_J9ByteCodeIlGenerator::loadInstance(int32_t cpIndex)
    {
+   if (_generateReadBarriersForFieldWatch && comp()->compileRelocatableCode())
+      comp()->failCompilation<J9::AOTNoSupportForOldAOTFailure>("NO support for old AOT in field watch");
+
    TR::SymbolReference * symRef = symRefTab()->findOrCreateShadowSymbol(_methodSymbol, cpIndex, false);
    TR::Symbol * symbol = symRef->getSymbol();
    TR::DataType type = symbol->getDataType();
@@ -5872,6 +5875,7 @@ TR_J9ByteCodeIlGenerator::loadInstance(int32_t cpIndex)
       }
 
    TR::Node * load, *dummyLoad;
+
    TR::ILOpCodes op = _generateReadBarriersForFieldWatch ? comp()->il.opCodeForIndirectReadBarrier(type): comp()->il.opCodeForIndirectLoad(type);
    dummyLoad = load = TR::Node::createWithSymRef(op, 1, 1, address, symRef);
 
@@ -5945,6 +5949,9 @@ TR_J9ByteCodeIlGenerator::loadInstance(int32_t cpIndex)
 void
 TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
    {
+   if (_generateReadBarriersForFieldWatch && comp()->compileRelocatableCode())
+      comp()->failCompilation<J9::AOTNoSupportForOldAOTFailure>("NO support for old AOT in field watch");
+
    _staticFieldReferenceEncountered = true;
    TR::SymbolReference * symRef = symRefTab()->findOrCreateStaticSymbol(_methodSymbol, cpIndex, false);
    if (comp()->getOption(TR_TraceILGen))
@@ -7213,6 +7220,9 @@ static bool storeCanBeRemovedForUnreadField(TR_PersistentFieldInfo * fieldInfo, 
 void
 TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
    {
+   if (_generateWriteBarriersForFieldWatch && comp()->compileRelocatableCode())
+      comp()->failCompilation<J9::AOTNoSupportForOldAOTFailure>("NO support for old AOT in field watch");
+
    TR::SymbolReference * symRef = symRefTab()->findOrCreateShadowSymbol(_methodSymbol, cpIndex, true);
    TR::Symbol * symbol = symRef->getSymbol();
    TR::DataType type = symbol->getDataType();
@@ -7350,6 +7360,9 @@ TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
 void
 TR_J9ByteCodeIlGenerator::storeStatic(int32_t cpIndex)
    {
+   if (_generateWriteBarriersForFieldWatch && comp()->compileRelocatableCode())
+      comp()->failCompilation<J9::AOTNoSupportForOldAOTFailure>("NO support for old AOT in field watch");
+
    _staticFieldReferenceEncountered = true;
    TR::Node * value = pop();
 


### PR DESCRIPTION
When reporting field read/write JIT code needs to pass a data block
containing data like fieldAddress, offset and owning method. This change
makes sure the data block contains correct value for AOT compilation.
Runtime stores are used to store the data into relavant field of data
block. Will add appropriate relocation types for data snippet when
performance becomes a concern in the future.

For relocating owning method, the code should work in new AOT world
which is not completely enabled yet. An AOT compilation exception is
added to abort AOT compilation for field watch for now. Code throwing
the exception in ilgen when generating rdbar/wrtbar can be deleted once
the new AOT is enabled completely.