### PR TITLE
Method and tests for jep334 MethodHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -27,8 +27,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 /*[IF Java12]*/
+import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DirectMethodHandleDesc.Kind;
 import java.lang.constant.MethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
 /*[ENDIF]*/
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Modifier;
@@ -40,6 +44,7 @@ import java.util.List;
 
 import java.util.Objects;
 /*[IF Java12]*/
+import java.util.NoSuchElementException;
 import java.util.Optional;
 /*[ENDIF]*/
 // {{{ JIT support
@@ -736,9 +741,102 @@ public abstract class MethodHandle
 	}
 	
 /*[IF Java12]*/
+	/**
+	 * Returns the nominal descriptor of this MethodHandle instance, or an empty Optional 
+	 * if construction is not possible.
+	 * 
+	 * @return Optional with a nominal descriptor of MethodHandle instance
+	 */
 	public Optional<MethodHandleDesc> describeConstable() {
-		/* Jep334 */
-		throw OpenJDKCompileStub.OpenJDKCompileStubThrowError();
+		try {
+			DirectMethodHandleDesc.Kind handleKind;
+
+			/* Define handle as a crackable type. If its not possible to do so this method should fail */
+			MethodHandleInfo handleInfo = Lookup.IMPL_LOOKUP.revealDirect(this);
+			switch(handleInfo.getReferenceKind()) {
+				case MethodHandleInfo.REF_getField:
+					handleKind = DirectMethodHandleDesc.Kind.GETTER;
+					break;
+				case MethodHandleInfo.REF_getStatic:
+					handleKind = DirectMethodHandleDesc.Kind.STATIC_GETTER;
+					break;
+				case MethodHandleInfo.REF_putField:
+					handleKind = DirectMethodHandleDesc.Kind.SETTER;
+					break;
+				case MethodHandleInfo.REF_putStatic:
+					handleKind = DirectMethodHandleDesc.Kind.STATIC_SETTER;
+					break;
+				case MethodHandleInfo.REF_invokeVirtual:
+					handleKind = DirectMethodHandleDesc.Kind.VIRTUAL;
+					break;
+				case MethodHandleInfo.REF_invokeStatic:
+					if (handleInfo.getDeclaringClass().isInterface()) {
+						handleKind = DirectMethodHandleDesc.Kind.INTERFACE_STATIC;
+					} else {
+						handleKind = DirectMethodHandleDesc.Kind.STATIC;
+					}
+					break;
+				case MethodHandleInfo.REF_invokeSpecial:
+					if (handleInfo.getDeclaringClass().isInterface()) {
+						handleKind = DirectMethodHandleDesc.Kind.INTERFACE_SPECIAL;
+					} else {
+						handleKind = DirectMethodHandleDesc.Kind.SPECIAL;
+					}
+					break;
+				case MethodHandleInfo.REF_newInvokeSpecial:
+					handleKind = DirectMethodHandleDesc.Kind.CONSTRUCTOR;	
+					break;
+				case MethodHandleInfo.REF_invokeInterface:
+					handleKind = DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL;
+					break;
+				default:
+					/* fail */
+					return Optional.empty();
+			}
+
+			/* create descriptor for the declaring class */
+			ClassDesc declaringDesc = handleInfo.getDeclaringClass().describeConstable().orElseThrow();
+
+			/* create handle descriptor */
+			MethodHandleDesc handleDesc;
+			switch(handleInfo.getReferenceKind()) {
+				/* field types */
+				case MethodHandleInfo.REF_getField:
+				case MethodHandleInfo.REF_getStatic:
+				case MethodHandleInfo.REF_putField:
+				case MethodHandleInfo.REF_putStatic:
+					ClassDesc fieldType = ((FieldHandle)this).fieldClass.describeConstable().orElseThrow();
+					handleDesc = MethodHandleDesc.ofField(handleKind, declaringDesc, handleInfo.getName(), fieldType);
+					break;
+				/* method types */
+				case MethodHandleInfo.REF_invokeVirtual:
+				case MethodHandleInfo.REF_invokeStatic:
+				case MethodHandleInfo.REF_invokeSpecial:
+				case MethodHandleInfo.REF_invokeInterface:
+					MethodTypeDesc lookupType = handleInfo.getMethodType().describeConstable().orElseThrow();
+					handleDesc = MethodHandleDesc.ofMethod(handleKind, declaringDesc, handleInfo.getName(), lookupType);
+					break;
+				/* constructor types */
+				case MethodHandleInfo.REF_newInvokeSpecial:
+					/* create list of descriptors for constructor parameters */
+					Class<?>[] handleParams = handleInfo.getMethodType().parameterArray();
+					int paramCount = handleParams.length;
+					ClassDesc[] paramDescs = new ClassDesc[paramCount];
+					for (int i = 0; i < paramCount; i++) {
+						paramDescs[i] = handleParams[i].describeConstable().orElseThrow();
+					}
+					handleDesc = MethodHandleDesc.ofConstructor(declaringDesc, paramDescs);
+					break;
+				default:
+					/* fail */
+					return Optional.empty();
+			}
+			return Optional.ofNullable(handleDesc);
+
+		} catch(IllegalArgumentException | SecurityException | NoSuchElementException e) {
+			/* fail */
+			return Optional.empty();
+		}
 	}
 /*[ENDIF]*/
 

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_MethodHandle.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_MethodHandle.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang_invoke;
+
+import org.openj9.test.java_lang_invoke.helpers.Jep334MHHelper;
+import org.openj9.test.java_lang_invoke.helpers.Jep334MHHelperImpl;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+import java.lang.constant.MethodHandleDesc;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandleInfo;
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+
+/**
+ * This test Java.lang.invoke.MethodHandle API added in Java 12 and later version.
+ * - describeConstable: one test for each constant in DirectMethodHandleDesc.Kind to make sure each type is supported
+ *
+ */
+public class Test_MethodHandle {
+    public static Logger logger = Logger.getLogger(Test_MethodHandle.class);
+
+	private static MethodType methodType = MethodType.methodType(void.class);
+	private static MethodHandle constructorHandle = null;
+	private static MethodHandle constructorWithArgsHandle = null;
+	private static MethodHandle getterHandle = null;
+	private static MethodHandle interfaceSpecialHandle = null;
+	private static MethodHandle interfaceStaticHandle = null;
+	private static MethodHandle interfaceVirtualHandle = null;
+	private static MethodHandle setterHandle = null;
+	private static MethodHandle specialHandle = null;
+	private static MethodHandle staticHandle = null;
+	private static MethodHandle staticGetterHandle = null;
+	private static MethodHandle staticSetterHandle = null;
+	private static MethodHandle virtualHandle = null;
+	private static MethodHandles.Lookup lookup = null;
+	private static MethodHandles.Lookup specialLookup = null;
+
+	/* helper for special test */
+	private static MethodHandle superHandle = null;
+
+	static {
+		lookup = MethodHandles.lookup();
+		specialLookup = Jep334MHHelperImpl.lookup();
+		try {
+			/* constructor handle */
+			constructorHandle = lookup.findConstructor(Jep334MHHelperImpl.class, methodType);
+			constructorWithArgsHandle = lookup.findConstructor(Jep334MHHelperImpl.class, MethodType.methodType(void.class, String.class, int.class));
+			
+			/* field handles */
+			getterHandle = lookup.findGetter(Jep334MHHelperImpl.class, "getterTest", int.class);
+			setterHandle = lookup.findSetter(Jep334MHHelperImpl.class, "setterTest", int.class);
+			staticGetterHandle = lookup.findStaticGetter(Jep334MHHelperImpl.class, "staticGetterTest", int.class);
+			staticSetterHandle = lookup.findStaticSetter(Jep334MHHelperImpl.class, "staticSetterTest", int.class);
+			
+			/* direct handles */
+			staticHandle = lookup.findStatic(Jep334MHHelperImpl.class, "staticTest", methodType);
+			interfaceStaticHandle = lookup.findStatic(Jep334MHHelperImpl.class, "staticTest", methodType);
+			specialHandle = specialLookup.findSpecial(Jep334MHHelperImpl.class, "specialTest", methodType, Jep334MHHelperImpl.class);
+			interfaceSpecialHandle = specialLookup.findSpecial(Jep334MHHelper.class, "specialTest", methodType, Jep334MHHelperImpl.class);
+
+			/* indirect handles */
+			interfaceVirtualHandle = lookup.findVirtual(Jep334MHHelper.class, "virtualTest", methodType);
+			virtualHandle = lookup.findVirtual(Jep334MHHelperImpl.class, "virtualTest", methodType);
+		} catch(Throwable e) {
+			Assert.fail("testMethodHandleDescribeConstable: " + e.toString());
+		}
+	}
+
+	/*
+	 * Test Java 12 API MethodHandle.describeConstable() for constructor types
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testMethodHandleDescribeConstableConstructor() throws Throwable {
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableConstructor for constructor", constructorHandle);
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableConstructor for constructor with arguments", constructorWithArgsHandle);
+	}
+
+	/*
+	 * Test Java 12 API MethodHandle.describeConstable() for field types
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testMethodHandleDescribeConstableField() throws Throwable {
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableField for getter", getterHandle);
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableField for setter", setterHandle);
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableField for static_getter", staticGetterHandle);
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableField for static_setter", staticSetterHandle);
+	}
+
+	/*
+	 * Test Java 12 API MethodHandle.describeConstable() for indirect handle types
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testMethodHandleDescribeConstableIndirect() throws Throwable {
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableIndirect for virtual", virtualHandle);
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableIndirect for interface_virtual", interfaceVirtualHandle);
+	}
+
+	/*
+	 * Test Java 12 API MethodHandle.describeConstable() for direct handle types
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testMethodHandleDescribeConstableDirect() throws Throwable {
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableDirect for static", staticHandle);
+		testMethodDescribeConstableGeneral("testMethodHandleDescribeConstableDirect for interface_static", interfaceStaticHandle);
+		testMethodDescribeConstableSpecial("testMethodHandleDescribeConstableDirect for special", specialHandle);
+		testMethodDescribeConstableSpecial("testMethodHandleDescribeConstableDirect for interface_special", interfaceSpecialHandle);
+	}
+	
+	private void testMethodDescribeConstableGeneral(String testName, MethodHandle handle) throws Throwable {
+		testMethodDescribeConstableGeneralSub(testName, handle, lookup);
+	}
+
+	private void testMethodDescribeConstableSpecial(String testName, MethodHandle handle) throws Throwable {
+		testMethodDescribeConstableGeneralSub(testName, handle, specialLookup);
+	}
+
+	private void testMethodDescribeConstableGeneralSub(String testName, MethodHandle handle, MethodHandles.Lookup resolveLookup) throws Throwable {
+		MethodHandleDesc handleDesc = handle.describeConstable().orElseThrow();
+
+		/* verify that descriptor can be resolved. If not ReflectiveOperationException will be thrown. */
+		MethodHandle resolvedHandle = (MethodHandle)handleDesc.resolveConstantDesc(resolveLookup);
+
+		/* verify that resolved MethodType is the same as original */
+		MethodHandleInfo oInfo = MethodHandles.lookup().revealDirect(handle);
+		MethodHandleInfo rInfo = MethodHandles.lookup().revealDirect(resolvedHandle);
+
+		logger.debug(testName + ": Descriptor of original MethodHandle " + oInfo.getMethodType().descriptorString() 
+			+ " descriptor of MethodHandleDesc is: " + rInfo.getMethodType().descriptorString());
+
+		Assert.assertTrue(oInfo.getMethodType().equals(rInfo.getMethodType()));
+		Assert.assertTrue(oInfo.getDeclaringClass().equals(rInfo.getDeclaringClass()));
+		Assert.assertTrue(oInfo.getName().equals(rInfo.getName()));
+		Assert.assertEquals(oInfo.getModifiers(), rInfo.getModifiers());
+		Assert.assertEquals(oInfo.getReferenceKind(), rInfo.getReferenceKind());
+	}
+
+}

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/helpers/Jep334MHHelper.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/helpers/Jep334MHHelper.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.java_lang_invoke.helpers;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
+/* methods to test MethodHandle interface types */
+public interface Jep334MHHelper {
+    public abstract void virtualTest();
+
+    default void specialTest() {}
+    
+    static void staticTest() {}
+}

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/helpers/Jep334MHHelperImpl.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/helpers/Jep334MHHelperImpl.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse License, v. 2.0 are satisfied: GNU
+ * General License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.java_lang_invoke.helpers;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.VarHandle;
+
+public class Jep334MHHelperImpl implements Jep334MHHelper {
+    /*
+     * MethodHandle helper fields & methods
+     */
+    /* fields */
+    public volatile int getterTest = 1;
+    public int setterTest = 2;
+    public static volatile int staticGetterTest = 3;
+    public static int staticSetterTest = 4;
+
+    /* constructors */
+    public Jep334MHHelperImpl() {}
+
+    public Jep334MHHelperImpl(String s, int i) {}
+
+    /* methods to invoke */
+    public void virtualTest() {}
+
+    public void specialTest() {}
+    
+    public static void staticTest() {}
+
+    /* special helper */
+    public static MethodHandles.Lookup lookup() {
+        return MethodHandles.lookup();
+    }
+}

--- a/test/functional/Java12andUp/testng.xml
+++ b/test/functional/Java12andUp/testng.xml
@@ -30,6 +30,7 @@
 			<class name="org.openj9.test.java_lang.Test_String" />
 			<class name="org.openj9.test.java_lang.Test_Class" />
 			<class name="org.openj9.test.java_lang_invoke.Test_MethodType" />
+			<class name="org.openj9.test.java_lang_invoke.Test_MethodHandle" />
 		</classes>
 	</test>
 


### PR DESCRIPTION
- describeConstable

Depends on (see https://github.com/eclipse/openj9/issues/4195): 
- Fix Java 12 build failures: https://github.com/eclipse/openj9/pull/3980
- Constants API stubs: https://github.com/eclipse/openj9/pull/4030
- Java12andUp test setup: https://github.com/eclipse/openj9/pull/4104
- Jep 334 Class methods: https://github.com/eclipse/openj9/pull/4157
- Jep 334 MethodType methods: https://github.com/eclipse/openj9/pull/4194

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>