### PR TITLE
Fix VM info deallocation bug

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2442,7 +2442,8 @@ ClientSessionData::~ClientSessionData()
       jitPersistentFree(_unloadedClassAddresses);
       }
    _staticMapMonitor->destroy();
-   jitPersistentFree(_vmInfo);
+   if (_vmInfo)
+      jitPersistentFree(_vmInfo);
    }
 
 void


### PR DESCRIPTION
VM info was always freed, even when it wasn't initialized in the first place,
which leads to occasional segfaults. Fix by checking if it's not NULL first.