### PR TITLE
WIP: Made changes to running_in_container to reflect new changes(OMR PR #3420)

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -225,8 +225,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 			OMRPORT_ACCESS_FROM_J9PORT(vm->portLibrary);
 			vm->sharedCacheAPI->xShareClassesPresent = FALSE;
 			if (J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm)) {
-				I_32 errorCode = 0;
-				BOOLEAN inContainer = omrsysinfo_is_running_in_container(&errorCode);;
+				BOOLEAN inContainer = omrsysinfo_is_running_in_container();;
 				/* Do not enable shared classes by default if running in Container */
 
 				if (FALSE == inContainer) {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1826,9 +1826,8 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				IDATA argIndexIgnoreUnrecognizedOptionsDisable = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXIDLETUNINGIGNOREUNRECOGNIZEDOPTIONSDISABLE, NULL);
 				BOOLEAN enableGcOnIdle = FALSE;
 				BOOLEAN inContainer = FALSE;
-				int32_t errorCode = 0;
 				
-				inContainer = omrsysinfo_is_running_in_container(&errorCode);
+				inContainer = omrsysinfo_is_running_in_container();
 
 				/* 
 				 * GcOnIdle is enabled only if:


### PR DESCRIPTION
This PR is dependent on [OMR PR](https://github.com/eclipse/omr/pull/3420) which modifies the API `omrsysinfo_is_running_in_container`. So to reflect the new changes if it gets merged i'm creating this PR.

Signed-off-by: bharathappali <bharath.appali@gmail.com>