### PR TITLE
Fix jep178_staticLinking test on OSX

### DIFF
--- a/runtime/tests/redirector/jep178/testjep178.h
+++ b/runtime/tests/redirector/jep178/testjep178.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,9 +48,13 @@
 #if defined(WIN32)
 #define J9PATH_DIRECTORY_SEPARATOR '\\'
 #define J9PATH_JVM_LIBRARY "jvm.dll"
-#else
+#else /* defined(WIN32) */
 #define J9PATH_DIRECTORY_SEPARATOR '/'
+#if defined(OSX)
+#define J9PATH_JVM_LIBRARY "libjvm.dylib"
+#else /* defined(OSX) */
 #define J9PATH_JVM_LIBRARY "libjvm.so"
-#endif
+#endif /* defined(OSX) */
+#endif /* defined(WIN32) */
 
 #endif /* !defined(_testjep178_h_) */


### PR DESCRIPTION
Shared libraries use ".dylib" as the file extension on OSX. The test
works once "libjvm.so" is changed to "libjvm.dylib".

Closes: #4316.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>