### PR TITLE
Verify VarHandle class initialization

### DIFF
--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticFieldVarHandleTests.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticFieldVarHandleTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,7 @@ public class StaticFieldVarHandleTests {
 	private final static VarHandle VH_STRING;
 	private final static VarHandle VH_CLASS;
 	private final static VarHandle VH_FINAL_INT;
+	private final static VarHandle VH_FINAL_NOINIT_INT;
 	
 	static {
 		StaticHelper.reset();
@@ -60,6 +61,7 @@ public class StaticFieldVarHandleTests {
 			VH_STRING = MethodHandles.lookup().findStaticVarHandle(StaticHelper.class, "l1", String.class);
 			VH_CLASS = MethodHandles.lookup().findStaticVarHandle(StaticHelper.class, "l2", Class.class);
 			VH_FINAL_INT = MethodHandles.lookup().findStaticVarHandle(StaticHelper.class, "finalI", int.class);
+			VH_FINAL_NOINIT_INT = MethodHandles.lookup().findStaticVarHandle(StaticHelper.StaticNoInitializationHelper.class, "finalI", int.class);
 		} catch (Throwable t) {
 			throw new Error(t);
 		}
@@ -2447,6 +2449,18 @@ public class StaticFieldVarHandleTests {
 			VH_FINAL_INT.getAndBitwiseXorRelease(3);
 			Assert.fail("Expected UnsupportedOperationException");
 		} catch (UnsupportedOperationException e) {}
+	}
+	
+	/**
+	 * Perform all the operations available on a StaticFieldViewVarHandle referencing a <b>final</b> {@link int} field.
+	 * Note: The static field StaticHelper.StaticNoInitializationHelper.finalI hasn't been initialized implicitly
+	 * by StaticHelper.reset() before VarHandle.get() is invoked.
+	 */
+	@Test
+	public void testFinalFieldInClassNotInitialized() {
+		// Getting value of final static field
+		int result = (int) VH_FINAL_NOINIT_INT.get();
+		Assert.assertEquals(result, StaticHelper.StaticNoInitializationHelper.finalI);
 	}
 	
 	/**

--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticHelper.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/StaticHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,5 +46,9 @@ public class StaticHelper {
 		l2 = String.class;
 		s = 1;
 		z = true;
+	}
+	
+	static final class StaticNoInitializationHelper {
+		static final int finalI = 1;
 	}
 }


### PR DESCRIPTION
Verify `VarHandle` class initialization

When a `static` field hasn't been initialized implicitly and a `VarHandle` is created to access this field. The field has to be initialized before returning the value via the `VarHandle`.
This test verifies that a `VarHandle` returns correct field value when there is no implicit static field initialization.

close #3205 
depends #3928 

Without dependent PR, this test fails with following stacktrace:
```
FAILED: testFinalFieldInClassNotInitialized
java.lang.AssertionError: expected [1] but found [0]
	at org.testng.Assert.fail(Assert.java:96)
	at org.testng.Assert.failNotEquals(Assert.java:776)
	at org.testng.Assert.assertEqualsImpl(Assert.java:137)
	at org.testng.Assert.assertEquals(Assert.java:118)
	at org.testng.Assert.assertEquals(Assert.java:652)
	at org.testng.Assert.assertEquals(Assert.java:662)
	at org.openj9.test.varhandle.StaticFieldVarHandleTests.testFinalFieldInClassNotInitialized(StaticFieldVarHandleTests.java:2463)
```

Manually verified that this test and the test from #3205 pass with #3928.

Reviewer: @DanHeidinga 
FYI: @llxia

Signed-off-by: Jason Feng <fengj@ca.ibm.com>