### PR TITLE
Disable SCC by default on all platforms for the 0.12.0 release

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -328,7 +328,12 @@ static const struct { \
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #if defined(OPENJ9_BUILD)
-#define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) TRUE
+/* Disable the sharedclasses by default feature due to performance regressions
+ * found prior to the 0.12.0 release.  Enabling the cache for bootstrap classes
+ * only interacts poorly with the JIT's logic to disable the iprofiler if a 
+ * warm cache is detected.  See https://github.com/eclipse/openj9/issues/4222
+ */
+#define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) FALSE
 #else /* defined(OPENJ9_BUILD) */
 #define J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm) FALSE
 #endif /* defined(OPENJ9_BUILD) */

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -381,6 +381,11 @@
 	</test>
 	<test>
 		<testCaseName>ShareClassesCMLOpenJ9</testCaseName>
+		<disabled>
+			SharedClasses by default is disabled from the 0.12.0 release while we
+			work through some performance issues related to lost iprofiler data.
+			See issue: https://github.com/eclipse/openj9/issues/4222
+		</disabled>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>


### PR DESCRIPTION
Opening the issue now so testing can be run to ensure that no additional changes are required to disable SCC by default.

issue: #4222 

Doc issue: https://github.com/eclipse/openj9-docs/issues/187

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>