### PR TITLE
Removed single line annotation comments from #include directives

### DIFF
--- a/runtime/compiler/codegen/CodeGenGC.cpp
+++ b/runtime/compiler/codegen/CodeGenGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,36 +31,36 @@
 
 #include "codegen/J9CodeGenerator.hpp" // IWYU pragma: keep
 
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include <string.h>                            // for memset, NULL
+#include <stdint.h>
+#include <string.h>
 #include "env/StackMemoryRegion.hpp"
-#include "codegen/BackingStore.hpp"            // for TR_BackingStore
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
+#include "codegen/BackingStore.hpp"
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
-#include "codegen/GCStackAtlas.hpp"            // for GCStackAtlas
-#include "codegen/GCStackMap.hpp"              // for TR_GCStackMap, etc
-#include "codegen/Instruction.hpp"             // for Instruction
-#include "codegen/Linkage.hpp"                 // for Linkage
-#include "codegen/Snippet.hpp"                 // for Snippet
-#include "compile/Compilation.hpp"             // for Compilation
+#include "codegen/GCStackAtlas.hpp"
+#include "codegen/GCStackMap.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/Linkage.hpp"
+#include "codegen/Snippet.hpp"
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "env/ObjectModel.hpp"                 // for ObjectModel
+#include "env/ObjectModel.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/TRMemory.hpp"                    // for TR_Memory, etc
-#include "env/jittypes.h"                      // for TR_ByteCodeInfo
-#include "il/Node.hpp"                         // for Node
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/SymbolReference.hpp"              // for SymbolReference
-#include "il/symbol/AutomaticSymbol.hpp"       // for AutomaticSymbol
-#include "il/symbol/ParameterSymbol.hpp"       // for ParameterSymbol
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/BitVector.hpp"                 // for TR_BitVector
-#include "infra/IGNode.hpp"                    // for IGNodeColour, etc
-#include "infra/InterferenceGraph.hpp"         // for TR_InterferenceGraph
-#include "infra/List.hpp"                      // for ListIterator, List
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/Node.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/IGNode.hpp"
+#include "infra/InterferenceGraph.hpp"
+#include "infra/List.hpp"
+#include "ras/Debug.hpp"
 
 void
 J9::CodeGenerator::createStackAtlas()

--- a/runtime/compiler/codegen/CodeGenRA.cpp
+++ b/runtime/compiler/codegen/CodeGenRA.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,59 +31,59 @@
 
 #include "codegen/J9CodeGenerator.hpp"
 
-#include <limits.h>                            // for INT_MAX
-#include <stdint.h>                            // for int32_t, uint8_t, etc
-#include <stdlib.h>                            // for NULL, atoi
-#include <algorithm>                           // for std::find, etc
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <algorithm>
 #include "codegen/BackingStore.hpp"
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
-#include "codegen/FrontEnd.hpp"                // for feGetEnv, etc
-#include "codegen/GCStackAtlas.hpp"            // for GCStackAtlas
-#include "codegen/Instruction.hpp"             // for Instruction
-#include "codegen/Linkage.hpp"                 // for Linkage
+#include "codegen/FrontEnd.hpp"
+#include "codegen/GCStackAtlas.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/Linkage.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/LiveReference.hpp"
 #include "codegen/LiveRegister.hpp"
-#include "codegen/Register.hpp"                // for Register
+#include "codegen/Register.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/TreeEvaluator.hpp"
-#include "compile/Compilation.hpp"             // for Compilation
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/IO.hpp"                          // for POINTER_PRINTF_FORMAT
-#include "env/ObjectModel.hpp"                 // for ObjectModel
+#include "env/IO.hpp"
+#include "env/ObjectModel.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                        // for Block
-#include "il/DataTypes.hpp"                    // for DataType, etc
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/ILOps.hpp"                        // for ILOpCode, etc
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/Node_inlines.hpp"                 // for Node::getType, etc
-#include "il/Symbol.hpp"                       // for Symbol
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
 #include "il/SymbolReference.hpp"
-#include "il/TreeTop.hpp"                      // for TreeTop
+#include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
 #include "il/symbol/AutomaticSymbol.hpp"
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol
+#include "il/symbol/MethodSymbol.hpp"
 #include "il/symbol/ParameterSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "infra/Array.hpp"                     // for TR_Array
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/BitVector.hpp"                 // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                       // for CFG
-#include "infra/Flags.hpp"                     // for flags32_t
-#include "infra/Link.hpp"                      // for TR_LinkHead
-#include "infra/List.hpp"                      // for List, etc
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
-#include "infra/TRCfgNode.hpp"                 // for CFGNode
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Flags.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
 #include "optimizer/Optimizations.hpp"
 #include "optimizer/RegisterCandidate.hpp"
 #include "optimizer/Structure.hpp"
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "ras/Debug.hpp"
 
 TR::AutomaticSymbol *
 J9::CodeGenerator::allocateVariableSizeSymbol(int32_t size)

--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,10 +30,10 @@
 #pragma csect(TEST,"TRJ9CGPhase#T")
 
 
-#include "codegen/CodeGenPhase.hpp"                   // for CodeGenPhase, etc
-#include "codegen/CodeGenerator.hpp"                  // for CodeGenerator, etc
-#include "compile/Compilation.hpp"                    // for Compilation
-#include "il/Block.hpp"                        // for Block
+#include "codegen/CodeGenPhase.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "il/Block.hpp"
 #include "optimizer/SequentialStoreSimplifier.hpp"
 #include "env/VMJ9.h"
 

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -24,13 +24,13 @@
 #pragma csect(STATIC,"TRJ9CGBase#S")
 #pragma csect(TEST,"TRJ9CGBase#T")
 
-#include <algorithm>                            // for std::find
+#include <algorithm>
 #include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/PicHelpers.hpp"
 #include "codegen/Relocation.hpp"
-#include "codegen/Instruction.hpp"              // for Instruction
+#include "codegen/Instruction.hpp"
 #include "codegen/MonitorState.hpp"
 #include "compile/AOTClassInfo.hpp"
 #include "compile/Compilation.hpp"
@@ -45,18 +45,18 @@
 #include "il/Block.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/NodePool.hpp"                // for NodePool
-#include "il/Symbol.hpp"                  // for Symbol
-#include "il/symbol/ParameterSymbol.hpp"       // for ParameterSymbol
-#include "il/symbol/AutomaticSymbol.hpp"  // for AutomaticSymbol
-#include "il/symbol/StaticSymbol.hpp"     // for StaticSymbol
-#include "il/symbol/LabelSymbol.hpp"      // for LabelSymbol
+#include "il/NodePool.hpp"
+#include "il/Symbol.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "il/symbol/LabelSymbol.hpp"
 #include "infra/Assert.hpp"
-#include "infra/BitVector.hpp"                      // for TR_BitVector, etc
+#include "infra/BitVector.hpp"
 #include "infra/List.hpp"
 #include "optimizer/Structure.hpp"
 #include "optimizer/TransformUtil.hpp"
-#include "ras/Delimiter.hpp"                   // for Delimiter
+#include "ras/Delimiter.hpp"
 #include "ras/DebugCounter.hpp"
 #include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheExceptions.hpp"

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -35,15 +35,15 @@ namespace J9 { typedef J9::CodeGenerator CodeGeneratorConnector; }
 
 #include "codegen/OMRCodeGenerator.hpp"
 
-#include <stdint.h>        // for int32_t
-#include "env/IO.hpp"      // for POINTER_PRINTF_FORMAT
-#include "env/jittypes.h"  // for uintptr_t
-#include "infra/List.hpp"  // for List, etc
+#include <stdint.h>
+#include "env/IO.hpp"
+#include "env/jittypes.h"
+#include "infra/List.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "optimizer/Dominators.hpp"
-#include "cs2/arrayof.h"   // for ArrayOf
+#include "cs2/arrayof.h"
 
 class NVVMIRBuffer;
 class TR_BitVector;

--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -22,14 +22,14 @@
 
 #include "codegen/TreeEvaluator.hpp"
 
-#include "util_api.h"                           // for instanceOfOrCheckCast, instanceOfOrCheckCastNoCacheUpdate
-#include "codegen/CodeGenerator.hpp"            // for CodeGenerator
+#include "util_api.h"
+#include "codegen/CodeGenerator.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/IO.hpp"                           // for POINTER_PRINTF_FORMAT
+#include "env/IO.hpp"
 #include "env/VMJ9.h"
 #include "il/symbol/StaticSymbol.hpp"
 #include "il/Node.hpp"
-#include "il/Node_inlines.hpp"                  // for getFirstChild, etc
+#include "il/Node_inlines.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "runtime/J9Profiler.hpp"
 #include "runtime/J9ValueProfiler.hpp"

--- a/runtime/compiler/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/codegen/J9UnresolvedDataSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ namespace J9 { typedef J9::UnresolvedDataSnippet UnresolvedDataSnippetConnector;
 
 #include "codegen/OMRUnresolvedDataSnippet.hpp"
 
-#include <stdint.h>                         // for uint8_t, int32_t
+#include <stdint.h>
 
 namespace TR { class SymbolReference; }
 namespace TR { class CodeGenerator; }

--- a/runtime/compiler/codegen/PicHelpers.hpp
+++ b/runtime/compiler/codegen/PicHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef PICHELPERS_HPP
 #define PICHELPERS_HPP
 
-#include <stdint.h>  // for uint32_t
+#include <stdint.h>
 
 namespace OMR { class RuntimeAssumption; }
 class TR_UnloadedClassPicSite;

--- a/runtime/compiler/compile/Compilation.hpp
+++ b/runtime/compiler/compile/Compilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef TR_COMPILATION_INCL
 #define TR_COMPILATION_INCL
 
-#include "compile/J9Compilation.hpp"  // for CompilationConnector
+#include "compile/J9Compilation.hpp"
 
 class TR_FrontEnd;
 class TR_Memory;

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -21,33 +21,33 @@
  *******************************************************************************/
 
 #include "codegen/CodeGenerator.hpp"
-#include "env/KnownObjectTable.hpp"        // for KnownObjectTable, etc
+#include "env/KnownObjectTable.hpp"
 #include "compile/AliasBuilder.hpp"
 #include "compile/Compilation.hpp"
-#include "compile/Method.hpp"                  // for mcount_t
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
+#include "compile/Method.hpp"
+#include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
-#include "cs2/hashtab.h"                       // for HashTable<>::Cursor, etc
+#include "cs2/hashtab.h"
 #include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                    // for TR_HeapMemory, etc
+#include "env/TRMemory.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/j9method.h"
 #include "env/jittypes.h"
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol, etc
-#include "il/symbol/StaticSymbol_inlines.hpp"  // for StaticSymbol, etc
-#include "il/symbol/ParameterSymbol.hpp"       // for ParameterSymbol
-#include "il/symbol/RegisterMappedSymbol.hpp"  // for RegisterMappedSymbol, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
+#include "il/SymbolReference.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "il/symbol/StaticSymbol_inlines.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "il/symbol/RegisterMappedSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
 #include "ilgen/IlGen.hpp"
 #include "ilgen/J9ByteCodeIlGenerator.hpp"
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/BitVector.hpp"                 // for TR_BitVector, etc
-#include "infra/List.hpp"                      // for List, ListIterator, etc
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/List.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "optimizer/J9TransformUtil.hpp"

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -34,9 +34,9 @@ namespace J9 { typedef J9::SymbolReferenceTable SymbolReferenceTableConnector; }
 
 #include "compile/OMRSymbolReferenceTable.hpp"
 
-#include <stddef.h>         // for size_t
-#include <stdint.h>         // for int32_t, uint32_t
-#include "env/jittypes.h"   // for intptrj_t, uintptrj_t
+#include <stddef.h>
+#include <stdint.h>
+#include "env/jittypes.h"
 
 class TR_BitVector;
 class TR_PersistentClassInfo;

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 #include "AtomicSupport.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "control/CompilationRuntime.hpp"   // for TR::CompilationInfo
+#include "control/CompilationRuntime.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "compile/Compilation.hpp"
@@ -30,7 +30,7 @@
 #include "compile/SymbolReferenceTable.hpp"
 #include "env/VMJ9.h"
 #include "runtime/J9Profiler.hpp"
-#include "exceptions/RuntimeFailure.hpp"    // for J9::EnforceProfiling
+#include "exceptions/RuntimeFailure.hpp"
 
 bool J9::Recompilation::_countingSupported = false;
 

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,20 +24,20 @@
 #define TR_RECOMPILATION_INFO_INCL
 
 
-#include <stddef.h>                       // for NULL
-#include <stdint.h>                       // for int32_t, uint32_t, etc
-#include "compile/Compilation.hpp"        // for Compilation
-#include "compile/CompilationTypes.hpp"   // for TR_Hotness
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"    // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/CHTable.hpp"
-#include "env/TRMemory.hpp"               // for TR_Memory, etc
-#include "env/defines.h"                  // for TR_HOST_X86
-#include "env/jittypes.h"                 // for uintptrj_t
-#include "infra/Assert.hpp"               // for TR_ASSERT
-#include "infra/Flags.hpp"                // for flags32_t, flags16_t
-#include "infra/Link.hpp"                 // for TR_LinkHead
-#include "infra/Timer.hpp"                // for TR_SingleTimer
+#include "env/TRMemory.hpp"
+#include "env/defines.h"
+#include "env/jittypes.h"
+#include "infra/Assert.hpp"
+#include "infra/Flags.hpp"
+#include "infra/Link.hpp"
+#include "infra/Timer.hpp"
 #include "runtime/J9Profiler.hpp"
 
 class TR_FrontEnd;

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,32 +22,32 @@
 
 #include "env/CHTable.hpp"
 
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, etc
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/KnownObjectTable.hpp"        // for KnownObjectTable, etc
-#include "compile/CompilationTypes.hpp"        // for TR_Hotness
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/VirtualGuard.hpp"            // for TR_VirtualGuard
+#include "env/KnownObjectTable.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/VirtualGuard.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentCHTable.hpp"           // for TR_PersistentCHTable
-#include "env/PersistentInfo.hpp"              // for PersistentInfo
-#include "env/jittypes.h"                      // for uintptrj_t
-#include "env/ClassTableCriticalSection.hpp"   // for ClassTableCriticalSection
-#include "env/VMAccessCriticalSection.hpp"     // for VMAccessCriticalSection
+#include "env/PersistentCHTable.hpp"
+#include "env/PersistentInfo.hpp"
+#include "env/jittypes.h"
+#include "env/ClassTableCriticalSection.hpp"
+#include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/SymbolReference.hpp"              // for SymbolReference
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Array.hpp"                     // for TR_Array
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/List.hpp"                      // for ListIterator, etc
-#include "optimizer/PreExistence.hpp"          // for TR_InnerAssumption
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/List.hpp"
+#include "optimizer/PreExistence.hpp"
 
 void
 TR_PreXRecompile::dumpInfo()

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,15 +23,15 @@
 #ifndef CHTABLE_INCL
 #define CHTABLE_INCL
 
-#include <stddef.h>                        // for NULL
-#include <stdint.h>                        // for uint8_t, int32_t, etc
-#include "compile/Compilation.hpp"         // for Compilation
-#include "compile/CompilationTypes.hpp"    // for TR_Hotness
-#include "compile/VirtualGuard.hpp"        // for TR_VirtualGuardKind
-#include "env/RuntimeAssumptionTable.hpp"  // for TR_RuntimeAssumptionKind, etc
-#include "env/TRMemory.hpp"                // for TR_Memory, etc
-#include "env/jittypes.h"                  // for uintptrj_t
-#include "infra/Link.hpp"                  // for TR_Link, TR_LinkHead
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "compile/VirtualGuard.hpp"
+#include "env/RuntimeAssumptionTable.hpp"
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "infra/Link.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 
 class TR_FrontEnd;

--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef CPUUTILIZATION_HPP
 #define CPUUTILIZATION_HPP
 
-#include <stdint.h>         // for int64_t
+#include <stdint.h>
 #include "jni.h"
 #include "j9.h"
 #include "j9port.h"
-#include "env/TRMemory.hpp" // for persistent alloc
+#include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
 
 namespace TR { class PersistentInfo; }

--- a/runtime/compiler/env/J9DebugEnv.cpp
+++ b/runtime/compiler/env/J9DebugEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,15 +20,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <stddef.h>                   // for NULL
-#include <stdint.h>                   // for int32_t, int64_t, uint32_t
+#include <stddef.h>
+#include <stdint.h>
 #include <assert.h>
 #include "compile/Compilation.hpp"
 #include "env/DebugEnv.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/jittypes.h"             // for uintptrj_t, intptrj_t
+#include "env/jittypes.h"
 #include "env/VMJ9.h"
-#include "infra/Assert.hpp"           // for TR_ASSERT
+#include "infra/Assert.hpp"
 #include "thrtypes.h"
 
 

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,30 +22,30 @@
 
 #include "env/PersistentCHTable.hpp"
 
-#include <stdint.h>                            // for int32_t
-#include <stdio.h>                             // for printf, fflush, NULL, etc
-#include <string.h>                            // for memcpy, memset, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv
-#include "compile/Compilation.hpp"             // for Compilation, etc
-#include "compile/CompilationTypes.hpp"        // for TR_Hotness
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentInfo.hpp"              // for PersistentInfo
+#include "env/PersistentInfo.hpp"
 #include "env/RuntimeAssumptionTable.hpp"
 #include "env/TRMemory.hpp"
-#include "env/jittypes.h"                      // for uintptrj_t
-#include "env/ClassTableCriticalSection.hpp"   // for ClassTableCriticalSection
+#include "env/jittypes.h"
+#include "env/ClassTableCriticalSection.hpp"
 #include "env/VMJ9.h"
-#include "il/DataTypes.hpp"                    // for etc
-#include "il/SymbolReference.hpp"              // for classNameToSignature, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Link.hpp"                      // for TR_LinkHead
-#include "infra/List.hpp"                      // for ListIterator, etc
+#include "il/DataTypes.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 
 class TR_OpaqueClassBlock;

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef TR_PERSISTENTCHTABLE_INCL
 #define TR_PERSISTENTCHTABLE_INCL
 
-#include <stdint.h>                      // for int32_t, uint8_t
-#include "compile/CompilationTypes.hpp"  // for TR_Hotness
-#include "env/TRMemory.hpp"              // for TR_Memory, etc
-#include "il/DataTypes.hpp"              // for TR_YesNoMaybe
-#include "infra/Link.hpp"                // for TR_LinkHead
+#include <stdint.h>
+#include "compile/CompilationTypes.hpp"
+#include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
+#include "infra/Link.hpp"
 
 #define CLASSHASHTABLE_SIZE  (4001) // close to 8000 classes will be loaded in WebSphere
 

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,9 @@
 #ifndef RUNTIMEASSUMPTIONTABLE_HPP
 #define RUNTIMEASSUMPTIONTABLE_HPP
 
-#include <stddef.h>        // for NULL, size_t
-#include <stdint.h>        // for int32_t, uint32_t
-#include "env/jittypes.h"  // for uintptrj_t
+#include <stddef.h>
+#include <stdint.h>
+#include "env/jittypes.h"
 
 class TR_FrontEnd;
 class TR_OpaqueClassBlock;

--- a/runtime/compiler/il/J9DataTypes.cpp
+++ b/runtime/compiler/il/J9DataTypes.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,11 @@
 
 #include "il/J9DataTypes.hpp"
 
-#include <stdint.h>          // for int32_t, uint8_t
-#include <string.h>          // for strlen
-#include <ctype.h>           // for isdigit
-#include "il/DataTypes.hpp"  // for TR::DataType
-#include "infra/Assert.hpp"  // for TR_ASSERT
+#include <stdint.h>
+#include <string.h>
+#include <ctype.h>
+#include "il/DataTypes.hpp"
+#include "infra/Assert.hpp"
 
 namespace J9 {
 

--- a/runtime/compiler/il/J9DataTypes.hpp
+++ b/runtime/compiler/il/J9DataTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ namespace J9 { typedef J9::DataType DataTypeConnector; }
 
 #include "il/OMRDataTypes.hpp"
 
-#include <stdint.h>  // for int32_t
+#include <stdint.h>
 
 namespace TR { class DataType; }
 

--- a/runtime/compiler/il/J9SymbolReference.cpp
+++ b/runtime/compiler/il/J9SymbolReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,13 +22,13 @@
 
 #include "il/J9SymbolReference.hpp"
 
-#include <stdint.h>                    // for uint32_t
-#include "compile/Compilation.hpp"     // for Compilation
+#include <stdint.h>
+#include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/VMAccessCriticalSection.hpp" // for VMAccessCriticalSection
-#include "il/Symbol.hpp"               // for Symbol
-#include "il/SymbolReference.hpp"      // for SymbolReference
-#include "il/symbol/StaticSymbol.hpp"  // for StaticSymbol
+#include "env/VMAccessCriticalSection.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/StaticSymbol.hpp"
 #include "il/symbol/ParameterSymbol.hpp"
 #include "env/KnownObjectTable.hpp"
 #include "runtime/RuntimeAssumptions.hpp"

--- a/runtime/compiler/il/J9SymbolReference.hpp
+++ b/runtime/compiler/il/J9SymbolReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,11 +34,11 @@ namespace J9 { typedef J9::SymbolReference SymbolReferenceConnector; }
 
 #include "il/OMRSymbolReference.hpp"
 
-#include <stdint.h>                          // for int32_t
-#include "compile/SymbolReferenceTable.hpp"  // for SymbolReferenceTable, etc
-#include "env/KnownObjectTable.hpp"          // for KnownObjectTable, etc
-#include "env/jittypes.h"                    // for intptrj_t
-#include "infra/Annotations.hpp"             // for OMR_EXTENSIBLE
+#include <stdint.h>
+#include "compile/SymbolReferenceTable.hpp"
+#include "env/KnownObjectTable.hpp"
+#include "env/jittypes.h"
+#include "infra/Annotations.hpp"
 
 class mcount_t;
 namespace TR { class Symbol; }

--- a/runtime/compiler/il/Node.hpp
+++ b/runtime/compiler/il/Node.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,10 +25,10 @@
 
 #include "il/J9Node.hpp"
 
-#include <stddef.h>               // for NULL
-#include <stdint.h>               // for uint16_t
-#include "il/ILOpCodes.hpp"       // for ILOpCodes
-#include "infra/Annotations.hpp"  // for OMR_EXTENSIBLE
+#include <stddef.h>
+#include <stdint.h>
+#include "il/ILOpCodes.hpp"
+#include "infra/Annotations.hpp"
 
 namespace TR
 {

--- a/runtime/compiler/il/Symbol.hpp
+++ b/runtime/compiler/il/Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "il/symbol/J9Symbol.hpp"
 
-#include <stdint.h>          // for uint32_t
-#include "il/DataTypes.hpp"  // for DataTypes
+#include <stdint.h>
+#include "il/DataTypes.hpp"
 
 namespace TR 
 {

--- a/runtime/compiler/il/SymbolReference.hpp
+++ b/runtime/compiler/il/SymbolReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,11 +25,11 @@
 
 #include "il/J9SymbolReference.hpp"
 
-#include <stdint.h>                          // for int32_t
-#include "env/KnownObjectTable.hpp"      // for KnownObjectTable, etc
-#include "compile/SymbolReferenceTable.hpp"  // for SymbolReferenceTable, etc
-#include "env/jittypes.h"                    // for intptrj_t
-#include "infra/Annotations.hpp"             // for OMR_EXTENSIBLE
+#include <stdint.h>
+#include "env/KnownObjectTable.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "env/jittypes.h"
+#include "infra/Annotations.hpp"
 
 class mcount_t;
 namespace TR { class Symbol; }

--- a/runtime/compiler/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,12 +22,12 @@
 
 #include "il/symbol/J9MethodSymbol.hpp"
 
-#include "compile/Compilation.hpp"             // for Compilation, comp
+#include "compile/Compilation.hpp"
 #include "env/TRMemory.hpp"
-#include "il/DataTypes.hpp"                    // for DataTypes, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "runtime/J9Runtime.hpp"               // for TR_RuntimeHelper, etc
+#include "il/DataTypes.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "runtime/J9Runtime.hpp"
 
 /**
  * Return true if this method is pure ie no side-effects.

--- a/runtime/compiler/il/symbol/J9MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,11 +34,11 @@ namespace J9 { typedef J9::MethodSymbol MethodSymbolConnector; }
 
 #include "il/symbol/OMRMethodSymbol.hpp"
 
-#include <stdint.h>                            // for uint16_t, uint8_t, etc
-#include "codegen/LinkageConventionsEnum.hpp"  // for TR_LinkageConventions, etc
-#include "compile/Method.hpp"                  // for TR_Method
-#include "il/DataTypes.hpp"                    // for DataTypes
-#include "runtime/J9Runtime.hpp"               // for TR_RuntimeHelper
+#include <stdint.h>
+#include "codegen/LinkageConventionsEnum.hpp"
+#include "compile/Method.hpp"
+#include "il/DataTypes.hpp"
+#include "runtime/J9Runtime.hpp"
 
 namespace TR { class Compilation; }
 

--- a/runtime/compiler/il/symbol/J9StaticSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9StaticSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,11 @@
 
 #include "il/symbol/J9StaticSymbol.hpp"
 
-#include <stddef.h>                    // for NULL
-#include "env/TRMemory.hpp"            // for PERSISTENT_NEW_DECLARE
+#include <stddef.h>
+#include "env/TRMemory.hpp"
 #include "il/Symbol.hpp"
-#include "il/symbol/LabelSymbol.hpp"   // for LabelSymbol
-#include "il/symbol/StaticSymbol.hpp"  // for StaticSymbolBase, etc
+#include "il/symbol/LabelSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
 
 #include "il/symbol/StaticSymbol_inlines.hpp"
 

--- a/runtime/compiler/il/symbol/J9StaticSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9StaticSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,8 @@ namespace J9 { typedef J9::StaticSymbol StaticSymbolConnector; }
 #include "il/Symbol.hpp"
 #include "il/symbol/OMRStaticSymbol.hpp"
 
-#include <stdint.h>          // for int32_t, uint32_t
-#include "il/DataTypes.hpp"  // for DataTypes
+#include <stdint.h>
+#include "il/DataTypes.hpp"
 
 namespace TR { class StaticSymbol; }
 

--- a/runtime/compiler/il/symbol/J9StaticSymbol_inlines.hpp
+++ b/runtime/compiler/il/symbol/J9StaticSymbol_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,10 +31,10 @@
 
 #include "il/symbol/J9StaticSymbol.hpp"
 
-#include <stddef.h>                    // for NULL
-#include "env/TRMemory.hpp"            // for PERSISTENT_NEW_DECLARE
+#include <stddef.h>
+#include "env/TRMemory.hpp"
 #include "il/Symbol.hpp"
-#include "il/symbol/LabelSymbol.hpp"   // for LabelSymbol
+#include "il/symbol/LabelSymbol.hpp"
 
 
 inline void

--- a/runtime/compiler/il/symbol/J9Symbol.cpp
+++ b/runtime/compiler/il/symbol/J9Symbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,22 +32,22 @@
 
 #include "il/symbol/OMRSymbol.hpp"
 
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for uint32_t, int32_t, etc
-#include <string.h>                            // for memcmp, strncmp
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd
-#include "compile/Compilation.hpp"             // for Compilation
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "env/TRMemory.hpp"
 #include "env/VMJ9.h"
-#include "il/DataTypes.hpp"                    // for DataType
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/SymbolReference.hpp"              // for SymbolReference
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "il/symbol/StaticSymbol_inlines.hpp"  // for StaticSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Flags.hpp"                     // for flags32_t
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "il/DataTypes.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "il/symbol/StaticSymbol_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Flags.hpp"
+#include "ras/Debug.hpp"
 
 TR::Symbol::RecognizedField
 J9::Symbol::searchRecognizedField(TR::Compilation * comp, TR_ResolvedMethod * owningMethod, int32_t cpIndex, bool isStatic)

--- a/runtime/compiler/il/symbol/J9Symbol.hpp
+++ b/runtime/compiler/il/symbol/J9Symbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,12 +34,12 @@ namespace J9 { typedef J9::Symbol SymbolConnector; }
 
 #include "il/symbol/OMRSymbol.hpp"
 
-#include <stddef.h>                 // for size_t
-#include <stdint.h>                 // for uint32_t, uint16_t, uint8_t, etc
-#include "env/TRMemory.hpp"         // for TR_Memory, etc
-#include "il/DataTypes.hpp"         // for TR::DataType, DataTypes
-#include "infra/Assert.hpp"         // for TR_ASSERT
-#include "infra/Flags.hpp"          // for flags32_t
+#include <stddef.h>
+#include <stdint.h>
+#include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Flags.hpp"
 
 class TR_FrontEnd;
 class TR_ResolvedMethod;

--- a/runtime/compiler/il/symbol/MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/MethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "il/symbol/J9MethodSymbol.hpp"
 
-#include <stddef.h>                            // for NULL
-#include "codegen/LinkageConventionsEnum.hpp"  // for TR_LinkageConventions, etc
+#include <stddef.h>
+#include "codegen/LinkageConventionsEnum.hpp"
 
 class TR_Method;
 

--- a/runtime/compiler/il/symbol/StaticSymbol.hpp
+++ b/runtime/compiler/il/symbol/StaticSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "il/symbol/J9StaticSymbol.hpp"
 
-#include <stdint.h>          // for uint32_t
-#include "il/DataTypes.hpp"  // for DataTypes
+#include <stdint.h>
+#include "il/DataTypes.hpp"
 
 /**
  * A symbol with an address

--- a/runtime/compiler/infra/J9Cfg.cpp
+++ b/runtime/compiler/infra/J9Cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,44 +20,44 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <algorithm>                              // for std::find, etc
-#include <limits.h>                               // for SHRT_MAX, UCHAR_MAX
-#include <stdio.h>                                // for NULL, sprintf
-#include <stdint.h>                               // for int32_t, uint32_t
-#include <string.h>                               // for NULL, memset
-#include "compile/Compilation.hpp"                // for Compilation
+#include <algorithm>
+#include <limits.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
-#include "cs2/arrayof.h"                          // for ArrayOf
+#include "cs2/arrayof.h"
 #include "cs2/bitvectr.h"
-#include "cs2/listof.h"                           // for ListOf
-#include "env/TRMemory.hpp"                       // for Allocator, etc
-#include "env/PersistentInfo.hpp"                 // for PersistentInfo
+#include "cs2/listof.h"
+#include "env/TRMemory.hpp"
+#include "env/PersistentInfo.hpp"
 #include "env/VMJ9.h"
-#include "il/Block.hpp"                           // for Block
-#include "il/ILOpCodes.hpp"                       // for ILOpCodes::athrow, etc
-#include "il/ILOps.hpp"                           // for ILOpCode
-#include "il/Node.hpp"                            // for Node, vcount_t
-#include "il/Node_inlines.hpp"                    // for Node::getBranchDestination
-#include "il/Symbol.hpp"                          // for Symbol
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
 #include "il/SymbolReference.hpp"
-#include "il/symbol/LabelSymbol.hpp"              // for LabelSymbol
+#include "il/symbol/LabelSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "il/TreeTop.hpp"                         // for TreeTop
-#include "il/TreeTop_inlines.hpp"                 // for TreeTop::getNode, etc
-#include "infra/Assert.hpp"                       // for TR_ASSERT
-#include "infra/Cfg.hpp"                          // for CFG
-#include "infra/Link.hpp"                         // for TR_LinkHead1
-#include "infra/List.hpp"                         // for ListIterator, List
-#include "infra/Stack.hpp"                        // for TR_Stack
-#include "infra/TRCfgEdge.hpp"                    // for CFGEdge
-#include "infra/TRCfgNode.hpp"                    // for CFGNode
-#include "optimizer/Optimizer.hpp"                // for Optimizer
-#include "optimizer/Structure.hpp"                // for TR_StructureSubGraphNode, etc
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "infra/Stack.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/Structure.hpp"
 #include "optimizer/StructuralAnalysis.hpp"
-#include "ras/Debug.hpp"                          // for TR_DebugBase
+#include "ras/Debug.hpp"
 #include "runtime/ExternalProfiler.hpp"
 #include "runtime/J9Profiler.hpp"
 

--- a/runtime/compiler/infra/J9Cfg.hpp
+++ b/runtime/compiler/infra/J9Cfg.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,15 +34,15 @@ namespace J9 { typedef J9::CFG CFGConnector; }
 
 #include "infra/OMRCfg.hpp"
 
-#include <stddef.h>             // for NULL
-#include <stdint.h>             // for int32_t, uint32_t
-#include "cs2/listof.h"         // for ListOf
-#include "env/TRMemory.hpp"     // for TR_Memory, etc
-#include "il/Node.hpp"          // for vcount_t
-#include "infra/Assert.hpp"     // for TR_ASSERT
-#include "infra/List.hpp"       // for TR_TwoListIterator, List
-#include "infra/TRCfgEdge.hpp"  // for CFGEdge
-#include "infra/TRCfgNode.hpp"  // for CFGNode
+#include <stddef.h>
+#include <stdint.h>
+#include "cs2/listof.h"
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "infra/Assert.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
 
 class TR_BitVector;
 class TR_BlockCloner;

--- a/runtime/compiler/optimizer/AllocationSinking.cpp
+++ b/runtime/compiler/optimizer/AllocationSinking.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,51 +22,51 @@
 
 #include "optimizer/AllocationSinking.hpp"
 
-#include <limits.h>                            // for INT_MAX, UINT_MAX, etc
-#include <math.h>                              // for exp
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include <stdio.h>                             // for printf, fflush, etc
-#include <stdlib.h>                            // for atoi
-#include <string.h>                            // for NULL, strncmp, strcmp, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv, etc
-#include "compile/Compilation.hpp"             // for Compilation, comp, etc
-#include "compile/Method.hpp"                  // for TR_Method
+#include <limits.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/TRMemory.hpp"                    // for SparseBitVector, etc
-#include "env/jittypes.h"                      // for TR_ByteCodeInfo, etc
-#include "il/Block.hpp"                        // for Block, toBlock, etc
-#include "il/DataTypes.hpp"                    // for DataTypes, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/NodePool.hpp"                     // for TR_NodePool
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ParameterSymbol.hpp"       // for ParameterSymbol
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Cfg.hpp"                       // for CFG, etc
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/NodePool.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
 #include "infra/ILWalk.hpp"
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
-#include "infra/TRCfgNode.hpp"                 // for CFGNode
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"   // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"             // for Optimizer
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "optimizer/Optimizer.hpp"
+#include "ras/Debug.hpp"
 
 
 int32_t TR_AllocationSinking::perform()

--- a/runtime/compiler/optimizer/AllocationSinking.hpp
+++ b/runtime/compiler/optimizer/AllocationSinking.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,12 +23,12 @@
 #ifndef ALLOCATIONSINKING_INCL
 #define ALLOCATIONSINKING_INCL
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include "compile/Compilation.hpp"            // for Compilation
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_AllocationSinking : public TR::Optimization
    {

--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -23,60 +23,60 @@
 #include "optimizer/DataAccessAccelerator.hpp"
 
 #include <algorithm>
-#include <limits.h>                            // for INT_MAX, UINT_MAX, etc
-#include <math.h>                              // for exp
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include <stdio.h>                             // for printf, fflush, etc
-#include <stdlib.h>                            // for atoi
-#include <string.h>                            // for NULL, strncmp, strcmp, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv, etc
-#include "codegen/Linkage.hpp"                 // for Linkage
-#include "codegen/RecognizedMethods.hpp"       // for RecognizedMethod, etc
+#include <limits.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/Linkage.hpp"
+#include "codegen/RecognizedMethods.hpp"
 #include "codegen/RegisterConstants.hpp"
-#include "compile/Compilation.hpp"             // for Compilation, comp, etc
-#include "compile/Method.hpp"                  // for TR_Method
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable, etc
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                    // for SparseBitVector, etc
-#include "env/jittypes.h"                      // for TR_ByteCodeInfo, etc
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
 #include "env/VMJ9.h"
-#include "il/Block.hpp"                        // for Block, toBlock, etc
-#include "il/DataTypes.hpp"                    // for DataType, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/NodePool.hpp"                     // for TR_NodePool
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ParameterSymbol.hpp"       // for ParameterSymbol
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Cfg.hpp"                       // for CFG, etc
-#include "infra/Stack.hpp"                     // for TR_Stack
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
-#include "infra/TRCfgNode.hpp"                 // for CFGNode
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/NodePool.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Stack.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"   // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"             // for Optimizer
-#include "optimizer/OSRGuardRemoval.hpp"       // for OSRGuardRemoval
-#include "optimizer/Structure.hpp"             // for TR_RegionStructure, etc
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/OSRGuardRemoval.hpp"
+#include "optimizer/Structure.hpp"
 #include "optimizer/TransformUtil.hpp"
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "ras/Debug.hpp"
 
 #define IS_VARIABLE_PD2I(callNode) (!isChildConst(callNode, 2) || !isChildConst(callNode, 3))
 

--- a/runtime/compiler/optimizer/DataAccessAccelerator.hpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,21 +23,21 @@
 #ifndef DATAACCESSACCELERATOR_INCL
 #define DATAACCESSACCELERATOR_INCL
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include <vector>                              // for std::vector
-#include "compile/Compilation.hpp"            // for Compilation
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
-#include "il/Block.hpp"                       // for Block
-#include "il/ILOpCodes.hpp"                   // for ILOpCodes, etc
-#include "il/Node.hpp"                        // for Node, etc
-#include "infra/Array.hpp"                    // for TR_Array
-#include "infra/Assert.hpp"                   // for TR_ASSERT
-#include "infra/BitVector.hpp"                // for TR_BitVector
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/Node.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
 #include "infra/ILWalk.hpp"
-#include "infra/List.hpp"                     // for List, TR_ScratchList
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class TreeTop; }
 

--- a/runtime/compiler/optimizer/DynamicLiteralPool.cpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.cpp
@@ -22,53 +22,53 @@
 
 #include "optimizer/DynamicLiteralPool.hpp"
 
-#include <limits.h>                            // for INT_MAX, UINT_MAX, etc
-#include <math.h>                              // for exp
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include <stdio.h>                             // for printf, fflush, etc
-#include <stdlib.h>                            // for atoi
-#include <string.h>                            // for NULL, strncmp, strcmp, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv, etc
-#include "compile/Compilation.hpp"             // for Compilation, comp, etc
-#include "compile/Method.hpp"                  // for TR_Method
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable, etc
-#include "compile/VirtualGuard.hpp"            // for TR_VirtualGuard
+#include <limits.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "compile/VirtualGuard.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentInfo.hpp"              // for PersistentInfo
+#include "env/PersistentInfo.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                    // for SparseBitVector, etc
-#include "env/jittypes.h"                      // for TR_ByteCodeInfo, etc
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                        // for Block, toBlock, etc
-#include "il/DataTypes.hpp"                    // for DataTypes, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/NodePool.hpp"                     // for TR_NodePool
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Cfg.hpp"                       // for CFG, etc
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/NodePool.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
 #include "infra/ILWalk.hpp"
-#include "infra/Stack.hpp"                     // for TR_Stack
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
-#include "infra/TRCfgNode.hpp"                 // for CFGNode
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "infra/Stack.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"   // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"             // for Optimizer
-#include "optimizer/Structure.hpp"             // for TR_RegionStructure, etc
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/Structure.hpp"
+#include "ras/Debug.hpp"
 #include "runtime/J9Runtime.hpp"
 
 

--- a/runtime/compiler/optimizer/DynamicLiteralPool.hpp
+++ b/runtime/compiler/optimizer/DynamicLiteralPool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,18 +23,18 @@
 #ifndef DYNAMICLITERALPOOL_INCL
 #define DYNAMICLITERALPOOL_INCL
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include "compile/Compilation.hpp"            // for Compilation
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
 #include "env/jittypes.h"
-#include "il/Block.hpp"                       // for Block
-#include "il/ILOpCodes.hpp"                   // for ILOpCodes, etc
-#include "il/Node.hpp"                        // for Node, etc
-#include "infra/Assert.hpp"                   // for TR_ASSERT
-#include "infra/List.hpp"                     // for List, TR_ScratchList
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/Node.hpp"
+#include "infra/Assert.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 
 namespace TR { class SymbolReference; }

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -26,69 +26,69 @@
 
 #include "optimizer/EscapeAnalysis.hpp"
 
-#include <algorithm>                           // for std::max, etc
-#include <stdint.h>                            // for int32_t, etc
-#include <stdio.h>                             // for NULL, printf, etc
-#include <string.h>                            // for strncmp, memset, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, etc
-#include "codegen/RecognizedMethods.hpp"       // for RecognizedMethod, etc
-#include "compile/Compilation.hpp"             // for Compilation, etc
-#include "compile/CompilationTypes.hpp"        // for TR_Hotness
-#include "compile/Method.hpp"                  // for TR_Method
+#include <algorithm>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/RecognizedMethods.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
-#include "compile/VirtualGuard.hpp"            // for TR_VirtualGuard
+#include "compile/VirtualGuard.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
-#include "control/Recompilation.hpp"           // for TR_Recompilation
-#include "control/RecompilationInfo.hpp"           // for TR_Recompilation
+#include "control/Options_inlines.hpp"
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "cs2/bitvectr.h"
 #include "env/CompilerEnv.hpp"
-#include "env/ObjectModel.hpp"                 // for ObjectModel
+#include "env/ObjectModel.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
-#include "env/VMAccessCriticalSection.hpp"     // for VMAccessCriticalSection
+#include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                        // for Block, toBlock
-#include "il/DataTypes.hpp"                    // for DataTypes, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::New, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, etc
-#include "il/Node.hpp"                         // for Node, etc
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/AutomaticSymbol.hpp"       // for AutomaticSymbol
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ParameterSymbol.hpp"       // for ParameterSymbol
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Array.hpp"                     // for TR_Array
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/BitVector.hpp"                 // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                       // for CFG, etc
-#include "infra/Checklist.hpp"                 // for NodeChecklist, etc
-#include "infra/Link.hpp"                      // for TR_LinkHead
-#include "infra/List.hpp"                      // for TR_ScratchList, etc
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Checklist.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
 #include "infra/SimpleRegex.hpp"
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
-#include "infra/TRCfgNode.hpp"                 // for CFGNode
-#include "optimizer/Inliner.hpp"               // for TR_InlineCall
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Inliner.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"             // for Optimizer
+#include "optimizer/Optimizer.hpp"
 #include "optimizer/Structure.hpp"
-#include "optimizer/TransformUtil.hpp"         // for TransformUtil
+#include "optimizer/TransformUtil.hpp"
 #include "optimizer/DataFlowAnalysis.hpp"
-#include "optimizer/UseDefInfo.hpp"            // for TR_UseDefInfo, etc
+#include "optimizer/UseDefInfo.hpp"
 #include "optimizer/ValueNumberInfo.hpp"
 #include "optimizer/LocalOpts.hpp"
 #include "optimizer/MonitorElimination.hpp"
-#include "ras/Debug.hpp"                       // for TR_DebugBase, etc
+#include "ras/Debug.hpp"
 #include "runtime/J9Profiler.hpp"
 #include "runtime/J9Runtime.hpp"
 

--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,20 +23,20 @@
 #ifndef ESCAPEANALYSIS_INCL
 #define ESCAPEANALYSIS_INCL
 
-#include <stddef.h>                            // for NULL
-#include <stdint.h>                            // for int32_t
-#include "compile/Compilation.hpp"             // for Compilation
-#include "env/TRMemory.hpp"                    // for TR_Memory, etc
-#include "il/DataTypes.hpp"                    // for DataTypes
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes
-#include "il/Node.hpp"                         // for Node, rcount_t
-#include "infra/BitVector.hpp"                 // for TR_BitVector
-#include "infra/Flags.hpp"                     // for flags32_t
-#include "infra/Link.hpp"                      // for TR_Link, TR_LinkHead
-#include "infra/List.hpp"                      // for TR_ScratchList, etc
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/Node.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Flags.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"   // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_EscapeAnalysis;
 class TR_OpaqueClassBlock;

--- a/runtime/compiler/optimizer/EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,12 +23,12 @@
 #include "env/StackMemoryRegion.hpp"
 #include "optimizer/EstimateCodeSize.hpp"
 
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd
-#include "compile/Compilation.hpp"             // for Compilation
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "optimizer/CallInfo.hpp"              // for TR_CallSite, etc
-#include "ras/LogTracer.hpp"                   // for heuristicTrace
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "optimizer/CallInfo.hpp"
+#include "ras/LogTracer.hpp"
 #include "env/VMJ9.h"
 #include "runtime/J9Profiler.hpp"
 

--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef ESTIMATECS_INCL
 #define ESTIMATECS_INCL
 
-#include <stddef.h>               // for size_t
-#include <stdint.h>               // for int32_t
-#include "env/TRMemory.hpp"       // for Allocator
-#include "infra/Flags.hpp"        // for flags8_t
-#include "optimizer/Inliner.hpp"  // for TR_InlinerTracer (ptr only), etc
+#include <stddef.h>
+#include <stdint.h>
+#include "env/TRMemory.hpp"
+#include "infra/Flags.hpp"
+#include "optimizer/Inliner.hpp"
 
 class TR_CallStack;
 namespace TR { class Compilation; }

--- a/runtime/compiler/optimizer/FearPointAnalysis.cpp
+++ b/runtime/compiler/optimizer/FearPointAnalysis.cpp
@@ -19,20 +19,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#include <stddef.h>                        // for NULL
-#include <stdint.h>                        // for int32_t
+#include <stddef.h>
+#include <stdint.h>
 #include "optimizer/FearPointAnalysis.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "compile/Compilation.hpp"         // for Compilation
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "env/TRMemory.hpp"                // for TR_Memory, etc
-#include "il/Node.hpp"                     // for Node, vcount_t
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "infra/Assert.hpp"                // for TR_ASSERT
-#include "infra/BitVector.hpp"             // for TR_BitVector
-#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Checklist.hpp"
 
 bool TR_FearPointAnalysis::virtualGuardsKillFear()
    {

--- a/runtime/compiler/optimizer/HCRGuardAnalysis.cpp
+++ b/runtime/compiler/optimizer/HCRGuardAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,20 +19,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#include <stddef.h>                        // for NULL
-#include <stdint.h>                        // for int32_t
+#include <stddef.h>
+#include <stdint.h>
 #include "optimizer/HCRGuardAnalysis.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "compile/Compilation.hpp"         // for Compilation
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "env/TRMemory.hpp"                // for TR_Memory, etc
-#include "il/Node.hpp"                     // for Node, vcount_t
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "infra/Assert.hpp"                // for TR_ASSERT
-#include "infra/BitVector.hpp"             // for TR_BitVector
-#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Checklist.hpp"
 #include "optimizer/FearPointAnalysis.hpp"
 
 static bool containsPrepareForOSR(TR::Block *block)

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -22,53 +22,53 @@
 
 #include "optimizer/IdiomRecognition.hpp"
 
-#include <stdint.h>                              // for int32_t, uint32_t, etc
-#include <stdio.h>                               // for printf, NULL, etc
-#include <stdlib.h>                              // for atoi
-#include <string.h>                              // for memset
-#include "codegen/CodeGenerator.hpp"             // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                  // for feGetEnv, etc
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
-#include "compile/Compilation.hpp"               // for Compilation
-#include "compile/CompilationTypes.hpp"          // for TR_Hotness
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "control/Recompilation.hpp"             // for TR_Recompilation
-#include "control/RecompilationInfo.hpp"             // for TR_Recompilation
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "cs2/bitvectr.h"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
-#include "il/Block.hpp"                          // for Block
-#include "il/DataTypes.hpp"                      // for DataTypes::NoType, etc
-#include "il/ILOpCodes.hpp"                      // for ILOpCodes::BBEnd, etc
-#include "il/ILOps.hpp"                          // for TR::ILOpCode, etc
-#include "il/Node.hpp"                           // for Node, vcount_t
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                         // for Symbol
-#include "il/SymbolReference.hpp"                // for SymbolReference
-#include "il/TreeTop.hpp"                        // for TreeTop
-#include "il/TreeTop_inlines.hpp"                // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"            // for MethodSymbol
-#include "infra/Assert.hpp"                      // for TR_ASSERT
-#include "infra/BitVector.hpp"                   // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                         // for CFG
-#include "infra/Flags.hpp"                       // for flags16_t, etc
-#include "infra/HashTab.hpp"                     // for TR_HashTabInt, etc
-#include "infra/Link.hpp"                        // for TR_LinkHead, etc
-#include "infra/List.hpp"                        // for List, ListIterator, etc
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Flags.hpp"
+#include "infra/HashTab.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
 #include "infra/SimpleRegex.hpp"
-#include "infra/TRCfgEdge.hpp"                   // for CFGEdge
-#include "infra/TRCfgNode.hpp"                   // for CFGNode
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
 #include "optimizer/IdiomRecognitionUtils.hpp"
-#include "optimizer/LoopCanonicalizer.hpp"       // for TR_LoopTransformer
+#include "optimizer/LoopCanonicalizer.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"     // for OptimizationManager
-#include "optimizer/Optimizer.hpp"               // for Optimizer
-#include "optimizer/Structure.hpp"               // for TR_RegionStructure, etc
-#include "optimizer/TransformUtil.hpp"           // for TransformUtil
-#include "optimizer/UseDefInfo.hpp"              // for TR_UseDefInfo, etc
-#include "ras/Debug.hpp"                         // for TR_DebugBase
+#include "optimizer/OptimizationManager.hpp"
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/Structure.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "optimizer/UseDefInfo.hpp"
+#include "ras/Debug.hpp"
 
 #define OPT_DETAILS "O^O NEWLOOPREDUCER: "
 #define VERBOSE 0

--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,24 +23,24 @@
 #ifndef IDIOMRECOGNITION_INCL
 #define IDIOMRECOGNITION_INCL
 
-#include <stdint.h>                           // for uint16_t, uint8_t, etc
-#include <string.h>                           // for NULL, memset
-#include "compile/Compilation.hpp"            // for Compilation
-#include "compile/CompilationTypes.hpp"       // for TR_Hotness
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
-#include "il/DataTypes.hpp"                   // for DataTypes, etc
-#include "il/ILOpCodes.hpp"                   // for ILOpCodes::NumIlOps, etc
-#include "il/ILOps.hpp"                       // for TR::ILOpCode
-#include "il/ILProps.hpp"                     // for ILTypeProp::Size_1
-#include "infra/Assert.hpp"                   // for TR_ASSERT
-#include "infra/BitVector.hpp"                // for TR_BitVector
-#include "infra/Flags.hpp"                    // for flags32_t, etc
-#include "infra/HashTab.hpp"                  // for TR_HashTabInt
-#include "infra/Link.hpp"                     // for TR_Pair, TR_Link
-#include "infra/List.hpp"                     // for List, etc
+#include <stdint.h>
+#include <string.h>
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/ILProps.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Flags.hpp"
+#include "infra/HashTab.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
 #include "infra/TRlist.hpp"
-#include "optimizer/LoopCanonicalizer.hpp"    // for TR_LoopTransformer
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "optimizer/LoopCanonicalizer.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_CISCTransformer;
 class TR_RegionStructure;

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,31 +22,31 @@
 
 #include "optimizer/IdiomRecognitionUtils.hpp"
 
-#include <algorithm>                       // for std::max, etc
-#include <stddef.h>                        // for NULL
-#include <stdint.h>                        // for int32_t, etc
-#include "codegen/CodeGenerator.hpp"       // for CodeGenerator
-#include "codegen/FrontEnd.hpp"            // for TR_FrontEnd
-#include "compile/Compilation.hpp"         // for Compilation
+#include <algorithm>
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/TRMemory.hpp"                // for PERSISTENT_NEW, etc
-#include "il/Block.hpp"                    // for Block, toBlock
-#include "il/DataTypes.hpp"                // for TR::DataType
-#include "il/ILOpCodes.hpp"                // for ILOpCodes::iconst, etc
-#include "il/ILOps.hpp"                    // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                     // for Node
-#include "il/Node_inlines.hpp"             // for Node::getInt, etc
-#include "il/Symbol.hpp"                   // for Symbol
-#include "il/SymbolReference.hpp"          // for SymbolReference
-#include "il/TreeTop.hpp"                  // for TreeTop
-#include "il/TreeTop_inlines.hpp"          // for TreeTop::getNextTreeTop
-#include "infra/Assert.hpp"                // for TR_ASSERT
-#include "infra/BitVector.hpp"             // for TR_BitVector
-#include "infra/List.hpp"                  // for ListIterator, List, etc
-#include "infra/TRCfgEdge.hpp"             // for CFGEdge
-#include "optimizer/IdiomRecognition.hpp"  // for TR_PCISCNode, etc
-#include "optimizer/Structure.hpp"         // for TR_BlockStructure
-#include "optimizer/TranslateTable.hpp"    // for TR_SetTranslateTable, etc
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "optimizer/IdiomRecognition.hpp"
+#include "optimizer/Structure.hpp"
+#include "optimizer/TranslateTable.hpp"
 
 /************************************/
 /************ Utilities *************/

--- a/runtime/compiler/optimizer/IdiomRecognitionUtils.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognitionUtils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 #ifndef IDIOM_RECOGNITION_UTILS_INCL
 #define IDIOM_RECOGNITION_UTILS_INCL
 
-#include <stddef.h>          // for NULL
-#include <stdint.h>          // for int32_t, etc
-#include "il/DataTypes.hpp"  // for TR::DataType, DataTypes
-#include "il/ILOpCodes.hpp"  // for ILOpCodes
+#include <stddef.h>
+#include <stdint.h>
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
 
 class TR_BitVector;
 class TR_CISCNode;

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,42 +20,42 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <stdint.h>                             // for int32_t, uint32_t, etc
-#include <stdio.h>                              // for sprintf, printf
-#include <stdlib.h>                             // for NULL, atoi
-#include <string.h>                             // for memset
-#include "codegen/CodeGenerator.hpp"            // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                 // for feGetEnv, etc
-#include "compile/Compilation.hpp"              // for Compilation
-#include "compile/SymbolReferenceTable.hpp"     // for SymbolReferenceTable
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "cs2/bitvectr.h"                       // for ABitVector<>::Cursor
+#include "cs2/bitvectr.h"
 #include "env/CompilerEnv.hpp"
-#include "env/TRMemory.hpp"                     // for PERSISTENT_NEW, etc
-#include "env/jittypes.h"                       // for uintptrj_t
-#include "il/Block.hpp"                         // for Block
-#include "il/DataTypes.hpp"                     // for DataType, etc
-#include "il/ILOpCodes.hpp"                     // for ILOpCodes::iconst, etc
-#include "il/ILOps.hpp"                         // for ILOpCode, etc
-#include "il/ILProps.hpp"                       // for ILTypeProp::Size_1, etc
-#include "il/Node.hpp"                          // for Node, vcount_t
-#include "il/Node_inlines.hpp"                  // for Node::getChild, etc
-#include "il/Symbol.hpp"                        // for Symbol
-#include "il/SymbolReference.hpp"               // for SymbolReference
-#include "il/TreeTop.hpp"                       // for TreeTop
-#include "il/TreeTop_inlines.hpp"               // for TreeTop::join, etc
-#include "il/symbol/AutomaticSymbol.hpp"        // for AutomaticSymbol
-#include "infra/Assert.hpp"                     // for TR_ASSERT
-#include "infra/BitVector.hpp"                  // for TR_BitVector
-#include "infra/Cfg.hpp"                        // for CFG
-#include "infra/List.hpp"                       // for List, ListIterator, etc
-#include "optimizer/IdiomRecognition.hpp"       // for TR_PCISCGraph, etc
-#include "optimizer/IdiomRecognitionUtils.hpp"  // for createOP2, etc
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/ILProps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/List.hpp"
+#include "optimizer/IdiomRecognition.hpp"
+#include "optimizer/IdiomRecognitionUtils.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/Optimizer.hpp"              // for Optimizer
-#include "optimizer/UseDefInfo.hpp"             // for TR_UseDefInfo, etc
-#include "ras/Debug.hpp"                        // for TR_DebugBase
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/UseDefInfo.hpp"
+#include "ras/Debug.hpp"
 
 #define OPT_DETAILS "O^O NEWLOOPREDUCER: "
 #define DISPTRACE(OBJ) ((OBJ)->trace())

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -43,10 +43,10 @@
 #include "optimizer/J9CallGraph.hpp"
 #include "optimizer/PreExistence.hpp"
 #include "optimizer/Structure.hpp"
-#include "codegen/CodeGenerator.hpp"                      // for CodeGenerator
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/ILOps.hpp"                                   // for ILOpCode, etc
+#include "il/ILOps.hpp"
 #include "ilgen/IlGenRequest.hpp"
 #include "ilgen/IlGeneratorMethodDetails.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
@@ -56,7 +56,7 @@
 #include "control/Recompilation.hpp"                      //TR_PersistentJittedBodyInfo
 #include "control/RecompilationInfo.hpp"                  //TR_PersistentJittedBodyInfo
 #include "optimizer/EstimateCodeSize.hpp"
-#include "env/SharedCache.hpp"                            // for TR_SharedCache
+#include "env/SharedCache.hpp"
 #include "env/VMJ9.h"
 #include "runtime/J9Profiler.hpp"
 #include "ras/DebugCounter.hpp"

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,38 +22,38 @@
 
 #include "optimizer/InterProceduralAnalyzer.hpp"
 
-#include <stdint.h>                            // for int32_t, uint32_t
-#include <string.h>                            // for NULL, memset, memcmp, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd
-#include "compile/Compilation.hpp"             // for Compilation, etc
-#include "compile/Method.hpp"                  // for TR_Method
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
+#include <stdint.h>
+#include <string.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "env/CHTable.hpp"                     // for TR_ClassQueries
+#include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentCHTable.hpp"           // for CLASSHASHTABLE_SIZE, etc
-#include "env/PersistentInfo.hpp"              // for PersistentInfo
-#include "env/TRMemory.hpp"                    // for TR_Link::operator new, etc
-#include "env/jittypes.h"                      // for uintptrj_t
-#include "env/ClassTableCriticalSection.hpp"   // for ClassTableCriticalSection
-#include "il/Block.hpp"                        // for Block
-#include "il/DataTypes.hpp"                    // for DataTypes::Address, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::New, etc
-#include "il/ILOps.hpp"                        // for ILOpCode
-#include "il/Node.hpp"                         // for Node, vcount_t
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
+#include "env/PersistentCHTable.hpp"
+#include "env/PersistentInfo.hpp"
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "env/ClassTableCriticalSection.hpp"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Link.hpp"                      // for TR_LinkHead
-#include "infra/List.hpp"                      // for TR_ScratchList, etc
-#include "infra/Stack.hpp"                     // for TR_Stack
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "infra/Stack.hpp"
+#include "ras/Debug.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 
 #define MAX_SNIFF_BYTECODE_SIZE             1000

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.hpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef IPA_h
 #define IPA_h
 
-#include <stdint.h>          // for int32_t, uint32_t
-#include "env/TRMemory.hpp"  // for TR_Memory, etc
-#include "il/Node.hpp"       // for vcount_t
-#include "infra/Link.hpp"    // for TR_LinkHead, TR_Link
-#include "infra/List.hpp"    // for ListElement (ptr only), TR_ScratchList, etc
+#include <stdint.h>
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
 
 class TR_ClassExtendCheck;
 class TR_ClassLoadCheck;

--- a/runtime/compiler/optimizer/J9OptimizationManager.cpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,20 +21,20 @@
  *******************************************************************************/
 
 #include "optimizer/OptimizationManager.hpp"
-#include "optimizer/OptimizationManager_inlines.hpp"        // for OptimizationManager::self, etc
+#include "optimizer/OptimizationManager_inlines.hpp"
 
-#include "codegen/CodeGenerator.hpp"             // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                  // for feGetEnv
-#include "compile/Compilation.hpp"               // for Compilation
-#include "compile/CompilationTypes.hpp"          // for TR_Hotness
-#include "compile/Method.hpp"                    // for TR_Method
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "compile/Method.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-#include "il/DataTypes.hpp"                      // for etc
+#include "il/DataTypes.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "infra/Flags.hpp"                       // for flags32_t
-#include "optimizer/Optimizations.hpp"           // for Optimizations, etc
+#include "infra/Flags.hpp"
+#include "optimizer/Optimizations.hpp"
 
 
 namespace TR { class Optimizer; }

--- a/runtime/compiler/optimizer/J9OptimizationManager.hpp
+++ b/runtime/compiler/optimizer/J9OptimizationManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,8 +34,8 @@ namespace J9 { typedef J9::OptimizationManager OptimizationManagerConnector; }
 
 #include "optimizer/OMROptimizationManager.hpp"
 
-#include <stddef.h>                     // for NULL
-#include "optimizer/Optimizations.hpp"  // for Optimizations
+#include <stddef.h>
+#include "optimizer/Optimizations.hpp"
 
 namespace TR { class OptimizationManager; }
 namespace TR { class Optimizer; }

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,10 +30,10 @@
 
 #include "optimizer/Optimizer.hpp"
 
-#include <stddef.h>                                       // for NULL
-#include <stdint.h>                                       // for uint16_t
+#include <stddef.h>
+#include <stdint.h>
 #include "compile/Compilation.hpp"
-#include "compile/Method.hpp"                             // for TR_Method
+#include "compile/Method.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
@@ -41,8 +41,8 @@
 #include "il/symbol/ResolvedMethodSymbol.hpp"
 #include "optimizer/AllocationSinking.hpp"
 #include "optimizer/IdiomRecognition.hpp"
-#include "optimizer/Inliner.hpp"                          // for TR_Inliner, etc
-#include "optimizer/J9Inliner.hpp"                          // for TR_Inliner, etc
+#include "optimizer/Inliner.hpp"
+#include "optimizer/J9Inliner.hpp"
 #include "optimizer/JitProfiler.hpp"
 #include "optimizer/LiveVariablesForGC.hpp"
 #include "optimizer/OptimizationManager.hpp"

--- a/runtime/compiler/optimizer/J9Optimizer.hpp
+++ b/runtime/compiler/optimizer/J9Optimizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,8 +34,8 @@ namespace J9 { typedef J9::Optimizer OptimizerConnector; }
 
 #include "optimizer/OMROptimizer.hpp"
 
-#include <stddef.h>                    // for NULL
-#include <stdint.h>                    // for uint16_t
+#include <stddef.h>
+#include <stdint.h>
 
 namespace TR { class Compilation; }
 namespace TR { class Optimizer; }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -33,16 +33,16 @@
 #include "il/TreeTop_inlines.hpp"
 #include "il/symbol/StaticSymbol.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/ILOps.hpp"                                   // for ILOpCode, etc
+#include "il/ILOps.hpp"
 #include "ilgen/IlGenRequest.hpp"
 #include "ilgen/IlGeneratorMethodDetails.hpp"
 #include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
 #include "optimizer/CallInfo.hpp"
 #include "optimizer/Structure.hpp"
-#include "codegen/CodeGenerator.hpp"                      // for CodeGenerator
+#include "codegen/CodeGenerator.hpp"
 #include "optimizer/TransformUtil.hpp"
-#include "env/j9method.h"     // for TR_J9MethodBase::isUnsafePut
-#include "optimizer/Optimization_inlines.hpp"  // for trace()
+#include "env/j9method.h"
+#include "optimizer/Optimization_inlines.hpp"
 
 void J9::RecognizedCallTransformer::processIntrinsicFunction(TR::TreeTop* treetop, TR::Node* node, TR::ILOpCodes opcode)
    {

--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,11 @@
 #include "optimizer/J9SimplifierHelpers.hpp"
 #include "optimizer/J9SimplifierHandlers.hpp"
 
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "compile/Compilation.hpp"             // for Compilation, comp
-#include "il/Block.hpp"                        // for Block
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 
 bool

--- a/runtime/compiler/optimizer/J9SimplifierHandlers.cpp
+++ b/runtime/compiler/optimizer/J9SimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,54 +26,54 @@
 #include "optimizer/J9SimplifierHandlers.hpp"
 #include "optimizer/Simplifier.hpp"
 
-#include <algorithm>                           // for std::max, etc
-#include <math.h>                              // for log10
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, int64_t, etc
-#include <stdio.h>                             // for sprintf
-#include <stdlib.h>                            // for abs
-#include <string.h>                            // for NULL, strlen, strcat, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv
+#include <algorithm>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
-#include "codegen/TreeEvaluator.hpp"           // for TreeEvaluator
-#include "compile/Compilation.hpp"             // for Compilation, comp
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
+#include "codegen/TreeEvaluator.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
-#include "cs2/bitvectr.h"                      // for ABitVector, etc
-#include "cs2/hashtab.h"                       // for HashTable, etc
-#include "env/IO.hpp"                          // for POINTER_PRINTF_FORMAT
-#include "env/ObjectModel.hpp"                 // for ObjectModel
-#include "env/TRMemory.hpp"                    // for Allocator, etc
+#include "control/Options_inlines.hpp"
+#include "cs2/bitvectr.h"
+#include "cs2/hashtab.h"
+#include "env/IO.hpp"
+#include "env/ObjectModel.hpp"
+#include "env/TRMemory.hpp"
 #include "env/VMJ9.h"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                        // for Block
-#include "il/DataTypes.hpp"                    // for DataTypes::Int8, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::iconst, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Bit.hpp"                       // for isNonNegativePowerOf2, etc
-#include "infra/Cfg.hpp"                       // for CFG
-#include "infra/HashTab.hpp"                   // for TR_HashTabInt, etc
-#include "infra/List.hpp"                      // for ListIterator, List
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Bit.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/HashTab.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"   // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"             // for Optimizer
-#include "optimizer/Structure.hpp"             // for TR_RegionStructure, etc
-#include "optimizer/Simplifier.hpp"            // for TR::Simplifier, etc
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/Structure.hpp"
+#include "optimizer/Simplifier.hpp"
 #include "optimizer/TransformUtil.hpp"
 
 

--- a/runtime/compiler/optimizer/J9SimplifierHelpers.cpp
+++ b/runtime/compiler/optimizer/J9SimplifierHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,9 +27,9 @@
 #include <math.h>
 #include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/IO.hpp"                          // for POINTER_PRINTF_FORMAT
+#include "env/IO.hpp"
 #include "env/jittypes.h"
-#include "il/DataTypes.hpp"                    // for getMaxSigned, etc
+#include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"

--- a/runtime/compiler/optimizer/J9SimplifierHelpers.hpp
+++ b/runtime/compiler/optimizer/J9SimplifierHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "optimizer/OMRSimplifierHelpers.hpp"
 
-#include "il/DataTypes.hpp"                    // for DataTypes
-#include "il/ILOps.hpp"                        // for TR::ILOpCode, ILOpCode
+#include "il/DataTypes.hpp"
+#include "il/ILOps.hpp"
 
 namespace TR { class Block; }
 namespace TR { class Node; }

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -22,25 +22,25 @@
 
 #include "optimizer/J9ValuePropagation.hpp"
 #include "optimizer/VPBCDConstraint.hpp"
-#include "compile/Compilation.hpp"              // for Compilation, comp
+#include "compile/Compilation.hpp"
 #include "il/symbol/ParameterSymbol.hpp"
-#include "il/Node.hpp"                          // for Node, etc
-#include "il/Node_inlines.hpp"                  // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                        // for Symbol, etc
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
 #include "env/CHTable.hpp"
 #include "env/ClassTableCriticalSection.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/VMJ9.h"
-#include "optimizer/Optimization_inlines.hpp"   // for trace()
+#include "optimizer/Optimization_inlines.hpp"
 #include "env/j9method.h"
-#include "env/TRMemory.hpp"                        // for Allocator, etc
-#include "il/Block.hpp"                        // for Block
-#include "infra/Cfg.hpp"                       // for CFG
-#include "compile/VirtualGuard.hpp"            // for VirtualGuard::createHCRGuard
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
+#include "infra/Cfg.hpp"
+#include "compile/VirtualGuard.hpp"
 #include "env/CompilerEnv.hpp"
-#include "optimizer/TransformUtil.hpp"       // for calculateElementAddress
-#include "il/symbol/StaticSymbol.hpp"           // for StaticSymbol
-#include "env/VMAccessCriticalSection.hpp"      // for VMAccessCriticalSection
+#include "optimizer/TransformUtil.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "env/VMAccessCriticalSection.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/J9JitMemory.hpp"
 #include "optimizer/HCRGuardAnalysis.hpp"

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -24,7 +24,7 @@
 #define J9_VALUEPROPAGATION_INCL
 
 #include "optimizer/OMRValuePropagation.hpp"
-#include "infra/List.hpp"                       // for ListIterator, List, etc
+#include "infra/List.hpp"
 
 namespace TR { class VP_BCDSign; }
 

--- a/runtime/compiler/optimizer/JProfilingBlock.cpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,11 +29,11 @@
 #include "infra/List.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "il/Node_inlines.hpp"
-#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "infra/Checklist.hpp"
 #include "ras/DebugCounter.hpp"
 #include "runtime/J9Profiler.hpp"
-#include "control/Recompilation.hpp"              // for TR_Recompilation, etc
-#include "control/RecompilationInfo.hpp"              // for TR_Recompilation, etc
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "optimizer/TransformUtil.hpp"
 
 // Global thresholds for the number of method enters required to trip

--- a/runtime/compiler/optimizer/JProfilingBlock.hpp
+++ b/runtime/compiler/optimizer/JProfilingBlock.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,11 +26,11 @@
 #define __TPF_DO_NOT_MAP_ATOE_REMOVE
 #endif
 
-#include <stdint.h>                           // for int32_t
+#include <stdint.h>
 #include <queue>
 #include <vector>
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class Block; }
 namespace TR { class BlockChecklist; }

--- a/runtime/compiler/optimizer/JProfilingRecompLoopTest.cpp
+++ b/runtime/compiler/optimizer/JProfilingRecompLoopTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,12 +28,12 @@
 #include "infra/List.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "il/Node_inlines.hpp"
-#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "infra/Checklist.hpp"
 #include "ras/DebugCounter.hpp"
-#include "control/Recompilation.hpp"              // for TR_Recompilation, etc
-#include "control/RecompilationInfo.hpp"              // for TR_Recompilation, etc
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "optimizer/TransformUtil.hpp"            // for TransformUtil
+#include "optimizer/TransformUtil.hpp"
 #include "optimizer/JProfilingBlock.hpp"
 
 int32_t TR_JProfilingRecompLoopTest::maxLoopRecompilationThreshold = 10000;

--- a/runtime/compiler/optimizer/JProfilingRecompLoopTest.hpp
+++ b/runtime/compiler/optimizer/JProfilingRecompLoopTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,9 +19,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 #include "infra/Checklist.hpp"                // fir NodeChecklist
 #include "runtime/J9Profiler.hpp"
 #include "optimizer/Structure.hpp"

--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,13 +29,13 @@
 #include "infra/List.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "il/Node_inlines.hpp"
-#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "infra/Checklist.hpp"
 #include "ras/DebugCounter.hpp"
 #include "runtime/J9Profiler.hpp"
-#include "control/Recompilation.hpp"              // for TR_Recompilation, etc
-#include "control/RecompilationInfo.hpp"              // for TR_Recompilation, etc
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "optimizer/TransformUtil.hpp"            // for TransformUtil
+#include "optimizer/TransformUtil.hpp"
 
 /**
  * Get the operation for direct store for a type.

--- a/runtime/compiler/optimizer/JProfilingValue.hpp
+++ b/runtime/compiler/optimizer/JProfilingValue.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,9 +22,9 @@
 #ifndef JPROFILINGVALUE_INCL
 #define JPROFILINGVALUE_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 #include "infra/Checklist.hpp"                // fir NodeChecklist
 
 #include "runtime/J9ValueProfiler.hpp"

--- a/runtime/compiler/optimizer/JitProfiler.cpp
+++ b/runtime/compiler/optimizer/JitProfiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,35 +22,35 @@
 
 #include "optimizer/JitProfiler.hpp"
 
-#include <stddef.h>                            // for NULL
-#include <stdint.h>                            // for int32_t, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
-#include "compile/Compilation.hpp"             // for Compilation
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/ObjectModel.hpp"                 // for ObjectModel
+#include "env/ObjectModel.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                    // for TR_Memory, etc
-#include "env/jittypes.h"                      // for intptrj_t, uintptrj_t
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
 #include "env/VMJ9.h"
-#include "il/Block.hpp"                        // for Block
-#include "il/DataTypes.hpp"                    // for DataTypes::Address
-#include "il/ILOps.hpp"                        // for ILOpCode
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::iconst, etc
-#include "il/Node.hpp"                         // for Node, vcount_t
-#include "il/Node_inlines.hpp"                 // for Node::getChild, etc
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/SymbolReference.hpp"              // for SymbolReference
-#include "il/TreeTop.hpp"                      // for TreeTop
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOps.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol
-#include "il/symbol/RegisterMappedSymbol.hpp"  // for RegisterMappedSymbol
-#include "infra/Cfg.hpp"                       // for CFG
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/RegisterMappedSymbol.hpp"
+#include "infra/Cfg.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "control/Recompilation.hpp"

--- a/runtime/compiler/optimizer/JitProfiler.hpp
+++ b/runtime/compiler/optimizer/JitProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef JITPROFILER_INCL
 #define JITPROFILER_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
-#include "il/Node.hpp"                        // for vcount_t
-#include "infra/Checklist.hpp"                // for Checklist
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
+#include "il/Node.hpp"
+#include "infra/Checklist.hpp"
 
 namespace TR { class Block; }
 namespace TR { class CFG; }

--- a/runtime/compiler/optimizer/LiveVariablesForGC.cpp
+++ b/runtime/compiler/optimizer/LiveVariablesForGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,30 +22,30 @@
 
 #include "optimizer/LiveVariablesForGC.hpp"
 
-#include <stddef.h>                                 // for NULL
-#include "codegen/CodeGenerator.hpp"                // for CodeGenerator
-#include "compile/Compilation.hpp"                  // for Compilation
-#include "compile/OSRData.hpp"                      // for HCRMode
+#include <stddef.h>
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/OSRData.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                         // for TR_Memory, etc
-#include "il/Block.hpp"                             // for Block, toBlock
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/Node.hpp"                              // for Node
-#include "il/Symbol.hpp"                            // for Symbol
-#include "il/SymbolReference.hpp"                   // for SymbolReference
-#include "il/TreeTop.hpp"                           // for TreeTop
+#include "il/Node.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
-#include "il/symbol/AutomaticSymbol.hpp"            // for AutomaticSymbol
+#include "il/symbol/AutomaticSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "infra/BitVector.hpp"                      // for TR_BitVector
-#include "infra/Cfg.hpp"                            // for CFG
-#include "infra/List.hpp"                           // for ListIterator, etc
-#include "infra/TRCfgEdge.hpp"                      // for CFGEdge
-#include "infra/TRCfgNode.hpp"                      // for CFGNode
-#include "optimizer/Optimization.hpp"               // for Optimization
-#include "optimizer/DataFlowAnalysis.hpp"  // for TR_Liveness
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/DataFlowAnalysis.hpp"
 
 // Local live variables for GC
 //

--- a/runtime/compiler/optimizer/LiveVariablesForGC.hpp
+++ b/runtime/compiler/optimizer/LiveVariablesForGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,9 @@
 #ifndef LIVEVARS_INCL
 #define LIVEVARS_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_BitVector;
 namespace TR { class Block; }

--- a/runtime/compiler/optimizer/LoopAliasRefiner.cpp
+++ b/runtime/compiler/optimizer/LoopAliasRefiner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,27 +22,27 @@
 
 #include "optimizer/LoopAliasRefiner.hpp"
 
-#include <stddef.h>                             // for NULL
-#include <stdint.h>                             // for int32_t
-#include "compile/Compilation.hpp"              // for Compilation
-#include "compile/SymbolReferenceTable.hpp"     // for SymbolReferenceTable
-#include "env/TRMemory.hpp"                     // for List::operator new, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "env/TRMemory.hpp"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                         // for Block
-#include "il/ILOpCodes.hpp"                     // for ILOpCodes::aloadi, etc
-#include "il/ILOps.hpp"                         // for ILOpCode
-#include "il/Node.hpp"                          // for Node, vcount_t
-#include "il/Node_inlines.hpp"                  // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                        // for Symbol
-#include "il/SymbolReference.hpp"               // for SymbolReference
-#include "infra/Assert.hpp"                     // for TR_ASSERT
-#include "infra/BitVector.hpp"                  // for TR_BitVector, etc
-#include "infra/List.hpp"                       // for TR_ScratchList, etc
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/List.hpp"
 #include "optimizer/LoopVersioner.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizations.hpp"
 #include "optimizer/SPMDPreCheck.hpp"
-#include "optimizer/Structure.hpp"              // for TR_RegionStructure
+#include "optimizer/Structure.hpp"
 
 namespace TR { class TreeTop; }
 

--- a/runtime/compiler/optimizer/LoopAliasRefiner.hpp
+++ b/runtime/compiler/optimizer/LoopAliasRefiner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,16 +23,16 @@
 #ifndef LOOPALIASREFINER_INCL
 #define LOOPALIASREFINER_INCL
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
-#include "il/Node.hpp"                        // for Node, vcount_t
-#include "il/SymbolReference.hpp"             // for SymbolReference
-#include "infra/Assert.hpp"                   // for TR_ASSERT
-#include "infra/BitVector.hpp"                // for TR_BitVector
-#include "infra/List.hpp"                     // for List (ptr only), etc
+#include <stddef.h>
+#include <stdint.h>
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "il/SymbolReference.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/List.hpp"
 #include "optimizer/LoopVersioner.hpp"
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_InductionVariable;
 class TR_RegionStructure;

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,57 +22,57 @@
 
 #include "optimizer/MonitorElimination.hpp"
 
-#include <stdint.h>                                // for int32_t, uint32_t, etc
-#include <stdlib.h>                                // for atoi
-#include <string.h>                                // for NULL, memset, etc
-#include <algorithm>                               // for std::find
-#include "codegen/CodeGenerator.hpp"               // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                    // for feGetEnv, etc
-#include "compile/Compilation.hpp"                 // for Compilation, etc
-#include "compile/Method.hpp"                      // for TR_Method
-#include "compile/ResolvedMethod.hpp"              // for TR_ResolvedMethod
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <algorithm>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"             // for TR::Options, etc
-#include "cs2/arrayof.h"                           // for ArrayOf
+#include "control/Options_inlines.hpp"
+#include "cs2/arrayof.h"
 #include "cs2/bitvectr.h"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                        // for Allocator, etc
+#include "env/TRMemory.hpp"
 #include "env/VMJ9.h"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                            // for Block, toBlock, etc
+#include "il/Block.hpp"
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/ILOps.hpp"                            // for ILOpCode, etc
-#include "il/Node.hpp"                             // for Node, etc
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                           // for Symbol
-#include "il/SymbolReference.hpp"                  // for SymbolReference, etc
-#include "il/TreeTop.hpp"                          // for TreeTop
-#include "il/TreeTop_inlines.hpp"                  // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"              // for MethodSymbol
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "il/symbol/StaticSymbol.hpp"              // for StaticSymbol
-#include "infra/Array.hpp"                         // for TR_Array
-#include "infra/Assert.hpp"                        // for TR_ASSERT
-#include "infra/BitVector.hpp"                     // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                           // for CFG, etc
-#include "infra/Link.hpp"                          // for TR_LinkHead, etc
-#include "infra/List.hpp"                          // for ListIterator, etc
-#include "infra/Stack.hpp"                         // for TR_Stack
-#include "infra/TRCfgEdge.hpp"                     // for CFGEdge
-#include "infra/TRCfgNode.hpp"                     // for CFGNode
-#include "optimizer/InterProceduralAnalyzer.hpp"   // for TR::GlobalSymbol
-#include "optimizer/Optimization.hpp"              // for Optimization
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "infra/Stack.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/InterProceduralAnalyzer.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"                 // for Optimizer
+#include "optimizer/Optimizer.hpp"
 #include "optimizer/Structure.hpp"
-#include "optimizer/TransformUtil.hpp"             // for TransformUtil
-#include "optimizer/UseDefInfo.hpp"                // for TR_UseDefInfo, etc
+#include "optimizer/TransformUtil.hpp"
+#include "optimizer/UseDefInfo.hpp"
 #include "optimizer/ValueNumberInfo.hpp"
-#include "ras/LogTracer.hpp"                       // for debugTrace, etc
+#include "ras/LogTracer.hpp"
 
 class TR_OpaqueClassBlock;
 

--- a/runtime/compiler/optimizer/MonitorElimination.hpp
+++ b/runtime/compiler/optimizer/MonitorElimination.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,17 +23,17 @@
 #ifndef MONITORELIM_INCL
 #define MONITORELIM_INCL
 
-#include <stddef.h>                               // for NULL
-#include <stdint.h>                               // for int32_t, uint32_t
-#include "env/TRMemory.hpp"                       // for TR_Memory, etc
-#include "il/Node.hpp"                            // for vcount_t
-#include "infra/BitVector.hpp"                    // for TR_BitVector
-#include "infra/Link.hpp"                         // for TR_LinkHead
-#include "infra/List.hpp"                         // for List, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
 #include "optimizer/InterProceduralAnalyzer.hpp"
-#include "optimizer/Optimization.hpp"             // for Optimization
+#include "optimizer/Optimization.hpp"
 #include "optimizer/OptimizationManager.hpp"
-#include "ras/LogTracer.hpp"                      // for TR_LogTracer
+#include "ras/LogTracer.hpp"
 
 class TR_ActiveMonitor;
 class TR_ClassExtendCheck;

--- a/runtime/compiler/optimizer/NewInitialization.cpp
+++ b/runtime/compiler/optimizer/NewInitialization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,46 +22,46 @@
 
 #include "optimizer/NewInitialization.hpp"
 
-#include <stdint.h>                                // for int32_t, uint32_t, etc
-#include <string.h>                                // for NULL, memset
-#include "codegen/CodeGenerator.hpp"               // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                    // for TR_FrontEnd, etc
-#include "compile/Compilation.hpp"                 // for Compilation
-#include "compile/CompilationTypes.hpp"            // for TR_Hotness
-#include "compile/ResolvedMethod.hpp"              // for TR_ResolvedMethod
+#include <stdint.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/CompilationTypes.hpp"
+#include "compile/ResolvedMethod.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"             // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/ObjectModel.hpp"                     // for ObjectModel
+#include "env/ObjectModel.hpp"
 #include "env/TRMemory.hpp"
 #include "env/VMJ9.h"
-#include "il/Block.hpp"                            // for Block
-#include "il/DataTypes.hpp"                        // for DataType
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/ILOps.hpp"                            // for ILOpCode
-#include "il/Node.hpp"                             // for Node, etc
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                           // for Symbol
-#include "il/SymbolReference.hpp"                  // for SymbolReference, etc
-#include "il/TreeTop.hpp"                          // for TreeTop
-#include "il/TreeTop_inlines.hpp"                  // for TreeTop::getNode, etc
-#include "il/symbol/ParameterSymbol.hpp"           // for ParameterSymbol
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/ParameterSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "il/symbol/StaticSymbol.hpp"              // for StaticSymbol
-#include "infra/Array.hpp"                         // for TR_Array
-#include "infra/Assert.hpp"                        // for TR_ASSERT
-#include "infra/BitVector.hpp"                     // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                           // for CFG (ptr only), etc
-#include "infra/Link.hpp"                          // for TR_LinkHead, etc
-#include "infra/List.hpp"                          // for TR_ScratchList
-#include "optimizer/CallInfo.hpp"                  // for TR_CallSite
-#include "optimizer/Inliner.hpp"                   // for TR_InlineCall, etc
-#include "optimizer/Optimization.hpp"              // for Optimization
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "optimizer/CallInfo.hpp"
+#include "optimizer/Inliner.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/Optimizer.hpp"                 // for Optimizer
-#include "optimizer/TransformUtil.hpp"             // for TransformUtil
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/TransformUtil.hpp"
 #include "optimizer/ValueNumberInfo.hpp"
-#include "ras/Debug.hpp"                           // for TR_DebugBase
+#include "ras/Debug.hpp"
 
 class TR_OpaqueClassBlock;
 namespace TR { class MethodSymbol; }

--- a/runtime/compiler/optimizer/NewInitialization.hpp
+++ b/runtime/compiler/optimizer/NewInitialization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef NEWINITIALIZATION_INCL
 #define NEWINITIALIZATION_INCL
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t
-#include "infra/Link.hpp"                     // for TR_LinkHead, TR_Link, etc
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stddef.h>
+#include <stdint.h>
+#include "infra/Link.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_BitVector;
 namespace TR { class Node; }

--- a/runtime/compiler/optimizer/OSRGuardAnalysis.cpp
+++ b/runtime/compiler/optimizer/OSRGuardAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,9 @@
 
 #include "codegen/CodeGenerator.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "compile/Compilation.hpp"         // for Compilation
-#include "env/TRMemory.hpp"                // for TR_Memory, etc
-#include "infra/BitVector.hpp"             // for TR_BitVector
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "infra/BitVector.hpp"
 
 /**
  * This data flow analysis will detect OSR guards that are no longer required. This is done by generating at yields

--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -32,7 +32,7 @@
 #include "optimizer/RematTools.hpp"
 #include "optimizer/TransformUtil.hpp"
 #include "ras/DebugCounter.hpp"
-#include "infra/Checklist.hpp"             // for TR::NodeChecklist
+#include "infra/Checklist.hpp"
 
 TR_Structure* fakeRegion(TR::Compilation *comp);
 

--- a/runtime/compiler/optimizer/OSRGuardInsertion.hpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.hpp
@@ -22,9 +22,9 @@
 #ifndef OSRGUARDINSERTION_INCL
 #define OSRGUARDINSERTION_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "optimizer/HCRGuardAnalysis.hpp"
 

--- a/runtime/compiler/optimizer/OSRGuardRemoval.cpp
+++ b/runtime/compiler/optimizer/OSRGuardRemoval.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 #include "il/Block.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "codegen/CodeGenerator.hpp"
-#include "compile/Compilation.hpp"         // for Compilation
+#include "compile/Compilation.hpp"
 #include "optimizer/OSRGuardAnalysis.hpp"
 #include "ras/DebugCounter.hpp"
 

--- a/runtime/compiler/optimizer/OSRGuardRemoval.hpp
+++ b/runtime/compiler/optimizer/OSRGuardRemoval.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,9 +22,9 @@
 #ifndef OSRGUARDREMOVAL_INCL
 #define OSRGUARDREMOVAL_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/DataFlowAnalysis.hpp"
 
 namespace TR { class Block; }

--- a/runtime/compiler/optimizer/OptimizationManager.hpp
+++ b/runtime/compiler/optimizer/OptimizationManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "optimizer/J9OptimizationManager.hpp"
 
-#include <stddef.h>                     // for NULL
-#include "optimizer/Optimizations.hpp"  // for Optimizations
+#include <stddef.h>
+#include "optimizer/Optimizations.hpp"
 
 namespace TR { class Optimizer; }
 struct OptimizationStrategy;

--- a/runtime/compiler/optimizer/Optimizer.hpp
+++ b/runtime/compiler/optimizer/Optimizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "optimizer/J9Optimizer.hpp"
 
-#include <stddef.h>                    // for NULL
-#include <stdint.h>                    // for uint16_t
+#include <stddef.h>
+#include <stdint.h>
 
 namespace TR { class Compilation; }
 namespace TR { class ResolvedMethodSymbol; }

--- a/runtime/compiler/optimizer/ProfileGenerator.cpp
+++ b/runtime/compiler/optimizer/ProfileGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,40 +22,40 @@
 
 #include "optimizer/ProfileGenerator.hpp"
 
-#include <limits.h>                            // for INT_MAX
-#include <stddef.h>                            // for NULL
-#include <stdint.h>                            // for uintptrj_t
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for TR_VerboseLog, etc
-#include "compile/Compilation.hpp"             // for Compilation
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
-#include "control/Recompilation.hpp"           // for TR_Recompilation, etc
-#include "control/RecompilationInfo.hpp"           // for TR_Recompilation, etc
+#include "control/Options_inlines.hpp"
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/IO.hpp"                          // for POINTER_PRINTF_FORMAT
+#include "env/IO.hpp"
 #include "env/TRMemory.hpp"
-#include "env/jittypes.h"                      // for uintptrj_t
-#include "il/Block.hpp"                        // for Block
-#include "il/DataTypes.hpp"                    // for DataType::Address, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::iconst, etc
-#include "il/ILOps.hpp"                        // for ILOpCode
-#include "il/Node.hpp"                         // for Node, vcount_t
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/SymbolReference.hpp"              // for SymbolReference
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/BitVector.hpp"                 // for TR_BitVector
-#include "infra/Cfg.hpp"                       // for CFG
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/TransformUtil.hpp"         // for calculateElementAddress
+#include "optimizer/TransformUtil.hpp"
 
 #define OPT_DETAILS "O^O PROFILE GENERATOR: "
 #define MAX_NUMBER_OF_ALLOWED_NODES 90000

--- a/runtime/compiler/optimizer/ProfileGenerator.hpp
+++ b/runtime/compiler/optimizer/ProfileGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,9 @@
 #ifndef PROFILEGENERATOR_INCL
 #define PROFILEGENERATOR_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class CFG; }
 namespace TR { class Node; }

--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -22,54 +22,54 @@
 
 #include "optimizer/SPMDParallelizer.hpp"
 
-#include <limits.h>                                // for INT_MAX
-#include <stdint.h>                                // for int32_t, uint16_t
-#include <stdio.h>                                 // for printf
-#include <string.h>                                // for NULL, memset, etc
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/FrontEnd.hpp"                    // for TR_VerboseLog, etc
+#include "codegen/FrontEnd.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/RecognizedMethods.hpp"
-#include "compile/Compilation.hpp"                 // for Compilation, etc
-#include "compile/ResolvedMethod.hpp"              // for TR_ResolvedMethod
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"             // for TR::Options, etc
-#include "cs2/allocator.h"                         // for shared_allocator
-#include "cs2/arrayof.h"                           // for ArrayOf<>::Cursor, etc
+#include "control/Options_inlines.hpp"
+#include "cs2/allocator.h"
+#include "cs2/arrayof.h"
 #include "cs2/bitvectr.h"
 #include "cs2/sparsrbit.h"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                        // for Allocator, etc
+#include "env/TRMemory.hpp"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                            // for Block, toBlock
+#include "il/Block.hpp"
 #include "il/DataTypes.hpp"
-#include "il/ILOpCodes.hpp"                        // for ILOpCodes, etc
-#include "il/ILOps.hpp"                            // for TR::ILOpCode, etc
-#include "il/Node.hpp"                             // for Node, etc
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                           // for Symbol
-#include "il/SymbolReference.hpp"                  // for SymbolReference
-#include "il/TreeTop.hpp"                          // for TreeTop
-#include "il/TreeTop_inlines.hpp"                  // for TreeTop::getNode, etc
-#include "il/symbol/AutomaticSymbol.hpp"           // for AutomaticSymbol
-#include "il/symbol/MethodSymbol.hpp"              // for MethodSymbol
-#include "infra/Assert.hpp"                        // for TR_ASSERT
-#include "infra/BitVector.hpp"                     // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                           // for CFG
-#include "infra/HashTab.hpp"                       // for TR_HashTab, etc
-#include "infra/List.hpp"                          // for ListIterator, etc
-#include "infra/TRCfgEdge.hpp"                     // for CFGEdge
-#include "infra/TRCfgNode.hpp"                     // for CFGNode
-#include "optimizer/Dominators.hpp"                // for TR_Dominators
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/HashTab.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TRCfgNode.hpp"
+#include "optimizer/Dominators.hpp"
 #include "optimizer/InductionVariable.hpp"
 #include "optimizer/LoopCanonicalizer.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"                 // for Optimizer
+#include "optimizer/Optimizer.hpp"
 #include "optimizer/SPMDPreCheck.hpp"
 #include "optimizer/Structure.hpp"
-#include "optimizer/UseDefInfo.hpp"                // for TR_UseDefInfo, etc
+#include "optimizer/UseDefInfo.hpp"
 #include "optimizer/ValueNumberInfo.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "ras/DebugCounter.hpp"

--- a/runtime/compiler/optimizer/SPMDParallelizer.hpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef SPMDPARALLELIZER_INCL
 #define SPMDPARALLELIZER_INCL
 
-#include "optimizer/GeneralLoopUnroller.hpp"     // for OptimizationManager
+#include "optimizer/GeneralLoopUnroller.hpp"
 
 class TR_SPMDKernelParallelizer : public TR_LoopTransformer
    {

--- a/runtime/compiler/optimizer/SPMDPreCheck.cpp
+++ b/runtime/compiler/optimizer/SPMDPreCheck.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,9 +21,9 @@
  *******************************************************************************/
 
 #include "optimizer/SPMDPreCheck.hpp"
-#include "il/ILOpCodes.hpp"                        // for ILOpCodes, etc
-#include "il/ILOps.hpp"                            // for TR::ILOpCode, etc
-#include "il/Node.hpp"                             // for Node, etc
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "codegen/CodeGenerator.hpp"
 

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,49 +22,49 @@
 
 #include "optimizer/SequentialStoreSimplifier.hpp"
 
-#include <limits.h>                             // for INT_MAX
-#include <stddef.h>                             // for NULL, size_t
-#include <stdint.h>                             // for intptr_t, int64_t, etc
-#include <stdio.h>                              // for printf, fprintf, etc
-#include <string.h>                             // for memmove, memset
-#include "codegen/CodeGenerator.hpp"            // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                 // for feGetEnv
-#include "codegen/Linkage.hpp"                  // for Linkage
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/Linkage.hpp"
 #include "codegen/StorageInfo.hpp"
-#include "compile/Compilation.hpp"              // for Compilation, etc
-#include "compile/SymbolReferenceTable.hpp"     // for SymbolReferenceTable
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"          // for TR::Options, etc
-#include "cs2/bitvectr.h"                       // for ABitVector
-#include "cs2/sparsrbit.h"                      // for ASparseBitVector, etc
+#include "control/Options_inlines.hpp"
+#include "cs2/bitvectr.h"
+#include "cs2/sparsrbit.h"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                     // for TR_Memory, etc
+#include "env/TRMemory.hpp"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                         // for Block, toBlock
-#include "il/DataTypes.hpp"                     // for DataTypes::Int8, etc
-#include "il/ILOpCodes.hpp"                     // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                         // for ILOpCode, etc
-#include "il/Node.hpp"                          // for Node, etc
-#include "il/Node_inlines.hpp"                  // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                        // for Symbol
-#include "il/SymbolReference.hpp"               // for SymbolReference
-#include "il/TreeTop.hpp"                       // for TreeTop
-#include "il/TreeTop_inlines.hpp"               // for TreeTop::getNode, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"   // for ResolvedMethodSymbol
-#include "infra/Array.hpp"                      // for TR_Array
-#include "infra/Assert.hpp"                     // for TR_ASSERT
-#include "infra/Cfg.hpp"                        // for CFG
-#include "infra/Link.hpp"                       // for TR_Pair
-#include "infra/List.hpp"                       // for TR_ScratchList, List, etc
-#include "infra/TRCfgEdge.hpp"                  // for CFGEdge
-#include "infra/TreeServices.hpp"               // for TR_AddressTree
-#include "optimizer/Optimization.hpp"           // for Optimization
-#include "optimizer/OptimizationManager.hpp"    // for OptimizationManager
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/Link.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
+#include "infra/TreeServices.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"              // for Optimizer
-#include "optimizer/Structure.hpp"              // for TR_BlockStructure, etc
-#include "ras/Debug.hpp"                        // for TR_DebugBase
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/Structure.hpp"
+#include "ras/Debug.hpp"
 
 
 #define OPT_DETAILS "O^O SEQUENTIAL STORE TRANSFORMATION: "

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.hpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,9 +23,9 @@
 #ifndef SEQUENTIAL_STORE_SIMPLIFIER_INCL
 #define SEQUENTIAL_STORE_SIMPLIFIER_INCL
 
-#include <stdint.h>                           // for int32_t
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class Node; }
 namespace TR { class TreeTop; }

--- a/runtime/compiler/optimizer/SignExtendLoads.cpp
+++ b/runtime/compiler/optimizer/SignExtendLoads.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,25 +22,25 @@
 
 #include "optimizer/SignExtendLoads.hpp"
 
-#include <stdint.h>                            // for int32_t, int64_t, etc
-#include <string.h>                            // for NULL, memset
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for feGetEnv
-#include "compile/Compilation.hpp"             // for Compilation
+#include <stdint.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                    // for TR_Memory, List::operator new
-#include "il/Block.hpp"                        // for Block
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::i2l, etc
-#include "il/ILOps.hpp"                        // for ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/Node_inlines.hpp"                 // for Node::getChild, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNextTreeTop, etc
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/List.hpp"                      // for ListIterator, TR_ScratchList
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/List.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "ras/Debug.hpp"
 
 #define OPT_DETAILS "O^O SIGN EXTENDING LOADS TRANSFORMATION: "
 

--- a/runtime/compiler/optimizer/SignExtendLoads.hpp
+++ b/runtime/compiler/optimizer/SignExtendLoads.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,14 +23,14 @@
 #ifndef SIGN_EXTEND_LOADS_INCL
 #define SIGN_EXTEND_LOADS_INCL
 
-#include "optimizer/Optimization.hpp"         // for Optimization
+#include "optimizer/Optimization.hpp"
 
-#include <stdint.h>                           // for int32_t
-#include "compile/Compilation.hpp"            // for Compilation
+#include <stdint.h>
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
-#include "env/jittypes.h"                     // for uintptrj_t
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "env/jittypes.h"
+#include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class Node; }
 template <class T> class TR_ScratchList;

--- a/runtime/compiler/optimizer/StringPeepholes.cpp
+++ b/runtime/compiler/optimizer/StringPeepholes.cpp
@@ -22,62 +22,62 @@
 
 #include "optimizer/StringPeepholes.hpp"
 
-#include <limits.h>                            // for INT_MAX, UINT_MAX, etc
-#include <math.h>                              // for exp
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include <stdio.h>                             // for printf, fflush, etc
-#include <stdlib.h>                            // for atoi
-#include <string.h>                            // for NULL, strncmp, strcmp, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv, etc
-#include "codegen/RecognizedMethods.hpp"       // for RecognizedMethod, etc
-#include "compile/Compilation.hpp"             // for Compilation, comp, etc
-#include "compile/Method.hpp"                  // for TR_Method
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable, etc
+#include <limits.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/RecognizedMethods.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/TRMemory.hpp"                    // for SparseBitVector, etc
-#include "env/jittypes.h"                      // for TR_ByteCodeInfo, etc
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
 #include "env/VMJ9.h"
-#include "il/Block.hpp"                        // for Block, toBlock, etc
-#include "il/DataTypes.hpp"                    // for TR::DataType, etc
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/NodePool.hpp"                     // for TR_NodePool
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "il/symbol/StaticSymbol.hpp"          // for StaticSymbol
-#include "infra/Array.hpp"                     // for TR_Array
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/Cfg.hpp"                       // for CFG, etc
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/NodePool.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
 #include "infra/ILWalk.hpp"
-#include "infra/List.hpp"                      // for List, TR_ScratchList, etc
-#include "infra/Stack.hpp"                     // for TR_Stack
-#include "optimizer/Inliner.hpp"               // for TR_InlineCall, etc
-#include "optimizer/Optimization.hpp"          // for Optimization
+#include "infra/List.hpp"
+#include "infra/Stack.hpp"
+#include "optimizer/Inliner.hpp"
+#include "optimizer/Optimization.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OptimizationManager.hpp"   // for OptimizationManager
+#include "optimizer/OptimizationManager.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Optimizer.hpp"             // for Optimizer
-#include "optimizer/TransformUtil.hpp"         // for TransformUtil
-#include "ras/Debug.hpp"                       // for TR_DebugBase
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "ras/Debug.hpp"
 #include "runtime/J9Profiler.hpp"
 #include "runtime/J9ValueProfiler.hpp"
 
-#include "env/PersistentCHTable.hpp"           // for CLASSHASHTABLE_SIZE, etc
-#include "env/PersistentInfo.hpp"              // for PersistentInfo
+#include "env/PersistentCHTable.hpp"
+#include "env/PersistentInfo.hpp"
 
 static void replaceCallNode(TR::Node *oldCall, TR::Node *newCall, TR::Node *node, vcount_t visitCount)
    {

--- a/runtime/compiler/optimizer/StringPeepholes.hpp
+++ b/runtime/compiler/optimizer/StringPeepholes.hpp
@@ -23,20 +23,20 @@
 #ifndef STRINGPEEPHOLES_INCL
 #define STRINGPEEPHOLES_INCL
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include "codegen/RecognizedMethods.hpp"      // for RecognizedMethod
-#include "compile/Compilation.hpp"            // for Compilation
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
-#include "il/Block.hpp"                       // for Block
-#include "il/ILOpCodes.hpp"                   // for ILOpCodes, etc
-#include "il/Node.hpp"                        // for Node, etc
-#include "infra/Array.hpp"                    // for TR_Array
-#include "infra/Assert.hpp"                   // for TR_ASSERT
-#include "infra/BitVector.hpp"                // for TR_BitVector
-#include "infra/List.hpp"                     // for List, TR_ScratchList
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/RecognizedMethods.hpp"
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/Node.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SymbolReference; }

--- a/runtime/compiler/optimizer/SwitchAnalyzer.cpp
+++ b/runtime/compiler/optimizer/SwitchAnalyzer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,26 +22,26 @@
 
 #include "optimizer/SwitchAnalyzer.hpp"
 
-#include <stdint.h>                            // for int8_t, int64_t, uint16_t
-#include <string.h>                            // for NULL, memset
-#include "codegen/FrontEnd.hpp"                // for TR::IO::fprintf, etc
-#include "compile/Compilation.hpp"             // for Compilation
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable
-#include "env/IO.hpp"                          // for IO
-#include "il/Block.hpp"                        // for Block
-#include "il/DataTypes.hpp"                    // for DataTypes::Int16, etc
-#include "il/ILOps.hpp"                        // for ILOpCode
-#include "il/Node.hpp"                         // for Node
-#include "il/Node_inlines.hpp"                 // for Node::getBranchDestination, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "infra/BitVector.hpp"                 // for TR_BitVector, etc
-#include "infra/Cfg.hpp"                       // for CFG
-#include "infra/List.hpp"                      // for ListIterator, List
-#include "infra/TRCfgEdge.hpp"                 // for CFGEdge
+#include <stdint.h>
+#include <string.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "env/IO.hpp"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgEdge.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/TransformUtil.hpp"         // for calculateElementAddress
+#include "optimizer/TransformUtil.hpp"
 
 #define MIN_SIZE_FOR_BIN_SEARCH 4
 #define MIN_CASES_FOR_OPT 4

--- a/runtime/compiler/optimizer/SwitchAnalyzer.hpp
+++ b/runtime/compiler/optimizer/SwitchAnalyzer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,15 +23,15 @@
 #ifndef SWITCHANALYZER_HPP
 #define SWITCHANALYZER_HPP
 
-#include <limits.h>                           // for INT_MAX, INT_MIN
-#include <stdint.h>                           // for int32_t
-#include "env/FilePointerDecl.hpp"            // for FILE
+#include <limits.h>
+#include <stdint.h>
+#include "env/FilePointerDecl.hpp"
 #include "env/TRMemory.hpp"
-#include "il/DataTypes.hpp"                   // for CASECONST_TYPE
-#include "il/ILOpCodes.hpp"                   // for ILOpCodes
-#include "infra/Link.hpp"                     // for TR_Link, TR_LinkHead
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "infra/Link.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_BitVector;
 class TR_FrontEnd;

--- a/runtime/compiler/optimizer/UnsafeFastPath.cpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,34 +22,34 @@
 
 #include "optimizer/UnsafeFastPath.hpp"
 
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv, etc
-#include "compile/Compilation.hpp"             // for Compilation, comp, etc
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
 #include "env/VMJ9.h"
 #include "env/j9method.h"
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "optimizer/Optimization.hpp"          // for Optimization
-#include "optimizer/Optimization_inlines.hpp"  // for trace()
-#include "optimizer/TransformUtil.hpp"         // for calculateElementAddress
-#include "infra/Checklist.hpp"                 // for NodeChecklist, etc
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "infra/Checklist.hpp"
 
 
 static TR::RecognizedMethod getVarHandleAccessMethodFromInlinedCallStack(TR::Compilation* comp, TR::Node* node)

--- a/runtime/compiler/optimizer/UnsafeFastPath.hpp
+++ b/runtime/compiler/optimizer/UnsafeFastPath.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 #ifndef UNSAFEFASTPATH_INCL
 #define UNSAFEFASTPATH_INCL 
 
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include "il/Node.hpp"                        // for Node
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "il/Node.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_UnsafeFastPath : public TR::Optimization
    {

--- a/runtime/compiler/optimizer/VPBCDConstraint.cpp
+++ b/runtime/compiler/optimizer/VPBCDConstraint.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,31 +22,31 @@
 
 #include "optimizer/VPBCDConstraint.hpp"
 
-#include <ctype.h>                              // for isdigit
-#include <stddef.h>                             // for size_t
-#include "codegen/FrontEnd.hpp"                 // for TR::IO::fprintf, etc
-#include "env/KnownObjectTable.hpp"         // for KnownObjectTable, etc
-#include "env/PersistentCHTable.hpp"            // for TR_PersistentCHTable
+#include <ctype.h>
+#include <stddef.h>
+#include "codegen/FrontEnd.hpp"
+#include "env/KnownObjectTable.hpp"
+#include "env/PersistentCHTable.hpp"
 #include "env/VMJ9.h"
-#include "compile/Compilation.hpp"              // for Compilation
-#include "compile/ResolvedMethod.hpp"           // for TR_ResolvedMethod
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/IO.hpp"
-#include "env/ObjectModel.hpp"                  // for ObjectModel
-#include "env/PersistentInfo.hpp"               // for PersistentInfo
+#include "env/ObjectModel.hpp"
+#include "env/PersistentInfo.hpp"
 #include "env/jittypes.h"
-#include "env/VMAccessCriticalSection.hpp"      // for VMAccessCriticalSection
-#include "il/DataTypes.hpp"                     // for getMaxSigned, etc
-#include "il/ILOps.hpp"                         // for ILOpCode
-#include "il/Node.hpp"                          // for Node, etc
-#include "il/Symbol.hpp"                        // for Symbol
-#include "il/SymbolReference.hpp"               // for SymbolReference, etc
-#include "il/symbol/StaticSymbol.hpp"           // for StaticSymbol
-#include "ilgen/IlGenRequest.hpp"               // for IlGenRequest
+#include "env/VMAccessCriticalSection.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "ilgen/IlGenRequest.hpp"
 #include "ilgen/IlGeneratorMethodDetails.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/J9ValuePropagation.hpp"       // for J9::ValuePropagation, etc
+#include "optimizer/J9ValuePropagation.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 
 // ***************************************************************************

--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,15 +21,15 @@
  *******************************************************************************/
 
 #include "optimizer/VarHandleTransformer.hpp"
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator, etc
-#include "codegen/FrontEnd.hpp"                // for TR_FrontEnd, feGetEnv, etc
-#include "compile/Compilation.hpp"             // for Compilation, comp, etc
-#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"    // for SymbolReferenceTable, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
 #include "exceptions/AOTFailure.hpp"
 #include "exceptions/FSDFailure.hpp"
@@ -37,20 +37,20 @@
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/j9method.h"
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::treetop, etc
-#include "il/ILOps.hpp"                        // for ILOpCode, TR::ILOpCode
-#include "il/Node.hpp"                         // for Node, etc
-#include "il/Node_inlines.hpp"                 // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                       // for Symbol, etc
-#include "il/SymbolReference.hpp"              // for SymbolReference, etc
-#include "il/TreeTop.hpp"                      // for TreeTop
-#include "il/TreeTop_inlines.hpp"              // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"          // for MethodSymbol, etc
-#include "il/symbol/ResolvedMethodSymbol.hpp"  // for ResolvedMethodSymbol
-#include "infra/Assert.hpp"                    // for TR_ASSERT
-#include "optimizer/Optimization.hpp"          // for Optimization
-#include "optimizer/Optimization_inlines.hpp"  // for trace()
-#include "optimizer/J9TransformUtil.hpp"       // for calculateElementAddress
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "il/symbol/ResolvedMethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "optimizer/J9TransformUtil.hpp"
 #include "env/JSR292Methods.h"
 
 // All VarHandle Access methods

--- a/runtime/compiler/optimizer/VarHandleTransformer.hpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 #ifndef VARHANDLETRANSFORMER_INCL
 #define VARHANDLETRANSFORMER_INCL 
 
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include "il/Node.hpp"                        // for Node
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stdint.h>
+#include "il/Node.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 class TR_VarHandleTransformer : public TR::Optimization
    {

--- a/runtime/compiler/p/codegen/GenerateInstructions.cpp
+++ b/runtime/compiler/p/codegen/GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,32 +22,32 @@
 
 #include "p/codegen/GenerateInstructions.hpp"
 
-#include <algorithm>                           // for std::max
-#include <stdint.h>                            // for int32_t, uint32_t, etc
-#include <stdlib.h>                            // for NULL, atoi
-#include "codegen/BackingStore.hpp"            // for TR_BackingStore
-#include "codegen/CodeGenerator.hpp"           // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                // for feGetEnv, TR_FrontEnd
-#include "codegen/InstOpCode.hpp"              // for InstOpCode, etc
-#include "codegen/Instruction.hpp"             // for Instruction, etc
-#include "codegen/MemoryReference.hpp"         // for MemoryReference
-#include "codegen/Register.hpp"                // for Register
-#include "codegen/Snippet.hpp"                 // for Snippet
-#include "compile/Compilation.hpp"             // for Compilation
+#include <algorithm>
+#include <stdint.h>
+#include <stdlib.h>
+#include "codegen/BackingStore.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/InstOpCode.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/Register.hpp"
+#include "codegen/Snippet.hpp"
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/Processors.hpp"
 #include "env/TRMemory.hpp"
-#include "env/jittypes.h"                      // for intptrj_t, uintptrj_t
-#include "il/Block.hpp"                        // for Block
-#include "il/ILOpCodes.hpp"                    // for ILOpCodes::BBEnd, etc
-#include "il/ILOps.hpp"                        // for ILOpCode
-#include "il/Node.hpp"                         // for Node
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/TreeTop.hpp"                      // for TreeTop
+#include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
-#include "infra/Assert.hpp"                    // for TR_ASSERT
+#include "infra/Assert.hpp"
 #include "p/codegen/PPCInstruction.hpp"
 #include "runtime/J9Runtime.hpp"
 

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
  *******************************************************************************/
 
 #include "j9cfg.h"
-#include "codegen/AheadOfTimeCompile.hpp"           // for AheadOfTimeCompile
+#include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "codegen/GenerateInstructions.hpp"

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 #include "omrmodroncore.h"
 #include "thrdsup.h"
 #include "thrtypes.h"
-#include "codegen/AheadOfTimeCompile.hpp"           // for AheadOfTimeCompile
+#include "codegen/AheadOfTimeCompile.hpp"
 #include "codegen/BackingStore.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,35 +22,35 @@
 
 #include "codegen/UnresolvedDataSnippet.hpp"
 
-#include <stddef.h>                                 // for NULL
-#include <stdint.h>                                 // for int32_t, uint8_t, etc
-#include "codegen/CodeGenerator.hpp"                // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                     // for TR_FrontEnd
-#include "codegen/Instruction.hpp"                  // for Instruction
-#include "codegen/Machine.hpp"                      // for Machine, etc
-#include "codegen/MemoryReference.hpp"              // for MemoryReference
-#include "codegen/RealRegister.hpp"                 // for RealRegister, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/Machine.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/RealRegister.hpp"
 #include "codegen/Relocation.hpp"
-#include "compile/Compilation.hpp"                  // for Compilation
+#include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"              // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/IO.hpp"
-#include "env/ObjectModel.hpp"                      // for ObjectModel
+#include "env/ObjectModel.hpp"
 #include "env/TRMemory.hpp"
-#include "env/jittypes.h"                           // for intptrj_t, uintptrj_t
+#include "env/jittypes.h"
 #include "env/VMJ9.h"
 #include "il/DataTypes.hpp"
-#include "il/Node.hpp"                              // for Node
-#include "il/Symbol.hpp"                            // for Symbol
-#include "il/SymbolReference.hpp"                   // for SymbolReference
-#include "il/symbol/LabelSymbol.hpp"                // for LabelSymbol, etc
-#include "il/symbol/StaticSymbol.hpp"               // for StaticSymbol
-#include "il/symbol/StaticSymbol_inlines.hpp"       // for StaticSymbol
-#include "infra/Assert.hpp"                         // for TR_ASSERT
-#include "p/codegen/PPCTableOfConstants.hpp"        // for PTOC_FULL_INDEX
-#include "ras/Debug.hpp"                            // for TR_Debug
+#include "il/Node.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/LabelSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "il/symbol/StaticSymbol_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "p/codegen/PPCTableOfConstants.hpp"
+#include "ras/Debug.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "env/CompilerEnv.hpp"
 

--- a/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/p/codegen/J9UnresolvedDataSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,9 +36,9 @@ namespace J9 { typedef J9::Power::UnresolvedDataSnippet UnresolvedDataSnippetCon
 
 #include "compiler/codegen/J9UnresolvedDataSnippet.hpp"
 
-#include <stdint.h>                                 // for int32_t, etc
-#include "codegen/Snippet.hpp"                      // for TR::PPCSnippet, etc
-#include "il/SymbolReference.hpp"                   // for SymbolReference
+#include <stdint.h>
+#include "codegen/Snippet.hpp"
+#include "il/SymbolReference.hpp"
 #include "infra/Flags.hpp"
 
 namespace TR { class CodeGenerator; }

--- a/runtime/compiler/p/codegen/Trampoline.cpp
+++ b/runtime/compiler/p/codegen/Trampoline.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,15 +20,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for uint8_t, int32_t, etc
-#include "codegen/CodeGenerator.hpp"          // for CodeGenerator
-#include "codegen/FrontEnd.hpp"               // for TR_FrontEnd
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"        // for TR::Options
-#include "env/jittypes.h"                     // for uintptrj_t
+#include "control/Options_inlines.hpp"
+#include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"
-#include "p/codegen/PPCTableOfConstants.hpp"  // for TR_PPCTableOfConstants
+#include "p/codegen/PPCTableOfConstants.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "env/VMJ9.h"
 

--- a/runtime/compiler/ras/DebugExt.hpp
+++ b/runtime/compiler/ras/DebugExt.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,17 +23,17 @@
 #ifndef DEBUGEXT_INCL
 #define DEBUGEXT_INCL
 
-#include <stddef.h>                      // for NULL, size_t
-#include <stdint.h>                      // for int32_t, uint32_t, uint8_t
-#include "compile/Compilation.hpp"       // for Compilation
-#include "env/jittypes.h"                // for uintptrj_t
-#include "infra/Assert.hpp"              // for TR_ASSERT
-#include "ras/HashTable.hpp"             // for TR_HashTable
-#include "optimizer/Optimizations.hpp"   // for Optimizations
+#include <stddef.h>
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "env/jittypes.h"
+#include "infra/Assert.hpp"
+#include "ras/HashTable.hpp"
+#include "optimizer/Optimizations.hpp"
 #include "ras/Debug.hpp"
-#include "ras/InternalFunctionsExt.hpp"  // for TR_Malloc_t
-#include "env/VMJ9.h"               // for TR_J9VM
-#include "ras/DebugExtSegmentProvider.hpp"  // for J9::DebugSegmentProvider
+#include "ras/InternalFunctionsExt.hpp"
+#include "env/VMJ9.h"
+#include "ras/DebugExtSegmentProvider.hpp"
 #include "env/Region.hpp"
 
 class TR_CHTable;

--- a/runtime/compiler/ras/HashTable.cpp
+++ b/runtime/compiler/ras/HashTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,13 +20,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "ras/HashTable.hpp"  // for TR_HashTable, TR_HashTableEntry, etc
+#include "ras/HashTable.hpp"
 
-#include <stddef.h>             // for size_t
-#include <stdint.h>             // for uint32_t
-#include <string.h>             // for memcpy
-#include "env/TRMemory.hpp"     // for TR_AllocationKind::heapAlloc, etc
-#include "infra/Assert.hpp"     // for TR_ASSERT
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "env/TRMemory.hpp"
+#include "infra/Assert.hpp"
 
 void *
 TR_HashTableEntry::operator new[] (size_t s, TR_Memory *mem)

--- a/runtime/compiler/ras/HashTable.hpp
+++ b/runtime/compiler/ras/HashTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 #ifndef HASHTABLE_INCL
 #define HASHTABLE_INCL
 
-#include <stddef.h>          // for size_t
-#include <stdint.h>          // for uint32_t
-#include "env/jittypes.h"    // for uintptrj_t
-#include "infra/Assert.hpp"  // for TR_ASSERT
+#include <stddef.h>
+#include <stdint.h>
+#include "env/jittypes.h"
+#include "infra/Assert.hpp"
 
 class TR_Memory;
 

--- a/runtime/compiler/ras/InternalFunctions.cpp
+++ b/runtime/compiler/ras/InternalFunctions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,16 +22,16 @@
 
 #include "ras/InternalFunctions.hpp"
 
-#include <stdarg.h>                            // for va_list
-#include <stddef.h>                            // for size_t
-#include <stdint.h>                            // for int32_t, uint16_t
-#include <stdio.h>                             // for NULL, printf, etc
-#include "codegen/FrontEnd.hpp"                // for feDebugBreak, etc
-#include "compile/Compilation.hpp"             // for Compilation
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
 #include "env/TRMemory.hpp"
-#include "env/defines.h"                       // for TR_HOST_X86
+#include "env/defines.h"
 #include "env/IO.hpp"
-#include "infra/Assert.hpp"                    // for TR_ASSERT
+#include "infra/Assert.hpp"
 #include "ras/Debug.hpp"
 
 

--- a/runtime/compiler/ras/InternalFunctions.hpp
+++ b/runtime/compiler/ras/InternalFunctions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,10 +32,10 @@
 #ifndef INTERNAL_FUNCTIONS_INCL
 #define INTERNAL_FUNCTIONS_INCL
 
-#include <stddef.h>                 // for size_t
-#include <stdint.h>                 // for int32_t
-#include "env/FilePointerDecl.hpp"  // for FILE
-#include "env/TRMemory.hpp"         // for TR_Memory, etc
+#include <stddef.h>
+#include <stdint.h>
+#include "env/FilePointerDecl.hpp"
+#include "env/TRMemory.hpp"
 
 class TR_FrontEnd;
 namespace TR { class Compilation; }

--- a/runtime/compiler/ras/InternalFunctionsExt.hpp
+++ b/runtime/compiler/ras/InternalFunctionsExt.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,16 +23,16 @@
 #ifndef INTERNAL_FUNCTIONS_EXT_INCL
 #define INTERNAL_FUNCTIONS_EXT_INCL
 
-#include <stddef.h>                            // for size_t, NULL
-#include <stdint.h>                            // for int32_t
-#include <stdlib.h>                            // for malloc
-#include "env/FilePointerDecl.hpp"             // for FILE
-#include "env/TRMemory.hpp"                    // for TR_AllocationKind, etc
-#include "env/jittypes.h"                      // for uintptrj_t
-#include "il/Symbol.hpp"                       // for Symbol
-#include "il/symbol/RegisterMappedSymbol.hpp"  // for RegisterMappedSymbol
-#include "ras/Debug.hpp"                       // for TR_DebugBase
-#include "ras/InternalFunctions.hpp"           // for TR_InternalFunctions
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "env/FilePointerDecl.hpp"
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/Symbol.hpp"
+#include "il/symbol/RegisterMappedSymbol.hpp"
+#include "ras/Debug.hpp"
+#include "ras/InternalFunctions.hpp"
 
 class TR_FrontEnd;
 class TR_ResolvedMethod;

--- a/runtime/compiler/runtime/ExternalProfiler.hpp
+++ b/runtime/compiler/runtime/ExternalProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef EXTERNALPROFILER_HPP
 #define EXTERNALPROFILER_HPP
 
-#include <stdint.h>  // for int32_t
+#include <stdint.h>
 
 class TR_ValueProfileInfo;
 namespace TR { class CFG; }

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,46 +21,46 @@
  *******************************************************************************/
 
 #include "runtime/J9Profiler.hpp"
-#include <string.h>                               // for memset, strncmp, etc
+#include <string.h>
 #include "AtomicSupport.hpp"
-#include "codegen/CodeGenerator.hpp"              // for CodeGenerator
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/RecognizedMethods.hpp"
-#include "compile/Compilation.hpp"                // for Compilation
-#include "compile/Method.hpp"                     // for TR_AOTMethodInfo, etc
-#include "compile/ResolvedMethod.hpp"             // for TR_ResolvedMethod
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/OptionsUtil.hpp"
-#include "control/Options_inlines.hpp"            // for TR::Options, etc
-#include "control/Recompilation.hpp"              // for TR_Recompilation, etc
-#include "control/RecompilationInfo.hpp"          // for TR_Recompilation, etc
+#include "control/Options_inlines.hpp"
+#include "control/Recompilation.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "env/IO.hpp"
 #include "env/PersistentCHTable.hpp"
-#include "env/PersistentInfo.hpp"                 // for PersistentInfo
+#include "env/PersistentInfo.hpp"
 #include "env/StackMemoryRegion.hpp"
-#include "env/jittypes.h"                         // for TR_ByteCodeInfo, etc
+#include "env/jittypes.h"
 #include "env/VMJ9.h"
-#include "il/Block.hpp"                           // for Block, toBlock
-#include "il/DataTypes.hpp"                       // for CONSTANT64, etc
-#include "il/ILOpCodes.hpp"                       // for ILOpCodes::iconst, etc
-#include "il/ILOps.hpp"                           // for ILOpCode, etc
-#include "il/Node.hpp"                            // for Node
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                          // for Symbol, etc
-#include "il/SymbolReference.hpp"                 // for SymbolReference, etc
-#include "il/TreeTop.hpp"                         // for TreeTop
-#include "il/TreeTop_inlines.hpp"                 // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"             // for MethodSymbol, etc
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "infra/Assert.hpp"                       // for TR_ASSERT
-#include "infra/BitVector.hpp"                    // for TR_BitVector
-#include "infra/Cfg.hpp"                          // for CFG, LOW_FREQ
-#include "infra/List.hpp"                         // for List, ListIterator
-#include "infra/TRCfgNode.hpp"                    // for CFGNode
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/List.hpp"
+#include "infra/TRCfgNode.hpp"
 #include "optimizer/Optimizations.hpp"
-#include "optimizer/Structure.hpp"                // for TR_RegionStructure, etc
-#include "optimizer/TransformUtil.hpp"            // for TransformUtil
+#include "optimizer/Structure.hpp"
+#include "optimizer/TransformUtil.hpp"
 #include "optimizer/JProfilingValue.hpp"
 #include "runtime/ExternalProfiler.hpp"
 #include "runtime/J9Runtime.hpp"

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,18 +24,18 @@
 #define J9_PROFILER_INCL
 
 #include <map>
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t, uint32_t, etc
-#include "codegen/FrontEnd.hpp"               // for TR_FrontEnd
-#include "compile/Compilation.hpp"            // for Compilation
-#include "env/TRMemory.hpp"                   // for TR_Memory, etc
-#include "env/jittypes.h"                     // for uintptrj_t
-#include "il/DataTypes.hpp"                   // for DataTypes
-#include "il/Node.hpp"                        // for vcount_t
-#include "infra/Flags.hpp"                    // for flags32_t
-#include "infra/Link.hpp"                     // for TR_Link
-#include "optimizer/Optimization.hpp"         // for Optimization
-#include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/DataTypes.hpp"
+#include "il/Node.hpp"
+#include "infra/Flags.hpp"
+#include "infra/Link.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/OptimizationManager.hpp"
 #include "env/VMJ9.h"
 #include "infra/TRlist.hpp"
 #include "runtime/J9ValueProfiler.hpp"

--- a/runtime/compiler/runtime/J9ValueProfiler.hpp
+++ b/runtime/compiler/runtime/J9ValueProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,14 +23,14 @@
 #ifndef VALUEPROFILER_INCL
 #define VALUEPROFILER_INCL
 
-#include <stdint.h>          // for uint32_t, int32_t, uint64_t
-#include <stdio.h>           // for fwrite, NULL, FILE
-#include "env/TRMemory.hpp"  // for TR_Memory, etc
-#include "env/jittypes.h"    // for TR_ByteCodeInfo, etc
-#include "il/DataTypes.hpp"  // for DataTypes
-#include "infra/CriticalSection.hpp" // for OMR::CriticalSection
+#include <stdint.h>
+#include <stdio.h>
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/DataTypes.hpp"
+#include "infra/CriticalSection.hpp"
 #include "compile/Compilation.hpp"
-#include "infra/vector.hpp"         // for TR::vector
+#include "infra/vector.hpp"
 
 // Global lock used by Array & List profilers
 extern TR::Monitor *vpMonitor;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@
 #include "env/j9method.h"
 #include "runtime/HWProfiler.hpp"
 #include "env/VMJ9.h"
-#include "env/J9CPU.hpp" // for TR_ProcessorFeatureFlags
+#include "env/J9CPU.hpp"
 
 namespace TR { class CompilationInfo; }
 class TR_RelocationRecord;

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -22,7 +22,7 @@
 
 #ifdef TR_HOST_X86
 #if defined(LINUX)
-#include <time.h>       // for clock_gettime
+#include <time.h>
 #endif
 #endif   // TR_HOST_X86
 

--- a/runtime/compiler/runtime/RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,15 +23,15 @@
 #ifndef RUNTIME_ASSUMPTIONS_INCL
 #define RUNTIME_ASSUMPTIONS_INCL
 
-#include <algorithm>                       // for std::max, etc
-#include <stddef.h>                        // for NULL
-#include <stdint.h>                        // for int32_t, uint8_t, etc
-#include "env/RuntimeAssumptionTable.hpp"  // for TR_RuntimeAssumptionKind, etc
-#include "env/TRMemory.hpp"                // for TR_Memory, etc
-#include "env/jittypes.h"                  // for uintptrj_t
-#include "infra/Flags.hpp"                 // for flags8_t
-#include "infra/Link.hpp"                  // for TR_LinkHead0, TR_Link0
-#include "runtime/OMRRuntimeAssumptions.hpp"  // for OMR::RuntimeAssumption
+#include <algorithm>
+#include <stddef.h>
+#include <stdint.h>
+#include "env/RuntimeAssumptionTable.hpp"
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "infra/Flags.hpp"
+#include "infra/Link.hpp"
+#include "runtime/OMRRuntimeAssumptions.hpp"
 
 
 class TR_FrontEnd;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -23,13 +23,13 @@
 #ifndef SYMBOL_VALIDATION_MANAGER_INCL
 #define SYMBOL_VALIDATION_MANAGER_INCL
 
-#include <algorithm>                       // for std::max, etc
+#include <algorithm>
 #include <map>
 #include <set>
 #include <vector>
-#include <stddef.h>                        // for NULL
-#include <stdint.h>                        // for int32_t, uint8_t, etc
-#include "env/jittypes.h"                  // for uintptrj_t
+#include <stddef.h>
+#include <stdint.h>
+#include "env/jittypes.h"
 #include "j9.h"
 #include "j9nonbuilder.h"
 #include "infra/TRlist.hpp"

--- a/runtime/compiler/x/amd64/codegen/AMD64GuardedDevirtualSnippet.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64GuardedDevirtualSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,13 +22,13 @@
 
 #include "x/amd64/codegen/AMD64GuardedDevirtualSnippet.hpp"
 
-#include <stddef.h>                         // for NULL
+#include <stddef.h>
 #include "codegen/GuardedDevirtualSnippet.hpp"
-#include "codegen/CodeGenerator.hpp"        // for CodeGenerator
-#include "codegen/Linkage.hpp"              // for Linkage
-#include "il/Symbol.hpp"                    // for Symbol
-#include "il/symbol/LabelSymbol.hpp"        // for LabelSymbol
-#include "il/symbol/MethodSymbol.hpp"       // for MethodSymbol
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage.hpp"
+#include "il/Symbol.hpp"
+#include "il/symbol/LabelSymbol.hpp"
+#include "il/symbol/MethodSymbol.hpp"
 
 uint8_t *TR::AMD64GuardedDevirtualSnippet::loadArgumentsIfNecessary(TR::Node *callNode, uint8_t *cursor, bool calculateSizeOnly, int32_t *sizeOfFlushArea)
    {

--- a/runtime/compiler/x/amd64/codegen/AMD64GuardedDevirtualSnippet.hpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64GuardedDevirtualSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 
 #include "x/codegen/GuardedDevirtualSnippet.hpp"
 
-#include <stdint.h>                               // for int32_t, uint8_t, etc
-#include "il/SymbolReference.hpp"                 // for SymbolReference
+#include <stdint.h>
+#include "il/SymbolReference.hpp"
 
 namespace TR { class Block; }
 namespace TR { class CodeGenerator; }

--- a/runtime/compiler/x/codegen/GuardedDevirtualSnippet.cpp
+++ b/runtime/compiler/x/codegen/GuardedDevirtualSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,24 +22,24 @@
 
 #include "x/codegen/GuardedDevirtualSnippet.hpp"
 
-#include <stddef.h>                               // for NULL
-#include <stdint.h>                               // for uint8_t, int32_t, etc
-#include "codegen/CodeGenerator.hpp"              // for CodeGenerator
-#include "codegen/FrontEnd.hpp"                   // for TR_FrontEnd
-#include "codegen/MemoryReference.hpp"            // for IA32SIBNoIndex, etc
-#include "codegen/RealRegister.hpp"               // for RealRegister, etc
-#include "codegen/RegisterConstants.hpp"          // for TR_RegisterSizes, etc
-#include "codegen/Snippet.hpp"                    // for commentString
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/RealRegister.hpp"
+#include "codegen/RegisterConstants.hpp"
+#include "codegen/Snippet.hpp"
 #include "codegen/SnippetGCMap.hpp"
-#include "compile/Compilation.hpp"                // for Compilation, comp
+#include "compile/Compilation.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
-#include "env/jittypes.h"                         // for uintptrj_t
-#include "il/Node.hpp"                            // for Node
-#include "il/Symbol.hpp"                          // for Symbol
-#include "il/SymbolReference.hpp"                 // for SymbolReference
-#include "il/symbol/LabelSymbol.hpp"              // for LabelSymbol
-#include "ras/Debug.hpp"                          // for TR_Debug
+#include "env/jittypes.h"
+#include "il/Node.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/LabelSymbol.hpp"
+#include "ras/Debug.hpp"
 #include "x/codegen/RestartSnippet.hpp"
 
 namespace TR { class Block; }

--- a/runtime/compiler/x/codegen/GuardedDevirtualSnippet.hpp
+++ b/runtime/compiler/x/codegen/GuardedDevirtualSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,10 +23,10 @@
 #ifndef GUARDEDDEVIRTUALSNIPPET_INCL
 #define GUARDEDDEVIRTUALSNIPPET_INCL
 
-#include <stddef.h>                      // for NULL
-#include <stdint.h>                      // for int32_t, uint32_t, uint8_t
-#include "codegen/Snippet.hpp"           // for TR::X86Snippet::Kind, etc
-#include "x/codegen/RestartSnippet.hpp"  // for TR::X86RestartSnippet
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/Snippet.hpp"
+#include "x/codegen/RestartSnippet.hpp"
 
 namespace TR { class Block; }
 namespace TR { class CodeGenerator; }

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,11 +37,11 @@ namespace J9 { typedef J9::X86::UnresolvedDataSnippet UnresolvedDataSnippetConne
 
 #include "compiler/codegen/J9UnresolvedDataSnippet.hpp"
 
-#include <stdint.h>                                 // for uint8_t, int32_t, etc
-#include "codegen/CodeGenerator.hpp"                // for CodeGenerator
-#include "il/Symbol.hpp"                            // for Symbol
-#include "il/SymbolReference.hpp"                   // for SymbolReference
-#include "runtime/J9Runtime.hpp"                    // for TR_RuntimeHelper
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "runtime/J9Runtime.hpp"
 #include "infra/Flags.hpp"
 #include "env/CompilerEnv.hpp"
 

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <algorithm>                            // for std::find
+#include <algorithm>
 #include "codegen/J9X86Instruction.hpp"
 #include "env/OMRMemory.hpp"
 #include "il/Node.hpp"

--- a/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.cpp
+++ b/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,28 +22,28 @@
 
 #include "codegen/InMemoryLoadStoreMarking.hpp"
 
-#include <stddef.h>                    // for NULL
-#include <stdint.h>                    // for int64_t
-#include <string.h>                    // for strcmp
-#include "codegen/FrontEnd.hpp"        // for TR_FrontEnd
-#include "compile/Compilation.hpp"     // for LexicalTimer, etc
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "codegen/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/VMJ9.h"
 #include "il/AliasSetInterface.hpp"
-#include "il/Block.hpp"                // for Block
-#include "il/DataTypes.hpp"            // for TR::DataType::getMaxLongDFPPrecision(), etc
-#include "il/ILOpCodes.hpp"            // for ILOpCodes::pdSetSign, etc
-#include "il/ILOps.hpp"                // for ILOpCode
-#include "il/Node.hpp"                 // for Node
-#include "il/Node_inlines.hpp"         // for Node::getType, etc
-#include "il/Symbol.hpp"               // for Symbol
-#include "il/SymbolReference.hpp"      // for SymbolReference
-#include "il/TreeTop.hpp"              // for TreeTop
-#include "il/TreeTop_inlines.hpp"      // for TreeTop::getNode, etc
-#include "il/symbol/MethodSymbol.hpp"  // for MethodSymbol
-#include "infra/Assert.hpp"            // for TR_ASSERT
-#include "infra/Bit.hpp"               // for isOdd
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/MethodSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Bit.hpp"
 
 
 #define OPT_DETAILS "O^O IN MEMORY LOAD/STORE MARKING: "

--- a/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.hpp
+++ b/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef IN_MEM_LOAD_STORE_MARK_INCL
 #define IN_MEM_LOAD_STORE_MARK_INCL
 
-#include "codegen/CodeGenerator.hpp"  // for CodeGenerator
-#include "compile/Compilation.hpp"    // for Compilation
-#include "env/TRMemory.hpp"           // for TR_Memory, etc
-#include "il/Node.hpp"                // for vcount_t
-#include "infra/List.hpp"             // for List
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "infra/List.hpp"
 
 namespace TR { class TreeTop; }
 

--- a/runtime/compiler/z/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,8 +29,8 @@
 #pragma csect(STATIC,"TRJ9ZCGPhase#S")
 #pragma csect(TEST,"TRJ9ZCGPhase#T")
 
-#include "codegen/CodeGenPhase.hpp"                   // for CodeGenPhase, etc
-#include "codegen/CodeGenerator.hpp"                  // for CodeGenerator, etc
+#include "codegen/CodeGenPhase.hpp"
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/InMemoryLoadStoreMarking.hpp"
 #include "codegen/ReduceSynchronizedFieldLoad.hpp"
 #include "codegen/UncommonBCDCHKAddressNode.hpp"

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -35,59 +35,59 @@
 #include "il/Node_inlines.hpp"
 #include "il/symbol/AutomaticSymbol.hpp"
 
-#include <stddef.h>                                 // for size_t
-#include <stdint.h>                                 // for int32_t, etc
-#include <string.h>                                 // for NULL, strcmp
-#include "codegen/CodeGenerator.hpp"                // for CodeGenerator, etc
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/ConstantDataSnippet.hpp"
-#include "codegen/FrontEnd.hpp"                     // for TR_FrontEnd, etc
-#include "codegen/InstOpCode.hpp"                   // for InstOpCode, etc
-#include "codegen/Instruction.hpp"                  // for Instruction, etc
-#include "codegen/Linkage.hpp"                      // for Linkage
+#include "codegen/FrontEnd.hpp"
+#include "codegen/InstOpCode.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/Linkage.hpp"
 #include "codegen/LiveRegister.hpp"
-#include "codegen/Machine.hpp"                      // for MAXDISP, Machine, etc
-#include "codegen/MemoryReference.hpp"              // for MemoryReference, etc
-#include "codegen/RealRegister.hpp"                 // for RealRegister, etc
-#include "codegen/Register.hpp"                     // for Register
+#include "codegen/Machine.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/RealRegister.hpp"
+#include "codegen/Register.hpp"
 #include "codegen/RegisterConstants.hpp"
-#include "codegen/RegisterPair.hpp"                 // for RegisterPair
+#include "codegen/RegisterPair.hpp"
 #include "codegen/Relocation.hpp"
-#include "codegen/Snippet.hpp"                      // for TR::S390Snippet, etc
+#include "codegen/Snippet.hpp"
 #include "codegen/TreeEvaluator.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"
-#include "compile/Compilation.hpp"                  // for Compilation
+#include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "cs2/sparsrbit.h"
 #include "env/CompilerEnv.hpp"
-#include "env/ObjectModel.hpp"                      // for ObjectModel
-#include "env/StackMemoryRegion.hpp"                // for TR::StackMemoryRegion
+#include "env/ObjectModel.hpp"
+#include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
-#include "env/defines.h"                            // for TR_HOST_64BIT
-#include "env/jittypes.h"                           // for intptrj_t, uintptrj_t
-#include "il/Block.hpp"                             // for Block
-#include "il/DataTypes.hpp"                         // for DataTypes, etc
+#include "env/defines.h"
+#include "env/jittypes.h"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/ILOps.hpp"                             // for ILOpCode
-#include "il/Node.hpp"                              // for Node, etc
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
-#include "il/Symbol.hpp"                            // for Symbol
-#include "il/SymbolReference.hpp"                   // for SymbolReference, etc
-#include "il/TreeTop.hpp"                           // for TreeTop
-#include "il/TreeTop_inlines.hpp"                   // for TreeTop::getNode
-#include "il/symbol/AutomaticSymbol.hpp"            // for AutomaticSymbol
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
 #include "il/symbol/RegisterMappedSymbol.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
-#include "il/symbol/StaticSymbol.hpp"               // for StaticSymbol
-#include "infra/Array.hpp"                          // for TR_Array
-#include "infra/Assert.hpp"                         // for TR_ASSERT
-#include "infra/Bit.hpp"                            // for trailingZeroes
-#include "infra/Flags.hpp"                          // for flags32_t
-#include "infra/List.hpp"                           // for List, etc
-#include "ras/Debug.hpp"                            // for TR_DebugBase
-#include "z/codegen/EndianConversion.hpp"           // for boi
+#include "il/symbol/StaticSymbol.hpp"
+#include "infra/Array.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Bit.hpp"
+#include "infra/Flags.hpp"
+#include "infra/List.hpp"
+#include "ras/Debug.hpp"
+#include "z/codegen/EndianConversion.hpp"
 #include "z/codegen/S390Evaluator.hpp"
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390Instruction.hpp"

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,34 +27,34 @@
 
 #include "codegen/UnresolvedDataSnippet.hpp"
 
-#include <stddef.h>                           // for NULL
-#include <stdint.h>                           // for int32_t, int16_t, etc
-#include "codegen/CodeGenerator.hpp"          // for CodeGenerator, etc
-#include "codegen/InstOpCode.hpp"             // for InstOpCode, etc
-#include "codegen/Instruction.hpp"            // for Instruction
-#include "codegen/MemoryReference.hpp"        // for MemoryReference
-#include "codegen/RealRegister.hpp"           // for RealRegister, etc
-#include "codegen/Register.hpp"               // for Register
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/InstOpCode.hpp"
+#include "codegen/Instruction.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/RealRegister.hpp"
+#include "codegen/Register.hpp"
 #include "codegen/RegisterDependency.hpp"
-#include "codegen/RegisterPair.hpp"           // for RegisterPair
-#include "codegen/Relocation.hpp"             // for AOTcgDiag1, etc
-#include "compile/Compilation.hpp"            // for Compilation
-#include "compile/ResolvedMethod.hpp"         // for TR_ResolvedMethod
-#include "compile/SymbolReferenceTable.hpp"   // for SymbolReferenceTable
+#include "codegen/RegisterPair.hpp"
+#include "codegen/Relocation.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"        // for TR::Options, etc
+#include "control/Options_inlines.hpp"
 #include "env/IO.hpp"
 #include "env/TRMemory.hpp"
-#include "env/jittypes.h"                     // for uintptrj_t, intptrj_t
-#include "il/DataTypes.hpp"                   // for DataTypes::Address, etc
-#include "il/Node.hpp"                        // for Node
-#include "il/Symbol.hpp"                      // for Symbol
-#include "il/SymbolReference.hpp"             // for SymbolReference
-#include "il/symbol/LabelSymbol.hpp"          // for LabelSymbol
-#include "il/symbol/StaticSymbol.hpp"         // for StaticSymbol
-#include "il/symbol/StaticSymbol_inlines.hpp" // for StaticSymbol
-#include "infra/Assert.hpp"                   // for TR_ASSERT
-#include "ras/Debug.hpp"                      // for TR_Debug
+#include "env/jittypes.h"
+#include "il/DataTypes.hpp"
+#include "il/Node.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/LabelSymbol.hpp"
+#include "il/symbol/StaticSymbol.hpp"
+#include "il/symbol/StaticSymbol_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "ras/Debug.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "env/CompilerEnv.hpp"
 

--- a/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.hpp
+++ b/runtime/compiler/z/codegen/J9UnresolvedDataSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,9 +36,9 @@ namespace J9 { typedef J9::Z::UnresolvedDataSnippet UnresolvedDataSnippetConnect
 
 #include "compiler/codegen/J9UnresolvedDataSnippet.hpp"
 
-#include <stdint.h>                // for uint8_t, uint32_t, int32_t
+#include <stdint.h>
 #include "codegen/Snippet.hpp"
-#include "il/SymbolReference.hpp"  // for SymbolReference
+#include "il/SymbolReference.hpp"
 
 namespace TR { class S390WritableDataSnippet; }
 namespace TR { class CodeGenerator; }

--- a/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp
+++ b/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,20 +22,20 @@
 
 #include "codegen/ReduceSynchronizedFieldLoad.hpp"
 
-#include <stddef.h>                    // for NULL
-#include <stdint.h>                    // for int64_t
+#include <stddef.h>
+#include <stdint.h>
 #include "j9.h"
 #include "j9cfg.h"
 #include "j9consts.h"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/TreeEvaluator.hpp"
 #include "env/VMJ9.h"
-#include "il/ILOps.hpp"                // for ILOpCode
-#include "il/ILOpCodes.hpp"            // for ILOpCodes::pdSetSign, etc
-#include "il/Node_inlines.hpp"         // for Node::getType, etc
-#include "il/TreeTop.hpp"              // for TreeTop
-#include "il/TreeTop_inlines.hpp"      // for TreeTop::getNode, etc
-#include "infra/Assert.hpp"            // for TR_ASSERT
+#include "il/ILOps.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
 #include "z/codegen/S390Evaluator.hpp"
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390Instruction.hpp"

--- a/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.hpp
+++ b/runtime/compiler/z/codegen/ReduceSynchronizedFieldLoad.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef REDUCE_SYNCHRONIZED_FIELD_LOAD_NODE
 #define REDUCE_SYNCHRONIZED_FIELD_LOAD_NODE
 
-#include "codegen/CodeGenerator.hpp"  // for CodeGenerator
-#include "compile/Compilation.hpp"    // for Compilation
-#include "env/TRMemory.hpp"           // for TR_Memory, etc
-#include "il/Node.hpp"                // for vcount_t
-#include "infra/List.hpp"             // for List
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "infra/List.hpp"
 #include "infra/ILWalk.hpp"
 
 /** \brief

--- a/runtime/compiler/z/codegen/S390AOTRelocation.hpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #ifndef J9AOTRELOCATION_INCL
 #define J9AOTRELOCATION_INCL
 
-#include "codegen/Relocation.hpp"  // for TR::LabelRelocation
+#include "codegen/Relocation.hpp"
 
 #include "codegen/Instruction.hpp"
 

--- a/runtime/compiler/z/codegen/S390Register.cpp
+++ b/runtime/compiler/z/codegen/S390Register.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,26 +22,26 @@
 
 #include "z/codegen/S390Register.hpp"
 
-#include <algorithm>                      // for std::max
-#include <stddef.h>                       // for NULL
-#include <stdint.h>                       // for int32_t, uint16_t
-#include "codegen/CodeGenerator.hpp"      // for CodeGenerator
-#include "codegen/FrontEnd.hpp"           // for TR_FrontEnd
-#include "codegen/Register.hpp"           // for Register
-#include "codegen/RegisterConstants.hpp"  // for TR_RegisterKinds::TR_SSR
-#include "compile/Compilation.hpp"        // for Compilation
+#include <algorithm>
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/FrontEnd.hpp"
+#include "codegen/Register.hpp"
+#include "codegen/RegisterConstants.hpp"
+#include "compile/Compilation.hpp"
 #include "env/TRMemory.hpp"
-#include "il/DataTypes.hpp"               // for DataType, etc
-#include "il/ILOps.hpp"                   // for ILOpCode
-#include "il/Node.hpp"                    // for Node, rcount_t
-#include "il/Node_inlines.hpp"            // for Node::getFirstChild, etc
-#include "il/Symbol.hpp"                  // for Symbol
-#include "il/SymbolReference.hpp"         // for SymbolReference
-#include "il/symbol/AutomaticSymbol.hpp"  // for AutomaticSymbol
-#include "infra/Assert.hpp"               // for TR_ASSERT
-#include "infra/Flags.hpp"                // for flags8_t
-#include "infra/List.hpp"                 // for List, ListIterator
-#include "ras/Debug.hpp"                  // for TR_DebugBase
+#include "il/DataTypes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Flags.hpp"
+#include "infra/List.hpp"
+#include "ras/Debug.hpp"
 
 TR_StorageReference::TR_StorageReference(TR::SymbolReference *t, TR::Compilation *c) : _temporary(t),
                                                                                      _node(NULL),

--- a/runtime/compiler/z/codegen/S390Register.hpp
+++ b/runtime/compiler/z/codegen/S390Register.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,15 +23,15 @@
 #ifndef S390REGISTER_INCL
 #define S390REGISTER_INCL
 
-#include <stddef.h>                       // for NULL
-#include <stdint.h>                       // for int32_t, uint32_t, etc
-#include "codegen/Register.hpp"           // for Register
-#include "codegen/RegisterConstants.hpp"  // for TR_RegisterKinds::TR_SSR
-#include "env/TRMemory.hpp"               // for TR_Memory, etc
-#include "il/DataTypes.hpp"               // for DataTypes, etc
-#include "il/Node.hpp"                    // for rcount_t
-#include "infra/Assert.hpp"               // for TR_ASSERT
-#include "infra/Flags.hpp"                // for flags16_t, flags8_t
+#include <stddef.h>
+#include <stdint.h>
+#include "codegen/Register.hpp"
+#include "codegen/RegisterConstants.hpp"
+#include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
+#include "il/Node.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Flags.hpp"
 
 class TR_OpaquePseudoRegister;
 class TR_PseudoRegister;

--- a/runtime/compiler/z/codegen/UncommonBCDCHKAddressNode.cpp
+++ b/runtime/compiler/z/codegen/UncommonBCDCHKAddressNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,18 +22,18 @@
 
 #include "codegen/UncommonBCDCHKAddressNode.hpp"
 
-#include <stddef.h>                    // for NULL
-#include <stdint.h>                    // for int64_t
-#include <string.h>                    // for strcmp
-#include "compile/Compilation.hpp"     // for LexicalTimer, etc
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "compile/Compilation.hpp"
 #include "env/VMJ9.h"
-#include "il/ILOpCodes.hpp"            // for ILOpCodes::pdSetSign, etc
-#include "il/ILOps.hpp"                // for ILOpCode
-#include "il/Node.hpp"                 // for Node
-#include "il/Node_inlines.hpp"         // for Node::getType, etc
-#include "il/TreeTop.hpp"              // for TreeTop
-#include "il/TreeTop_inlines.hpp"      // for TreeTop::getNode, etc
-#include "infra/Assert.hpp"            // for TR_ASSERT
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
 
 
 #define OPT_DETAILS "O^O UNCOMMON BCDCHK ADDRESS NODE: "

--- a/runtime/compiler/z/codegen/UncommonBCDCHKAddressNode.hpp
+++ b/runtime/compiler/z/codegen/UncommonBCDCHKAddressNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,11 @@
 #ifndef UNCOMMON_BCDCHK_ADDRESS_NODE
 #define UNCOMMON_BCDCHK_ADDRESS_NODE
 
-#include "codegen/CodeGenerator.hpp"  // for CodeGenerator
-#include "compile/Compilation.hpp"    // for Compilation
-#include "env/TRMemory.hpp"           // for TR_Memory, etc
-#include "il/Node.hpp"                // for vcount_t
-#include "infra/List.hpp"             // for List
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "env/TRMemory.hpp"
+#include "il/Node.hpp"
+#include "infra/List.hpp"
 
 /**
  * \brief The Uncommon BCDCHK Address Node codegen phase is designed to cope with incorrect OOL PD copy problem


### PR DESCRIPTION
Removed annotation describing feature included from the file. This is a
port of the work done in eclipse/omr#3522.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>