### PR TITLE
Rename J9VMGCRememberedSet to MM_GCRememberedSet

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1687,7 +1687,7 @@ TR_J9VMBase::getFragmentParentOffset()
    {
 
 #if defined(J9VM_GC_REALTIME)
-    return offsetof(J9VMGCRememberedSetFragment, fragmentParent);
+    return offsetof(MM_GCRememberedSetFragment, fragmentParent);
 #endif
    return 0;
    }
@@ -1696,7 +1696,7 @@ UDATA
 TR_J9VMBase::getRememberedSetGlobalFragmentOffset()
    {
 #if defined(J9VM_GC_REALTIME)
-      return offsetof(J9VMGCRememberedSet, globalFragmentIndex);
+      return offsetof(MM_GCRememberedSet, globalFragmentIndex);
 #endif
    return 0;
    }
@@ -1705,7 +1705,7 @@ UDATA
 TR_J9VMBase::getLocalFragmentOffset()
    {
 #if defined(J9VM_GC_REALTIME)
-       return offsetof(J9VMGCRememberedSetFragment, localFragmentIndex);
+       return offsetof(MM_GCRememberedSetFragment, localFragmentIndex);
 #endif
     return 0;
    }

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2683,8 +2683,8 @@ private:
 	internalPreStoreObjectSATB(J9VMThread *vmThread, j9object_t object, fj9object_t *destAddress, j9object_t value)
 	{
 #if defined(J9VM_GC_REALTIME)
-		J9VMGCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
-		J9VMGCRememberedSet *parent = fragment->fragmentParent;
+		MM_GCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
+		MM_GCRememberedSet *parent = fragment->fragmentParent;
 		/* Check if the barrier is enabled.  No work if barrier is not enabled */
 		if (0 != parent->globalFragmentIndex) {
 			/* if the double barrier is enabled call OOL */
@@ -2714,8 +2714,8 @@ private:
 	internalStaticPreStoreObjectSATB(J9VMThread *vmThread, j9object_t object, j9object_t *destAddress, j9object_t value)
 	{
 #if defined(J9VM_GC_REALTIME)
-		J9VMGCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
-		J9VMGCRememberedSet *parent = fragment->fragmentParent;
+		MM_GCRememberedSetFragment *fragment =  &vmThread->sATBBarrierRememberedSetFragment;
+		MM_GCRememberedSet *parent = fragment->fragmentParent;
 		/* Check if the barrier is enabled.  No work if barrier is not enabled */
 		if (0 != parent->globalFragmentIndex) {
 			/* if the double barrier is enabled call OOL */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2723,14 +2723,6 @@ typedef struct J9VMGCSegregatedAllocationCacheEntry {
 
 #endif /* J9VM_GC_REALTIME */
 
-#if defined(J9VM_GC_STACCATO)
-
-typedef MM_GCRememberedSet J9VMGCRememberedSet;
-
-typedef MM_GCRememberedSetFragment J9VMGCRememberedSetFragment;
-
-#endif /* J9VM_GC_STACCATO */
-
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 
 typedef struct J9GCVMInfo {
@@ -4826,8 +4818,8 @@ typedef struct J9VMThread {
 	struct J9StackWalkState* stackWalkState;
 	struct J9VMEntryLocalStorage* entryLocalStorage;
 	UDATA gpProtected;
-	J9VMGCSublistFragment gcRememberedSet;
-	J9VMGCRememberedSetFragment sATBBarrierRememberedSetFragment;
+	struct J9VMGCSublistFragment gcRememberedSet;
+	struct MM_GCRememberedSetFragment sATBBarrierRememberedSetFragment;
 	void* gcTaskListPtr;
 	UDATA* dropBP;
 	UDATA dropFlags;


### PR DESCRIPTION
Last step in adding missing struct MM_GCRememberedSet to OMR and replacing the original J9VMGCRememberedSet structure.
Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>