### PR TITLE
cmake: explicitly add OMR_PLATFORM compile options to TR

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,6 +163,8 @@ set(J9_INCLUDES
 # Platform specific list of flags, derived directly from the
 # Makefiles
 set(J9_SHAREDFLAGS
+	${OMR_PLATFORM_COMPILE_OPTIONS}
+	${OMR_PLATFORM_C_COMPILE_OPTIONS}
 	-fno-strict-aliasing
 	-Wno-deprecated
 	-Wno-enum-compare
@@ -177,6 +179,8 @@ set(J9_SHAREDFLAGS
 # Platform specific CXX flags, also derived from the
 # Makefiles
 set(J9_CXXFLAGS
+	${OMR_PLATFORM_COMPILE_OPTIONS}
+	${OMR_PLATFORM_CXX_COMPILE_OPTIONS}
 	${J9_SHAREDFLAGS}
 	-fno-rtti
 	-fno-threadsafe-statics


### PR DESCRIPTION
For the compiler, we're blowing away the cmake build flags, to start
with a fresh set of options. In doing so, we're removing the flags
installed by OmrPlatform, which are required on every target.

This PR adds those missing options back in to the compiler targets, and
fixes a recent OMR integration issue where some options were moved from
TR to the OmrPlatform variables.

Signed-off-by: Robert Young <rwy0717@gmail.com>