### PR TITLE
Remove hardcoded system property java.util.prefs.PreferencesFactory

### DIFF
--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -202,12 +202,6 @@ addBFUSystemProperties(J9JavaVM* javaVM)
 	}
 #endif
 
-	if (J9SYSPROP_ERROR_NOT_FOUND == vmfunc->getSystemProperty(javaVM, "java.util.prefs.PreferencesFactory", NULL)) {
-		rc = vmfunc->addSystemProperty(javaVM, "java.util.prefs.PreferencesFactory", "java.util.prefs.FileSystemPreferencesFactory", 0);
-		if (J9SYSPROP_ERROR_NONE != rc) {
-			return rc;
-		}
-	}
 	if (fontPathSize >= 0) {
 		if (J9SYSPROP_ERROR_NOT_FOUND == vmfunc->getSystemProperty(javaVM, "sun.java2d.fontpath", NULL)) {
 			rc = vmfunc->addSystemProperty(javaVM, "sun.java2d.fontpath", fontPathBuffer, 0);


### PR DESCRIPTION
Remove hardcoded system property `java.util.prefs.PreferencesFactory`

This only affects `J9VM_UNIX` platforms.

This modification conforms to specification, and allows a `PreferencesFactory` implementation from a `jar` file containing a provider-configuration file named `java.util.prefs.PreferencesFactory` in
the resource directory `META-INF/services` when this system property is not set.

In case neither the system property nor an extension jar file is provided, a default `PreferencesFactory` implementation for the underlying platform is provided. For a platform not `Windows` or `OS X`, a default `PreferencesFactory` is `java.util.prefs.FileSystemPreferencesFactory` which was hardcoded via system property java.util.prefs.PreferencesFactory.

References: https://docs.oracle.com/en/java/javase/11/docs/api/java.prefs/java/util/prefs/Preferences.html - "Implementation Note"
https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9/src/java.prefs/share/classes/java/util/prefs/Preferences.java#L293-L302

Note: Not able to trace back why this system property was hardcoded within `VM`. There are couple of `VmArgumentTests` that verify this system property can be override by command line options, which is irrelevant to this PR. (a person build with this PR still passes the test in question) 
https://github.ibm.com/runtimes/openj9/blob/ibm_sdk/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java#L215-L273

closes: https://github.com/eclipse/openj9/issues/3232 

Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>