### PR TITLE
Change J9VMGCRememberedSet to OMR's MM_GCRememberedSet

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2725,19 +2725,9 @@ typedef struct J9VMGCSegregatedAllocationCacheEntry {
 
 #if defined(J9VM_GC_STACCATO)
 
-typedef struct J9VMGCRememberedSet {
-	UDATA globalFragmentIndex;
-	UDATA preservedGlobalFragmentIndex;
-} J9VMGCRememberedSet;
+typedef MM_GCRememberedSet J9VMGCRememberedSet;
 
-typedef struct J9VMGCRememberedSetFragment {
-	UDATA** fragmentAlloc;
-	UDATA** fragmentTop;
-	void* fragmentStorage;
-	UDATA localFragmentIndex;
-	UDATA preservedLocalFragmentIndex;
-	struct J9VMGCRememberedSet* fragmentParent;
-} J9VMGCRememberedSetFragment;
+typedef MM_GCRememberedSetFragment J9VMGCRememberedSetFragment;
 
 #endif /* J9VM_GC_STACCATO */
 
@@ -4836,8 +4826,8 @@ typedef struct J9VMThread {
 	struct J9StackWalkState* stackWalkState;
 	struct J9VMEntryLocalStorage* entryLocalStorage;
 	UDATA gpProtected;
-	struct J9VMGCSublistFragment gcRememberedSet;
-	struct J9VMGCRememberedSetFragment sATBBarrierRememberedSetFragment;
+	J9VMGCSublistFragment gcRememberedSet;
+	J9VMGCRememberedSetFragment sATBBarrierRememberedSetFragment;
 	void* gcTaskListPtr;
 	UDATA* dropBP;
 	UDATA dropFlags;


### PR DESCRIPTION
After adding this typedef to use OMR's new MM_GCRememberedSet structure, usage of J9VMGCRememberedSet in both OMR and OpenJ9 can be changed to MM_GCRememberedSet. This structure is used in OMR but was previously missing.

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>