### PR TITLE
AArch64: Enable env_data64 in buildspec

### DIFF
--- a/buildspecs/linux_aarch64.spec
+++ b/buildspecs/linux_aarch64.spec
@@ -117,9 +117,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<flag id="build_j2se" value="true"/>
 		<flag id="build_java8" value="false"/>
 		<flag id="build_vmContinuous" value="true"/>
+		<flag id="env_data64" value="true"/>
 		<flag id="env_hasFPU" value="true"/>
 		<flag id="env_littleEndian" value="true"/>
-		<flag id="gc_alignObjects" value="true"/>
 		<flag id="gc_batchClearTLH" value="true"/>
 		<flag id="gc_debugAsserts" value="true"/>
 		<flag id="gc_inlinedAllocFields" value="true"/>


### PR DESCRIPTION
This commit adds a line for env_data64 in buildspec/linux_aarch64.spec.
In addition, it removes a line for gc_alignObjects because it conflicts
with env_data64.

Signed-off-by: knn-k <konno@jp.ibm.com>