### PR TITLE
Jep334 VarHandle and VarHandleDesc

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/ArrayVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,11 @@ package java.lang.invoke;
 
 import static java.lang.invoke.MethodType.methodType;
 import static java.lang.invoke.ArrayVarHandle.ArrayVarHandleOperations.*;
+
+/*[IF Java12]*/
+import java.lang.constant.ClassDesc;
+import java.util.Optional;
+/*[ENDIF] Java12 */
 
 /**
  * {@link VarHandle} subclass for array element {@link VarHandle} instances.
@@ -100,6 +105,19 @@ final class ArrayVarHandle extends VarHandle {
 	ArrayVarHandle(Class<?> arrayType) {
 		super(arrayType.getComponentType(), new Class<?>[] {arrayType, int.class}, populateMHs(arrayType), 0);
 	}
+
+/*[IF Java12]*/
+	@Override
+	public Optional<VarHandleDesc> describeConstable() {
+		VarHandleDesc result = null;
+		/* coordinateTypes[0] contains array type */
+		Optional<ClassDesc> descOp = coordinateTypes[0].describeConstable();
+		if (descOp.isPresent()) {
+			result = VarHandleDesc.ofArray(descOp.get());
+		}
+		return Optional.ofNullable(result);
+	}
+/*[ENDIF] Java12 */
 
 	/**
 	 * Type specific methods used by array element VarHandle methods.

--- a/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/FieldVarHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,10 @@
  *******************************************************************************/
 package java.lang.invoke;
 
+/*[IF Java12]*/
+import java.lang.constant.ClassDesc;
+import java.util.Optional;
+/*[ENDIF] Java12 */
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import static java.lang.invoke.MethodType.*;
@@ -73,6 +77,24 @@ abstract class FieldVarHandle extends VarHandle {
 		checkSetterFieldFinality(handleTable);
 	}
 	
+	/*[IF Java12]*/
+	@Override
+	public Optional<VarHandleDesc> describeConstable() {
+		VarHandleDesc result = null;
+		Optional<ClassDesc> fieldTypeOp = fieldType.describeConstable();
+		Optional<ClassDesc> declaringClassOp = definingClass.describeConstable();
+
+		if (fieldTypeOp.isPresent() && declaringClassOp.isPresent()) {
+			if (this instanceof InstanceFieldVarHandle) {
+				result = VarHandleDesc.ofField(declaringClassOp.get(), fieldName, fieldTypeOp.get());
+			} else { /* static */
+				result = VarHandleDesc.ofStaticField(declaringClassOp.get(), fieldName, fieldTypeOp.get());
+			}
+		}
+		return Optional.ofNullable(result);
+	}
+	/*[ENDIF] Java12 */
+
 	/**
 	 * Checks whether the field referenced by this VarHandle, is final. 
 	 * If so, MethodHandles in the handleTable that represent access modes that may modify the field, 

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandle.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandle.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang_invoke;
+
+import org.openj9.test.java_lang_invoke.helpers.Jep334MHHelperImpl;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.VarHandle.VarHandleDesc;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This test Java.lang.invoke.VarHandle API added in Java 12 and later version.
+ *
+ * new methods: 
+ * - describeConstable 
+ * - equals 
+ * - hashCode 
+ * - toString
+ */
+public class Test_VarHandle {
+	public static Logger logger = Logger.getLogger(Test_VarHandle.class);
+
+	/* test VarHandles */
+	private static VarHandle instanceTest;
+	private static VarHandle staticTest;
+	private static VarHandle arrayTest;
+	private static VarHandle arrayTest2;
+	/* hash tests */
+	private static VarHandle instanceTestCopy;
+	private static VarHandle staticTestCopy;
+	private static VarHandle arrayTestCopy;
+	private static VarHandle arrayTest2Copy;
+	static {
+		try {
+			instanceTest = Jep334MHHelperImpl.getInstanceTest();
+			staticTest = Jep334MHHelperImpl.getStaticTest();
+			arrayTest = Jep334MHHelperImpl.getArrayTest();
+			arrayTest2 = Jep334MHHelperImpl.getArrayTest2();
+			/* used for hash tests */
+			instanceTestCopy = Jep334MHHelperImpl.getInstanceTest();
+			staticTestCopy = Jep334MHHelperImpl.getStaticTest();
+			arrayTestCopy = Jep334MHHelperImpl.getArrayTest();
+			arrayTest2Copy = Jep334MHHelperImpl.getArrayTest2();
+		} catch (Throwable e) {
+			Assert.fail("Test variables could not be initialized for Test_VarHandle.");
+		}
+	};
+
+	/*
+	 * Test Java 12 API VarHandle.describeConstable() for instance field type
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescribeConstableInstanceField() throws Throwable {
+		describeConstableTestGeneral("testVarHandleDescribeConstableInstanceField", instanceTest);
+	}
+
+	/*
+	 * Test Java 12 API VarHandle.describeConstable() for static field type
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescribeConstableStaticField() throws Throwable {
+		describeConstableTestGeneral("testVarHandleDescribeConstableStaticField", staticTest);
+	}
+
+	/*
+	 * Test Java 12 API VarHandle.describeConstable() for array type
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescribeConstableArray() throws Throwable {
+		describeConstableTestGeneral("testVarHandleDescribeConstableArray (1)", arrayTest);
+		describeConstableTestGeneral("testVarHandleDescribeConstableArray (2)", arrayTest2);
+	}
+
+	private void describeConstableTestGeneral(String testName, VarHandle handle) throws Throwable {
+		VarHandleDesc desc = handle.describeConstable().orElseThrow();
+
+		/*
+		 * verify that descriptor can be resolved. Otherwise will throw
+		 * ReflectiveOperationException
+		 */
+		VarHandle resolvedHandle = (VarHandle) desc.resolveConstantDesc(MethodHandles.lookup());
+
+		logger.debug(testName + ": Descriptor of original class varType is: " + handle.varType().descriptorString());
+		logger.debug(testName + ": Descriptor of VarHandleDesc varType is: " + resolvedHandle.varType().descriptorString());
+		Assert.assertTrue(handle.equals(resolvedHandle));
+	}
+
+	/*
+	 * Test Java 12 API VarHandle.equals()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleEquals() {
+		testVarHandleEqualsSub("testVarHandleEquals instance test: ", instanceTest, arrayTest2);
+		testVarHandleEqualsSub("testVarHandleEquals static test: ", staticTest, arrayTest2);
+		testVarHandleEqualsSub("testVarHandleEquals array test: ", arrayTest, arrayTest2);
+		testVarHandleEqualsSub("testVarHandleEquals array test: ", arrayTest2, instanceTest);
+	}
+
+	private void testVarHandleEqualsSub(String testName, VarHandle tester, VarHandle diffHandle) {
+		logger.debug(testName + " the same VarHandle should be equal to itself: " + tester.equals(tester));
+		Assert.assertTrue(tester.equals(tester));
+		logger.debug(testName + " different VarHandle instances should not be equal: " + !tester.equals(diffHandle));
+		Assert.assertTrue(!tester.equals(diffHandle));
+	}
+
+	/*
+	 * Test Java 12 API VarHandle.hashCode()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleHashCode() {
+		testVarHandleHashCodeSub("testVarHandleHashCode instance test: ", instanceTest, instanceTestCopy);
+		testVarHandleHashCodeSub("testVarHandleHashCode static test: ", staticTest, staticTestCopy);
+		testVarHandleHashCodeSub("testVarHandleHashCode array test: ", arrayTest, arrayTestCopy);
+		testVarHandleHashCodeSub("testVarHandleHashCode array test 2: ", arrayTest2, arrayTest2Copy);
+	}
+
+	private void testVarHandleHashCodeSub(String testName, VarHandle tester, VarHandle copy) {
+		/*
+		 * The hashcode is stored for each instance once the method is called. Use a
+		 * replica of the handle for tests so its computed twice
+		 */
+		int testerHash = tester.hashCode();
+		int copyHash = copy.hashCode();
+		logger.debug(testName + " The same VarHandle should produce the same hash. " + (testerHash == copyHash));
+		Assert.assertTrue(testerHash == copyHash);
+	}
+
+	/*
+	 * Test Java 12 API VarHandle.toString()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleToString() {
+		testHandleString("testVarHandleToString (instance)", instanceTest);
+		testHandleString("testVarHandleToString (static)", staticTest);
+		testHandleString("testVarHandleToString (array)", arrayTest);
+		testHandleString("testVarHandleToString (array 2)", arrayTest2);
+	}
+
+	private void testHandleString(String testName, VarHandle handle) {
+		String handleString = handle.toString();
+
+		/* the general format is: VarHandle[varType=, coord=[]] */
+		Assert.assertTrue(handleString.startsWith("VarHandle["));
+		Assert.assertTrue(handleString.contains("varType=" + handle.varType().getName()));
+
+		List<Class<?>> coordList = handle.coordinateTypes();
+		String coordString = coordList.stream().map(coord -> String.valueOf(coord)).collect(Collectors.joining(", "));
+
+		logger.debug(testName + ": var handle string is " + handleString + " string should include coords of: " + coordString);
+		Assert.assertTrue(handleString.contains("coord=[" + coordString + "]"));
+	}
+}

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandleDesc.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/Test_VarHandleDesc.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.java_lang_invoke;
+
+import org.openj9.test.java_lang_invoke.helpers.Jep334MHHelperImpl;
+
+import java.lang.constant.ClassDesc;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.VarHandle.VarHandleDesc;
+import java.util.Optional;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/**
+ * This test Java.lang.invoke.VarHandleDesc API added in Java 12 and later
+ * version.
+ *
+ * new methods: 
+ * - ofArray 
+ * - ofField 
+ * - ofStaticField 
+ * - resolveConstantDesc 
+ * - toString 
+ * - varType: covered in ofArray / ofField / ofStaticField tests
+ */
+public class Test_VarHandleDesc {
+	public static Logger logger = Logger.getLogger(Test_VarHandleDesc.class);
+
+	private static VarHandle instanceTest;
+	private static VarHandle staticTest;
+	private static VarHandle arrayTest;
+	private static VarHandle arrayTest2;
+	private static ClassDesc declaringClassDesc;
+	static {
+		try {
+			instanceTest = Jep334MHHelperImpl.getInstanceTest();
+			staticTest = Jep334MHHelperImpl.getStaticTest();
+			arrayTest = Jep334MHHelperImpl.getArrayTest();
+			arrayTest2 = Jep334MHHelperImpl.getArrayTest2();
+		} catch (Throwable e) {
+			Assert.fail("Test variables could not be initialized for Test_VarHandleDesc.");
+		}
+
+		/* setup declaring class */
+		Optional<ClassDesc> declaringClassDescOptional = Jep334MHHelperImpl.class.describeConstable();
+		if (!declaringClassDescOptional.isPresent()) {
+			Assert.fail("Error with tests ClassDesc for declaring class could not be generated for Test_VarHandleDesc.");
+		}
+		declaringClassDesc = declaringClassDescOptional.get();
+	};
+
+	/*
+	 * Test Java 12 API VarHandleDesc.ofArray()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescOfArray() {
+		ofTestGeneral("testVarHandleDescOfArray (1)", Jep334MHHelperImpl.array_test, arrayTest);
+		ofTestGeneral("testVarHandleDescOfArray (2)", Jep334MHHelperImpl.array_test, arrayTest2);
+	}
+
+	/*
+	 * Test Java 12 API VarHandleDesc.ofField()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescOfField() {
+		ofTestGeneral("testVarHandleDescOfField", Jep334MHHelperImpl.instance_test, instanceTest);
+	}
+
+	/*
+	 * Test Java 12 API VarHandleDesc.ofStaticField()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescOfStaticField() {
+		ofTestGeneral("testVarHandleDescOfStaticField", Jep334MHHelperImpl.static_test, staticTest);
+	}
+
+	/* generic test for ofStaticField, ofField and ofArray */
+	private void ofTestGeneral(String testName, int test_type, VarHandle handle) {
+		/* setup */
+		Optional<ClassDesc> descOptional = null;
+		if (test_type == Jep334MHHelperImpl.array_test) {
+			descOptional = handle.varType().arrayType().describeConstable();
+		} else {
+			descOptional = handle.varType().describeConstable();
+		}
+		if (!descOptional.isPresent()) {
+			Assert.fail(testName + ": error with tests ClassDesc could not be generated.");
+			return;
+		}
+		ClassDesc desc = descOptional.get();
+
+		/* call test method ofArray */
+		VarHandleDesc varDesc = null;
+		String originalDescriptor = null;
+		switch (test_type) {
+		case Jep334MHHelperImpl.array_test:
+			varDesc = VarHandleDesc.ofArray(desc);
+			originalDescriptor = desc.componentType().descriptorString();
+			break;
+		case Jep334MHHelperImpl.instance_test:
+			varDesc = VarHandleDesc.ofField(declaringClassDesc, desc.displayName(), desc);
+			originalDescriptor = desc.descriptorString();
+			break;
+		case Jep334MHHelperImpl.static_test:
+			varDesc = VarHandleDesc.ofStaticField(declaringClassDesc, desc.displayName(), desc);
+			originalDescriptor = desc.descriptorString();
+			break;
+		default:
+			Assert.fail(testName + ": unsupported test type.");
+		}
+
+		/* verify that the array class is properly described */
+		String newDescriptor = varDesc.varType().descriptorString();
+		logger.debug(testName + ": Descriptor of original class is: " + originalDescriptor
+				+ " descriptor of VarHandleDesc is: " + newDescriptor);
+		Assert.assertTrue(originalDescriptor.equals(newDescriptor));
+	}
+
+	/*
+	 * Test Java 12 API VarHandleDesc.toString() for static type
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescToStringStatic() {
+		toStringTestGeneral("testVarHandleDescToStringStatic", Jep334MHHelperImpl.static_test, staticTest);
+	}
+
+	/*
+	 * Test Java 12 API VarHandleDesc.toString() for instance type
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescToStringInstance() {
+		toStringTestGeneral("testVarHandleDescToStringInstance", Jep334MHHelperImpl.instance_test, instanceTest);
+	}
+
+	/*
+	 * Test Java 12 API VarHandleDesc.toString() for array type
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescToStringArray() {
+		toStringTestGeneral("testVarHandleDescToStringArray (1)", Jep334MHHelperImpl.array_test, arrayTest);
+		toStringTestGeneral("testVarHandleDescToStringArray (2)", Jep334MHHelperImpl.array_test, arrayTest2);
+	}
+
+	/* generic test for toString() */
+	private void toStringTestGeneral(String testName, int test_type, VarHandle handle) {
+		Optional<ClassDesc> descOptional = null;
+		if (test_type == Jep334MHHelperImpl.array_test) {
+			descOptional = handle.varType().arrayType().describeConstable();
+		} else {
+			descOptional = handle.varType().describeConstable();
+		}
+		if (!descOptional.isPresent()) {
+			Assert.fail(testName + ": error with tests ClassDesc could not be generated.");
+			return;
+		}
+		ClassDesc desc = descOptional.get();
+
+		VarHandleDesc varDesc = null;
+		String resultString = null;
+		switch (test_type) {
+		case Jep334MHHelperImpl.array_test:
+			varDesc = VarHandleDesc.ofArray(desc);
+			resultString = "VarHandleDesc[" + desc.displayName() + "[]]";
+			break;
+		case Jep334MHHelperImpl.instance_test:
+			varDesc = VarHandleDesc.ofField(declaringClassDesc, desc.displayName(), desc);
+			resultString = "VarHandleDesc[" + declaringClassDesc.displayName() + "." + varDesc.constantName() + ":"
+					+ varDesc.varType().displayName() + "]";
+			break;
+		case Jep334MHHelperImpl.static_test:
+			varDesc = VarHandleDesc.ofStaticField(declaringClassDesc, desc.displayName(), desc);
+			resultString = "VarHandleDesc[static " + declaringClassDesc.displayName() + "." + varDesc.constantName()
+					+ ":" + varDesc.varType().displayName() + "]";
+			break;
+		default:
+			Assert.fail(testName + ": unsupported test type.");
+		}
+
+		String outputString = varDesc.toString();
+		logger.debug(testName + ": toString output is: " + outputString + " and should be: " + resultString);
+		Assert.assertTrue(outputString.equals(resultString));
+	}
+
+	/*
+	 * Test Java 12 API VarHandleDesc.resolveConstantDesc()
+	 */
+	@Test(groups = { "level.sanity" })
+	public void testVarHandleDescResolveConstantDesc() throws Throwable {
+		resolveConstantDescTestGeneric("testVarHandleDescResolveConstantDesc: test array", arrayTest);
+		resolveConstantDescTestGeneric("testVarHandleDescResolveConstantDesc: test array 2", arrayTest2); // fails
+		resolveConstantDescTestGeneric("testVarHandleDescResolveConstantDesc: test instance", instanceTest); // fails
+		resolveConstantDescTestGeneric("testVarHandleDescResolveConstantDesc: test static", staticTest);
+	}
+
+	private void resolveConstantDescTestGeneric(String testName, VarHandle handle) throws Throwable {
+		VarHandleDesc handleDesc = handle.describeConstable().orElseThrow();
+		VarHandle resolvedHandle = resolvedHandle = handleDesc.resolveConstantDesc(MethodHandles.lookup());
+
+		logger.debug(testName + " is running.");
+		Assert.assertTrue(handle.equals(resolvedHandle));
+	}
+}

--- a/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/helpers/Jep334MHHelperImpl.java
+++ b/test/functional/Java12andUp/src/org/openj9/test/java_lang_invoke/helpers/Jep334MHHelperImpl.java
@@ -27,29 +27,58 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.VarHandle;
 
 public class Jep334MHHelperImpl implements Jep334MHHelper {
-    /*
-     * MethodHandle helper fields & methods
-     */
-    /* fields */
-    public volatile int getterTest = 1;
-    public int setterTest = 2;
-    public static volatile int staticGetterTest = 3;
-    public static int staticSetterTest = 4;
+	/*
+	 * MethodHandle helper fields & methods
+	 */
+	/* fields */
+	public volatile int getterTest = 1;
+	public int setterTest = 2;
+	public static volatile int staticGetterTest = 3;
+	public static int staticSetterTest = 4;
 
-    /* constructors */
-    public Jep334MHHelperImpl() {}
+	/* constructors */
+	public Jep334MHHelperImpl() {}
 
-    public Jep334MHHelperImpl(String s, int i) {}
+	public Jep334MHHelperImpl(String s, int i) {}
 
-    /* methods to invoke */
-    public void virtualTest() {}
+	/* methods to invoke */
+	public void virtualTest() {}
 
-    public void specialTest() {}
-    
-    public static void staticTest() {}
+	public void specialTest() {}
 
-    /* special helper */
-    public static MethodHandles.Lookup lookup() {
-        return MethodHandles.lookup();
-    }
+	public static void staticTest() {}
+
+	/* special helper */
+	public static MethodHandles.Lookup lookup() {
+		return MethodHandles.lookup();
+	}
+
+	/*
+	 * VarHandle helper fields & methods
+	 */
+
+	/* test types */
+	final public static int array_test = 1;
+	final public static int instance_test = 2;
+	final public static int static_test = 3;
+
+	public static int staticTest;
+	public Integer instanceTest;
+
+	public static VarHandle getInstanceTest() throws Throwable {
+		return MethodHandles.lookup().findVarHandle(Jep334MHHelperImpl.class, "instanceTest", Integer.class);
+	}
+
+	public static VarHandle getStaticTest() throws Throwable {
+		return MethodHandles.lookup().findStaticVarHandle(Jep334MHHelperImpl.class, "staticTest", int.class);
+	}
+
+	public static VarHandle getArrayTest() throws Throwable {
+		return MethodHandles.arrayElementVarHandle(double[].class);
+	}
+
+	public static VarHandle getArrayTest2() throws Throwable {
+		return MethodHandles.arrayElementVarHandle(Float[][].class);
+	}
 }
+

--- a/test/functional/Java12andUp/testng.xml
+++ b/test/functional/Java12andUp/testng.xml
@@ -31,6 +31,8 @@
 			<class name="org.openj9.test.java_lang.Test_Class" />
 			<class name="org.openj9.test.java_lang_invoke.Test_MethodType" />
 			<class name="org.openj9.test.java_lang_invoke.Test_MethodHandle" />
+			<class name="org.openj9.test.java_lang_invoke.Test_VarHandle" />
+			<class name="org.openj9.test.java_lang_invoke.Test_VarHandleDesc" />
 		</classes>
 	</test>
 


### PR DESCRIPTION
Depends on (see https://github.com/eclipse/openj9/issues/4195): 
- Fix Java 12 build failures: https://github.com/eclipse/openj9/pull/3980
- Constants API stubs: https://github.com/eclipse/openj9/pull/4030
- Java12andUp test setup: https://github.com/eclipse/openj9/pull/4104
- Jep 334 Class methods: https://github.com/eclipse/openj9/pull/4157

Methods:
- VarHandleDesc constructor
- VarHandleDesc.ofArray
- VarHandleDesc.ofField
- VarHandleDesc.ofStaticField
- VarHandleDesc.resolveConstantDesc
- VarHandleDesc.toString
- VarHandleDesc.varType

- VarHandle.describeConstable
- VarHandle.equals
- VarHandle.hashCode
- VarHandle.toString