### PR TITLE
Fix JIT compiler warnings

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,13 +109,13 @@ uint32_t getInstanceOfOrCheckCastTopProfiledClass(TR::CodeGenerator *cg, TR::Nod
 
    if (!valueProfileInfo)
       {
-      return NULL;
+      return 0;
       }
 
    TR_AddressInfo * valueInfo = static_cast<TR_AddressInfo*>(valueProfileInfo->getValueInfo(bcInfo, comp, AddressInfo, TR_ValueProfileInfoManager::justInterpreterProfileInfo));
    if (!valueInfo || valueInfo->getNumProfiledValues() == 0)
       {
-      return NULL;
+      return 0;
       }
 
    if (topClassWasCastClass)

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1411,7 +1411,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
        && !comp()->compileRelocatableCode())
       {
       TR::VMAccessCriticalSection getObjectReferenceLocation(comp());
-      if (*((uintptrj_t*)dataAddress) != NULL)
+      if (*((uintptrj_t*)dataAddress) != 0)
          {
          TR_J9VMBase *fej9 = comp()->fej9();
          TR_OpaqueClassBlock *declaringClass = owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -266,7 +266,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
                *hintCount = 10 * _initialHintSCount;
 
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8*)scHintData;
+            descriptor.address = (U_8 *)(uintptrj_t)scHintData;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;
@@ -322,7 +322,7 @@ TR_J9SharedCache::addHint(J9Method * method, TR_SharedCacheHint theHint)
          if (updateHint)
             {
             J9SharedDataDescriptor descriptor;
-            descriptor.address = (U_8*)scHintData;
+            descriptor.address = (U_8 *)(uintptrj_t)scHintData;
             descriptor.length = scHintDataLength; // Size includes the 2nd data field, currently only used for TR_HintFailedValidation
             descriptor.type = J9SHR_ATTACHED_DATA_TYPE_JITHINT;
             descriptor.flags = J9SHR_ATTACHED_DATA_NO_FLAGS;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8391,7 +8391,7 @@ TR_J9VM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
 
       // j9class points to the J9Class corresponding to java/lang/Object
       if (TR::Compiler->om.generateCompressedObjectHeaders())
-         j9class = (J9Class *) *((uint32_t *) ((uintptrj_t) javaLangClass + (uintptrj_t) TR::Compiler->om.offsetOfObjectVftField()));
+         j9class = (J9Class *)(uintptrj_t) *((uint32_t *) ((uintptrj_t) javaLangClass + (uintptrj_t) TR::Compiler->om.offsetOfObjectVftField()));
       else
          j9class = (J9Class *)(*((J9Class **) ((uintptrj_t) javaLangClass + (uintptrj_t) TR::Compiler->om.offsetOfObjectVftField())));
       }

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -8290,7 +8290,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                {
                // copy filters in a list, so that we don't have to use filterIndexList
                // to determine if a filter is null later on
-               haveFilter[i] = fej9->getReferenceElement(filters, i) != NULL;
+               haveFilter[i] = fej9->getReferenceElement(filters, i) != 0;
                if (knotEnabled)
                   filterIndexList[i] = knot->getIndex(fej9->getReferenceElement(filters, i));
                }

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6238,7 +6238,7 @@ TR_J9ByteCodeIlGenerator::loadStatic(int32_t cpIndex)
          {
          void * staticClass = method()->classOfStatic(cpIndex);
          loadSymbol(TR::loadaddr, symRefTab()->findOrCreateClassSymbol(_methodSymbol, cpIndex, staticClass, true /* cpIndexOfStatic */));
-         load = TR::Node::createWithSymRef(comp()->il.opCodeForDirectReadBarrier(type), 1, pop(), NULL, symRef);
+         load = TR::Node::createWithSymRef(comp()->il.opCodeForDirectReadBarrier(type), 1, pop(), 0, symRef);
          }
       else if (cg()->getAccessStaticsIndirectly() && isResolved && type != TR::Address && (!comp()->compileRelocatableCode() || comp()->getOption(TR_UseSymbolValidationManager)))
          {

--- a/runtime/compiler/runtime/HWProfiler.cpp
+++ b/runtime/compiler/runtime/HWProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -791,7 +791,7 @@ TR_HWProfiler::registerRecords(J9JITExceptionTable *metaData, TR::Compilation *c
 
       // Initialize the special first element
       cursor->_bytecodePC = (void *)METADATA_MAPPING_EYECATCHER;
-      cursor->_instructionAddr = (void *)arraySize;
+      cursor->_instructionAddr = (void *)(uintptrj_t)arraySize;
       cursor++;
 
       for (uint32_t i = 0; i < arraySize; i++, cursor++)

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -230,7 +230,7 @@ TR_IProfiler::createBalancedBST(uintptrj_t *pcEntries, int32_t low, int32_t high
                                 TR::Compilation *comp, uintptrj_t cacheStartAddress, uintptrj_t cacheSize)
    {
    if (high < low)
-      return NULL;
+      return 0;
 
    TR_IPBCDataStorageHeader * storage = (TR_IPBCDataStorageHeader *) memChunk;
    int32_t middle = (high+low)/2;
@@ -4306,7 +4306,7 @@ uintptrj_t CallSiteProfileInfo::getClazz(int index)
    {
 #if defined(J9VM_GC_COMPRESSED_POINTERS) //compressed references
    //support for convert code, when it is implemented, "uncompress"
-   return (uintptrj_t)TR::Compiler->cls.convertClassOffsetToClassPtr((TR_OpaqueClassBlock *)_clazz[index]);
+   return (uintptrj_t)TR::Compiler->cls.convertClassOffsetToClassPtr((TR_OpaqueClassBlock *)(uintptrj_t)_clazz[index]);
 #else
    return (uintptrj_t)_clazz[index]; //things are just stored as regular pointers otherwise
 #endif //J9VM_GC_COMPRESSED_POINTERS

--- a/runtime/compiler/runtime/RelocationTarget.cpp
+++ b/runtime/compiler/runtime/RelocationTarget.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,7 +132,7 @@ TR_RelocationTarget::loadClassAddressForHeader(uint8_t *reloLocation)
    {
    // reloLocation points at the start of the address, so just need to dereference as uint8_t *
 #ifdef J9VM_INTERP_COMPRESSED_OBJECT_HEADER
-   return (uint8_t *) loadUnsigned32b(reloLocation);
+   return (uint8_t *) (uintptr_t) loadUnsigned32b(reloLocation);
 #else
    return (uint8_t *) loadPointer(reloLocation);
 #endif

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -953,7 +953,7 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
       relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(
             cursor,
             *(uint8_t **)cursor,
-             getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+             getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
             TR_ConstantPool,
             cg());
 
@@ -1137,7 +1137,7 @@ uint8_t *TR::X86UnresolvedVirtualCallSnippet::emitSnippetBody()
    cg()->addExternalRelocation(
       new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                             (uint8_t *)cpAddr,
-                                                            getNode() ? (uint8_t *)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                                                            getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                             TR_ConstantPool,
                                                             cg()),
                  __FILE__, __LINE__, getNode());

--- a/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
+++ b/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -287,7 +287,7 @@ uint8_t *TR::X86CheckFailureSnippetWithResolve::emitSnippetBody()
    *(int32_t *)buffer = (int32_t) (intptr_t) getDataSymbolReference()->getOwningMethod(cg()->comp())->constantPool();
    cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(buffer,
                                                                            *(uint8_t **)buffer,
-                                                                           getCheckInstruction()->getNode() ? (uint8_t *)getCheckInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                                                                           getCheckInstruction()->getNode() ? (uint8_t *)(uintptr_t)getCheckInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                            TR_ConstantPool, cg()),
                           __FILE__, __LINE__,
                           getCheckInstruction()->getNode());

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -55,7 +55,7 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
        && _cg->getPicSlotCount())
       {
       _cg->addExternalRelocation(new (_cg->trHeapMemory()) TR::ExternalRelocation(NULL,
-                                                                                 (uint8_t *)_cg->getPicSlotCount(),
+                                                                                 (uint8_t *)(uintptr_t)_cg->getPicSlotCount(),
                                                                                  TR_PicTrampolines, _cg),
                             __FILE__,
                             __LINE__,

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -294,7 +294,7 @@ J9::X86::UnresolvedDataSnippet::emitConstantPoolAddress(uint8_t *cursor)
          }
 
       cg()->addProjectSpecializedRelocation(cursor,(uint8_t *)getDataSymbolReference()->getOwningMethod(comp)->constantPool(),
-            node ? (uint8_t *)node->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
+            node ? (uint8_t *)(uintptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
                              __FILE__, __LINE__, node);
       }
 
@@ -528,7 +528,7 @@ J9::X86::UnresolvedDataSnippet::fixupDataReferenceInstruction(uint8_t *cursor)
          uint8_t *stringConstantPtr = (cursor - bytesToCopy) + getDataReferenceInstruction()->getBinaryLength() - TR::Compiler->om.sizeofReferenceAddress();
 
          cg()->addProjectSpecializedRelocation(stringConstantPtr, (uint8_t *)getDataSymbolReference()->getOwningMethod(TR::comp())->constantPool(),
-               getDataReferenceInstruction()->getNode() ? (uint8_t *)getDataReferenceInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
+               getDataReferenceInstruction()->getNode() ? (uint8_t *)(uintptr_t)getDataReferenceInstruction()->getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ConstantPool,
                     __FILE__, __LINE__, getDataReferenceInstruction()->getNode());
          }
       }

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,7 +101,7 @@ uint8_t *TR::X86MemImmSnippetInstruction::generateBinaryEncoding()
          {
          if (std::find(cg()->comp()->getStaticHCRPICSites()->begin(), cg()->comp()->getStaticHCRPICSites()->end(), this) != cg()->comp()->getStaticHCRPICSites()->end())
             {
-            cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *) getSourceImmediateAsAddress()), (void *) cursor);
+            cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *)(uintptr_t)getSourceImmediateAsAddress()), (void *) cursor);
             }
          *(int32_t *)cursor = (int32_t)getSourceImmediate();
          if (getUnresolvedSnippet() != NULL)

--- a/runtime/compiler/x/runtime/X86PicBuilderC.cpp
+++ b/runtime/compiler/x/runtime/X86PicBuilderC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -131,7 +131,7 @@ extern "C" void adjustTrampolineInterpretedDispatchGlueDisp32_unwrapper(void **a
 (int32_t)(uintptr_t)argsPtr[2],  // cpIndex
          (uint8_t *)argsPtr[3]); // call site
 
-   *resPtr = (void *)disp32;
+   *resPtr = (void *)(uintptr_t)disp32;
    }
 
 
@@ -141,5 +141,5 @@ extern "C" void interpretedDispatchGlueDisp32_unwrapper(void **argsPtr, void **r
       (J9Method *)argsPtr[0],  // ramMethod
        (uint8_t *)argsPtr[1]); // call site
 
-   *resPtr = (void *)disp32;
+   *resPtr = (void *)(uintptr_t)disp32;
    }


### PR DESCRIPTION
This fixes all the warnings (other than those covered by `-Wformat`) in common areas and for x86
* conversion-null: converting to non-pointer type from NULL
* int-to-pointer-cast: cast to pointer from integer of different size
* pointer-arith: NULL used in arithmetic