### PR TITLE
Adding library to ldconfig on ppc64le centos7 Dockerfile 

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -117,6 +117,10 @@ RUN cd /usr/local \
   && tar -xJf gcc-7.tar.xz --strip-components=1 \
   && rm -rf gcc-7.tar.xz
 
+# Edit ldconfig to connect this library
+RUN echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig
+
 #Building and setting up git version 2.5.3
 RUN yum -y update \
   && yum -y install \


### PR DESCRIPTION
 Adding library to ldconfig on ppc64le centos7 Dockerfile

When docker was used to build openj9, this error message popped up:
- ../ddrgen: /lib64/libstdc++.so.6: \
- version `GLIBCXX_3.4.20' not found (required by ../ddrgen)
- ../ddrgen: /lib64/libstdc++.so.6: version \
- `GLIBCXX_3.4.21’ not found (required by ../ddrgen)
They are not found because we are getting gcc from AdoptOpenJDK.
The links are normally made when gcc is installed from a package manager.
After adding the library to ldconfig, it was able to build successfully.

[skip ci]

Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>