### PR TITLE
WIP: Migrate CodeCacheManager reservationInterfaceCache to OpenJ9

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -613,3 +613,16 @@ J9::CodeCacheManager::isInRange(uintptr_t address1, uintptr_t address2, uintptr_
       return (address2 - address1) <= range;
    }
 
+void
+J9::CodeCacheManager::reservationInterfaceCache(void *callSite, TR_OpaqueMethodBlock *method)
+   {
+   TR::CodeCacheConfig &config = self()->codeCacheConfig();
+   if (!config.needsMethodTrampolines())
+      return;
+
+   TR::CodeCache *codeCache = self()->findCodeCacheFromPC(callSite);
+   if (!codeCache)
+      return;
+
+   codeCache->findOrAddResolvedMethod(method);
+   }

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,13 +107,21 @@ public:
    uintptr_t getSomeJitLibraryAddress();
    bool isInRange(uintptr_t address1, uintptr_t address2, uintptr_t range);
 
+   /**
+    * @brief Reserve a trampoline for an interface PIC slot.
+    *
+    * @param[in] callSite : address in the code cache of the call instruction
+    * @param[in] method : J9Method for the interface
+    */
+   void reservationInterfaceCache(void *callSite, TR_OpaqueMethodBlock *method);
+
 private :
    TR_FrontEnd *_fe;
    static TR::CodeCacheManager *_codeCacheManager;
    static J9JITConfig *_jitConfig;
    static J9JavaVM *_javaVM;
    };
-   
+
 } // namespace J9
 
 #endif // J9_CODECACHEMANAGER_INCL


### PR DESCRIPTION
This is OpenJ9-specific functionality.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>