### PR TITLE
Prepare JEP331 with an empty implementation

### DIFF
--- a/runtime/include/jvmti.h
+++ b/runtime/include/jvmti.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,10 +44,10 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM* vm, char *options, void *reserved)
 #define JVMTI_VERSION_1_1 0x30010100
 #define JVMTI_VERSION_1_2 0x30010200
 #define JVMTI_VERSION_1 (JVMTI_VERSION_1_0)
-#define JVMTI_VERSION_9_0 0x30090000
+#define JVMTI_VERSION_9  0x30090000
+#define JVMTI_VERSION_11 0x300b0000
 
-/* Required as of Java 9 b14x */
-#define JVMTI_VERSION JVMTI_VERSION_9_0
+#define JVMTI_VERSION JVMTI_VERSION_11
 
 #define JVMTI_1_0_SPEC_VERSION           (JVMTI_VERSION_1_0 + 37)	/* Spec version is 1.0.37 */
 #define JVMTI_1_1_SPEC_VERSION           (JVMTI_VERSION_1_1 + 102)	/* Spec version is 1.1.102 */
@@ -483,7 +483,8 @@ typedef struct {
 	unsigned int can_generate_resource_exhaustion_threads_events : 1;
 	unsigned int can_generate_early_vmstart : 1;
 	unsigned int can_generate_early_class_hook_events : 1;
-	unsigned int : 5;
+	unsigned int can_generate_sampled_object_alloc_events : 1;
+	unsigned int : 4;
 	unsigned int : 16;
 	unsigned int : 16;
 	unsigned int : 16;
@@ -733,8 +734,9 @@ typedef enum jvmtiEvent {
 	JVMTI_EVENT_GARBAGE_COLLECTION_FINISH = 82,
 	JVMTI_EVENT_OBJECT_FREE = 83,
 	JVMTI_EVENT_VM_OBJECT_ALLOC = 84,
+	JVMTI_EVENT_SAMPLED_OBJECT_ALLOC = 86,
 
-	JVMTI_MAX_EVENT_TYPE_VAL = 84,
+	JVMTI_MAX_EVENT_TYPE_VAL = 86,
 	jvmtiEventEnsureWideEnum = 0x1000000						/* ensure 4-byte enum */
 } jvmtiEvent;
 
@@ -948,6 +950,14 @@ typedef void (JNICALL *jvmtiEventResourceExhausted) (
 	const void* reserved,
 	const char* description);
 
+typedef void (JNICALL *jvmtiEventSampledObjectAlloc) (
+	jvmtiEnv *jvmti_env,
+	JNIEnv *jni_env,
+	jthread thread,
+	jobject object,
+	jclass object_klass,
+	jlong size);
+
 typedef void * jvmtiEventReserved;
 
 typedef struct {
@@ -986,6 +996,8 @@ typedef struct {
 	jvmtiEventGarbageCollectionFinish GarbageCollectionFinish;
 	jvmtiEventObjectFree ObjectFree;
 	jvmtiEventVMObjectAlloc VMObjectAlloc;
+	jvmtiEventReserved reserved85;
+	jvmtiEventSampledObjectAlloc SampledObjectAlloc;
 } jvmtiEventCallbacks;
 
 /*
@@ -1150,6 +1162,7 @@ typedef struct JVMTINativeInterface_ {
 	jvmtiError (JNICALL * GetOwnedMonitorStackDepthInfo)(jvmtiEnv* env, jthread thread, jint* monitor_info_count_ptr, jvmtiMonitorStackDepthInfo** monitor_info_ptr);
 	jvmtiError (JNICALL * GetObjectSize)(jvmtiEnv* env,	jobject object,	jlong* size_ptr);
 	jvmtiError (JNICALL * GetLocalInstance)(jvmtiEnv* env, jthread thread, jint depth, jobject* value_ptr);
+	jvmtiError (JNICALL * SetHeapSamplingInterval)(jvmtiEnv* env, jint sampling_interval);
 } jvmtiNativeInterface;
 
 struct _jvmtiEnv {
@@ -1302,6 +1315,7 @@ struct _jvmtiEnv {
 	jvmtiError GetOwnedMonitorStackDepthInfo (jthread thread, jint* monitor_info_count_ptr, jvmtiMonitorStackDepthInfo** monitor_info_ptr) { return functions->GetOwnedMonitorStackDepthInfo(this, thread, monitor_info_count_ptr, monitor_info_ptr); }
 	jvmtiError GetObjectSize (jobject object, jlong* size_ptr) { return functions->GetObjectSize(this, object, size_ptr); }
 	jvmtiError GetLocalInstance (jthread thread, jint depth, jobject* value_ptr) { return functions->GetLocalInstance(this, thread, depth, value_ptr); }
+	jvmtiError SetHeapSamplingInterval (jint sampling_interval) { return functions->SetHeapSamplingInterval(this, sampling_interval); }
 #endif
 };
 

--- a/runtime/jvmti/j9jvmti.tdf
+++ b/runtime/jvmti/j9jvmti.tdf
@@ -1,4 +1,4 @@
-//Copyright (c) 2006, 2017 IBM Corp. and others
+//Copyright (c) 2006, 2019 IBM Corp. and others
 //	
 //This program and the accompanying materials are made available under
 //the terms of the Eclipse Public License 2.0 which accompanies this
@@ -617,3 +617,8 @@ TraceEvent=Trc_JVMTI_jvmtiAddCapabilities_turnOfRomMethodSorting Overhead=1 Leve
 
 TraceEntry=Trc_JVMTI_jvmtiHookModuleSystemStarted_Entry Overhead=1 Level=1 Noenv Template="ModuleSystemStarted"
 TraceExit=Trc_JVMTI_jvmtiHookModuleSystemStarted_Exit Overhead=1 Level=1 Noenv Template="ModuleSystemStarted"
+
+TraceEntry=Trc_JVMTI_jvmtiSetHeapSamplingInterval_Entry Overhead=1 Level=5 Noenv Template="SetHeapSamplingInterval env=%p samplingInterval=%d"
+TraceExit=Trc_JVMTI_jvmtiSetHeapSamplingInterval_Exit Overhead=1 Level=5 Noenv Template="SetHeapSamplingInterval: returning %d"
+TraceEntry=Trc_JVMTI_jvmtiHookSampledObjectAlloc_Entry Overhead=1 Level=5 Noenv Template="HookSampledObjectAlloc starts"
+TraceExit=Trc_JVMTI_jvmtiHookSampledObjectAlloc_Exit Overhead=1 Level=5 Noenv Template="HookSampledObjectAlloc"

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,6 +92,8 @@ dumpCapabilities(J9JavaVM * vm, const jvmtiCapabilities *capabilities, const cha
 	PRINT_CAPABILITY(can_generate_early_vmstart);
 	PRINT_CAPABILITY(can_generate_early_class_hook_events);
 
+	/* JVMTI 11 */
+	PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
 #undef PRINT_CAPABILITY
 }
 
@@ -165,6 +167,11 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 
 	if (isEventHookable(j9env, JVMTI_EVENT_VM_OBJECT_ALLOC)) {
 		rv_capabilities.can_generate_vm_object_alloc_events = 1;
+	}
+	
+	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)) {
+		/* hardcode to 0 (not enabled) for empty JEP331 implementation */
+		rv_capabilities.can_generate_sampled_object_alloc_events = 0;
 	}
 
 	if (isEventHookable(j9env, JVMTI_EVENT_NATIVE_METHOD_BIND)) {
@@ -539,6 +546,10 @@ mapCapabilitiesToEvents(J9JVMTIEnv * j9env, jvmtiCapabilities * capabilities, J9
 
 	if (capabilities->can_generate_vm_object_alloc_events) {
 		rc |= eventHookFunction(j9env, JVMTI_EVENT_VM_OBJECT_ALLOC);
+	}
+
+	if (capabilities->can_generate_sampled_object_alloc_events) {
+		rc |= eventHookFunction(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC);
 	}
 
 	if (capabilities->can_generate_object_free_events) {

--- a/runtime/jvmti/jvmtiEventManagement.c
+++ b/runtime/jvmti/jvmtiEventManagement.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,7 +149,11 @@ jvmtiSetEventNotificationMode(jvmtiEnv* env,
 				case  JVMTI_EVENT_VM_OBJECT_ALLOC:
 					ENSURE_CAPABILITY(env, can_generate_vm_object_alloc_events);
 					break;
- 
+
+				case  JVMTI_EVENT_SAMPLED_OBJECT_ALLOC:
+					ENSURE_CAPABILITY(env, can_generate_sampled_object_alloc_events);
+					break;
+
 				case JVMTI_EVENT_NATIVE_METHOD_BIND:
 					ENSURE_CAPABILITY(env, can_generate_native_method_bind_events);
 					break;

--- a/runtime/jvmti/jvmtiFunctionTable.c
+++ b/runtime/jvmti/jvmtiFunctionTable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -179,6 +179,7 @@ jvmtiNativeInterface jvmtiFunctionTable = {
 	jvmtiGetOwnedMonitorStackDepthInfo,
 	jvmtiGetObjectSize,
 	jvmtiGetLocalInstance,
+	jvmtiSetHeapSamplingInterval,
 };
 
 

--- a/runtime/jvmti/jvmtiGeneral.c
+++ b/runtime/jvmti/jvmtiGeneral.c
@@ -186,7 +186,7 @@ jvmtiGetVersionNumber(jvmtiEnv* env,
 	ENSURE_NON_NULL(version_ptr);
 
 	if (J2SE_VERSION(vm) >= J2SE_V11) {
-		rv_version = JVMTI_VERSION_9_0;
+		rv_version = JVMTI_VERSION_11;
 	}
 
 	rc = JVMTI_ERROR_NONE;

--- a/runtime/jvmti/jvmtiHelpers.c
+++ b/runtime/jvmti/jvmtiHelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,132 +25,6 @@
 #include "j9cp.h"
 
 extern jvmtiNativeInterface jvmtiFunctionTable;
-
-static jvmtiCapabilities capabilitiesMask10 = {
-	1, /* can_tag_objects */
-	1, /* can_generate_field_modification_events */
-	1, /* can_generate_field_access_events */
-	1, /* can_get_bytecodes */
-	1, /* can_get_synthetic_attribute */
-	1, /* can_get_owned_monitor_info */
-	1, /* can_get_current_contended_monitor */
-	1, /* can_get_monitor_info */
-	1, /* can_pop_frame */
-	1, /* can_redefine_classes */
-	1, /* can_signal_thread */
-	1, /* can_get_source_file_name */
-	1, /* can_get_line_numbers */
-	1, /* can_get_source_debug_extension */
-	1, /* can_access_local_variables */
-	1, /* can_maintain_original_method_order */
-	1, /* can_generate_single_step_events */
-	1, /* can_generate_exception_events */
-	1, /* can_generate_frame_pop_events */
-	1, /* can_generate_breakpoint_events */
-	1, /*  can_suspend */
-	1, /* can_redefine_any_class */
-	1, /* can_get_current_thread_cpu_time */
-	1, /* can_get_thread_cpu_time */
-	1, /* can_generate_method_entry_events */
-	1, /* can_generate_method_exit_events */
-	1, /* can_generate_all_class_hook_events */
-	1, /* can_generate_compiled_method_load_events */
-	1, /* can_generate_monitor_events */
-	1, /* can_generate_vm_object_alloc_events */
-	1, /* can_generate_native_method_bind_events */
-	1, /* can_generate_garbage_collection_events */
-	1, /* can_generate_object_free_events */
-};
-
-static jvmtiCapabilities capabilitiesMask11 = {
-	1, /* can_tag_objects */
-	1, /* can_generate_field_modification_events */
-	1, /* can_generate_field_access_events */
-	1, /* can_get_bytecodes */
-	1, /* can_get_synthetic_attribute */
-	1, /* can_get_owned_monitor_info */
-	1, /* can_get_current_contended_monitor */
-	1, /* can_get_monitor_info */
-	1, /* can_pop_frame */
-	1, /* can_redefine_classes */
-	1, /* can_signal_thread */
-	1, /* can_get_source_file_name */
-	1, /* can_get_line_numbers */
-	1, /* can_get_source_debug_extension */
-	1, /* can_access_local_variables */
-	1, /* can_maintain_original_method_order */
-	1, /* can_generate_single_step_events */
-	1, /* can_generate_exception_events */
-	1, /* can_generate_frame_pop_events */
-	1, /* can_generate_breakpoint_events */
-	1, /*  can_suspend */
-	1, /* can_redefine_any_class */
-	1, /* can_get_current_thread_cpu_time */
-	1, /* can_get_thread_cpu_time */
-	1, /* can_generate_method_entry_events */
-	1, /* can_generate_method_exit_events */
-	1, /* can_generate_all_class_hook_events */
-	1, /* can_generate_compiled_method_load_events */
-	1, /* can_generate_monitor_events */
-	1, /* can_generate_vm_object_alloc_events */
-	1, /* can_generate_native_method_bind_events */
-	1, /* can_generate_garbage_collection_events */
-	1, /* can_generate_object_free_events */
-	1, /* can_force_early_return */
-	1, /* can_get_owned_monitor_stack_depth_info */
-	1, /* can_get_constant_pool */
-	1, /* can_set_native_method_prefix */
-	1, /* can_retransform_classes */
-	1, /* can_retransform_any_class */
-	1, /* can_generate_resource_exhaustion_heap_events */
-	1, /* can_generate_resource_exhaustion_threads_events */
-};
-
-static jvmtiCapabilities capabilitiesMask90 = {
-	1, /* can_tag_objects */
-	1, /* can_generate_field_modification_events */
-	1, /* can_generate_field_access_events */
-	1, /* can_get_bytecodes */
-	1, /* can_get_synthetic_attribute */
-	1, /* can_get_owned_monitor_info */
-	1, /* can_get_current_contended_monitor */
-	1, /* can_get_monitor_info */
-	1, /* can_pop_frame */
-	1, /* can_redefine_classes */
-	1, /* can_signal_thread */
-	1, /* can_get_source_file_name */
-	1, /* can_get_line_numbers */
-	1, /* can_get_source_debug_extension */
-	1, /* can_access_local_variables */
-	1, /* can_maintain_original_method_order */
-	1, /* can_generate_single_step_events */
-	1, /* can_generate_exception_events */
-	1, /* can_generate_frame_pop_events */
-	1, /* can_generate_breakpoint_events */
-	1, /*  can_suspend */
-	1, /* can_redefine_any_class */
-	1, /* can_get_current_thread_cpu_time */
-	1, /* can_get_thread_cpu_time */
-	1, /* can_generate_method_entry_events */
-	1, /* can_generate_method_exit_events */
-	1, /* can_generate_all_class_hook_events */
-	1, /* can_generate_compiled_method_load_events */
-	1, /* can_generate_monitor_events */
-	1, /* can_generate_vm_object_alloc_events */
-	1, /* can_generate_native_method_bind_events */
-	1, /* can_generate_garbage_collection_events */
-	1, /* can_generate_object_free_events */
-	1, /* can_force_early_return */
-	1, /* can_get_owned_monitor_stack_depth_info */
-	1, /* can_get_constant_pool */
-	1, /* can_set_native_method_prefix */
-	1, /* can_retransform_classes */
-	1, /* can_retransform_any_class */
-	1, /* can_generate_resource_exhaustion_heap_events */
-	1, /* can_generate_resource_exhaustion_threads_events */
-	1, /* can_generate_early_vmstart */
-	1, /* can_generate_early_class_hook_events */
-};
 
 /* Jazz 99339: Map JVMTI event number to the reason code for zAAP switching on zOS.
  * Note: refer to jvmtiEventCallbacks (/runtime/include/jvmti.h) for reserved JVMTI events.
@@ -199,6 +73,7 @@ static const UDATA reasonCodeFromJVMTIEvent[] = {
 	J9_JNI_OFFLOAD_SWITCH_J9JVMTI_VM_DUMP_END,							/* J9JVMTI_EVENT_COM_IBM_VM_DUMP_END */
 	J9_JNI_OFFLOAD_SWITCH_J9JVMTI_GC_CYCLE_START,						/* J9JVMTI_EVENT_COM_IBM_GARBAGE_COLLECTION_CYCLE_START */
 	J9_JNI_OFFLOAD_SWITCH_J9JVMTI_GC_CYCLE_FINISH,						/* J9JVMTI_EVENT_COM_IBM_GARBAGE_COLLECTION_CYCLE_FINISH */
+	J9_JNI_OFFLOAD_SWITCH_JVMTI_SAMPLED_OBJECT_ALLOC,					/* JVMTI_EVENT_VM_OBJECT_ALLOC */
 };
 #endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 
@@ -423,14 +298,6 @@ allocateEnvironment(J9InvocationJavaVM * invocationJavaVM, jint version, void **
 #if defined (J9VM_INTERP_NATIVE_SUPPORT)
 			j9env->jitHook.hookInterface = jitHook;
 #endif
-			j9env->capabilitiesMask = capabilitiesMask10;
-			if (version >= JVMTI_VERSION_1_1) {
-				j9env->capabilitiesMask = capabilitiesMask11;
-			}
-			if (version >= JVMTI_VERSION_9_0) {
-				j9env->capabilitiesMask = capabilitiesMask90;
-			}
-
 			if ((j9env->vmHook.agentID = (*vmHook)->J9HookAllocateAgentID(vmHook)) == 0) {
 				goto fail;
 			}

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -124,6 +124,7 @@ static void jvmtiHookMethodEnter (J9HookInterface** hook, UDATA eventNum, void* 
 #if defined(J9VM_INTERP_NATIVE_SUPPORT)
 static int J9THREAD_PROC compileEventThreadProc (void *entryArg);
 #endif /* INTERP_NATIVE_SUPPORT */
+static void jvmtiHookSampledObjectAlloc (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookObjectAllocate (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookThreadEnd (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 static void jvmtiHookFindMethodFromPC (J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
@@ -435,6 +436,9 @@ processEvent(J9JVMTIEnv* j9env, jint event, J9HookRedirectorFunction redirectorF
 
 		case JVMTI_EVENT_VM_OBJECT_ALLOC:
 			return redirectorFunction(vmHook, J9HOOK_VM_OBJECT_ALLOCATE, jvmtiHookObjectAllocate, OMR_GET_CALLSITE(), j9env);
+
+		case JVMTI_EVENT_SAMPLED_OBJECT_ALLOC:
+			return redirectorFunction(vmHook, J9HOOK_SAMPLED_OBJECT_ALLOCATE, jvmtiHookSampledObjectAlloc, OMR_GET_CALLSITE(), j9env);
 
 		case JVMTI_EVENT_NATIVE_METHOD_BIND:
 			return redirectorFunction(vmHook, J9HOOK_VM_JNI_NATIVE_BIND, jvmtiHookJNINativeBind, OMR_GET_CALLSITE(), j9env);
@@ -1555,7 +1559,12 @@ jvmtiHookGetEnv(J9HookInterface** hook, UDATA eventNum, void* eventData, void* u
 	if (data->rc == JNI_EVERSION) {
 		jint version = data->version & ~JVMTI_VERSION_MASK_MICRO;
 
-		if ((version == JVMTI_VERSION_1_0) || (version == JVMTI_VERSION_1_1) || (version == JVMTI_VERSION_1_2) || (version == JVMTI_VERSION_9_0)) {
+		if ((version == JVMTI_VERSION_1_0) 
+			|| (version == JVMTI_VERSION_1_1) 
+			|| (version == JVMTI_VERSION_1_2) 
+			|| (version == JVMTI_VERSION_9)
+			|| (version == JVMTI_VERSION_11)
+		) {
 			/* Jazz 99339: obtain the pointer to J9JavaVM from J9InvocationJavaVM so as to store J9NativeLibrary in J9JVMTIEnv */
 			J9InvocationJavaVM * invocationJavaVM = (J9InvocationJavaVM *)data->jvm;
 			J9JVMTIData * jvmtiData = userData;
@@ -2776,6 +2785,42 @@ jvmtiHookCompilingEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, v
 
 #endif /* INTERP_NATIVE_SUPPORT */
 
+static void 
+jvmtiHookSampledObjectAlloc(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)
+{
+	J9JVMTIEnv * j9env = userData;
+	jvmtiEventSampledObjectAlloc callback = j9env->callbacks.SampledObjectAlloc;
+
+	Trc_JVMTI_jvmtiHookSampledObjectAlloc_Entry();
+
+	ENSURE_EVENT_PHASE_LIVE(jvmtiHookSampledObjectAlloc, j9env);
+
+	if (NULL != callback) {
+		J9SampledObjectAllocateEvent *data = eventData;
+		J9VMThread *currentThread = data->currentThread;
+		jthread threadRef = NULL;
+		UDATA hadVMAccess = 0;
+		UDATA javaOffloadOldState = 0;
+
+		if (prepareForEvent(j9env, currentThread, currentThread, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, &threadRef, &hadVMAccess, TRUE, 2, &javaOffloadOldState)) {
+			j9object_t *objectRef = (j9object_t*) currentThread->arg0EA;
+			j9object_t *classRef = (j9object_t*) (currentThread->arg0EA - 1);
+			J9Class *clazz = NULL;
+			J9InternalVMFunctions const * const vmFuncs = currentThread->javaVM->internalVMFunctions;
+
+			*objectRef = data->object;
+			clazz = J9OBJECT_CLAZZ(currentThread, data->object);
+			*classRef = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
+			vmFuncs->internalExitVMToJNI(currentThread);
+			callback((jvmtiEnv *) j9env, (JNIEnv *) currentThread, threadRef, (jobject) objectRef, (jclass) classRef, (jlong) data->size);
+			vmFuncs->internalEnterVMFromJNI(currentThread);
+			data->object = *objectRef;
+			finishedEvent(currentThread, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, hadVMAccess, javaOffloadOldState);
+		}
+	}
+
+	TRACE_JVMTI_EVENT_RETURN(jvmtiHookSampledObjectAlloc);
+}
 
 static void
 jvmtiHookObjectAllocate(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData)

--- a/runtime/jvmti/jvmtiMemory.c
+++ b/runtime/jvmti/jvmtiMemory.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,4 +80,21 @@ jvmtiDeallocate(jvmtiEnv* env,
 	TRACE_JVMTI_RETURN(jvmtiDeallocate);
 }
 
+jvmtiError JNICALL 
+jvmtiSetHeapSamplingInterval(jvmtiEnv *env, 
+	jint samplingInterval)
+{
+	jvmtiError rc = JVMTI_ERROR_NONE;
+	
+	Trc_JVMTI_jvmtiSetHeapSamplingInterval_Entry(env, samplingInterval);
+	
+	ENSURE_PHASE_ONLOAD_OR_LIVE(env);
+	ENSURE_CAPABILITY(env, can_generate_sampled_object_alloc_events);
+	ENSURE_NON_NEGATIVE(samplingInterval);
 
+	/* this method is to be implemented via https://github.com/eclipse/openj9/pull/3754 */
+	JVMTI_ERROR(JVMTI_ERROR_UNSUPPORTED_VERSION);
+
+done:
+	TRACE_JVMTI_RETURN(jvmtiSetHeapSamplingInterval);
+}

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1505,6 +1505,15 @@ jvmtiGetLocalInstance(jvmtiEnv* env,
 	jint depth,
 	jobject* value_ptr);
 
+/**
+* @brief Set the allocation sampling interval
+* @param env The JVMTI environment pointer.
+* @param samplingInterval The sampling interval in bytes.
+* @return jvmtiError Error code returned by JVMTI function
+*/
+jvmtiError JNICALL 
+jvmtiSetHeapSamplingInterval(jvmtiEnv *env,
+	jint samplingInterval);
 
 /**
 * @brief

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -770,6 +770,7 @@ extern "C" {
 #define J9_JNI_OFFLOAD_SWITCH_J9JVMTI_GC_CYCLE_START					0x3E
 #define J9_JNI_OFFLOAD_SWITCH_J9JVMTI_GC_CYCLE_FINISH					0x3F
 #define J9_JNI_OFFLOAD_SWITCH_TRACE_SUBSCRIBER_THREAD					0x40
+#define J9_JNI_OFFLOAD_SWITCH_JVMTI_SAMPLED_OBJECT_ALLOC				0x41
 
 #define J9_JNI_OFFLOAD_SWITCH_THRESHOLD 0x4000
 

--- a/runtime/oti/j9vm.hdf
+++ b/runtime/oti/j9vm.hdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2006, 2018 IBM Corp. and others
+Copyright (c) 2006, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1277,5 +1277,16 @@ typedef UDATA (* lookupNativeAddressCallback)(struct J9VMThread *currentThread, 
 		<struct>J9VMRuntimeStateChanged</struct>
 		<data type="struct J9VMThread*" name="vmThread" description="current thread" />
 		<data type="U_32" name="state" description="the VM runtime state" />
+	</event>
+	
+	<event>
+		<name>J9HOOK_SAMPLED_OBJECT_ALLOCATE</name>
+		<description>
+			Triggered when the size of objects specified via SetHeapSamplingInterval have been allocated. See JVMTI spec for details.
+		</description>
+		<struct>J9SampledObjectAllocateEvent</struct>
+		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
+		<data type="j9object_t" name="object" return="true" description="the object which was just allocated" />
+		<data type="UDATA" name="size" description="the number of bytes allocated" />
 	</event>
 </interface>

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,7 +154,6 @@ typedef struct J9JVMTIEnv {
 	omrthread_monitor_t mutex;
 	void* environmentLocalStorage;
 	jvmtiCapabilities capabilities;
-	jvmtiCapabilities capabilitiesMask;
 	jvmtiEventCallbacks callbacks;
 	J9JVMTIExtensionCallbacks extensionCallbacks;
 	omrthread_monitor_t threadDataPoolMutex;

--- a/runtime/tests/jvmtitests/agent/agent.c
+++ b/runtime/tests/jvmtitests/agent/agent.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,7 +70,7 @@ Agent_Prepare(JavaVM * vm, char *phase, char * options, void * reserved)
 	}
 	tprintf(env, 100, "%s options: [%s]\n", phase, options);
 
-	rc = (*vm)->GetEnv(vm, (void **) &jvmti_env, JVMTI_VERSION_9_0);
+	rc = (*vm)->GetEnv(vm, (void **) &jvmti_env, JVMTI_VERSION);
 	if (rc != JNI_OK) {
 		if ((rc != JNI_EVERSION) || ((rc = (*vm)->GetEnv(vm, (void **) &jvmti_env, JVMTI_VERSION_1_2)) != JNI_OK)) {
 			error(env, err, "Failed to GetEnv %d\n", rc);

--- a/runtime/tests/jvmtitests/agent/tests.c
+++ b/runtime/tests/jvmtitests/agent/tests.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,6 +128,7 @@ static jvmtiTest jvmtiTestList[] =
 	{ "mt001",   mt001,   "com.ibm.jvmti.tests.modularityTests.mt001", "Test Modularity functions"},
 	{ "nmr001",     nmr001,    "com.ibm.jvmti.tests.nestMatesRedefinition.nmr001", "Test nestmates redefinition"},
 	{ "snmp001",     snmp001,    "com.ibm.jvmti.tests.setNativeMethodPrefix.snmp001", "Tests setting a native method prefix and disposing a subsequent environment"},
+	{ "soae001", soae001, "com.ibm.jvmti.tests.samplingObjectAllocation.soae001", "Test JEP331 low-overhead sampling heap object allocation" },
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/runtime/tests/jvmtitests/agent/version.c
+++ b/runtime/tests/jvmtitests/agent/version.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@ const static char *versionNames[] =
 	"JVMTI 1.1",
 	"JVMTI 1.2",
 	"JVMTI 9.0",
+	"JVMTI 11",
 	"unknown"
 };
 
@@ -59,8 +60,10 @@ getVersionName(agentEnv * agent_env, jint version)
 			return versionNames[1];
 		case JVMTI_VERSION_1_2:
 			return versionNames[2];
-		case JVMTI_VERSION_9_0:
+		case JVMTI_VERSION_9:
 			return versionNames[3];
+		case JVMTI_VERSION_11:
+			return versionNames[4];
 		default:
 			error(agent_env, JVMTI_ERROR_UNSUPPORTED_VERSION, "Query for an unknown version");
 	}

--- a/runtime/tests/jvmtitests/include/jvmti_test.h
+++ b/runtime/tests/jvmtitests/include/jvmti_test.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -243,5 +243,6 @@ jint JNICALL aln001(agentEnv * agent_env, char * args);
 jint JNICALL mt001(agentEnv * agent_env, char * args);
 jint JNICALL nmr001(agentEnv * agent_env, char * args);
 jint JNICALL snmp001(agentEnv * agent_env, char * args);
+jint JNICALL soae001(agentEnv * agent_env, char * args);
 
 #endif /*JVMTI_TEST_H_*/

--- a/runtime/tests/jvmtitests/module.xml
+++ b/runtime/tests/jvmtitests/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2001, 2018 IBM Corp. and others
+  Copyright (c) 2001, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -204,6 +204,10 @@
 		<export name="Java_com_ibm_jvmti_tests_nestMatesRedefinition_nmr001_redefineClass" />
 		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_setPrefix" />
 		<export name="Java_com_ibm_jvmti_tests_setNativeMethodPrefix_snmp001_nat" />
+		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_reset" />
+		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_enable" />
+		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_disable" />
+		<export name="Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_check" />
 	</exports>
 
 	<artifact type="shared" name="jvmtitest" bundle="jvmti_test" appendrelease="false">

--- a/runtime/tests/jvmtitests/src/CMakeLists.txt
+++ b/runtime/tests/jvmtitests/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,6 +169,8 @@ add_library(jvmti_test_src STATIC
 	com/ibm/jvmti/tests/vmDump/vmd001.c
 
 	com/ibm/jvmti/tests/setNativeMethodPrefix/snmp001.c
+	
+	com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
 )
 
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc001.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,54 +71,59 @@ getCapabilities(jvmtiCapabilities * caps, int * availableCount, int * unavailabl
 	
 	PRINT_CAPABILITY(can_tag_objects);
 	PRINT_CAPABILITY(can_generate_field_modification_events);
-    PRINT_CAPABILITY(can_generate_field_access_events);
-    PRINT_CAPABILITY(can_get_bytecodes);
-    PRINT_CAPABILITY(can_get_synthetic_attribute);
-    PRINT_CAPABILITY(can_get_owned_monitor_info);
-    PRINT_CAPABILITY(can_get_current_contended_monitor);
-    PRINT_CAPABILITY(can_get_monitor_info);
-    PRINT_CAPABILITY(can_pop_frame);
-    PRINT_CAPABILITY(can_redefine_classes);
-    PRINT_CAPABILITY(can_signal_thread);
-    PRINT_CAPABILITY(can_get_source_file_name);
-    PRINT_CAPABILITY(can_get_line_numbers);
-    PRINT_CAPABILITY(can_get_source_debug_extension);
-    PRINT_CAPABILITY(can_access_local_variables);
-    PRINT_CAPABILITY(can_maintain_original_method_order);
-    PRINT_CAPABILITY(can_generate_single_step_events);
-    PRINT_CAPABILITY(can_generate_exception_events);
-    PRINT_CAPABILITY(can_generate_frame_pop_events);
-    PRINT_CAPABILITY(can_generate_breakpoint_events);
-    PRINT_CAPABILITY(can_suspend);
-    PRINT_CAPABILITY(can_redefine_any_class);
-    PRINT_CAPABILITY(can_get_current_thread_cpu_time);
-    PRINT_CAPABILITY(can_get_thread_cpu_time);
-    PRINT_CAPABILITY(can_generate_method_entry_events);
-    PRINT_CAPABILITY(can_generate_method_exit_events);
-    PRINT_CAPABILITY(can_generate_all_class_hook_events);
-    PRINT_CAPABILITY(can_generate_compiled_method_load_events);
-    PRINT_CAPABILITY(can_generate_monitor_events);
-    PRINT_CAPABILITY(can_generate_vm_object_alloc_events);
-    PRINT_CAPABILITY(can_generate_native_method_bind_events);
-    PRINT_CAPABILITY(can_generate_garbage_collection_events);
-    PRINT_CAPABILITY(can_generate_object_free_events);
+	PRINT_CAPABILITY(can_generate_field_access_events);
+	PRINT_CAPABILITY(can_get_bytecodes);
+	PRINT_CAPABILITY(can_get_synthetic_attribute);
+	PRINT_CAPABILITY(can_get_owned_monitor_info);
+	PRINT_CAPABILITY(can_get_current_contended_monitor);
+	PRINT_CAPABILITY(can_get_monitor_info);
+	PRINT_CAPABILITY(can_pop_frame);
+	PRINT_CAPABILITY(can_redefine_classes);
+	PRINT_CAPABILITY(can_signal_thread);
+	PRINT_CAPABILITY(can_get_source_file_name);
+	PRINT_CAPABILITY(can_get_line_numbers);
+	PRINT_CAPABILITY(can_get_source_debug_extension);
+	PRINT_CAPABILITY(can_access_local_variables);
+	PRINT_CAPABILITY(can_maintain_original_method_order);
+	PRINT_CAPABILITY(can_generate_single_step_events);
+	PRINT_CAPABILITY(can_generate_exception_events);
+	PRINT_CAPABILITY(can_generate_frame_pop_events);
+	PRINT_CAPABILITY(can_generate_breakpoint_events);
+	PRINT_CAPABILITY(can_suspend);
+	PRINT_CAPABILITY(can_redefine_any_class);
+	PRINT_CAPABILITY(can_get_current_thread_cpu_time);
+	PRINT_CAPABILITY(can_get_thread_cpu_time);
+	PRINT_CAPABILITY(can_generate_method_entry_events);
+	PRINT_CAPABILITY(can_generate_method_exit_events);
+	PRINT_CAPABILITY(can_generate_all_class_hook_events);
+	PRINT_CAPABILITY(can_generate_compiled_method_load_events);
+	PRINT_CAPABILITY(can_generate_monitor_events);
+	PRINT_CAPABILITY(can_generate_vm_object_alloc_events);
+	PRINT_CAPABILITY(can_generate_native_method_bind_events);
+	PRINT_CAPABILITY(can_generate_garbage_collection_events);
+	PRINT_CAPABILITY(can_generate_object_free_events);
 
-    /* JVMTI 1.1 */
-    
-    PRINT_CAPABILITY(can_force_early_return);
-    PRINT_CAPABILITY(can_get_owned_monitor_stack_depth_info);
-    PRINT_CAPABILITY(can_get_constant_pool);
-    PRINT_CAPABILITY(can_set_native_method_prefix);
-    PRINT_CAPABILITY(can_retransform_classes);
-    PRINT_CAPABILITY(can_retransform_any_class);
-    PRINT_CAPABILITY(can_generate_resource_exhaustion_heap_events);
-    PRINT_CAPABILITY(can_generate_resource_exhaustion_threads_events);
+	/* JVMTI 1.1 */
 	
-    /* JVMTI 9.0 */
-    if (JVMTI_VERSION_9_0 == env->jvmtiVersion) {
-        PRINT_CAPABILITY(can_generate_early_vmstart);
-        PRINT_CAPABILITY(can_generate_early_class_hook_events);
-    }
+	PRINT_CAPABILITY(can_force_early_return);
+	PRINT_CAPABILITY(can_get_owned_monitor_stack_depth_info);
+	PRINT_CAPABILITY(can_get_constant_pool);
+	PRINT_CAPABILITY(can_set_native_method_prefix);
+	PRINT_CAPABILITY(can_retransform_classes);
+	PRINT_CAPABILITY(can_retransform_any_class);
+	PRINT_CAPABILITY(can_generate_resource_exhaustion_heap_events);
+	PRINT_CAPABILITY(can_generate_resource_exhaustion_threads_events);
+	
+	/* JVMTI 9.0 */
+	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
+		PRINT_CAPABILITY(can_generate_early_vmstart);
+		PRINT_CAPABILITY(can_generate_early_class_hook_events);
+	}
+
+	/* JVMTI 11 */
+	if (env->jvmtiVersion >= JVMTI_VERSION_11) {
+		PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
+	}
 }
 
 jboolean JNICALL
@@ -129,45 +134,50 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyOnLoadCapabilitie
 	
 	getCapabilities(&initialCapabilities, &availableCount, &unavailableCount);
 
-    if (initialCapabilities.can_retransform_any_class == 0) {
-    	unavailableCount--;
-    }
-    
-    if (initialCapabilities.can_redefine_any_class == 0) {
-    	unavailableCount--;
-    }
-    
-    /* s390 thread/port lib does not support this functionality */
-    if (initialCapabilities.can_get_current_thread_cpu_time == 0) {
-        unavailableCount--;
-    }
+	if (initialCapabilities.can_retransform_any_class == 0) {
+		unavailableCount--;
+	}
+	
+	if (initialCapabilities.can_redefine_any_class == 0) {
+		unavailableCount--;
+	}
+	
+	/* s390 thread/port lib does not support this functionality */
+	if (initialCapabilities.can_get_current_thread_cpu_time == 0) {
+		unavailableCount--;
+	}
+	
+	/* s390 thread/port lib does not support this functionality */
+	if (initialCapabilities.can_get_thread_cpu_time == 0) {
+		unavailableCount--;
+	}
 
-    /* s390 thread/port lib does not support this functionality */
-    if (initialCapabilities.can_get_thread_cpu_time == 0) {
-        unavailableCount--;
-    }
+	if (env->jvmtiVersion >= JVMTI_VERSION_11) {
+		/* Empty JEP331 implementation doesn't enable capability can_generate_sampled_object_alloc_events. */
+		if (initialCapabilities.can_generate_sampled_object_alloc_events == 0) {
+			unavailableCount--;
+		}
+	}
+	
+	if (unavailableCount != 0) {
+		error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of unavailable capabilities. Expected 0", unavailableCount);
+		return JNI_FALSE;
+	}
 
-    if (unavailableCount != 0) {
-    	error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of unavailable capabilities. Expected 0", unavailableCount);
-    	return JNI_FALSE;
-    }
+	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
+		if (0 == initialCapabilities.can_generate_early_vmstart) {
+			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should be available in onload phase.");
+			return JNI_FALSE;
+		}
 
-    if (JVMTI_VERSION_9_0 == env->jvmtiVersion) {
-    	if (0 == initialCapabilities.can_generate_early_vmstart) {
-    		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should be available in onload phase.");
-    		return JNI_FALSE;
-    	}
-
-    	if (0 == initialCapabilities.can_generate_early_class_hook_events) {
-    		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should be available in onload phase.");
-    		return JNI_FALSE;
-    	}
-    }
-    
+		if (0 == initialCapabilities.can_generate_early_class_hook_events) {
+			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should be available in onload phase.");
+			return JNI_FALSE;
+		}
+	}
+	
 	return JNI_TRUE;
 }
-
-
 
 jboolean JNICALL
 Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyLiveCapabilities(JNIEnv *jni_env, jclass cls)
@@ -177,7 +187,7 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyLiveCapabilities(
 	int unavailableCount = 0;
  	jvmtiCapabilities capabilities;
 	jvmtiPhase phase;
-	jvmtiError err;                                
+	jvmtiError err;
 
 	err = (*jvmti_env)->GetPhase(jvmti_env, &phase);
 	if (err != JVMTI_ERROR_NONE) {
@@ -199,22 +209,22 @@ Java_com_ibm_jvmti_tests_getPotentialCapabilities_gpc001_verifyLiveCapabilities(
  
 	getCapabilities(&capabilities, &availableCount, &unavailableCount);
 
-    if (availableCount <= 0) {
-    	error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of available capabilities.", availableCount);
-    	return JNI_FALSE;
-    }
-    
-    if (JVMTI_VERSION_9_0 == env->jvmtiVersion) {
-    	if (1 == capabilities.can_generate_early_vmstart) {
-    		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should not be available in live phase.");
-    		return JNI_FALSE;
-    	}
-
-    	if (1 == capabilities.can_generate_early_class_hook_events) {
-    		error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should not be available in the live phase.");
-    		return JNI_FALSE;
-    	}
-    }
+	if (availableCount <= 0) {
+		error(env, JVMTI_ERROR_INTERNAL, "Unexpected number [%d] of available capabilities.", availableCount);
+		return JNI_FALSE;
+	}
+	
+	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
+		if (1 == capabilities.can_generate_early_vmstart) {
+			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_vmstart should not be available in live phase.");
+			return JNI_FALSE;
+		}
+		
+		if (1 == capabilities.can_generate_early_class_hook_events) {
+			error(env, JVMTI_ERROR_INTERNAL, "can_generate_early_class_hook_events should not be available in the live phase.");
+			return JNI_FALSE;
+		}
+	}
 
 	return JNI_TRUE;
 }

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc002.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/getPotentialCapabilities/gpc002.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -181,11 +181,16 @@ getCapabilities(jvmtiCapabilities * caps, int * availableCount, int * unavailabl
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_heap_events);
 	PRINT_CAPABILITY(can_generate_resource_exhaustion_threads_events);
 
-    /* JVMTI 9.0 */
-    if (JVMTI_VERSION_9_0 == env->jvmtiVersion) {
-        PRINT_CAPABILITY(can_generate_early_vmstart);
-        PRINT_CAPABILITY(can_generate_early_class_hook_events);
-    }
+	/* JVMTI 9.0 */
+	if (env->jvmtiVersion >= JVMTI_VERSION_9) {
+		PRINT_CAPABILITY(can_generate_early_vmstart);
+		PRINT_CAPABILITY(can_generate_early_class_hook_events);
+	}
+	
+	/* JVMTI 11 */
+	if (env->jvmtiVersion >= JVMTI_VERSION_11) {
+		PRINT_CAPABILITY(can_generate_sampled_object_alloc_events);
+	}
 }
 
 

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.c
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+
+#include "ibmjvmti.h"
+#include "jvmti_test.h"
+
+/* the standard agent test context which lives for the duration of the test - this is supposed to be held for error logging */
+static agentEnv *env;
+/* the callback method of the event JVMTI_EVENT_SAMPLED_OBJECT_ALLOC */
+static void JNICALL sampledObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread, jobject object, jclass object_klass, jlong size); 
+/* the number of time the callback sampledObjectAlloc invoked */
+static jint soaeResult = 0;
+
+jint JNICALL
+soae001(agentEnv *agent_env, char *args)
+{
+	JVMTI_ACCESS_FROM_AGENT(agent_env);
+	jvmtiEventCallbacks callbacks;
+	jvmtiCapabilities capabilities;
+	jvmtiError err = JVMTI_ERROR_NONE;
+	jint result = JNI_OK;
+
+	env = agent_env;
+
+	/* Set the JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event callback */
+	memset(&callbacks, 0, sizeof(jvmtiEventCallbacks));
+	callbacks.SampledObjectAlloc = sampledObjectAlloc;
+	err = (*jvmti_env)->SetEventCallbacks(jvmti_env, &callbacks, sizeof(jvmtiEventCallbacks));
+	if (JVMTI_ERROR_NONE != err) {
+		error(agent_env, err, "Failed to set callback for JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
+		result = JNI_ERR;
+	} else {
+		/* we require the can_generate_sampled_object_alloc_events capability if we want to enable allocation callbacks */
+		memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+		capabilities.can_generate_sampled_object_alloc_events = 1;
+		err = (*jvmti_env)->AddCapabilities(jvmti_env, &capabilities);
+		if (JVMTI_ERROR_NONE != err) {
+			error(agent_env, err, "Failed to add capabilities can_generate_sampled_object_alloc_events");
+			result = JNI_ERR;
+		}
+	}
+	
+	return JNI_OK;
+}
+
+static void JNICALL
+sampledObjectAlloc(jvmtiEnv *jvmti_env,
+	JNIEnv *jni_env,
+	jthread thread,
+	jobject object,
+	jclass object_klass,
+	jlong size) 
+{
+	soaeResult++;
+}
+
+void JNICALL
+Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_reset(JNIEnv *jni_env, jclass cls)
+{
+	soaeResult = 0;
+}
+
+jint JNICALL
+Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_enable(JNIEnv *jni_env, jclass cls)
+{
+	jint result = JNI_OK;
+	jvmtiError err = JVMTI_ERROR_NONE;
+	JVMTI_ACCESS_FROM_AGENT(env);
+	
+	/* Enable the JVMTI_EVENT_SAMPLED_OBJECT_ALLOC callback */
+	err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
+	if (JVMTI_ERROR_NONE != err) {
+		error(env, err, "Failed to enable JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
+		result = JNI_ERR;
+	}
+	
+	return result;
+}
+
+jint JNICALL
+Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_disable(JNIEnv *jni_env, jclass cls)
+{
+	jint result = JNI_OK;
+	jvmtiError err = JVMTI_ERROR_NONE;
+	JVMTI_ACCESS_FROM_AGENT(env);
+	
+	/* Enable the JVMTI_EVENT_SAMPLED_OBJECT_ALLOC callback */
+	err = (*jvmti_env)->SetEventNotificationMode(jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
+	if (JVMTI_ERROR_NONE != err) {
+		error(env, err, "Failed to disable JVMTI_EVENT_SAMPLED_OBJECT_ALLOC event");
+		result = JNI_ERR;
+	}
+	
+	return result;
+}
+
+jint JNICALL
+Java_com_ibm_jvmti_tests_samplingObjectAllocation_soae001_check(JNIEnv *jni_env, jclass cls)
+{
+	return soaeResult;
+}

--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
 <!--
-  Copyright (c) 2004, 2018 IBM Corp. and others
+  Copyright (c) 2004, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -410,6 +410,11 @@
  	<!-- This should be last test to clean up any cache left behind	-->
 	<test id="Cleanup any shared cache left behind" modeHints="HINT_SHARECLASSES">
  		<command>$EXE$ $JVM_OPTS$ -Xshareclasses:destroyAll</command>
+		<return type="success" value="1"/>
+	</test>
+
+	<test id="soae001">
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:soae001 -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="1"/>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
+++ b/test/functional/cmdLineTests/jvmtitests/src/com/ibm/jvmti/tests/samplingObjectAllocation/soae001.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package com.ibm.jvmti.tests.samplingObjectAllocation;
+
+public class soae001 {
+	private final static int DEFAULT_SAMPLING_RATE = 512 * 1024; /* 512 KB */
+	
+	private native static void reset();	/* reset native internal counters */
+	private native static int enable();	/* enable event JVMTI_EVENT_SAMPLED_OBJECT_ALLOC */
+	private native static int disable();	/* disable event JVMTI_EVENT_SAMPLED_OBJECT_ALLOC */
+	private native static int check();	/* check how many times the event callback was invoked */
+	
+	public boolean testDefaultInterval() {
+		boolean result = false;
+		int jvmtiResult = 0;
+
+		reset();
+		jvmtiResult = enable();
+		if (0 != jvmtiResult) {
+			System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.enable() failed with: " + jvmtiResult);
+			// following to be deleted when actual JEP331 implementation is in place
+			System.out.println("This is expected with an empty JEP331 implementation!");
+			result = true;
+		} else {
+			byte[] bytes;
+			bytes = new byte[DEFAULT_SAMPLING_RATE];
+			System.out.println("Allocated a byte array with size " + bytes.length);
+			
+			int samplingResult = check();
+			if (1 != samplingResult) {
+				System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.check() failed, expected 1 but got: " + samplingResult);
+			} else {
+				jvmtiResult = disable();
+				if (0 != jvmtiResult) {
+					System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.disable() failed with: " + jvmtiResult);
+				} else {
+					reset();
+					bytes = new byte[DEFAULT_SAMPLING_RATE];
+					System.out.println("Allocated another byte array with size " + bytes.length);
+					samplingResult = check();
+					if (0 != samplingResult) {
+						System.out.println("com.ibm.jvmti.tests.samplingObjectAllocation.soae001.check() failed, expected 0 but got: " + samplingResult);
+					} else {
+						result = true;
+					}
+				}
+			}
+		}
+		
+		return result;
+	}
+	public String helpDefaultInterval() {
+		return "Test that with default sampling interval the event callback is invoked once as expected after enabled, and not invoked if the event is disable.";
+	}
+}


### PR DESCRIPTION
Prepare `JEP331` with an empty implementation

This is a subset of https://github.com/eclipse/openj9/pull/3754 without `GC` related functionalities.
Updated `jvmti.h` with `JVMTI 11` version, new event and method defines, changed `JVMTI_VERSION_9_0` to `JVMTI_VERSION_9` to match RI (this addresses the issue reported at https://openj9.slack.com/archives/C8312LCV9/p1548360917133500);
Added a sanity test;
Removed unused `J9JVMTIEnv.capabilitiesMask` and related code.
Note: this might have an impact on https://github.com/eclipse/openj9/issues/2368

closes #4667

Peer reviewer: @tajila 
Reviewer: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>