### PR TITLE
Fold ClassFromMethod into method records

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1485,8 +1485,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Static Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+               traceMsg(self()->comp(), "\n Validate Static Method From CP: methodID=%d, definingClassID=%d, beholderID=%d, cpIndex=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_beholderID,
                         binaryTemplate->_cpIndex);
                }
@@ -1505,8 +1506,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Special Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+               traceMsg(self()->comp(), "\n Validate Special Method From CP: methodID=%d, definingClassID=%d, beholderID=%d, cpIndex=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_beholderID,
                         binaryTemplate->_cpIndex);
                }
@@ -1525,8 +1527,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Virtual Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+               traceMsg(self()->comp(), "\n Validate Virtual Method From CP: methodID=%d, definingClassID=%d, beholderID=%d, cpIndex=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_beholderID,
                         binaryTemplate->_cpIndex);
                }
@@ -1545,11 +1548,12 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Virtual Method From Offset: methodID=%d, beholderID=%d, virtualCallOffset=%d, ignoreRtResolve=%s ",
+               traceMsg(self()->comp(), "\n Validate Virtual Method From Offset: methodID=%d, definingClassID=%d, beholderID=%d, virtualCallOffset=%d, ignoreRtResolve=%s ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_beholderID,
-                        binaryTemplate->_virtualCallOffset,
-                        binaryTemplate->_ignoreRtResolve ? "true" : "false");
+                        binaryTemplate->_virtualCallOffsetAndIgnoreRtResolve & ~1,
+                        (binaryTemplate->_virtualCallOffsetAndIgnoreRtResolve & 1) ? "true" : "false");
                }
             cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate);
             self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
@@ -1566,8 +1570,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Interface Method From CP: methodID=%d, beholderID=%d, lookupID=%d, cpIndex=%d ",
+               traceMsg(self()->comp(), "\n Validate Interface Method From CP: methodID=%d, definingClassID=%d, beholderID=%d, lookupID=%d, cpIndex=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_beholderID,
                         (uint32_t)binaryTemplate->_lookupID,
                         binaryTemplate->_cpIndex);
@@ -1587,8 +1592,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Improper Interface Method From CP: methodID=%d, beholderID=%d, cpIndex=%d ",
+               traceMsg(self()->comp(), "\n Validate Improper Interface Method From CP: methodID=%d, definingClassID=%d, beholderID=%d, cpIndex=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_beholderID,
                         binaryTemplate->_cpIndex);
                }
@@ -1607,9 +1613,10 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Method From Class and Sig: methodID=%d, methodClassID=%d, beholderID=%d, romMethodOffsetInSCC=%p ",
+               traceMsg(self()->comp(), "\n Validate Method From Class and Sig: methodID=%d, definingClassID=%d, lookupClassID=%d, beholderID=%d, romMethodOffsetInSCC=%p ",
                         (uint32_t)binaryTemplate->_methodID,
-                        (uint32_t)binaryTemplate->_methodClassID,
+                        (uint32_t)binaryTemplate->_definingClassID,
+                        (uint32_t)binaryTemplate->_lookupClassID,
                         (uint32_t)binaryTemplate->_beholderID,
                         binaryTemplate->_romMethodOffsetInSCC);
                }
@@ -1667,8 +1674,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Method From Single Implementor: methodID=%d, thisClassID=%d, cpIndexOrVftSlot=%d, callerMethodID=%d, useGetResolvedInterfaceMethod=%d ",
+               traceMsg(self()->comp(), "\n Validate Method From Single Implementor: methodID=%d, definingClassID=%d, thisClassID=%d, cpIndexOrVftSlot=%d, callerMethodID=%d, useGetResolvedInterfaceMethod=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_thisClassID,
                         binaryTemplate->_cpIndexOrVftSlot,
                         (uint32_t)binaryTemplate->_callerMethodID,
@@ -1689,8 +1697,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Method From Single Interface Implementor: methodID=%d, thisClassID=%d, cpIndex=%d, callerMethodID=%d ",
+               traceMsg(self()->comp(), "\n Validate Method From Single Interface Implementor: methodID=%d, definingClassID=%d, thisClassID=%d, cpIndex=%d, callerMethodID=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_thisClassID,
                         binaryTemplate->_cpIndex,
                         (uint32_t)binaryTemplate->_callerMethodID);
@@ -1710,8 +1719,9 @@ J9::AheadOfTimeCompile::dumpRelocationData()
                   reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *>(cursor);
             if (isVerbose)
                {
-               traceMsg(self()->comp(), "\n Validate Method From Single Interface Implementor: methodID=%d, thisClassID=%d, vftSlot=%d, callerMethodID=%d ",
+               traceMsg(self()->comp(), "\n Validate Method From Single Interface Implementor: methodID=%d, definingClassID=%d, thisClassID=%d, vftSlot=%d, callerMethodID=%d ",
                         (uint32_t)binaryTemplate->_methodID,
+                        (uint32_t)binaryTemplate->_definingClassID,
                         (uint32_t)binaryTemplate->_thisClassID,
                         binaryTemplate->_vftSlot,
                         (uint32_t)binaryTemplate->_callerMethodID);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1260,25 +1260,6 @@ J9::AheadOfTimeCompile::dumpRelocationData()
             }
             break;
 
-         case TR_ValidateClassFromMethod:
-            {
-            cursor++;
-            if (is64BitTarget)
-               cursor += 4;     // padding
-            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
-            TR_RelocationRecordValidateClassFromMethodBinaryTemplate *binaryTemplate =
-                  reinterpret_cast<TR_RelocationRecordValidateClassFromMethodBinaryTemplate *>(cursor);
-            if (isVerbose)
-               {
-               traceMsg(self()->comp(), "\n Validate Class From Method: classID=%d, methodID=%d ",
-                        (uint32_t)binaryTemplate->_classID,
-                        (uint32_t)binaryTemplate->_methodID);
-               }
-            cursor += sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate);
-            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
-            }
-            break;
-
          case TR_ValidateArrayClassFromComponentClass:
             {
             cursor++;

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -437,9 +437,8 @@ TR_ResolvedMethod * TR_PersistentCHTable::findSingleImplementer(
                                                                  callerMethod->getPersistentIdentifier(),
                                                                  useGetResolvedInterfaceMethod);
       if (validated)
-         validated = svm->addClassFromMethodRecord(implementer->classOfMethod(), implementer->getPersistentIdentifier());
-
-      if (!validated)
+         SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+      else
          implementer = NULL;
       }
 
@@ -487,9 +486,8 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
                                                                           callerMethod->getPersistentIdentifier());
 
       if (validated)
-         validated = svm->addClassFromMethodRecord(implementer->classOfMethod(), implementer->getPersistentIdentifier());
-
-      if (!validated)
+         SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+      else
          implementer = NULL;
       }
 
@@ -594,9 +592,8 @@ TR_PersistentCHTable::findSingleAbstractImplementer(
                                                                          callerMethod->getPersistentIdentifier());
 
       if (validated)
-         validated = svm->addClassFromMethodRecord(implementer->classOfMethod(), implementer->getPersistentIdentifier());
-
-      if (!validated)
+         SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+      else
          implementer = NULL;
       }
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8586,7 +8586,8 @@ TR_J9SharedCacheVM::getClassOfMethod(TR_OpaqueMethodBlock *method)
 
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
-      validated = comp->getSymbolValidationManager()->addClassFromMethodRecord(classPointer, method);
+      SVM_ASSERT_ALREADY_VALIDATED(comp->getSymbolValidationManager(), classPointer);
+      validated = true;
       }
    else
       {
@@ -8675,11 +8676,9 @@ TR_J9SharedCacheVM::getResolvedMethodForNameAndSignature(TR_Memory * trMemory, T
    if (comp->getOption(TR_UseSymbolValidationManager))
       {
       TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *)((TR_ResolvedJ9Method *)resolvedMethod)->ramMethod();
-      /*
-       * TR_J9VM::getResolvedMethodForNameAndSignature will call getMatchingMethodFromNameAndSignature
-       * which adds a MethodFromClassRecord.
-       */
-      validated = comp->getSymbolValidationManager()->addClassFromMethodRecord(getClassFromMethodBlock(method), method);
+      TR_OpaqueClassBlock *clazz = getClassFromMethodBlock(method);
+      SVM_ASSERT_ALREADY_VALIDATED(comp->getSymbolValidationManager(), clazz);
+      validated = true;
       }
    else
       {

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1363,7 +1363,7 @@ TR_ResolvedRelocatableJ9Method::TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBl
             {
             TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
             SVM_ASSERT_ALREADY_VALIDATED(svm, aMethod);
-            svm->addClassFromMethodRecord(containingClass(), aMethod);
+            SVM_ASSERT_ALREADY_VALIDATED(svm, containingClass());
             }
          else
             {

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -889,8 +889,8 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
                   continue;
                /* call getResolvedMethod again to generate the validation records */
                TR_ResolvedMethod* target_method = getResolvedMethod (tempreceiverClass);
-               if (!comp()->getSymbolValidationManager()->addClassFromMethodRecord(target_method->classOfMethod(), target_method->getPersistentIdentifier()))
-                  continue;
+               TR_OpaqueClassBlock *classOfMethod = target_method->classOfMethod();
+               SVM_ASSERT_ALREADY_VALIDATED(comp()->getSymbolValidationManager(), classOfMethod);
                }
 
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3570,18 +3570,23 @@ int32_t
 TR_RelocationRecordValidateStaticMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_beholderID);
-   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+   uint32_t cpIndex = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if ((reloFlags(reloTarget) & TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT) != 0)
+      cpIndex |= J9_STATIC_SPLIT_TABLE_INDEX_FLAG;
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticMethodFromCPRecord(methodID, beholderID, cpIndex))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateStaticMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3591,18 +3596,23 @@ int32_t
 TR_RelocationRecordValidateSpecialMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_beholderID);
-   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+   uint32_t cpIndex = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+
+   if ((reloFlags(reloTarget) & TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT) != 0)
+      cpIndex |= J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG;
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateSpecialMethodFromCPRecord(methodID, beholderID, cpIndex))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateSpecialMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3612,18 +3622,20 @@ int32_t
 TR_RelocationRecordValidateVirtualMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_beholderID);
-   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+   uint32_t cpIndex = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *)_record)->_cpIndex);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromCPRecord(methodID, beholderID, cpIndex))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3633,20 +3645,23 @@ int32_t
 TR_RelocationRecordValidateVirtualMethodFromOffset::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_beholderID);
-   uint32_t virtualCallOffset = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_virtualCallOffset);
-   bool ignoreRtResolve = (bool)reloTarget->loadUnsigned8b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_ignoreRtResolve);
+   uint16_t virtualCallOffsetAndIgnoreRtResolve = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_virtualCallOffsetAndIgnoreRtResolve);
+   int32_t virtualCallOffset = (int32_t)(int16_t)(virtualCallOffsetAndIgnoreRtResolve & ~1);
+   bool ignoreRtResolve = (virtualCallOffsetAndIgnoreRtResolve & 1) != 0;
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: virtualCallOffset %d\n", virtualCallOffset);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: ignoreRtResolve %s\n", ignoreRtResolve ? "true" : "false");
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromOffsetRecord(methodID, beholderID, virtualCallOffset, ignoreRtResolve))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateVirtualMethodFromOffsetRecord(methodID, definingClassID, beholderID, virtualCallOffset, ignoreRtResolve))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3656,20 +3671,22 @@ int32_t
 TR_RelocationRecordValidateInterfaceMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_beholderID);
    uint16_t lookupID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_lookupID);
-   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+   uint32_t cpIndex = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: lookupID %d\n", lookupID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateInterfaceMethodFromCPRecord(methodID, beholderID, lookupID, cpIndex))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateInterfaceMethodFromCPRecord(methodID, definingClassID, beholderID, lookupID, cpIndex))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3679,18 +3696,20 @@ int32_t
 TR_RelocationRecordValidateImproperInterfaceMethodFromCP::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_beholderID);
-   uint32_t cpIndex = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
+   uint32_t cpIndex = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *)_record)->_cpIndex);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateImproperInterfaceMethodFromCPRecord(methodID, beholderID, cpIndex))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateImproperInterfaceMethodFromCPRecord(methodID, definingClassID, beholderID, cpIndex))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3700,7 +3719,8 @@ int32_t
 TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_methodID);
-   uint16_t methodClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_methodClassID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_definingClassID);
+   uint16_t lookupClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_lookupClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_beholderID);
 
    void *romMethodOffset = (void *)reloTarget->loadRelocationRecordValue((uintptrj_t *) &((TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate *)_record)->_romMethodOffsetInSCC);
@@ -3710,12 +3730,13 @@ TR_RelocationRecordValidateMethodFromClassAndSig::applyRelocation(TR_RelocationR
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodClassID %d\n", methodClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: lookupClassID %d\n", lookupClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: beholderID %d\n", beholderID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: romMethod %p\n", romMethod);
       }
 
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassAndSignatureRecord(methodID, methodClassID, beholderID, static_cast<J9ROMMethod *>(romMethod)))
+   if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromClassAndSignatureRecord(methodID, definingClassID, lookupClassID, beholderID, static_cast<J9ROMMethod *>(romMethod)))
       return 0;
    else
       return compilationAotClassReloFailure;
@@ -3765,6 +3786,7 @@ int32_t
 TR_RelocationRecordValidateMethodFromSingleImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_definingClassID);
    uint16_t thisClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_thisClassID);
    int32_t cpIndexOrVftSlot = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_cpIndexOrVftSlot);
    uint16_t callerMethodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *)_record)->_callerMethodID);
@@ -3774,6 +3796,7 @@ TR_RelocationRecordValidateMethodFromSingleImpl::applyRelocation(TR_RelocationRu
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: thisClassID %d\n", thisClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndexOrVftSlot %d\n", cpIndexOrVftSlot);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: callerMethodID %d\n", callerMethodID);
@@ -3781,6 +3804,7 @@ TR_RelocationRecordValidateMethodFromSingleImpl::applyRelocation(TR_RelocationRu
       }
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromSingleImplementerRecord(methodID,
+                                                                                                    definingClassID,
                                                                                                     thisClassID,
                                                                                                     cpIndexOrVftSlot,
                                                                                                     callerMethodID,
@@ -3794,20 +3818,23 @@ int32_t
 TR_RelocationRecordValidateMethodFromSingleInterfaceImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_definingClassID);
    uint16_t thisClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_thisClassID);
-   int32_t cpIndex = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_cpIndex);
+   int32_t cpIndex = reloTarget->loadSigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_cpIndex);
    uint16_t callerMethodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *)_record)->_callerMethodID);
 
    if (reloRuntime->reloLogger()->logEnabled())
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: thisClassID %d\n", thisClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: cpIndex %d\n", cpIndex);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: callerMethodID %d\n", callerMethodID);
       }
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromSingleInterfaceImplementerRecord(methodID,
+                                                                                                             definingClassID,
                                                                                                              thisClassID,
                                                                                                              cpIndex,
                                                                                                              callerMethodID))
@@ -3820,6 +3847,7 @@ int32_t
 TR_RelocationRecordValidateMethodFromSingleAbstractImpl::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_methodID);
+   uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_definingClassID);
    uint16_t thisClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_thisClassID);
    int32_t vftSlot = reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_vftSlot);
    uint16_t callerMethodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *)_record)->_callerMethodID);
@@ -3828,12 +3856,14 @@ TR_RelocationRecordValidateMethodFromSingleAbstractImpl::applyRelocation(TR_Relo
       {
       reloRuntime->reloLogger()->printf("%s\n", name());
       reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
+      reloRuntime->reloLogger()->printf("\tapplyRelocation: definingClassID %d\n", definingClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: thisClassID %d\n", thisClassID);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: vftSlot %d\n", vftSlot);
       reloRuntime->reloLogger()->printf("\tapplyRelocation: callerMethodID %d\n", callerMethodID);
       }
 
    if (reloRuntime->comp()->getSymbolValidationManager()->validateMethodFromSingleAbstractImplementerRecord(methodID,
+                                                                                                            definingClassID,
                                                                                                             thisClassID,
                                                                                                             vftSlot,
                                                                                                             callerMethodID))

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -337,9 +337,6 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
       case TR_ValidateStaticClassFromCP:
          reloRecord = new (storage) TR_RelocationRecordValidateStaticClassFromCP(reloRuntime, record);
          break;
-      case TR_ValidateClassFromMethod:
-         reloRecord = new (storage) TR_RelocationRecordValidateClassFromMethod(reloRuntime, record);
-         break;
       case TR_ValidateArrayClassFromComponentClass:
          reloRecord = new (storage) TR_RelocationRecordValidateArrayClassFromComponentClass(reloRuntime, record);
          break;
@@ -3344,25 +3341,6 @@ TR_RelocationRecordValidateStaticClassFromCP::applyRelocation(TR_RelocationRunti
    }
 
 int32_t
-TR_RelocationRecordValidateClassFromMethod::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
-   {
-   uint16_t classID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromMethodBinaryTemplate *)_record)->_classID);
-   uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassFromMethodBinaryTemplate *)_record)->_methodID);
-
-   if (reloRuntime->reloLogger()->logEnabled())
-      {
-      reloRuntime->reloLogger()->printf("%s\n", name());
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: classID %d\n", classID);
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: methodID %d\n", methodID);
-      }
-
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassFromMethodRecord(classID, methodID))
-      return 0;
-   else
-      return compilationAotClassReloFailure;
-   }
-
-int32_t
 TR_RelocationRecordValidateArrayClassFromComponentClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t arrayClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateArrayFromCompBinaryTemplate *)_record)->_arrayClassID);
@@ -4578,7 +4556,7 @@ uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRel
    sizeof(TR_RelocationRecordValidateClassFromCPBinaryTemplate),                     // TR_ValidateClassFromCP                          = 66
    sizeof(TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate),             // TR_ValidateDefiningClassFromCP                  = 67
    sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate),               // TR_ValidateStaticClassFromCP                    = 68
-   sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate),                 // TR_ValidateClassFromMethod                      = 69
+   0,                                                                                // TR_ValidateClassFromMethod                      = 69
    0,                                                                                // TR_ValidateComponentClassFromArrayClass         = 70
    sizeof(TR_RelocationRecordValidateArrayFromCompBinaryTemplate),                   // TR_ValidateArrayClassFromComponentClass         = 71
    sizeof(TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate),             // TR_ValidateSuperClassFromClass                  = 72

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -299,11 +299,14 @@ struct TR_RelocationRecordValidateMethodFromClassBinaryTemplate : public TR_Relo
    uint32_t _index;
    };
 
+#define TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT 0x01
+
 struct TR_RelocationRecordValidateMethodFromCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _methodID;
+   uint16_t _definingClassID;
    uint16_t _beholderID;
-   uint32_t _cpIndex;
+   uint16_t _cpIndex; // constrained to 16 bits by the class file format
    };
 
 typedef TR_RelocationRecordValidateMethodFromCPBinaryTemplate TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate;
@@ -313,24 +316,28 @@ typedef TR_RelocationRecordValidateMethodFromCPBinaryTemplate TR_RelocationRecor
 
 struct TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
-   bool _ignoreRtResolve;
    uint16_t _methodID;
+   uint16_t _definingClassID;
    uint16_t _beholderID;
-   uint32_t _virtualCallOffset;
+
+   // Value is (offset | ignoreRtResolve); offset must be even
+   uint16_t _virtualCallOffsetAndIgnoreRtResolve;
    };
 
 struct TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _methodID;
+   uint16_t _definingClassID;
    uint16_t _beholderID;
    uint16_t _lookupID;
-   uint32_t _cpIndex;
+   uint16_t _cpIndex; // constrained to 16 bits by the class file format
    };
 
 struct TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _methodID;
-   uint16_t _methodClassID;
+   uint16_t _definingClassID;
+   uint16_t _lookupClassID;
    uint16_t _beholderID;
    UDATA _romMethodOffsetInSCC;
    };
@@ -338,6 +345,7 @@ struct TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate : public T
 struct TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _methodID;
+   uint16_t _definingClassID;
    uint16_t _thisClassID;
    int32_t _cpIndexOrVftSlot;
    uint16_t _callerMethodID;
@@ -347,17 +355,19 @@ struct TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate : public TR
 struct TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _methodID;
+   uint16_t _definingClassID;
    uint16_t _thisClassID;
-   int32_t _cpIndex;
    uint16_t _callerMethodID;
+   uint16_t _cpIndex; // constrained to 16 bits by the class file format
    };
 
 struct TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _methodID;
+   uint16_t _definingClassID;
    uint16_t _thisClassID;
-   int32_t _vftSlot;
    uint16_t _callerMethodID;
+   int32_t _vftSlot;
    };
 
 struct TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate : public TR_RelocationRecordBinaryTemplate

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -232,12 +232,6 @@ struct TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate : public TR_
 
 typedef TR_RelocationRecordValidateClassFromCPBinaryTemplate TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate;
 
-struct TR_RelocationRecordValidateClassFromMethodBinaryTemplate : public TR_RelocationRecordBinaryTemplate
-   {
-   uint16_t _classID;
-   uint16_t _methodID;
-   };
-
 struct TR_RelocationRecordValidateArrayFromCompBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _arrayClassID;
@@ -1450,18 +1444,6 @@ class TR_RelocationRecordValidateStaticClassFromCP : public TR_RelocationRecord
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateStaticClassFromCP"; }
       virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate); }
-      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-   };
-
-class TR_RelocationRecordValidateClassFromMethod : public TR_RelocationRecord
-   {
-   public:
-      TR_RelocationRecordValidateClassFromMethod() {}
-      TR_RelocationRecordValidateClassFromMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassFromMethod"; }
-      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate); }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -422,13 +422,6 @@ TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *cla
    }
 
 bool
-TR::SymbolValidationManager::addClassFromMethodRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueMethodBlock *method)
-   {
-   SVM_ASSERT_ALREADY_VALIDATED(this, method);
-   return addClassRecord(clazz, new (_region) ClassFromMethodRecord(clazz, method));
-   }
-
-bool
 TR::SymbolValidationManager::addArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass)
    {
    // Class chain validation for the base component type is already taken care of
@@ -757,13 +750,6 @@ TR::SymbolValidationManager::validateStaticClassFromCPRecord(uint16_t classID, u
    J9Class *beholder = getJ9ClassFromID(beholderID);
    J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
    return validateSymbol(classID, TR_ResolvedJ9Method::getClassOfStaticFromCP(_fej9, beholderCP, cpIndex));
-   }
-
-bool
-TR::SymbolValidationManager::validateClassFromMethodRecord(uint16_t classID, uint16_t methodID)
-   {
-   J9Method *method = getJ9MethodFromID(methodID);
-   return validateSymbol(classID, J9_CLASS_FROM_METHOD(method));
    }
 
 bool
@@ -1248,22 +1234,6 @@ void TR::StaticClassFromCPRecord::printFields()
    traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
    printClass(_beholder);
    traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
-   }
-
-bool TR::ClassFromMethodRecord::isLessThanWithinKind(
-   SymbolValidationRecord *other)
-   {
-   TR::ClassFromMethodRecord *rhs = downcast(this, other);
-   return LexicalOrder::by(_class, rhs->_class)
-      .thenBy(_method, rhs->_method).less();
-   }
-
-void TR::ClassFromMethodRecord::printFields()
-   {
-   traceMsg(TR::comp(), "ClassFromMethodRecord\n");
-   traceMsg(TR::comp(), "\t_class=0x%p\n", _class);
-   printClass(_class);
-   traceMsg(TR::comp(), "\t_method=0x%p\n", _method);
    }
 
 bool TR::ArrayClassFromComponentClassRecord::isLessThanWithinKind(

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -781,6 +781,19 @@ private:
    void appendNewRecord(void *symbol, TR::SymbolValidationRecord *record);
    void appendRecordIfNew(void *symbol, TR::SymbolValidationRecord *record);
 
+   struct ClassChainInfo
+      {
+      ClassChainInfo()
+         : _baseComponent(NULL), _baseComponentClassChain(NULL), _arrayDims(0) {}
+
+      TR_OpaqueClassBlock *_baseComponent;
+      void *_baseComponentClassChain;
+      int32_t _arrayDims;
+      };
+
+   bool getClassChainInfo(TR_OpaqueClassBlock *clazz, TR::SymbolValidationRecord *record, ClassChainInfo &info);
+   void appendClassChainInfoRecords(TR_OpaqueClassBlock *clazz, const ClassChainInfo &info);
+
    bool addVanillaRecord(void *symbol, TR::SymbolValidationRecord *record);
    bool addClassRecord(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record);
    bool addClassRecordWithRomClass(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record, int arrayDims);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -509,17 +509,17 @@ struct InterfaceMethodFromCPRecord : public MethodValidationRecord
 struct MethodFromClassAndSigRecord : public MethodValidationRecord
    {
    MethodFromClassAndSigRecord(TR_OpaqueMethodBlock *method,
-                               TR_OpaqueClassBlock *methodClass,
+                               TR_OpaqueClassBlock *lookupClass,
                                TR_OpaqueClassBlock *beholder)
       : MethodValidationRecord(TR_ValidateMethodFromClassAndSig, method),
-        _methodClass(methodClass),
+        _lookupClass(lookupClass),
         _beholder(beholder)
       {}
 
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueClassBlock *_methodClass;
+   TR_OpaqueClassBlock *_lookupClass;
    TR_OpaqueClassBlock *_beholder;
    };
 
@@ -724,23 +724,26 @@ public:
    bool validateClassChainRecord(uint16_t classID, void *classChain);
 
    bool validateMethodFromClassRecord(uint16_t methodID, uint16_t beholderID, uint32_t index);
-   bool validateStaticMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
-   bool validateSpecialMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
-   bool validateVirtualMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
-   bool validateVirtualMethodFromOffsetRecord(uint16_t methodID, uint16_t beholderID, int32_t virtualCallOffset, bool ignoreRtResolve);
-   bool validateInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, uint16_t lookupID, int32_t cpIndex);
-   bool validateImproperInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t beholderID, int32_t cpIndex);
-   bool validateMethodFromClassAndSignatureRecord(uint16_t methodID, uint16_t methodClassID, uint16_t beholderID, J9ROMMethod *romMethod);
+   bool validateStaticMethodFromCPRecord(uint16_t methodID, uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
+   bool validateSpecialMethodFromCPRecord(uint16_t methodID, uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
+   bool validateVirtualMethodFromCPRecord(uint16_t methodID, uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
+   bool validateVirtualMethodFromOffsetRecord(uint16_t methodID, uint16_t definingClassID, uint16_t beholderID, int32_t virtualCallOffset, bool ignoreRtResolve);
+   bool validateInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t definingClassID, uint16_t beholderID, uint16_t lookupID, int32_t cpIndex);
+   bool validateImproperInterfaceMethodFromCPRecord(uint16_t methodID, uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
+   bool validateMethodFromClassAndSignatureRecord(uint16_t methodID, uint16_t definingClassID, uint16_t lookupClassID, uint16_t beholderID, J9ROMMethod *romMethod);
    bool validateMethodFromSingleImplementerRecord(uint16_t methodID,
+                                                  uint16_t definingClassID,
                                                   uint16_t thisClassID,
                                                   int32_t cpIndexOrVftSlot,
                                                   uint16_t callerMethodID,
                                                   TR_YesNoMaybe useGetResolvedInterfaceMethod);
    bool validateMethodFromSingleInterfaceImplementerRecord(uint16_t methodID,
+                                                uint16_t definingClassID,
                                                 uint16_t thisClassID,
                                                 int32_t cpIndex,
                                                 uint16_t callerMethodID);
    bool validateMethodFromSingleAbstractImplementerRecord(uint16_t methodID,
+                                               uint16_t definingClassID,
                                                uint16_t thisClassID,
                                                int32_t vftSlot,
                                                uint16_t callerMethodID);
@@ -797,8 +800,8 @@ private:
    bool validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type);
    bool validateSymbol(uint16_t idToBeValidated, TR_OpaqueClassBlock *clazz);
    bool validateSymbol(uint16_t idToBeValidated, J9Class *clazz);
-   bool validateSymbol(uint16_t idToBeValidated, TR_OpaqueMethodBlock *method);
-   bool validateSymbol(uint16_t idToBeValidated, J9Method *method);
+   bool validateSymbol(uint16_t methodID, uint16_t definingClassID, TR_OpaqueMethodBlock *method);
+   bool validateSymbol(uint16_t methodID, uint16_t definingClassID, J9Method *method);
 
    bool isDefinedID(uint16_t id);
    void setSymbolOfID(uint16_t id, void *symbol, TR::SymbolType type);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -384,11 +384,26 @@ struct ClassChainRecord : public SymbolValidationRecord
    void *_classChain;
    };
 
-struct MethodFromClassRecord : public SymbolValidationRecord
+struct MethodValidationRecord : public SymbolValidationRecord
+   {
+   MethodValidationRecord(TR_ExternalRelocationTargetKind kind, TR_OpaqueMethodBlock *method)
+      : SymbolValidationRecord(kind),
+        _method(method)
+      {}
+
+   TR_OpaqueClassBlock *definingClass()
+      {
+      return reinterpret_cast<TR_OpaqueClassBlock *>(
+         J9_CLASS_FROM_METHOD(reinterpret_cast<J9Method *>(_method)));
+      }
+
+   TR_OpaqueMethodBlock *_method;
+   };
+
+struct MethodFromClassRecord : public MethodValidationRecord
    {
    MethodFromClassRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, uint32_t index)
-      : SymbolValidationRecord(TR_ValidateMethodFromClass),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateMethodFromClass, method),
         _beholder(beholder),
         _index(index)
       {}
@@ -396,18 +411,16 @@ struct MethodFromClassRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    uint32_t _index;
    };
 
-struct StaticMethodFromCPRecord : public SymbolValidationRecord
+struct StaticMethodFromCPRecord : public MethodValidationRecord
    {
    StaticMethodFromCPRecord(TR_OpaqueMethodBlock *method,
                                TR_OpaqueClassBlock *beholder,
                                int32_t cpIndex)
-      : SymbolValidationRecord(TR_ValidateStaticMethodFromCP),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateStaticMethodFromCP, method),
         _beholder(beholder),
         _cpIndex(cpIndex)
       {}
@@ -415,18 +428,16 @@ struct StaticMethodFromCPRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    int32_t _cpIndex;
    };
 
-struct SpecialMethodFromCPRecord : public SymbolValidationRecord
+struct SpecialMethodFromCPRecord : public MethodValidationRecord
    {
    SpecialMethodFromCPRecord(TR_OpaqueMethodBlock *method,
                              TR_OpaqueClassBlock *beholder,
                              int32_t cpIndex)
-      : SymbolValidationRecord(TR_ValidateSpecialMethodFromCP),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateSpecialMethodFromCP, method),
         _beholder(beholder),
         _cpIndex(cpIndex)
       {}
@@ -434,18 +445,16 @@ struct SpecialMethodFromCPRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    int32_t _cpIndex;
    };
 
-struct VirtualMethodFromCPRecord : public SymbolValidationRecord
+struct VirtualMethodFromCPRecord : public MethodValidationRecord
    {
    VirtualMethodFromCPRecord(TR_OpaqueMethodBlock *method,
                              TR_OpaqueClassBlock *beholder,
                              int32_t cpIndex)
-      : SymbolValidationRecord(TR_ValidateVirtualMethodFromCP),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateVirtualMethodFromCP, method),
         _beholder(beholder),
         _cpIndex(cpIndex)
       {}
@@ -453,19 +462,17 @@ struct VirtualMethodFromCPRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    int32_t _cpIndex;
    };
 
-struct VirtualMethodFromOffsetRecord : public SymbolValidationRecord
+struct VirtualMethodFromOffsetRecord : public MethodValidationRecord
    {
    VirtualMethodFromOffsetRecord(TR_OpaqueMethodBlock *method,
                                  TR_OpaqueClassBlock *beholder,
                                  int32_t virtualCallOffset,
                                  bool ignoreRtResolve)
-      : SymbolValidationRecord(TR_ValidateVirtualMethodFromOffset),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateVirtualMethodFromOffset, method),
         _beholder(beholder),
         _virtualCallOffset(virtualCallOffset),
         _ignoreRtResolve(ignoreRtResolve)
@@ -474,20 +481,18 @@ struct VirtualMethodFromOffsetRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    int32_t _virtualCallOffset;
    bool _ignoreRtResolve;
    };
 
-struct InterfaceMethodFromCPRecord : public SymbolValidationRecord
+struct InterfaceMethodFromCPRecord : public MethodValidationRecord
    {
    InterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method,
                                TR_OpaqueClassBlock *beholder,
                                TR_OpaqueClassBlock *lookup,
                                int32_t cpIndex)
-      : SymbolValidationRecord(TR_ValidateInterfaceMethodFromCP),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateInterfaceMethodFromCP, method),
         _beholder(beholder),
         _lookup(lookup),
         _cpIndex(cpIndex)
@@ -496,19 +501,17 @@ struct InterfaceMethodFromCPRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    TR_OpaqueClassBlock *_lookup;
    int32_t _cpIndex;
    };
 
-struct MethodFromClassAndSigRecord : public SymbolValidationRecord
+struct MethodFromClassAndSigRecord : public MethodValidationRecord
    {
    MethodFromClassAndSigRecord(TR_OpaqueMethodBlock *method,
                                TR_OpaqueClassBlock *methodClass,
                                TR_OpaqueClassBlock *beholder)
-      : SymbolValidationRecord(TR_ValidateMethodFromClassAndSig),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateMethodFromClassAndSig, method),
         _methodClass(methodClass),
         _beholder(beholder)
       {}
@@ -516,7 +519,6 @@ struct MethodFromClassAndSigRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_methodClass;
    TR_OpaqueClassBlock *_beholder;
    };
@@ -555,15 +557,14 @@ struct ClassInfoIsInitialized : public SymbolValidationRecord
    bool _isInitialized;
    };
 
-struct MethodFromSingleImplementer : public SymbolValidationRecord
+struct MethodFromSingleImplementer : public MethodValidationRecord
    {
    MethodFromSingleImplementer(TR_OpaqueMethodBlock *method,
                                TR_OpaqueClassBlock *thisClass,
                                int32_t cpIndexOrVftSlot,
                                TR_OpaqueMethodBlock *callerMethod,
                                TR_YesNoMaybe useGetResolvedInterfaceMethod)
-      : SymbolValidationRecord(TR_ValidateMethodFromSingleImplementer),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateMethodFromSingleImplementer, method),
         _thisClass(thisClass),
         _cpIndexOrVftSlot(cpIndexOrVftSlot),
         _callerMethod(callerMethod),
@@ -573,21 +574,19 @@ struct MethodFromSingleImplementer : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_thisClass;
    int32_t _cpIndexOrVftSlot;
    TR_OpaqueMethodBlock *_callerMethod;
    TR_YesNoMaybe _useGetResolvedInterfaceMethod;
    };
 
-struct MethodFromSingleInterfaceImplementer : public SymbolValidationRecord
+struct MethodFromSingleInterfaceImplementer : public MethodValidationRecord
    {
    MethodFromSingleInterfaceImplementer(TR_OpaqueMethodBlock *method,
                                         TR_OpaqueClassBlock *thisClass,
                                         int32_t cpIndex,
                                         TR_OpaqueMethodBlock *callerMethod)
-      : SymbolValidationRecord(TR_ValidateMethodFromSingleInterfaceImplementer),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateMethodFromSingleInterfaceImplementer, method),
         _thisClass(thisClass),
         _cpIndex(cpIndex),
         _callerMethod(callerMethod)
@@ -596,20 +595,18 @@ struct MethodFromSingleInterfaceImplementer : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_thisClass;
    int32_t _cpIndex;
    TR_OpaqueMethodBlock *_callerMethod;
    };
 
-struct MethodFromSingleAbstractImplementer : public SymbolValidationRecord
+struct MethodFromSingleAbstractImplementer : public MethodValidationRecord
    {
    MethodFromSingleAbstractImplementer(TR_OpaqueMethodBlock *method,
                                        TR_OpaqueClassBlock *thisClass,
                                        int32_t vftSlot,
                                        TR_OpaqueMethodBlock *callerMethod)
-      : SymbolValidationRecord(TR_ValidateMethodFromSingleAbstractImplementer),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateMethodFromSingleAbstractImplementer, method),
         _thisClass(thisClass),
         _vftSlot(vftSlot),
         _callerMethod(callerMethod)
@@ -618,19 +615,17 @@ struct MethodFromSingleAbstractImplementer : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_thisClass;
    int32_t _vftSlot;
    TR_OpaqueMethodBlock *_callerMethod;
    };
 
-struct ImproperInterfaceMethodFromCPRecord : public SymbolValidationRecord
+struct ImproperInterfaceMethodFromCPRecord : public MethodValidationRecord
    {
    ImproperInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method,
                                TR_OpaqueClassBlock *beholder,
                                int32_t cpIndex)
-      : SymbolValidationRecord(TR_ValidateImproperInterfaceMethodFromCP),
-        _method(method),
+      : MethodValidationRecord(TR_ValidateImproperInterfaceMethodFromCP, method),
         _beholder(beholder),
         _cpIndex(cpIndex)
       {}
@@ -638,7 +633,6 @@ struct ImproperInterfaceMethodFromCPRecord : public SymbolValidationRecord
    virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
    virtual void printFields();
 
-   TR_OpaqueMethodBlock *_method;
    TR_OpaqueClassBlock *_beholder;
    int32_t _cpIndex;
    };
@@ -798,7 +792,7 @@ private:
    bool addClassRecord(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record);
    bool addClassRecordWithRomClass(TR_OpaqueClassBlock *clazz, TR::ClassValidationRecord *record, int arrayDims);
    void addMultipleArrayRecords(TR_OpaqueClassBlock *clazz, int arrayDims);
-   bool addMethodRecord(TR_OpaqueMethodBlock *method, TR::SymbolValidationRecord *record);
+   bool addMethodRecord(TR::MethodValidationRecord *record);
 
    bool validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type);
    bool validateSymbol(uint16_t idToBeValidated, TR_OpaqueClassBlock *clazz);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -225,21 +225,6 @@ struct StaticClassFromCPRecord : public ClassValidationRecord
    uint32_t  _cpIndex;
    };
 
-struct ClassFromMethodRecord : public ClassValidationRecord
-   {
-   ClassFromMethodRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueMethodBlock *method)
-      : ClassValidationRecord(TR_ValidateClassFromMethod),
-        _class(clazz),
-        _method(method)
-      {}
-
-   virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
-   virtual void printFields();
-
-   TR_OpaqueClassBlock * _class;
-   TR_OpaqueMethodBlock *_method;
-   };
-
 struct ArrayClassFromComponentClassRecord : public ClassValidationRecord
    {
    ArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass)
@@ -669,7 +654,6 @@ public:
    bool addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
    bool addDefiningClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex, bool isStatic = false);
    bool addStaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex);
-   bool addClassFromMethodRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueMethodBlock *method);
    bool addArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass);
    bool addSuperClassFromClassRecord(TR_OpaqueClassBlock *superClass, TR_OpaqueClassBlock *childClass);
    bool addClassInstanceOfClassRecord(TR_OpaqueClassBlock *classOne, TR_OpaqueClassBlock *classTwo, bool objectTypeIsFixed, bool castTypeIsFixed, bool isInstanceOf);
@@ -711,7 +695,6 @@ public:
    bool validateClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateDefiningClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex, bool isStatic);
    bool validateStaticClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
-   bool validateClassFromMethodRecord(uint16_t classID, uint16_t methodID);
    bool validateArrayClassFromComponentClassRecord(uint16_t arrayClassID, uint16_t componentClassID);
    bool validateSuperClassFromClassRecord(uint16_t superClassID, uint16_t childClassID);
    bool validateClassInstanceOfClassRecord(uint16_t classOneID, uint16_t classTwoID, bool objectTypeIsFixed, bool castTypeIsFixed, bool wasInstanceOf);

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -675,22 +675,6 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          }
          break;
 
-      case TR_ValidateClassFromMethod:
-         {
-         TR::ClassFromMethodRecord *record = reinterpret_cast<TR::ClassFromMethodRecord *>(relocation->getTargetAddress());
-
-         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
-
-         TR_RelocationRecordValidateClassFromMethodBinaryTemplate *binaryTemplate =
-               reinterpret_cast<TR_RelocationRecordValidateClassFromMethodBinaryTemplate *>(cursor);
-
-         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
-         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
-
-         cursor += sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate);
-         }
-         break;
-
       case TR_ValidateArrayClassFromComponentClass:
          {
          TR::ArrayClassFromComponentClassRecord *record = reinterpret_cast<TR::ArrayClassFromComponentClassRecord *>(relocation->getTargetAddress());
@@ -1305,7 +1289,7 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    sizeof(TR_RelocationRecordValidateClassFromCPBinaryTemplate),       // TR_ValidateClassFromCP                 = 66,
    sizeof(TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate),//TR_ValidateDefiningClassFromCP         = 67,
    sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate), // TR_ValidateStaticClassFromCP           = 68,
-   sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate),   // TR_ValidateClassFromMethod             = 69,
+   0,                                                                  // TR_ValidateClassFromMethod             = 69,
    0,                                                                  // TR_ValidateComponentClassFromArrayClass= 70,
    sizeof(TR_RelocationRecordValidateArrayFromCompBinaryTemplate),     // TR_ValidateArrayClassFromComponentClass= 71,
    sizeof(TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate),//TR_ValidateSuperClassFromClass         = 72,

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -616,9 +616,15 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
          TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate *>(cursor);
+         TR_ASSERT_FATAL(
+            (record->_cpIndex & J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG) == 0,
+            "static method cpIndex has special split table flag set");
+         if ((record->_cpIndex & J9_STATIC_SPLIT_TABLE_INDEX_FLAG) != 0)
+            *flagsCursor |= TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT;
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_cpIndex = static_cast<uintptrj_t>(record->_cpIndex);
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex & J9_SPLIT_TABLE_INDEX_MASK);
          cursor += sizeof(TR_RelocationRecordValidateStaticMethodFromCPBinaryTemplate);
          }
          break;
@@ -628,9 +634,15 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
          TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate *>(cursor);
+         TR_ASSERT_FATAL(
+            (record->_cpIndex & J9_STATIC_SPLIT_TABLE_INDEX_FLAG) == 0,
+            "special method cpIndex has static split table flag set");
+         if ((record->_cpIndex & J9_SPECIAL_SPLIT_TABLE_INDEX_FLAG) != 0)
+            *flagsCursor |= TR_VALIDATE_STATIC_OR_SPECIAL_METHOD_FROM_CP_IS_SPLIT;
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_cpIndex = static_cast<uintptrj_t>(record->_cpIndex);
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex & J9_SPLIT_TABLE_INDEX_MASK);
          cursor += sizeof(TR_RelocationRecordValidateSpecialMethodFromCPBinaryTemplate);
          }
          break;
@@ -641,8 +653,9 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate *>(cursor);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_cpIndex = static_cast<uintptrj_t>(record->_cpIndex);
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex);
          cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromCPBinaryTemplate);
          }
          break;
@@ -652,10 +665,14 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
          TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *>(cursor);
+         TR_ASSERT_FATAL((record->_virtualCallOffset & 1) == 0, "virtualCallOffset must be even");
+         TR_ASSERT_FATAL(
+            record->_virtualCallOffset == (int32_t)(int16_t)record->_virtualCallOffset,
+            "virtualCallOffset must fit in a 16-bit signed integer");
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_virtualCallOffset = record->_virtualCallOffset;
-         binaryTemplate->_ignoreRtResolve = record->_ignoreRtResolve;
+         binaryTemplate->_virtualCallOffsetAndIgnoreRtResolve = (uint16_t)(record->_virtualCallOffset | (int)record->_ignoreRtResolve);
          cursor += sizeof(TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate);
          }
          break;
@@ -666,6 +683,7 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateInterfaceMethodFromCPBinaryTemplate *>(cursor);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
          binaryTemplate->_lookupID = symValManager->getIDFromSymbol(static_cast<void *>(record->_lookup));
          binaryTemplate->_cpIndex = static_cast<uintptrj_t>(record->_cpIndex);
@@ -679,8 +697,9 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate *>(cursor);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
-         binaryTemplate->_cpIndex = static_cast<uintptrj_t>(record->_cpIndex);
+         binaryTemplate->_cpIndex = static_cast<uint16_t>(record->_cpIndex);
          cursor += sizeof(TR_RelocationRecordValidateImproperInterfaceMethodFromCPBinaryTemplate);
          }
          break;
@@ -695,7 +714,8 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(methodToValidate);
          void *romMethodOffsetInSharedCache = sharedCache->offsetInSharedCacheFromPointer(romMethod);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
-         binaryTemplate->_methodClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_methodClass));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
+         binaryTemplate->_lookupClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_lookupClass));
          binaryTemplate->_beholderID = symValManager->getIDFromSymbol(static_cast<void *>(record->_beholder));
          binaryTemplate->_romMethodOffsetInSCC = reinterpret_cast<uintptrj_t>(romMethodOffsetInSharedCache);
          cursor += sizeof(TR_RelocationRecordValidateMethodFromClassAndSigBinaryTemplate);
@@ -708,6 +728,7 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleImplBinaryTemplate *>(cursor);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_thisClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_thisClass));
          binaryTemplate->_cpIndexOrVftSlot = record->_cpIndexOrVftSlot;
          binaryTemplate->_callerMethodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_callerMethod));
@@ -722,9 +743,10 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate *>(cursor);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_thisClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_thisClass));
-         binaryTemplate->_cpIndex = record->_cpIndex;
          binaryTemplate->_callerMethodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_callerMethod));
+         binaryTemplate->_cpIndex = (uint16_t)record->_cpIndex;
          cursor += sizeof(TR_RelocationRecordValidateMethodFromSingleInterfaceImplBinaryTemplate);
          }
          break;
@@ -735,6 +757,7 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *binaryTemplate =
                reinterpret_cast<TR_RelocationRecordValidateMethodFromSingleAbstractImplBinaryTemplate *>(cursor);
          binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
+         binaryTemplate->_definingClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->definingClass()));
          binaryTemplate->_thisClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_thisClass));
          binaryTemplate->_vftSlot = record->_vftSlot;
          binaryTemplate->_callerMethodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_callerMethod));

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -477,17 +477,6 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor += sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate);
          }
          break;
-      case TR_ValidateClassFromMethod:
-         {
-         TR::ClassFromMethodRecord *record = reinterpret_cast<TR::ClassFromMethodRecord *>(relocation->getTargetAddress());
-         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
-         TR_RelocationRecordValidateClassFromMethodBinaryTemplate *binaryTemplate =
-               reinterpret_cast<TR_RelocationRecordValidateClassFromMethodBinaryTemplate *>(cursor);
-         binaryTemplate->_classID = symValManager->getIDFromSymbol(static_cast<void *>(record->_class));
-         binaryTemplate->_methodID = symValManager->getIDFromSymbol(static_cast<void *>(record->_method));
-         cursor += sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate);
-         }
-         break;
       case TR_ValidateArrayClassFromComponentClass:
          {
          TR::ArrayClassFromComponentClassRecord *record = reinterpret_cast<TR::ArrayClassFromComponentClassRecord *>(relocation->getTargetAddress());
@@ -1468,7 +1457,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    sizeof(TR_RelocationRecordValidateClassFromCPBinaryTemplate),       // TR_ValidateClassFromCP                 = 66,
    sizeof(TR_RelocationRecordValidateDefiningClassFromCPBinaryTemplate),//TR_ValidateDefiningClassFromCP         = 67,
    sizeof(TR_RelocationRecordValidateStaticClassFromCPBinaryTemplate), // TR_ValidateStaticClassFromCP           = 68,
-   sizeof(TR_RelocationRecordValidateClassFromMethodBinaryTemplate),   // TR_ValidateClassFromMethod             = 69,
+   0,                                                                  // TR_ValidateClassFromMethod             = 69,
    0,                                                                  // TR_ValidateComponentClassFromArrayClass= 70,
    sizeof(TR_RelocationRecordValidateArrayFromCompBinaryTemplate),     // TR_ValidateArrayClassFromComponentClass= 71,
    sizeof(TR_RelocationRecordValidateSuperClassFromClassBinaryTemplate),//TR_ValidateSuperClassFromClass         = 72,


### PR DESCRIPTION
This series changes records that define method symbols to include a defining class ID, so that they can define both the method and its defining class. Previously, (almost) all method records needed a separate `ClassFromMethod` record to tie the method to its class. Including this as part of the method record is much more space-efficient. `ClassFromMethod` is removed because it is no longer necessary