### PR TITLE
Enable double compile of methods, remote and local

### DIFF
--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -339,9 +339,9 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static TR::Options *unpackOptions(char *clientOptions, size_t clientOptionsSize, TR_Memory *trMemory);
    static uint8_t *appendContent(char * &charPtr, uint8_t * curPos, size_t length);
    static std::string packLogFile(TR::FILE *fp);
-   void setLogFileForClientOptions();
+   void setLogFileForClientOptions(int doubleCompile = 0);
    void closeLogFileForClientOptions();
-   void writeLogFileFromServer(const std::string& logFileContent);
+   int writeLogFileFromServer(const std::string& logFileContent);
 
    bool  fePreProcess(void *base);
    bool  fePostProcessAOT(void *base);


### PR DESCRIPTION
Allows JITaaS developers to compare remote and local compilations of a method for the purpose of tracking differences that lead to performance gaps. This "double compilation" is activated with `-Xjit:enableJITaaSDoLocalCompilesForRemoteCompiles`
[skip ci]
Depends on: https://github.com/eclipse/omr/pull/3451
Issue: #3635 

Signed-off-by: Harry Yu <harryyu1994@gmail.com>