### PR TITLE
Cherry pick add cmdLineTester_CryptoTest for OpenSSL to v0.12.0-release

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -768,6 +768,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
 	</test>
 
 	<test>

--- a/test/functional/cmdLineTests/openssl/build.xml
+++ b/test/functional/cmdLineTests/openssl/build.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<project name="OpenSSL" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests_OpenSSL
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/openssl" />
+	<property name="PROJECT_ROOT" location="." />
+	<property name="src" location="./src"/>
+	<property name="build" location="./bin"/>
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:				yes</echo>
+		<echo>===executable:			${compiler.javac}</echo>
+		<echo>===debug:				on</echo>
+		<echo>===destdir:				${DEST}</echo>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"/>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/openssltest.jar" filesonly="true">
+			<fileset dir="${build}"/>
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml,*.mk" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/openssl/openssl.xml
+++ b/test/functional/cmdLineTests/openssl/openssl.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="OpenSSL Tests" timeout="300">
+
+	<variable name="CLASSPATH" value="-cp $Q$$TEST_RESROOT$$Q$openssltest.jar" />
+
+	<test id="CryptoTest">
+		<command>$EXE$ -Djdk.nativeCryptoTrace=true $CLASSPATH$ org.openj9.test.openssl.CryptoTest</command>
+		<output regex="no" type="success">using Native crypto library</output>
+		<output regex="no" type="required">Crypto test COMPLETED</output>
+		<output type="failure" caseSensitive="no" regex="no">Native crypto library load failed</output>
+		<output type="failure" caseSensitive="yes" regex="no">Crypto test FAILED</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/openssl/playlist.xml
+++ b/test/functional/cmdLineTests/openssl/playlist.xml
@@ -44,6 +44,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
 		<subsets>
 			<subset>8</subset>
 			<subset>9</subset>
@@ -70,6 +73,9 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
 		<subsets>
 			<subset>11</subset>
 		</subsets>

--- a/test/functional/cmdLineTests/openssl/playlist.xml
+++ b/test/functional/cmdLineTests/openssl/playlist.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2019, 2019 IBM Corp. and others
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] http://openjdk.java.net/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="../../../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>cmdLineTester_CryptoTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)openssl.xml$(Q) \
+		-verbose -explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<!-- Temporarily exclude on aix until OpenSSL is enabled on aix -->
+		<!-- Temporarily exclude on osx on jdk8 until https://github.com/ibmruntimes/openj9-openjdk-jdk11/issues/98 
+			is fixed. If the issue is fixed, cmdLineTester_CryptoTest and cmdLineTester_CryptoTest_11 can be merged into one. -->
+		<platformRequirements>^os.aix,^os.osx</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>8</subset>
+			<subset>9</subset>
+			<subset>10</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_CryptoTest_11</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS)' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)openssl.xml$(Q) \
+		-verbose -explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<!-- Temporarily exclude on aix until OpenSSL is enabled on aix -->
+		<!-- Temporarily exclude on osx, win on jdk11 until https://github.com/ibmruntimes/openj9-openjdk-jdk11/issues/98 
+			is fixed. If the issue is fixed, cmdLineTester_CryptoTest and cmdLineTester_CryptoTest_11 can be merged into one. -->
+		<platformRequirements>^os.aix,^os.osx,^os.win</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>11</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/openssl/src/org/openj9/test/openssl/CryptoTest.java
+++ b/test/functional/cmdLineTests/openssl/src/org/openj9/test/openssl/CryptoTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package org.openj9.test.openssl;
+
+import java.security.KeyFactory;
+
+public class CryptoTest {
+	public static void main(String[] args) {
+		try {
+			KeyFactory.getInstance("RSA");
+			System.out.println("Crypto test COMPLETED");
+		} catch (Exception e) {
+			System.out.println("Crypto test FAILED");
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick from https://github.com/eclipse/openj9/pull/4376 and https://github.com/eclipse/openj9/pull/4421