### PR TITLE
Handle setCallCount if client IProfiler is disabled

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2061,7 +2061,9 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          auto bcIndex = std::get<1>(recv);
          auto count = std::get<2>(recv);
          TR_IProfiler * iProfiler = fe->getIProfiler();
-         iProfiler->setCallCount(method, bcIndex, count, comp);
+         if (iProfiler)
+            // iProfiler will be NULL, if disabled on the client but not on the server
+            iProfiler->setCallCount(method, bcIndex, count, comp);
          client->write(JITaaS::Void());
          }
          break;


### PR DESCRIPTION
If interpreter profiling is disabled on the client,
the profiler instance is NULL. Handle this case by
checking if client IProfiler exists.

Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>