### PR TITLE
Respect resolving static method low-tag on X86-32

### DIFF
--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -185,9 +185,12 @@ interpreterUnresolvedStaticGlue:
       push        edi                                       ; The RET will mispredict anyway so we can get away with pushing
                                                             ; the adjusted RA back on the stack.
 
-      ; The interpreter may low-tag the result to avoid populating the constant pool--whack it.
+      ; The interpreter may low-tag the result to avoid populating the constant pool -- whack it and record in CF.
       ;
-      and         eax, -2
+      btr         eax, 0
+
+      ; Skip code patching if the interpreter low-tag the RAM mathod
+      jc          .fin
 
       ; Patch the call that brought us here into a load of the resolved RAM method into EDI.
       ;
@@ -201,6 +204,7 @@ interpreterUnresolvedStaticGlue:
       movdqu      xmm0, [esp+8]
       add         esp, 24                                   ; 24 = 16 + 4*2 (for two pushes)
 
+   .fin:
       ; Load the resolved RAM method into EDI so that the caller doesn't have to re-run patched code
       mov         edi, eax
       ret

--- a/runtime/compiler/x/runtime/X86Unresolveds.pasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.pasm
@@ -193,9 +193,16 @@ interpreterUnresolvedStaticGlue proc near
       push        edi                                          ; The RET will mispredict anyway so we can get away with pushing
                                                                ; the adjusted RA back on the stack.
 
-      ; The interpreter may low-tag the result to avoid populating the constant pool--whack it.
+      ; The interpreter may low-tag the result to avoid populating the constant pool -- whack it and record in CF.
       ;
-      and         eax, -2
+      btr         eax, 0
+
+      ; Skip code patching if the interpreter low-tag the RAM mathod
+ifdef WINDOWS
+      jc          @@fin
+else
+      jc          0f
+endif
 
       ; Patch the call that brought us here into a load of the resolved RAM method into EDI.
       ;
@@ -209,6 +216,11 @@ interpreterUnresolvedStaticGlue proc near
       movdqu      xmm0, [esp+8]
       add         esp, 24                                      ; 24 = 16 + 4*2 (for two pushes)
 
+ifdef WINDOWS
+   @@fin:
+else
+   0:
+endif
       ; Load the resolved RAM method into EDI so that the caller doesn't have to re-run patched code
       mov         edi, eax
       ret


### PR DESCRIPTION
Interpreter may low-tag the RAM method when resolving static method.
When the lowest bit is set, JIT should skip code patch.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>