### PR TITLE
Remove references to WIN32_IBMC

### DIFF
--- a/runtime/oti/gp.h
+++ b/runtime/oti/gp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,13 +24,8 @@
 #define gp_h
 
 struct J9SigContext;
-#ifdef WIN32_IBMC
-typedef uintptr_t (* protected_fn)(void *);
-typedef void (* handler_fn)(uintptr_t gpType, void *gpInfo, void *userData, struct J9SigContext *gpContext);
-#else
 typedef uintptr_t (*protected_fn)(void *);
 typedef void (*handler_fn)(uintptr_t gpType, void *gpInfo, void *userData, struct J9SigContext *gpContext);
-#endif
 
 #define J9PrimErrGPF 0
 #define J9PrimErrGPFInvalidRead 1

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -155,7 +155,7 @@ I_32 numCodeSets (void);
 
 /* X86 for MS compilers, __i386__ for GNU compilers */
 
-#if !defined(J9_SOFT_FLOAT) && (defined(_X86_) || defined (WIN32_IBMC) || defined (__i386__) || defined(J9HAMMER) || defined(OSX))
+#if !defined(J9_SOFT_FLOAT) && (defined(_X86_) || defined (__i386__) || defined(J9HAMMER) || defined(OSX))
 
 #define 	J9_SETUP_FPU_STATE() helperInitializeFPU()
 

--- a/runtime/tests/jvmtitests/agent/error.c
+++ b/runtime/tests/jvmtitests/agent/error.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -188,11 +188,7 @@ _error(agentEnv * env, jvmtiError err, agentErrorType errType, char *file, const
 	char errorMsg[JVMTI_TEST_ERROR_MSG_MAX];
 
 	va_start(args, format);
-#ifdef WIN32
-	_vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#else
 	vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#endif
 	va_end(args);
 
 	agentErr = __error(env, err, errType, file, fnname, line, errorMsg);
@@ -214,11 +210,7 @@ error(agentEnv * env, jvmtiError err, char * format, ...)
 
 	va_start(args, format);
 
-#if defined(WIN32_IBMC) || defined(J9ZOS390)
 	vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#else
-	_vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#endif
 
 	va_end(args);
 
@@ -241,11 +233,7 @@ softError(agentEnv * env, jvmtiError err, char * format, ...)
 
 	va_start(args, format);
 
-#if defined(WIN32_IBMC) || defined(J9ZOS390)
 	vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#else
-	_vsnprintf(errorMsg, JVMTI_TEST_ERROR_MSG_MAX, format, args);
-#endif
 
 	va_end(args);
 

--- a/runtime/vm/linearswalk.c
+++ b/runtime/vm/linearswalk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -373,11 +373,7 @@ lswRecordSlot(J9StackWalkState * walkState, const void * slotAddress, UDATA slot
 	slot->type = slotType;
 
 	va_start(args, format);
-#if defined(WIN32)
-	_vsnprintf(buf, LSW_STRING_MAX, format, args);
-#else
 	vsnprintf(buf, LSW_STRING_MAX, format, args);
-#endif
 	va_end(args);
 
 	slot->name = lswStrDup(slotWalker, buf);
@@ -746,11 +742,7 @@ lswPrintf(struct J9PortLibrary *privatePortLibrary, const char *format, ...)
 	va_list args;
 
 	va_start(args, format);
-#if defined(WIN32)
-	_vsnprintf(buf, LSW_STRING_MAX, format, args);
-#else
 	vsnprintf(buf, LSW_STRING_MAX, format, args);
-#endif
 	va_end(args);
 
 	j9tty_printf(privatePortLibrary, buf);


### PR DESCRIPTION
This macro is no longer used. Also remove use of _vsnprintf, which can result
in an unterminated string.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>