### PR TITLE
Compress interface dispatch tables

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -437,7 +437,7 @@ fast_jitNewObjectImpl(J9VMThread *currentThread, J9Class *objectClass, bool chec
 			goto slow;
 		}
 	}
-	if (J9_UNEXPECTED(J9_ARE_ANY_BITS_SET(objectClass->romClass->modifiers, J9AccAbstract | J9AccInterface))) {
+	if (J9_UNEXPECTED(J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(objectClass->romClass))) {
 		goto slow;
 	}
 	{
@@ -471,7 +471,7 @@ slow_jitNewObjectImpl(J9VMThread *currentThread, bool checkClassInit, bool nonZe
 	if (nonZeroTLH) {
 		allocationFlags |= J9_GC_ALLOCATE_OBJECT_NON_ZERO_TLH;
 	}
-	if (J9_ARE_ANY_BITS_SET(objectClass->romClass->modifiers, J9AccAbstract | J9AccInterface)) {
+	if (J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(objectClass->romClass)) {
 		buildJITResolveFrameForRuntimeHelper(currentThread, parmCount);
 		addr = setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGINSTANTIATIONERROR | J9_EX_CTOR_CLASS, J9VM_J9CLASS_TO_HEAPCLASS(objectClass));
 		goto done;

--- a/runtime/codert_vm/jswalk.c
+++ b/runtime/codert_vm/jswalk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1117,10 +1117,10 @@ static void jitWalkResolveMethodFrame(J9StackWalkState *walkState)
 			J9ITable *allInterfaces = (J9ITable*)resolvedClass->iTable;
 			for(;;) {
 				J9Class *interfaceClass = allInterfaces->interfaceClass;
-				UDATA methodCount = interfaceClass->romClass->romMethodCount;
+				UDATA methodCount = J9INTERFACECLASS_ITABLEMETHODCOUNT(interfaceClass);
 				if (methodIndex < methodCount) {
 					/* iTable segment located */
-					ramMethod = interfaceClass->ramMethods + methodIndex;
+					ramMethod = iTableMethodAtIndex(interfaceClass, methodIndex);
 					break;
 				}
 				methodIndex -= methodCount;

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,8 +99,9 @@ lookupInterfaceMethod(J9VMThread *currentThread, J9Class *lookupClass, J9UTF8 *n
 			method = NULL;
 		} else {
 			if (J9_ARE_ANY_BITS_SET(J9_CLASS_FROM_METHOD(method)->romClass->modifiers, J9_JAVA_INTERFACE)) {
-				*methodIndex = getITableIndexForMethod(method, lookupClass);
-				if (-1  == *methodIndex) {
+				if (J9ROMMETHOD_IN_ITABLE(J9_ROM_METHOD_FROM_RAM_METHOD(method))) {
+					*methodIndex = getITableIndexForMethod(method, lookupClass);
+				} else {
 					PORT_ACCESS_FROM_VMC(currentThread);
 					J9Class *clazz = J9_CLASS_FROM_METHOD(method);
 					J9UTF8 *className = J9ROMCLASS_CLASSNAME(clazz->romClass);

--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,5 +99,12 @@
 #define J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass) _J9ROMCLASS_SUNMODIFIER_IS_ANY_SET((romClass), J9AccClassArray | J9AccClassInternalPrimitiveType)
 #define J9ROMMETHOD_IS_NON_EMPTY_OBJECT_CONSTRUCTOR(romMethod) \
 	((((romMethod)->modifiers) & (J9AccMethodObjectConstructor | J9AccEmptyMethod)) == J9AccMethodObjectConstructor)
+
+#define J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(romClass) \
+	J9_ARE_ANY_BITS_SET((romClass)->modifiers, J9AccAbstract | J9AccInterface)
+
+/* Only public vTable methods go into the iTable */
+#define J9ROMMETHOD_IN_ITABLE(romMethod) \
+	J9_ARE_ALL_BITS_SET((romMethod)->modifiers, J9AccMethodVTable | J9AccPublic)
 
 #endif	/* _J9MODIFIERS_API_H */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2979,6 +2979,10 @@ typedef struct J9Class {
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
 } J9Class;
 
+/* Interface classes can never be instantiated - overload the totalInstanceSize slot to hold the iTable method count */
+#define J9INTERFACECLASS_ITABLEMETHODCOUNT(clazz) ((clazz)->totalInstanceSize)
+#define J9INTERFACECLASS_SET_ITABLEMETHODCOUNT(clazz, value) (clazz)->totalInstanceSize = (value)
+
 typedef struct J9ArrayClass {
 	UDATA eyecatcher;
 	struct J9ROMClass* romClass;

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1868,13 +1868,31 @@ getReturnTypeFromSignature(U_8 * inData, UDATA inLength, U_8 **outData);
 /* ---------------- mthutil.c ---------------- */
 
 /**
+ * @brief Retrieve the J9Method which maps to the index within the iTable for interfaceClass.
+ * @param interfaceClass The interface class to query
+ * @param index The iTable index
+ * @return J9Method* The J9Method which maps to index within interfaceClass
+  */
+J9Method *
+iTableMethodAtIndex(J9Class *interfaceClass, UDATA index);
+
+/**
+ * @brief Retrieve the iTable index of an interface method within the iTable for
+ *        its declaring class.
+ * @param method The interface method
+ * @return UDATA The iTable index (not including the fixed J9ITable header)
+ */
+UDATA
+getITableIndexWithinDeclaringClass(J9Method *method);
+
+/**
  * @brief Retrieve the index of an interface method within the iTable for an interface
  *        (not necessarily the same interface, as iTables contain methods from all
  *        extended interfaces as well as the local one).
  * @param method The interface method
  * @param targetInterface The interface in whose table to search
  *                        (NULL to use the declaring class of method)
- * @return UDATA The iTable index (not including the fixed J9ITable header), or -1 if not found
+ * @return UDATA The iTable index (not including the fixed J9ITable header)
  */
 UDATA
 getITableIndexForMethod(J9Method * method, J9Class *targetInterface);

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -7221,7 +7221,7 @@ retry:
 		J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);
 		J9RAMClassRef *ramCPEntry = ((J9RAMClassRef*)ramConstantPool) + index;
 		J9Class* volatile resolvedClass = ramCPEntry->value;
-		if ((NULL != resolvedClass) && (resolvedClass->romClass->modifiers & (J9AccAbstract | J9AccInterface)) == 0) {
+		if ((NULL != resolvedClass) && !J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(resolvedClass->romClass)) {
 			if (!VM_VMHelpers::classRequiresInitialization(_currentThread, resolvedClass)) {
 				j9object_t instance = _objectAllocate.inlineAllocateObject(_currentThread, resolvedClass);
 				if (NULL == instance) {

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -259,7 +259,7 @@ tryAgain:
 	ramClassRefWrapper = (J9RAMClassRef *)&ramCP[cpIndex];
 	resolvedClass = ramClassRefWrapper->value;
 	/* If resolving for "new", check if the class is instantiable */
-	if ((NULL != resolvedClass) && (J9_ARE_NO_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_INSTANTIABLE) || J9_ARE_NO_BITS_SET(resolvedClass->romClass->modifiers, J9AccAbstract | J9AccInterface))) {
+	if ((NULL != resolvedClass) && (J9_ARE_NO_BITS_SET(resolveFlags, J9_RESOLVE_FLAG_INSTANTIABLE) || !J9ROMCLASS_IS_ABSTRACT_OR_INTERFACE(resolvedClass->romClass))) {
 		/* ensure that the caller can safely read the modifiers field if it so desires */
 		issueReadBarrier();
 		goto done;


### PR DESCRIPTION
iTables contain vTable indices appropriate for the implementing class.
Today, iTables have a slot for every method in the interface, whether
that method has a vTable mapping or not, resulting in wasted space.

Compress iTables so they contain only appropriate methods (public
methods that appear in the vTable). For performance, overload the
totalInstanceSize field in interface J9Class structures to represent the
size of the iTable (interfaces can never be instantiated, so this field
is currently unused).

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>