### PR TITLE
Enable NASM assembler on x86 Linux and Windows

### DIFF
--- a/runtime/compiler/build/files/host/i386.mk
+++ b/runtime/compiler/build/files/host/i386.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,7 +18,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 
+ifeq ($(NASM_ASSEMBLER),yes)
+JIT_PRODUCT_SOURCE_FILES+=\
+    compiler/x/i386/runtime/IA32Recompilation.nasm \
+    compiler/x/i386/runtime/J9IA32CompressString.nasm \
+    compiler/x/i386/runtime/J9IA32Math64.nasm
+else
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/x/i386/runtime/IA32Recompilation.asm \
     compiler/x/i386/runtime/J9IA32CompressString.asm \
     compiler/x/i386/runtime/J9IA32Math64.asm
+endif

--- a/runtime/compiler/build/platform/host/amd64-linux-gcc.mk
+++ b/runtime/compiler/build/platform/host/amd64-linux-gcc.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,3 +24,4 @@ HOST_BITS=32
 OS=linux
 C_COMPILER=gcc
 TOOLCHAIN=gnu
+NASM_ASSEMBLER=yes

--- a/runtime/compiler/build/platform/host/ia32-win32-mvs.mk
+++ b/runtime/compiler/build/platform/host/ia32-win32-mvs.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2017 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,3 +23,4 @@ HOST_SUBARCH=i386
 HOST_BITS=32
 OS=win
 TOOLCHAIN=win-msvc
+NASM_ASSEMBLER=yes

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1231,11 +1231,19 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_AMD64induceRecompilation,             (void *)_induceRecompilation,     TR_Helper);
 #endif /* NASM_ASSEMBLER */
 #else /* TR_HOST_64BIT */
+#if defined(NASM_ASSEMBLER)
+   SET(TR_IA32samplingRecompileMethod,          (void *)samplingRecompileMethod, TR_Helper);
+   SET(TR_IA32countingRecompileMethod,          (void *)countingRecompileMethod, TR_Helper);
+   SET(TR_IA32samplingPatchCallSite,            (void *)samplingPatchCallSite,   TR_Helper);
+   SET(TR_IA32countingPatchCallSite,            (void *)countingPatchCallSite,   TR_Helper);
+   SET(TR_IA32induceRecompilation,              (void *)induceRecompilation,     TR_Helper);
+#else
    SET(TR_IA32samplingRecompileMethod,          (void *)_samplingRecompileMethod, TR_Helper);
    SET(TR_IA32countingRecompileMethod,          (void *)_countingRecompileMethod, TR_Helper);
    SET(TR_IA32samplingPatchCallSite,            (void *)_samplingPatchCallSite,   TR_Helper);
    SET(TR_IA32countingPatchCallSite,            (void *)_countingPatchCallSite,   TR_Helper);
    SET(TR_IA32induceRecompilation,              (void *)_induceRecompilation,     TR_Helper);
+#endif /* NASM_ASSEMBLER */
 #endif /* TR_HOST_64BIT */
 
 #elif defined(TR_HOST_POWER)

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -414,10 +414,29 @@ JIT_HELPER(methodHandleJ2I_unwrapper);
 //                                    IA32
 // --------------------------------------------------------------------------------
 
-#else // HOST64_BIT
+#else /* TR_HOST_64BIT */
+#if defined(NASM_ASSEMBLER)
+JIT_HELPER(longDivide);
+JIT_HELPER(longRemainder);
+
+
+JIT_HELPER(X87doubleRemainder);
+JIT_HELPER(X87floatRemainder);
+
+JIT_HELPER(SSEfloatRemainderIA32Thunk);
+JIT_HELPER(SSEdoubleRemainderIA32Thunk);
+JIT_HELPER(SSEdouble2LongIA32);
+
+JIT_HELPER(compressString);
+JIT_HELPER(compressStringNoCheck);
+JIT_HELPER(compressStringJ);
+JIT_HELPER(compressStringNoCheckJ);
+JIT_HELPER(andORString);
+JIT_HELPER(encodeUTF16Big);
+JIT_HELPER(encodeUTF16Little);
+#else /* NASM_ASSEMBLER */
 JIT_HELPER(_longDivide);
 JIT_HELPER(_longRemainder);
-JIT_HELPER(SMPVPicInit);
 
 JIT_HELPER(_X87doubleRemainder);
 JIT_HELPER(_X87floatRemainder);
@@ -433,9 +452,10 @@ JIT_HELPER(_compressStringNoCheckJ);
 JIT_HELPER(_andORString);
 JIT_HELPER(_encodeUTF16Big);
 JIT_HELPER(_encodeUTF16Little);
+#endif /* NASM_ASSEMBLER */
 
+JIT_HELPER(SMPVPicInit);
 JIT_HELPER(resolveAndPopulateVTableDispatch);
-
 JIT_HELPER(interpreterEAXStaticGlue);
 JIT_HELPER(interpreterEDXEAXStaticGlue);
 JIT_HELPER(interpreterST0FStaticGlue);
@@ -445,7 +465,7 @@ JIT_HELPER(interpreterSyncEAXStaticGlue);
 JIT_HELPER(interpreterSyncEDXEAXStaticGlue);
 JIT_HELPER(interpreterSyncST0FStaticGlue);
 JIT_HELPER(interpreterSyncST0DStaticGlue);
-#endif
+#endif /* TR_HOST_64BIT */
 
 #elif defined(TR_HOST_POWER)
 JIT_HELPER(__longDivide);
@@ -1282,9 +1302,13 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 #else // AMD64
 
    // -------------------------------- IA32 ------------------------------------
-
+#if defined(NASM_ASSEMBLER)
+   SET(TR_IA32longDivide,                             (void *)longDivide,               TR_Helper);
+   SET(TR_IA32longRemainder,                          (void *)longRemainder,            TR_Helper);
+#else
    SET(TR_IA32longDivide,                             (void *)_longDivide,               TR_Helper);
    SET(TR_IA32longRemainder,                          (void *)_longRemainder,            TR_Helper);
+#endif
 
    SET(TR_X86interpreterVoidStaticGlue,               (void *)interpreterVoidStaticGlue,       TR_Helper);
    SET(TR_X86interpreterIntStaticGlue,                (void *)interpreterEAXStaticGlue,        TR_Helper);
@@ -1301,14 +1325,36 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 
    SET(TR_IA32jitCollapseJNIReferenceFrame,           (void *)jitCollapseJNIReferenceFrame,    TR_Helper);
 
+#if defined(NASM_ASSEMBLER)
+   SET(TR_IA32floatRemainder,                         (void *)X87floatRemainder,  TR_Helper);
+   SET(TR_IA32doubleRemainder,                        (void *)X87doubleRemainder, TR_Helper);
+
+   SET(TR_IA32floatRemainderSSE,                      (void *)SSEfloatRemainderIA32Thunk,  TR_Helper);
+   SET(TR_IA32doubleRemainderSSE,                     (void *)SSEdoubleRemainderIA32Thunk, TR_Helper);
+   SET(TR_IA32double2LongSSE,                         (void *)SSEdouble2LongIA32, TR_Helper);
+
+   SET(TR_IA32doubleToLong,                           (void *)doubleToLong, TR_Helper);
+   SET(TR_IA32doubleToInt,                            (void *)doubleToInt,  TR_Helper);
+   SET(TR_IA32floatToLong,                            (void *)floatToLong,  TR_Helper);
+   SET(TR_IA32floatToInt,                             (void *)floatToInt,   TR_Helper);
+
+   SET(TR_IA32compressString,                         (void *)compressString,            TR_Helper);
+   SET(TR_IA32compressStringNoCheck,                  (void *)compressStringNoCheck,     TR_Helper);
+   SET(TR_IA32compressStringJ,                        (void *)compressStringJ,           TR_Helper);
+   SET(TR_IA32compressStringNoCheckJ,                 (void *)compressStringNoCheckJ,    TR_Helper);
+   SET(TR_IA32andORString,                            (void *)andORString,               TR_Helper);
+   SET(TR_IA32arrayTranslateTRTO,                     (void *)arrayTranslateTRTO,        TR_Helper);
+   SET(TR_IA32arrayTranslateTROTNoBreak,              (void *)arrayTranslateTROTNoBreak, TR_Helper);
+   SET(TR_IA32arrayTranslateTROT,                     (void *)arrayTranslateTROT,        TR_Helper);
+   SET(TR_IA32encodeUTF16Big,                         (void *)encodeUTF16Big,            TR_Helper);
+   SET(TR_IA32encodeUTF16Little,                      (void *)encodeUTF16Little,         TR_Helper);
+#else
    SET(TR_IA32floatRemainder,                         (void *)_X87floatRemainder,  TR_Helper);
    SET(TR_IA32doubleRemainder,                        (void *)_X87doubleRemainder, TR_Helper);
 
    SET(TR_IA32floatRemainderSSE,                      (void *)_SSEfloatRemainderIA32Thunk,  TR_Helper);
    SET(TR_IA32doubleRemainderSSE,                     (void *)_SSEdoubleRemainderIA32Thunk, TR_Helper);
-#ifndef TR_HOST_64BIT
    SET(TR_IA32double2LongSSE,                         (void *)_SSEdouble2LongIA32, TR_Helper);
-#endif
 
    SET(TR_IA32doubleToLong,                           (void *)_doubleToLong, TR_Helper);
    SET(TR_IA32doubleToInt,                            (void *)_doubleToInt,  TR_Helper);
@@ -1325,8 +1371,9 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_IA32arrayTranslateTROT,                     (void *)_arrayTranslateTROT,        TR_Helper);
    SET(TR_IA32encodeUTF16Big,                         (void *)_encodeUTF16Big,            TR_Helper);
    SET(TR_IA32encodeUTF16Little,                      (void *)_encodeUTF16Little,         TR_Helper);
+#endif
 
-   SET(TR_jitAddPicToPatchOnClassUnload,              (void *) jitAddPicToPatchOnClassUnload, TR_Helper);
+   SET(TR_jitAddPicToPatchOnClassUnload,              (void *)jitAddPicToPatchOnClassUnload, TR_Helper);
    SET(TR_IA32interpreterUnresolvedVTableSlotGlue,    (void *)resolveAndPopulateVTableDispatch, TR_Helper);
 
    SET(TR_IA32JitMonitorEnterReserved,                    (void *)jitMonitorEnterReserved,                    TR_CHelper);

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -64,7 +64,7 @@ extern "C" {
  * is set for OS variants that currently use NASM and is used to
  * decide the version of helper names to use.
  */
-#if defined(TR_HOST_X86) && defined(TR_HOST_64BIT)
+#if (defined(TR_HOST_X86) && defined(TR_HOST_64BIT)) || defined (WINDOWS) // enable across x86-64 and 32bit Windows
 #define NASM_ASSEMBLER
 #endif
 

--- a/runtime/compiler/runtime/asmprotos.h
+++ b/runtime/compiler/runtime/asmprotos.h
@@ -64,7 +64,7 @@ extern "C" {
  * is set for OS variants that currently use NASM and is used to
  * decide the version of helper names to use.
  */
-#if (defined(TR_HOST_X86) && defined(TR_HOST_64BIT)) || defined (WINDOWS) // enable across x86-64 and 32bit Windows
+#if defined(TR_HOST_X86)
 #define NASM_ASSEMBLER
 #endif
 

--- a/runtime/compiler/x/i386/runtime/IA32CompressString_nasm.inc
+++ b/runtime/compiler/x/i386/runtime/IA32CompressString_nasm.inc
@@ -1,0 +1,246 @@
+; Copyright (c) 2000, 2019 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+segment .text
+
+                DECLARE_GLOBAL  compressString
+                DECLARE_GLOBAL  compressStringJ
+                DECLARE_GLOBAL  compressStringNoCheck
+                DECLARE_GLOBAL  compressStringNoCheckJ
+                DECLARE_GLOBAL  andORString
+                align   16
+;
+; A c-style memmove with no assumptions on the element size
+; or copy direction required.
+; ecx has length of copy in bytes
+; esi has source address
+; edi has destination address
+compressStringJ:
+        SHR  ECX, 4
+        ADD  ESI, EAX
+        ADD  ESI, EAX
+        MOV  EDX, 0
+eightcharsJ:
+        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        OR   EDX, EBX
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI], EAX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EAX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        OR   EDX, EBX
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI+4], EAX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+16]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, DWORD  [ESI+20]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        OR   EDX, EBX
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI+8], EAX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+24]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EAX, DWORD  [ESI+28]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        OR   EDX, EBX
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI+12], EAX			; write the low 2 bytes of the 4 byte value in the destination
+
+
+        ADD  EDI, 16
+        ADD  ESI, 32		
+        LOOP eightcharsJ
+        AND  EDX, 0ff80ff80h
+        MOV  EAX, EDX
+                ret
+;
+
+compressString:
+        SHR  ECX, 3
+        ADD  ESI, EAX
+        ADD  ESI, EAX
+        MOV  EDX, 0
+eightchars:
+        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI+2], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI+4], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EDX, EAX				;
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI+6], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        ADD  EDI, 8
+        ADD  ESI, 16		
+        LOOP eightchars
+        AND  EDX, 0ff80ff80h
+        MOV  EAX, EDX
+                ret
+;
+
+
+
+andORString:
+        SHR  ECX, 4
+        ADD  ESI, EAX
+        ADD  ESI, EAX
+        MOV  EBX, 0
+        MOV  EDX, 0ffffffffh
+eightchars2:
+        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+16]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+20]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+24]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        MOV  EAX, DWORD  [ESI+28]  		; load 4 bytes from the source array into EAX (2 chars)
+        OR   EBX, EAX
+        AND  EDX, EAX
+        ADD  ESI, 32		
+        LOOP eightchars2
+
+        MOV  EAX, EBX
+        SHL  EAX, 16
+        OR   EBX, EAX
+        SHR  EBX, 16
+        
+        MOV  EAX, EDX
+        SHL  EAX, 16
+        AND  EAX, EDX
+
+        OR   EAX, EBX		; AND is in the high word and OR is in the low word.
+        MOV  EDX, EAX
+                ret
+;
+
+
+compressStringNoCheckJ:
+        SHR  ECX, 4
+        ADD  ESI, EAX
+        ADD  ESI, EAX
+eightcharsNoCheckJ:
+
+        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI], EAX			; write the low 2 bytes of the 4 byte value in the destination
+        
+        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI+4], EAX			; write the low 2 bytes of the 4 byte value in the destination
+        
+        MOV  EAX, DWORD  [ESI+16]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, DWORD  [ESI+20]  		; load 4 bytes from the source array into EAX (2 chars)
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI+8], EAX			; write the low 2 bytes of the 4 byte value in the destination
+        
+        MOV  EAX, DWORD  [ESI+24]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, DWORD  [ESI+28]  		; load 4 bytes from the source array into EAX (2 chars)
+        SHL  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  DWORD  [EDI+12], EAX			; write the low 2 bytes of the 4 byte value in the destination
+
+        ADD  EDI, 16
+        ADD  ESI, 32		
+        LOOP eightcharsNoCheckJ
+                ret
+;
+
+
+compressStringNoCheck:
+        SHR  ECX, 3
+        ADD  ESI, EAX
+        ADD  ESI, EAX
+eightcharsNoCheck:
+        MOV  EAX, DWORD  [ESI]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+4]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI+2], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+8]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI+4], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        MOV  EAX, DWORD  [ESI+12]  		; load 4 bytes from the source array into EAX (2 chars)
+        MOV  EBX, EAX					; copy the loaded value
+        SHR  EBX, 8					; shift right by 8
+        OR   EAX, EBX					; or the 2 values
+        MOV  WORD  [EDI+6], AX			; write the low 2 bytes of the 4 byte value in the destination
+
+        ADD  EDI, 8
+        ADD  ESI, 16		
+        LOOP eightcharsNoCheck
+                ret
+;
+

--- a/runtime/compiler/x/i386/runtime/IA32Math64_nasm.inc
+++ b/runtime/compiler/x/i386/runtime/IA32Math64_nasm.inc
@@ -1,0 +1,398 @@
+; Copyright (c) 2000, 2019 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+	
+      
+        %include "jilconsts.inc"
+
+segment .text
+
+        DECLARE_GLOBAL longDivide
+        DECLARE_GLOBAL longRemainder
+        DECLARE_GLOBAL jitMathHelpersDivideBegin
+        DECLARE_GLOBAL jitMathHelpersDivideEnd
+        DECLARE_GLOBAL jitMathHelpersRemainderBegin
+        DECLARE_GLOBAL jitMathHelpersRemainderEnd
+;
+      align    16
+longRemainder:
+jitMathHelpersRemainderBegin:
+      ; divides two signed 64-bit numbers and returns the remainder.
+      ;
+      ; In: [ESP+8]:[ESP+4] = dividend
+      ; [ESP+16]:[ESP+12] = divisor
+      ;
+      ; OUTPUT: EDX:EAX = remainder of division
+
+      push    ebx                                 ; scratch registers
+      push    ecx                                 ; ebx, ecx, edi, esi
+      push    edi                                 ; esi is preserved later
+      
+      mov     ecx, dword  [esp+28]             ; divisor-hi
+      mov     ebx, dword  [esp+24]             ; divisor-lo
+      mov     edx, ecx                            ; check to see if we are 
+      or      edx, ebx                            ; going to throw div/0            
+      jz      zero_remainder                      ; exception
+      mov     edx, dword  [esp+20]             ; dividend-hi
+      mov     eax, dword  [esp+16]             ; dividend-lo
+                                                        
+      cmp     edx, -1                             ; check the exception case MIN_INT/-1
+      jz      short high_dividend_neg_one         ; handle that separately
+
+      test    eax, eax                            ; and other simple cases 
+      jnz     short perform_remainder             ; when dividing with -1
+      cmp     edx, 080000000h
+      jnz     short perform_remainder
+      mov     eax, ecx
+      and     eax, ebx
+      not     eax
+      test    eax, eax
+      mov     eax, 0h
+      jnz     short perform_remainder
+      jmp     short return_eax
+      
+high_dividend_neg_one:                        
+      cmp     eax, 080000000h           
+      jb      short perform_remainder
+      cmp     ebx, -1
+      jnz     short perform_remainder
+      cmp     ecx, -1
+      jnz     short perform_remainder
+      xor     eax, eax
+      
+return_eax:
+      cdq                                         ; extend the sign
+      pop     edi                                 ; restore the scratch registers
+      pop     ecx                                 ; edi, ecx, ebx
+      pop     ebx
+      ret     16
+            
+perform_remainder:                                ; main remainder entry point
+      push    esi                                 ; the VM assumes 3 slots for exception handling
+                                                  ; saving the 4th scratch register (esi) now when we
+                                                  ; can't throw exception
+      
+      mov     esi, edx                            ; the sign of the remainder is the sign of the dividend
+      sar     esi, 31                             ; save that value in esi
+      xor     eax, esi                            ; if dividend is < 0
+      xor     edx, esi                            ; compute 1's complement of dividend
+      sub     eax, esi                            ; if dividend is < 0
+      sbb     edx, esi                            ; compute 2's complement of dividend
+      mov     edi, ecx                            ; compute the sign of the divisor
+      sar     edi, 31                             ; save that in edi
+      xor     ebx, edi                            ; if divisor is < 0
+      xor     ecx, edi                            ; compute 1's complement of divisor
+      sub     ebx, edi                            ; if divisor is < 0
+      sbb     ecx, edi                            ; compute 2's complement of divisor
+      
+      jnz     long_long_rem                       ; if divisor is greater than 32bit value do long remainder
+      
+      cmp     edx, ebx                            ; Is this remainder with integer values
+      jae     long_int_rem                        ; No, we have long remainder with integer divisor
+                                                  ; Fallthrough, Yes, we can live with one division only Int%Int
+      div     ebx                                 ; EAX = quotient low
+      mov     eax, edx                            ; EAX = remainder low
+      mov     edx, ecx                                
+      xor     eax, esi                            ; Use the remembered sign in esi
+      xor     edx, esi                            ; to set the sign of the remainder
+      sub     eax, esi                            ; by computing 1's and 2's complement
+      sbb     edx, esi                                
+      
+      pop     esi                                 ; restore the scratch registers
+      pop     edi                                 ; edi, ecx, ebx, esi
+      pop     ecx 
+      pop     ebx 
+      
+      ret     16
+      
+long_int_rem:
+      mov     ecx, eax                            ; spill divident low in ecx, we'll do that div later
+      mov     eax, edx                            ; setup division of the high word 
+      xor     edx, edx                            ; zero extend it into edx
+      div     ebx                                 ; eax = quotient high, edx = intermediate result
+      mov     eax, ecx                            ; restore divident low, edx to be used from the previous div
+      div     ebx                                 ; eax = quotient low, edx = remainder low
+      mov     eax, edx                            ; copy the result into eax, and zero out the high result
+      xor     edx, edx                            ; remainder high = 0
+      jmp     sign_rem                            ; make remainder signed based on sign registers esi, edi
+
+long_long_rem:
+                                                  ; test for ugly edge cases that cause overflow
+      cmp     edx, ecx
+      jbe     test_for_edge_cases
+
+      cmp     eax, 0ffffffffh                     ; test for MAX_LONG divident
+      jne     long_long_rem_begin
+      cmp     edx, 07fffffffh
+      je      very_slow_path                      ; if it's MAX_LONG do the slow loop
+      
+long_long_rem_begin:                              ; the following algorithm is based on the
+                                                  ; AMD opteron optimization guide
+
+      sub     esp, 16                             ; make room for four spills
+      mov     dword  [esp], eax                ; save dividend low
+      mov     dword  [esp+4], ebx              ; save divisor low
+      mov     dword  [esp+8], edx              ; save dividend high
+      mov     dword  [esp+12], ecx             ; save divisor high
+      mov     edi, ecx                            ; spill divisor high
+      shr     edx, 1                              ; shift right by 1 both
+      rcr     eax, 1                              ; divisor and
+      ror     edi, 1                              ; and dividend
+      rcr     ebx, 1                     
+      bsr     ecx, ecx                            ; ecx = number of remaining shifts
+      shrd    ebx, edi, cl                        ; scale down divisor and
+      shrd    eax, edx, cl                        ; dividend such that divisor is
+      shr     edx, cl                             ; less than 2^32 (that is, fits in EBX)
+      rol     edi, 1                              ; restore original divisor high
+      div     ebx                                 ; compute quotient
+      mov     ebx, dword  [esp]                ; restore dividend low
+      mov     ecx, eax                            ; save quotient
+      imul    edi, eax                            ; quotient * divisor high word (low only)
+      mul     dword  [esp+4]                   ; quotient * divisor low word
+      add     edx, edi                            ; edx:eax = quotient * divisor
+      sub     ebx, eax                            ; dividend low - (quotient * divisor low)
+      mov     ecx, dword  [esp+8]              ; dividend high
+      sbb     ecx, edx                            ; subtract divisor * quotient from dividend.
+      sbb     eax, eax                            ; remainder < 0 ? 0xffffffff : 0
+      mov     edx, dword  [esp+12]             ; divisor high
+      and     edx, eax                            ; remainder < 0 ? divisor high : 0
+      and     eax, dword  [esp+4]              ; remainder < 0 ? divisor low : 0
+      add     eax, ebx                            ; remainder low
+      adc     edx, ecx                            ; remainder high
+      add     esp, 16                             ; restore stack shape
+
+sign_rem:
+
+      xor     eax, esi                            ; if remainder is < 0,
+      xor     edx, esi                            ; compute 1's complement of result.
+      sub     eax, esi                            ; if remainder is < 0,
+      sbb     edx, esi                            ; compute 2's complement of result.
+      
+exit_rem_4regs:      
+      pop     esi                                 ; restore the scratch registers
+      pop     edi                                 ; edi, ecx, ebx, esi
+      pop     ecx
+      pop     ebx
+
+      ret     16
+
+zero_remainder:
+      div     edx                                 ; cause div / 0 exception
+      
+      pop     edi                                 ; restore the scratch registers
+      pop     ecx                                 ; edi, ecx, ebx
+      pop     ebx
+      ret     16
+      
+test_for_edge_cases:
+                                                  ; divident highword is smaller or equal to divisor highword
+      jb      short long_remainder_end            ; we are done very quickly if divident is smaller than divisor
+      cmp     eax, ebx                            ; divident highword is the same as divisor highword
+      jb      short long_remainder_end            ; check if divident is smaller than divisor using low word
+      ja      short long_long_rem_begin           ; divisor is smaller than divident go divide
+      xor     edx, edx                            ; divident and divisor are equal
+      xor     eax, eax                            ; remainder is 0
+long_remainder_end:
+
+      test    esi, esi                            ; divident is smaller than divisor
+      jz      short exit_rem_4regs                ; remainder is the divident, just make sure we set the sign right
+      neg     eax
+      adc     edx, 0
+      neg     edx
+      jmp     short exit_rem_4regs                ; done making the sign, return
+
+
+very_slow_path:
+
+      push    ebp                                 ; save some extra registers
+      push    esi                                 ; ebp and the two sign spill registers
+      push    edi
+      
+      xor     esi, esi
+      xor     ebp, ebp
+      mov     edi, ebx
+      mov     bl, 40h
+      
+long_rem_loop:
+      shl     eax, 1
+      rcl     edx, 1
+      rcl     esi, 1
+      rcl     ebp, 1
+      cmp     ebp, ecx
+      ja      short lrem_div_too_big
+      jb      short lrem_next_iter
+      cmp     esi, edi
+      jb      short lrem_next_iter
+       
+lrem_div_too_big:
+      sub     esi, edi
+      sbb     ebp, ecx
+       
+lrem_next_iter:
+      dec     bl
+      jnz     short long_rem_loop
+      mov     eax, esi
+      mov     edx, ebp
+      
+lrem_path_end:
+      pop     edi
+      pop     esi
+      pop     ebp                                 ; restore register state and jump
+      jmp     sign_rem                            ; to set the sign
+                  
+jitMathHelpersRemainderEnd:
+ret
+
+
+;
+; longDivide divides two signed 64-bit numbers and delivers the quotient
+;
+; INPUT: [ESP+8]:[ESP+4] dividend
+; [ESP+16]:[ESP+12] divisor
+;
+; OUTPUT: EDX:EAX quotient of division
+
+       align 16
+longDivide:
+jitMathHelpersDivideBegin:
+	mov edx, dword [esp + 12]
+	or  edx, dword [esp + 16]
+	jz  _zero_divisor
+	push ebx 				; save ebx as per private linkage
+	push esi 				; save esi as per private linkage
+	push ecx 				; save ecx as per private linkage
+	push edi 				; save edi as per private linkage
+	mov ecx, [esp+32] 			; divisor-hi
+	mov ebx, [esp+28] 			; divisor-lo
+	mov edx, [esp+24] 			; dividend-hi
+	mov eax, [esp+20] 			; dividend-lo
+
+	mov esi, ecx 				;divisor-hi
+	xor esi, edx 				;divisor-hi ^ dividend-hi
+	sar esi, 31 				;(quotient < 0) ? -1 : 0
+	mov edi, edx 				;dividend-hi
+	sar edi, 31 				;(dividend < 0) ? -1 : 0
+	xor eax, edi 				;if (dividend < 0)
+	xor edx, edi 				;compute 1's complement of dividend
+	sub eax, edi 				;if (dividend < 0)
+	sbb edx, edi 				;compute 2's complement of dividend
+	mov edi, ecx 				;divisor-hi
+	sar edi, 31 				;(divisor < 0) ? -1 : 0
+	xor ebx, edi 				;if (divisor < 0)
+	xor ecx, edi 				;compute 1's complement of divisor
+	sub ebx, edi 				;if (divisor < 0)
+	sbb ecx, edi 				; compute 2's complement of divisor
+	jnz _big_divisor 			; divisor > 2^32-1
+
+	cmp edx, ebx 				;only one division needed ? (ecx = 0)
+	jae _two_divs 				;need two divisions
+	
+	div ebx 				;eax = quotient-lo
+	mov edx, ecx 				;edx = quotient-hi = 0
+	; (quotient in edx:eax)
+	xor eax, esi 				;if (quotient < 0)
+	xor edx, esi 				;compute 1's complement of result
+	sub eax, esi 				;if (quotient < 0)
+	sbb edx, esi 				;compute 2's complement of result
+	pop edi 				; restore edi as per private linkage
+	pop ecx 				; restore ecx as per private linkage
+	pop esi 				; restore esi as per private linkage
+	pop ebx 				; restore ebx as per private linkage
+	ret 16					; return
+_two_divs:
+	mov ecx, eax 				;save dividend-lo in ecx
+	mov eax, edx 				;get dividend-hi
+	
+	xor edx, edx 				;zero extend it into edx:eax
+	div ebx 				;quotient-hi in eax
+	xchg eax, ecx 				;ecx = quotient-hi, eax = dividend-lo
+	div ebx 				;eax = quotient-lo
+	mov edx, ecx 				;edx = quotient-hi
+	; (quotient in edx:eax)
+	jmp _make_sign 				;make quotient signed
+
+_big_divisor:
+	sub esp, 12 				;create three local variables
+	mov [esp], eax 				;dividend-lo
+	mov [esp+4], ebx 			;divisor-lo
+	mov [esp+8], edx 			;dividend-hi
+	mov edi, ecx 				;save divisor-hi
+	shr edx, 1 				;shift both
+	rcr eax, 1 				;divisor and
+	ror edi, 1 				;and dividend
+	rcr ebx, 1 				;right by 1 bit
+	bsr ecx, ecx 				;ecx = number of remaining shifts
+	shrd ebx, edi, cl 			;scale down divisor and
+	shrd eax, edx, cl 			;dividend such that divisor
+	shr edx, cl 				;less than 2^32 (i.e. fits in ebx)
+	rol edi, 1 				;restore original divisor-hi
+	test eax, eax				;for edge cases
+	jz _slow_path				;goto the slow path
+	div ebx 				;compute quotient
+	mov ebx, [esp] 				;dividend-lo
+	mov ecx, eax 				;save quotient
+	imul edi, eax 				;quotient * divisor hi-word (low only)
+	mul dword  [esp+4] 			;quotient * divisor lo-word
+	add edx, edi 				;edx:eax = quotient * divisor
+	sub ebx, eax 				;dividend-lo - (quot.*divisor)-lo
+	mov eax, ecx 				;get quotient
+	mov ecx, [esp+8] 			;dividend-hi
+	sbb ecx, edx 				;subtract divisor * quot. from dividend
+	sbb eax, 0 				;adjust quotient if remainder negative
+	xor edx, edx 				;clear hi-word of quotient
+	add esp, 12 				;remove local variables
+	
+_make_sign:
+	xor eax, esi 				;if (quotient < 0)
+	xor edx, esi 				;compute 1's complement of result
+	sub eax, esi 				;if (quotient < 0)
+	sbb edx, esi 				;compute 2's complement of result
+	pop edi 				; restore edi as per private linkage
+	pop ecx 				; restore ecx as per private linkage
+	pop esi 				; restore esi as per private linkage
+	pop ebx 				; restore ebx as per private linkage
+	ret 16					; return
+
+_zero_divisor:
+	div edx
+
+_slow_path:
+	add esp, 12 				; remove local variables and adjust the stack
+	pop edi 				; restore edi as per private linkage
+	pop ecx 				; restore ecx as per private linkage
+	pop esi 				; restore esi as per private linkage
+	pop ebx 				; restore ebx as per private linkage
+	push     ecx
+	fstcw    word [esp]
+	mov      word [esp+2], 0f7fH
+	fldcw    word [esp+2]
+	fild     qword [esp+8]
+	fild     qword [esp+16]
+	fdivp    st1, st0
+	fistp    qword [esp+8]
+	fclex
+	fldcw    word [esp]
+	add      esp, 4
+	mov      eax, dword [esp+4]
+	mov      edx, dword [esp+8]
+	ret      16	
+
+jitMathHelpersDivideEnd:
+ret
+

--- a/runtime/compiler/x/i386/runtime/IA32Recompilation.nasm
+++ b/runtime/compiler/x/i386/runtime/IA32Recompilation.nasm
@@ -1,0 +1,359 @@
+; Copyright (c) 2000, 2019 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%ifndef TR_HOST_64BIT
+
+        %include "jilconsts.inc"
+
+segment .text
+
+        DECLARE_EXTERN jitRetranslateMethod
+        DECLARE_EXTERN induceRecompilation_unwrapper
+        DECLARE_EXTERN initialInvokeExactThunk_unwrapper
+        DECLARE_EXTERN jitCallCFunction
+
+        DECLARE_GLOBAL countingRecompileMethod
+        DECLARE_GLOBAL samplingRecompileMethod
+        DECLARE_GLOBAL countingPatchCallSite
+        DECLARE_GLOBAL samplingPatchCallSite
+        DECLARE_GLOBAL induceRecompilation
+        DECLARE_GLOBAL initialInvokeExactThunkGlue
+
+
+; Offsets for induceRecompilationSnippet
+eq_induceSnippet_startPCOffset  equ 5
+
+; Offsets from esp for sampling
+;
+eq_stack_samplingBodyInfo	equ 0
+eq_stack_samplingCodeStart	equ 8
+
+; Offsets from esp for counting
+eq_stack_countingStartPCToBodyInfo    equ -8
+eq_stack_countingStartPCToMethodStart equ 13
+
+eq_BodyInfo_MethodInfo          equ 4
+eq_MethodInfo_J9Method          equ 0
+eq_MethodInfo_Flags             equ 4
+eq_MethodInfo_HasBeenReplaced   equ 0100000h
+
+;
+        align 16
+;
+; [esp] contains address of recompilation info:
+;   0:  offset to start of method (dec/cmp)
+;
+countingRecompileMethod:
+;
+        pop     edi
+
+        push    edx
+
+        ; TODO: This slot on the stack is no longer required and should be removed.
+                ;
+        push    0
+        
+        ; repush senderPC
+        push    dword  [esp+8]
+
+        mov     eax, edi
+        add     eax, dword [edi]
+        push    eax                     ; Old start address
+        mov     eax, dword [eax+eq_stack_countingStartPCToBodyInfo] ; Body info
+        mov     edx, dword [eax+eq_BodyInfo_MethodInfo] ; Method info
+        mov     eax, dword [edx+eq_MethodInfo_J9Method]
+        push    eax                     ; J9 method
+        CallHelperUseReg jitRetranslateMethod,eax
+
+        test    eax, eax
+        jnz     countingGotStartAddress
+
+        ; If the compilation hasn't been done yet, skip the counting
+        ; code at the start of the method and continue with the rest of
+        ; the method body
+        mov     eax, edi
+        add     eax, dword [edi]     ; start of method
+        test    dword  [edx+eq_MethodInfo_Flags], eq_MethodInfo_HasBeenReplaced
+        jnz     countingGotStartAddress ; HCR: old body is invalid; must execute revert-to-interpreter code at start of method
+        add     eax, eq_stack_countingStartPCToMethodStart	; skip the sub/jl (or cmp/jl)
+countingGotStartAddress:
+
+        ; Now the new start address is in eax.
+        mov     edi, eax
+        add     esp, 4
+        pop     edx
+        
+        ; Note: If the JIT linkage ever expects EAX to be loaded with the receiver on
+        ; method entry then the above code will have to rematerialize EAX before passing
+        ; control to the method below.
+        
+        jmp     edi
+;
+;
+
+
+
+;
+        align 16
+;
+; [esp] contains address of recompilation info:
+;   0:  address of persistent method info
+;
+samplingRecompileMethod:
+;
+        pop     edi
+        
+        ; TODO: These two slots on the stack are no longer required and should be removed.
+                ;
+        push    0
+        push    0
+
+        ; repush senderPC
+        push    dword  [esp+8]
+
+        ; Get the old start address and push it
+        lea     eax, [edi+eq_stack_samplingCodeStart]
+        push    eax
+
+                ; Get the J9Method and push it
+        mov     eax, dword [edi+eq_stack_samplingBodyInfo] ; Body Info
+        mov     eax, dword [eax+eq_BodyInfo_MethodInfo] ; Method Info
+        mov     eax, dword [eax+eq_MethodInfo_J9Method]
+        push    eax
+        CallHelperUseReg jitRetranslateMethod,eax
+
+        ; If the compilation has not been done yet, restart this method.
+                ; It should now execute normally
+        test    eax, eax
+        jnz     samplingGotStartAddress
+        lea     edi, [edi+eq_stack_samplingCodeStart]
+                add     esp, 8
+
+                ; Note: If the JIT linkage ever expects EAX to be loaded with the receiver on
+                ; method entry then the above code will have to rematerialize EAX before passing
+                ; control to the method below.
+
+        jmp 	edi
+
+samplingGotStartAddress:
+        mov 	edi, eax
+                add     esp, 8
+
+                ; Note: If the JIT linkage ever expects EAX to be loaded with the receiver on
+                ; method entry then the above code will have to rematerialize EAX before passing
+                ; control to the method below.
+
+        jmp     edi
+;
+;
+
+
+                align 16
+;
+induceRecompilation:
+;
+                xchg    edi, [esp] ; Return address in snippet
+                push    eax        ; Preserve
+
+                ; old startPC
+                mov     eax, dword [edi+eq_induceSnippet_startPCOffset]
+                add     eax, edi
+
+                ; set up args to induceRecompilation_unwrapper
+                push    ebp        ; parm: vmThread
+                push    eax        ; parm: startPC
+
+                ; set up args to jitCallCFunction (right-to-left)
+        mov     eax, esp
+                push    eax                                    ; parm: result pointer; don't care
+        push    eax                                    ; parm: args array
+                MoveHelper eax, induceRecompilation_unwrapper  ; parm: C function to call
+        push    eax
+
+                CallHelper jitCallCFunction
+                add     esp, 8
+
+                ; restore regs and return to snippet
+                pop     eax
+                xchg    edi, [esp]
+                ret
+
+;
+;
+
+
+        align 16
+;
+; [esp] contains (old start PC + 5)
+;
+countingPatchCallSite:
+;
+        xchg    dword [esp], edi
+
+                ; These two pushes *should not* be required any longer as they are done to preserve the
+                ; registers for an IPICDispatch.
+        push    edx
+        push    eax
+
+        ; Get the old start address
+        sub     edi, 5
+
+        ; Get the new start address and push it
+        mov     eax, dword [edi+eq_stack_countingStartPCToBodyInfo] ; Body info
+        mov	eax, dword [eax+eq_BodyInfo_MethodInfo]
+        mov     eax, dword [eax+eq_MethodInfo_J9Method]
+        mov     eax, dword [eax+J9TR_MethodPCStartOffset]
+        test    eax, 1 ; HCR: Has method been replaced by one that's not jitted yet?
+        jne     countingPatchToRecompile
+        push    eax
+
+        ; Get the call site
+        mov     edx, dword [esp+16]
+
+patchCallSite:
+        ; Check for a call immediate
+        cmp     byte [edx-5], 0e8h
+        jne     patchDone
+
+        ; Check for a direct call to the method
+        mov     eax, dword [edx-4]
+        add     eax, edx
+        cmp     eax, edi
+        jne     patchDone
+
+        ; Call site is a call immediate. Patch it with the new address
+        mov     eax, dword [esp]
+        sub     eax, edx
+        mov     dword [edx-4], eax
+
+patchDone:
+        ; Must preserve eax and edx as they were on entry since this may go to
+        ; another patch point which will expect eax and edx to be set up
+        ; properly for the IPicDispatch case
+                ;
+                ; TODO: This *should not* be required because patchCallSite does not
+                ; patch vtable slots any longer.
+                ;
+        pop     edi
+        pop     eax
+        pop     edx
+        add     esp, 4                  ; was pushed as caller's edi
+        jmp     edi
+
+countingPatchToRecompile:
+        ; HCR: we've got our hands on a new j9method that hasn't been compiled yet,
+        ; so there's no way to patch the call site without first compiling the new method
+        ;
+        ; edi points to this:
+        ;   CALL  patchCallSite        (5 bytes)
+        ;   DB    ??                   (2 byte offset to oldStartPC)
+        ;   JL    recompilationSnippet   (always 6 bytes)
+        ;
+        ; Restore registers and stack the way they looked originally, then jump to the recompilationSnippet
+        pop     eax
+        pop     edx
+        add     edi, 5+2+6             ; end of JL instruction
+        add     edi, dword  [edi-4] ; start of recompilationSnippet
+        xchg    dword [esp], edi    ; restore edi
+        ret                            ; jump to recompilationSnippet while minimizing damage to return address branch prediction
+        
+;
+
+        align 16
+;
+; [esp] contains address of patch info:
+;   0:  persistent method info
+;   4:  3-byte padding
+;   7:  slot for return info
+;  11:  old code start
+;
+;
+samplingPatchCallSite:
+;
+        xchg    dword [esp], edi
+        push    edx
+        push    eax
+
+        ; Get the new start address from the method info and push it
+        mov     eax, dword [edi+eq_stack_samplingBodyInfo]
+        mov     eax, dword [eax+eq_BodyInfo_MethodInfo]
+        mov     eax, dword [eax+eq_MethodInfo_J9Method]
+        mov     eax, dword [eax+J9TR_MethodPCStartOffset]
+        test    eax, 1 ; HCR: Has method been replaced by one that's not jitted yet?
+        jne     samplingPatchToRecompile
+        push    eax
+
+        ; Get the old start address
+        add     edi, eq_stack_samplingCodeStart
+
+        ; Get the call site
+        mov     edx, dword [esp+16]
+
+                jmp     patchCallSite
+
+samplingPatchToRecompile:
+        ; HCR: we've got our hands on a new j9method that hasn't been compiled yet,
+        ; so there's no way to patch the call site without first compiling the new method
+        ;
+        ; Make the world look the way it should for a call to samplingRecompileMethod
+        pop     eax
+        pop     edx
+        xchg    dword [esp], edi
+        jmp     samplingRecompileMethod
+;
+
+                align 16
+;
+initialInvokeExactThunkGlue:
+;
+        ; preserve all non-scratch regs
+        push    eax
+        push    edi ; use this as a temporary here.  It's volatile, and we can't change eax because it has the receiver.  In fact we may not need to save it!
+
+        ; set up args to initialInvokeExactThunk_unwrapper
+        push    ebp        ; parm: vmThread
+        push    eax        ; parm: receiver MethodHandle; also, result goes here
+
+        ; set up args to jitCallCFunction (right-to-left)
+        mov     edi, esp
+        push    edi                                             ; parm: args array
+        push    edi                                             ; parm: result pointer
+        MoveHelper edi, initialInvokeExactThunk_unwrapper       ; parm: C function to call
+        push    edi
+        CallHelper jitCallCFunction
+        
+        pop     eax ; returned startPC
+        pop     edi ; discard pushed ebp
+
+        pop     edi ; Restore
+
+        ; Restore eax and jump to address returned by initialInvokeExactThunk
+        ; Sadly, this probably kills return address stack branch prediction
+        xchg    eax, [esp]
+        ret
+;
+;
+
+
+%else
+segment .data
+IA32Recompilation:
+                db      00h
+%endif

--- a/runtime/compiler/x/i386/runtime/J9IA32CompressString.nasm
+++ b/runtime/compiler/x/i386/runtime/J9IA32CompressString.nasm
@@ -1,0 +1,34 @@
+; Copyright (c) 2000, 2019 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%ifndef TR_HOST_64BIT
+
+        %include "jilconsts.inc"
+        %include "IA32CompressString_nasm.inc"
+
+J9TR_ObjectColorBlack equ 03h
+
+
+%else            ; TR_HOST_64BIT
+segment .data
+IA32ArrayCopy:
+                db      00h
+
+%endif           ; TR_HOST_64BIT

--- a/runtime/compiler/x/i386/runtime/J9IA32Math64.nasm
+++ b/runtime/compiler/x/i386/runtime/J9IA32Math64.nasm
@@ -1,0 +1,30 @@
+; Copyright (c) 2000, 2019 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+; or the Apache License, Version 2.0 which accompanies this distribution and
+; is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following
+; Secondary Licenses when the conditions for such availability set
+; forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+; General Public License, version 2 with the GNU Classpath
+; Exception [1] and GNU General Public License, version 2 with the
+; OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+%ifndef TR_HOST_64BIT
+
+    %include "IA32Math64_nasm.inc"
+
+%else ; TR_HOST_64BIT
+segment .data
+IA32Math64:
+                db      00h
+                
+%endif ; TR_HOST_64BIT

--- a/runtime/compiler/x/runtime/X86ArrayTranslate.nasm
+++ b/runtime/compiler/x/runtime/X86ArrayTranslate.nasm
@@ -1,4 +1,4 @@
-; Copyright (c) 2000, 2018 IBM Corp. and others
+; Copyright (c) 2000, 2019 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,46 +38,46 @@ segment .text
    %ifdef TR_HOST_64BIT
       mov ecx, ecx
    %endif
-      xor  rax, rax
-      cmp  rcx, 8
+      xor  _rax, _rax
+      cmp  _rcx, 8
       jl   byteresidualTO
       movd xmm1, edx
       pshufd xmm1, xmm1, 0
-      cmp  rcx, 16
+      cmp  _rcx, 16
       jl   eightcharsTO
    sixteencharsTO:
-      movdqu xmm2, [rsi+2*rax]
+      movdqu xmm2, [_rsi+2*_rax]
       ptest xmm2, xmm1          ; SSE4.1 instruction
       jnz  failedloopTO
-      movdqu xmm3, [rsi+2*rax+16]
+      movdqu xmm3, [_rsi+2*_rax+16]
       ptest xmm3, xmm1          ; SSE4.1 instruction
       jnz  eightcharsTO
       packuswb xmm2, xmm3
-      movdqu oword [rdi+rax], xmm2
-      sub  rcx, 16
-      add  rax, 16
-      cmp  rcx, 16
+      movdqu oword [_rdi+_rax], xmm2
+      sub  _rcx, 16
+      add  _rax, 16
+      cmp  _rcx, 16
       jge  sixteencharsTO
-      cmp  rcx, 8
+      cmp  _rcx, 8
       jl   byteresidualTO
    eightcharsTO:
-      movdqu xmm2, [rsi+2*rax]
+      movdqu xmm2, [_rsi+2*_rax]
       ptest xmm2, xmm1          ; SSE4.1 instruction
       jnz  failedloopTO
       packuswb xmm2, xmm1       ; only the first 8 bytes of xmm2 are meaningful
-      movq qword [rdi+rax], xmm2
-      sub  rcx, 8
-      add  rax, 8
+      movq qword [_rdi+_rax], xmm2
+      sub  _rcx, 8
+      add  _rax, 8
    byteresidualTO:
-      and rcx, rcx
+      and _rcx, _rcx
       je  doneTO
    failedloopTO:
-      mov  bx, word [rsi+2*rax]
+      mov  bx, word [_rsi+2*_rax]
       test bx, dx
       jnz  doneTO
-      mov  byte [rdi+rax], bl
-      inc  rax
-      dec  rcx
+      mov  byte [_rdi+_rax], bl
+      inc  _rax
+      dec  _rcx
       jnz  failedloopTO
    doneTO:   ;EAX is result register
       ret
@@ -90,62 +90,62 @@ segment .text
    %ifdef TR_HOST_64BIT
       mov ecx, ecx
    %endif
-      xor    rax, rax
+      xor    _rax, _rax
       xorps  xmm3, xmm3
-      cmp    rcx, 16
+      cmp    _rcx, 16
       jl     qwordResidualOTNoBreak
 
    sixteencharsOTNoBreak:
-      movdqu  xmm1, [rsi+rax]
+      movdqu  xmm1, [_rsi+_rax]
       movdqu  xmm2, xmm1
       punpcklbw xmm1, xmm3
       punpckhbw xmm2, xmm3
-      movdqu [rdi+rax*2], xmm1
-      movdqu [rdi+rax*2+16], xmm2
-      sub rcx, 16
-      add rax, 16
-      cmp rcx, 16
+      movdqu [_rdi+_rax*2], xmm1
+      movdqu [_rdi+_rax*2+16], xmm2
+      sub _rcx, 16
+      add _rax, 16
+      cmp _rcx, 16
       jge sixteencharsOTNoBreak
 
    slideWindowResidualOTNoBreak:
-      test rcx, rcx
+      test _rcx, _rcx
       jz doneOTNoBreak
-      sub rax, 16
-      add rax, rcx
-      mov rcx, 16
+      sub _rax, 16
+      add _rax, _rcx
+      mov _rcx, 16
       jmp sixteencharsOTNoBreak
 
    doneOTNoBreak:
       ret
 
    qwordResidualOTNoBreak:
-      bt rcx, 3
+      bt _rcx, 3
       jnc dwordResidualOTNoBreak
-      movq xmm1, qword [rsi+rax]
+      movq xmm1, qword [_rsi+_rax]
       punpcklbw xmm1, xmm3
-      movdqu [rdi+rax*2], xmm1
-      add rax, 8
-      sub rcx, 8
+      movdqu [_rdi+_rax*2], xmm1
+      add _rax, 8
+      sub _rcx, 8
 
    dwordResidualOTNoBreak:
-      bt rcx, 2
+      bt _rcx, 2
       jnc byteResidualOTNoBreak
-      movd xmm1, dword [rsi+rax]
+      movd xmm1, dword [_rsi+_rax]
       punpcklbw xmm1, xmm3
-      movq qword [rdi+rax*2], xmm1
-      add rax, 4
-      sub rcx, 4
+      movq qword [_rdi+_rax*2], xmm1
+      add _rax, 4
+      sub _rcx, 4
 
    byteResidualOTNoBreak:
-      test rcx, rcx
+      test _rcx, _rcx
       jz doneOTNoBreak
       xor  bx, bx
 
    failedloopOTNoBreak:
-      mov  bl, [rsi+rax]
-      mov  [rdi+rax*2], bx
-      inc  rax
-      dec  rcx
+      mov  bl, [_rsi+_rax]
+      mov  [_rdi+_rax*2], bx
+      inc  _rax
+      dec  _rcx
       jnz  failedloopOTNoBreak
       jmp  doneOTNoBreak
 
@@ -161,32 +161,32 @@ segment .text
    %ifdef TR_HOST_64BIT
       mov ecx, ecx
    %endif
-      xor    rax, rax
+      xor    _rax, _rax
       xorps  xmm3, xmm3
-      cmp    rcx, 16
+      cmp    _rcx, 16
       jl     qwordResidualOT
 
    sixteencharsOT:
-      movdqu  xmm1, [rsi+rax]
+      movdqu  xmm1, [_rsi+_rax]
       pmovmskb ebx, xmm1
       test ebx, ebx
       jnz    computeNewLengthOT
       movdqu  xmm2, xmm1
       punpcklbw xmm1, xmm3
       punpckhbw xmm2, xmm3
-      movdqu [rdi+rax*2], xmm1
-      movdqu [rdi+rax*2+16], xmm2
-      sub rcx, 16
-      add rax, 16
-      cmp rcx, 16
+      movdqu [_rdi+_rax*2], xmm1
+      movdqu [_rdi+_rax*2+16], xmm2
+      sub _rcx, 16
+      add _rax, 16
+      cmp _rcx, 16
       jge sixteencharsOT
 
    slideWindowResidualOT:
-      test rcx, rcx
+      test _rcx, _rcx
       jz doneOT
-      sub rax, 16
-      add rax, rcx
-      mov rcx, 16
+      sub _rax, 16
+      add _rax, _rcx
+      mov _rcx, 16
       jmp sixteencharsOT
 
    doneOT:
@@ -197,46 +197,46 @@ segment .text
    %ifdef TR_HOST_64BIT
       mov ebx, ebx
    %endif
-      mov rcx, rbx
-      cmp rax, 16
+      mov _rcx, _rbx
+      cmp _rax, 16
       jge slideWindowResidualOT
 
    qwordResidualOT:
-      bt rcx, 3
+      bt _rcx, 3
       jnc dwordResidualOT
-      movq xmm1, qword [rsi+rax]
+      movq xmm1, qword [_rsi+_rax]
       pmovmskb ebx, xmm1
       test ebx, ebx
       jnz computeNewLengthOT
       punpcklbw xmm1, xmm3
-      movdqu [rdi+rax*2], xmm1
-      add rax, 8
-      sub rcx, 8
+      movdqu [_rdi+_rax*2], xmm1
+      add _rax, 8
+      sub _rcx, 8
 
    dwordResidualOT:
-      bt rcx, 2
+      bt _rcx, 2
       jnc byteResidualOT
-      movd xmm1, dword [rsi+rax]
+      movd xmm1, dword [_rsi+_rax]
       pmovmskb ebx, xmm1
       test ebx, ebx
       jnz computeNewLengthOT
       punpcklbw xmm1, xmm3
-      movq qword [rdi+rax*2], xmm1
-      add rax, 4
-      sub rcx, 4
+      movq qword [_rdi+_rax*2], xmm1
+      add _rax, 4
+      sub _rcx, 4
 
    byteResidualOT:
-      test rcx, rcx
+      test _rcx, _rcx
       jz doneOT
       xor  bx, bx
 
    failedloopOT:
-      mov  bl, [rsi+rax]
+      mov  bl, [_rsi+_rax]
       test bl, 80h
       jnz  doneOT
-      mov  [rdi+rax*2], bx
-      inc  rax
-      dec  rcx
+      mov  [_rdi+_rax*2], bx
+      inc  _rax
+      dec  _rcx
       jnz  failedloopOT
       jmp doneOT
 

--- a/runtime/compiler/x/runtime/X86EncodeUTF16.nasm
+++ b/runtime/compiler/x/runtime/X86EncodeUTF16.nasm
@@ -1,4 +1,4 @@
-; Copyright (c) 2014, 2018 IBM Corp. and others
+; Copyright (c) 2014, 2019 IBM Corp. and others
 ;
 ; This program and the accompanying materials are made available under
 ; the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,18 +77,18 @@ encodeUTF16Big_shufmask:
 %1:                                      ; helperName
                 ; Remember original count -
                 ; will subtract at return to compute number converted
-                mov rax, rdx
-                cmp rdx, 0
+                mov _rax, _rdx
+                cmp _rdx, 0
                 je Lend_%1               ; helpername
-                sub rdi, rsi             ; relative to _rsi, only advance _rsi
-                cmp rdx, SSE_MIN_CHARS
+                sub _rdi, _rsi             ; relative to _rsi, only advance _rsi
+                cmp _rdx, SSE_MIN_CHARS
                 jl Lresidue_loop_%1      ; helperName
 
 Lprealign_%1:                            ; helperName
-                test rsi, 0fh
+                test _rsi, 0fh
                 jz Laligned16_%1         ; helperName
 
-                mov cx, word [rsi]
+                mov cx, word [_rsi]
 
                 ; return if surrogate
                 mov bx, cx
@@ -100,14 +100,14 @@ Lprealign_%1:                            ; helperName
 %if %2 ;bigEndian
                 xchg cl, ch
 %endif
-                mov word [rsi + rdi], cx
-                add rsi, 2
-                dec rdx
+                mov word [_rsi + _rdi], cx
+                add _rsi, 2
+                dec _rdx
                 jg Lprealign_%1          ; helperName
                 jmp Lend_%1              ; helperName
 
 Laligned16_%1:                           ; helperName
-                sub rdx, 8
+                sub _rdx, 8
                 jl Lresidue_%1           ; helperName
 
                 ; initialize constant vectors:
@@ -129,7 +129,7 @@ Laligned16_%1:                           ; helperName
 L8_at_a_time_%1:                         ; helperName
                 ; read 8 chars
                 ; should this use movdqu, start once 8-byte aligned?
-                movdqa xmm2, oword [rsi]
+                movdqa xmm2, oword [_rsi]
 
                 ; jump to residue loop if any are surrogate
                 movdqa xmm3, xmm2
@@ -144,19 +144,19 @@ L8_at_a_time_%1:                         ; helperName
 %endif
 
                 ; write 8 chars
-                movdqu oword [rsi + rdi], xmm2
+                movdqu oword [_rsi + _rdi], xmm2
 
-                add rsi, 16
-                sub rdx, 8
+                add _rsi, 16
+                sub _rdx, 8
                 jge L8_at_a_time_%1      ; helperName
 
 Lresidue_%1:                             ; helperName
-                add rdx, 8
-                cmp rdx, 0
+                add _rdx, 8
+                cmp _rdx, 0
                 je Lend_%1               ; helperName
 
 Lresidue_loop_%1:                        ; helperName
-                mov cx, word [rsi]
+                mov cx, word [_rsi]
 
                                          ; return if surrogate
                 mov bx, cx
@@ -168,13 +168,13 @@ Lresidue_loop_%1:                        ; helperName
 %if %2 ;&bigEndian
                 xchg cl, ch
 %endif
-                mov word [rsi + rdi], cx
-                add rsi, 2
-                dec rdx
+                mov word [_rsi + _rdi], cx
+                add _rsi, 2
+                dec _rdx
                 jg Lresidue_loop_%1     ; helperName
 
 Lend_%1: ;&helperName:
-                sub rax, rdx
+                sub _rax, _rdx
                 ret
 
 %endmacro

--- a/runtime/compiler/x/runtime/X86PicBuilder.nasm
+++ b/runtime/compiler/x/runtime/X86PicBuilder.nasm
@@ -26,8 +26,6 @@
 ;
 ; --------------------------------------------------------------------------------
 
-      CPU PPRO
-
       %include "jilconsts.inc"
       %include "X86PicBuilder_nasm.inc"
 
@@ -207,11 +205,7 @@ callResolveInterfaceMethod:
 
       ; Attempt to patch the code.
       ;
-%ifdef WINDOWS
-      lock cmpxchg8b    qword [edi-5]                                   ; EA of CMP instruction in mainline
-%else
       lock cmpxchg8b    [edi-5]                                         ; EA of CMP instruction in mainline
-%endif
 
       pop         ecx                                                   ; restore
       pop         ebx                                                   ; restore
@@ -345,11 +339,7 @@ mergePopulateIPicClass:
 
       ; Attempt to patch in the CMP instruction.
       ;
-%ifdef WINDOWS
-      lock cmpxchg8b    qword  [edi-5]                            ; EA of CMP instruction in mainline
-%else
       lock cmpxchg8b    [edi-5]                                   ; EA of CMP instruction in mainline
-%endif
 
 
 %ifdef ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING
@@ -685,11 +675,7 @@ mergeFindDataBlockForResolveVPicClass:
 
       ; Attempt to patch the code.
       ;
-%ifdef WINDOWS
-      lock cmpxchg8b    qword  [edi-5]                            ; EA of CMP instruction in mainline
-%else
       lock cmpxchg8b    [edi-5]                                   ; EA of CMP instruction in mainline
-%endif
 
       pop         ecx                                             ; restore
       pop         ebx                                             ; restore
@@ -793,11 +779,7 @@ mergePopulateVPicClass:
 
       ; Attempt to patch in the CMP instruction.
       ;
-%ifdef WINDOWS
-      lock        cmpxchg8b qword [edi-5]                         ; EA of CMP instruction in mainline
-%else
       lock        cmpxchg8b [edi-5]                               ; EA of CMP instruction in mainline
-%endif
 
 
 %ifdef ASM_J9VM_GC_DYNAMIC_CLASS_UNLOADING
@@ -1071,11 +1053,8 @@ populateVPicVTableDispatch:
 
       ; Attempt to patch the code.
       ;
-%ifdef WINDOWS
-      lock        cmpxchg8b qword  [edi]                          ; EA of vtable dispatch
-%else
+
       lock        cmpxchg8b [edi]                                 ; EA of vtable dispatch
-%endif
 
       mov         dword  [esp+24], edi                            ; fix RA to run the vtable call
       pop         esi                                             ; restore
@@ -1182,11 +1161,7 @@ resolveAndPopulateVTableDispatch:
       ; Attempt to patch the code. No need to check for failure as we will always
       ; back up and re-run the instruction in the mainline code.
       ;
-%ifdef WINDOWS
-      lock cmpxchg8b    qword  [edi]                  ; EA of vtable dispatch
-%else
       lock cmpxchg8b    [edi]                         ; EA of vtable dispatch
-%endif
 
       mov         dword  [esp+24], edi                ; fix RA to run the vtable call
       pop         esi                                 ; restore

--- a/runtime/compiler/x/runtime/X86Unresolveds.nasm
+++ b/runtime/compiler/x/runtime/X86Unresolveds.nasm
@@ -26,9 +26,6 @@
 ;
 ; --------------------------------------------------------------------------------
 
-      CPU P2
-      CPU P4
-
       eq_offsetof_J9Object_clazz equ 8                            ; offset of class pointer in a J9Object
 
       %include "jilconsts.inc"
@@ -108,7 +105,7 @@
 %ifdef WINDOWS
       DECLARE_EXTERN j9thread_self
       DECLARE_EXTERN j9thread_tls_get
-      DECLARE_EXTERN vmThreadTLSKey:dword
+      DECLARE_EXTERN vmThreadTLSKey
 %endif
 
       DECLARE_EXTERN memoryFence
@@ -303,11 +300,8 @@ updateInterpreterDispatchGlueSite:
 
       ; Attempt to patch the code.
       ;
-%ifdef WINDOWS
-      lock cmpxchg8b qword  [esi]
-%else
+
       lock cmpxchg8b [esi]
-%endif
 
       mov dword  [esp+12], esi                              ; update return address to re-run
 
@@ -395,9 +389,9 @@ patchBarrierWithNop:
       mov         bl, byte  [edx]                           ; get instruction length from instruciton descriptor
       and         ebx, 0f0h                                 ; mask size of instruction
       shr         ebx, 4                                    ; shift size to last nibble of byte
-      lea         ebx, dword  [ebx - eq_MemFenceCallLength32] ; get the delta between the RA in the mainline code and
+      lea         ebx, [ebx - eq_MemFenceCallLength32] ; get the delta between the RA in the mainline code and
                                                             ; the end of the store instruction
-      lea         esi, dword  [esi + ebx]                   ; find the end of the store instruction
+      lea         esi, [esi + ebx]                   ; find the end of the store instruction
 
       ; determine what kind of fence we are dealing with: mfence or LOCK OR [ESP] (on legacy systems)
       ;
@@ -410,7 +404,7 @@ patchBarrierWithNop:
 
       ; 3 byte memory fence
       ;
-      lea         esi, dword  [esi + 3]                     ; find the 4 byte aligned address
+      lea         esi, [esi + 3]                     ; find the 4 byte aligned address
       and         esi, 0fffffffch                           ; should now have a 4 byte aligned instruction of the memfence
 
       ;make sure we are patching over an mfence (avoids potential race condition with lock cmpxchg patching)
@@ -432,8 +426,8 @@ doLOCKORESP:
       ; edx:eax original instruction
       ;
       mov         esi, dword  [esp + eq_MemFenceRAOffset32]         ; esp + 128 = RA of mainline code (mfence instruction or nop)
-      lea         esi, dword  [esi + ebx]                           ; find the end of the store instruction
-      lea         esi, dword  [esi + 7]                             ; find the 8 byte aligned address of the lock or [esp]
+      lea         esi, [esi + ebx]                           ; find the end of the store instruction
+      lea         esi, [esi + 7]                             ; find the 8 byte aligned address of the lock or [esp]
       and         esi, 0fffffff8h
       mov         eax, dword  [esi]                                 ; construct the edx:eax pair (original instruction)
       mov         edx, dword  [esi + 4]
@@ -441,11 +435,8 @@ doLOCKORESP:
       mov         ecx, edx
       mov         cl, 00h
 
-%ifdef WINDOWS ; write the nop
-      lock cmpxchg8b qword  [esi]
-%else
       lock cmpxchg8b [esi]
-%endif
+
       jmp restoreRegs
 
 
@@ -494,11 +485,7 @@ patchMainlineInstruction:
       mov         edx, dword  [esp + 4]                             ; Restore the call instruction (edx:eax) that should have brought
       mov         eax, dword  [esp + 8]                             ; us to this snippet + the following 3 bytes.
 
-%ifdef WINDOWS
-      lock cmpxchg8b qword  [esi - 5]
-%else
       lock cmpxchg8b [esi - 5]
-%endif
 
       test        ebp, ebp
       jnz         patchBarrierWithNop
@@ -574,7 +561,7 @@ retn
 ; --------------------------------------------------------------------------------
 
 
-%macro DataResolvePrologue
+%macro DataResolvePrologue 0
       ; local: doneFPRpreservation, preserveX87loop
 
       pushfd                        ; save flags , addr=esp+28
@@ -590,7 +577,7 @@ retn
       ; Restore the VMThread into ebp
       ;
       call        j9thread_self
-      push        [vmThreadTLSKey]
+      push        dword [vmThreadTLSKey]
       push        eax
       call        j9thread_tls_get
       add         esp, 8
@@ -961,11 +948,8 @@ noVolatileCheck:
 
       ; Attempt to patch the code.
       ;
-%ifdef WINDOWS
-      lock cmpxchg8b qword  [esi-5]
-%else
+
       lock cmpxchg8b [esi-5]
-%endif
 
 doneDataResolution:
 

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -74,23 +74,13 @@ createConstant(OMRPortLibrary *OMRPORTLIB, char const *name, UDATA value)
 	}
 #if defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_ARM)
 	return omrstr_printf(line, sizeof(line), "#define %s %zu\n", name, value);
-#elif defined(LINUX) /* J9VM_ARCH_POWER || J9VM_ARCH_ARM */
-	#if defined(J9VM_ENV_DATA64)
-		#if defined(J9VM_ARCH_X86)
-			return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
-		#else /* J9VM_ARCH_X86 */
-			return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
-		#endif /* J9VM_ARCH_X86 */
-	#else /* J9VM_ENV_DATA64 */
-		return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
-	#endif
-#elif defined(WIN32) /* LINUX */
-		return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
-#elif defined(J9ZOS390) /* WIN32 */
-	return omrstr_printf(line, sizeof(line), "%s EQU %zu\n", name, value);
-#elif defined(OSX) /* J9ZOS390 */
+#elif defined(J9VM_ARCH_X86) /* J9VM_ARCH_POWER || J9VM_ARCH_ARM */
 	return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
-#else /* OSX */
+#elif defined(LINUX) /* J9VM_ARCH_X86 */
+	return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
+#elif defined(J9ZOS390) /* LINUX */
+	return omrstr_printf(line, sizeof(line), "%s EQU %zu\n", name, value);
+#else
 #error "Unknown constant format"
 #endif /* J9VM_ARCH_POWER || J9VM_ARCH_ARM */
 }
@@ -132,75 +122,36 @@ static char const *macroString = "\n\
 \n";
 #else /* J9VM_ENV_DATA64 */
 static char const *macroString = "\n\
-ASM_J9VM_USE_GOT = 1\n\
+%macro MoveHelper 2 ; MACRO register,helperName\n\
+	lea %1, [%2]\n\
+%endmacro\n\
 \n\
-LoadGOTInto MACRO register\n\
-.att_syntax\n\
-  call    1f\n\
-  1:\n\
-  pop     %&register\n\
-  add     $_GLOBAL_OFFSET_TABLE_+[.-1b], %&register\n\
-.intel_syntax noprefix\n\
-ENDM\n\
+%macro CallHelper 1 ; MACRO helperName\n\
+	call %1\n\
+%endmacro\n\
 \n\
-MoveHelper MACRO register,helperName\n\
-		LoadGOTInto &register\n\
-		lea &register, &helperName&@GOTOFF[&register]\n\
-ENDM\n\
+%macro CallHelperUseReg 2 ; MACRO helperName,register\n\
+	call %1\n\
+%endmacro\n\
 \n\
-CompareHelper MACRO source,helperName\n\
-	   	push esi\n\
-		LoadGOTInto esi\n\
-		lea esi, &helperName&@GOTOFF[&esi]\n\
-	  	cmp &source, esi\n\
-	   	pop esi\n\
-ENDM\n\
+%macro DECLARE_EXTERN 1 ; helperName\n\
+	extern %1\n\
+%endmacro\n\
 \n\
-CompareHelperUseReg MACRO source,helperName,register\n\
-		LoadGOTInto &register\n\
-		lea &register, &helperName&@GOTOFF[&register]\n\
-		cmp &source, &register\n\
-ENDM\n\
+%macro DECLARE_GLOBAL 1 ; helperName\n\
+	global %1\n\
+%endmacro\n\
 \n\
-CallHelper MACRO helperName\n\
-		 call &helperName&@PLT\n\
-ENDM\n\
-\n\
-CallHelperUseReg MACRO helperName,register\n\
-		 call &helperName&@PLT\n\
-ENDM\n\
-\n\
-JumpTableHelper MACRO temp,index,table\n\
-			push &temp\n\
-			MoveHelper &temp,&table\n\
-			mov &temp,[&temp&+&index&*4]\n\
-			xchg &temp,[esp]\n\
-			ret\n\
-ENDM\n\
-\n\
-JumpTableStart MACRO table\n\
-			              	public &table&\n\
-			              	.data\n\
-			              	align   04h\n\
-table&:\n\
-ENDM\n\
-\n\
-JumpTableEnd MACRO table\n\
-			.text\n\
-ENDM\n\
-\n\
-JumpHelper MACRO helperName\n\
-				jmp       &helperName&@PLT\n\
-ENDM\n\
-\n\
-ExternHelper MACRO helperName\n\
-ENDM\n\
-\n\
-GlueHelper MACRO        	helperName\n\
-	   	       	test      byte ptr[edi+J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit\n\
-	   	       	jz       mergedStaticGlueCallFixer\n\
-	   	       	JumpHelper &helperName\n\
-ENDM\n";
+%define _rax eax\n\
+%define _rbx ebx\n\
+%define _rcx ecx\n\
+%define _rdx edx\n\
+%define _rsi esi\n\
+%define _rdi edi\n\
+%define _rsp esp\n\
+%define _rbp ebp\n\
+%define _rel\n\
+\n";
 #endif /* J9VM_ENV_DATA64 */
 #elif defined(OSX) /* LINUX */
 static char const *macroString = "\n\

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -85,11 +85,7 @@ createConstant(OMRPortLibrary *OMRPORTLIB, char const *name, UDATA value)
 		return omrstr_printf(line, sizeof(line), "%s = %zu\n", name, value);
 	#endif
 #elif defined(WIN32) /* LINUX */
-	#if defined(J9VM_ENV_DATA64)
 		return omrstr_printf(line, sizeof(line), "%%define %s %zu\n", name, value);
-	#else /* J9VM_ENV_DATA64 */
-		return omrstr_printf(line, sizeof(line), "%s equ %zu\n", name, value);
-	#endif
 #elif defined(J9ZOS390) /* WIN32 */
 	return omrstr_printf(line, sizeof(line), "%s EQU %zu\n", name, value);
 #elif defined(OSX) /* J9ZOS390 */
@@ -132,7 +128,7 @@ static char const *macroString = "\n\
 %define _rdi rdi\n\
 %define _rsp rsp\n\
 %define _rbp rbp\n\
-%define _rip\n\
+%define _rel rel\n\
 \n";
 #else /* J9VM_ENV_DATA64 */
 static char const *macroString = "\n\
@@ -238,7 +234,7 @@ static char const *macroString = "\n\
 %define _rdi rdi\n\
 %define _rsp rsp\n\
 %define _rbp rbp\n\
-%define _rip\n\
+%define _rel rel\n\
 \n";
 #else /* LINUX */
 #if defined(J9VM_ENV_DATA64)
@@ -271,59 +267,42 @@ static char const *macroString = "\n\
 %define _rdi rdi\n\
 %define _rsp rsp\n\
 %define _rbp rbp\n\
-%define _rip\n\
+%define _rel rel\n\
 \n";
 #else /* J9VM_ENV_DATA64 */
 static char const *macroString = "\n\
-MoveHelper MACRO register,helperName\n\
-	mov &register,offset flat:&helperName\n\
-ENDM\n\
+%macro MoveHelper 2 ; MACRO register,helperName\n\
+	lea %1, [%2]\n\
+%endmacro\n\
 \n\
-CompareHelper MACRO source,helperName\n\
-	cmp &source,offset flat:&helperName\n\
-ENDM\n\
+%macro CallHelper 1 ; MACRO helperName\n\
+	call %1\n\
+%endmacro\n\
 \n\
-CompareHelperUseReg MACRO source,helperName,register\n\
-	cmp &source,offset flat:&helperName\n\
-ENDM\n\
+%macro CallHelperUseReg 2 ; MACRO helperName,register\n\
+	call %1\n\
+%endmacro\n\
 \n\
-CallHelper MACRO helperName\n\
-	call &helperName\n\
-ENDM\n\
+%macro DECLARE_EXTERN 1 ; helperName\n\
+	extern _%1\n\
+	%define %1 _%1\n\
+%endmacro\n\
 \n\
-CallHelperUseReg MACRO helperName,register\n\
-	call &helperName\n\
-ENDM\n\
+%macro DECLARE_GLOBAL 1 ; helperName\n\
+	global _%1\n\
+	%define %1 _%1\n\
+%endmacro\n\
 \n\
-JumpTableHelper MACRO temp,index,table\n\
-	jmp dword ptr [&index&*4 + &table&]\n\
-ENDM\n\
-\n\
-JumpTableStart MACRO table\n\
-		_CONST32 SEGMENT PARA USE32 PUBLIC 'CONST'\n\
-		_CONST32 ends\n\
-		_CONST32 SEGMENT PARA USE32 PUBLIC 'CONST'\n\
-		align   04h\n\
-table&:\n\
-ENDM\n\
-\n\
-JumpTableEnd MACRO table\n\
-	_CONST32 ends\n\
-ENDM\n\
-\n\
-JumpHelper MACRO helperName\n\
-		jmp       &helperName\n\
-ENDM\n\
-\n\
-ExternHelper MACRO helperName\n\
-	extrn &helperName&:near\n\
-ENDM\n\
-\n\
-GlueHelper MACRO	helperName\n\
-		test      byte ptr[edi+J9TR_MethodPCStartOffset], J9TR_MethodNotCompiledBit\n\
-		jnz         &helperName\n\
-		jmp      mergedStaticGlueCallFixer\n\
-ENDM\n";
+%define _rax eax\n\
+%define _rbx ebx\n\
+%define _rcx ecx\n\
+%define _rdx edx\n\
+%define _rsi esi\n\
+%define _rdi edi\n\
+%define _rsp esp\n\
+%define _rbp ebp\n\
+%define _rel\n\
+\n";
 #endif /* J9VM_ENV_DATA64 */
 #endif /* LINUX */
 


### PR DESCRIPTION
This PR enables NASM support for building the JIT assembly files in the 32bit x86 platforms, and completes the migration process for using an unified x86 assembler solution across the supported X platforms. From this point, the old MASM files will no longer be used. Please see the commit messages for details on the changes made.

Issue: #3148 