### PR TITLE
Enable JITInlineFieldwatch when option specified

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7909,6 +7909,14 @@ TR::CompilationInfoPerThreadBase::compile(
          // GC can go ahead now.
          }
 
+      // The inlineFieldWatches flag is set when Field Watch is actually triggered at runtime.
+      // When it happens, all the methods on stack are decompiled and those in
+      // the compilation queue are invalidated. Set the option here to guarantee the
+      // mode is detected at the right moment so that all methods compiled after respect the
+      // data watch point.
+      if (_jitConfig->inlineFieldWatches)
+         compiler->setOption(TR_EnableFieldWatch);
+
       // Compile the method
       //
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2313,6 +2313,12 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       {
       self()->setOption(TR_DisableNextGenHCR);
       }
+
+#if !defined(TR_HOST_X86)
+   //The bit is set when -XX:+JITInlineWatches is specified
+   if (J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_JIT_INLINE_WATCHES))
+      TR_ASSERT_FATAL(false, "this platform doesn't support JIT inline field watch");
+#endif
 
    // GCR and JProfiling are disabled under FSD for a number of reasons
    // First, there is confusion between the VM and the JIT as to whether a call to jitRetranslateCallerWithPreparation is a decompilation point.


### PR DESCRIPTION
This change enables JIT inlined field watch on X86 when
-XX:+JITInlineWatches is specified in the Java command line.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>