### PR TITLE
Combine enter/exit tracing queries into one method

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,8 +71,7 @@ class ClientSessionData
       // The following is a hashtable that maps a bcIndex to IProfiler data
       // The hashtable is created on demand (nullptr means it is missing)
       IPTable_t *_IPData;
-      bool _isMethodEnterTracingEnabled;
-      bool _isMethodExitTracingEnabled;
+      bool _isMethodTracingEnabled;
       };
 
    // This struct contains information about VM that does not change during its lifetime.
@@ -269,7 +268,7 @@ class JITaaSHelpers
       };
    // NOTE: when adding new elements to this tuple, add them to the end,
    // to not mess with the established order.
-   using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<std::tuple<bool, bool>>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t>;
+   using ClassInfoTuple = std::tuple<std::string, J9Method *, TR_OpaqueClassBlock *, int32_t, TR_OpaqueClassBlock *, std::vector<TR_OpaqueClassBlock *>, std::vector<uint8_t>, bool, uintptrj_t , bool, uint32_t, TR_OpaqueClassBlock *, void *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *, uintptrj_t>;
    static ClassInfoTuple packRemoteROMClassInfo(J9Class *clazz, TR_J9VM *fe, TR_Memory *trMemory);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple);
    static void cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class *clazz, J9ROMClass *romClass, ClassInfoTuple *classInfoTuple, ClientSessionData::ClassInfo &classInfo);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,6 +118,7 @@
 #include "runtime/J9Profiler.hpp"
 #include "env/J9JitMemory.hpp"
 #include "infra/Bit.hpp"               //for trailingZeroes
+#include "VMHelpers.hpp"
 
 #ifdef LINUX
 #include <signal.h>
@@ -3313,23 +3314,22 @@ TR_J9VMBase::lowerAsyncCheck(TR::Compilation * comp, TR::Node * root, TR::TreeTo
    return treeTop;
    }
 
+bool
+TR_J9VMBase::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
+   {
+   return VM_VMHelpers::methodBeingTraced(_jitConfig->javaVM, (J9Method *)method);
+   }
 
 bool
 TR_J9VMBase::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
    {
-   J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
-
-   return jitMethodEnterTracingEnabled(getCurrentVMThread(), (J9Method *)method);
+   return isMethodTracingEnabled(method);
    }
 
 bool
 TR_J9VMBase::isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method)
    {
-   J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
-
-   return jitMethodExitTracingEnabled(getCurrentVMThread(), (J9Method *)method);
+   return isMethodTracingEnabled(method);
    }
 
 bool

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -907,6 +907,7 @@ public:
 
     TR::TreeTop * lowerAsyncCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
     TR::TreeTop * lowerAtcCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodEnterTracingEnabled(J9Method *j9method)
       {

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -160,36 +160,19 @@ TR_J9ServerVM::getSystemClassFromClassName(const char * name, int32_t length, bo
    }
 
 bool
-TR_J9ServerVM::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
+TR_J9ServerVM::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
    {
       {
       OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
       auto it = _compInfoPT->getClientData()->getJ9MethodMap().find((J9Method*) method);
       if (it != _compInfoPT->getClientData()->getJ9MethodMap().end())
          {
-         return it->second._isMethodEnterTracingEnabled;
+         return it->second._isMethodTracingEnabled;
          }
       }
 
    JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isMethodEnterTracingEnabled, method);
-   return std::get<0>(stream->read<bool>());
-   }
-
-bool
-TR_J9ServerVM::isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-      {
-      OMR::CriticalSection getRemoteROMClass(_compInfoPT->getClientData()->getROMMapMonitor());
-      auto it = _compInfoPT->getClientData()->getJ9MethodMap().find((J9Method*) method);
-      if (it != _compInfoPT->getClientData()->getJ9MethodMap().end())
-         {
-         return it->second._isMethodExitTracingEnabled;
-         }
-      }
-
-   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITaaS::J9ServerMessageType::VM_isMethodExitTracingEnabled, method);
+   stream->write(JITaaS::J9ServerMessageType::VM_isMethodTracingEnabled, method);
    return std::get<0>(stream->read<bool>());
    }
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,8 +56,7 @@ public:
 //   virtual bool isClassFinal(TR_OpaqueClassBlock *) override;
 //   virtual bool isAbstractClass(TR_OpaqueClassBlock *clazzPointer) override;
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool isVettedForAOT) override;
-   virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method) override;
-   virtual bool isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method) override;
+   virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool canMethodEnterEventBeHooked() override;
    virtual bool canMethodExitEventBeHooked() override;
    virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer) override;

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,8 +114,9 @@ enum J9ServerMessageType
 //   VM_isAbstractClass = 207;
    VM_getStaticReferenceFieldAtAddress = 207;
    VM_getSystemClassFromClassName = 208;
-   VM_isMethodEnterTracingEnabled = 209;
-   VM_isMethodExitTracingEnabled = 210;
+   VM_isMethodTracingEnabled = 209;
+   // VM_isMethodEnterTracingEnabled = 209;
+   // VM_isMethodExitTracingEnabled = 210;
    VM_getClassClassPointer = 211;
    VM_setJ2IThunk = 212;
    VM_getClassOfMethod = 213;


### PR DESCRIPTION
TR_J9VMBase::isMethodEnterTracingEnabled() and TR_J9VMBase::isMethodExitTracingEnabled()
are implemented as the same. Combine them into one method
TR_J9VMBase::isMethodTracingEnabled(). The tracing info sent between the JITaas client
and the server is reduced to a vector of uint8_t values instead of a vector of tuples
of bool values.

Issue: #3585

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>