### PR TITLE
Reducing messages for ResolvedMethod_getClassFromConstantPool

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2630,6 +2630,13 @@ ClientSessionData::ClassInfo::freeClassInfo()
       _classOfStaticCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
       jitPersistentFree(_classOfStaticCache);
       }
+
+   if (_constantClassPoolCache)
+      {
+      _constantClassPoolCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
+      jitPersistentFree(_constantClassPoolCache);
+      }
+
    }
 
 ClientSessionData::VMInfo *
@@ -2885,6 +2892,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct.arrayClass = std::get<15>(classInfo);
    classInfoStruct.totalInstanceSize = std::get<16>(classInfo);
    classInfoStruct._classOfStaticCache = nullptr;
+   classInfoStruct._constantClassPoolCache = nullptr;
 
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -63,6 +63,7 @@ class ClientSessionData
       TR_OpaqueClassBlock * arrayClass;
       uintptrj_t totalInstanceSize;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_classOfStaticCache;
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_constantClassPoolCache;
       };
 
    struct J9MethodInfo

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -146,8 +146,31 @@ TR_ResolvedJ9JITaaSServerMethod::staticAttributes(TR::Compilation * comp, I_32 c
 TR_OpaqueClassBlock *
 TR_ResolvedJ9JITaaSServerMethod::getClassFromConstantPool(TR::Compilation * comp, uint32_t cpIndex, bool)
    {
+   TR::CompilationInfoPerThread *compInfoPT = _fe->_compInfoPT;
+      {
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
+      auto &constantClassPoolCache = getJ9ClassInfo(compInfoPT, _ramClass)._constantClassPoolCache;
+      if (!constantClassPoolCache)
+         {
+         // initialize cache, called once per ram class
+         constantClassPoolCache = new (PERSISTENT_NEW) PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>(PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>::allocator_type(TR::Compiler->persistentAllocator()));
+         }
+      else
+         {
+         auto it = constantClassPoolCache->find(cpIndex);
+         if (it != constantClassPoolCache->end())
+            return it->second;
+         }
+      }
    _stream->write(JITaaS::J9ServerMessageType::ResolvedMethod_getClassFromConstantPool, _remoteMirror, cpIndex);
-   return std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
+   TR_OpaqueClassBlock *resolvedClass = std::get<0>(_stream->read<TR_OpaqueClassBlock *>());
+   if (resolvedClass)
+      {
+      OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
+      auto constantClassPoolCache = getJ9ClassInfo(compInfoPT, _ramClass)._constantClassPoolCache;
+      constantClassPoolCache->insert({cpIndex, resolvedClass});
+      }
+   return resolvedClass;
    }
 
 TR_OpaqueClassBlock *


### PR DESCRIPTION
Persistent map cache is created in the ClassInfo for the constant class pool.
Cache is checked before posting message to the client.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>