### PR TITLE
DDR: Fix printing of class static field values

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,10 +62,9 @@ import com.ibm.j9ddr.vm29.types.UDATA;
 /**
  * Class that calculates offsets into an Object of fields.
  * Based on:
- * resolvefield.c 1.48
- * description.c 1.25
+ * resolvefield.cpp
+ * description.c
  */
-
 public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator {
 
 	private J9JavaVMPointer vm;
@@ -73,7 +72,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	private J9ClassPointer superClazz;
 	private Iterator romFieldsShapeIterator;
 	private J9ClassPointer instanceClass;
-	
+
 	private U32 doubleSeen = new U32(0);
 	private U32 doubleStaticsSeen = new U32(0);
 	private UDATA firstDoubleOffset = new UDATA(0);
@@ -93,7 +92,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	private UDATA lockOffset = new UDATA(0);
 
 	private boolean isHidden;
-	
+
 	@SuppressWarnings("unused")
 	private UDATA finalizeLinkOffset = new UDATA(0);
 	private int hiddenInstanceFieldWalkIndex = -1;
@@ -112,12 +111,12 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		this.walkFlags = flags;
 		// Can't call init or set romClass in the constructor because they can throw a CorruptDataException
 	}
-	
+
 	private void init() throws CorruptDataException {
 		calculateInstanceSize(romClass, superClazz); //initInstanceSize(romClass, superClazz);
 		romFieldsShapeIterator = new J9ROMFieldShapeIterator(romClass.romFields(), romClass.romFieldCount());
 	}
-	
+
 	private void nextField() throws CorruptDataException {
 		boolean walkHiddenFields = false;
 		isHidden = false;
@@ -133,7 +132,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				walkHiddenFields = true;
 				/* Start the walk over the hidden fields array in reverse order. */
 				hiddenInstanceFieldWalkIndex = hiddenInstanceFieldList.size();
-			} 
+			}
 		} else {
 			walkHiddenFields = true;
 		}
@@ -197,7 +196,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE)) {
 					if (modifiers.anyBitsIn(J9FieldFlagObject)) {
 						if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_BACKFILL_OBJECT_FIELD)) {
-//							Assert_VM_true(state->backfillOffsetToUse >= 0);
+							// Assert_VM_true(state->backfillOffsetToUse >= 0);
 							offset = new UDATA(backfillOffsetToUse);
 							walkFlags = walkFlags.bitAnd(new U32(new UDATA(J9VM_FIELD_OFFSET_WALK_BACKFILL_OBJECT_FIELD).bitNot()));
 						} else {
@@ -212,7 +211,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 							doubleSeen = doubleSeen.add(1);
 						} else {
 							if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_BACKFILL_SINGLE_FIELD)) {
-//								Assert_VM_true(state->backfillOffsetToUse >= 0);
+								// Assert_VM_true(state->backfillOffsetToUse >= 0);
 								offset = new UDATA(backfillOffsetToUse);
 								walkFlags = walkFlags.bitAnd(new U32(new UDATA(J9VM_FIELD_OFFSET_WALK_BACKFILL_SINGLE_FIELD).bitNot()));
 							} else {
@@ -249,7 +248,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		if (!walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_CALCULATE_INSTANCE_SIZE)) {
 			return;
 		}
-		ObjectFieldInfo fieldInfo  = new ObjectFieldInfo(romClass);
+		ObjectFieldInfo fieldInfo = new ObjectFieldInfo(romClass);
 
 		/*
 		 * Step 1: Calculate the size of the superclass and backfill offset.
@@ -280,7 +279,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				 * superClazz is java.lang.Object: subtract off non-inherited monitor field.
 				 * Note that java.lang.Object's backfill slot can be only at the end.
 				 */
-				/* this may  have been rounded to 8 bytes so also get rid of the padding */
+				/* this may have been rounded to 8 bytes so also get rid of the padding */
 				if (fieldInfo.isSuperclassBackfillSlotAvailable()) { /* j.l.Object was not end aligned */
 					newSuperSize -= BACKFILL_SIZE;
 					fieldInfo.setSuperclassBackfillOffset(NO_BACKFILL_AVAILABLE);
@@ -301,9 +300,9 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		} else {
 			/*
 			 * Superclass is not finalizable.
-			 * We add the field if the class marked as needing finalization.  In addition when HCR is enabled we also add the field if the
+			 * We add the field if the class marked as needing finalization. In addition when HCR is enabled we also add the field if the
 			 * the class is not the class for java.lang.Object (superclass name in java.lang.object isnull) and the class has a finalize
-			 * method regardless of whether this method is empty or not.  We need to do this because when HCR is enabled it is possible
+			 * method regardless of whether this method is empty or not. We need to do this because when HCR is enabled it is possible
 			 * that the method will be re-transformed such that there finalization is needed and in that case
 			 * we need the field to be in the shape of the existing objects
 			 */
@@ -342,14 +341,14 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		}
 
 		/*
-		 * Calculate offsets (from the object header) for hidden fields.  Hidden fields follow immediately the instance fields of the same type.
+		 * Calculate offsets (from the object header) for hidden fields. Hidden fields follow immediately the instance fields of the same type.
 		 * Give instance fields priority for backfill slots.
 		 * Note that the hidden fields remember their offsets, so this need be done once only.
 		 */
 		if (!hiddenInstanceFieldList.isEmpty()) {
 			UDATA hiddenSingleOffset = firstSingleOffset.add(J9Object.SIZEOF + (fieldInfo.getNonBackfilledInstanceSingleCount() * U32.SIZEOF));
 			UDATA hiddenDoubleOffset = firstDoubleOffset.add(J9Object.SIZEOF + (fieldInfo.getInstanceDoubleCount() * U64.SIZEOF));
-			UDATA hiddenObjectOffset =  firstObjectOffset.add(J9Object.SIZEOF + (fieldInfo.getNonBackfilledInstanceObjectCount() * fj9object_t_SizeOf));
+			UDATA hiddenObjectOffset = firstObjectOffset.add(J9Object.SIZEOF + (fieldInfo.getNonBackfilledInstanceObjectCount() * fj9object_t_SizeOf));
 			boolean useBackfillForObject = false;
 			boolean useBackfillForSingle = false;
 
@@ -391,7 +390,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		}
 		backfillOffsetToUse = new IDATA(fieldInfo.getMyBackfillOffset()); /* backfill offset for this class's fields */
 	}
-	
+
 	static PrintStream err = System.err;
 
 	/**
@@ -401,7 +400,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	 * @param romClass
 	 * @param ramSuperClass
 	 * @param instanceClass
-	 * @return NO_LOCKWORD_NEEDED if no lockword, lockword offset if it inherits a lockword, 
+	 * @return NO_LOCKWORD_NEEDED if no lockword, lockword offset if it inherits a lockword,
 	 * LOCKWORD_NEEDED if lockword needed and superclass does not have a lockword
 	 * @throws CorruptDataException
 	 */
@@ -409,37 +408,35 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		if (!J9BuildFlags.thr_lockNursery) {
 			return NO_LOCKWORD_NEEDED;
 		}
-		
+
 		J9ClassPointer ramClassForRomClass = instanceClass;
-		while (!ramClassForRomClass.isNull() &&(!romClass.equals(ramClassForRomClass.romClass()))) {
+		while (!ramClassForRomClass.isNull() && (!romClass.equals(ramClassForRomClass.romClass()))) {
 			ramClassForRomClass = J9ClassHelper.superclass(ramClassForRomClass);
 		}
-		// if the class does not have a lock offset then one was not needed 
-		if (ramClassForRomClass.lockOffset().eq(NO_LOCKWORD_NEEDED)){
+		// if the class does not have a lock offset then one was not needed
+		if (ramClassForRomClass.lockOffset().eq(NO_LOCKWORD_NEEDED)) {
 			return NO_LOCKWORD_NEEDED;
 		}
 
-		
-		// if class inherited its lockword from its parent then we return the offset 
-		if ((ramSuperClass != null)&&(! ramSuperClass.isNull())&&(ramClassForRomClass.lockOffset().eq(ramSuperClass.lockOffset()))){
+		// if class inherited its lockword from its parent then we return the offset
+		if ((ramSuperClass != null) && (!ramSuperClass.isNull()) && ramClassForRomClass.lockOffset().eq(ramSuperClass.lockOffset())) {
 			return ramSuperClass.lockOffset();
-		} 
+		}
 
 		// class has lockword and did not get it from its parent so a lockword was needed
 		return LOCKWORD_NEEDED;
 	}
 
 	public boolean hasNext() {
-		
 		if (next != null) {
 			return true;
 		}
-		
+
 		next = getNext();
-		
+
 		return next != null;
-		
-//		
+
+//
 //		if (romFieldsShapeIterator.hasNext()) {
 //			return true;
 //		}
@@ -449,18 +446,18 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 //		return false;
 	}
 
-	private J9ObjectFieldOffset getNext() 
+	private J9ObjectFieldOffset getNext()
 	{
 		if (romFieldsShapeIterator == null) {
 			try {
 				init();
 			} catch (CorruptDataException e) {
 				// Tell anyone listening there was corrupt data.
-				raiseCorruptDataEvent("CorruptDataException in  com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator_V1.init()", e, false);
+				raiseCorruptDataEvent("CorruptDataException in com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator_V1.init()", e, false);
 				return null;
 			}
 		}
-		
+
 		try {
 			nextField();
 			if (field == null) {
@@ -481,9 +478,9 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 
 	public J9ObjectFieldOffset next() {
 		if (!hasNext()) {
-			throw new NoSuchElementException();	
+			throw new NoSuchElementException();
 		}
-		
+
 		J9ObjectFieldOffset toReturn = next;
 		next = null;
 		return toReturn;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9IndexableObjectHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9IndexableObjectHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.j9.ObjectModel;
+import com.ibm.j9ddr.vm29.pointer.I16Pointer;
 import com.ibm.j9ddr.vm29.pointer.I32Pointer;
 import com.ibm.j9ddr.vm29.pointer.I64Pointer;
 import com.ibm.j9ddr.vm29.pointer.ObjectReferencePointer;
@@ -212,7 +213,7 @@ public class J9IndexableObjectHelper extends J9ObjectHelper
 			throw new ArrayIndexOutOfBoundsException("Supplied destination array too small. Requires: " + destStart + length + ", was " + dst.length);
 		}
 		for (int i = 0; i < length; i++) {
-			dst[destStart + i] = (byte)U8Pointer.cast(ObjectModel.getElementAddress(objPointer, start + i, 1)).at(0).intValue();
+			dst[destStart + i] = U8Pointer.cast(ObjectModel.getElementAddress(objPointer, start + i, 1)).at(0).byteValue();
 		}
 	}
 	
@@ -274,7 +275,7 @@ public class J9IndexableObjectHelper extends J9ObjectHelper
 			throw new ArrayIndexOutOfBoundsException("Supplied destination array too small. Requires: " + destStart + length + ", was " + dst.length);
 		}
 		for (int i = 0; i < length; i++) {
-			dst[destStart + i] = (short)U16Pointer.cast(ObjectModel.getElementAddress(objPointer, start + i, 2)).at(0).intValue();
+			dst[destStart + i] = I16Pointer.cast(ObjectModel.getElementAddress(objPointer, start + i, 2)).at(0).shortValue();
 		}
 	}
 	

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ShcItemHdrHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ShcItemHdrHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ public class ShcItemHdrHelper {
 	
 	// #define CCITEM(ih) (((U_8*)(ih)) - (CCITEMLEN(ih) - sizeof(ShcItemHdr)))
 	public static U8Pointer CCITEM(ShcItemHdrPointer ptr) throws CorruptDataException {
-		return U8Pointer.cast(ptr).sub(CCITEMLEN(ptr).sub((int)ShcItemHdr.SIZEOF));
+		return U8Pointer.cast(ptr).sub(CCITEMLEN(ptr).sub(ShcItemHdr.SIZEOF));
 	}
 
 	// #define CCITEMNEXT(ih) ((ShcItemHdr*)(CCITEM(ih) - sizeof(ShcItemHdr)))

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9StaticsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9StaticsCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,28 +51,25 @@ import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState;
 import com.ibm.j9ddr.vm29.types.U32;
 
-public class J9StaticsCommand extends Command 
-{
-	public J9StaticsCommand()
-	{
+public class J9StaticsCommand extends Command {
+
+	public J9StaticsCommand() {
 		addCommand("j9statics", "<ramclass>", "Display static fields of a ram class");
 	}
 
-	long staticFieldAddress(J9VMThreadPointer vmStruct, J9ROMClassPointer romClass, String fieldName, String signature, long options) 
-	{
+	long staticFieldAddress(J9VMThreadPointer vmStruct, J9ROMClassPointer romClass, String fieldName, String signature, long options) {
 		return 0;
 	}
 
-	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException 
-	{
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException {
 		try {
 			if (args.length != 1) {
 				CommandUtils.dbgPrint(out, "Usage: !j9statics <classAddress>\n");
 				return;
 			}
-			
+
 			long address = CommandUtils.parsePointer(args[0], J9BuildFlags.env_data64);
-			
+
 			J9ClassPointer ramClass = J9ClassPointer.cast(address);
 			J9ROMClassPointer romClass = ramClass.romClass();
 			J9UTF8Pointer className = romClass.className();
@@ -91,40 +88,44 @@ public class J9StaticsCommand extends Command
 				switch (sig.charAt(0)) {
 				case 'L':
 				case '[':
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticstringfieldshape %s) = !j9object %s\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), fieldAddress.at(0).getHexValue());
+					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticfieldshape %s) = !j9object %s\n",
+							fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), fieldAddress.at(0).getHexValue());
 					break;
 				case 'D':
 					DoublePointer  doublePointer = DoublePointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticdoublefieldshape %s) = %s (%s)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), doublePointer.getHexValue(), new Double(doublePointer.doubleAt(0)).toString());
+					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticfieldshape %s) = %s (%s)\n",
+							fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), doublePointer.getHexValue(), Double.toString(doublePointer.doubleAt(0)));
 					break;
 				case 'F':
 					FloatPointer floatPointer = FloatPointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticsinglefieldshape %s) = %s (%s)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), floatPointer.getHexValue(), new Float(floatPointer.floatAt(0)).toString());
+					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticfieldshape %s) = %s (%s)\n",
+							fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), floatPointer.getHexValue(), Float.toString(floatPointer.floatAt(0)));
 					break;
 				case 'J':
 					I64Pointer longPointer = I64Pointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticdoublefieldshape %s) = %s (%d)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), longPointer.getHexValue(), longPointer.at(0).longValue());
+					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticfieldshape %s) = %s (%d)\n",
+							fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), longPointer.getHexValue(), longPointer.at(0).longValue());
 					break;
+				case 'B': // byte
+				case 'C': // char
+				case 'S': // short
+				case 'Z': // boolean
+					/*
+					 * All fields are allocated a minimum of 32-bits. Thus, we must read 32-bits
+					 * even for smaller primitive types to handle byte ordering properly.
+					 * See J9ObjectStructureFormatter, which does likewise for instance fields.
+					 */
+					// fall through
 				case 'I':
 					I32Pointer intPointer = I32Pointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticsinglefieldshape %s) = %s (%d)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), intPointer.getHexValue(), intPointer.at(0).intValue());
-					break;
-				case 'B':
-					I8Pointer bytePointer = I8Pointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticsinglefieldshape %s) = %s (%s)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), bytePointer.getHexValue(), bytePointer.at(0).byteValue());
-					break;
-				case 'S':	
-					I16Pointer shortPointer = I16Pointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticsinglefieldshape %s) = %s (%d)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), shortPointer.getHexValue(), shortPointer.at(0).shortValue());
-					break;
-				case 'Z':
-					BoolPointer booleanPointer = BoolPointer.cast(fieldAddress);
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticsinglefieldshape %s) = %s (%s)\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), booleanPointer.getHexValue(), booleanPointer.boolAt(0)? "true" : "false");
+					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticfieldshape %s) = %s (%d)\n",
+							fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), intPointer.getHexValue(), intPointer.at(0).intValue());
 					break;
 				default:
-					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticsinglefieldshape %s) = %s\n", fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), fieldAddress.at(0).getHexValue());
+					CommandUtils.dbgPrint(out, "\t%s %s %s (!j9romstaticfieldshape %s) = %s\n",
+							fieldAddress.getHexAddress(), name, sig, field.getHexAddress(), fieldAddress.at(0).getHexValue());
 					break;
-				}				
+				}
 			}
 		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException(e);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaRuntime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -660,21 +660,18 @@ public class DTFJJavaRuntime implements JavaRuntime {
 				}
 			}
 		}
-
 	}
 
-
 	@SuppressWarnings("rawtypes")
-
-	public Iterator getHeaps() throws UnsupportedOperationException {		
+	public Iterator getHeaps() throws UnsupportedOperationException {
 		try {
 			LinkedList<Object> heaps = new LinkedList<Object>();
-			
+
 			VoidPointer memorySpace = DTFJContext.getVm().defaultMemorySpace();
 			MM_MemorySpacePointer defaultMemorySpace = MM_MemorySpacePointer.cast(memorySpace);
 			U8Pointer namePtr = defaultMemorySpace._name();
 			String name = "No name"; //MEMORY_SPACE_NAME_UNDEFINED
-			if( namePtr != null && namePtr != U8Pointer.NULL ) {
+			if (namePtr != null && !namePtr.isNull()) {
 				try {
 					name = namePtr.getCStringAtOffset(0);
 				} catch (com.ibm.j9ddr.CorruptDataException e) {
@@ -682,7 +679,7 @@ public class DTFJJavaRuntime implements JavaRuntime {
 				}
 			}
 			heaps.add(new DTFJJavaHeap(defaultMemorySpace, name, DTFJContext.getImagePointer(memorySpace.getAddress())));
-			
+
 			return heaps.iterator();
 		} catch (Throwable t) {
 			CorruptData cd = J9DDRDTFJUtils.handleAsCorruptData(DTFJContext.getProcess(), t);

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,13 +98,8 @@ public class Constants {
 	public static final String STACKSLOTS_FAILURE_KEY = "";
 
 	public static final String J9VMTHREAD_CMD = "j9vmthread";
-	public static final String J9VMTHREAD_SUCCESS_KEYS = "J9VMThread,J9Method,!j9javavm 0x0*[1-9a-fA-F][0-9a-fA-F]*";// make
-																														// sure
-																														// j9javavm's
-																														// address
-																														// is
-																														// not
-																														// 0
+	// make sure j9javavm's address is not 0
+	public static final String J9VMTHREAD_SUCCESS_KEYS = "J9VMThread,J9Method,!j9javavm 0x0*[1-9a-fA-F][0-9a-fA-F]*";
 	public static final String J9VMTHREAD_FAILURE_KEY = "";
 	
 	public static final String J9POOL_CMD = "j9pool";
@@ -157,60 +152,16 @@ public class Constants {
 	public static final String SHRC_AOTSTATS_FAILURE_KEY = "no shared cache";
 
 	public static final String SHRC_ORPHANSTATS = "orphanstats";
-	public static final String SHRC_ORPHANSTATS_SUCCESS_KEY = "ORPHAN,j9romclass"; // may
-																					// needs
-																					// expansion
-																					// -
-																					// seems
-																					// like
-																					// the
-																					// orphan
-																					// output
-																					// is
-																					// very
-																					// much
-																					// tied
-																					// with
-																					// the
-																					// dump
-																					// produced
+	// may need expansion - seems like the orphan output is very much tied with the dump produced
+	public static final String SHRC_ORPHANSTATS_SUCCESS_KEY = "ORPHAN,j9romclass";
+
 	public static final String SHRC_ORPHANSTATS_FAILURE_KEY = "no shared cache";
 
 	public static final String SHRC_SCOPESTATS = "scopestats";
-	public static final String SHRC_SCOPESTATS_SUCCESS_KEY = "SCOPE,vm.jar,j9utf8,BYTEDATA Summary,ROMClass"; // may
-																												// needs
-																												// expansion
-																												// -
-																												// seems
-																												// like
-																												// the
-																												// orphan
-																												// output
-																												// is
-																												// very
-																												// much
-																												// tied
-																												// with
-																												// the
-																												// dump
-																												// produced
-	public static final String SHRC_SCOPESTATS_SUCCESS_KEY_JAVA9 = "SCOPE,lib[[/\\\\]]modules,j9utf8,BYTEDATA Summary,ROMClass"; // may
-	// needs
-	// expansion
-	// -
-	// seems
-	// like
-	// the
-	// orphan
-	// output
-	// is
-	// very
-	// much
-	// tied
-	// with
-	// the
-	// dump
-	// produced
+	// may need expansion - seems like the orphan output is very much tied with the dump produced
+	public static final String SHRC_SCOPESTATS_SUCCESS_KEY = "SCOPE,vm.jar,j9utf8,BYTEDATA Summary,ROMClass";
+	// may need expansion - seems like the orphan output is very much tied with the dump produced
+	public static final String SHRC_SCOPESTATS_SUCCESS_KEY_JAVA9 = "SCOPE,lib[[/\\\\]]modules,j9utf8,BYTEDATA Summary,ROMClass";
 	public static final String SHRC_SCOPESTATS_FAILURE_KEY = "no shared cache";
 
 	public static final String SHRC_BYTESTATS = "bytestats";
@@ -219,42 +170,17 @@ public class Constants {
 	public static final String SHRC_BYTESTATS_FAILURE_KEY = "UNKNOWN\\(,no shared cache";
 
 	public static final String SHRC_UBYTESTATS = "ubytestats";
-	public static final String SHRC_UBYTESTATS_SUCCESS_KEY = "UNINDEXEDBYTE"; // currently
-																				// our
-																				// dump
-																				// does
-																				// not
-																				// contain
-																				// any
-																				// data
-																				// for
-																				// this
+
+	// currently our dump does not contain any data for this
+	public static final String SHRC_UBYTESTATS_SUCCESS_KEY = "UNINDEXEDBYTE";
 	public static final String SHRC_UBYTESTATS_FAILURE_KEY = "no shared cache";
 
 	public static final String SHRC_CLSTATS = "clstats";
-	public static final String SHRC_CLSTATS_SUCCESS_KEY_NONRTP = "No entry found in the cache"; // In
-																								// case
-																								// of
-																								// non-real-time
-																								// platforms
-																								// we
-																								// should
-																								// not
-																								// see
-																								// any
-																								// cachelet
-																								// info
+	// In case of non-real-time platforms we should not see any cachelet info
+	public static final String SHRC_CLSTATS_SUCCESS_KEY_NONRTP = "No entry found in the cache";
 	public static final String SHRC_CLSTATS_FAILURE_KEY_NONRTP = "no shared cache";
-	public static final String SHRC_CLSTATS_SUCCESS_KEY_RTP = "CACHELET count,CACHELET,!shrc cachelet"; // In
-																										// case
-																										// of
-																										// real-time
-																										// platforms
-																										// we
-																										// should
-																										// see
-																										// cachelet
-																										// info
+	// In case of real-time platforms we should see cachelet info
+	public static final String SHRC_CLSTATS_SUCCESS_KEY_RTP = "CACHELET count,CACHELET,!shrc cachelet";
 	public static final String SHRC_CLSTATS_FAILURE_KEY_RTP = "No entry found in the cache,no shared cache";
 
 	public static final String SHRC_CACHELET = "cachelet";
@@ -367,7 +293,7 @@ public class Constants {
 	public static final String J9VTABLES_SUCCESS_KEY = "j9class,j9method,"+J9CLASSSHAPE_TEST_CLASS;
 
 	public static final String J9STATICS_CMD = "j9statics";
-	public static final String J9STATICS_SUCCESS_KEY = "j9romstaticsinglefieldshape,"+J9CLASSSHAPE_TEST_CLASS;
+	public static final String J9STATICS_SUCCESS_KEY = "j9romstaticfieldshape," + J9CLASSSHAPE_TEST_CLASS;
 
 	public static final String CL_FOR_NAME_CMD = "classforname";
 	public static final String CL_FOR_NAME_CLASS = "java/lang/Object";
@@ -428,12 +354,8 @@ public class Constants {
 	public static final String DUMP_ROM_CLASS_INVALID_NAME_FAILURE_KEY = "";
 
 	public static final String QUERY_ROM_CLASS_CMD = "queryromclass";
-	public static final String QUERY_ROM_CLASS_QUERY = "/romHeader"; // may add
-																		// more
-																		// queries
-																		// later
-																		// like
-																		// /romHeader/className,/methods,
+	// may add more queries later like /romHeader/className,/methods,
+	public static final String QUERY_ROM_CLASS_QUERY = "/romHeader";
 	public static final String QUERY_ROM_CLASS_SUCCESS_KEY = "romSize,className,Section Start: romHeader,Section End: romHeader,optionalInfo";
 	public static final String QUERY_ROM_CLASS_FAILURE_KEY = "matched nothing";
 
@@ -458,7 +380,7 @@ public class Constants {
 	public static final String DUMP_ALL_SEGMENTS_COMMON_SUCCESS_KEY = "memorySegments.+!j9memorysegmentlist 0x[0-9a-f]+,segment.+start.+alloc.+end.+type.+size.+,([0-9a-f]+ +){5}[0-9a-f]+,classMemorySegments,jit code segments,jit data segments,";
 	public static final String DUMP_ALL_SEGMENTS_64BITCORE_SUCCESS_KEY = "segment.+start.+warmAlloc.+coldAlloc.+end.+size.+";
 	public static final String DUMP_ALL_SEGMENTS_32BITCORE_SUCCESS_KEY = "segment.+start.+warm.+cold.+end.+size.+";
-																																													// dump
+	// dump
 	public static final String DUMP_ALL_SEGMENTS_FAILURE_KEY = "";
 
 	public static final String DUMP_SEGMENTS_IN_LIST_CMD = "dumpsegmentsinlist";
@@ -659,8 +581,7 @@ public class Constants {
 	public static final String SHOWDUMPAGENTS_CMD = "showdumpagents";
 	// create dump with option:
 	// -Xdump:system:defaults:file=${system.dump},request=exclusive+compact+prepwalk,
-	// expect to see the info in showdumpagents. refer to tck_ddrext.xml for
-	// detail.
+	// expect to see the info in showdumpagents. refer to tck_ddrext.xml for detail.
 	public static final String SHOWDUMPAGENTS_SUCCESS_KEYS = "-Xdump,request=exclusive\\+compact\\+prepwalk,events=systhrow,"
 			+ "filter=java/lang/OutOfMemoryError";
 	public static final String SHOWDUMPAGENTS_FAILURE_KEYS = "No dump agent";


### PR DESCRIPTION
* access a minimum of 32-bits (as the VM does) to handle byte ordering properly
* `!j9statics` output now suggests use of `!j9romstaticfieldshape` instead of non-existent commands `!j9romstaticdoublefieldshape`, `!j9romstaticsinglefieldshape` or `!j9romstaticstringfieldshape`
* remove unnecessary casts
* fix test for NULL pointer
* correct C/C++ source references