### PR TITLE
Exclude test variants of testSoftMxDisclaimMemory

### DIFF
--- a/test/functional/JLM_Tests/playlist.xml
+++ b/test/functional/JLM_Tests/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -614,7 +614,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^arch.390</platformRequirements>
+		<platformRequirements>^arch.390,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -711,7 +711,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^arch.ppc,^arch.390</platformRequirements>
+		<platformRequirements>^arch.ppc,^arch.390,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -780,7 +780,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^arch.390</platformRequirements>
+		<platformRequirements>^arch.390,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -878,7 +878,7 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^os.zos,^os.linux_390</platformRequirements>
+		<platformRequirements>^os.zos,^os.linux_390,^os.osx</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Tests, which use j9vm.test.softmx.SoftmxAdvanceTest, have been disabled
on OSX. These tests will be re-enabled once SoftmxAdvanceTest is updated
to work properly on OSX.

Issue: #4090

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>