### PR TITLE
Fix tools for formatting tracepoints

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/SnapFormatWrapperCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/commands/SnapFormatWrapperCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,11 +38,10 @@ public class SnapFormatWrapperCommand extends Command {
 		addCommand("snapformat", "[<filename>]", "format trace buffers to a specified file or stdout");
 		addCommand("snapformat", "-help", "print detailed help");
 		addCommand("snapformat", "[-f <filename>] [-d <datfile_directory>] [-t <j9vmthread id>] [-s <filter>]", "format trace buffers for all threads or just the specified thread to a file or stdout using the specified .dat files");
-	}	
+	}
 
 	public void run(String command, String[] args, Context context,
 			PrintStream out) throws DDRInteractiveCommandException {
-		
 		if ((args.length > 0) && (args[0].equals("-help") || args[0].equals("-h") || args[0].equals("-?"))) {
 			out.println("Format selected trace buffers.");
 			out.println();
@@ -64,35 +63,21 @@ public class SnapFormatWrapperCommand extends Command {
 			return;
 		}
 		try {
-			Class snapFormatCommandCls = Class.forName("com.ibm.j9ddr.tools.ddrinteractive.commands.SnapFormatCommand");
+			Class<?> snapFormatCommandCls = Class.forName("com.ibm.j9ddr.tools.ddrinteractive.commands.SnapFormatCommand");
 			Object snapFormatCommandInstance = snapFormatCommandCls.newInstance();
-			if( snapFormatCommandInstance instanceof Command) {
-				Command c = (Command)snapFormatCommandInstance;
+			if (snapFormatCommandInstance instanceof Command) {
+				Command c = (Command) snapFormatCommandInstance;
 				c.run(command, args, context, out);
 			} else {
 				throw new DDRInteractiveCommandException("Unable to format trace. Could not create formatter.");
 			}
-		} catch (ClassNotFoundException e) {
-			//e.printStackTrace(out);
-			throw new DDRInteractiveCommandException("Unable to format trace. " + e.getMessage(), e);
-		} catch (IllegalAccessException e) {
-			//e.printStackTrace(out);
-			throw new DDRInteractiveCommandException("Unable to format trace. " + e.getMessage(), e);
-		} catch (InstantiationException e) {
-			//e.printStackTrace(out);
-			throw new DDRInteractiveCommandException("Unable to format trace. " + e.getMessage(), e);
-		} catch (SecurityException e) {
-			//e.printStackTrace(out);
-			throw new DDRInteractiveCommandException("Unable to format trace. " + e.getMessage(), e);
-		} catch (IllegalArgumentException e) {
-			//e.printStackTrace(out);
+		} catch (ClassNotFoundException
+				| IllegalAccessException
+				| IllegalArgumentException
+				| InstantiationException
+				| SecurityException e) {
 			throw new DDRInteractiveCommandException("Unable to format trace. " + e.getMessage(), e);
 		}
-//		catch (java.lang.Error e) {
-//			/* Naughty catching this but good for catching unresolved com.ibm.jvm.trace.* problems. */
-//			//e.printStackTrace(out);
-//			throw new DDRInteractiveCommandException("Unable to format trace. " + e.getMessage(), e);
-//		}
 	}
 
 }

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImageFactory.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImageFactory.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,6 +66,7 @@ public class ImageFactory implements com.ibm.dtfj.image.ImageFactory {
 	private ClassLoader imageFactoryClassLoader;
 	private File tmpdir = null; // the directory which holds any extracted files
 
+	/*[IF Sidecar19-SE]*/
 	static {
 		/* 
 		 * Even though j9ddr.jar is a resource within the module openj9.dtfj,
@@ -99,9 +100,10 @@ public class ImageFactory implements com.ibm.dtfj.image.ImageFactory {
 			exportToAll.invoke(null, thisModule, "com.ibm.java.diagnostics.utils"); //$NON-NLS-1$
 			exportToAll.invoke(null, thisModule, "com.ibm.java.diagnostics.utils.commands"); //$NON-NLS-1$
 		} catch (Exception e) {
-			// assume pre-Java 9 jvm
+			throw new InternalError("Failed to adjust module exports", e); //$NON-NLS-1$
 		}
 	}
+	/*[ENDIF] Sidecar19-SE*/
 	
 	/**
 	 * This public constructor is intended for use with Class.newInstance().

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/extract/Main.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/extract/Main.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -207,7 +207,6 @@ public class Main {
 			}
 			return result;
 		}
-
 
 		public Object buildSymbol(Object addressSpace, String functionName, long relocatedFunctionAddress) {
 			return new Object();
@@ -474,25 +473,30 @@ public class Main {
 		for (Iterator iter = _dump.getAdditionalFileNames(); iter.hasNext();) {
 			files.add(iter.next());
 		}
-		
-			
+
 		try {
-			// Add the trace formatting template files (Traceformat.dat and J9TraceFormat.dat) into the zip
+			// Add trace formatting template files (Traceformat.dat, J9TraceFormat.dat and OMRTraceFormat.dat) into the archive.
 			String lib_dir = System.getProperty("java.home") + File.separator + "lib" + File.separator;
 			String trace = lib_dir + "TraceFormat.dat";
-			if (new File(trace).exists())
+			if (new File(trace).exists()) {
 				files.add(trace);
+			}
 			String j9trace = lib_dir + "J9TraceFormat.dat";
-			if (new File(j9trace).exists())
+			if (new File(j9trace).exists()) {
 				files.add(j9trace);
-			
+			}
+			String omrtrace = lib_dir + "OMRTraceFormat.dat";
+			if (new File(omrtrace).exists()) {
+				files.add(omrtrace);
+			}
+
 			// Add the debugger extension library into the zip, available only on AIX
 			String osName = System.getProperty("os.name");
 			if (osName != null && osName.equalsIgnoreCase("AIX")) {
 				files.add("libdbx_j9.so");
 			}
 		} catch (Exception e) {
-				// Ignore
+			// Ignore
 		}
 
 		try {
@@ -635,7 +639,6 @@ public class Main {
 		}
 	}
 
-	
 	private native long getEnvironmentPointer(IAbstractAddressSpace dump) throws Exception;
 	private native void doCommand(IAbstractAddressSpace dump, String command) throws Exception;
 

--- a/jcl/src/openj9.dtfj/share/classes/module-info.java
+++ b/jcl/src/openj9.dtfj/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@ module openj9.dtfj {
 	requires transitive java.desktop;
 	requires transitive java.logging;
 	requires java.xml;
+	requires openj9.traceformat;
 	/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
 	requires com.ibm.jzos;
 	/*[ENDIF]*/

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceFormat.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceFormat.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -448,6 +448,16 @@ final public class TraceFormat
 			TraceFormat.outStream.println("*** Could not find a J9TraceFormat.dat file. JVM trace points may be formatted incorrectly.");
 		}
 		
+		/*
+		 * Now load OMRTraceFormat.dat if available.
+		 */
+		String omrFormatFilePath = findDatFile(dirsToSearch, "OMRTraceFormat.dat");
+
+		if (omrFormatFilePath != null) {
+			/* we found a suitable dat file */
+			tryMessageFileInstantiation(omrFormatFilePath);
+		}
+
 		/*
 		 * Also load TraceFormat.dat as it contains the trace points for the class libraries.
 		 */

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/traceformat/TraceFormat.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/traceformat/TraceFormat.java
@@ -1,12 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE]*/
-package com.ibm.jvm.traceformat;
-/*[ELSE]
-package com.ibm.jvm;
-/*[ENDIF]*/
-
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corp. and others
+ * Copyright (c) 2010, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +20,11 @@ package com.ibm.jvm;
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+/*[IF Sidecar19-SE]*/
+package com.ibm.jvm.traceformat;
+/*[ELSE]
+package com.ibm.jvm;
+/*[ENDIF]*/
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -55,7 +54,7 @@ import com.ibm.jvm.trace.format.api.TraceThread;
 
 /**
  * !!! WARNING !!!
- * Adding any new top level classes in this file requires modification to jcl\jcl_build.mk
+ * Adding any new top level classes in this file requires modification to jcl/jcl_build.mk
  * to ensure the new classes are included within traceformat.jar for Java 8.
  */
 public class TraceFormat
@@ -528,9 +527,11 @@ class MessageFile extends ProgramOption {
 	List messageFiles = new LinkedList();
 
 	String getDescription() {
-		return "A comma separated list of files containing the trace format strings. By default the following files are used:"+System.getProperty("line.separator")+
-			   "		$JAVA_HOME/lib/J9TraceFormat.dat"+System.getProperty("line.separator")+
-			   "		$JAVA_HOME/lib/TraceFormat.dat";
+		String eol = System.getProperty("line.separator", "\n");
+		return "A comma separated list of files containing the trace format strings. By default the following files are used:" + eol
+			 + "  $JAVA_HOME/lib/J9TraceFormat.dat" + eol
+			 + "  $JAVA_HOME/lib/OMRTraceFormat.dat" + eol
+			 + "  $JAVA_HOME/lib/TraceFormat.dat";
 	}
 
 	String getName() {
@@ -554,13 +555,11 @@ class MessageFile extends ProgramOption {
 				token = st.nextToken();
 				/* construct files from the tokens. These files must exist */
 				File datFile = new File(token);
-				if( !datFile.exists() ) {
-					throw new FileNotFoundException(token);
+				if (!datFile.exists()) {
+					throw new IllegalArgumentException("dat file \"" + token + "\" not found");
 				}
 				messageFiles.add(datFile);
 			}
-		} catch (FileNotFoundException e) {
-			throw new IllegalArgumentException("dat file \""+token+"\" not found");
 		} catch (SecurityException e) {
 			throw new IllegalArgumentException("The application does not have permission to access the specified dat file, \""+token+"\"");
 		}
@@ -571,6 +570,7 @@ class MessageFile extends ProgramOption {
 		dir = dir.concat(File.separator).concat("lib").concat(File.separator);
 		
 		setValue(dir + "J9TraceFormat.dat");
+		setValue(dir + "OMRTraceFormat.dat");
 		try {
 			setValue(dir + "TraceFormat.dat");
 		} catch (IllegalArgumentException e) {

--- a/jcl/src/openj9.traceformat/share/classes/module-info.java
+++ b/jcl/src/openj9.traceformat/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,5 +20,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
- module openj9.traceformat {
- }
+module openj9.traceformat {
+	exports com.ibm.jvm.trace.format.api;
+}


### PR DESCRIPTION
* adjust module graph
-- openj9.traceformat must export com.ibm.jvm.trace.format.api for use by openj9.dtfj
-- openj9.dtfj must require openj9.traceformat

* rework handling of missing format files (e.g. TraceFormat.dat) in SnapFormatCommand
-- also include data from OMRTraceFormat.dat
-- remove dead code (expression parsing methods never return null)

* merge catch clauses & remove stale comment in SnapFormatWrapperCommand

* in j9.ImageFactory, use the preprocessor to omit calls to addExportsToAllUnnamed() for Java8

* jextract should include OMRTraceFormat.dat in the archive it creates

* all trace format implementations now also consult OMRTraceFormat.dat

Fixes #4039.