### PR TITLE
Use class chains for by-name class records

### DIFF
--- a/doc/compiler/aot/SymbolValidationManager.md
+++ b/doc/compiler/aot/SymbolValidationManager.md
@@ -134,18 +134,14 @@ generates records relating the array class to each of its (transitive)
 component classes until the leaf component class is reached, and then
 generates a class chain validation for the leaf component class.
 
-Some class records use a ROM class offset or a class chain offset in
-order to identify the class by name:
-- ClassByName and SystemClassByName use ROM class offsets.
-- ProfiledClass uses a class chain offset.
-
-Since array ROM classes are not in the shared class cache, these records
-are unable to name array classes directly. If an array class is found in
-any of these ways, the SVM finds the leaf component class, then creates
-a record for the leaf component instead of the array (and if necessary a
-class chain validation for it), followed by records relating each
-(transitive) component type to its corresponding array type, until the
-original array class is reached.
+Some class records (ClassByName, SystemClassByName, and ProfiledClass)
+use a class chain offset in order to identify the class by name. Since
+array ROM classes are not in the shared class cache, these records are
+unable to name array classes directly. If an array class is found in any
+of these ways, the SVM finds the leaf component class, then creates a
+record for the leaf component instead of the array, followed by records
+relating each (transitive) component type to its corresponding array
+type, until the original array class is reached.
 
 ### Primitive Classes
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1169,10 +1169,10 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateClassByNameBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Class By Name: classID=%d beholderID=%d romClassOffsetInSCC=%p ",
+               traceMsg(self()->comp(), "\n Validate Class By Name: classID=%d beholderID=%d classChainOffsetInSCC=%p ",
                         (uint32_t)binaryTemplate->_classID,
                         (uint32_t)binaryTemplate->_beholderID,
-                        binaryTemplate->_romClassOffsetInSCC);
+                        binaryTemplate->_classChainOffsetInSCC);
                }
             cursor += sizeof(TR_RelocationRecordValidateClassByNameBinaryTemplate);
             self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
@@ -1368,9 +1368,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate System Class By Name: systemClassID=%d romClassOffsetInSCC=%p ",
+               traceMsg(self()->comp(), "\n Validate System Class By Name: systemClassID=%d classChainOffsetInSCC=%p ",
                         (uint32_t)binaryTemplate->_systemClassID,
-                        binaryTemplate->_romClassOffsetInSCC);
+                        binaryTemplate->_classChainOffsetInSCC);
                }
             cursor += sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate);
             self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -421,6 +421,17 @@ TR_J9SharedCache::isPointerInSharedCache(void *ptr, void * & cacheOffset)
    return false;
    }
 
+J9ROMClass *
+TR_J9SharedCache::startingROMClassOfClassChain(UDATA *classChain)
+   {
+   UDATA lengthInBytes = classChain[0];
+   TR_ASSERT_FATAL(lengthInBytes >= 2 * sizeof (UDATA), "class chain is too short!");
+
+   void *romClassOffset = reinterpret_cast<void*>(classChain[1]);
+   void *romClass = pointerFromOffsetInSharedCache(romClassOffset);
+   return static_cast<J9ROMClass*>(romClass);
+   }
+
 // convert an offset into a string of 8 characters
 void
 TR_J9SharedCache::convertUnsignedOffsetToASCII(UDATA offset, char *buffer)

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,8 @@ public:
 
    bool isPointerInSharedCache(void *ptr, void * & cacheOffset);
 
-   
+   J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
+
    enum TR_J9SharedCacheDisabledReason
       {
       UNINITIALIZED,

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3239,18 +3239,18 @@ TR_RelocationRecordValidateClassByName::applyRelocation(TR_RelocationRuntime *re
    {
    uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_classID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_beholderID);
-   void *romClassOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_romClassOffsetInSCC);
-   void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffset);
+   void *classChainOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateClassByNameBinaryTemplate *)_record)->_classChainOffsetInSCC);
+   uintptrj_t *classChain = (uintptrj_t*)reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: romClass %p\n", romClass);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classChain %p\n", classChain);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassByNameRecord(classID, beholderID, static_cast<J9ROMClass *>(romClass)))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassByNameRecord(classID, beholderID, classChain))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3451,17 +3451,17 @@ int32_t
 TR_RelocationRecordValidateSystemClassByName::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t systemClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *)_record)->_systemClassID);
-   void *romClassOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *)_record)->_romClassOffsetInSCC);
-   void *romClass = reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(romClassOffset);
+   void *classChainOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *)_record)->_classChainOffsetInSCC);
+   uintptrj_t *classChain = (uintptrj_t*)reloRuntime->fej9()->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: systemClassID %d\n", systemClassID);
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: romClass %p\n", romClass);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: classChain %p\n", classChain);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateSystemClassByNameRecord(systemClassID, static_cast<J9ROMClass *>(romClass)))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateSystemClassByNameRecord(systemClassID, classChain))
       return 0;
    else
       return compilationAotClassReloFailure;

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -205,7 +205,7 @@ struct TR_RelocationRecordValidateClassByNameBinaryTemplate : public TR_Relocati
    {
    uint16_t _classID;
    uint16_t _beholderID;
-   UDATA _romClassOffsetInSCC;
+   UDATA _classChainOffsetInSCC;
    };
 
 struct TR_RelocationRecordValidateProfiledClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
@@ -268,7 +268,7 @@ struct TR_RelocationRecordValidateClassInstanceOfClassBinaryTemplate : public TR
 struct TR_RelocationRecordValidateSystemClassByNameBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _systemClassID;
-   UDATA _romClassOffsetInSCC;
+   UDATA _classChainOffsetInSCC;
    };
 
 struct TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -294,20 +294,27 @@ TR::SymbolValidationManager::addClassRecord(TR_OpaqueClassBlock *clazz, TR::Clas
    }
 
 bool
-TR::SymbolValidationManager::addClassRecordWithRomClass(TR_OpaqueClassBlock *component, TR::ClassValidationRecord *record, int arrayDims)
+TR::SymbolValidationManager::addClassRecordWithChain(TR::ClassValidationRecordWithChain *record)
    {
-   if (shouldNotDefineSymbol(component))
+   if (shouldNotDefineSymbol(record->_class))
       return abandonRecord(record);
 
-   SVM_ASSERT(!_fej9->isClassArray(component), "expected base component type");
+   int arrayDims = 0;
+   record->_class = getBaseComponentClass(record->_class, arrayDims);
 
-   if (!_fej9->isPrimitiveClass(component))
+   if (!_fej9->isPrimitiveClass(record->_class))
       {
-      if (!addClassRecord(component, record))
+      record->_classChain = _fej9->sharedCache()->rememberClass(record->_class);
+      if (record->_classChain == NULL)
+         {
+         _region.deallocate(record);
          return false;
+         }
+
+      appendRecordIfNew(record->_class, record);
       }
 
-   addMultipleArrayRecords(component, arrayDims);
+   addMultipleArrayRecords(record->_class, arrayDims);
    return true;
    }
 
@@ -380,11 +387,7 @@ bool
 TR::SymbolValidationManager::addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder)
    {
    SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
-
-   int32_t arrayDims = 0;
-   clazz = getBaseComponentClass(clazz, arrayDims);
-   TR::ClassValidationRecord *record = new (_region) ClassByNameRecord(clazz, beholder);
-   return addClassRecordWithRomClass(clazz, record, arrayDims);
+   return addClassRecordWithChain(new (_region) ClassByNameRecord(clazz, beholder));
    }
 
 bool
@@ -485,10 +488,7 @@ TR::SymbolValidationManager::addClassInstanceOfClassRecord(TR_OpaqueClassBlock *
 bool
 TR::SymbolValidationManager::addSystemClassByNameRecord(TR_OpaqueClassBlock *systemClass)
    {
-   int32_t arrayDims = 0;
-   systemClass = getBaseComponentClass(systemClass, arrayDims);
-   TR::ClassValidationRecord *record = new (_region) SystemClassByNameRecord(systemClass);
-   return addClassRecordWithRomClass(systemClass, record, arrayDims);
+   return addClassRecordWithChain(new (_region) SystemClassByNameRecord(systemClass));
    }
 
 bool
@@ -734,15 +734,17 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, J9Method *
    }
 
 bool
-TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_t beholderID, J9ROMClass *romClass)
+TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_t beholderID, uintptrj_t *classChain)
    {
    J9Class *beholder = getJ9ClassFromID(beholderID);
    J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
-
+   J9ROMClass *romClass = _fej9->sharedCache()->startingROMClassOfClassChain(classChain);
    J9UTF8 * classNameData = J9ROMCLASS_CLASSNAME(romClass);
    char *className = reinterpret_cast<char *>(J9UTF8_DATA(classNameData));
    uint32_t classNameLength = J9UTF8_LENGTH(classNameData);
-   return validateSymbol(classID, _fej9->getClassFromSignature(className, classNameLength, beholderCP));
+   TR_OpaqueClassBlock *clazz = _fej9->getClassFromSignature(className, classNameLength, beholderCP);
+   return validateSymbol(classID, clazz)
+      && _fej9->sharedCache()->classMatchesCachedVersion(clazz, classChain);
    }
 
 bool
@@ -828,12 +830,14 @@ TR::SymbolValidationManager::validateClassInstanceOfClassRecord(uint16_t classOn
    }
 
 bool
-TR::SymbolValidationManager::validateSystemClassByNameRecord(uint16_t systemClassID, J9ROMClass *romClass)
+TR::SymbolValidationManager::validateSystemClassByNameRecord(uint16_t systemClassID, uintptrj_t *classChain)
    {
+   J9ROMClass *romClass = _fej9->sharedCache()->startingROMClassOfClassChain(classChain);
    J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
    TR_OpaqueClassBlock *systemClassByName = _fej9->getSystemClassFromClassName(reinterpret_cast<const char *>(J9UTF8_DATA(className)),
                                                                               J9UTF8_LENGTH(className));
-   return validateSymbol(systemClassID, systemClassByName);
+   return validateSymbol(systemClassID, systemClassByName)
+      && _fej9->sharedCache()->classMatchesCachedVersion(systemClassByName, classChain);
    }
 
 bool
@@ -1182,9 +1186,17 @@ namespace // file-local
       };
    }
 
+void TR::ClassValidationRecordWithChain::printFields()
+   {
+   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
+   printClass(_class);
+   traceMsg(TR::comp(), "\t_classChain=0x%p\n", _classChain);
+   }
+
 bool TR::ClassByNameRecord::isLessThanWithinKind(SymbolValidationRecord *other)
    {
    TR::ClassByNameRecord *rhs = downcast(this, other);
+   // Don't compare _classChain - it's determined by _class
    return LexicalOrder::by(_class, rhs->_class)
       .thenBy(_beholder, rhs->_beholder).less();
    }
@@ -1192,8 +1204,7 @@ bool TR::ClassByNameRecord::isLessThanWithinKind(SymbolValidationRecord *other)
 void TR::ClassByNameRecord::printFields()
    {
    traceMsg(TR::comp(), "ClassByNameRecord\n");
-   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
-   printClass(_class);
+   TR::ClassValidationRecordWithChain::printFields();
    traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
    printClass(_beholder);
    }
@@ -1364,14 +1375,14 @@ void TR::ClassInstanceOfClassRecord::printFields()
 bool TR::SystemClassByNameRecord::isLessThanWithinKind(SymbolValidationRecord *other)
    {
    TR::SystemClassByNameRecord *rhs = downcast(this, other);
-   return LexicalOrder::by(_systemClass, rhs->_systemClass).less();
+   // Don't compare _classChain - it's determined by _class
+   return LexicalOrder::by(_class, rhs->_class).less();
    }
 
 void TR::SystemClassByNameRecord::printFields()
    {
    traceMsg(TR::comp(), "SystemClassByNameRecord\n");
-   traceMsg(TR::comp(), "\t_systemClass=0x%p\n", _systemClass);
-   printClass(_systemClass);
+   TR::ClassValidationRecordWithChain::printFields();
    }
 
 bool TR::ClassFromITableIndexCPRecord::isLessThanWithinKind(

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -142,19 +142,35 @@ struct ClassValidationRecord : public SymbolValidationRecord
    virtual bool isClassValidationRecord() { return true; }
    };
 
-struct ClassByNameRecord : public ClassValidationRecord
+// A class validation where the class chain provides data that is used to find
+// the class (e.g. its name). It can be advantageous to use a class chain even
+// when it is not required for the validation at hand, since each class needs a
+// class chain validation at some point. By including one in ClassByNameRecord
+// (for example), it's possible to eliminate the separate ClassChainRecord that
+// would otherwise be required.
+struct ClassValidationRecordWithChain : public ClassValidationRecord
+   {
+   ClassValidationRecordWithChain(TR_ExternalRelocationTargetKind kind, TR_OpaqueClassBlock *clazz)
+      : ClassValidationRecord(kind), _class(clazz), _classChain(NULL)
+      {}
+
+   virtual void printFields();
+
+   TR_OpaqueClassBlock * _class;
+   void * _classChain;
+   };
+
+struct ClassByNameRecord : public ClassValidationRecordWithChain
    {
    ClassByNameRecord(TR_OpaqueClassBlock *clazz,
                      TR_OpaqueClassBlock *beholder)
-      : ClassValidationRecord(TR_ValidateClassByName),
-        _class(clazz),
+      : ClassValidationRecordWithChain(TR_ValidateClassByName, clazz),
         _beholder(beholder)
       {}
 
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueClassBlock * _class;
    TR_OpaqueClassBlock * _beholder;
    };
 
@@ -306,17 +322,14 @@ struct ClassInstanceOfClassRecord : public SymbolValidationRecord
    bool _isInstanceOf;
    };
 
-struct SystemClassByNameRecord : public ClassValidationRecord
+struct SystemClassByNameRecord : public ClassValidationRecordWithChain
    {
    SystemClassByNameRecord(TR_OpaqueClassBlock *systemClass)
-      : ClassValidationRecord(TR_ValidateSystemClassByName),
-        _systemClass(systemClass)
+      : ClassValidationRecordWithChain(TR_ValidateSystemClassByName, systemClass)
       {}
 
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
-
-   TR_OpaqueClassBlock *_systemClass;
    };
 
 struct ClassFromITableIndexCPRecord : public ClassValidationRecord
@@ -728,7 +741,7 @@ public:
 
 
 
-   bool validateClassByNameRecord(uint16_t classID, uint16_t beholderID, J9ROMClass *romClass);
+   bool validateClassByNameRecord(uint16_t classID, uint16_t beholderID, uintptrj_t *classChain);
    bool validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated);
    bool validateClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateDefiningClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex, bool isStatic);
@@ -738,7 +751,7 @@ public:
    bool validateArrayClassFromComponentClassRecord(uint16_t arrayClassID, uint16_t componentClassID);
    bool validateSuperClassFromClassRecord(uint16_t superClassID, uint16_t childClassID);
    bool validateClassInstanceOfClassRecord(uint16_t classOneID, uint16_t classTwoID, bool objectTypeIsFixed, bool castTypeIsFixed, bool wasInstanceOf);
-   bool validateSystemClassByNameRecord(uint16_t systemClassID, J9ROMClass *romClass);
+   bool validateSystemClassByNameRecord(uint16_t systemClassID, uintptrj_t *classChain);
    bool validateClassFromITableIndexCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
    bool validateClassClassRecord(uint16_t classClassID, uint16_t objectClassID);
@@ -800,7 +813,7 @@ private:
 
    bool addVanillaRecord(void *symbol, TR::SymbolValidationRecord *record);
    bool addClassRecord(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record);
-   bool addClassRecordWithRomClass(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record, int arrayDims);
+   bool addClassRecordWithChain(TR::ClassValidationRecordWithChain *record);
    void addMultipleArrayRecords(TR_OpaqueClassBlock *clazz, int arrayDims);
    bool addMethodRecord(TR_OpaqueMethodBlock *method, TR::SymbolValidationRecord *record);
 

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -583,13 +583,12 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          TR_RelocationRecordValidateClassByNameBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateClassByNameBinaryTemplate *>(cursor);
 
-         // Store rom class to get name of class
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(record->_class));
-         void *romClassOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romClass);
-
-         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
-         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_romClassOffsetInSCC = reinterpret_cast<uintptrj_t>(romClassOffsetInSharedCache);
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         void *classChainOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(record->_classChain);
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(record->_class);
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(record->_beholder);
+         binaryTemplate->_classChainOffsetInSCC = reinterpret_cast<uintptrj_t>(classChainOffsetInSharedCache);
 
          cursor += sizeof(TR_RelocationRecordValidateClassByNameBinaryTemplate);
          }
@@ -767,12 +766,11 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *>(cursor);
 
-         // Store rom class to get name of class
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(record->_systemClass));
-         void *romClassOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romClass);
-
-         binaryTemplate->_systemClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_systemClass));
-         binaryTemplate->_romClassOffsetInSCC = reinterpret_cast<uintptrj_t>(romClassOffsetInSharedCache);
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         void *classChainOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(record->_classChain);
+         binaryTemplate->_systemClassID = symValManager->getIDFromSymbol(record->_class);
+         binaryTemplate->_classChainOffsetInSCC = reinterpret_cast<uintptrj_t>(classChainOffsetInSharedCache);
 
          cursor += sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate);
          }

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -411,12 +411,12 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
          TR_RelocationRecordValidateClassByNameBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateClassByNameBinaryTemplate *>(cursor);
-         // Store rom class to get name of class
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(record->_class));
-         void *romClassOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romClass);
-         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
-         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_romClassOffsetInSCC = reinterpret_cast<uintptrj_t>(romClassOffsetInSharedCache);
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         void *classChainOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(record->_classChain);
+         binaryTemplate->_classID = symValManager->getIDFromSymbol(record->_class);
+         binaryTemplate->_beholderID = symValManager->getIDFromSymbol(record->_beholder);
+         binaryTemplate->_classChainOffsetInSCC = reinterpret_cast<uintptrj_t>(classChainOffsetInSharedCache);
          cursor += sizeof(TR_RelocationRecordValidateClassByNameBinaryTemplate);
          }
          break;
@@ -541,11 +541,11 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
          TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateSystemClassByNameBinaryTemplate *>(cursor);
-         // Store rom class to get name of class
-         void *romClass = reinterpret_cast<void *>(fej9->getPersistentClassPointerFromClassPointer(record->_systemClass));
-         void *romClassOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romClass);
-         binaryTemplate->_systemClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_systemClass));
-         binaryTemplate->_romClassOffsetInSCC = reinterpret_cast<uintptrj_t>(romClassOffsetInSharedCache);
+         // Store class chain to get name of class. Checking the class chain for
+         // this record eliminates the need for a separate class chain validation.
+         void *classChainOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(record->_classChain);
+         binaryTemplate->_systemClassID = symValManager->getIDFromSymbol(record->_class);
+         binaryTemplate->_classChainOffsetInSCC = reinterpret_cast<uintptrj_t>(classChainOffsetInSharedCache);
          cursor += sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate);
          }
          break;


### PR DESCRIPTION
By using the class chain rather than the ROM class, `ClassByNameRecord` and `SystemClassByNameRecord` can now validate the class chain themselves, so that there is no need to store a separate `ClassChainRecord`.

Currently `ClassChainRecord` is avoided only when the class was *first* found by one of these two records. Further improvements are possible in the future:

- A `ClassChainRecord` could be eliminated if the same class is found by name before the first use of that class that needs its class chain to match, e.g. for constant pool lookup.

- All `ClassChainRecord`s for classes that were ever found by name could be eliminated by deferring them to the end, and having by-name validations suppress them. This would require constant pool lookups to bound-check the constant pool index, and type check the constant pool entry found there.