### PR TITLE
Create jvmti.h.m4 to generate different versions of jvmti.h

### DIFF
--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -60,7 +60,7 @@ if test "x$RUN_LINT" = "xyes"; then
   mkdir $CMAKE_BUILD_DIR
   cd $CMAKE_BUILD_DIR
   cmake -C $J9SRC/cmake/caches/linux_x86-64_cmprssptrs.cmake ..
-  make -j $MAKE_JOBS run_cptool omrgc_hookgen j9vm_hookgen j9jit_tracegen j9vm_nlsgen
+  make -j $MAKE_JOBS run_cptool omrgc_hookgen j9vm_hookgen j9jit_tracegen j9vm_nlsgen j9vm_m4gen
 
   # Now we can build the linter plugin
   cd $OMRCHECKER_DIR

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -150,6 +150,19 @@ else()
 	add_custom_target(j9vm_nlsgen)
 endif()
 
+# Generate jvmti header
+if(J9VM_IS_NON_STAGING)
+	set(JVMTI_HEADER_DIR  "${CMAKE_CURRENT_BINARY_DIR}/include")
+	file(MAKE_DIRECTORY "${JVMTI_HEADER_DIR}")
+else()
+	set(JVMTI_HEADER_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+endif()
+add_custom_command(OUTPUT "${JVMTI_HEADER_DIR}/jvmti.h" 
+   	COMMAND m4 -D "JAVA_SPEC_VERSION=${JAVA_SPEC_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4" > "jvmti.h"
+	VERBATIM
+	WORKING_DIRECTORY "${JVMTI_HEADER_DIR}"
+)
+
 # Note we do this here rather than in the redirector directory to work arround
 # issues in cmake. If we did it there each target which consumed generated.c has
 # its own rule to create it. Which causes a race condition when building in parallel
@@ -170,20 +183,13 @@ add_custom_target(j9vm_m4gen
 	DEPENDS
 		"${CMAKE_CURRENT_BINARY_DIR}/redirector/generated.c"
 		"${CMAKE_CURRENT_BINARY_DIR}/j9vm/generated.h"
+		"${JVMTI_HEADER_DIR}/jvmti.h"
 )
 
 if(J9VM_IS_NON_STAGING)
 	add_custom_target(copy_default_options ALL
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/options.default" "${CMAKE_CURRENT_BINARY_DIR}/options.default"
 	)
-
-	# Copy jvmti.h, later this will actually be generated
-	add_custom_target(copy_jvmti_h
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h" "${CMAKE_CURRENT_BINARY_DIR}/include/jvmti.h"
-	)
-else()
-	# just  create a dummy target that does noting
-	add_custom_target(copy_jvmti_h)
 endif()
 
 ###
@@ -214,7 +220,6 @@ add_dependencies(j9vm_interface
 	j9vm_hookgen
 	j9vm_m4gen
 	j9vm_nlsgen
-	copy_jvmti_h
 )
 
 # j9vm_gc_includes is used to track the include directories that are consumed by the various gc components

--- a/runtime/buildtools.mk
+++ b/runtime/buildtools.mk
@@ -188,7 +188,12 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 configure : constantpool nls
 	mkdir -p build && cd build && $(CMAKE) -C ../cmake/caches/$(SPEC).cmake  $(CMAKE_ARGS) $(EXTRA_CMAKE_ARGS) ..
 else
-configure : uma
+.PHONY : j9includegen
+
+j9includegen : uma
+	$(MAKE) -C include j9include_generate
+
+configure : j9includegen
 	$(MAKE) -C omr -f run_configure.mk 'SPEC=$(SPEC)' 'OMRGLUE=$(OMRGLUE)' 'CONFIG_INCL_DIR=$(CONFIG_INCL_DIR)' 'OMRGLUE_INCLUDES=$(OMRGLUE_INCLUDES)' 'EXTRA_CONFIGURE_ARGS=$(EXTRA_CONFIGURE_ARGS)'
 endif
 

--- a/runtime/compiler/linter.mk
+++ b/runtime/compiler/linter.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ include $(JIT_MAKE_DIR)/toolcfg/common.mk
 # is different from an automake build.
 #
 ifneq ("$(CMAKE_BUILD_DIR)","")
-CXX_INCLUDES+=$(CMAKE_BUILD_DIR)/runtime $(CMAKE_BUILD_DIR)/runtime/omr $(CMAKE_BUILD_DIR)/runtime/nls
+CXX_INCLUDES+=$(CMAKE_BUILD_DIR)/runtime $(CMAKE_BUILD_DIR)/runtime/omr $(CMAKE_BUILD_DIR)/runtime/nls $(CMAKE_BUILD_DIR)/runtime/include
 endif
 
 #

--- a/runtime/include/jvmti.h.m4
+++ b/runtime/include/jvmti.h.m4
@@ -19,6 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+changequote(`[',`]')dnl
 
 #ifndef jvmti_h
 #define jvmti_h
@@ -481,10 +482,10 @@ typedef struct {
 	unsigned int can_retransform_any_class : 1;
 	unsigned int can_generate_resource_exhaustion_heap_events : 1;
 	unsigned int can_generate_resource_exhaustion_threads_events : 1;
-	unsigned int can_generate_early_vmstart : 1;
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	unsigned int can_generate_early_vmstart : 1;
 	unsigned int can_generate_early_class_hook_events : 1;
-	unsigned int can_generate_sampled_object_alloc_events : 1;
-	unsigned int : 4;
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [    unsigned int can_generate_sampled_object_alloc_events : 1;
+	unsigned int : 4;], [    unsigned int : 5;])], [	unsigned int : 7;])
 	unsigned int : 16;
 	unsigned int : 16;
 	unsigned int : 16;
@@ -734,7 +735,7 @@ typedef enum jvmtiEvent {
 	JVMTI_EVENT_GARBAGE_COLLECTION_FINISH = 82,
 	JVMTI_EVENT_OBJECT_FREE = 83,
 	JVMTI_EVENT_VM_OBJECT_ALLOC = 84,
-	JVMTI_EVENT_SAMPLED_OBJECT_ALLOC = 86,
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [	JVMTI_EVENT_SAMPLED_OBJECT_ALLOC = 86,], [dnl])
 
 	JVMTI_MAX_EVENT_TYPE_VAL = 86,
 	jvmtiEventEnsureWideEnum = 0x1000000						/* ensure 4-byte enum */
@@ -950,13 +951,13 @@ typedef void (JNICALL *jvmtiEventResourceExhausted) (
 	const void* reserved,
 	const char* description);
 
-typedef void (JNICALL *jvmtiEventSampledObjectAlloc) (
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [typedef void (JNICALL *jvmtiEventSampledObjectAlloc) (
 	jvmtiEnv *jvmti_env,
 	JNIEnv *jni_env,
 	jthread thread,
 	jobject object,
 	jclass object_klass,
-	jlong size);
+	jlong size);], [dnl])
 
 typedef void * jvmtiEventReserved;
 
@@ -997,7 +998,7 @@ typedef struct {
 	jvmtiEventObjectFree ObjectFree;
 	jvmtiEventVMObjectAlloc VMObjectAlloc;
 	jvmtiEventReserved reserved85;
-	jvmtiEventSampledObjectAlloc SampledObjectAlloc;
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [	jvmtiEventSampledObjectAlloc SampledObjectAlloc;], [	jvmtiEventReserved reserved86;])
 } jvmtiEventCallbacks;
 
 /*
@@ -1009,7 +1010,7 @@ typedef struct {
 typedef struct JVMTINativeInterface_ {
 	void *reserved1;
 	jvmtiError (JNICALL * SetEventNotificationMode)(jvmtiEnv* env,	jvmtiEventMode mode,	jvmtiEvent event_type,	jthread event_thread,	...);
-	jvmtiError (JNICALL * GetAllModules)(jvmtiEnv* env, jint* module_count_ptr, jobject** modules_ptr);
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	jvmtiError (JNICALL * GetAllModules)(jvmtiEnv* env, jint* module_count_ptr, jobject** modules_ptr);], [	void *reserved3;])
 	jvmtiError (JNICALL * GetAllThreads)(jvmtiEnv* env,	jint* threads_count_ptr,	jthread** threads_ptr);
 	jvmtiError (JNICALL * SuspendThread)(jvmtiEnv* env,	jthread thread);
 	jvmtiError (JNICALL * ResumeThread)(jvmtiEnv* env,	jthread thread);
@@ -1046,7 +1047,7 @@ typedef struct JVMTINativeInterface_ {
 	jvmtiError (JNICALL * RawMonitorNotifyAll)(jvmtiEnv* env,	jrawMonitorID monitor);
 	jvmtiError (JNICALL * SetBreakpoint)(jvmtiEnv* env,	jmethodID method,	jlocation location);
 	jvmtiError (JNICALL * ClearBreakpoint)(jvmtiEnv* env,	jmethodID method,	jlocation location);
-	jvmtiError (JNICALL * GetNamedModule)(jvmtiEnv* env, jobject class_loader, const char* package_name, jobject* module_ptr);
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	jvmtiError (JNICALL * GetNamedModule)(jvmtiEnv* env, jobject class_loader, const char* package_name, jobject* module_ptr);], [	void *reserved40;])
 	jvmtiError (JNICALL * SetFieldAccessWatch)(jvmtiEnv* env,	jclass klass,	jfieldID field);
 	jvmtiError (JNICALL * ClearFieldAccessWatch)(jvmtiEnv* env,	jclass klass,	jfieldID field);
 	jvmtiError (JNICALL * SetFieldModificationWatch)(jvmtiEnv* env,	jclass klass,	jfieldID field);
@@ -1100,12 +1101,18 @@ typedef struct JVMTINativeInterface_ {
 	jvmtiError (JNICALL * IsMethodObsolete)(jvmtiEnv* env,	jmethodID method,	jboolean* is_obsolete_ptr);
 	jvmtiError (JNICALL * SuspendThreadList)(jvmtiEnv* env,	jint request_count,	const jthread* request_list,	jvmtiError* results);
 	jvmtiError (JNICALL * ResumeThreadList)(jvmtiEnv* env,	jint request_count,	const jthread* request_list,	jvmtiError* results);
-	jvmtiError (JNICALL * AddModuleReads)(jvmtiEnv* env, jobject module, jobject to_module);
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	jvmtiError (JNICALL * AddModuleReads)(jvmtiEnv* env, jobject module, jobject to_module);
 	jvmtiError (JNICALL * AddModuleExports)(jvmtiEnv* env, jobject module, const char* pkg_name, jobject to_module);
 	jvmtiError (JNICALL * AddModuleOpens)(jvmtiEnv* env, jobject module, const char* pkg_name, jobject to_module);
 	jvmtiError (JNICALL * AddModuleUses)(jvmtiEnv* env, jobject module, jclass service);
 	jvmtiError (JNICALL * AddModuleProvides)(jvmtiEnv* env, jobject module, jclass service, jclass impl_class);
-	jvmtiError (JNICALL * IsModifiableModule)(jvmtiEnv* env, jobject module, jboolean* is_modifiable_module_ptr);
+	jvmtiError (JNICALL * IsModifiableModule)(jvmtiEnv* env, jobject module, jboolean* is_modifiable_module_ptr);], 
+	[	void *reserved94;
+	void *reserved95;
+	void *reserved96;
+	void *reserved97;
+	void *reserved98;
+	void *reserved99;])
 	jvmtiError (JNICALL * GetAllStackTraces)(jvmtiEnv* env,	jint max_frame_count,	jvmtiStackInfo** stack_info_ptr,	jint* thread_count_ptr);
 	jvmtiError (JNICALL * GetThreadListStackTraces)(jvmtiEnv* env,	jint thread_count,	const jthread* thread_list,	jint max_frame_count,	jvmtiStackInfo** stack_info_ptr);
 	jvmtiError (JNICALL * GetThreadLocalStorage)(jvmtiEnv* env,	jthread thread,	void** data_ptr);
@@ -1162,7 +1169,8 @@ typedef struct JVMTINativeInterface_ {
 	jvmtiError (JNICALL * GetOwnedMonitorStackDepthInfo)(jvmtiEnv* env, jthread thread, jint* monitor_info_count_ptr, jvmtiMonitorStackDepthInfo** monitor_info_ptr);
 	jvmtiError (JNICALL * GetObjectSize)(jvmtiEnv* env,	jobject object,	jlong* size_ptr);
 	jvmtiError (JNICALL * GetLocalInstance)(jvmtiEnv* env, jthread thread, jint depth, jobject* value_ptr);
-	jvmtiError (JNICALL * SetHeapSamplingInterval)(jvmtiEnv* env, jint sampling_interval);
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1, [	jvmtiError (JNICALL * SetHeapSamplingInterval)(jvmtiEnv* env, jint sampling_interval);], 
+	[	void *reserved156;])
 } jvmtiNativeInterface;
 
 struct _jvmtiEnv {
@@ -1170,7 +1178,7 @@ struct _jvmtiEnv {
 #ifdef __cplusplus
 	jvmtiError SetEventNotificationMode (jvmtiEventMode mode,	jvmtiEvent event_type,	jthread event_thread,	...) { return functions->SetEventNotificationMode(this, mode, event_type, event_thread); }
 	jvmtiError GetAllThreads (jint* threads_count_ptr,	jthread** threads_ptr) { return functions->GetAllThreads(this, threads_count_ptr, threads_ptr); }
-	jvmtiError GetAllModules (jint* module_count_ptr, jobject** modules_ptr) { return functions->GetAllModules(this, module_count_ptr, modules_ptr); }
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	jvmtiError GetAllModules (jint* module_count_ptr, jobject** modules_ptr) { return functions->GetAllModules(this, module_count_ptr, modules_ptr); }], [dnl])
 	jvmtiError SuspendThread (jthread thread) { return functions->SuspendThread(this, thread); }
 	jvmtiError ResumeThread (jthread thread) { return functions->ResumeThread(this, thread); }
 	jvmtiError StopThread (jthread thread,	jobject exception) { return functions->StopThread(this, thread, exception); }
@@ -1206,7 +1214,7 @@ struct _jvmtiEnv {
 	jvmtiError RawMonitorNotifyAll (jrawMonitorID monitor) { return functions->RawMonitorNotifyAll(this, monitor); }
 	jvmtiError SetBreakpoint (jmethodID method,	jlocation location) { return functions->SetBreakpoint(this, method, location); }
 	jvmtiError ClearBreakpoint (jmethodID method,	jlocation location) { return functions->ClearBreakpoint(this, method, location); }
-	jvmtiError GetNamedModule(jvmtiEnv* env, jobject class_loader, const char* package_name, jobject* module_ptr) { return functions->GetNamedModule(this, class_loader, package_name, module_ptr); }
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	jvmtiError GetNamedModule(jvmtiEnv* env, jobject class_loader, const char* package_name, jobject* module_ptr) { return functions->GetNamedModule(this, class_loader, package_name, module_ptr); }], [dnl])
 	jvmtiError SetFieldAccessWatch (jclass klass,	jfieldID field) { return functions->SetFieldAccessWatch(this, klass, field); }
 	jvmtiError ClearFieldAccessWatch (jclass klass,	jfieldID field) { return functions->ClearFieldAccessWatch(this, klass, field); }
 	jvmtiError SetFieldModificationWatch (jclass klass,	jfieldID field) { return functions->SetFieldModificationWatch(this, klass, field); }
@@ -1259,12 +1267,12 @@ struct _jvmtiEnv {
 	jvmtiError IsMethodObsolete (jmethodID method,	jboolean* is_obsolete_ptr) { return functions->IsMethodObsolete(this, method, is_obsolete_ptr); }
 	jvmtiError SuspendThreadList (jint request_count,	const jthread* request_list,	jvmtiError* results) { return functions->SuspendThreadList(this, request_count, request_list, results); }
 	jvmtiError ResumeThreadList (jint request_count,	const jthread* request_list,	jvmtiError* results) { return functions->ResumeThreadList(this, request_count, request_list, results); }
-	jvmtiError AddModuleReads(jvmtiEnv* env, jobject module, jobject to_module) { return functions->AddModuleReads(this, module, to_module); }
+ifelse(eval(JAVA_SPEC_VERSION >= 9), 1, [	jvmtiError AddModuleReads(jvmtiEnv* env, jobject module, jobject to_module) { return functions->AddModuleReads(this, module, to_module); }
 	jvmtiError AddModuleExports(jvmtiEnv* env, jobject module, const char* pkg_name, jobject to_module) { return functions->AddModuleExports(this, module, pkg_name, to_module); }
 	jvmtiError AddModuleOpens(jvmtiEnv* env, jobject module, const char* pkg_name, jobject to_module) { return functions->AddModuleOpens(this, module, pkg_name, to_module); }
 	jvmtiError AddModuleUses(jvmtiEnv* env, jobject module, jclass service) { return functions->AddModuleUses(this, module, service); }
 	jvmtiError AddModuleProvides(jvmtiEnv* env, jobject module, jclass service, jclass impl_class) { return functions->AddModuleProvides(this, module, service, impl_class); }
-	jvmtiError IsModifiableModule(jvmtiEnv* env, jobject module, jboolean* is_modifiable_module_ptr) { return functions->IsModifiableModule(this, module, is_modifiable_module_ptr); }
+	jvmtiError IsModifiableModule(jvmtiEnv* env, jobject module, jboolean* is_modifiable_module_ptr) { return functions->IsModifiableModule(this, module, is_modifiable_module_ptr); }], [dnl])
 	jvmtiError GetAllStackTraces (jint max_frame_count,	jvmtiStackInfo** stack_info_ptr,	jint* thread_count_ptr) { return functions->GetAllStackTraces(this, max_frame_count, stack_info_ptr, thread_count_ptr); }
 	jvmtiError GetThreadListStackTraces (jint thread_count,	const jthread* thread_list,	jint max_frame_count,	jvmtiStackInfo** stack_info_ptr) { return functions->GetThreadListStackTraces(this, thread_count, thread_list, max_frame_count, stack_info_ptr); }
 	jvmtiError GetThreadLocalStorage (jthread thread,	void** data_ptr) { return functions->GetThreadLocalStorage(this, thread, data_ptr); }
@@ -1315,7 +1323,7 @@ struct _jvmtiEnv {
 	jvmtiError GetOwnedMonitorStackDepthInfo (jthread thread, jint* monitor_info_count_ptr, jvmtiMonitorStackDepthInfo** monitor_info_ptr) { return functions->GetOwnedMonitorStackDepthInfo(this, thread, monitor_info_count_ptr, monitor_info_ptr); }
 	jvmtiError GetObjectSize (jobject object, jlong* size_ptr) { return functions->GetObjectSize(this, object, size_ptr); }
 	jvmtiError GetLocalInstance (jthread thread, jint depth, jobject* value_ptr) { return functions->GetLocalInstance(this, thread, depth, value_ptr); }
-	jvmtiError SetHeapSamplingInterval (jint sampling_interval) { return functions->SetHeapSamplingInterval(this, sampling_interval); }
+ifelse(eval(JAVA_SPEC_VERSION >= 11), 1,[ 	jvmtiError SetHeapSamplingInterval (jint sampling_interval) { return functions->SetHeapSamplingInterval(this, sampling_interval); }], [dnl])
 #endif
 };
 

--- a/runtime/include/module.xml
+++ b/runtime/include/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  Copyright (c) 2016, 2017 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
  
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,4 +25,18 @@
 <module>
 	<artifact type="reference" name="j9include">
 	</artifact>
+
+	<artifact type="target" name="generate_jvmti" all="false">
+		<commands>
+			<command type="all" line="m4 -D JAVA_SPEC_VERSION=$(VERSION_MAJOR) jvmti.h.m4 > jvmti.h"/>
+			<command type="clean" line="$(RM) jvmti.h"/>
+		</commands>
+	</artifact>
+
+	<artifact type="target" name="j9include_generate" all="false">
+		<dependencies>
+			<dependency name="generate_jvmti"/>
+		</dependencies>
+	</artifact>
+	
 </module>

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -89,11 +89,15 @@ dumpCapabilities(J9JavaVM * vm, const jvmtiCapabilities *capabilities, const cha
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_threads_events);
 
 	/* JVMTI 9.0 */
+#if JAVA_SPEC_VERSION >= 9
 	PRINT_CAPABILITY(can_generate_early_vmstart);
 	PRINT_CAPABILITY(can_generate_early_class_hook_events);
+#endif /* JAVA_SPEC_VERSION >= 9 */
 
 	/* JVMTI 11 */
+#if JAVA_SPEC_VERSION >= 11
 	PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #undef PRINT_CAPABILITY
 }
 
@@ -168,11 +172,13 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 	if (isEventHookable(j9env, JVMTI_EVENT_VM_OBJECT_ALLOC)) {
 		rv_capabilities.can_generate_vm_object_alloc_events = 1;
 	}
-	
+
+#if JAVA_SPEC_VERSION >= 11
 	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)) {
 		/* hardcode to 0 (not enabled) for empty JEP331 implementation */
 		rv_capabilities.can_generate_sampled_object_alloc_events = 0;
 	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (isEventHookable(j9env, JVMTI_EVENT_NATIVE_METHOD_BIND)) {
 		rv_capabilities.can_generate_native_method_bind_events = 1;
@@ -282,10 +288,12 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 		rv_capabilities.can_generate_resource_exhaustion_heap_events = 1;
 	}
 
+#if JAVA_SPEC_VERSION >= 9
 	if (JVMTI_PHASE_ONLOAD == jvmtiData->phase) {
 		rv_capabilities.can_generate_early_vmstart = 1;
 		rv_capabilities.can_generate_early_class_hook_events = 1;
 	}
+#endif /* JAVA_SPEC_VERSION >= 9 */
 
 	rc = JVMTI_ERROR_NONE;
 	omrthread_monitor_exit(jvmtiData->mutex);
@@ -548,9 +556,11 @@ mapCapabilitiesToEvents(J9JVMTIEnv * j9env, jvmtiCapabilities * capabilities, J9
 		rc |= eventHookFunction(j9env, JVMTI_EVENT_VM_OBJECT_ALLOC);
 	}
 
+#if JAVA_SPEC_VERSION >= 11
 	if (capabilities->can_generate_sampled_object_alloc_events) {
 		rc |= eventHookFunction(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC);
 	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (capabilities->can_generate_object_free_events) {
 		rc |= eventHookFunction(j9env, JVMTI_EVENT_OBJECT_FREE);

--- a/runtime/jvmti/jvmtiEventManagement.c
+++ b/runtime/jvmti/jvmtiEventManagement.c
@@ -150,9 +150,11 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 					ENSURE_CAPABILITY(env, can_generate_vm_object_alloc_events);
 					break;
 
+#if JAVA_SPEC_VERSION >= 11
 				case  JVMTI_EVENT_SAMPLED_OBJECT_ALLOC:
 					ENSURE_CAPABILITY(env, can_generate_sampled_object_alloc_events);
 					break;
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 				case JVMTI_EVENT_NATIVE_METHOD_BIND:
 					ENSURE_CAPABILITY(env, can_generate_native_method_bind_events);

--- a/runtime/jvmti/jvmtiFunctionTable.c
+++ b/runtime/jvmti/jvmtiFunctionTable.c
@@ -23,10 +23,22 @@
 #include "jvmtiHelpers.h"
 #include "jvmti_internal.h"
 
+#if JAVA_SPEC_VERSION >= 9
+#define JVMTI_9_ENTRY(name) name
+#else /* JAVA_SPEC_VERSION >= 9 */
+#define JVMTI_9_ENTRY(name) NULL
+#endif /* JAVA_SPEC_VERSION >= 9 */
+
+#if JAVA_SPEC_VERSION >= 11
+#define JVMTI_11_ENTRY(name) name
+#else /* JAVA_SPEC_VERSION >= 11 */
+#define JVMTI_11_ENTRY(name) NULL
+#endif /* JAVA_SPEC_VERSION >= 11*/
+
 jvmtiNativeInterface jvmtiFunctionTable = {
 	NULL,
 	jvmtiSetEventNotificationMode,
-	jvmtiGetAllModules,
+	JVMTI_9_ENTRY(jvmtiGetAllModules),
 	jvmtiGetAllThreads,
 	jvmtiSuspendThread,
 	jvmtiResumeThread,
@@ -63,7 +75,7 @@ jvmtiNativeInterface jvmtiFunctionTable = {
 	jvmtiRawMonitorNotifyAll,
 	jvmtiSetBreakpoint,
 	jvmtiClearBreakpoint,
-	jvmtiGetNamedModule,
+	JVMTI_9_ENTRY(jvmtiGetNamedModule),
 	jvmtiSetFieldAccessWatch,
 	jvmtiClearFieldAccessWatch,
 	jvmtiSetFieldModificationWatch,
@@ -117,12 +129,12 @@ jvmtiNativeInterface jvmtiFunctionTable = {
 	jvmtiIsMethodObsolete,
 	jvmtiSuspendThreadList,
 	jvmtiResumeThreadList,
-	jvmtiAddModuleReads,
-	jvmtiAddModuleExports,
-	jvmtiAddModuleOpens,
-	jvmtiAddModuleUses,
-	jvmtiAddModuleProvides,
-	jvmtiIsModifiableModule,
+	JVMTI_9_ENTRY(jvmtiAddModuleReads),
+	JVMTI_9_ENTRY(jvmtiAddModuleExports),
+	JVMTI_9_ENTRY(jvmtiAddModuleOpens),
+	JVMTI_9_ENTRY(jvmtiAddModuleUses),
+	JVMTI_9_ENTRY(jvmtiAddModuleProvides),
+	JVMTI_9_ENTRY(jvmtiIsModifiableModule),
 	jvmtiGetAllStackTraces,
 	jvmtiGetThreadListStackTraces,
 	jvmtiGetThreadLocalStorage,
@@ -179,7 +191,7 @@ jvmtiNativeInterface jvmtiFunctionTable = {
 	jvmtiGetOwnedMonitorStackDepthInfo,
 	jvmtiGetObjectSize,
 	jvmtiGetLocalInstance,
-	jvmtiSetHeapSamplingInterval,
+	JVMTI_11_ENTRY(jvmtiSetHeapSamplingInterval),
 };
 
 

--- a/runtime/jvmti/jvmtiMemory.c
+++ b/runtime/jvmti/jvmtiMemory.c
@@ -80,6 +80,7 @@ jvmtiDeallocate(jvmtiEnv* env,
 	TRACE_JVMTI_RETURN(jvmtiDeallocate);
 }
 
+#if JAVA_SPEC_VERSION >= 11
 jvmtiError JNICALL 
 jvmtiSetHeapSamplingInterval(jvmtiEnv *env, 
 	jint samplingInterval)
@@ -98,3 +99,4 @@ jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
 done:
 	TRACE_JVMTI_RETURN(jvmtiSetHeapSamplingInterval);
 }
+#endif /* JAVA_SPEC_VERSION >= 11 */

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1510,9 +1510,11 @@ jvmtiGetLocalInstance(jvmtiEnv* env,
 * @param samplingInterval The sampling interval in bytes.
 * @return jvmtiError Error code returned by JVMTI function
 */
+#if JAVA_SPEC_VERSION >= 11
 jvmtiError JNICALL 
 jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
 	jint samplingInterval);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 /**
 * @brief
@@ -2508,6 +2510,7 @@ jvmtiSetFieldModificationWatch(jvmtiEnv* env,
 	jclass klass,
 	jfieldID field);
 
+#if JAVA_SPEC_VERSION >= 9
 /* ---------------- jvmtiModules.c ---------------- */
 /**
 * @brief
@@ -2568,6 +2571,7 @@ jvmtiIsModifiableModule(jvmtiEnv* env,
 		jobject module,
 		jboolean* is_modifiable_module_ptr);
 
+#endif /* JAVA_SPEC_VERSION >= 9 */
 /* ---------------- suspendhelper.cpp ---------------- */
 /**
 * @brief

--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -125,10 +125,14 @@ static jvmtiTest jvmtiTestList[] =
 	{ "rnwr001",   rnwr001,   "com.ibm.jvmti.tests.registerNativesWithRetransformation.rnwr001", "Test RegisterNatives JNI API in FSD" },
 	{ "aln001",    aln001,    "com.ibm.jvmti.tests.agentLibraryNatives.aln001",               "Test natives in agent libraries" },
 	{ "rbc001",   rbc001,   "com.ibm.jvmti.tests.redefineBreakpointCombo.rbc001", "Test Redefine-breakpoint combination"},
+#if JAVA_SPEC_VERSION >= 9
 	{ "mt001",   mt001,   "com.ibm.jvmti.tests.modularityTests.mt001", "Test Modularity functions"},
+#endif /* JAVA_SPEC_VERSION >= 9 */
 	{ "nmr001",     nmr001,    "com.ibm.jvmti.tests.nestMatesRedefinition.nmr001", "Test nestmates redefinition"},
 	{ "snmp001",     snmp001,    "com.ibm.jvmti.tests.setNativeMethodPrefix.snmp001", "Tests setting a native method prefix and disposing a subsequent environment"},
+#if JAVA_SPEC_VERSION >= 11	
 	{ "soae001", soae001, "com.ibm.jvmti.tests.samplingObjectAllocation.soae001", "Test JEP331 low-overhead sampling heap object allocation" },
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -24,7 +24,7 @@
 
 #include "j9comp.h"
 #include "jvmti.h"
-
+#include "j9cfg.h"
 
 /* TODO: remove */
 #define BUFFER_SIZE 65536

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -196,14 +196,20 @@
 		<export name="Java_com_ibm_jvmti_tests_registerNativesWithRetransformation_rnwr001_retransformClass" />
 		<export name="Java_com_ibm_jvmti_tests_agentLibraryNatives_aln001_shortname" />
 		<export name="Java_com_ibm_jvmti_tests_agentLibraryNatives_aln001_longname__I" />
+		<export name="Java_com_ibm_jvmti_tests_nestMatesRedefinition_nmr001_redefineClass" />
+		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_setPrefix" />
+		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat" />
+	</exports>
+		
+	<exports group="jdk9">
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleReads" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleExports" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleUses" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleOpens" />
 		<export name="Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleProvides" />
-		<export name="Java_com_ibm_jvmti_tests_nestMatesRedefinition_nmr001_redefineClass" />
-		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_setPrefix" />
-		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat" />
+	</exports>
+		
+	<exports group="jdk11">
 		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_reset" />
 		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_enable" />
 		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_disable" />
@@ -215,6 +221,12 @@
 		<phase>jvmti_tests</phase>
 		<exports>
 			<group name="all"/>
+			<group name="jdk9">
+				<include-if condition="spec.java9"/>
+			</group>
+			<group name="jdk11">
+				<include-if condition="spec.java11"/>
+			</group>
 		</exports>
 		<includes>
 			<include path="jvmti_test_include"/>

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
@@ -113,17 +113,17 @@ getCapabilities(jvmtiCapabilities * caps, int * availableCount, int * unavailabl
 	PRINT_CAPABILITY(can_retransform_any_class);
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_heap_events);
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_threads_events);
-	
-	/* JVMTI 9.0 */
-	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
-		PRINT_CAPABILITY(can_generate_early_vmstart);
-		PRINT_CAPABILITY(can_generate_early_class_hook_events);
-	}
 
+#if JAVA_SPEC_VERSION >= 9   
+	/* JVMTI 9.0 */
+	PRINT_CAPABILITY(can_generate_early_vmstart);
+	PRINT_CAPABILITY(can_generate_early_class_hook_events);
+#endif /* JAVA_SPEC_VERSION >= 9 */
+
+#if JAVA_SPEC_VERSION >= 11
 	/* JVMTI 11 */
-	if (env->jvmtiVersion >= JVMTI_VERSION_11) {
-		PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
-	}
+	PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
 jboolean JNICALL
@@ -152,29 +152,29 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilitie
 		unavailableCount--;
 	}
 
-	if (env->jvmtiVersion >= JVMTI_VERSION_11) {
-		/* Empty JEP331 implementation doesn't enable capability can_generate_sampled_object_alloc_events. */
-		if (initialCapabilities.can_generate_sampled_object_alloc_events == 0) {
-			unavailableCount--;
-		}
+#if JAVA_SPEC_VERSION >= 11
+	/* Empty JEP331 implementation doesn't enable capability can_generate_sampled_object_alloc_events. */
+	if (initialCapabilities.can_generate_sampled_object_alloc_events == 0) {
+		unavailableCount--;
 	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 	
 	if (unavailableCount != 0) {
 		error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of unavailable capabilities. Expected 0", unavailableCount);
 		return JNI_FALSE;
 	}
 
-	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
-		if (0 == initialCapabilities.can_generate_early_vmstart) {
-			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should be available in onload phase.");
-			return JNI_FALSE;
-		}
-
-		if (0 == initialCapabilities.can_generate_early_class_hook_events) {
-			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should be available in onload phase.");
-			return JNI_FALSE;
-		}
+#if JAVA_SPEC_VERSION >= 9
+	if (0 == initialCapabilities.can_generate_early_vmstart) {
+		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should be available in onload phase.");
+		return JNI_FALSE;
 	}
+
+	if (0 == initialCapabilities.can_generate_early_class_hook_events) {
+		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should be available in onload phase.");
+		return JNI_FALSE;
+	}
+#endif /* JAVA_SPEC_VERSION >= 9 */
 	
 	return JNI_TRUE;
 }
@@ -213,18 +213,18 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyLiveCapabilities(
 		error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of available capabilities.", availableCount);
 		return JNI_FALSE;
 	}
-	
-	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
-		if (1 == capabilities.can_generate_early_vmstart) {
-			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should not be available in live phase.");
-			return JNI_FALSE;
-		}
-		
-		if (1 == capabilities.can_generate_early_class_hook_events) {
-			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should not be available in the live phase.");
-			return JNI_FALSE;
-		}
+
+#if JAVA_SPEC_VERSION >= 9
+	if (1 == capabilities.can_generate_early_vmstart) {
+		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should not be available in live phase.");
+		return JNI_FALSE;
 	}
+		
+	if (1 == capabilities.can_generate_early_class_hook_events) {
+		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should not be available in the live phase.");
+		return JNI_FALSE;
+	}
+#endif /* JAVA_SPEC_VERSION >= 9 */
 
 	return JNI_TRUE;
 }

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc002.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc002.c
@@ -181,16 +181,17 @@ getCapabilities(jvmtiCapabilities * caps, int * availableCount, int * unavailabl
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_heap_events);
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_threads_events);
 
+#if JAVA_SPEC_VERSION >= 9
 	/* JVMTI 9.0 */
-	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
-		PRINT_CAPABILITY(can_generate_early_vmstart);
-		PRINT_CAPABILITY(can_generate_early_class_hook_events);
-	}
-	
+	PRINT_CAPABILITY(can_generate_early_vmstart);
+	PRINT_CAPABILITY(can_generate_early_class_hook_events);
+#endif /* JAVA_SPEC_VERSION >= 9 */
 	/* JVMTI 11 */
-	if (env->jvmtiVersion >= JVMTI_VERSION_11) {
-		PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
-	}
+
+#if JAVA_SPEC_VERSION >= 11
+	PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
+#endif /* JAVA_SPEC_VERSION >= 11 */
+
 }
 
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/modularityTests/mt001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/modularityTests/mt001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,7 @@
 #include "jvmti_test.h"
 
 static agentEnv * env;
+#if JAVA_SPEC_VERSION >= 9
 
 jint JNICALL
 mt001(agentEnv * agent_env, char * args)
@@ -102,3 +103,4 @@ Java_com_ibm_jvmti_tests_modularityTests_mt001_addModuleProvides(JNIEnv * jni_en
 
 	return (jint) (*jvmti_env)->AddModuleProvides(jvmti_env, module, service, implClass);;
 }
+#endif /* JAVA_SPEC_VERSION >= 9 */

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
@@ -32,6 +32,8 @@ static void JNICALL sampledObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jth
 /* the number of time the callback sampledObjectAlloc invoked */
 static jint soaeResult = 0;
 
+#if JAVA_SPEC_VERSION >= 11
+
 jint JNICALL
 soae001(agentEnv *agent_env, char *args)
 {
@@ -120,3 +122,4 @@ Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_check(JNIEnv *jni_env,
 {
 	return soaeResult;
 }
+#endif /* JAVA_SPEC_VERSION >= 11 */


### PR DESCRIPTION
we use m4 to generate different jvmti header files to support different JDKs

we need to generate jvmti header by using m4 so that it is specific to
the Java release version, since vm will support Java 8, 9, 10, 11, 12.
Some PRs in extension repositories are created.

There are some changes:

- use m4 preprocessor and macros to generate different header
- add macros in other jvmti implementation files so that it matches header files
- modify dependency in `runtime/CMakeList.txt` to support cmake build
- modify dependency in `runtime/buildtools.mk` to support Uma build
- modify dependency in `runtime/compiler/linter.mk` to support linter build

Closes: #2368
 
Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>