### PR TITLE
Update compiler component to use renamed enums

### DIFF
--- a/runtime/compiler/codegen/LinkageConventions.enum
+++ b/runtime/compiler/codegen/LinkageConventions.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,6 +25,6 @@
  * and enumerator definitions are permitted.
  */
 
-#include "omr/compiler/codegen/LinkageConventions.enum"
+#include "codegen/OMRLinkageConventions.enum"
 
    TR_CHelper,

--- a/runtime/compiler/optimizer/DataFlowAnalysis.enum
+++ b/runtime/compiler/optimizer/DataFlowAnalysis.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
  * and enumerator definitions are permitted.
  */
 
-#include "omr/compiler/optimizer/DataFlowAnalysis.enum"
+#include "optimizer/OMRDataFlowAnalysis.enum"
 
 FearPointAnalysis,
 HCRGuardAnalysis,

--- a/runtime/compiler/optimizer/OptimizationGroups.enum
+++ b/runtime/compiler/optimizer/OptimizationGroups.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
  * and enumerator definitions are permitted.
  */
 
-#include "omr/compiler/optimizer/OptimizationGroups.enum"
+#include "optimizer/OMROptimizationGroups.enum"
 
    OPTIMIZATION(profilingGroup)
 

--- a/runtime/compiler/optimizer/Optimizations.enum
+++ b/runtime/compiler/optimizer/Optimizations.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
  * and enumerator definitions are permitted.
  */
 
-#include "omr/compiler/optimizer/Optimizations.enum"
+#include "optimizer/OMROptimizations.enum"
 
    OPTIMIZATION(profileGenerator)
    OPTIMIZATION(sequentialStoreSimplification)


### PR DESCRIPTION
Use renamed enums from omr see eclipse/omr#3189

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>