### PR TITLE
Remove varargs from try / catch handles in MHs.catchException

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2182,7 +2182,7 @@ public class MethodHandles {
 			}
 		}
 		
-		MethodHandle result = buildTransformHandle(new CatchHelper(tryHandle, catchHandle, throwableClass), tryType);
+		MethodHandle result = buildTransformHandle(new CatchHelper(tryHandle.asFixedArity(), catchHandle.asFixedArity(), throwableClass), tryType);
 		if (true) {
 			MethodHandle thunkable = CatchHandle.get(tryHandle, throwableClass, catchHandle, result);
 			assert(thunkable.type() == result.type());


### PR DESCRIPTION
There are two handles, tryHandle & catchHandle, that get wrapped up in the
CatchHelper class.  If they are VarargsCollectorHandles, the collect-operate-spread
pattern used incorrect double wraps the Object[].

Forcing them to be fixedArity seems to fix the issue and provides the expected
behaviour.

Fixes #3274 
Fixes #3917 

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>