### PR TITLE
Don't inline Unsafe.put from cold block

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -296,6 +296,13 @@ void J9::RecognizedCallTransformer::processUnsafeAtomicCall(TR::TreeTop* treetop
             traceMsg(comp(), "Created isFinal test node n%dn, non-final-static field will fall through to Block_%d, final field goes to Block_%d\n",
                      isFinalNode->getGlobalIndex(), treetop->getEnclosingBlock()->getNumber(), ifTree->getEnclosingBlock()->getNumber());
             }
+         TR::DebugCounter::prependDebugCounter(comp(),
+                                               TR::DebugCounter::debugCounterName(comp(),
+                                                                                  "illegalWriteReport/atomic/(%s %s)",
+                                                                                  comp()->signature(),
+                                                                                  comp()->getHotnessName(comp()->getMethodHotness())),
+                                                                                  ifTree->getNextTreeTop());
+
          }
 
       // Calculate static address


### PR DESCRIPTION
Trivial inliner doesn't look at block info, it inlines calls from cold
block. Unsafe call from a cold block can be a product of Unsafe
inlining, thus should not be inlined.

Also add debug counter for illegal write notification.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>