### PR TITLE
Update omrsysinfo_is_running_in_container() signature

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -225,8 +225,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 			OMRPORT_ACCESS_FROM_J9PORT(vm->portLibrary);
 			vm->sharedCacheAPI->xShareClassesPresent = FALSE;
 			if (J9_SHARED_CACHE_DEFAULT_BOOT_SHARING(vm)) {
-				I_32 errorCode = 0;
-				BOOLEAN inContainer = omrsysinfo_is_running_in_container(&errorCode);;
+				BOOLEAN inContainer = omrsysinfo_is_running_in_container();
 				/* Do not enable shared classes by default if running in Container */
 
 				if (FALSE == inContainer) {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1825,10 +1825,7 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				IDATA argIndexIgnoreUnrecognizedOptionsEnable = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXIDLETUNINGIGNOREUNRECOGNIZEDOPTIONSENABLE, NULL);
 				IDATA argIndexIgnoreUnrecognizedOptionsDisable = FIND_AND_CONSUME_ARG(EXACT_MATCH, VMOPT_XXIDLETUNINGIGNOREUNRECOGNIZEDOPTIONSDISABLE, NULL);
 				BOOLEAN enableGcOnIdle = FALSE;
-				BOOLEAN inContainer = FALSE;
-				int32_t errorCode = 0;
-				
-				inContainer = omrsysinfo_is_running_in_container(&errorCode);
+				BOOLEAN inContainer = omrsysinfo_is_running_in_container();
 
 				/* 
 				 * GcOnIdle is enabled only if:


### PR DESCRIPTION
OMR updated omrsysinfo_is_running_in_container() to remove the
`errorCode` parameter in https://github.com/eclipse/omr/pull/3420

This change helps the openj9-omr to promote

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>