### PR TITLE
Add symbols of guaranteed IDs to _seenSymbolsSet

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -93,6 +93,7 @@ TR::SymbolValidationManager::defineGuaranteedID(void *symbol, TR::SymbolType typ
    uint16_t id = getNewSymbolID();
    _symbolToIdMap.insert(std::make_pair(symbol, id));
    setSymbolOfID(id, symbol, type);
+   _seenSymbolsSet.insert(symbol);
    }
 
 void


### PR DESCRIPTION
The `_seenSymbolsSet` ensures that at load time no two distinct IDs are both mapped to the same value. This is necessary because during compilation the original values corresponding to those IDs were unequal, and the compiler may have made use of that inequality.

The values corresponding to the guaranteed IDs were missing from this set, allowing each guaranteed ID to collide with up to one ID defined by a validation record. For example, if a validation record were to attempt to define a class ID for a class that turned out at load time to be `byte[]`, it would be (incorrectly) allowed to do so.

This is the fix mentioned in #4072