### PR TITLE
Stop emitting SVM records for primitive arrays

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -62,6 +62,13 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
       TR_OpaqueClassBlock *component = _fej9->getComponentClassFromArrayClass(arrayClass);
       defineGuaranteedID(arrayClass, TR::SymbolType::typeClass);
       defineGuaranteedID(component, TR::SymbolType::typeClass);
+
+      // Records relating the arrayClass and componentClass here would be
+      // redundant.
+      _alreadyGeneratedRecords.insert(
+         new (_region) ArrayClassFromComponentClassRecord(arrayClass, component));
+      _alreadyGeneratedRecords.insert(
+         new (_region) ComponentClassFromArrayClassRecord(component, arrayClass));
       }
    }
 


### PR DESCRIPTION
Even with guaranteed IDs for the primitive types and their (1-dimensional) array types, the symbol validation manager (SVM) could still emit redundant records for these array-component relationships. For example, if `byte[]` were found by name, `addClassByNameRecord()` would create an `ArrayClassFromComponentClass` record, and the record would actually be emitted because it isn't a duplicate.

Since such records are never necessary, the `_alreadyGeneratedRecords` set will now be seeded with them so that they are no longer emitted.