### PR TITLE
Update release notes for OpenSSL RSA support

### DIFF
--- a/doc/release-notes/0.12/0.12.md
+++ b/doc/release-notes/0.12/0.12.md
@@ -99,6 +99,12 @@ the state of the VM is set to idle. </td>
 information about this change, see the <a href="https://www.eclipse.org/openj9/docs/version0.12/">user documentation</a>.</td>
 </tr>
 
+<tr><td valign="top"><a href="https://github.com/eclipse/openj9/issues/3636">#3636</a></td>
+<td valign="top">OpenSSL V1.1 support for the RSA algorithm</td>
+<td valign="top">OpenJDK8 and later (All platforms except AIX)</td>
+<td valign="top">OpenSSL 1.1.x support is now available for the RSA algorithm, in addition to Digest, CBC, and GCM.</a></td>
+</tr>
+
 </table>
 
 


### PR DESCRIPTION
Add a new row to the Changes table to include the
RSA support for OpenSSL 1.1 on all platforms except
AIX.

[ci-skip]

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>