### PR TITLE
Schedule remote sync compilation to local first

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2330,7 +2330,7 @@ remoteCompilationEnd(
 
    if (TR::Options::getVerboseOption(TR_VerboseJITaaS))
       {
-      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d has successfully compiled %s", 
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITaaS, "compThreadID=%d has successfully compiled %s",
          entry->_compInfoPT->getCompThreadId(), entry->_compInfoPT->getCompilation()->signature());
       }
    }

--- a/runtime/compiler/control/MethodToBeCompiled.cpp
+++ b/runtime/compiler/control/MethodToBeCompiled.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,6 +86,7 @@ void TR_MethodToBeCompiled::initialize(TR::IlGeneratorMethodDetails & details, v
    _methodIsInSharedCache = TR_maybe;
    _clientOptions = nullptr;
    _clientOptionsSize = 0;
+   _origOptLevel = unknownHotness;
 
    TR_ASSERT_FATAL(_freeTag & ENTRY_IN_POOL_FREE, "initializing an entry which is not free");
 

--- a/runtime/compiler/control/MethodToBeCompiled.hpp
+++ b/runtime/compiler/control/MethodToBeCompiled.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "compile/CompilationTypes.hpp"
 #include "control/CompilationPriority.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 
@@ -66,6 +67,7 @@ struct TR_MethodToBeCompiled
    bool isOutOfProcessCompReq() const { return _stream != nullptr; } // at the server
    uint64_t getClientUID() const;
    void cleanupJITaaS();
+   bool hasChangedToLocalSyncComp() const { return _origOptLevel != unknownHotness; }
 
    TR_MethodToBeCompiled *_next;
    TR::IlGeneratorMethodDetails _methodDetailsStorage;
@@ -124,6 +126,7 @@ struct TR_MethodToBeCompiled
    JITaaS::J9ServerStream  *_stream; // a non-NULL field denotes an out-of-process compilation request
    char                  *_clientOptions;
    size_t                _clientOptionsSize;
+   TR_Hotness            _origOptLevel; // used to cache original optLevel when transforming a remote sync compilation to a local cheap one
    }; // TR_MethodToBeCompiled
 
 

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -2393,7 +2393,8 @@ void TR_DebugExt::dxPrintMethodToBeCompiled(TR_MethodToBeCompiled *remoteCompEnt
    _dbgPrintf("\tint16_t                       _index = %d\n",localCompEntry->_index);
    _dbgPrintf("\tbool                          _freeTag = %d\n",localCompEntry->_freeTag);
    _dbgPrintf("\tuint8_t                       _weight = %u\n",localCompEntry->_weight);
-   _dbgPrintf("\tbool                          _hasIncrementedNumCompThreadsCompilingHotterMethods = %d\n\n",localCompEntry->_hasIncrementedNumCompThreadsCompilingHotterMethods);
+   _dbgPrintf("\tbool                          _hasIncrementedNumCompThreadsCompilingHotterMethods = %d\n",localCompEntry->_hasIncrementedNumCompThreadsCompilingHotterMethods);
+   _dbgPrintf("\tTR_Hotness                   _origOptLevel = 0x%p\n\n", localCompEntry->_origOptLevel);
 
    struct J9Method *ramMethod = (struct J9Method *)dxGetJ9MethodFromMethodToBeCompiled(remoteCompEntry);
    if (ramMethod)


### PR DESCRIPTION
Remote synchronous compilations have much higher latency due to network communication,
It’s proposed to schedule a cheap (cold) synchronous compilation at the client
immediately followed by an expensive re-compilation performed at the server.
This heuristic should be enabled only when -Xjit:enableJITaaSHeuristics is present.

Issue: #4093

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>