### PR TITLE
Add logic to specify test with different aot tags

### DIFF
--- a/test/TestConfig/playlist.xsd
+++ b/test/TestConfig/playlist.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  Copyright (c) 2017, 2018 IBM Corp. and others
+  Copyright (c) 2017, 2019 IBM Corp. and others
 
   This program and the accompanying materials are made available under
   the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,7 @@
               <xs:element type="xs:string" name="disabled" minOccurs="0"/>
               <xs:element type="xs:string" name="capabilities" minOccurs="0"/>
               <xs:element type="xs:string" name="platformRequirements" minOccurs="0"/>
+              <xs:element type="xs:string" name="aot"/>
               <xs:element name="tags" minOccurs="0">
                 <xs:complexType>
                   <xs:sequence>

--- a/test/TestConfig/run_configure.mk
+++ b/test/TestConfig/run_configure.mk
@@ -1,5 +1,5 @@
 ##############################################################################
-#  Copyright (c) 2016, 2018 IBM Corp. and others
+#  Copyright (c) 2016, 2019 IBM Corp. and others
 #
 #  This program and the accompanying materials are made available under
 #  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,7 +68,7 @@ autoconfig:
 
 autogen: autoconfig
 	cd $(CURRENT_DIR)$(D)scripts$(D)testKitGen; \
-	perl testKitGen.pl --graphSpecs=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) $(OPTS); \
+	perl testKitGen.pl --graphSpecs=$(SPEC) --jdkVersion=$(JDK_VERSION) --impl=$(JDK_IMPL) --buildList=${BUILD_LIST} --iterations=$(TEST_ITERATIONS) --testFlag=$(TEST_FLAG) $(OPTS); \
 	cd $(CURRENT_DIR);
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)

--- a/test/TestConfig/scripts/testKitGen/testKitGen.pl
+++ b/test/TestConfig/scripts/testKitGen/testKitGen.pl
@@ -40,6 +40,7 @@ my $impl           = '';
 my $output         = '';
 my $buildList      = '';
 my $iterations     = 1;
+my $testFlag       = '';
 my @allLevels      = ( "sanity", "extended", "special" );
 my @allGroups      = ( "functional", "openjdk", "external", "perf", "jck", "system" );
 my @allImpls       = ( "openj9", "ibm", "hotspot", "sap" );
@@ -63,6 +64,8 @@ foreach my $argv (@ARGV) {
 		$buildList = $1;
 	} elsif ( $argv =~ /^--iterations=(.*)/ ) {
 		$iterations = $1;
+	} elsif ( $argv =~ /^--testFlag=(.*)/ ) {
+		$testFlag = $1;
 	} else {
 		print "This program will search projectRootDir provided and find/parse playlist.xml to generate\n"
 			. "makefile (per project)\n"
@@ -83,7 +86,8 @@ foreach my $argv (@ARGV) {
 			. "                            If the ottawaCsv is not provided, the program will try to find ottawa.csv under projectRootDir/TestConfig/resources.\n"
 			. "  --buildList=<paths>       Comma separated project paths to search playlist.xml. The paths are relative to projectRootDir.\n"
 			. "                            If the buildList is not provided, the program will search all files under projectRootDir.\n"
-			. "  --iterations=<number>     Repeatedly generate test command based on iteration number. The default value is 1.\n";
+			. "  --iterations=<number>     Repeatedly generate test command based on iteration number. The default value is 1.\n"
+			. "  --testFlag=<string>       Comma separated string to specify different test flag. The default is empty.\n";
 			die "Please specify valid options!";
 	}
 }
@@ -110,6 +114,7 @@ if ( !$impl ) {
 }
 
 # run make file generator
-runmkgen( $projectRootDir, \@allLevels, \@allGroups, $output, $graphSpecs, $jdkVersion, \@allImpls, $impl, $modesxml, $ottawacsv, $buildList, $iterations );
+
+runmkgen( $projectRootDir, \@allLevels, \@allGroups, $output, $graphSpecs, $jdkVersion, \@allImpls, $impl, $modesxml, $ottawacsv, $buildList, $iterations, $testFlag );
 
 print "\nTEST AUTO GEN SUCCESSFUL\n";


### PR DESCRIPTION
- test can be tagged with aot applicable, nonapplicable and explicit
- when TEST_FLAG contains aot, the tests will behave differently as follows
- nonapplicable test will not be generated
- applicable test will be specially generated (iterations and aot options)
- explicit test will be generated as is

[ci skip]

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>