### PR TITLE
Methods and tests for jep334 MethodType

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -30,6 +30,7 @@ import java.io.ObjectStreamField;
 import java.io.Serializable;
 /*[IF Java12]*/
 import java.lang.constant.Constable;
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 /*[ENDIF]*/
 import java.lang.ref.Reference;
@@ -43,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 /*[IF Java12]*/
+import java.util.NoSuchElementException;
 import java.util.Optional;
 /*[ENDIF]*/
 import java.util.Set;
@@ -1271,14 +1273,38 @@ public final class MethodType implements Serializable
 /*[ENDIF]*/
 
 /*[IF Java12]*/
+	/**
+	 * Return field descriptor of MethodType instance.
+	 * 
+	 * @return field descriptor of MethodType instance
+	 */
 	public String descriptorString() {
-		/* Jep334 */
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		return methodDescriptor;
 	}
 
+	/**
+	 * Returns the nominal descriptor of this MethodType instance, or an empty Optional 
+	 * if construction is not possible.
+	 * 
+	 * @return Optional with a nominal descriptor of MethodType instance
+	 */
 	public Optional<MethodTypeDesc> describeConstable() {
-		/* Jep334 */
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		try {
+			ClassDesc returnDesc = returnType.describeConstable().orElseThrow();
+
+			/* convert parameter classes to ClassDesc */
+			final int argumentsLength = arguments.length;
+			ClassDesc[] paramDescs = new ClassDesc[argumentsLength];
+			for (int i = 0; i < argumentsLength; i++) {
+				paramDescs[i] = arguments[i].describeConstable().orElseThrow();
+			}
+
+			/* create MethodTypeDesc */
+			MethodTypeDesc typeDesc = MethodTypeDesc.of(returnDesc, paramDescs);
+			return Optional.of(typeDesc);
+		} catch(NoSuchElementException e) {
+			return Optional.empty();
+		}
 	}
 /*[ENDIF]*/
 }

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_MethodType.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_MethodType.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang_invoke;
+
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Optional;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/**
+ * This test Java.lang.invoke.MethodType API added in Java 12 and later version.
+ *
+ * new methods:
+ * - descriptorString: returns methodDescriptor, not tested
+ * - describeConstable
+ */
+public class Test_MethodType {
+    public static Logger logger = Logger.getLogger(Test_MethodType.class);
+
+	/*
+	 * Test Java 12 API MethodType.describeConstable()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testMethodTypeDescribeConstable() throws Throwable {
+		describeConstableTestGeneral("testMethodTypeDescribeConstable", MethodType.methodType(void.class));
+		describeConstableTestGeneral("testMethodTypeDescribeConstable", MethodType.methodType(String.class));
+		describeConstableTestGeneral("testMethodTypeDescribeConstable", MethodType.methodType(String.class, int.class));
+	}
+
+	private void describeConstableTestGeneral(String testName, MethodType type) throws Throwable {
+		Optional<MethodTypeDesc> descOp = type.describeConstable();
+
+		MethodTypeDesc desc = descOp.orElseThrow();
+
+		/* verify that descriptor can be resolved. Otherwise a ReflectiveOperationExeption will be thrown */
+		MethodType resolveType = (MethodType)desc.resolveConstantDesc(MethodHandles.lookup());
+
+		logger.debug(testName + ": Descriptor of original type is: " + type.descriptorString() + " descriptor of descriptor is: " + resolveType.descriptorString());
+		Assert.assertTrue(type.equals(resolveType));
+	}
+}

--- a/test/functional/Java12andUp/testng.xml
+++ b/test/functional/Java12andUp/testng.xml
@@ -29,6 +29,7 @@
 		<classes>
 			<class name="org.openj9.test.java_lang.Test_String" />
 			<class name="org.openj9.test.java_lang.Test_Class" />
+			<class name="org.openj9.test.java_lang_invoke.Test_MethodType" />
 		</classes>
 	</test>
 


### PR DESCRIPTION
- describeConstable
- descriptorString

Depends on (see https://github.com/eclipse/openj9/issues/4195): 
- Fix Java 12 build failures: https://github.com/eclipse/openj9/pull/3980
- Constants API stubs: https://github.com/eclipse/openj9/pull/4030
- Java12andUp test setup: https://github.com/eclipse/openj9/pull/4104
- Jep 334 Class methods: https://github.com/eclipse/openj9/pull/4157

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>