### PR TITLE
Localize releaseCodeMemory to OpenJ9 FrontEnd

### DIFF
--- a/runtime/compiler/arm/runtime/Recomp.cpp
+++ b/runtime/compiler/arm/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -230,7 +230,8 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
          printf("\tsampling recomp, releasing code memory oldStartPC = 0x%x, bytesToSaveAtStart = 0x%x\n",oldStartPC, bytesToSaveAtStart);
          fflush(stdout);
          }
-      fe->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+      fej9->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
       }
    }
 

--- a/runtime/compiler/p/runtime/Recomp.cpp
+++ b/runtime/compiler/p/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -184,7 +184,10 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
    // without counting method bodies.  _countingPatchCallSite still refers
    // to the methodInfo poitner in the snippet area.
    if (linkageInfo->isSamplingMethodBody() && !codeMemoryWasAlreadyReleased)
-      fe->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
+      {
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+      fej9->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
+      }
    }
 
 void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *fe)

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -263,7 +263,8 @@ void J9::Recompilation::methodHasBeenRecompiled(void *oldStartPC, void *newStart
       // Now tell the VM that the method has been uncommitted - and the code memory
       // allocated can be reused
       //
-      fe->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+      fej9->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
       }
    }
 

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -319,7 +319,10 @@ J9::Recompilation::methodHasBeenRecompiled(void * oldStartPC, void * newStartPC,
    // allocated can be reused
    //
    if (!codeMemoryWasAlreadyReleased)
-      fe->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
+      {
+      TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+      fej9->releaseCodeMemory(oldStartPC, bytesToSaveAtStart);
+      }
 
    }
 


### PR DESCRIPTION
This FrontEnd functionality is exclusive to OpenJ9.  In preparation for
removing it from OMR, localize its use to the OpenJ9 FrontEnd.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>