### PR TITLE
Initial implementation of JVM_CopySwapMemory

### DIFF
--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2007, 2018 IBM Corp. and others
+Copyright (c) 2007, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -287,6 +287,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<export name="_JVM_GetMethodTypeAnnotations@8"/>
 		<export name="_JVM_IsVMGeneratedMethodIx@12"/>
 		<export name="JVM_GetTemporaryDirectory"/>
+		<export name="_JVM_CopySwapMemory@44"/>
 
 		<!-- Additions for Java 9 (Modularity) -->
 		<export name="JVM_DefineModule"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2001, 2018 IBM Corp. and others
+dnl Copyright (c) 2001, 2019 IBM Corp. and others
 dnl
 dnl This program and the accompanying materials are made available under
 dnl the terms of the Eclipse Public License 2.0 which accompanies this
@@ -256,6 +256,7 @@ _X(JVM_GetMethodParameters,JNICALL,true,jobjectArray ,JNIEnv *env, jobject metho
 _X(JVM_GetMethodTypeAnnotations,JNICALL,true,jbyteArray ,JNIEnv *env, jobject method)
 _X(JVM_IsVMGeneratedMethodIx,JNICALL,true,jboolean ,JNIEnv *env, jclass cb, jint index)
 _X(JVM_GetTemporaryDirectory,JNICALL,false,jstring ,JNIEnv *env)
+_X(JVM_CopySwapMemory,JNICALL,true,void ,JNIEnv *env, jobject srcObj, jlong srcOffset, jobject dstObj, jlong dstOffset, jlong size, jlong elemSize)
 _X(JVM_GetPrimitiveField,JNICALL,true,jobject ,jint arg0, jint arg1, jint arg2, jint arg3)
 _X(JVM_InitializeCompiler,JNICALL,true,jobject ,jint arg0, jint arg1)
 _X(JVM_IsSilentCompiler,JNICALL,true,jobject ,jint arg0, jint arg1)


### PR DESCRIPTION
New function to copy and endian flip memory of various sizes. The
current implementation has given no thought to performance.

Closes: #4312

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>