### PR TITLE
Remove references to legacy Java 9 classes

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/MsgHelp.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/MsgHelp.java
@@ -3,7 +3,7 @@
 package com.ibm.oti.vm;
 
 /*******************************************************************************
- * Copyright (c) 2003, 2018 IBM Corp. and others
+ * Copyright (c) 2003, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,11 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /*[IF Sidecar19-SE]
-/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
-/*[ELSE]
-import java.lang.reflect.Module;
-/*[ENDIF]
 import jdk.internal.reflect.CallerSensitive;
 /*[ELSE]*/
 import sun.reflect.CallerSensitive;

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corp. and others
+ * Copyright (c) 2007, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,16 +43,12 @@ import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
 
 /*[IF Sidecar19-SE]
-/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
 import java.util.Iterator;
 import java.util.List;
 /*[IF Java11]*/
 import java.nio.charset.Charset;
 import java.nio.charset.CharacterCodingException;
-/*[ENDIF]*/
-/*[ELSE]
-import java.lang.reflect.Module;
 /*[ENDIF]*/
 /*[IF Java12]*/
 import jdk.internal.access.JavaLangAccess;
@@ -221,11 +217,7 @@ final class Access implements JavaLangAccess {
 	 }
 	
 	public 
-/*[IF Sidecar19-SE-OpenJ9]	
 	java.lang.ModuleLayer
-/*[ELSE]*/
-	java.lang.reflect.Layer
-/*[ENDIF]*/	
 	getBootLayer() {
 		return System.bootLayer;
 	}

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,12 +27,8 @@ import java.lang.invoke.MethodType;
 /*[ENDIF]*/
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Version;
-/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.IllegalCallerException;
 import java.lang.Module;
-/*[ELSE]
-import java.lang.reflect.Module;
-/*[ENDIF]*/
 import java.security.Permission;
 import java.util.Collections;
 import java.util.HashSet;
@@ -185,7 +181,7 @@ public final class StackWalker {
 				s -> s.limit(2).collect(Collectors.toList()));
 		if (result.size() < 2) {
 			/*[MSG "K0640", "getCallerClass() called from method with no caller"]*/
-			/*[IF Sidecar19-SE-OpenJ9]
+			/*[IF Sidecar19-SE]
 			throw new IllegalCallerException(com.ibm.oti.util.Msg.getString("K0640")); //$NON-NLS-1$
 			/*[ELSE]*/
 			throw new IllegalStateException(com.ibm.oti.util.Msg.getString("K0640")); //$NON-NLS-1$

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,11 +39,7 @@ import jdk.internal.misc.SharedSecrets;
 /*[ENDIF]*/
 import jdk.internal.misc.VM;
 import java.lang.StackWalker.Option;
-/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
-/*[ELSE]
-import java.lang.reflect.Module;
-/*[ENDIF]*/
 import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.CallerSensitive;
 import java.util.*;
@@ -106,11 +102,7 @@ public final class System {
 	private static String osEncoding;
 
 /*[IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE-OpenJ9]
 	static java.lang.ModuleLayer	bootLayer;
-/*[ELSE]*/
-	static java.lang.reflect.Layer	bootLayer;
-/*[ENDIF]*/
 /*[ENDIF]*/
 	
 	// Initialize all the slots in System on first use.
@@ -189,7 +181,7 @@ public final class System {
 		/*[ELSE]*/
 		StringCoding.encode(new char[1], 0, 1);
 		/*[ENDIF]*/
-		/*[IF Sidecar18-SE-OpenJ9|Sidecar19-SE]*/
+		/*[IF Sidecar19-SE]*/
 		setErr(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true));
 		setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), true));
 		/*[IF Sidecar19-SE_RAWPLUSJ9]*/

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corp. and others
+ * Copyright (c) 2005, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,13 +24,8 @@ package com.ibm.java.lang.management.internal;
 
 import java.lang.management.PlatformLoggingMXBean;
 /*[IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.Module;
 import java.lang.ModuleLayer;
-/*[ELSE]
-import java.lang.reflect.Module;
-import java.lang.reflect.Layer;
-/*[ENDIF]*/
 /*[ENDIF]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,7 @@
  *******************************************************************************/
 package java.lang.management;
 
-/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.ModuleLayer;
-/*[ELSE]
-import java.lang.reflect.Layer;
-/*[ENDIF]*/
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,7 @@
  *******************************************************************************/
 package com.ibm.lang.management.internal;
 
-/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.ModuleLayer;
-/*[ELSE]
-import java.lang.reflect.Layer;
-/*[ENDIF]*/
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,13 +25,8 @@
 package openj9.lang.management.internal;
 
 /*[IF Sidecar19-SE]*/
-/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.Module;
 import java.lang.ModuleLayer;
-/*[ELSE]
-import java.lang.reflect.Module;
-import java.lang.reflect.Layer;
-/*[ENDIF]*/
 /*[ENDIF]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;


### PR DESCRIPTION
Remove references to java.lang.reflect.Module and java.lang.reflect.Layer.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>