### PR TITLE
Supporting changes for Symbol Validation Manager on Z

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1456,13 +1456,20 @@ TR_ResolvedRelocatableJ9Method::isInterpreted()
    {
    bool alwaysTreatAsInterpreted = true;
 #if defined(TR_TARGET_S390)
-   alwaysTreatAsInterpreted = false;
+   TR::Compilation *comp = TR::comp();
+   if (comp && comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager))
+      alwaysTreatAsInterpreted = true;
+   else
+      alwaysTreatAsInterpreted = false;
 #elif defined(TR_TARGET_X86)
 
    /*if isInterpreted should be only overridden for JNI methods.
    Otherwise buildDirectCall in X86PrivateLinkage.cpp will generate CALL 0
    for certain jitted methods as startAddressForJittedMethod still returns NULL in AOT
-   this is not an issue on z as direct calls are dispatched via snippets
+   this is not an issue on z as direct calls are dispatched via snippets.
+   For Z under AOT while using SVM, we do not need to treat all calls unresolved as it was case
+   for oldAOT. So alwaysTreatAsInterpreted is set to true in AOT using SVM so that call snippet
+   can be generated using correct j9method address.
 
    If one of the options to disable JNI is specified
    this function reverts back to the old behaviour

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -204,7 +204,7 @@ J9::Z::CodeGenerator::CodeGenerator() :
 
    const bool accessStaticsIndirectly = !cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z10) ||
          comp->getOption(TR_DisableDirectStaticAccessOnZ) ||
-         comp->compileRelocatableCode();
+         (comp->compileRelocatableCode() && !comp->getOption(TR_UseSymbolValidationManager));
 
    cg->setAccessStaticsIndirectly(accessStaticsIndirectly);
 
@@ -3756,9 +3756,8 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
    const int32_t offsetFromEPRegisterValueToJ9MethodAddress = CalcCodeSize(basrInstruction->getNext(), cursor);
 
    j9MethodAddressMemRef->setOffset(offsetFromEPRegisterValueToJ9MethodAddress);
-
-   // Symbol reference is NULL as we don't use it when adding ExternalRelocation for J9Method
-   encodingRelocation = new (self()->trHeapMemory()) TR::S390EncodingRelocation(TR_RamMethod, NULL);
+   TR::SymbolReference *methodSymRef = new (self()->trHeapMemory()) TR::SymbolReference(self()->symRefTab(), methodSymbol);
+   encodingRelocation = new (self()->trHeapMemory()) TR::S390EncodingRelocation(TR_RamMethod, methodSymRef);
 
    AOTcgDiag2(comp, "Add encodingRelocation = %p reloType = %p\n", encodingRelocation, encodingRelocation->getReloType());
 

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2422,7 +2422,7 @@ TR::S390PrivateLinkage::buildDirectCall(TR::Node * callNode, TR::SymbolReference
       TR::LabelSymbol * label = generateLabelSymbol(cg());
       TR::Snippet * snippet;
 
-      if (callSymRef->isUnresolved() || comp()->compileRelocatableCode())
+      if (callSymRef->isUnresolved() || (comp()->compileRelocatableCode() && !comp()->getOption(TR_UseSymbolValidationManager)))
          {
          snippet = new (trHeapMemory()) TR::S390UnresolvedCallSnippet(cg(), callNode, label, argSize);
          }

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,16 +53,44 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
    if (_reloType==TR_ClassAddress)
       {
       AOTcgDiag2(  comp, "TR_ClassAddress cursor=%x symbolReference=%x\n", cursor, _symbolReference);
+      if (cg->comp()->getOption(TR_UseSymbolValidationManager))
+         {
+         TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock*)(*((uintptrj_t*)cursor));
+         TR_ASSERT_FATAL(clazz, "TR_ClassAddress relocation : cursor = %x, clazz can not be null", cursor);
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, 
+                                                                           (uint8_t *)clazz, 
+                                                                           (uint8_t *) TR::SymbolType::typeClass,
+                                                                           TR_SymbolFromManager,
+                                                                           cg),
+                                                                        file, line, node);
 
-      *((uintptrj_t*)cursor)=fej9->getPersistentClassPointerFromClassPointer((TR_OpaqueClassBlock*)(*((uintptrj_t*)cursor)));
-      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_ClassAddress, cg),
-                              file, line, node);
+         }
+      else
+         {
+         *((uintptrj_t*)cursor)=fej9->getPersistentClassPointerFromClassPointer((TR_OpaqueClassBlock*)(*((uintptrj_t*)cursor)));
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) _symbolReference, (uint8_t *)_inlinedSiteIndex, TR_ClassAddress, cg),
+                           file, line, node);
+         }
       }
    else if (_reloType==TR_RamMethod)
       {
       AOTcgDiag1(  comp, "TR_RamMethod cursor=%x\n", cursor);
-      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg), file, line, node);
-
+      if (cg->comp()->getOption(TR_UseSymbolValidationManager))
+         {
+         TR::ResolvedMethodSymbol *methodSym = (TR::ResolvedMethodSymbol*) _symbolReference->getSymbol();
+         uint8_t * j9Method = (uint8_t *) (reinterpret_cast<intptrj_t>(methodSym->getResolvedMethod()->resolvedMethodAddress()));
+         TR_ASSERT_FATAL(j9Method, "TR_RamMethod relocation : cursor = %x, j9Method can not be null", cursor);
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, 
+                                                                           j9Method, 
+                                                                           (uint8_t *) TR::SymbolType::typeMethod,
+                                                                           TR_SymbolFromManager,
+                                                                           cg),
+                                                                        file, line, node);
+         }
+      else
+         {
+         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg), file, line, node);
+         }
       }
    else if (_reloType==TR_HelperAddress)
       {


### PR DESCRIPTION
This commit contains following changes.
1. In AOT compiled method call are made through snippet which is generated
   through J9CallSnippet which needs ramMethod address for the method. As
   under SVM we do not tread method call unresolved always, we need to make
   sure we have correct ramMethod for methods that are resolved for which we
   need to set alwaysTreatAsInterpreted to true if it is using SVM under AOT.

2. In AOT while using SVM it can access statics direcly. Do not need to set it
   to false.

3. Update S390AOTRelocation to use SVM
   On Z, for data constant snippet, it uses S390AOTRelocation as
   a manager to add relocations according to relocation type.
   Update this manager to use SVM for ClassAddress and RamMethod.

4. Update call dispatch sequence for SVM
   Under SVM, we do not need to consider all calls
   unresolved. So under AOT generate Unresolved call
   snippet only when it is not using SVM.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>