### PR TITLE
Use strip '-t' option to remove debug symbols

### DIFF
--- a/runtime/makelib/targets.mk.aix.inc.ftl
+++ b/runtime/makelib/targets.mk.aix.inc.ftl
@@ -36,7 +36,7 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 ifdef j9vm_uma_gnuDebugSymbols
 	cp $(UMA_DLLTARGET) $(UMA_DLLTARGET).dbg
 endif
-	strip -X32_64 $(UMA_DLLTARGET)
+	strip -X32_64 -t $(UMA_DLLTARGET)
 </#assign>
 
 <#assign exe_target_rule>


### PR DESCRIPTION
Using `strip -t` doesn't appear to have the problems encountered with `strip -r` in https://github.com/eclipse/openj9/pull/4276.