### PR TITLE
Fix pltest on OSX

### DIFF
--- a/runtime/tests/port/j9processTest.c
+++ b/runtime/tests/port/j9processTest.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2230,12 +2230,14 @@ j9process_runTests(struct J9PortLibrary *portLibrary, char *argv0, char* j9proce
 		rc |= j9process_testRedirect(portLibrary);
 #if !defined(WIN32)
 		rc |= j9process_testCreateInNewProcessGroupUnix(portLibrary);
-#if !(defined(J9ZOS390) || defined(LINUX))
-		/* z/OS: writes extra characters to the console in the build environment when a process catches a SIGQUIT
-		 * Linux: in certain linux distros the /bin/sh command receives the SIGQUIT, see PR 56109 
+#if !(defined(J9ZOS390) || defined(LINUX) || defined(OSX))
+		/* z/OS: writes extra characters to the console in the build environment when a process catches a SIGQUIT.
+		 * Linux: in certain Linux distros the /bin/sh command receives a SIGQUIT signal, see PR 56109.
+		 * OSX: make, tee and other test framework processes receive a SIGQUIT signal, which causes the test
+		 *      framework to crash. See https://github.com/eclipse/openj9/issues/4520.
 		 */
 		rc |= j9process_testNewProcessGroupByTriggeringSignal(portLibrary);
-#endif /* !defined(J9ZOS390) */
+#endif /* !(defined(J9ZOS390) || defined(LINUX) || defined(OSX)) */
 #endif	/* !defined(WIN32) */
 		rc |= j9process_envTest(portLibrary);
 	}

--- a/runtime/tests/port/si.c
+++ b/runtime/tests/port/si.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2269,9 +2269,9 @@ j9sysinfo_runTests(struct J9PortLibrary *portLibrary, char *argv0)
 	rc |= j9sysinfo_test_get_groups(portLibrary);
 #endif /* !(defined(WIN32) || defined(WIN64)) */
 	rc |= j9sysinfo_test_get_l1dcache_line_size(portLibrary);
-#if !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM))
+#if !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM) || defined(OSX))
 	rc |= j9sysinfo_test_get_levels_and_types(portLibrary);
-#endif
+#endif /* !(defined(LINUXPPC) || defined(S390) || defined(J9ZOS390) || defined(J9ARM) || defined(OSX)) */
 #if defined(LINUX) || defined(AIXPPC)
 	/* Not supported on Z & OSX (and Windows, of course).  Enable, when available. */
 	rc |= j9sysinfo_test_get_open_file_count(portLibrary);

--- a/runtime/tests/port/si.c
+++ b/runtime/tests/port/si.c
@@ -1854,8 +1854,12 @@ j9sysinfo_test_get_cwd3(struct J9PortLibrary *portLibrary)
 	if (0 != rc) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "error failed to change current directory rc: %d\n", rc);
 	}
-#else
+#else /* defined(WIN32) */
+#if defined(OSX)
+	const char *utf8 = "/private/tmp/j9sysinfo_test_get_cwd3/";
+#else /* defined(OSX) */
 	const char *utf8 = "/tmp/j9sysinfo_test_get_cwd3/";
+#endif /* defined(OSX) */
 
 	reportTestEntry(portLibrary, testName);
 
@@ -1870,9 +1874,9 @@ j9sysinfo_test_get_cwd3(struct J9PortLibrary *portLibrary)
 	}
 #if defined(J9ZOS390)
 	rc = atoe_chdir(utf8);
-#else
+#else /* defined(J9ZOS390) */
 	rc = chdir(utf8);
-#endif
+#endif /* defined(J9ZOS390) */
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "cd %s failed rc: %d\n", utf8, rc);
 	} else {

--- a/test/functional/cmdLineTests/pltest/playlist.xml
+++ b/test/functional/cmdLineTests/pltest/playlist.xml
@@ -32,7 +32,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<!-- temporarily disable this test on windows; https://github.com/eclipse/openj9/issues/3212 -->
-		<!-- temporarily disable this test on osx; https://github.com/eclipse/openj9/issues/3685 -->
 		<platformRequirements>^os.aix,^os.win,^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -40,6 +39,37 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<groups>
 			<group>functional</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+		<subsets>
+			<subset>8</subset>
+			<subset>9</subset>
+			<subset>11+</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>cmdLineTester_pltest_osx</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
+	$(JAVA_COMMAND) $(JVM_OPTIONS) -DRESOURCES_DIR=$(Q)$(RESOURCES_DIR)$(Q) -DJVM_TEST_ROOT=$(Q)$(JVM_TEST_ROOT)$(Q) \
+	-DEXE='$(JAVA_SHARED_LIBRARIES_DIR)$(D)pltest -exclude:j9sock $(_JVM_OPTIONS)' -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)pltest.xml$(Q) -verbose -explainExcludes \
+	-xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.osx</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 		<subsets>
 			<subset>8</subset>
 			<subset>9</subset>


### PR DESCRIPTION
**1. Disable `j9sysinfo_test_get_levels_and_types` on OSX**

`j9sysinfo_test_get_levels_and_types` tests `j9sysinfo_get_cache_info` for
retrieving details about the cache types and levels. On OSX,
`j9sysinfo_get_cache_info` doesn't retrieve information about the cache
types and levels. So, `j9sysinfo_test_get_levels_and_types` is disabled on
OSX.

**2. Fix `j9sysinfo_test_get_cwd3` on OSX**

On OSX, "/tmp" is a symlink for "/private/tmp". On OSX,
`j9sysinfo_get_cwd` will return the full path, "/private/tmp". In
`j9sysinfo_test_get_cwd3`, "/private/tmp" should be used instead of "/tmp"
for testing `j9sysinfo_get_cwd` on OSX. `j9sysinfo_test_get_cwd3` has been
updated to account for this change.

**3. Disable j9process_testNewProcessGroupByTriggeringSignal on OSX**

`j9process_testNewProcessGroupByTriggeringSignal` sends a `SIGQUIT` signal
to the process group. When running this test on OSX, `make`, `tee` and other
test framework processes receive a `SIGQUIT` signal. This causes the test
framework to crash. Due to the incompatibility with the test framework,
this test is disabled on OSX.

**Issue:** #4520

**4. Add a new test target for the `pltest` suite on OSX**

All of the test issues in #3685 have been resolved. The `j9sock` API is
unimplemented on OSX. So, a new test target has been introduced to run
`pltest` on OSX while excluding the tests for the `j9sock` API. 

Add `<impls>...</impls>` for `cmdLineTester_pltest` and
`cmdLineTester_pltest_osx`.

**Closes:** #3685

**Note:** #4503 has been opened to implement the `j9sock` API for OSX.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>