### PR TITLE
Generate ProfiledClassRecord for new classes only

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -304,6 +304,13 @@ TR::SymbolValidationManager::addClassRecordWithRomClass(TR_OpaqueClassBlock *com
          return false;
       }
 
+   addMultipleArrayRecords(component, arrayDims);
+   return true;
+   }
+
+void
+TR::SymbolValidationManager::addMultipleArrayRecords(TR_OpaqueClassBlock *component, int arrayDims)
+   {
    for (int i = 0; i < arrayDims; i++)
       {
       TR_OpaqueClassBlock *array = _fej9->getArrayClassFromComponentClass(component);
@@ -312,8 +319,6 @@ TR::SymbolValidationManager::addClassRecordWithRomClass(TR_OpaqueClassBlock *com
          new (_region) ArrayClassFromComponentClassRecord(array, component));
       component = array;
       }
-
-   return true;
    }
 
 bool
@@ -392,8 +397,11 @@ TR::SymbolValidationManager::addProfiledClassRecord(TR_OpaqueClassBlock *clazz)
    if (classChain == NULL)
       return false;
 
-   TR::ClassValidationRecord *record = new (_region) ProfiledClassRecord(clazz, classChain);
-   return addClassRecordWithRomClass(clazz, record, arrayDims);
+   if (!isAlreadyValidated(clazz))
+      appendNewRecord(clazz, new (_region) ProfiledClassRecord(clazz, classChain));
+
+   addMultipleArrayRecords(clazz, arrayDims);
+   return true;
    }
 
 bool

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1170,6 +1170,7 @@ private:
    bool addVanillaRecord(void *symbol, TR::SymbolValidationRecord *record);
    bool addClassRecord(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record);
    bool addClassRecordWithRomClass(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record, int arrayDims);
+   void addMultipleArrayRecords(TR_OpaqueClassBlock *clazz, int arrayDims);
    bool addMethodRecord(TR_OpaqueMethodBlock *method, TR::SymbolValidationRecord *record);
 
    bool validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type);


### PR DESCRIPTION
A `ProfiledClassRecord` for a class that has already been determined causes the validation process to choose arbitrarily from the classes that match the given class chain, and then to verify that this new choice agrees with the existing one. Eliminating the `ProfiledClassRecord` in this case saves space, and causes the validation process to behave as though it always makes the correct choice.