### PR TITLE
Release VM Access at end of JVM_ArrayCopy

### DIFF
--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2018 IBM Corp. and others
+ * Copyright (c) 2002, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -245,8 +245,7 @@ JVM_ArrayCopy(JNIEnv *env, jclass ignored, jobject src, jint src_pos, jobject ds
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGARRAYSTOREEXCEPTION, NULL);
 		}
 	}
-
-	return;
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 


### PR DESCRIPTION
Also delete unnecessary "return".

Fixes https://github.com/eclipse/openj9/issues/4130

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>