### PR TITLE
Remove references to WIN32_IBMS

### DIFF
--- a/runtime/oti/gp.h
+++ b/runtime/oti/gp.h
@@ -24,13 +24,8 @@
 #define gp_h
 
 struct J9SigContext;
-#ifdef WIN32_IBMC
-typedef uintptr_t (* protected_fn)(void *);
-typedef void (* handler_fn)(uintptr_t gpType, void *gpInfo, void *userData, struct J9SigContext *gpContext);
-#else
 typedef uintptr_t (*protected_fn)(void *);
 typedef void (*handler_fn)(uintptr_t gpType, void *gpInfo, void *userData, struct J9SigContext *gpContext);
-#endif
 
 #define J9PrimErrGPF 0
 #define J9PrimErrGPFInvalidRead 1

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -155,7 +155,7 @@ I_32 numCodeSets (void);
 
 /* X86 for MS compilers, __i386__ for GNU compilers */
 
-#if !defined(J9_SOFT_FLOAT) && (defined(_X86_) || defined (WIN32_IBMC) || defined (__i386__) || defined(J9HAMMER) || defined(OSX))
+#if !defined(J9_SOFT_FLOAT) && (defined(_X86_) || defined (__i386__) || defined(J9HAMMER) || defined(OSX))
 
 #define 	J9_SETUP_FPU_STATE() helperInitializeFPU()
 

--- a/runtime/tests/jvmtitests/agent/error.c
+++ b/runtime/tests/jvmtitests/agent/error.c
@@ -214,11 +214,7 @@ error(agentEnv * env, jvmtiError err, char * format, ...)
 
 	va_start(args, format);
 
-#if defined(WIN32_IBMC) || defined(J9ZOS390)
 	vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#else
-	_vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#endif
 
 	va_end(args);
 
@@ -241,11 +237,7 @@ softError(agentEnv * env, jvmtiError err, char * format, ...)
 
 	va_start(args, format);
 
-#if defined(WIN32_IBMC) || defined(J9ZOS390)
 	vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#else
-	_vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#endif
 
 	va_end(args);
 


### PR DESCRIPTION
This macro is no longer used.

Signed-off-by: Peter Bain <pdbain@acm.org>