### PR TITLE
Use strip '-r' option to retain external symbols

### DIFF
--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -36,7 +36,7 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 ifdef j9vm_uma_gnuDebugSymbols
 	cp $(UMA_DLLTARGET) $(UMA_DLLTARGET).dbg
 endif
-	strip -X32_64 $(UMA_DLLTARGET)
+	strip -X32_64 -r $(UMA_DLLTARGET)
 </#assign>
 
 <#assign exe_target_rule>


### PR DESCRIPTION
For example, launchers need to link to libjvm.so which must export `JNI_CreateJavaVM`.