### PR TITLE
Replace enter/exit tracing method with isMethodTracingEnabled

### DIFF
--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -874,6 +874,10 @@ public:
     TR::TreeTop * lowerAsyncCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
     TR::TreeTop * lowerAtcCheck( TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
+   virtual bool isMethodTracingEnabled(J9Method *j9method)
+      {
+      return isMethodTracingEnabled((TR_OpaqueMethodBlock *)j9method);
+      }
    virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodEnterTracingEnabled(J9Method *j9method)
       {
@@ -1123,6 +1127,7 @@ public:
 
    virtual bool               stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
 
+   virtual bool               isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool               isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool               isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool               traceableMethodsCanBeInlined();

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -1130,7 +1130,7 @@ TR_J9ByteCodeIlGenerator::prependEntryCode(TR::Block * firstBlock)
    TR::Node * methodEnterHook = 0;
 
    static const char* disableMethodHookForCallees = feGetEnv("TR_DisableMethodHookForCallees");
-   if ((fej9()->isMethodEnterTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
+   if ((fej9()->isMethodTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
         TR::Compiler->vm.canMethodEnterEventBeHooked(comp()))
          && (isOutermostMethod() || !disableMethodHookForCallees))
       {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -7065,7 +7065,7 @@ TR_J9ByteCodeIlGenerator::genReturn(TR::ILOpCodes nodeop, bool monitorExit)
       }
 
    static const char* disableMethodHookForCallees = feGetEnv("TR_DisableMethodHookForCallees");
-   if ((fej9()->isMethodExitTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
+   if ((fej9()->isMethodTracingEnabled(_methodSymbol->getResolvedMethod()->getPersistentIdentifier()) ||
         TR::Compiler->vm.canMethodExitEventBeHooked(comp()))
          && (isOutermostMethod() || !disableMethodHookForCallees))
       {

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1523,13 +1523,13 @@ createMethodMetaData(
 
       // Set some flags in the AOTMethodHeader
       //
-      if (!vm->isMethodExitTracingEnabled(vmMethod->getPersistentIdentifier()) &&
+      if (!vm->isMethodTracingEnabled(vmMethod->getPersistentIdentifier()) &&
           !vm->canMethodExitEventBeHooked())
          {
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfMethodExitTracing;
          }
 
-      if (!vm->isMethodEnterTracingEnabled(vmMethod->getPersistentIdentifier()) &&
+      if (!vm->isMethodTracingEnabled(vmMethod->getPersistentIdentifier()) &&
           !vm->canMethodEnterEventBeHooked())
          {
          aotMethodHeaderEntry->flags |= TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing;

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -2942,7 +2942,7 @@ TR_RelocationRecordMethodEnterCheck::name()
 bool
 TR_RelocationRecordMethodEnterCheck::ignore(TR_RelocationRuntime *reloRuntime)
    {
-   bool reportMethodEnter = reloRuntime->fej9()->isMethodEnterTracingEnabled((TR_OpaqueMethodBlock *) reloRuntime->method()) || reloRuntime->fej9()->canMethodEnterEventBeHooked();
+   bool reportMethodEnter = reloRuntime->fej9()->isMethodTracingEnabled((TR_OpaqueMethodBlock *) reloRuntime->method()) || reloRuntime->fej9()->canMethodEnterEventBeHooked();
    RELO_LOG(reloRuntime->reloLogger(), 6,"\tignore: reportMethodEnter %d\n", reportMethodEnter);
    return !reportMethodEnter;
    }
@@ -2958,7 +2958,7 @@ TR_RelocationRecordMethodExitCheck::name()
 bool
 TR_RelocationRecordMethodExitCheck::ignore(TR_RelocationRuntime *reloRuntime)
    {
-   bool reportMethodExit = reloRuntime->fej9()->isMethodExitTracingEnabled((TR_OpaqueMethodBlock *) reloRuntime->method()) || reloRuntime->fej9()->canMethodExitEventBeHooked();
+   bool reportMethodExit = reloRuntime->fej9()->isMethodTracingEnabled((TR_OpaqueMethodBlock *) reloRuntime->method()) || reloRuntime->fej9()->canMethodExitEventBeHooked();
    RELO_LOG(reloRuntime->reloLogger(), 6,"\tignore: reportMethodExit %d\n", reportMethodExit);
    return !reportMethodExit;
    }

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -194,14 +194,14 @@ TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThread* vmThread,
 
    // If we want to trace this method but the AOT body is not prepared to handle it
    // we must fail this AOT load with an error code that will force retrial
-   if ((fej9->isMethodExitTracingEnabled((TR_OpaqueMethodBlock*)theMethod) || fej9->canMethodExitEventBeHooked())
+   if ((fej9->isMethodTracingEnabled((TR_OpaqueMethodBlock*)theMethod) || fej9->canMethodExitEventBeHooked())
       &&
        (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_IsNotCapableOfMethodExitTracing))
       {
       setReturnCode(compilationAotValidateMethodExitFailure);
       return NULL; // fail
       }
-   if ((fej9->isMethodEnterTracingEnabled((TR_OpaqueMethodBlock*)theMethod) || fej9->canMethodEnterEventBeHooked())
+   if ((fej9->isMethodTracingEnabled((TR_OpaqueMethodBlock*)theMethod) || fej9->canMethodEnterEventBeHooked())
       &&
        (_aotMethodHeaderEntry->flags & TR_AOTMethodHeader_IsNotCapableOfMethodEnterTracing))
       {


### PR DESCRIPTION
In practice we never enable methodEnterTracing without methodExitTracing.
These two methods are replaced with isMethodTracingEnabled().

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>