### PR TITLE
Fix the hang during abort and re-enable the gpTest suite on OSX

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2018 IBM Corp. and others
+ * Copyright (c) 2003, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1837,6 +1837,7 @@ JavaCoreDumpWriter::writeThreadSection(void)
 	_OutputStream.writeInteger(_VirtualMachine->daemonThreadCount, "%i");
 	_OutputStream.writeCharacters("\n");
 
+#if !defined(OSX)
 	/* if thread preempt is enabled, and we have the lock, then collect the native stacks */
 	if ((_Agent->requestMask & J9RAS_DUMP_DO_PREEMPT_THREADS) && _PreemptLocked
 #if defined(WIN32)
@@ -1845,7 +1846,7 @@ JavaCoreDumpWriter::writeThreadSection(void)
 		 */
 		&& !(_Context->eventFlags & J9RAS_DUMP_ON_THREAD_START)
 		&& !(_Context->eventFlags & J9RAS_DUMP_ON_THREAD_END)
-#endif
+#endif /* defined(WIN32) */
 	) {
 		struct walkClosure closure;
 		UDATA sink = 0;
@@ -1856,6 +1857,7 @@ JavaCoreDumpWriter::writeThreadSection(void)
 				J9PORT_SIG_FLAG_SIGALLSYNC|J9PORT_SIG_FLAG_MAY_RETURN,
 				&sink);
 	}
+#endif /* !defined(OSX) */
 
 	if( !_ThreadsWalkStarted ) {
 		struct walkClosure closure;

--- a/test/functional/cmdLineTests/gptest/playlist.xml
+++ b/test/functional/cmdLineTests/gptest/playlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2016, 2018 IBM Corp. and others
+  Copyright (c) 2016, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,8 +41,7 @@
 	-Xint -jar $(CMDLINETESTER_JAR) \
 	-config  $(Q)$(TEST_RESROOT)$(D)gptests.xml$(Q) -verbose -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
 	${TEST_STATUS}	</command>
-		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3686 -->
-		<platformRequirements>^os.win,^os.osx</platformRequirements>
+		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Mirror of https://github.com/eclipse/openj9/pull/4402 for the **0.12.0** release branch.

**1. Disable the call to `protectedWriteThreadsWithNativeStacks`**

While writing the thread section for the javacore, the call to
`protectedWriteThreadsWithNativeStacks` has been disabled since the
`omrintrospect` library causes a hang and fails to retrieve the backtraces
and symbols for native threads on OSX.

**2. Re-enable the gpTest suite on OSX**

All the issues, reported in #3789, have been resolved. Thus, the gpTest
suite is re-enabled on OSX.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>