### PR TITLE
Added NULL parent check to SPMDParallelizer

### DIFF
--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3425,7 +3425,13 @@ TR_SPMDKernelParallelizer::perform()
    ListIterator<TR_RegionStructure> sit(&simdLoops);
    for (TR_RegionStructure *loop = sit.getFirst(); loop; loop = sit.getNext())
       {
-      if (loop->getPrimaryInductionVariable())
+      /*
+       * The GPU transformation might make the block we are trying to vectorize unreachable due
+       * to creating and using a new GPU path. We check for this case by checking if the loop's
+       * parent is NULL or not. If it is NULL, vectorization of the unreachable block is not
+       * necessary and can be skipped.
+       */
+      if (loop->getPrimaryInductionVariable() && (NULL != loop->getParent()))
          {
          if (reductionOperationsHashTab->locate(loop, id))
             {


### PR DESCRIPTION
A problem arises if the enableGPU={enforce} Xjit option is used and
vectorization is attempted on the non-GPU path that is parallel to a newly
created JIT GPU path. Due to the enforce option, the non-GPU path is never
taken and the block is unreachable. However, the SIMD part of the
optimization still knows about the non-GPU path blocks.

This change adds a check before vectorization is done to check if the
loop to be vectorized is unreachable. It does this by checking if the
loop's parent is NULL. If it is NULL, vectorization is not performed.

Issue: #4337
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>