### PR TITLE
Reducing messages for ResolvedMethod_getClassFromConstantPool

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2630,6 +2630,13 @@ ClientSessionData::ClassInfo::freeClassInfo()
       _classOfStaticCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
       jitPersistentFree(_classOfStaticCache);
       }
+
+   if (_constantClassPoolCache)
+      {
+      _constantClassPoolCache->~PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *>();
+      jitPersistentFree(_constantClassPoolCache);
+      }
+
    }
 
 ClientSessionData::VMInfo *
@@ -2885,6 +2892,7 @@ JITaaSHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Class
    classInfoStruct.arrayClass = std::get<15>(classInfo);
    classInfoStruct.totalInstanceSize = std::get<16>(classInfo);
    classInfoStruct._classOfStaticCache = nullptr;
+   classInfoStruct._constantClassPoolCache = nullptr;
 
    clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct});
 

--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -63,6 +63,7 @@ class ClientSessionData
       TR_OpaqueClassBlock * arrayClass;
       uintptrj_t totalInstanceSize;
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_classOfStaticCache;
+      PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> *_constantClassPoolCache;
       };
 
    struct J9MethodInfo


### PR DESCRIPTION
Persistent map cache is created in the ClassInfo for the constant class pool.
Cache is checked before posting message to the client.

Signed-off-by: Satbir Singh <satbir.singh1@ibm.com>