### PR TITLE
Report final field modification by calling runtime helper

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1097,9 +1097,9 @@ TR_J9InlinerPolicy::createUnsafePutWithOffset(TR::ResolvedMethodSymbol *calleeSy
          traceMsg(comp(),"\t Duplicate Tree for ordered call, orderedCallNode = %p\n",orderedCallNode);
       }
 
-   static char *enableIllegalWriteReport = feGetEnv("TR_EnableIllegalWriteReport");
+   static char *disableIllegalWriteReport = feGetEnv("TR_DisableIllegalWriteReport");
    TR::TreeTop* reportFinalFieldModification = NULL;
-   if (enableIllegalWriteReport && !comp()->getOption(TR_DisableGuardedStaticFinalFieldFolding))
+   if (!disableIllegalWriteReport && !comp()->getOption(TR_DisableGuardedStaticFinalFieldFolding))
       {
       reportFinalFieldModification = TR::TransformUtil::generateReportFinalFieldModificationCallTree(comp(), unsafeCall->getArgument(1)->duplicateTree());
       }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -264,9 +264,9 @@ void J9::RecognizedCallTransformer::processUnsafeAtomicCall(TR::TreeTop* treetop
       if (enableTrace)
          traceMsg(comp(), "Created isNotLowTagged test node n%dn, static field will fall through to Block_%d\n", isNotLowTaggedNode->getGlobalIndex(), treetop->getEnclosingBlock()->getNumber());
 
-      static char *enableIllegalWriteReport = feGetEnv("TR_EnableIllegalWriteReport");
+      static char *disableIllegalWriteReport = feGetEnv("TR_DisableIllegalWriteReport");
       // Test if the call is a write to a static final field
-      if (enableIllegalWriteReport
+      if (!disableIllegalWriteReport
           && !comp()->getOption(TR_DisableGuardedStaticFinalFieldFolding)
           && TR_J9MethodBase::isUnsafePut(unsafeCall->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod()))
          {

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1931,3 +1931,14 @@ void J9::TransformUtil::separateNullCheck(TR::Compilation* comp, TR::TreeTop* tr
          break;
       }
    }
+
+TR::TreeTop *
+J9::TransformUtil::generateReportFinalFieldModificationCallTree(TR::Compilation *comp, TR::Node *node)
+   {
+   TR::Node* j9class = TR::Node::createWithSymRef(node, TR::aloadi, 1, node, comp->getSymRefTab()->findOrCreateClassFromJavaLangClassSymbolRef());
+   // If this is the first modification on static final field for this class, the notification is a stop-the-world event, gc may happen.
+   TR::SymbolReference* symRef = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_reportFinalFieldModified, true /*canGCandReturn*/, false /*canGCandExcept*/, true);
+   TR::Node *callNode = TR::Node::createWithSymRef(node, TR::call, 1, j9class, symRef);
+   TR::TreeTop *tt = TR::TreeTop::create(comp, TR::Node::create(TR::treetop, 1, callNode));
+   return tt;
+   }

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -139,6 +139,15 @@ public:
     *   \param trace Bool to enable tracing
     */
    static void separateNullCheck(TR::Compilation* comp, TR::TreeTop* tree, bool trace = false);
+   /*
+    * \brief
+    *    Generate a tree to report modification to a static final field after intialization.
+    *
+    * \param node The java/lang/Class object
+    *
+    * \return Tree with the call to `jitReportFinalFieldModified`
+    */
+   static TR::TreeTop* generateReportFinalFieldModificationCallTree(TR::Compilation *comp, TR::Node *node);
 
 protected:
    /**

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1131,6 +1131,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_reportMethodEnter,          (void *)jitReportMethodEnter,          TR_Helper);
    SET(TR_reportStaticMethodEnter,    (void *)jitReportStaticMethodEnter,    TR_Helper);
    SET(TR_reportMethodExit,           (void *)jitReportMethodExit,           TR_Helper);
+   SET(TR_reportFinalFieldModified,   (void *)jitReportFinalFieldModified,   TR_Helper);
    SET(TR_acquireVMAccess,            (void *)jitAcquireVMAccess,            TR_Helper);
    SET(TR_jitReportInstanceFieldRead, (void *)jitReportInstanceFieldRead,    TR_Helper);
    SET(TR_jitReportInstanceFieldWrite,(void *)jitReportInstanceFieldWrite,   TR_Helper);


### PR DESCRIPTION
Keeping the Unsafe call as the slow path is suboptimal compared to using
the runtime helper.
- Unsafe call consumes more arguments, which means more registers.
- Unsafe call has more use and def aliases and not transparent to the
  optimizer.
- For Unsafe call that returns a result, a temp has to be created to
  store result from the fast path and from the slow path.

Therefore, report the ilegal modification through the runtime helper
jitReportFinalFieldModified.

Also Enable the illegal write notification in this PR.

closes: #4385

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>