### PR TITLE
Define a guaranteed ID for null in the SVM

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1075,11 +1075,17 @@ public:
 
    SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee);
 
-   void* getSymbolFromID(uint16_t id, TR::SymbolType type);
-   TR_OpaqueClassBlock *getClassFromID(uint16_t id);
-   J9Class *getJ9ClassFromID(uint16_t id);
-   TR_OpaqueMethodBlock *getMethodFromID(uint16_t id);
-   J9Method *getJ9MethodFromID(uint16_t id);
+   enum Presence
+      {
+      SymRequired,
+      SymOptional
+      };
+
+   void* getSymbolFromID(uint16_t id, TR::SymbolType type, Presence presence = SymRequired);
+   TR_OpaqueClassBlock *getClassFromID(uint16_t id, Presence presence = SymRequired);
+   J9Class *getJ9ClassFromID(uint16_t id, Presence presence = SymRequired);
+   TR_OpaqueMethodBlock *getMethodFromID(uint16_t id, Presence presence = SymRequired);
+   J9Method *getJ9MethodFromID(uint16_t id, Presence presence = SymRequired);
 
    uint16_t tryGetIDFromSymbol(void *symbol);
    uint16_t getIDFromSymbol(void *symbol);

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -261,12 +261,7 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
             TR_OpaqueMethodBlock *method = resolvedMethod->getPersistentIdentifier();
             TR_OpaqueClassBlock *thisClass = guard->getThisClass();
             uint16_t methodID = symValManager->getIDFromSymbol(static_cast<void *>(method));
-            uint16_t receiverClassID = 0;
-            if (relocation->getTargetKind() == TR_InlinedInterfaceMethodWithNopGuard ||
-                relocation->getTargetKind() == TR_InlinedAbstractMethodWithNopGuard)
-               {
-               receiverClassID = symValManager->getIDFromSymbol(static_cast<void *>(thisClass));
-               }
+            uint16_t receiverClassID = symValManager->getIDFromSymbol(static_cast<void *>(thisClass));
 
             uintptrj_t data = 0;
             data = (((uintptrj_t)receiverClassID << 16) | (uintptrj_t)methodID);


### PR DESCRIPTION
This allows ID fields of validation and relocation records to be made optional. Previously, all ID lookups required as a precondition that the mapped value is not null, simply due to the fact that null was not stored in the mappings. Now they will continue to require this by default, so that the lookup does not unexpectedly return null. In cases where the value is optional, callers must pass `SymOptional` to explicitly allow null.