### PR TITLE
Provide method name when constructing VarHandleInvokeHandle

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInvokeHandle.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/VarHandleInvokeHandle.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@ abstract class VarHandleInvokeHandle extends PrimitiveHandle {
 		/* Prepend a VarHandle receiver argument to match the how this MethodHandle will be invoked
 		 * Note: the modifiers are specific to the access mode methods in VarHandle.
 		 */
-		super(accessModeType.insertParameterTypes(0, VarHandle.class), null, null, kind, PUBLIC_FINAL_NATIVE, null);
+		super(accessModeType.insertParameterTypes(0, VarHandle.class), null, accessMode.methodName(), kind, PUBLIC_FINAL_NATIVE, null);
 		this.defc = VarHandle.class;
 		this.operation = accessMode.ordinal();
 		// Append a VarHandle argument to match the VarHandle's internal method signature


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/3180

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>