### PR TITLE
Update JIT bytecode enum to match a change from VM

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -22,6 +22,10 @@
 
 #define J9_EXTERNAL_TO_VM
 
+#if defined (_MSC_VER) && (_MSC_VER < 1900)
+#define snprintf _snprintf
+#endif
+
 #include "env/VMJ9.h"
 
 #include <algorithm>
@@ -4723,11 +4727,21 @@ TR_J9VMBase::getOverflowSafeAllocSize()
    }
 
 void
+TR_J9VMBase::unsupportedByteCode(TR::Compilation * comp, U_8 opcode)
+   {
+   char errMsg[40];
+   snprintf(errMsg, 40, "bytecode %d not supported by JIT", opcode);
+   comp->failCompilation<TR::CompilationException>(errMsg);
+   }
+
+void
 TR_J9VMBase::unknownByteCode(TR::Compilation * comp, U_8 opcode)
    {
    // an unknown bytecode may be seen if the method contains a breakpoint, in that case we should abort the compile
    //
-   comp->failCompilation<TR::CompilationException>("Unknown bytecode");
+   char errMsg[40];
+   snprintf(errMsg, 40, "Unknown bytecode %d to JIT", opcode);
+   comp->failCompilation<TR::CompilationException>(errMsg);
    }
 
 char*

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -393,6 +393,7 @@ public:
 
    virtual TR::PersistentInfo * getPersistentInfo()  { return ((TR_PersistentMemory *)_jitConfig->scratchSegment)->getPersistentInfo(); }
    void                       unknownByteCode( TR::Compilation *, uint8_t opcode);
+   void                       unsupportedByteCode( TR::Compilation *, uint8_t opcode);
 
    virtual bool isBenefitInliningCheckIfFinalizeObject() { return false; }
 

--- a/runtime/compiler/ilgen/J9ByteCode.hpp
+++ b/runtime/compiler/ilgen/J9ByteCode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -110,6 +110,8 @@ enum TR_J9ByteCode
    J9BCmonitorenter, J9BCmonitorexit,
    J9BCwide,
    J9BCasyncCheck,
+   J9BCdefaultvalue,
+   J9BCwithfield,
    J9BCunknown
    };
 

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -357,14 +357,22 @@ const TR_J9ByteCode TR_J9ByteCodeIterator::_opCodeToByteCodeEnum[] =
    /* 198 */ J9BCifnull, J9BCifnonnull,
    /* 200 */ J9BCgotow, J9BCunknown,
    /* 202 */ J9BCunknown,
-   /* 203 */ J9BCiloadw, J9BClloadw, J9BCfloadw, J9BCdloadw, J9BCaloadw,
-   /* 208 */ J9BCistorew, J9BClstorew, J9BCfstorew, J9BCdstorew, J9BCastorew,
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+   /* 203 */ J9BCdefaultvalue,
+   /* 204 */ J9BCwithfield,
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+   /* 203 */ J9BCunknown,
+   /* 204 */ J9BCunknown,
+#endif
+   /* 205 */ J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown,
+   /* 209 */ J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown,
    /* 213 */ J9BCiincw, J9BCunknown,
    /* 215 - JBaload0getfield */ J9BCaload0,
    /* 216 - JBnewdup */ J9BCnew,
-   /* 217 */ J9BCunknown, J9BCunknown,
-   /* 219 */ J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown,
-   /* 224 */ J9BCunknown, J9BCunknown, J9BCunknown, J9BCunknown,
+   /* 217 */ J9BCiloadw, J9BClloadw, J9BCfloadw, J9BCdloadw, J9BCaloadw,
+   /* 222 */ J9BCistorew, J9BClstorew, J9BCfstorew, J9BCdstorew, J9BCastorew,
+   /* 227 */ J9BCunknown,
    /* 228 */ J9BCgenericReturn, J9BCgenericReturn, J9BCunknown, J9BCinvokeinterface2,
    /* 232 */ J9BCinvokehandle, J9BCinvokehandlegeneric,
    /* 234 */ J9BCinvokestaticsplit, J9BCinvokespecialsplit,

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1527,6 +1527,9 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
             _bcIndex = genReturn(method()->returnOpCode(), method()->isSynchronized());
             break;
 
+         case J9BCdefaultvalue:
+         case J9BCwithfield:
+            fej9()->unsupportedByteCode(comp(), opcode);
          case J9BCunknown:
             fej9()->unknownByteCode(comp(), opcode);
             break;


### PR DESCRIPTION
A recent change in VM added 2 new opcodes and changed the
internal bytecodes. Update the JIT counter part in this
commit.

https://github.com/eclipse/openj9/pull/3416

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>