### PR TITLE
WIP Enable OpenSSL on AIX jdk8, including the test

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -202,7 +202,7 @@ aix_ppc-64_cmprssptrs:
       12: 'hw.arch.ppc64 && sw.os.aix'
       next: 'hw.arch.ppc64 && sw.os.aix'
   extra_configure_options:
-    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8'
+    8: '--with-cups-include=/opt/freeware/include --disable-ccache --with-jobs=8 --with-openssl=fetched'
     9: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     10: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'
     11: '--with-cups-include=/opt/freeware/include --disable-warnings-as-errors --with-jobs=8'

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -761,7 +761,6 @@
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>^os.aix</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Now that https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/227 is
merged, OpenSSL on AIX can be supported.

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>