### PR TITLE
Provide an OpenJ9 version of CodeGenerator reserveCodeCache

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -432,6 +432,12 @@ public:
     */
    void trimCodeMemoryToActualSize();
 
+   /**
+    * \brief Request and reserve a CodeCache for use by this compilation.  Fail
+    *        the compilation appropriately if a CodeCache cannot be allocated.
+    */
+   void reserveCodeCache();
+
 private:
 
    enum // Flags


### PR DESCRIPTION
In preparation for refactoring the FrontEnd `getDesignatedCodeCache`
without causing build breaks in OpenJ9, provide an OpenJ9-specific
version of the `reserveCodeCache` function.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>