### PR TITLE
Update testSCCMLTests6 to check for cache full message.

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright (c) 2012, 2018 IBM Corp. and others
+  Copyright (c) 2012, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,8 +89,8 @@
 	<!-- On windows, full cache has J9SHR_MIN_GAP_BEFORE_METADATA (=1024) free bytes, on other platforms free bytes should be 0 -->
 	<test id="Test 200-b: CMVC 197811: Make sure cache created in previous test is full" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,printStats</command>
-		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$NON_WINDOWS_PLATFORMS$">free bytes[\s]*= 0</output>
-		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes" showMatch="yes" platforms="$WINDOWS_PLATFORMS$">free bytes[\s]*= 1024</output>
+		<output type="success" caseSensitive="yes" showMatch="yes" platforms="$NON_WINDOWS_PLATFORMS$">Cache is 100% full</output>
+		<output type="success" caseSensitive="yes" showMatch="yes" platforms="$WINDOWS_PLATFORMS$">Cache is 99% full</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>


### PR DESCRIPTION
Check for cache full message instead of free bytes on a full cache.

Fixes #4425

Signed-off-by: hangshao <hangshao@ca.ibm.com>