### PR TITLE
Revert "Remove references to legacy Java 9 classes"

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/MsgHelp.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/MsgHelp.java
@@ -3,7 +3,7 @@
 package com.ibm.oti.vm;
 
 /*******************************************************************************
- * Copyright (c) 2003, 2019 IBM Corp. and others
+ * Copyright (c) 2003, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,11 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /*[IF Sidecar19-SE]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
+/*[ELSE]
+import java.lang.reflect.Module;
+/*[ENDIF]
 import jdk.internal.reflect.CallerSensitive;
 /*[ELSE]*/
 import sun.reflect.CallerSensitive;

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2007, 2019 IBM Corp. and others
+ * Copyright (c) 2007, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,12 +43,16 @@ import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
 
 /*[IF Sidecar19-SE]
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
 import java.util.Iterator;
 import java.util.List;
 /*[IF Java11]*/
 import java.nio.charset.Charset;
 import java.nio.charset.CharacterCodingException;
+/*[ENDIF]*/
+/*[ELSE]
+import java.lang.reflect.Module;
 /*[ENDIF]*/
 /*[IF Java12]*/
 import jdk.internal.access.JavaLangAccess;
@@ -217,7 +221,11 @@ final class Access implements JavaLangAccess {
 	 }
 	
 	public 
+/*[IF Sidecar19-SE-OpenJ9]	
 	java.lang.ModuleLayer
+/*[ELSE]*/
+	java.lang.reflect.Layer
+/*[ENDIF]*/	
 	getBootLayer() {
 		return System.bootLayer;
 	}

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,8 +27,12 @@ import java.lang.invoke.MethodType;
 /*[ENDIF]*/
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Version;
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.IllegalCallerException;
 import java.lang.Module;
+/*[ELSE]
+import java.lang.reflect.Module;
+/*[ENDIF]*/
 import java.security.Permission;
 import java.util.Collections;
 import java.util.HashSet;
@@ -181,7 +185,7 @@ public final class StackWalker {
 				s -> s.limit(2).collect(Collectors.toList()));
 		if (result.size() < 2) {
 			/*[MSG "K0640", "getCallerClass() called from method with no caller"]*/
-			/*[IF Sidecar19-SE]
+			/*[IF Sidecar19-SE-OpenJ9]
 			throw new IllegalCallerException(com.ibm.oti.util.Msg.getString("K0640")); //$NON-NLS-1$
 			/*[ELSE]*/
 			throw new IllegalStateException(com.ibm.oti.util.Msg.getString("K0640")); //$NON-NLS-1$

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -2,7 +2,7 @@
 package java.lang;
 
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,11 @@ import jdk.internal.misc.SharedSecrets;
 /*[ENDIF]*/
 import jdk.internal.misc.VM;
 import java.lang.StackWalker.Option;
+/*[IF Sidecar19-SE-OpenJ9]
 import java.lang.Module;
+/*[ELSE]
+import java.lang.reflect.Module;
+/*[ENDIF]*/
 import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.CallerSensitive;
 import java.util.*;
@@ -102,7 +106,11 @@ public final class System {
 	private static String osEncoding;
 
 /*[IF Sidecar19-SE]*/
+/*[IF Sidecar19-SE-OpenJ9]
 	static java.lang.ModuleLayer	bootLayer;
+/*[ELSE]*/
+	static java.lang.reflect.Layer	bootLayer;
+/*[ENDIF]*/
 /*[ENDIF]*/
 	
 	// Initialize all the slots in System on first use.
@@ -181,7 +189,7 @@ public final class System {
 		/*[ELSE]*/
 		StringCoding.encode(new char[1], 0, 1);
 		/*[ENDIF]*/
-		/*[IF Sidecar19-SE]*/
+		/*[IF Sidecar18-SE-OpenJ9|Sidecar19-SE]*/
 		setErr(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true));
 		setOut(new PrintStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), true));
 		/*[IF Sidecar19-SE_RAWPLUSJ9]*/

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/LoggingMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corp. and others
+ * Copyright (c) 2005, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,8 +24,13 @@ package com.ibm.java.lang.management.internal;
 
 import java.lang.management.PlatformLoggingMXBean;
 /*[IF Sidecar19-SE]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.Module;
 import java.lang.ModuleLayer;
+/*[ELSE]
+import java.lang.reflect.Module;
+import java.lang.reflect.Layer;
+/*[ENDIF]*/
 /*[ENDIF]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,11 @@
  *******************************************************************************/
 package java.lang.management;
 
+/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.ModuleLayer;
+/*[ELSE]
+import java.lang.reflect.Layer;
+/*[ENDIF]*/
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar19-SE]*/
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,11 @@
  *******************************************************************************/
 package com.ibm.lang.management.internal;
 
+/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.ModuleLayer;
+/*[ELSE]
+import java.lang.reflect.Layer;
+/*[ENDIF]*/
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar17]*/
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,13 @@
 package openj9.lang.management.internal;
 
 /*[IF Sidecar19-SE]*/
+/*[IF Sidecar19-SE-OpenJ9]*/
 import java.lang.Module;
 import java.lang.ModuleLayer;
+/*[ELSE]
+import java.lang.reflect.Module;
+import java.lang.reflect.Layer;
+/*[ENDIF]*/
 /*[ENDIF]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;


### PR DESCRIPTION
Reverts eclipse/openj9#4352

Apparently the travis build wasn't sufficient, as #4352 seems to be causing build failures.
i.e. https://ci.eclipse.org/openj9/job/Build-JDK8-aix_ppc-64_cmprssptrs/1017
```
12:47:35 /home/u0020236/workspace/Build-JDK8-aix_ppc-64_cmprssptrs/build/aix-ppc64-normal-server-release/jdk/j9jcl_sources/jdk/src/share/classes/java/lang/System.java:152: error: package com.ibm.jvm.io does not exist
12:47:35 		setErr(com.ibm.jvm.io.ConsolePrintStream.localize(new BufferedOutputStream(new FileOutputStream(FileDescriptor.err)), true));
12:47:35 		                     ^
12:47:35 /home/u0020236/workspace/Build-JDK8-aix_ppc-64_cmprssptrs/build/aix-ppc64-normal-server-release/jdk/j9jcl_sources/jdk/src/share/classes/java/lang/System.java:153: error: package com.ibm.jvm.io does not exist
12:47:35 		setOut(com.ibm.jvm.io.ConsolePrintStream.localize(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), true));
12:47:35 		                     ^
```