### PR TITLE
Add TR_MethodCallAddress implementation for x86

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -203,6 +203,15 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_MethodCallAddress:
+         {
+         TR_RelocationRecordMethodCallAddress *mcaRecord = reinterpret_cast<TR_RelocationRecordMethodCallAddress *>(reloRecord);
+
+         mcaRecord->setEipRelative(reloTarget);
+         mcaRecord->setAddress(reloTarget, relocation->getTargetAddress());
+         }
+         break;
+
       default:
          return cursor;
       }
@@ -276,6 +285,14 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
       case TR_AbsoluteMethodAddress:
          {
          self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
+         }
+         break;
+
+      case TR_MethodCallAddress:
+         {
+         TR_RelocationRecordMethodCallAddress *mcaRecord = reinterpret_cast<TR_RelocationRecordMethodCallAddress *>(reloRecord);
+         traceMsg(self()->comp(), "\n Method Call Address: address=" POINTER_PRINTF_FORMAT, mcaRecord->address(reloTarget));
+         self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
          }
          break;
 

--- a/runtime/compiler/ras/DebugExt.cpp
+++ b/runtime/compiler/ras/DebugExt.cpp
@@ -3484,6 +3484,12 @@ typedef struct TR_RelocationClassAddress
    uintptr_t cpIndex;
    } TR_RelocationClassAddress;
 
+typedef struct TR_RelocationRecordMethodCallAddress
+   {
+   TR_RelocationRecordHeaderPadded hdr;
+   uintptr_t methodAddress;
+   } TR_RelocationRecordMethodCallAddress;
+
 typedef TR_RelocationRecordMethodEnterExitCheck TR_RelocationRecordUnresolvedAddressMaterializationHCR;
 
 typedef TR_RelocationRecordConstantPool TR_RelocationRecordThunks;
@@ -3658,6 +3664,13 @@ TR_DebugExt::dxPrintAOTinfo(void *addr)
             {
             TR_RelocationClassAddress *record = (TR_RelocationClassAddress *) reloRecord;
             _dbgPrintf("0x%-16x  0x%-16x", record->inlinedSiteIndex, record->constantPool);
+            ptr = (U_8*) (record+1);
+            }
+         break;
+         case TR_MethodCallAddress:
+            {
+            TR_RelocationRecordMethodCallAddress *record = (TR_RelocationRecordMethodCallAddress *)reloRecord;
+            _dbgPrintf("0x%-16x", record->methodAddress);
             ptr = (U_8*) (record+1);
             }
          break;

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -385,6 +385,10 @@ struct TR_RelocationRecordSymbolFromManagerBinaryTemplate : public TR_Relocation
    uint16_t _symbolType;
    };
 
+struct TR_RelocationRecordMethodCallAddressBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   UDATA _methodAddress;
+   };
 
 extern char* AOTcgDiagOn;
 
@@ -1881,6 +1885,23 @@ class TR_RelocationRecordClassUnloadAssumption : public TR_RelocationRecord
       virtual int32_t bytesInHeaderAndPayload();
 
       virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+   };
+
+class TR_RelocationRecordMethodCallAddress : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordMethodCallAddress() {}
+      TR_RelocationRecordMethodCallAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual char *name() { return "TR_MethodCallAddress"; }
+      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordMethodCallAddressBinaryTemplate); }
+      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+      uint8_t* address(TR_RelocationTarget *reloTarget);
+      void setAddress(TR_RelocationTarget *reloTarget, uint8_t* callTargetAddress);
+
+   private:
+      uint8_t *computeTargetMethodAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *baseLocation);
    };
 
 #endif   // RELOCATION_RECORD_INCL

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -1323,6 +1323,7 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    sizeof(TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate),//TR_ValidateMethodFromSingleAbstractImplementer= 96,
    sizeof(TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate),//TR_ValidateImproperInterfaceMethodFromCP= 97,
    sizeof(TR_RelocationRecordSymbolFromManagerBinaryTemplate),         // TR_SymbolFromManager = 98,
+   sizeof(TR_RelocationRecordMethodCallAddressBinaryTemplate),         // TR_MethodCallAddress                   = 99,
 #else
 
    12,                                              // TR_ConstantPool                        = 0


### PR DESCRIPTION
This patch introduces an x86 implementation for the newly added OMR relocation `TR_MethodCallAddress`, which is suitable for relocating a relative call to a fixed, known target address.

Depends on https://github.com/eclipse/omr/pull/3427.