### PR TITLE
Delete package-private getChars( byte[]) method

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -1848,14 +1848,6 @@ public final class String implements Serializable, Comparable<String>, CharSeque
 		}
 	}
 
-	void getChars(int start, int end, byte[] data, int index) {
-		if (0 <= start && start <= end && end <= lengthInternal() && 0 <= index && ((end - start) <= ((data.length / 2) - index))) {
-			getCharsNoBoundChecks(start, end, data, index);
-		} else {
-			throw new StringIndexOutOfBoundsException();
-		}
-	}
-
 	// This is a package protected method that performs the getChars operation without explicit bound checks.
 	// Caller of this method must validate bound safety for String indexing and array copying.
 	void getCharsNoBoundChecks(int start, int end, byte[] data, int index) {


### PR DESCRIPTION
As discussed in https://github.com/eclipse/openj9/pull/4224#issuecomment-454577251 , this method was necessary for zOS but not anymore.  Now that 9b148 is removed, it can be deleted.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>