### PR TITLE
Removing the -xml parameter from jdmpview help

### DIFF
--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/Session.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar18-SE]*/
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,6 @@ public class Session implements ISession {
 	public static String prompt = "> ";
 	
 	private static final String ARG_CORE = "-core";
-	private static final String ARG_XML = "-xml";
 	private static final String ARG_ZIP = "-zip";
 	private static final String ARG_VERSION = "-version";
 	private static final String ARG_VERBOSE = "-verbose";
@@ -152,7 +151,6 @@ public class Session implements ISession {
 		pairedargs.add(ARG_CORE);
 		pairedargs.add(ARG_OUTFILE);
 		pairedargs.add(ARG_CHARSET);
-		pairedargs.add(ARG_XML);
 		pairedargs.add(ARG_ZIP);
 		
 		// define the list of session commands - ones which run against the session context, not the per-image context
@@ -467,12 +465,10 @@ public class Session implements ISession {
 		String launcher = System.getProperty(SYSPROP_LAUNCHER, "dtfjview");
 		
 		out.print(
-				"Usage: \"" + launcher + " -core <core_file> [-xml <xml_file>] [-verbose]\" or \n" +
+				"Usage: \"" + launcher + " -core <core_file> [-verbose]\" or \n" +
 				"       \"" + launcher + " -zip <zip_file> [-verbose]\" or \n" +
 				"       \"" + launcher + " -version\"\n\n" +
-				"To analyze dumps from DDR-enabled JVMs, " + launcher + " only requires a core file, no XML file " +
-				"is needed.\n\nTo analyze dumps from non DDR-enabled JVMs, " + launcher + " requires both core and " +
-				"XML files (jextract must be run on the dump first, to produce the XML file).\n\n" +
+				"To analyze dumps from DDR-enabled JVMs, " + launcher + " only requires a core file.\n\n" + 
 				"The default ImageFactory is " + factoryName + ". To change the ImageFactory use: \n" +
 				"\t -J-D" + SYSPROP_FACTORY + "=<classname> \n\n");	
 		
@@ -612,11 +608,7 @@ public class Session implements ISession {
 				exit(ARG_ZIP + " and " + ARG_CORE + " cannot be specified at the same time", JDMPVIEW_SYNTAX_ERROR);
 			} else {
 				coreFilePath = args.get(ARG_CORE);
-				if(args.containsKey(ARG_XML)) {
-					ctxroot.execute("open " + coreFilePath + " " + args.get(ARG_XML) , out.getPrintStream());
-				} else {
-					ctxroot.execute("open " + coreFilePath , out.getPrintStream());
-				}
+				ctxroot.execute("open " + coreFilePath , out.getPrintStream());
 			}
 		} else {
 			coreFilePath = args.get(ARG_ZIP);	//if -core has been set it is handled in the first part of this if statement


### PR DESCRIPTION
Removed the -xml parameter from the help message and the supporting code in the file.

Fixes #1193 

Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>