### PR TITLE
Add Class enumVars and cachedEnumConstants as recognized known object field

### DIFF
--- a/runtime/compiler/il/symbol/J9Symbol.cpp
+++ b/runtime/compiler/il/symbol/J9Symbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,6 +163,8 @@ J9::Symbol::searchRecognizedField(TR::Compilation * comp, TR_ResolvedMethod * ow
        {r(TR::Symbol::Java_lang_Character_value,                      "java/lang/Character", "value", "C")},
        {r(TR::Symbol::Java_lang_Short_value,                          "java/lang/Short", "value", "S")},
        {r(TR::Symbol::Java_lang_Boolean_value,                        "java/lang/Boolean", "value", "Z")},
+       {r(TR::Symbol::Java_lang_Class_enumVars,                       "java/lang/Class", "enumVars", "Ljava/lang/Class$EnumVars;")},
+       {r(TR::Symbol::Java_lang_ClassEnumVars_cachedEnumConstants,    "java/lang/Class$EnumVars", "cachedEnumConstants", "[Ljava/lang/Object;")},
        {TR::Symbol::UnknownField}
       };
 
@@ -180,7 +182,7 @@ J9::Symbol::searchRecognizedField(TR::Compilation * comp, TR_ResolvedMethod * ow
         */
        {recognizedFieldName_c, 17, 22},
        {0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},
-       {recognizedFieldName_j, 16, 52}
+       {recognizedFieldName_j, 14, 52}
       };
    const char minClassPrefix = 'c';
    const char maxClassPrefix = 'j';
@@ -310,6 +312,8 @@ J9::Symbol::createRecognizedShadow(AllocatorType m, TR::DataType d, RecognizedFi
    auto * sym = createShadow(m, d);
    sym->_recognizedField = f;
    sym->_flags.set(RecognizedShadow);
+   if ((f == TR::Symbol::Java_lang_Class_enumVars) || (f == TR::Symbol::Java_lang_ClassEnumVars_cachedEnumConstants))
+      sym->_flags.set(RecognizedKnownObjectShadow);
    return sym;
    }
 
@@ -320,6 +324,8 @@ J9::Symbol::createRecognizedShadow(AllocatorType m, TR::DataType d, uint32_t s, 
    auto * sym = createShadow(m,d,s);
    sym->_recognizedField = f;
    sym->_flags.set(RecognizedShadow);
+   if ((f == TR::Symbol::Java_lang_Class_enumVars) || (f == TR::Symbol::Java_lang_ClassEnumVars_cachedEnumConstants))
+      sym->_flags.set(RecognizedKnownObjectShadow);
    return sym;
    }
 

--- a/runtime/compiler/il/symbol/J9Symbol.hpp
+++ b/runtime/compiler/il/symbol/J9Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -166,6 +166,8 @@ public:
       Java_lang_Character_value,
       Java_lang_Short_value,
       Java_lang_Boolean_value,
+      Java_lang_Class_enumVars,
+      Java_lang_ClassEnumVars_cachedEnumConstants,
       assertionsDisabled,
       NumRecognizedFields
       };


### PR DESCRIPTION
Add new recognized field Java_lang_Class_enumVars and
Java_lang_ClassEnumVars_cachedEnumConstants. Add new flag
RecognizedKnownObjectShadow to these shadow sym refs, indicating these are
special fields that are initlized just once if null, to a non-null value
and do not change during the VM run time.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>