### PR TITLE
Use the appropriate JIT API when enabling field watches

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1374,7 +1374,13 @@ jitDataBreakpointAdded(J9VMThread * currentThread)
 
 		/* Toss the compilation queue */
 
-		jitConfig->jitFlushCompilationQueue(currentThread, J9FlushCompQueueDataBreakpoint);
+		if (inlineWatches) {
+			jitConfig->jitFlushCompilationQueue(currentThread, J9FlushCompQueueDataBreakpoint);
+			/* Make all future compilations inline the field watch code */
+			jitConfig->inlineFieldWatches = TRUE;
+		} else {
+			jitConfig->jitClassesRedefined(currentThread, 0, NULL);			
+		}
 
 		/* Find every method which has been translated and mark it for retranslation */
 
@@ -1387,11 +1393,6 @@ jitDataBreakpointAdded(J9VMThread * currentThread)
 		/* Mark every JIT method in every stack for decompilation */
 
 		decompileAllMethodsInAllStacks(currentThread, JITDECOMP_DATA_BREAKPOINT);
-
-		if (inlineWatches) {
-			/* Make all future compilations inline the field watch code */
-			jitConfig->inlineFieldWatches = TRUE;
-		}
 	}
 
 	Trc_Decomp_jitDataBreakpointAdded_Exit(currentThread);


### PR DESCRIPTION
Use the old jitClassesRedefined API to flush the compilation queue if
inline field watches are not enabled. If they are enabled, use the new
jitFlushCompilationQueue API.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>