### PR TITLE
Update playlist for the access check on module

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -786,6 +786,7 @@
 	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED $(ADD_EXPORTS_JDK_INTERNAL_REFLECT) \
 	--add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED \
 	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
+	--add-exports java.base/sun.net.www.protocol.jrt=ALL-UNNAMED \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
 	--add-opens=java.base/java.security=ALL-UNNAMED \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(JAXB_API_JAR)$(Q) \


### PR DESCRIPTION
The minor change is to export the requested 
Oracle class to unnamed modules.

Close #4313

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>