### PR TITLE
Fix DDR test for free tag

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/MonitorIterator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/walkers/MonitorIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,11 +49,10 @@ import com.ibm.j9ddr.vm29.types.UDATA;
  * walks the heap in order to find any flat object monitors.
  * 
  * @author Adam Pilkington
- *
  */
 @SuppressWarnings("rawtypes")
 public class MonitorIterator implements Iterator {
-	private static final long freeTag = new UDATA(-1).longValue();
+	private static final UDATA FREE_TAG = new UDATA(-1);
 	private final Logger log = Logger.getLogger(LoggerNames.LOGGER_WALKERS);
 	private J9ThreadMonitorPoolPointer pool;
 	private int index = 0;
@@ -107,7 +106,7 @@ public class MonitorIterator implements Iterator {
 			while(index < poolSize) {
 				J9ThreadMonitorPointer monitor = J9ThreadMonitorPointer.cast(poolEntries.add(index));
 				index++;
-				if(freeTag != monitor.count().longValue()) {
+				if (!FREE_TAG.eq(monitor.count())) {
 					J9ThreadAbstractMonitorPointer lock = J9ThreadAbstractMonitorPointer.cast(monitor);
 					if (lock.flags().allBitsIn(J9ThreadAbstractMonitor.J9THREAD_MONITOR_OBJECT)) {
 						if(!lock.userData().eq(0)) {	//this is an object monitor in the system monitor table


### PR DESCRIPTION
Instead of the test succeeding, it would throw:
> InvalidDataTypeException: U64 contains value larger than Long.MAX_VALUE