### PR TITLE
Update windows target version to windows 7

### DIFF
--- a/runtime/compiler/build/toolcfg/win-msvc/common.mk
+++ b/runtime/compiler/build/toolcfg/win-msvc/common.mk
@@ -81,10 +81,9 @@ CX_DEFINES+=\
     $(TARGET_DEFINES) \
     CRTAPI1=_cdecl \
     CRTAPI2=_cdecl \
-    _WIN95 \
-    _WIN32_WINDOWS=0x400 \
-    _WIN32_IE=0x300 \
-    WINVER=0x400 \
+    _WIN32_WINDOWS=0x601 \
+    _WIN32_WINNT=0x0601 \
+    WINVER=0x601\
     _WIN32 \
     WIN32 \
     _CRT_SECURE_NO_WARNINGS \
@@ -127,7 +126,6 @@ endif
 
 ifeq ($(HOST_BITS),64)
     CX_DEFINES+=\
-        _WIN32_WINNT=0x0400 \
         _WINSOCKAPI_ \
         J9HAMMER
 endif

--- a/runtime/makelib/targets.mk.win.inc.ftl
+++ b/runtime/makelib/targets.mk.win.inc.ftl
@@ -1,5 +1,5 @@
 <#-- 
-	Copyright (c) 1998, 2018 IBM Corp. and others
+	Copyright (c) 1998, 2019 IBM Corp. and others
 	
 	This program and the accompanying materials are made available under
 	the terms of the Eclipse Public License 2.0 which accompanies this
@@ -175,29 +175,15 @@ ifdef USE_CLANG
   CLANG_CXXFLAGS+=-DCRTAPI1=_cdecl -DCRTAPI2=_cdecl
 endif
 
-
-CFLAGS+=-D_WIN95 -D_WIN32_WINDOWS=0x0500 /D_WIN32_DCOM
-CXXFLAGS+=-D_WIN95 -D_WIN32_WINDOWS=0x0500 /D_WIN32_DCOM
-ifdef USE_CLANG
-  CLANG_CXXFLAGS+=-D_WIN95 -D_WIN32_WINDOWS=0x0500 -D_WIN32_DCOM
-endif
-
-# from win32.mak: regardless of the TARGET OS, define compile time UMA_WINVER to match APPVER macro
-CFLAGS+=-D_WIN32_IE=0x0500 -DWINVER=0x0501
-CXXFLAGS+=-D_WIN32_IE=0x0500 -DWINVER=0x0501
-ifdef USE_CLANG
-  CLANG_CXXFLAGS+=-D_WIN32_IE=0x0500 -DWINVER=0x0501
-endif
-
+# Target Win 7 by default
 ifndef UMA_WINVER
-  UMA_WINVER=0x0501
+  UMA_WINVER=0x0601
 endif
 
-# TODO: is this define obsolete?
-CFLAGS+=-D_WIN32_WINNT=$(UMA_WINVER)
-CXXFLAGS+=-D_WIN32_WINNT=$(UMA_WINVER)
+CFLAGS+=-DWINVER=$(UMA_WINVER) -D_WIN32_WINNT=$(UMA_WINVER) -D_WIN32_WINDOWS=$(UMA_WINVER)
+CXXFLAGS+=-DWINVER=$(UMA_WINVER) -D_WIN32_WINNT=$(UMA_WINVER) -D_WIN32_WINDOWS=$(UMA_WINVER)
 ifdef USE_CLANG
-  CLANG_CXXFLAGS+=-D_WIN32_WINNT=$(UMA_WINVER)
+  CLANG_CXXFLAGS+=-DWINVER=$(UMA_WINVER) -D_WIN32_WINNT=$(UMA_WINVER) -D_WIN32_WINDOWS=$(UMA_WINVER)
 endif
 
 # -Zm200 max memory is 200% default


### PR DESCRIPTION
Minimum supported windows version for java 8 is windows 7. Also remove
IE target version as it is not relevant

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>