### PR TITLE
Remove semicolon from SVM_ASSERT_ALREADY_VALIDATED

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -82,7 +82,7 @@
          #symbol,                                        \
          _0symbol);                                      \
       }                                                  \
-   while (false);
+   while (false)
 
 namespace TR {
 


### PR DESCRIPTION
The semicolon included in the macro definition makes the following a series of two statements (the second being empty):

    SVM_ASSERT_ALREADY_VALIDATED(svm, symbol);

This allows omission of the terminating semicolon, which should probably be required, and it causes a syntax error when the assertion is followed immediately by `else`, e.g.:

    if (foo)
        SVM_ASSERT_ALREADY_VALIDATED(svm, symbol);
    else
        bar();