### PR TITLE
Revert "Fix incorrect -Xdump:dump:defaults output"

### DIFF
--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -340,9 +340,9 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 #endif
 		"Output file",
 		doHeapDump,
-		{ J9RAS_DUMP_ON_EXCEPTION_SYSTHROW,
-		  "java/lang/OutOfMemoryError",
-		  1, 4,
+		{ J9RAS_DUMP_ON_GP_FAULT | J9RAS_DUMP_ON_USER_SIGNAL,
+		  NULL,
+		  1, 0,
 		  "heapdump.%Y" "%m%d.%H" "%M" "%S.%pid.%seq.phd",
 		  "PHD",
 		  500,


### PR DESCRIPTION
Reverts eclipse/openj9#563 which changed the default `-Xdump` options. This will restore the old defaults and we can explore fixing the help output later.