### PR TITLE
Remove deprecated FrontEnd CodeCache boundary inquiry functions

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2354,33 +2354,6 @@ TR_J9VMBase::getAllocationNoZeroPrefetchCodeSnippetAddress(TR::Compilation * com
    }
 #endif
 
-
-U_8 *
-TR_J9VMBase::getCodeCacheBase()
-   {
-   return _jitConfig->codeCache->heapBase;
-   }
-
-U_8 *
-TR_J9VMBase::getCodeCacheBase(TR::CodeCache * codeCache)
-   {
-   // Used by S390 canUseRelativeLongInstructions to get code cache base.
-   return codeCache->getCodeBase();
-   }
-
-U_8 *
-TR_J9VMBase::getCodeCacheTop()
-   {
-   return _jitConfig->codeCache->heapTop;
-   }
-
-U_8 *
-TR_J9VMBase::getCodeCacheTop(TR::CodeCache * codeCache)
-   {
-   // Used by S390 canUseRelativeLongInstructions to get code cache top.
-   return codeCache->getCodeTop();
-   }
-
 // This routine may be called on the compilation thread or from a runtime hook
 //
 void

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -412,10 +412,6 @@ public:
    virtual uint8_t *          allocateCodeMemory( TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
    virtual void               resizeCodeMemory( TR::Compilation *, uint8_t *, uint32_t numBytes);
 
-   virtual uint8_t *          getCodeCacheBase();
-   virtual uint8_t *          getCodeCacheBase(TR::CodeCache *);
-   virtual uint8_t *          getCodeCacheTop();
-   virtual uint8_t *          getCodeCacheTop(TR::CodeCache *);
    virtual void               releaseCodeMemory(void *startPC, uint8_t bytesToSaveAtStart);
    virtual uint8_t *          allocateRelocationData( TR::Compilation *, uint32_t numBytes);
 


### PR DESCRIPTION
* `getCodeCacheTop`
* `getCodeCacheBase`

Signed-off-by: Daryl Maier <maier@ca.ibm.com>