### PR TITLE
allow dollars in identifiers

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -171,7 +171,6 @@ set(J9_SHAREDFLAGS
 	-Wno-write-strings
 	-fomit-frame-pointer
 	-fasynchronous-unwind-tables
-	-fno-dollars-in-identifiers
 	-Wreturn-type
 	-pthread
 )

--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,7 +105,6 @@ CX_FLAGS+=\
     -fomit-frame-pointer \
     -fasynchronous-unwind-tables \
     -Wreturn-type \
-    -fno-dollars-in-identifiers \
     -fno-strict-aliasing
 
 CXX_FLAGS+=\

--- a/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
+++ b/runtime/compiler/build/toolcfg/ztpf-gcc/common.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,7 +115,6 @@ CX_FLAGS+=\
     -fomit-frame-pointer \
     -fasynchronous-unwind-tables \
     -Wreturn-type \
-    -fno-dollars-in-identifiers \
     -fno-strict-aliasing
 
 CXX_FLAGS+=\


### PR DESCRIPTION
Apple patches libstdc++v3 with additional support for dtrace. These dtrace
symbols use dollar signs identifiers, and are incompatible with the
compile option -fno-dollars-in-identifiers. This commit removes the
option.

Signed-off-by: Robert Young <rwy0717@gmail.com>