### PR TITLE
Avoid unnecessary code patching on X86

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -268,6 +268,7 @@ JIT_HELPER(interpreterUnresolvedStaticFieldSetterGlue);
 JIT_HELPER(interpreterUnresolvedFieldGlue);
 JIT_HELPER(interpreterUnresolvedFieldSetterGlue);
 JIT_HELPER(interpreterUnresolvedConstantDynamicGlue);
+JIT_HELPER(interpreterStaticAndSpecialGlue);
 
 #if defined(NASM_ASSEMBLER)
 JIT_HELPER(SMPinterpreterUnresolvedStaticGlue);
@@ -1193,6 +1194,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_X86interpreterUnresolvedFieldGlue,                (void *)interpreterUnresolvedFieldGlue,                TR_Helper);
    SET(TR_X86interpreterUnresolvedFieldSetterGlue,          (void *)interpreterUnresolvedFieldSetterGlue,          TR_Helper);
    SET(TR_X86interpreterUnresolvedConstantDynamicGlue,      (void *)interpreterUnresolvedConstantDynamicGlue,      TR_Helper);
+   SET(TR_X86interpreterStaticAndSpecialGlue,               (void *)interpreterStaticAndSpecialGlue,               TR_Helper);
 
    SET(TR_X86prefetchTLH,                (void *)prefetchTLH,                 TR_Helper);
    SET(TR_X86newPrefetchTLH,             (void *)newPrefetchTLH,              TR_Helper);

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -924,9 +924,9 @@ uint8_t *TR::X86CallSnippet::emitSnippetBody()
 
       // CALL updateInterpreterDispatchGlueSite
       //
-      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86updateInterpreterDispatchGlueSite, false, false, false);
+      helperSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_X86interpreterStaticAndSpecialGlue, false, false, false);
 
-      *cursor++ = 0xe8;    // CALL
+      *cursor++ = 0xe9;    // JMP
       disp32 = cg()->branchDisplacementToHelperOrTrampoline(cursor+4, helperSymRef);
       *(int32_t *)cursor = disp32;
 


### PR DESCRIPTION
All `icallVMprJavaSendStatic{*}` jump directly to `j2iTransition`, and hence JIT does not need multiple glue helpers differenting the type; this changeset eliminates the type-based `interpreter{*}StaticGlue` with `interpreterStaticAndSpecialGlue`.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>