### PR TITLE
Preserve null check on Unsafe

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -296,7 +296,6 @@ private:
    // [PR 124693] To check types on invokespecial within interface methods.
    bool skipInvokeSpecialInterfaceTypeChecks();
    void expandInvokeSpecialInterface(TR::TreeTop *tree);
-   void separateNullCheck(TR::TreeTop *tree);
 
    // Expand MethodHandle invoke
    void expandInvokeHandle(TR::TreeTop *tree);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3994,7 +3994,7 @@ TR_J9ByteCodeIlGenerator::genInvokeInterface(int32_t cpIndex)
 
       TR_ASSERT_FATAL(callTree != bbExit, "invokeinterface call tree not found\n");
 
-      separateNullCheck(callTree);
+      TR::TransformUtil::separateNullCheck(comp(), callTree, comp()->getOption(TR_TraceILGen));
 
       uint32_t interfaceCPIndex = owningMethod->classCPIndexOfMethod(cpIndex);
       push(callNode->getArgument(0));

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,6 +132,15 @@ public:
 
    static void prohibitOSROverRange(TR::Compilation* comp, TR::TreeTop* start, TR::TreeTop* end);
    static void removePotentialOSRPointHelperCalls(TR::Compilation* comp, TR::TreeTop* start, TR::TreeTop* end);
+   /**
+    *   \brief
+    *       Move NULLCHK to a separate tree
+    *
+    *   \param comp  The compilation Object
+    *   \param tree  The tree containing the null check
+    *   \param trace Bool to enable tracing
+    */
+   static void separateNullCheck(TR::Compilation* comp, TR::TreeTop* tree, bool trace = false);
 
 protected:
    /**


### PR DESCRIPTION
Preserve the null check before Unsafe inlining.

Also move `TR_J9ByteCodeIlGenerator::separateNullCheck` to
`TransformUtil` so that it can be used in both ILGen and optimizer.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>