### PR TITLE
Combine enter/exit tracing queries into one method

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -117,6 +117,7 @@
 #include "runtime/J9Profiler.hpp"
 #include "env/J9JitMemory.hpp"
 #include "infra/Bit.hpp"               //for trailingZeroes
+#include "VMHelpers.hpp"
 
 #ifdef LINUX
 #include <signal.h>
@@ -3503,23 +3504,22 @@ TR_J9VMBase::lowerAsyncCheck(TR::Compilation * comp, TR::Node * root, TR::TreeTo
    return treeTop;
    }
 
+bool
+ TR_J9VMBase::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
+    {
+    return VM_VMHelpers::methodBeingTraced(_jitConfig->javaVM, (J9Method *)method);
+    }
 
 bool
 TR_J9VMBase::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
    {
-   J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
-
-   return jitMethodEnterTracingEnabled(getCurrentVMThread(), (J9Method *)method);
+   return isMethodTracingEnabled(method);
    }
 
 bool
 TR_J9VMBase::isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method)
    {
-   J9JavaVM * javaVM = _jitConfig->javaVM;
-   J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
-
-   return jitMethodExitTracingEnabled(getCurrentVMThread(), (J9Method *)method);
+   return isMethodTracingEnabled(method);
    }
 
 bool

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -878,6 +878,7 @@ public:
 
     TR::TreeTop * lowerAsyncCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
     TR::TreeTop * lowerAtcCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
+   virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodEnterTracingEnabled(J9Method *j9method)
       {


### PR DESCRIPTION
TR_J9VMBase::isMethodEnterTracingEnabled() and
TR_J9VMBase::isMethodExitTracingEnabled()
are implemented as the same. Combine them into a new
method TR_J9VMBase::isMethodTracingEnabled().

Issue: #3585

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>