### PR TITLE
Enable String.indexOf transformation for JITaaS

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -975,6 +975,20 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(fe->dereferenceStaticFinalAddress(address, addressType));
          }
          break;
+      case J9ServerMessageType::VM_getStringLength:
+         {
+         auto recv = client->getRecvData<uintptrj_t>();
+         client->write(fe->getStringLength(std::get<0>(recv)));
+         }
+         break;
+      case J9ServerMessageType::VM_getStringCharacter:
+         {
+         auto recv = client->getRecvData<uintptrj_t, int32_t>();
+         uintptrj_t objectPointer = std::get<0>(recv);
+         int32_t index = std::get<1>(recv);
+         client->write(fe->getStringCharacter(objectPointer, index));
+         }
+         break;
       case J9ServerMessageType::mirrorResolvedJ9Method:
          {
          // allocate a new TR_ResolvedRelocatableJ9Method on the heap, to be used as a mirror for performing actions which are only

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1417,3 +1417,18 @@ TR_J9ServerVM::dereferenceStaticFinalAddress(void *staticAddress, TR::DataType a
    return it->second;
    }
 
+int32_t
+TR_J9ServerVM::getStringLength(uintptrj_t objectPointer)
+   {
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITaaS::J9ServerMessageType::VM_getStringLength, objectPointer);
+   return std::get<0>(stream->read<int32_t>());
+   }
+
+uint16_t
+TR_J9ServerVM::getStringCharacter(uintptrj_t objectPointer, int32_t index)
+   {
+   JITaaS::J9ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITaaS::J9ServerMessageType::VM_getStringCharacter, objectPointer, index);
+   return std::get<0>(stream->read<uint16_t>());
+   }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -165,6 +165,8 @@ public:
    virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;
    virtual TR_IProfiler *getIProfiler() override;
    virtual TR_StaticFinalData dereferenceStaticFinalAddress(void *staticAddress, TR::DataType addressType) override;
+   virtual int32_t getStringLength(uintptrj_t objectPointer) override;
+   virtual uint16_t getStringCharacter(uintptrj_t objectPointer, int32_t index) override;
    };
 
 #endif // VMJ9SERVER_H

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -515,7 +515,7 @@ J9::TransformUtil::transformStringIndexOfCall(TR::Compilation * comp, TR::Node *
                                                                     TR::VMAccessCriticalSection::tryToAcquireVMAccess,
                                                                     comp);
 
-   if (!transformStringIndexCriticalSection.hasVMAccess())
+   if (!transformStringIndexCriticalSection.hasVMAccess() && !comp->isOutOfProcessCompilation())
       return callNode;
 
    uintptrj_t stringStaticAddr = (uintptrj_t)needle->getSymbol()->castToStaticSymbol()->getStaticAddress();

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -211,6 +211,8 @@ enum J9ServerMessageType
    VM_getVMInfo = 301;
    VM_isAnonymousClass = 302;
    VM_dereferenceStaticAddress = 303;
+   VM_getStringLength = 304;
+   VM_getStringCharacter = 305;
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled = 400;


### PR DESCRIPTION
`J9TransformUtil::transformStringIndexofCall` was not working, because `criticalsection.hasVMAccess()` always returns false on the server, which aborts this transformation.
Enable this transformation by continuing without VM access in JITaaS, and overriding front-end `getStringLength` and `getStringCharacter` for the server