### PR TITLE
AIX: strip symbols and debugging information from shared libraries

### DIFF
--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -1,5 +1,5 @@
 <#--
-Copyright (c) 1998, 2018 IBM Corp. and others
+Copyright (c) 1998, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,7 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 ifdef j9vm_uma_gnuDebugSymbols
 	cp $(UMA_DLLTARGET) $(UMA_DLLTARGET).dbg
 endif
+	strip -X32_64 $(UMA_DLLTARGET)
 </#assign>
 
 <#assign exe_target_rule>


### PR DESCRIPTION
Even though core files seem to have similar sizes, `dtfj` often takes much longer to open an AIX core file created by a VM with unstripped shared libraries.

#3995 added the need to start stripping the shared libraries.