### PR TITLE
Add options to print a javacore dump to STDOUT and STDERR

### DIFF
--- a/runtime/rasdump/TextFileStream.cpp
+++ b/runtime/rasdump/TextFileStream.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2014 IBM Corp. and others
+ * Copyright (c) 2003, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,11 @@ void
 TextFileStream::open(const char* fileName, bool cacheWrites)
 {
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
-	if (fileName[0] != '-' ) {
+	if (NULL != strstr(fileName, "/STDOUT/")) {
+		_FileHandle = 1; 
+	} else if (NULL != strstr(fileName, "/STDERR/")) {
+		_FileHandle = 2;
+	} else if (fileName[0] != '-' ) {
 		_FileHandle = j9file_open(fileName, EsOpenWrite | EsOpenCreate | EsOpenTruncate | EsOpenCreateNoTag, 0666);
 	}
 	if(!cacheWrites) {

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -886,11 +886,13 @@ static omr_error_t
 doJavaDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 {
 	J9JavaVM *vm = context->javaVM;
-
-	if (makePath(vm, label) == OMR_ERROR_INTERNAL) {
-		/* Nowhere available to write the dump, we are done, makePath() will have issued error message */
-		return OMR_ERROR_INTERNAL;
+	if ((0 != strcmp(label, "/STDOUT/")) && (0 != strcmp(label, "/STDERR/"))) {
+		if (makePath(vm, label) == OMR_ERROR_INTERNAL) {
+			/* Nowhere available to write the dump, we are done, makePath() will have issued error message */
+			return OMR_ERROR_INTERNAL;
+		}
 	}
+	
 	runJavadump(label, context, agent);
 
 	return OMR_ERROR_NONE;

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+Copyright (c) 2019, 2019 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="J9 Command-Line Option Tests" timeout="180">
+    
+    <test id="Verify Generate a javacore to STDOUT">
+        <command>$EXE$ -Xdump:java:events=vmstart,file=/STDOUT/</command>
+        <output type="success" caseSensitive="yes" regex="no">TITLE subcomponent dump routine</output>
+        <output type="success" caseSensitive="yes" regex="no">END OF DUMP</output>
+        <output regex="no" type="failure">Command-line option unrecognised</output>
+        <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+        <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+    </test>
+
+    <test id="Verify Generate a javacore to STDERR">
+        <command>$EXE$ -Xdump:java:events=vmstart,file=/STDERR/</command>
+        <output type="success" caseSensitive="yes" regex="no">TITLE subcomponent dump routine</output>
+        <output type="success" caseSensitive="yes" regex="no">END OF DUMP</output>
+        <output regex="no" type="failure">Command-line option unrecognised</output>
+        <output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+        <output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+    </test>
+
+</suite>
+

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/playlist.xml
@@ -62,4 +62,25 @@
 			<subset>9+</subset>
 		</subsets>
 	</test>
+	
+	<test>
+		<testCaseName>cmdLineTest_J9test_extended</testCaseName>
+		<command>$(JAVA_COMMAND) -Xdump $(JVM_OPTIONS) -DFIBJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)cmdLineTests$(D)utils$(D)utils.jar$(Q) \
+	-DTESTDIR=$(Q)$(TEST_RESROOT)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) -DEXE='$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump' \
+	-Xint -jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)j9tests.xml$(Q) \
+	-xids all,$(PLATFORM) -plats all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)j9tests_exclude.xml$(Q) \
+	-explainExcludes -nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 </playlist>


### PR DESCRIPTION
Add the option -Xdump:java:file=/STDOUT/ to print a javacore dump to STDOUT
Add the option -Xdump:java:file=/STDERR/ to print a javacore dump to STDERR

Steps:
-Change the filedescriptor to 1 to print to STDOUT if the inputed filename is "/STDOUT"
-Change the filedescriptor to 2 to print to STDERR if the inputed filename is "/STDERR"

Doc issue https://github.com/eclipse/openj9-docs/issues/204

Fixes #2837
Signed-off-by: Aidan Ha <qbha@edu.uwaterloo.ca>