### PR TITLE
Travis: update to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,15 +22,12 @@
 os:
   - linux
 language: cpp
-sudo: false
 cache:
   directories:
     - $HOME/.ccache
-dist: trusty
+dist: xenial
 addons:
   apt:
-    sources:
-      - llvm-toolchain-trusty
     packages:
       - autoconf
       - ca-certificates
@@ -65,8 +62,6 @@ addons:
       - llvm-3.8
       - libclang-3.8-dev
       - llvm-3.8-dev
-before_install:
-  - jdk_switcher use oraclejdk8
 before_script:
   - ccache -s -z --max-size=1G
 script:


### PR DESCRIPTION
Update the travis environment to use Ubuntu Xenial. Also stop using the
container based worker (and move to the vm based worker), since it has
been deprecated
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>