### PR TITLE
[WIP] Revert "Updated gcc-7 install for centos7"

### DIFF
--- a/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/ppc64le/centos7/Dockerfile
@@ -116,6 +116,10 @@ RUN cd /usr/local \
   && tar -xJf gcc-7.tar.xz --strip-components=1 \
   && rm -rf gcc-7.tar.xz
 
+# Edit ldconfig to connect this library
+RUN echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf \
+  && ldconfig
+
 #Building and setting up git version 2.5.3
 RUN yum -y update \
   && yum -y install \


### PR DESCRIPTION
This reverts commit 3d1787345369a66880659fd58f9c4c11dab97d29.

I believe that this change causes gcc to not find glibc on ppcle

[skip ci]

Signed-off-by: Samuel Rubin samuel.rubin@ibm.com