### PR TITLE
Add missing checks on data array for getChars

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1830,7 +1830,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *				when buffer is null
 	 */
 	public void getChars(int start, int end, char[] data, int index) {
-		if (0 <= start && start <= end && end <= lengthInternal()) {
+		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
 			getCharsNoBoundChecks(start, end, data, index);
 		} else {
 			throw new StringIndexOutOfBoundsException();
@@ -1849,7 +1849,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	}
 
 	void getChars(int start, int end, byte[] data, int index) {
-		if (0 <= start && start <= end && end <= lengthInternal()) {
+		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= ((data.length / 2) - index))) {
 			getCharsNoBoundChecks(start, end, data, index);
 		} else {
 			throw new StringIndexOutOfBoundsException();
@@ -5906,7 +5906,7 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 	 *				when buffer is null
 	 */
 	public void getChars(int start, int end, char[] data, int index) {
-		if (0 <= start && start <= end && end <= lengthInternal()) {
+		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= (data.length - index))) {
 			if (enableCompression && (null == compressionFlag || count >= 0)) {
 				decompress(value, start, data, index, end - start);
 			} else {

--- a/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/jcl/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -3,7 +3,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1384,7 +1384,7 @@ public synchronized StringBuffer replace(int start, int end, String string) {
 					capacity = capacity & ~sharedBit;
 				}
 				
-				string.getChars(0, size, value, start);
+				string.getCharsNoBoundChecks(0, size, value, start);
 				
 				count = currentLength - difference;
 				


### PR DESCRIPTION
Bound check and null check on data array are missing. Fix it.

Fixes #4122

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>