### PR TITLE
Add new draft user documentation URL site

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -34,6 +34,10 @@ A more complete set of build instructions are included here for multiple platfor
 - [macOS :apple:](#macos)
 - [ARM :iphone:](#arm)
 
+User documentation for the latest release of Eclipse OpenJ9 is available at the [Eclipse Foundation](https://www.eclipse.org/openj9/docs).
+If you build a binary from the current OpenJ9 source, new features and changes might be in place for the next release of OpenJ9. Draft user
+documentation for the next release of OpenJ9 can be found [here](https://eclipse.github.io/openj9-docs/).
+
 ----------------------------------
 
 ## Linux

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -34,6 +34,10 @@ A more complete set of build instructions are included here for multiple platfor
 - [MacOS :apple:](#macos)
 - [ARM :iphone:](#arm)
 
+User documentation for the latest release of Eclipse OpenJ9 is available at the [Eclipse Foundation](https://www.eclipse.org/openj9/docs). 
+If you build a binary from the current OpenJ9 source, new features and changes might be in place for the next release of OpenJ9. Draft user
+documentation for the next release of OpenJ9 can be found [here](https://eclipse.github.io/openj9-docs/).
+
 ----------------------------------
 
 ## Linux


### PR DESCRIPTION
Users who build against the latest OpenJ9 source
now need to refer to documentation at the new
draft doc site: https://eclipse.github.io/openj9-docs/

The user doc at the Eclipse website will be the
last release. See https://github.com/eclipse/openj9-docs/issues/176

This PR to be merged for the GA of the 0.12.0 release

[ci-skip]

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>