### PR TITLE
Remove unused parameters from call-in functions

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1887,7 +1887,7 @@ performOSR(J9VMThread *currentThread, J9StackWalkState *walkState, J9OSRBuffer *
 	currentThread->osrJittedFrameCopy = osrJittedFrameCopy;
 	currentThread->osrFrameIndex = sizeof(J9OSRBuffer);
 	currentThread->privateFlags |= J9_PRIVATE_FLAGS_OSR_IN_PROGRESS;
-	currentThread->javaVM->internalVMFunctions->jitFillOSRBuffer(currentThread, osrBlock, 0, 0, 0);
+	currentThread->javaVM->internalVMFunctions->jitFillOSRBuffer(currentThread, osrBlock);
 	currentThread->privateFlags &= ~J9_PRIVATE_FLAGS_OSR_IN_PROGRESS;
 	currentThread->osrBuffer = NULL;
 	currentThread->osrJittedFrameCopy = NULL;

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -953,7 +953,7 @@ completeInitialization(J9JavaVM * vm)
 	J9VMThread *currentThread = vm->mainThread;
 	
 	vmFuncs->internalEnterVMFromJNI(currentThread);
-	vmFuncs->sendCompleteInitialization(currentThread, 0, 0, 0, 0);
+	vmFuncs->sendCompleteInitialization(currentThread);
 	vmFuncs->internalReleaseVMAccess(currentThread);
 	
 	if (NULL == currentThread->currentException) {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4475,7 +4475,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *acquireExclusiveVMAccess)(struct J9VMThread * vmThread) ;
 	void  ( *releaseExclusiveVMAccess)(struct J9VMThread * vmThread) ;
 	void  ( *internalReleaseVMAccess)(struct J9VMThread * currentThread) ;
-	void  (JNICALL *sendInit)(struct J9VMThread *vmContext, j9object_t object, struct J9Class *senderClass, UDATA lookupOptions, UDATA reserved0) ;
+	void  (JNICALL *sendInit)(struct J9VMThread *vmContext, j9object_t object, struct J9Class *senderClass, UDATA lookupOptions) ;
 	void  ( *internalAcquireVMAccessNoMutex)(struct J9VMThread * vmThread) ;
 	struct J9Class*  ( *internalCreateArrayClass)(struct J9VMThread* vmThread, struct J9ROMArrayClass* romClass, struct J9Class* elementClass) ;
 	IDATA  ( *attachSystemDaemonThread)(struct J9JavaVM * vm, struct J9VMThread ** p_env, const char * threadName) ;
@@ -4513,7 +4513,7 @@ typedef struct J9InternalVMFunctions {
 	struct J9Method*  ( *resolveInterfaceMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags) ;
 	UDATA  ( *getVTableOffsetForMethod)(struct J9Method * method, struct J9Class *clazz, struct J9VMThread *vmThread) ;
 	IDATA  ( *checkVisibility)(struct J9VMThread* currentThread, struct J9Class* sourceClass, struct J9Class* destClass, UDATA modifiers, UDATA lookupOptions) ;
-	void  (JNICALL *sendClinit)(struct J9VMThread *vmContext, struct J9Class *clazz, UDATA reserved1, UDATA reserved2, UDATA reserved3) ;
+	void  (JNICALL *sendClinit)(struct J9VMThread *vmContext, struct J9Class *clazz) ;
 	void  ( *freeStackWalkCaches)(struct J9VMThread * currentThread, J9StackWalkState * walkState) ;
 	UDATA  ( *genericStackDumpIterator)(struct J9VMThread *currentThread, J9StackWalkState *walkState) ;
 	UDATA  ( *exceptionHandlerSearch)(struct J9VMThread *currentThread, J9StackWalkState *walkState) ;
@@ -4551,8 +4551,8 @@ typedef struct J9InternalVMFunctions {
 #endif /* J9VM_INTERP_SIG_QUIT_THREAD || J9VM_RAS_DUMP_AGENTS */
 	void  (JNICALL *initializeAttachedThread)(struct J9VMThread *vmContext, const char *name, j9object_t *group, UDATA daemon, struct J9VMThread *initializee) ;
 	void  ( *initializeMethodRunAddressNoHook)(struct J9JavaVM* vm, J9Method *method) ;
-	void  (JNICALL *sidecarInvokeReflectMethod)(struct J9VMThread *vmContext, jobject methodRef, jobject recevierRef, jobjectArray argsRef, void *unused) ;
-	void  (JNICALL *sidecarInvokeReflectConstructor)(struct J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused) ;
+	void  (JNICALL *sidecarInvokeReflectMethod)(struct J9VMThread *vmContext, jobject methodRef, jobject recevierRef, jobjectArray argsRef) ;
+	void  (JNICALL *sidecarInvokeReflectConstructor)(struct J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef) ;
 	struct J9MemorySegmentList*  ( *allocateMemorySegmentListWithSize)(struct J9JavaVM * javaVM, U_32 numberOfMemorySegments, UDATA sizeOfElements, U_32 memoryCategory) ;
 	void  ( *freeMemorySegmentListEntry)(struct J9MemorySegmentList *segmentList, struct J9MemorySegment *segment) ;
 	void  ( *acquireExclusiveVMAccessFromExternalThread)(struct J9JavaVM * vm) ;
@@ -4638,7 +4638,7 @@ typedef struct J9InternalVMFunctions {
 	void  ( *copyUTF8ToUnicode)(struct J9VMThread * vmThread, U_8 * data, UDATA length, UDATA stringFlags, j9object_t charArray, UDATA startIndex) ;
 	UDATA  ( *verifyQualifiedName)(struct J9VMThread *vmThread, j9object_t string) ;
 	UDATA ( *copyStringToUTF8Helper)(struct J9VMThread *vmThread, j9object_t string, UDATA stringFlags, UDATA stringOffset, UDATA stringLength, U_8 *utf8Data, UDATA utf8DataLength);
-	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4) ;
+	void  (JNICALL *sendCompleteInitialization)(struct J9VMThread *vmContext) ;
 	IDATA  ( *J9RegisterAsyncEvent)(struct J9JavaVM * vm, J9AsyncEventHandler eventHandler, void * userData) ;
 	IDATA  ( *J9UnregisterAsyncEvent)(struct J9JavaVM * vm, IDATA handlerKey) ;
 	IDATA  ( *J9SignalAsyncEvent)(struct J9JavaVM * vm, struct J9VMThread * targetThread, IDATA handlerKey) ;
@@ -4685,7 +4685,7 @@ typedef struct J9InternalVMFunctions {
 	struct J9Method*  ( *findJNIMethod)(struct J9VMThread* currentThread, J9Class* clazz, char* name, char* signature) ;
 	const char*  ( *getJ9VMVersionString)(struct J9JavaVM * vm) ;
 	j9object_t  ( *resolveMethodTypeRef)(struct J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags) ;
-	void  (JNICALL *sendFromMethodDescriptorString)(struct J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType, UDATA reserved4) ;
+	void  (JNICALL *sendFromMethodDescriptorString)(struct J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType) ;
 	UDATA  ( *addToBootstrapClassLoaderSearch)(struct J9JavaVM * vm, const char * pathSegment, UDATA classLoaderType, BOOLEAN enforceJarRestriction) ;
 	UDATA  ( *addToSystemClassLoaderSearch)(struct J9JavaVM * vm, const char * pathSegment, UDATA classLoaderType, BOOLEAN enforceJarRestriction) ;
 	UDATA  ( *queryLogOptions)(struct J9JavaVM *vm, I_32 buffer_size, void *options_buffer, I_32 *data_size) ;
@@ -4696,8 +4696,8 @@ typedef struct J9InternalVMFunctions {
 #endif /* J9VM_THR_LOCK_NURSERY */
 	void*  ( *jniArrayAllocateMemoryFromThread)(struct J9VMThread* vmThread, UDATA sizeInBytes) ;
 	void  ( *jniArrayFreeMemoryFromThread)(struct J9VMThread* vmThread, void* location) ;
-	void  (JNICALL *sendForGenericInvoke)(struct J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg, UDATA reserved4) ;
-	void  (JNICALL *jitFillOSRBuffer)(struct J9VMThread *vmContext, void *osrBlock, UDATA reserved1, UDATA reserved2, UDATA reserved3) ;
+	void  (JNICALL *sendForGenericInvoke)(struct J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg) ;
+	void  (JNICALL *jitFillOSRBuffer)(struct J9VMThread *vmContext, void *osrBlock) ;
 	void  (JNICALL *sendResolveMethodHandle)(struct J9VMThread *vmThread, UDATA cpIndex, J9ConstantPool *ramCP, J9Class *definingClass, J9ROMNameAndSignature* nameAndSig) ;
 	j9object_t ( *resolveConstantDynamic)(struct J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags) ;
 	j9object_t  ( *resolveInvokeDynamic)(struct J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags) ;

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1283,35 +1283,35 @@ extern J9_CFUNC UDATA  dropPendingSendPushes (J9VMThread *currentThread);
 /* J9VMJavaInterpreterStartup*/
 #ifndef _J9VMJAVAINTERPRETERSTARTUP_
 #define _J9VMJAVAINTERPRETERSTARTUP_
-extern J9_CFUNC void  JNICALL cleanUpAttachedThread (J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4);
-extern J9_CFUNC void  JNICALL handleUncaughtException (J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4);
-extern J9_CFUNC void  JNICALL sidecarInvokeReflectMethod (J9VMThread *vmContext, jobject methodRef, jobject recevierRef, jobjectArray argsRef, void *unused);
-extern J9_CFUNC void  JNICALL sidecarInvokeReflectMethodImpl (J9VMThread *vmContext, jobject methodRef, jobject recevierRef, jobjectArray argsRef, void *unused);
-extern J9_CFUNC void  JNICALL sendInit (J9VMThread *vmContext, j9object_t object, J9Class *senderClass, UDATA lookupOptions, UDATA reserved0);
-extern J9_CFUNC void  JNICALL printStackTrace (J9VMThread *vmContext, j9object_t exception, UDATA reserved1, UDATA reserved2, UDATA reserved3);
-extern J9_CFUNC void  JNICALL sendLoadClass (J9VMThread *vmContext, j9object_t classLoaderObject, j9object_t classNameObject, UDATA reserved1, UDATA reserved2);
-extern J9_CFUNC void  JNICALL runJavaThread (J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4);
-extern J9_CFUNC void  JNICALL sendCompleteInitialization (J9VMThread *vmContext, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4);
-extern J9_CFUNC void  JNICALL sendClinit (J9VMThread *vmContext, J9Class *clazz, UDATA reserved1, UDATA reserved2, UDATA reserved3);
-extern J9_CFUNC void  JNICALL sendInitializationAlreadyFailed (J9VMThread *vmContext, J9Class *clazz, UDATA reserved1, UDATA reserved2, UDATA reserved3);
-extern J9_CFUNC void  JNICALL sendRecordInitializationFailure (J9VMThread *vmContext, J9Class *clazz, j9object_t throwable, UDATA reserved2, UDATA reserved3);
+extern J9_CFUNC void  JNICALL cleanUpAttachedThread (J9VMThread *vmContext);
+extern J9_CFUNC void  JNICALL handleUncaughtException (J9VMThread *vmContext);
+extern J9_CFUNC void  JNICALL sidecarInvokeReflectMethod (J9VMThread *vmContext, jobject methodRef, jobject recevierRef, jobjectArray argsRef);
+extern J9_CFUNC void  JNICALL sidecarInvokeReflectMethodImpl (J9VMThread *vmContext, jobject methodRef, jobject recevierRef, jobjectArray argsRef);
+extern J9_CFUNC void  JNICALL sendInit (J9VMThread *vmContext, j9object_t object, J9Class *senderClass, UDATA lookupOptions);
+extern J9_CFUNC void  JNICALL printStackTrace (J9VMThread *vmContext, j9object_t exception);
+extern J9_CFUNC void  JNICALL sendLoadClass (J9VMThread *vmContext, j9object_t classLoaderObject, j9object_t classNameObject);
+extern J9_CFUNC void  JNICALL runJavaThread (J9VMThread *vmContext);
+extern J9_CFUNC void  JNICALL sendCompleteInitialization (J9VMThread *vmContext);
+extern J9_CFUNC void  JNICALL sendClinit (J9VMThread *vmContext, J9Class *clazz);
+extern J9_CFUNC void  JNICALL sendInitializationAlreadyFailed (J9VMThread *vmContext, J9Class *clazz);
+extern J9_CFUNC void  JNICALL sendRecordInitializationFailure (J9VMThread *vmContext, J9Class *clazz, j9object_t throwable);
 extern J9_CFUNC void  JNICALL runCallInMethod (JNIEnv *env, jobject receiver, jclass clazz, jmethodID methodID, void* args);
 extern J9_CFUNC void  JNICALL internalSendExceptionConstructor (J9VMThread *vmContext, J9Class *exceptionClass, j9object_t exception, j9object_t detailMessage, UDATA constructorIndex);
-extern J9_CFUNC void  JNICALL sendInitCause (J9VMThread *vmContext, j9object_t receiver, j9object_t cause, UDATA reserved4, UDATA reserved5);
+extern J9_CFUNC void  JNICALL sendInitCause (J9VMThread *vmContext, j9object_t receiver, j9object_t cause);
 extern J9_CFUNC void  JNICALL initializeAttachedThread (J9VMThread *vmContext, const char *name, j9object_t *group, UDATA daemon, J9VMThread *initializee);
 extern J9_CFUNC void  JNICALL initializeAttachedThreadImpl (J9VMThread *vmContext, const char *name, j9object_t *group, UDATA daemon, J9VMThread *initializee);
 extern J9_CFUNC void  JNICALL runStaticMethod (J9VMThread *vmContext, U_8* className, J9NameAndSignature* selector, UDATA argCount, UDATA* arguments);
 extern J9_CFUNC void  JNICALL internalRunStaticMethod (J9VMThread *vmContext, J9Method *method, BOOLEAN returnsObject, UDATA argCount, UDATA* arguments);
-extern J9_CFUNC void  JNICALL sendCheckPackageAccess (J9VMThread *vmContext, J9Class * clazz, j9object_t protectionDomain, UDATA reserved1, UDATA reserved2);
-extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructor (J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused);
-extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructorImpl (J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused);
-extern J9_CFUNC void  JNICALL sendFromMethodDescriptorString (J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType, UDATA reserved4);
+extern J9_CFUNC void  JNICALL sendCheckPackageAccess (J9VMThread *vmContext, J9Class * clazz, j9object_t protectionDomain);
+extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructor (J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef);
+extern J9_CFUNC void  JNICALL sidecarInvokeReflectConstructorImpl (J9VMThread *vmContext, jobject constructorRef, jobject recevierRef, jobjectArray argsRef);
+extern J9_CFUNC void  JNICALL sendFromMethodDescriptorString (J9VMThread *vmThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType);
 extern J9_CFUNC void  JNICALL sendResolveMethodHandle (J9VMThread *vmThread, UDATA cpIndex, J9ConstantPool *ramCP, J9Class *definingClass, J9ROMNameAndSignature* nameAndSig);
-extern J9_CFUNC void  JNICALL sendForGenericInvoke (J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg, UDATA reserved4);
+extern J9_CFUNC void  JNICALL sendForGenericInvoke (J9VMThread *vmThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg);
 extern J9_CFUNC void  JNICALL sendResolveConstantDynamic (J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIndex, J9ROMNameAndSignature* nameAndSig, U_16* bsmData);
 extern J9_CFUNC void  JNICALL sendResolveInvokeDynamic (J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA callSiteIndex, J9ROMNameAndSignature* nameAndSig, U_16* bsmData);
-extern J9_CFUNC void  JNICALL jitFillOSRBuffer (struct J9VMThread *vmContext, void *osrBlock, UDATA reserved1, UDATA reserved2, UDATA reserved3);
-extern J9_CFUNC void  JNICALL sendRunThread(J9VMThread *vmContext, j9object_t tenantContext, UDATA reserved1, UDATA reserved2, UDATA reserved3);
+extern J9_CFUNC void  JNICALL jitFillOSRBuffer (struct J9VMThread *vmContext, void *osrBlock);
+extern J9_CFUNC void  JNICALL sendRunThread(J9VMThread *vmContext, j9object_t tenantContext);
 #endif /* _J9VMJAVAINTERPRETERSTARTUP_ */
 
 /* J9VMNativeHelpersLarge*/

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2018 IBM Corp. and others
+ * Copyright (c) 2002, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -328,7 +328,7 @@ JVM_NewInstanceFromConstructor_Impl(JNIEnv * env, jobject c, jobjectArray args)
 
 	obj = (*env)->AllocObject(env, classRef);
 	if (obj) {
-		vmFuncs->sidecarInvokeReflectConstructor(vmThread, c, obj, args, NULL);
+		vmFuncs->sidecarInvokeReflectConstructor(vmThread, c, obj, args);
 		if ((*env)->ExceptionCheck(env)) {
 			(*env)->DeleteLocalRef(env, obj);
 			obj = (jobject) NULL;
@@ -351,7 +351,7 @@ JVM_InvokeMethod_Impl(JNIEnv * env, jobject method, jobject obj, jobjectArray ar
 
 	Trc_SunVMI_InvokeMethod_Entry(vmThread, method, obj, args);
 
-	vmThread->javaVM->internalVMFunctions->sidecarInvokeReflectMethod(vmThread, method, obj, args, NULL);
+	vmThread->javaVM->internalVMFunctions->sidecarInvokeReflectMethod(vmThread, method, obj, args);
 
 	Trc_SunVMI_InvokeMethod_Exit(vmThread, vmThread->returnValue);
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3035,7 +3035,7 @@ done:
 		} else {
 			pushObjectInSpecialFrame(REGISTER_ARGS, instance);
 			updateVMStruct(REGISTER_ARGS);
-			sendInit(_currentThread, instance, senderClass, J9_LOOK_NEW_INSTANCE|J9_LOOK_REFLECT_CALL, 0);
+			sendInit(_currentThread, instance, senderClass, J9_LOOK_NEW_INSTANCE|J9_LOOK_REFLECT_CALL);
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			if (VM_VMHelpers::exceptionPending(_currentThread)) {
 				rc = GOTO_THROW_CURRENT_EXCEPTION;
@@ -7904,7 +7904,7 @@ retry:
 				} else {
 					buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 					updateVMStruct(REGISTER_ARGS);
-					sendForGenericInvoke (_currentThread, mhReceiver, type, FALSE /* dropFirstArg */, 0 /* reserved */);
+					sendForGenericInvoke (_currentThread, mhReceiver, type, FALSE /* dropFirstArg */);
 					VMStructHasBeenUpdated(REGISTER_ARGS);
 					mhReceiver = (j9object_t) _currentThread->returnValue;
 					if (VM_VMHelpers::exceptionPending(_currentThread)) {
@@ -8027,7 +8027,7 @@ done:
 					buildGenericSpecialStackFrame(REGISTER_ARGS, 0);
 					pushObjectInSpecialFrame(REGISTER_ARGS, varHandle);
 					updateVMStruct(REGISTER_ARGS);
-					sendForGenericInvoke(_currentThread, methodHandle, callSiteType, FALSE /* dropFirstArg */, 0 /* reserved */);
+					sendForGenericInvoke(_currentThread, methodHandle, callSiteType, FALSE /* dropFirstArg */);
 					VMStructHasBeenUpdated(REGISTER_ARGS);
 					varHandle = popObjectInSpecialFrame(REGISTER_ARGS);
 					restoreGenericSpecialStackFrame(REGISTER_ARGS);

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,7 +90,7 @@ initializeImpl(J9VMThread *currentThread, J9Class *clazz)
 	}
 
 	if (J9ROMCLASS_HAS_CLINIT(clazz->romClass)) {
-		sendClinit(currentThread, clazz, 0, 0, 0);
+		sendClinit(currentThread, clazz);
 		clazz = VM_VMHelpers::currentClass(clazz);
 		if (VM_VMHelpers::exceptionPending(currentThread)) {
 			TRIGGER_J9HOOK_VM_CLASS_INITIALIZE_FAILED(vm->hookInterface, currentThread, clazz);
@@ -470,7 +470,7 @@ doVerify:
 				if (desiredState < J9_CLASS_INIT_INITIALIZED) {
 					Trc_VM_classInitStateMachine_desiredStateReached(currentThread);
 				} else {
-					sendInitializationAlreadyFailed(currentThread, clazz, 0, 0, 0);
+					sendInitializationAlreadyFailed(currentThread, clazz);
 				}
 				goto done;
 			}
@@ -551,7 +551,7 @@ initFailed:
 					j9object_t throwable = currentThread->currentException;
 					currentThread->currentException = NULL;
 					PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, initializationLock);
-					sendRecordInitializationFailure(currentThread, clazz, throwable, 0, 0);
+					sendRecordInitializationFailure(currentThread, clazz, throwable);
 					initializationLock = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 					clazz = VM_VMHelpers::currentClass(clazz);
 					initializationLock = setInitStatus(currentThread, clazz, J9ClassInitFailed, initializationLock);

--- a/runtime/vm/MHInterpreter.cpp
+++ b/runtime/vm/MHInterpreter.cpp
@@ -554,7 +554,7 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 				IDATA spOffset = spPriorToFrameBuild - _currentThread->arg0EA;
 				IDATA frameOffset = (UDATA*)currentTypeFrame - _currentThread->arg0EA;
 
-				sendForGenericInvoke(_currentThread, methodHandleFromTable, accessModeType, FALSE /* dropFirstArg */, 0 /* reserved */);
+				sendForGenericInvoke(_currentThread, methodHandleFromTable, accessModeType, FALSE /* dropFirstArg */);
 				methodHandle = (j9object_t)_currentThread->returnValue;
 
 				if (VM_VMHelpers::exceptionPending(_currentThread)) {
@@ -1003,7 +1003,7 @@ VM_MHInterpreter::doInvokeGeneric(j9object_t methodHandle)
 		spOffset = spPriorToFrameBuild - _currentThread->arg0EA;
 		frameOffset = (UDATA*)currentTypeFrame - _currentThread->arg0EA;
 
-		sendForGenericInvoke(_currentThread, targetHandle, castType, FALSE, 0);
+		sendForGenericInvoke(_currentThread, targetHandle, castType, FALSE);
 		targetHandle = (j9object_t)_currentThread->returnValue;
 
 		/* If there's an exception, don't do anything and return the old handle */

--- a/runtime/vm/callin.cpp
+++ b/runtime/vm/callin.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -401,7 +401,7 @@ restoreCallInFrame(J9VMThread *currentThread)
 }
 
 void JNICALL
-sendClinit(J9VMThread *currentThread, J9Class *clazz, UDATA reserved1, UDATA reserved2, UDATA reserved3)
+sendClinit(J9VMThread *currentThread, J9Class *clazz)
 {
 	Trc_VM_sendClinit_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -424,7 +424,7 @@ sendClinit(J9VMThread *currentThread, J9Class *clazz, UDATA reserved1, UDATA res
 }
 
 void JNICALL
-sendLoadClass(J9VMThread *currentThread, j9object_t classLoaderObject, j9object_t classNameObject, UDATA reserved1, UDATA reserved2)
+sendLoadClass(J9VMThread *currentThread, j9object_t classLoaderObject, j9object_t classNameObject)
 {
 	Trc_VM_sendLoadClass_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -444,7 +444,7 @@ sendLoadClass(J9VMThread *currentThread, j9object_t classLoaderObject, j9object_
 }
 
 void JNICALL
-cleanUpAttachedThread(J9VMThread *currentThread, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4)
+cleanUpAttachedThread(J9VMThread *currentThread)
 {
 	Trc_VM_cleanUpAttachedThread_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -465,7 +465,7 @@ cleanUpAttachedThread(J9VMThread *currentThread, UDATA reserved1, UDATA reserved
 }
 
 void JNICALL
-handleUncaughtException(J9VMThread *currentThread, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4)
+handleUncaughtException(J9VMThread *currentThread)
 {
 	Trc_VM_handleUncaughtException_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -607,7 +607,7 @@ internalSendExceptionConstructor(J9VMThread *currentThread, J9Class *exceptionCl
 }
 
 void JNICALL
-printStackTrace(J9VMThread *currentThread, j9object_t exception, UDATA reserved1, UDATA reserved2, UDATA reserved3)
+printStackTrace(J9VMThread *currentThread, j9object_t exception)
 {
 	Trc_VM_printStackTrace_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -628,7 +628,7 @@ printStackTrace(J9VMThread *currentThread, j9object_t exception, UDATA reserved1
 }
 
 void JNICALL
-runJavaThread(J9VMThread *currentThread, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4)
+runJavaThread(J9VMThread *currentThread)
 {
 	Trc_VM_runJavaThread_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -706,7 +706,7 @@ internalRunStaticMethod(J9VMThread *currentThread, J9Method *method, BOOLEAN ret
 }
 
 void JNICALL
-sendCheckPackageAccess(J9VMThread *currentThread, J9Class *clazz, j9object_t protectionDomain, UDATA reserved3, UDATA reserved4)
+sendCheckPackageAccess(J9VMThread *currentThread, J9Class *clazz, j9object_t protectionDomain)
 {
 	Trc_VM_sendCheckPackageAccess_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -723,7 +723,7 @@ sendCheckPackageAccess(J9VMThread *currentThread, J9Class *clazz, j9object_t pro
 }
 
 void JNICALL
-sendCompleteInitialization(J9VMThread *currentThread, UDATA reserved1, UDATA reserved2, UDATA reserved3, UDATA reserved4)
+sendCompleteInitialization(J9VMThread *currentThread)
 {
 	Trc_VM_sendCompleteInitialization_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -771,7 +771,7 @@ isAccessibleToAllModulesViaReflection(J9VMThread *currentThread, J9Class *clazz,
 }
 
 void JNICALL
-sendInit(J9VMThread *currentThread, j9object_t object, J9Class *senderClass, UDATA lookupOptions, UDATA reserved4)
+sendInit(J9VMThread *currentThread, j9object_t object, J9Class *senderClass, UDATA lookupOptions)
 {
 	Trc_VM_sendInit_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -810,7 +810,7 @@ sendInit(J9VMThread *currentThread, j9object_t object, J9Class *senderClass, UDA
 }
 
 void JNICALL
-sendInitCause(J9VMThread *currentThread, j9object_t receiver, j9object_t cause, UDATA reserved3, UDATA reserved4)
+sendInitCause(J9VMThread *currentThread, j9object_t receiver, j9object_t cause)
 {
 	Trc_VM_sendInitCause_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -832,7 +832,7 @@ sendInitCause(J9VMThread *currentThread, j9object_t receiver, j9object_t cause, 
 }
 
 void JNICALL
-sendInitializationAlreadyFailed(J9VMThread *currentThread, J9Class *clazz, UDATA reserved2, UDATA reserved3, UDATA reserved4)
+sendInitializationAlreadyFailed(J9VMThread *currentThread, J9Class *clazz)
 {
 	Trc_VM_sendInitializationAlreadyFailed_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -848,7 +848,7 @@ sendInitializationAlreadyFailed(J9VMThread *currentThread, J9Class *clazz, UDATA
 }
 
 void JNICALL
-sendRecordInitializationFailure(J9VMThread *currentThread, J9Class *clazz, j9object_t throwable, UDATA reserved3, UDATA reserved4)
+sendRecordInitializationFailure(J9VMThread *currentThread, J9Class *clazz, j9object_t throwable)
 {
 	Trc_VM_sendRecordInitializationFailure_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -865,7 +865,7 @@ sendRecordInitializationFailure(J9VMThread *currentThread, J9Class *clazz, j9obj
 }
 
 void JNICALL
-sendFromMethodDescriptorString(J9VMThread *currentThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType, UDATA reserved4)
+sendFromMethodDescriptorString(J9VMThread *currentThread, J9UTF8 *descriptor, J9ClassLoader *classLoader, J9Class *appendArgType)
 {
 	Trc_VM_sendFromMethodDescriptorString_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -925,7 +925,7 @@ sendResolveMethodHandle(J9VMThread *currentThread, UDATA cpIndex, J9ConstantPool
 }
 
 void JNICALL
-sendForGenericInvoke(J9VMThread *currentThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg, UDATA reserved4)
+sendForGenericInvoke(J9VMThread *currentThread, j9object_t methodHandle, j9object_t methodType, UDATA dropFirstArg)
 {
 	Trc_VM_sendForGenericInvoke_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -1078,7 +1078,7 @@ runCallInMethod(JNIEnv *env, jobject receiver, jclass clazz, jmethodID methodID,
 }
 
 void JNICALL
-sidecarInvokeReflectMethodImpl(J9VMThread *currentThread, jobject methodRef, jobject recevierRef, jobjectArray argsRef, void *unused)
+sidecarInvokeReflectMethodImpl(J9VMThread *currentThread, jobject methodRef, jobject recevierRef, jobjectArray argsRef)
 {
 	Trc_VM_sidecarInvokeReflectMethod_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -1203,7 +1203,7 @@ done:
 }
 
 void JNICALL
-sidecarInvokeReflectConstructorImpl(J9VMThread *currentThread, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused)
+sidecarInvokeReflectConstructorImpl(J9VMThread *currentThread, jobject constructorRef, jobject recevierRef, jobjectArray argsRef)
 {
 	Trc_VM_sidecarInvokeReflectConstructor_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -1255,7 +1255,7 @@ done:
 }
 
 void JNICALL
-jitFillOSRBuffer(struct J9VMThread *currentThread, void *osrBlock, UDATA reserved1, UDATA reserved2, UDATA reserved3)
+jitFillOSRBuffer(struct J9VMThread *currentThread, void *osrBlock)
 {
 	Trc_VM_jitFillOSRBuffer_Entry(currentThread);
 	J9VMEntryLocalStorage newELS;
@@ -1277,18 +1277,18 @@ initializeAttachedThread(J9VMThread *currentThread, const char *name, j9object_t
 }
 
 void JNICALL
-sidecarInvokeReflectMethod(J9VMThread *currentThread, jobject methodRef, jobject recevierRef, jobjectArray argsRef, void *unused)
+sidecarInvokeReflectMethod(J9VMThread *currentThread, jobject methodRef, jobject recevierRef, jobjectArray argsRef)
 {
 	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
-	sidecarInvokeReflectMethodImpl(currentThread, methodRef, recevierRef, argsRef, unused);
+	sidecarInvokeReflectMethodImpl(currentThread, methodRef, recevierRef, argsRef);
 	VM_VMAccess::inlineExitVMToJNI(currentThread);
 }
 
 void JNICALL
-sidecarInvokeReflectConstructor(J9VMThread *currentThread, jobject constructorRef, jobject recevierRef, jobjectArray argsRef, void *unused)
+sidecarInvokeReflectConstructor(J9VMThread *currentThread, jobject constructorRef, jobject recevierRef, jobjectArray argsRef)
 {
 	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
-	sidecarInvokeReflectConstructorImpl(currentThread, constructorRef, recevierRef, argsRef, unused);
+	sidecarInvokeReflectConstructorImpl(currentThread, constructorRef, recevierRef, argsRef);
 	VM_VMAccess::inlineExitVMToJNI(currentThread);
 }
 

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -649,7 +649,7 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 		J9JavaVM * vm = vmThread->javaVM;
 
 		Trc_VM_internalFindClass_sendLoadClass(vmThread, classNameLength, className, classNameString, classLoader->classLoaderObject);
-		sendLoadClass(vmThread, classLoader->classLoaderObject, classNameString, 0, 0);
+		sendLoadClass(vmThread, classLoader->classLoaderObject, classNameString);
 		sendLoadClassResult = (j9object_t) vmThread->returnValue;
 		if (NULL == sendLoadClassResult) {
 			j9object_t exception;

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -457,7 +457,7 @@ internalExceptionDescribe(J9VMThread * vmThread)
 
 		if (vm->runtimeFlags & J9_RUNTIME_INITIALIZED) {
 			PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, exception);
-			printStackTrace(vmThread, exception, 0, 0, 0);
+			printStackTrace(vmThread, exception);
 			exception = POP_OBJECT_IN_SPECIAL_FRAME(vmThread);
 			if (vmThread->currentException == NULL) {
 				goto done;

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -691,7 +691,7 @@ sendConstructor:
 	cause = POP_OBJECT_IN_SPECIAL_FRAME(currentThread); /* cause */
 	if (currentThread->currentException == NULL) {
 		if (cause != NULL) {
-			sendInitCause(currentThread, (j9object_t) exception, cause, 0, 0);
+			sendInitCause(currentThread, (j9object_t) exception, cause);
 			exception = (j9object_t) currentThread->returnValue; /* initCause returns the receiver */
 		}
 	} else {

--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -338,7 +338,7 @@ protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
 
 	/* Do the java cleanup */
 	enterVMFromJNI(vmThread);
-	cleanUpAttachedThread(vmThread, 0, 0, 0, 0);
+	cleanUpAttachedThread(vmThread);
 	releaseVMAccess(vmThread);
 
 	TRIGGER_J9HOOK_VM_SHUTTING_DOWN(vm->hookInterface, vmThread, 0);

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,7 +134,7 @@ packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t
 	} else if (canRunJavaCode) {
 		if (J9_ARE_NO_BITS_SET(currentThread->privateFlags2, J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS)) {
 			currentThread->privateFlags2 |= J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS;
-			sendCheckPackageAccess(currentThread, targetClass, protectionDomain, 0, 0);
+			sendCheckPackageAccess(currentThread, targetClass, protectionDomain);
 			currentThread->privateFlags2 &= ~J9_PRIVATE_FLAGS2_CHECK_PACKAGE_ACCESS;
 		}
 		if (!threadEventsPending(currentThread)) {
@@ -1381,7 +1381,7 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 				/* Call VM Entry point to create the MethodType - Result is put into the
 				 * vmThread->returnValue as entry points don't "return" in the expected way
 				 */
-				sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, NULL, 0);
+				sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, NULL);
 				methodType = (j9object_t) vmStruct->returnValue;
 
 				/* check if an exception is already pending */
@@ -1553,7 +1553,7 @@ resolveVirtualMethodRefInto(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA c
 					 * E.g. the MethodType for "(I)I" will have the following descriptor string:
 					 *     "(Ijava/lang/invoke/VarHandle;)I"
 					 */
-					sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, J9VMJAVALANGINVOKEVARHANDLE_OR_NULL(vm), 0);
+					sendFromMethodDescriptorString(vmStruct, sigUTF, J9_CLASS_FROM_CP(ramCP)->classLoader, J9VMJAVALANGINVOKEVARHANDLE_OR_NULL(vm));
 					methodType = (j9object_t)vmStruct->returnValue;
 
 					/* Check if an exception is already pending */
@@ -1686,7 +1686,7 @@ resolveMethodTypeRefInto(J9VMThread *vmThread, J9ConstantPool *ramCP, UDATA cpIn
 	 */
 	romMethodTypeRef = ((J9ROMMethodTypeRef *) &(J9_ROM_CP_FROM_CP(ramCP)[cpIndex]));
 	lookupSig = J9ROMMETHODTYPEREF_SIGNATURE(romMethodTypeRef);
-	sendFromMethodDescriptorString(vmThread, lookupSig, J9_CLASS_FROM_CP(ramCP)->classLoader, NULL, 0);
+	sendFromMethodDescriptorString(vmThread, lookupSig, J9_CLASS_FROM_CP(ramCP)->classLoader, NULL);
 	methodType = (j9object_t) vmThread->returnValue;
 
 	/* check if an exception is already pending */

--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -382,7 +382,7 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 	enterVMFromJNI(vmThread);
 	/* Inform ThreadGroup about any uncaught exception.  Tiny VMs do not have ThreadGroup, so they just dump the exception. */
 	if (vmThread->currentException) {
-		handleUncaughtException(vmThread, 0, 0, 0, 0);
+		handleUncaughtException(vmThread);
 		/* Safe to call this whether handleUncaughtException clears the exception or not */
 		internalExceptionDescribe(vmThread);
 	}
@@ -413,7 +413,7 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 	/* Do the java dance to indicate thread death */
 
 	acquireVMAccess(vmThread);
-	cleanUpAttachedThread(vmThread, 0, 0, 0, 0);
+	cleanUpAttachedThread(vmThread);
 	releaseVMAccess(vmThread);
 	
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
@@ -2055,7 +2055,7 @@ javaProtectedThreadProc(J9PortLibrary* portLibrary, void * entryarg)
 
 		{
 			/* Start running the thread */
-			runJavaThread(vmThread, 0, 0, 0, 0);
+			runJavaThread(vmThread);
 		}
 
 #ifdef J9VM_OPT_DEPRECATED_METHODS


### PR DESCRIPTION
Legacy code required all VM entry points to have the same function
prototype. This is no longer necessary, so remove the unused parameters.

Related: #4134

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>