### PR TITLE
Update subset logic in TestKitGen

### DIFF
--- a/test/TestConfig/scripts/testKitGen/testKitGen.pl
+++ b/test/TestConfig/scripts/testKitGen/testKitGen.pl
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,6 @@ my $buildList      = '';
 my $iterations     = 1;
 my @allLevels      = ( "sanity", "extended", "special" );
 my @allGroups      = ( "functional", "openjdk", "external", "perf", "jck", "system" );
-my @allSubsets     = ( '8', '9', '10', '11', "Panama", "Valhalla" );
 my @allImpls       = ( "openj9", "ibm", "hotspot", "sap" );
 
 foreach my $argv (@ARGV) {
@@ -111,6 +110,6 @@ if ( !$impl ) {
 }
 
 # run make file generator
-runmkgen( $projectRootDir, \@allLevels, \@allGroups, \@allSubsets, $output, $graphSpecs, $jdkVersion, \@allImpls, $impl, $modesxml, $ottawacsv, $buildList, $iterations );
+runmkgen( $projectRootDir, \@allLevels, \@allGroups, $output, $graphSpecs, $jdkVersion, \@allImpls, $impl, $modesxml, $ottawacsv, $buildList, $iterations );
 
 print "\nTEST AUTO GEN SUCCESSFUL\n";

--- a/test/docs/OpenJ9TestUserGuide.md
+++ b/test/docs/OpenJ9TestUserGuide.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -94,9 +94,12 @@ Please read [DependentLibs.md](./DependentLibs.md) for details.
       - impl:    [openj9|hotspot] (filter test based on exported JDK_IMPL 
                  value; a test can be tagged with multiple impls at the 
                  same time; default to all impls)
-      - subset:  [8|9|10|11|Panama|Valhalla] (filter test based on 
+      - subset:  [8|8+|9|9+|10|10+|11|11+|Panama|Valhalla] (filter test based on 
                  exported JDK_VERSION value; a test can be tagged with 
-                 multiple subsets at the same time; default to all subsets)
+                 multiple subsets at the same time; if a test tagged with 
+                 a number (e.g., 8), it will used to match JDK_VERSION; if
+                 a test tagged with a number followed by + sign, any JDK_VERSION
+                 after the number will be a match; default to always match)
 
     - Most OpenJ9 FV tests are written with TestNG. We leverage
     TestNG groups to create test make targets. This means that

--- a/test/functional/Jsr292/playlist.xml
+++ b/test/functional/Jsr292/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<include>variables.mk</include>
 	<test>
-		<testCaseName>jsr292Test_SE80</testCaseName>
+		<testCaseName>jsr292Test_jdk8</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>
@@ -50,7 +50,7 @@
 	</test>
 
 	<test>
-		<testCaseName>jsr292Test</testCaseName>
+		<testCaseName>jsr292Test_jdk9_jdk10</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>
@@ -76,34 +76,34 @@
 		</subsets>
 	</test>
 
-        <test>
-                <testCaseName>jsr292Test_SE110</testCaseName>
-                <variations>
-                        <variation>NoOptions</variation>
-                        <variation>Mode195</variation>
-                </variations>
-                <command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-        --add-opens=java.base/java.lang=ALL-UNNAMED \
-        -Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
-        -cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
-        org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
-        -testnames jsr292Test,jsr292Test_B95up,jsr292Test_Java11up,jsr292Test_optional \
-        -groups $(TEST_GROUP) \
-        -excludegroups $(DEFAULT_EXCLUDE); \
-        $(TEST_STATUS)</command>
-                <levels>
-                        <level>extended</level>
-                </levels>
-                <groups>
-                        <group>functional</group>
-                </groups>
-                <subsets>
-                        <subset>11</subset>
-                </subsets>
-        </test>
+    <test>
+		<testCaseName>jsr292Test</testCaseName>
+		<variations>
+				<variation>NoOptions</variation>
+				<variation>Mode195</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	-Djava.security.policy=$(Q)$(TEST_RESROOT)$(D)java.policy$(Q) \
+	-cp $(Q)$(TEST_RESROOT)$(D)jsr292test.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(LIB_DIR)$(D)asm-all.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
+	-testnames jsr292Test,jsr292Test_B95up,jsr292Test_Java11up,jsr292Test_optional \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
+	</test>
 
 	<test>
-		<testCaseName>jsr292Test_JitCount0_SE80</testCaseName>
+		<testCaseName>jsr292Test_JitCount0_jdk8</testCaseName>
 		<variations>
 			<variation>-Xjit:count=0</variation>
 		</variations>
@@ -149,14 +149,12 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 
 	<test>
-		<testCaseName>jsr292BootstrapTest_SE80</testCaseName>
+		<testCaseName>jsr292BootstrapTest_jdk8</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode195</variation>
@@ -202,9 +200,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 
@@ -226,9 +222,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 
@@ -251,9 +245,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 
@@ -276,12 +268,6 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 
 </playlist>

--- a/test/functional/TestExample/playlist.xml
+++ b/test/functional/TestExample/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,11 +46,5 @@
 			<impl>ibm</impl>
 			<impl>hotspot</impl>
 		</impls>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -408,8 +408,8 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>SE110</subset>
-			<subset>SE80</subset>
+			<subset>11</subset>
+			<subset>8</subset>
 		</subsets>
 		<impls>
 			<impl>openj9</impl>


### PR DESCRIPTION
- remove the hardcoded subset check
- support jdkVersion+
- modify Jsr292 playlist.xml to use new subset logic
- remove any reference to SE version
- this avoids any change in TKG when new subset is enabled

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>