### PR TITLE
Improve robustness of checking tags of allocated memory blocks

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9MemTagHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9MemTagHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corp. and others
+ * Copyright (c) 2010, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,9 +72,8 @@ public class J9MemTagHelper
 	 */
 	public static IDATA j9mem_check_tags(VoidPointer memoryPointer, long headerEyecatcher, long footerEyecatcher) throws J9MemTagCheckError 
 	{
-		J9MemTagPointer headerTagAddress, footerTagAddress = J9MemTagPointer.NULL;
-
-		headerTagAddress = j9mem_get_header_tag(memoryPointer);
+		J9MemTagPointer headerTagAddress = j9mem_get_header_tag(memoryPointer);
+		J9MemTagPointer footerTagAddress = J9MemTagPointer.NULL;
 
 		try {
 			footerTagAddress = j9mem_get_footer_tag(headerTagAddress);
@@ -266,8 +265,9 @@ public class J9MemTagHelper
 	
 	public static UDATA ROUNDED_FOOTER_OFFSET(UDATA number) 
 	{
-		UDATA a = (number.add(ROUNDING_GRANULARITY - 1)).add(J9MemTag.SIZEOF);
-		UDATA b = new UDATA(ROUNDING_GRANULARITY - 1).bitNot();
+		UDATA mask = new UDATA(ROUNDING_GRANULARITY - 1);
+		UDATA a = mask.add(number).add(J9MemTag.SIZEOF);
+		UDATA b = mask.bitNot();
 		return a.bitAnd(b);
 	}
 	
@@ -294,7 +294,7 @@ public class J9MemTagHelper
 
 		public J9MemTagPointer getMemTag()
 		{
-			return  memTag;
+			return memTag;
 		}
 	}
 }


### PR DESCRIPTION
J9MemTag.allocSize has type uintptr_t (aka UDATA), which is mapped to U64 by MSVC on Windows (or with the changes in eclipse/omr#3355 on all 64-bit platforms). A random address treated as a pointer to a J9MemTag has a 50% chance of referring to a J9MemTag where allocSize >= 2^63 which would trigger an InvalidDataTypeException from U64.longValue(). This change modifies ROUNDED_FOOTER_OFFSET() so it always returns a UDATA object independent of the actual
argument type, thus avoiding that exception for blocks that otherwise would fail the sanity checks.

https://github.com/eclipse/omr/pull/3422 replays eclipse/omr#3355.