### PR TITLE
With no SVM, fail AOT Load on invalid inlined site

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2311,6 +2311,13 @@ TR_RelocationRecordInlinedMethod::applyRelocation(TR_RelocationRuntime *reloRunt
    TR_RelocationRecordInlinedMethodPrivateData *reloPrivateData = &(privateData()->inlinedMethod);
    if (reloPrivateData->_failValidation)
       {
+      // When not using the SVM, the safest thing to do is to fail the AOT Load
+      if (!reloRuntime->comp()->getOption(TR_UseSymbolValidationManager))
+         {
+         RELO_LOG(reloRuntime->reloLogger(), 6,"\t\tapplyRelocation: Failing AOT Load\n");
+         return compilationAotClassReloFailure;
+         }
+
       RELO_LOG(reloRuntime->reloLogger(), 6,"\t\tapplyRelocation: invalidating guard\n");
 
       invalidateGuard(reloRuntime, reloTarget, reloLocation);


### PR DESCRIPTION
When an inlined site is deemed invalid during the AOT validation phase,
when not using the SVM, the safest thing to do is to fail the AOT load.
the following is a "brief" explanation why.

In the AOT infrastructure, when an inlined site is deemed invalid, the
guard gets patched, and the inlined site entry in the metadata remains
unrelocated, i.e. the method pointer value remains -1. The -1 is then
used by future relocations as an indicator whether the relocation should
be ignored.

When not using the SVM, because of symref sharing, it is possible that a
relocation outside the region protected by the guard needs to access
information via an entry in the inlined site table in the metadata.
However, this can cause problems if the entry is set to -1 because the
relocation that should happen (because it is independant of the disabled
inlined site) now gets ignored. #3828 attempted to fix this issue, by
disabling the inlined site, but allowing the inlined table entry to get
relocated. This resulted in exposing another issue: if the shape of the
class of the method changed, then not only should the inlined site be
disabled, but all future relocations that depend on that inlined site
entry should also fail; however, leaving would inlined table entry
unrelocated would cause those relocations to get ignored rather than
result in a failed AOT load.

To fix this issue entirely would involve remembering why the inlined
site was invalidated, and either failing the AOT load (if the shape
changed) or only disabling the inlined site and relocating the inlined
talbe entry in the metadata (if the method was overridden, or if the
site was disabled via an option). However, because this requires some
refactoring work in the relocation infrastructure, and because the plan
is to have AOT with the SVM become the default, the simplest solution is
to fail the AOT load when an inlined site is deemed invalid.

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>

Fixes https://github.com/eclipse/openj9/issues/4135