### PR TITLE
Fix compile error

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -634,8 +634,8 @@ void j9gc_jvmPhaseChange(J9VMThread *currentThread, UDATA phase)
 				}
 
 				/* Gradually learn, by averaging new values with old values - it may take a few restarts before hint converge to stable values */
-				hintDefault = (uintptr_t)MM_Math::weightedAverage(hintDefaultOld, hintDefault, (1.0 - extensions->heapSizeStatupHintWeightNewValue));
-				hintTenure = (uintptr_t)MM_Math::weightedAverage(hintTenureOld, hintTenure, (1.0 - extensions->heapSizeStatupHintWeightNewValue));
+				hintDefault = (uintptr_t)MM_Math::weightedAverage((float)hintDefaultOld, (float)hintDefault, (1.0f - extensions->heapSizeStatupHintWeightNewValue));
+				hintTenure = (uintptr_t)MM_Math::weightedAverage((float)hintTenureOld, (float)hintTenure, (1.0f - extensions->heapSizeStatupHintWeightNewValue));
 
 				vm->sharedClassConfig->storeGCHints(currentThread, hintDefault, hintTenure, true);
 				/* Nothing to do if store fails, storeGCHints already issues a trace point */

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -947,7 +947,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
-			extensions->heapSizeStatupHintConservativeFactor = ((float)percentage) / 100.0;
+			extensions->heapSizeStatupHintConservativeFactor = ((float)percentage) / 100.0f;
 			continue ;
 		}
 
@@ -961,7 +961,7 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 				returnValue = JNI_EINVAL;
 				break;
 			}
-			extensions->heapSizeStatupHintWeightNewValue = ((float)percentage) / 100.0;
+			extensions->heapSizeStatupHintWeightNewValue = ((float)percentage) / 100.0f;
 			continue ;
 		}
 


### PR DESCRIPTION
Caused by https://github.com/eclipse/openj9/pull/4168

20:51:30 mmparseXXgc.cpp(950) : error C2220: warning treated as error -
no 'object' file generated
20:51:30 mmparseXXgc.cpp(950) : warning C4244: '=' : conversion from
'double' to 'float', possible loss of data
20:51:30 mmparseXXgc.cpp(964) : warning C4244: '=' : conversion from
'double' to 'float', possible loss of data

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>