### PR TITLE
Revert "Use strip '-r' option to retain external symbols"

### DIFF
--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -36,7 +36,7 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 ifdef j9vm_uma_gnuDebugSymbols
 	cp $(UMA_DLLTARGET) $(UMA_DLLTARGET).dbg
 endif
-	strip -X32_64 -r $(UMA_DLLTARGET)
+	strip -X32_64 $(UMA_DLLTARGET)
 </#assign>
 
 <#assign exe_target_rule>


### PR DESCRIPTION
Reverts eclipse/openj9#4276

It seems not to be working as desired. Internal jdk8 testing is showing consistent failures in 64-bit (both compressedrefs and not) cmdLineTester_callsitedbgddrext DDR testing.

```
Testing: Run !printallcallsites
...
>> Success condition was not found: [Output match: jvminit.c]
```
```
Testing: Run !findallcallsites
...
 [OUT] > Unexpected CDE reading contents of 10010012630
 [OUT] com.ibm.j9ddr.corereaders.memory.MemoryFault: Memory Fault reading 0x90000000D9F7C2C : MemoryFault loading cache block, unbacked memory
```