### PR TITLE
Remove GCC 4 from containers 

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -50,8 +50,6 @@ RUN yum -y update \
     fontconfig \
     fontconfig-devel \
     freetype-devel \
-    gcc-4.8.5 \
-    gcc-c++-4.8.5 \
     gettext \
     glibc \
     glibc-common \
@@ -106,16 +104,14 @@ RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
   && cpanm Text::CSV \
   && cpanm JSON
 
-# Setup links to GCC-4.8.5
-RUN rm /usr/bin/c++ /usr/bin/cc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s gcc /usr/bin/cc
-
 # Install GCC-7.3.1
 RUN cd /usr/local \
   && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.ppc64le.tar.xz" \
   && tar -xJf gcc-7.tar.xz --strip-components=1 \
-  && rm -rf gcc-7.tar.xz
+  && rm -rf gcc-7.tar.xz \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/cc \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ 
 
 # Edit ldconfig to connect this library
 RUN echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \

--- a/buildenv/jenkins/docker-slaves/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/ubuntu16/Dockerfile
@@ -48,8 +48,8 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
-    g++-4.8 \
-    gcc-4.8 \
+    g++-7 \
+    gcc-7 \
     gdb \
     git \
     make \

--- a/buildenv/jenkins/docker-slaves/ppc64le/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/ubuntu18/Dockerfile
@@ -44,9 +44,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
-    g++-4.8 \
     g++-7 \
-    gcc-4.8 \
     gcc-7 \
     gdb \
     git \
@@ -60,13 +58,6 @@ RUN apt-get update \
 
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV
-
-# Create links for c++,g++,cc,gcc
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -48,8 +48,6 @@ RUN apt-get update \
     cpio \
     curl \
     file \
-    g++-4.8 \
-    gcc-4.8 \
     gdb \
     git \
     git-core \
@@ -81,8 +79,10 @@ RUN apt-get update \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Docker module to run test framework
-RUN echo yes | cpan install JSON Text::CSV
+# Dependency required by test framework
+RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
+  && cpanm Text::CSV \
+  && cpanm JSON
 
 # Install GCC-7.4
 RUN cd /usr/local \
@@ -92,15 +92,14 @@ RUN cd /usr/local \
 
 # Create links for c++,g++,cc,gcc and for GCC to access the C library
 # There is a true at the end of the library link because it throws an error and it allows the container to be built
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc \
-  && ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
+RUN ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
   && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include | true \ 
   && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++-7 \
   && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc-7
+
+# Edit ldconfig to connect the new libstdc++.so* library
+RUN echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu18/Dockerfile
@@ -44,9 +44,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
-    g++-4.8 \
     g++-7 \
-    gcc-4.8 \
     gcc-7 \
     gdb \
     git \
@@ -60,13 +58,6 @@ RUN apt-get update \
 
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV
-
-# Create links for c++,g++,cc,gcc
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -111,24 +111,15 @@ RUN wget -O - http://cpanmin.us | perl - --self-upgrade \
   && cpanm Text::CSV \
   && cpanm JSON
 
-# install GCC-4.8 and GCC-7.3
-RUN cd /etc/yum.repos.d \
-  && wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo \
-  && yum -y update \
-  && yum -y install devtoolset-2-gcc devtoolset-2-binutils \
-  && yum -y install devtoolset-2-gcc-c++ devtoolset-2-gcc-gfortran \
-  && yum clean all \
-  && scl enable devtoolset-2 bash \
-  && mv /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 \
-  && mv /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8 \
-  && ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 /usr/bin/gcc \
-  && ln -s /opt/rh/devtoolset-2/root/usr/bin/g++-4.8 /usr/bin/g++ \
-  && ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 /usr/bin/cc \
-  && yum -y update \
+# Install GCC-7.3
+RUN yum -y update \
   && yum -y install centos-release-scl \
   && yum -y install devtoolset-7-gcc-7.3* devtoolset-7-binutils \
   && yum -y install devtoolset-7-gcc-c++-7.3* devtoolset-2-gcc-gfortran-7.3* \
-  && yum clean all
+  && yum clean all \
+  && ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/bin/cc \
+  && ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /usr/bin/gcc \
+  && ln -s /opt/rh/devtoolset-7/root/usr/bin/g++ /usr/bin/g++ 
 
 #Building and setting up git version 2.5.3
 RUN yum -y update \

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu16/Dockerfile
@@ -49,9 +49,7 @@ RUN apt-get update \
     cpio \
     curl \
     file \
-    g++-4.8 \
     g++-7 \
-    gcc-4.8 \
     gcc-7 \
     gdb \
     git \
@@ -85,13 +83,6 @@ RUN apt-get update \
 
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV
-
-# Create links for c++,g++,cc,gcc
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \

--- a/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/ubuntu18/Dockerfile
@@ -44,9 +44,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     curl \
-    g++-4.8 \
     g++-7 \
-    gcc-4.8 \
     gcc-7 \
     gdb \
     git \
@@ -60,13 +58,6 @@ RUN apt-get update \
 
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV
-
-# Create links for c++,g++,cc,gcc
-RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
-  && ln -s g++ /usr/bin/c++ \
-  && ln -s g++-4.8 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \


### PR DESCRIPTION
Removing GCC 4 because it is no longer being used to compile java
Installing GCC-7 where it is not already being installed
Adding libstdc++.so* to ldconfig when using precompiled gcc-7

[skip ci]

Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>