### PR TITLE
Add missing platform check for defining NASM_ASSEMBLER macro

### DIFF
--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,7 @@ extern "C" {
  * is set for OS variants that currently use NASM and is used to
  * decide the version of helper names to use.
  */
-#if defined(OSX) || (defined(LINUX) && defined(TR_HOST_64BIT))
+#if defined(OSX) || (defined(LINUX) && defined(TR_HOST_X86) && defined(TR_HOST_64BIT))
 #define NASM_ASSEMBLER
 #endif
 

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,11 @@ createConstant(OMRPortLibrary *OMRPORTLIB, char const *name, UDATA value)
 	return omrstr_printf(line, sizeof(line), "#define %s %zu\n", name, value);
 #elif defined(LINUX) /* J9VM_ARCH_POWER || J9VM_ARCH_ARM */
 	#if defined(J9VM_ENV_DATA64)
-		return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
+		#if defined(J9VM_ARCH_X86)
+			return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
+		#else /* J9VM_ARCH_X86 */
+			return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
+		#endif /* J9VM_ARCH_X86 */
 	#else /* J9VM_ENV_DATA64 */
 		return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
 	#endif


### PR DESCRIPTION
Fix bug that defined NASM_ASSEMBLER on unsupported platforms.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

Edit: Also added an additional check for x86 in jilconsts generator to prevent outputting the wrong format for zLinux.

Closes: #4206 