### PR TITLE
Fix compile error

### DIFF
--- a/runtime/j9vm/j8vmi.c
+++ b/runtime/j9vm/j8vmi.c
@@ -121,8 +121,8 @@ JVM_GetTemporaryDirectory(JNIEnv *env)
 void JNICALL
 JVM_CopySwapMemory(JNIEnv *env, jobject srcObj, jlong srcOffset, jobject dstObj, jlong dstOffset, jlong size, jlong elemSize)
 {
-	void *srcBytes = NULL;
-	void *dstBytes = NULL;
+	U_8 *srcBytes = NULL;
+	U_8 *dstBytes = NULL;
 	U_8 *dstAddr = NULL;
 	if (NULL != srcObj) {
 		srcBytes = (*env)->GetPrimitiveArrayCritical(env, srcObj, NULL);


### PR DESCRIPTION
It's illegal to add an integer to a void pointer.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>