### PR TITLE
Add flattening support for valuetypes

### DIFF
--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1401,9 +1401,10 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 	UDATA limit = objectClass->totalInstanceSize;
 
 	if (isValueType) {
-		if (0 <= (IDATA)objectClass->lockOffset) {
-			/* skip lockword */
-			limit -= sizeof(j9objectmonitor_t);
+		U_32 firstFieldOffset = (U_32) objectClass->backfillOffset;
+		if (0 != firstFieldOffset) {
+			/* subtract padding */
+			offset += firstFieldOffset;
 			descriptionBits >>= 1;
 			descriptionIndex -= 1;
 		}

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -351,16 +351,9 @@ public:
 	}
 
 	VMINLINE UDATA
-	mixedObjectGetDataSize(J9Class *objectClass, bool dontIncludeLockword)
+	mixedObjectGetDataSize(J9Class *objectClass)
 	{
-		UDATA size = objectClass->totalInstanceSize;
-		if (dontIncludeLockword) {
-			if ((0 <= (IDATA)objectClass->lockOffset)) {
-				size -= sizeof(j9objectmonitor_t);
-			}
-		}
-
-		return size;
+		return objectClass->totalInstanceSize;
 	}
 
 	VMINLINE void
@@ -395,8 +388,11 @@ public:
 			}
 		} else {
 			UDATA offset = 0;
-			bool isValueType = J9_IS_J9CLASS_VALUETYPE(objectClass);
-			UDATA limit = mixedObjectGetDataSize(objectClass, isValueType);
+			UDATA limit = mixedObjectGetDataSize(objectClass);
+			
+			if (J9_IS_J9CLASS_VALUETYPE(objectClass)) {
+				offset += objectClass->backfillOffset;
+			}
 			
 			while (offset < limit) {
 				*(fj9object_t *)((UDATA)destObject + offset + destOffset) = *(fj9object_t *)((UDATA)srcObject + offset + srcOffset);

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -453,6 +453,7 @@ classForSignature(struct J9VMThread *vmThread, U_8 **sigDataPtr, struct J9ClassL
 
 	/* Non-array case */
 	switch (c) {
+	case 'Q':
 	case 'L': {
 		/* object case */
 		U_8 *tempData = sigData;

--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -667,8 +667,14 @@ jvmtiGetClassFields(jvmtiEnv* env,
 
 			i = 0;
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			result = vmFuncs->fieldOffsetsStartDo(vm, romClass, GET_SUPERCLASS(clazz), &state,
+					J9VM_FIELD_OFFSET_WALK_INCLUDE_STATIC | J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE, clazz->flattenedClassCache);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			result = vmFuncs->fieldOffsetsStartDo(vm, romClass, GET_SUPERCLASS(clazz), &state,
 					J9VM_FIELD_OFFSET_WALK_INCLUDE_STATIC | J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE );
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 			while (NULL != result->field) {
 				UDATA inconsistentData = 0;
 				J9JNIFieldID * fieldID = vmFuncs->getJNIFieldID(currentThread, clazz, result->field, result->offset, &inconsistentData);

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1116,7 +1116,14 @@ findFieldIndexFromOffset(J9VMThread *currentThread, J9Class *clazz, UDATA offset
 		J9ROMClass * const romClass = clazz->romClass;
 		J9Class * const superclazz = GET_SUPERCLASS(clazz);
 		J9ROMFieldOffsetWalkState state;
-		J9ROMFieldOffsetWalkResult *result = vmFuncs->fieldOffsetsStartDo(vm, romClass, superclazz, &state, walkFlags);
+		J9ROMFieldOffsetWalkResult *result = NULL;
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		result = vmFuncs->fieldOffsetsStartDo(vm, romClass, superclazz, &state, walkFlags, clazz->flattenedClassCache);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+		result = vmFuncs->fieldOffsetsStartDo(vm, romClass, superclazz, &state, walkFlags);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 		while (NULL != result->field) {
 			if (staticBit == (result->field->modifiers & J9AccStatic)) {
 				if (offset == result->offset) {

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -72,6 +72,11 @@
  */
 #define J9ROMCLASS_IS_CONTENDED(romClass)	_J9ROMCLASS_J9MODIFIER_IS_SET((romClass), J9AccClassIsContended)
 
+#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
+/* Will need to modify this if ValObject/RefObject proposal goes through */
+#define J9ROMCLASS_IS_VALUE(romClass)	_J9ROMCLASS_SUNMODIFIER_IS_SET((romClass), J9AccValueType)
+#endif/* #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES */
+
 #define J9ROMMETHOD_IS_GETTER(romMethod)				_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccGetterMethod)
 #define J9ROMMETHOD_IS_FORWARDER(romMethod)				_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccForwarderMethod)
 #define J9ROMMETHOD_IS_EMPTY(romMethod)					_J9ROMMETHOD_J9MODIFIER_IS_SET((romMethod), J9AccEmptyMethod)

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -356,6 +356,7 @@ enum INIT_STAGE {
 #define VMOPT_OPT_XXNOINTERLEAVEMEMORY "-XX:-InterleaveMemory"
 #define VMOPT_OPT_XXINTERLEAVEMEMORY "-XX:+InterleaveMemory"
 #define VMOPT_ROMMETHODSORTTHRESHOLD_EQUALS "-XX:ROMMethodSortThreshold="
+#define VMOPT_VALUEFLATTENINGTHRESHOLD_EQUALS "-XX:ValueTypeFlatteningThreshold="
 #define VMOPT_XXREDUCECPUMONITOROVERHEAD "-XX:+ReduceCPUMonitorOverhead"
 #define VMOPT_XXNOREDUCECPUMONITOROVERHEAD "-XX:-ReduceCPUMonitorOverhead"
 #define VMOPT_XXENABLECPUMONITOR "-XX:+EnableCPUMonitor"

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2166,15 +2166,20 @@ instanceFieldOffsetWithSourceClass(J9VMThread *vmStruct, J9Class *clazz, U_8 *fi
 
 /**
 * @brief Iterate over fields of the specified class in JVMTI order.
-* @param vm[in]			pointer to the J9JavaVM
-* @param romClass[in]	the ROM class whose fields will be iterated
-* @param superClazz[in] the RAM super class of the class whose fields will be iterated
-* @param state[in/out]  the walk state that can subsequently be passed to fieldOffsetsNextDo()
-* @param flags[in]		J9VM_FIELD_OFFSET_WALK_* flags
+* @param vm[in]					pointer to the J9JavaVM
+* @param romClass[in]			the ROM class whose fields will be iterated
+* @param superClazz[in]			the RAM super class of the class whose fields will be iterated
+* @param state[in/out]			the walk state that can subsequently be passed to fieldOffsetsNextDo()
+* @param flags[in]				J9VM_FIELD_OFFSET_WALK_* flags
+* @param flattenedClassCache[in]	A table of all flattened instance field types
 * @return J9ROMFieldOffsetWalkResult *
 */
 J9ROMFieldOffsetWalkResult *
+#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
+fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9ROMFieldOffsetWalkState *state, U_32 flags, J9FlattenedClassCache *flattenedClassCache);
+#else
 fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9ROMFieldOffsetWalkState *state, U_32 flags);
+#endif
 
 /**
 * @brief Iterate over fields of the specified class in JVMTI order.
@@ -2202,6 +2207,32 @@ fullTraversalFieldOffsetsStartDo(J9JavaVM *vm, J9Class *clazz, J9ROMFullTraversa
 */
 J9ROMFieldShape *
 fullTraversalFieldOffsetsNextDo(J9ROMFullTraversalFieldOffsetWalkState *state);
+
+#ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
+/**
+ * @brief Search for ramClass in flattened class cache
+ *
+ * @param flattenedClassCache[in]	A table of flattend instance field types
+ * @param className[in]				Name of class to search
+ * @param classNameLength[in]		Length of class name to search
+ *
+ * @return J9Class if found NULL otherwise
+ */
+J9Class *
+findJ9ClassInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, U_8 *className, UDATA classNameLength);
+
+/**
+ * @brief Search for index of field in flattened class cache
+ *
+ * @param flattenedClassCache[in]	A table of flattend instance field types
+ * @param nameAndSignature[in]		The name and signature of field to look for
+ *
+ * @return index if found 0 otherwise
+ */
+UDATA
+findIndexInFlattenedClassCache(J9FlattenedClassCache *flattenedClassCache, J9ROMNameAndSignature *nameAndSignature);
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
+
 
 /**
 * @brief

--- a/runtime/tests/vm/resolvefield_tests.c
+++ b/runtime/tests/vm/resolvefield_tests.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2014 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -161,9 +161,13 @@ checkForFieldOverlaps(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClass, U
 	for (i = 0; i < sizeof(J9Object); i++) {
 		buf[i] = 0xff;
 	}
-
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	walkResult = fieldOffsetsStartDo(vm, romClass, superClass, &walkState,
+			J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN, NULL);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	walkResult = fieldOffsetsStartDo(vm, romClass, superClass, &walkState,
 			J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	while (NULL != walkResult->field) {
 
 		fieldSize = calculateFieldSize(walkResult->field->modifiers);
@@ -209,8 +213,14 @@ checkForPresenceOfField(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClass,
 	J9ROMFieldOffsetWalkResult *walkResult;
 	J9ROMFieldOffsetWalkState walkState;
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	walkResult = fieldOffsetsStartDo(vm, romClass, superClass, &walkState,
+			J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN, NULL);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	walkResult = fieldOffsetsStartDo(vm, romClass, superClass, &walkState,
 			J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE | J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 	while (NULL != walkResult->field) {
 		J9UTF8 *resultFieldName = SRP_GET(walkResult->field->nameAndSignature.name, J9UTF8*);
 		UDATA resultFieldSize = calculateFieldSize(walkResult->field->modifiers);
@@ -281,8 +291,11 @@ testAddHiddenInstanceFields(J9PortLibrary *portLib, const char *testName,
 		outputErrorMessage(TEST_ERROR_ARGS, "createFakeROMClass() failed!\n");
 		goto _exit_test;
 	}
-
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	walkResult = fieldOffsetsStartDo(&javaVM, fakeROMClass, NULL, &walkState, J9VM_FIELD_OFFSET_WALK_CALCULATE_INSTANCE_SIZE, NULL);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	walkResult = fieldOffsetsStartDo(&javaVM, fakeROMClass, NULL, &walkState, J9VM_FIELD_OFFSET_WALK_CALCULATE_INSTANCE_SIZE);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	if (NULL == walkResult) {
 		outputErrorMessage(TEST_ERROR_ARGS, "fieldOffsetsStartDo() returned NULL!\n");
 		goto _exit_test;
@@ -311,8 +324,11 @@ testAddHiddenInstanceFields(J9PortLibrary *portLib, const char *testName,
 				javaVM.hiddenInstanceFields->offsetReturnPtr != &fieldOffset);
 			goto _exit_test;
 		}
-
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		walkResult = fieldOffsetsStartDo(&javaVM, fakeROMClass, NULL, &walkState, J9VM_FIELD_OFFSET_WALK_CALCULATE_INSTANCE_SIZE, NULL);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		walkResult = fieldOffsetsStartDo(&javaVM, fakeROMClass, NULL, &walkState, J9VM_FIELD_OFFSET_WALK_CALCULATE_INSTANCE_SIZE);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		if (NULL == walkResult) {
 			outputErrorMessage(TEST_ERROR_ARGS, "fieldOffsetsStartDo() returned NULL!\n");
 			goto _exit_test;

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, 2018 IBM Corp. and others
+// Copyright (c) 2006, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -777,3 +777,5 @@ TraceEntry=Trc_VM_sendResolveConstantDynamic_Entry Overhead=1 Level=2 Template="
 TraceExit=Trc_VM_sendResolveConstantDynamic_Exit Overhead=1 Level=2 Template="sendResolveConstantDynamic"
 
 TraceException=Trc_VM_CreateRAMClassFromROMClass_nestedValueClassNotVisible Overhead=1 Level=1 Template="Nested field (RAM class=%p, classloader=%p, this classloader=%p) is not visible. Throw IllegalAccessError"
+
+TraceEvent=Trc_VM_CreateRAMClassFromROMClass_valueTypeIsFlattened Overhead=1 Level=7 Template="ValueType is eligible for flattening name=%.*s j9class=%p"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2109,6 +2109,17 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				}
 			}
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			/* TODO pick a reasonable default */
+			vm->valueFlatteningThreshold = UDATA_MAX;
+			if ((argIndex = FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, VMOPT_VALUEFLATTENINGTHRESHOLD_EQUALS, NULL)) >= 0) {
+				UDATA threshold = 0;
+				char *optname = VMOPT_VALUEFLATTENINGTHRESHOLD_EQUALS;
+				GET_INTEGER_VALUE(argIndex, optname, threshold);
+				vm->valueFlatteningThreshold = threshold;
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 			if ((argIndex = FIND_AND_CONSUME_ARG(STARTSWITH_MATCH, VMOPT_XXDUMPLOADEDCLASSLIST, NULL)) >= 0) {
 				J9HookInterface **vmHooks = vm->internalVMFunctions->getVMHookInterface(vm);
 				GET_OPTION_VALUE(argIndex, '=', &optionValue);


### PR DESCRIPTION
Add flattening support for valuetypes 

This PR does not address volatile access of flattened fields
This PR does not address flattened value hidden fields
This PR does not allow flattened value contended fields
This PR does not address flattened value static fields
This PR does not address flattened value arrays

This PR introduces an option to -XX:ValueTypeFlatteningThreshold 
to set the threshold at which a flattenable value type is no 
longer flattened. 

Fields are ordered in the following manner:
- FlattenedTypeContainingDoubles
- Doubles
- FlattenedTypeContainingObjects
- Objects
- FlattenedTypeContainingSingles
- Singles

A valueType with a Q signature is flattenable. However, the JVM 
will only flatten it if the J9ClassIsFlattened bit is set in the 
classFlags (this is determined by the flattening threshold). If 
the instance field is resolved, flattened fields will have the 
J9FieldFlagFlattened bit set in the ram CP flags slot. If this
bit is set, the offset contained in the ram CP entry is not the 
field offset, rather it is an offset into the 
clazz->flattenedFieldCache[] table. Each entry in this table 
contains the J9Class for the flattened field and the real field 
offset.

When a field is flattened it does not contain a the lockword 
or padding, only instance fields. In order to do anything with a 
field one must first retrieve it with the getField bytecode, this
bytecode will create a new object and copy the contents of the 
flattened field into the new object, then place a reference to 
the new object on the stack. The new object will not have a 
lockword. If the first field requires an 8 byte alignment padding 
will be added after the header. If a type with padding bytes is 
flattened, the padding bytes will be ommitted from the the 
flattened representation. In order to determine if a ValueType 
has padding bytes, the backfilloffset is used to denote the 
starting offset of the first field. For a type without padding
this will be zero.

Some of this work is based on the PackedObjects tech preview and 
the work done by Eric Zhang.

Signed-off-by: tajila <atobia@ca.ibm.com>
Some of this work is based on the PackedObjects tech preview and 
the work done by Eric Zhang.

Signed-off-by: tajila <atobia@ca.ibm.com>