### PR TITLE
Finalise release notes for 0.12.0

### DIFF
--- a/doc/release-notes/0.12/0.12.md
+++ b/doc/release-notes/0.12/0.12.md
@@ -24,9 +24,6 @@
 
 # Eclipse OpenJ9 version 0.12.0 release notes
 
-:construction:
-These release notes are under construction and are not yet complete. The content reflects the January milestone build of Eclipse OpenJ9.
-
 These release notes support the [Eclipse OpenJ9 0.12.0 release plan](https://projects.eclipse.org/projects/technology.openj9/releases/0.12.0/plan).
 
 
@@ -37,9 +34,7 @@ OpenJ9 release 0.12.0 supports OpenJDK 8 and OpenJDK 11. Binaries are available 
 - [OpenJDK with OpenJ9 version 8](https://adoptopenjdk.net/archive.html?variant=openjdk8&jvmVariant=openj9)
 - [OpenJDK with OpenJ9 version 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=openj9)
 
-OpenJ9 release 0.12.0 provides support for the MacOS platform on OpenJDK 8. Early builds of OpenJDK 8 with OpenJ9 on MacOS are available at the AdoptOpenJDK project at the following link:  
-
-- [OpenJDK v8 with OpenJ9](https://adoptopenjdk.net/nightly.html?variant=openjdk8&jvmVariant=openj9)
+This release includes support for macOS&reg; on OpenJDK 8 with OpenJ9. Platform support for macOS is now available on OpenJDK 8 and OpenJDK 11 binaries that contain the OpenJ9 VM.
 
 All builds are tested against the OpenJ9 functional verification (FV) test suite, the OpenJDK test suites, and additional tests at AdoptOpenJDK.
 


### PR DESCRIPTION
Release notes updated to reflect the GA features
and limitations of Eclipse OpenJ9 0.12.0.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>