### PR TITLE
Introduce trimCodeMemoryToActualSize CodeGenerator query

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -39,6 +39,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
+#include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/jittypes.h"
 #include "il/Block.hpp"
@@ -56,6 +57,7 @@
 #include "optimizer/TransformUtil.hpp"
 #include "ras/Delimiter.hpp"                   // for Delimiter
 #include "ras/DebugCounter.hpp"
+#include "runtime/CodeCache.hpp"
 #include "env/CHTable.hpp"
 #include "env/PersistentCHTable.hpp"
 
@@ -4633,3 +4635,20 @@ J9::CodeGenerator::isMethodInAtomicLongGroup(TR::RecognizedMethod rm)
       }
    }
 
+
+void
+J9::CodeGenerator::trimCodeMemoryToActualSize()
+   {
+   uint8_t *bufferStart = self()->getBinaryBufferStart();
+   size_t actualCodeLengthInBytes = self()->getCodeEnd() - bufferStart;
+
+   TR::VMAccessCriticalSection trimCodeMemoryAllocation(self()->comp());
+   self()->getCodeCache()->trimCodeMemoryAllocation(bufferStart, actualCodeLengthInBytes);
+   }
+
+
+void
+J9::CodeGenerator::resizeCodeMemory()
+   {
+   self()->trimCodeMemoryToActualSize();
+   }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -416,6 +416,21 @@ public:
     *    transforming a monitored region with transactional lock elision.
     */
    int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; }
+
+   /**
+    * \brief This is just a J9 override of this function and simply redirects
+    *        to the newly named function `trimCodeMemoryToActualSize`.  It exists
+    *        solely to coordinate refactoring with OMR and will be very transient.
+    */
+   void resizeCodeMemory();
+
+   /**
+    * \brief Trim the size of code memory required by this method to match the
+    *        actual code length required, allowing the reclaimed memory to be
+    *        reused.  This is needed when the conservative length estimate
+    *        exceeds the actual memory requirement.
+    */
+   void trimCodeMemoryToActualSize();
 
 private:
 


### PR DESCRIPTION
This function deprecates the existing CodeGenerator function `resizeCodeMemory`.
It is introduced in this staged fashion to allow upstream changes in OMR to occur
without breaking OpenJ9.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>