### PR TITLE
Remove now deprecated resizeCodeMemory functions

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4649,13 +4649,6 @@ J9::CodeGenerator::trimCodeMemoryToActualSize()
 
 
 void
-J9::CodeGenerator::resizeCodeMemory()
-   {
-   self()->trimCodeMemoryToActualSize();
-   }
-
-
-void
 J9::CodeGenerator::reserveCodeCache()
    {
    self()->setCodeCache(self()->fej9()->getDesignatedCodeCache(self()->comp()));

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -418,13 +418,6 @@ public:
    int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; }
 
    /**
-    * \brief This is just a J9 override of this function and simply redirects
-    *        to the newly named function `trimCodeMemoryToActualSize`.  It exists
-    *        solely to coordinate refactoring with OMR and will be very transient.
-    */
-   void resizeCodeMemory();
-
-   /**
     * \brief Trim the size of code memory required by this method to match the
     *        actual code length required, allowing the reclaimed memory to be
     *        reused.  This is needed when the conservative length estimate

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2319,15 +2319,6 @@ TR_J9VMBase::allocateCodeMemory(TR::Compilation * comp, uint32_t warmCodeSize, u
    return warmCode;
    }
 
-void
-TR_J9VMBase::resizeCodeMemory(TR::Compilation * comp, U_8 *bufferStart, uint32_t numBytes)
-   {
-   // I don't see a reason to acquire VM access for this call
-   TR::VMAccessCriticalSection resizeCodeMemory(this);
-   TR::CodeCache * codeCache = comp->cg()->getCodeCache();
-   codeCache->resizeCodeMemory(bufferStart, numBytes);
-   }
-
 bool
 TR_J9VMBase::supportsCodeCacheSnippets()
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -410,7 +410,6 @@ public:
    uint32_t                   getNumMethods(TR_OpaqueClassBlock *classPointer);
 
    virtual uint8_t *          allocateCodeMemory( TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
-   virtual void               resizeCodeMemory( TR::Compilation *, uint8_t *, uint32_t numBytes);
 
    virtual void               releaseCodeMemory(void *startPC, uint8_t bytesToSaveAtStart);
    virtual uint8_t *          allocateRelocationData( TR::Compilation *, uint32_t numBytes);

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,13 +87,6 @@ J9MemorySegment *
 J9::CodeCache::j9segment()
    {
    return self()->trj9segment()->j9segment();
-   }
-
-
-bool
-J9::CodeCache::resizeCodeMemory(void *memoryBlock, size_t newSize)
-   {
-   return self()->OMR::CodeCache::resizeCodeMemory(memoryBlock, newSize);
    }
 
 

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,8 +75,6 @@ public:
                                          size_t allocatedCodeCacheSizeInBytes);
 
    static TR::CodeCache *     allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, int32_t reservingCompThreadID);
-
-   bool                       resizeCodeMemory(void *memoryBlock, size_t newSize);
 
    // Code Cache Reclamation
    void                       addFreeBlock(OMR::FaintCacheBlock *block);


### PR DESCRIPTION
`resizeCodeMemory` functionality in various classes has been deprecated
in lieu of `trimCodeMemoryToActualSize` and supporting functionality.
Remove old functions.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>