### PR TITLE
Load test pipeline on node where tests run

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
+++ b/buildenv/jenkins/jobs/builds/Build-Test-Any-Platform
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,9 +43,6 @@ timeout(time: 10, unit: 'HOURS') {
                 }
 
                 buildFile = load 'buildenv/jenkins/common/build'
-                if (run_tests()) {
-                    testFile = load 'buildenv/jenkins/common/test'
-                }
             } finally {
                 // Temporarily turn off disableDeferredWipeout. See https://issues.jenkins-ci.org/browse/JENKINS-54225
                 cleanWs notFailBuild: true, disableDeferredWipeout: false
@@ -59,6 +56,9 @@ timeout(time: 10, unit: 'HOURS') {
                 // clean up
                 buildFile.build_all()
             } else {
+                checkout scm
+                testFile = load 'buildenv/jenkins/common/test'
+                cleanWs()
                 buildFile.build_pr()
                 testFile.test_all()
             }


### PR DESCRIPTION
- Since JAVA_BIN etc are set when the test file is loaded,
  we need to load on the node where the tests will run.
  This is due to the absolute PATH used. Since the WORKSPACE
  differs from the setup machine and the agents, setting
  JAVA_BIN on the worker would refer to a PATH that didn't
  exist on the agent.

Fixes #4397
[skip ci]

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>