### PR TITLE
Make sure the cache file path is shorter than the OS limit

### DIFF
--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2018 IBM Corp. and others
+# Copyright (c) 2000, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6693,4 +6693,12 @@ J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_NUM_STARTUP_HINTS.sample_input_3=345876
 J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_NUM_STARTUP_HINTS.explanation=NOTAG
 J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_NUM_STARTUP_HINTS.system_action=
 J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_NUM_STARTUP_HINTS.user_response=
+# END NON-TRANSLATABLE
+
+J9NLS_SHRC_SHRINIT_CACHEFILEPATH_BUFFER_OVERFLOW=The length of shared cache file path should be less than %d.
+# START NON-TRANSLATABLE
+J9NLS_SHRC_SHRINIT_CACHEFILEPATH_BUFFER_OVERFLOW.sample_input_1=259
+J9NLS_SHRC_SHRINIT_CACHEFILEPATH_BUFFER_OVERFLOW.explanation=The cache file path exceeds the maximum length allowed.
+J9NLS_SHRC_SHRINIT_CACHEFILEPATH_BUFFER_OVERFLOW.system_action=The JVM terminates.
+J9NLS_SHRC_SHRINIT_CACHEFILEPATH_BUFFER_OVERFLOW.user_response=Specify a shorter string to option(s) "cacheDir=" and/or "cacheName=".
 # END NON-TRANSLATABLE

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -170,8 +170,10 @@
 #define J9PORT_SHSEM_MODE_NOWAIT ((uintptr_t) 2)
 /** @} */
 
-/* The following defines are used by j9shmem and j9shsem */
+/* The following defines are used by j9shmem.c, j9shsem.c and j9shsem_deprecated.c */
 #define J9SH_MAXPATH EsMaxPath
+#define J9SH_MUTEX_STR "_mutex"
+#define J9SH_SET_STR "_set"
 
 #define J9SH_MEMORY_ID "_memory_"
 #define J9SH_SEMAPHORE_ID "_semaphore_"

--- a/runtime/port/sysvipc/j9sharedhelper.h
+++ b/runtime/port/sysvipc/j9sharedhelper.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2014 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,6 @@ BOOLEAN unlinkControlFile(struct J9PortLibrary* portLibrary, const char *control
 #define J9SH_FILE_DOES_NOT_EXIST -4
 
 /* The following defines are used by j9shmem and j9shsem */
-#define J9SH_MAXPATH EsMaxPath
 #define J9SH_VERSION (EsVersionMajor*100 + EsVersionMinor)
 
 /* Macros dealing with control file modlevel.

--- a/runtime/port/win32/j9shsem.c
+++ b/runtime/port/win32/j9shsem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -398,7 +398,7 @@ createSemaphore(struct J9PortLibrary* portLibrary, struct j9shsem_handle* shsem_
 	
 	for (i = 0; i < shsem_handle->setSize; i++) {
 		HANDLE debugHandle;
-		omrstr_printf(semaphoreName, J9SH_MAXPATH, "%s_set%d", shsem_handle->rootName, i);
+		omrstr_printf(semaphoreName, J9SH_MAXPATH, "%s"J9SH_SET_STR"%d", shsem_handle->rootName, i);
 		Trc_PRT_shsem_j9shsem_createsemaphore_creatingset(i, semaphoreName);   
 		  
 		unicodeSemaphoreName = port_convertFromUTF8(OMRPORTLIB, semaphoreName, unicodeBuffer, UNICODE_BUFFER_SIZE);
@@ -431,7 +431,7 @@ openSemaphore(struct J9PortLibrary* portLibrary, struct j9shsem_handle* shsem_ha
 	Trc_PRT_shsem_j9shsem_opensemaphore_entered(shsem_handle->rootName);
 
 	for (i = 0; i < shsem_handle->setSize; i++) {
-		omrstr_printf(semaphoreName, J9SH_MAXPATH, "%s_set%d", shsem_handle->rootName, i);
+		omrstr_printf(semaphoreName, J9SH_MAXPATH, "%s"J9SH_SET_STR"%d", shsem_handle->rootName, i);
 		Trc_PRT_shsem_j9shsem_opensemaphore_openingset(i, semaphoreName);          
 
 		/*convert the name to unicode*/

--- a/runtime/port/win32/j9shsem_deprecated.c
+++ b/runtime/port/win32/j9shsem_deprecated.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -122,7 +122,7 @@ j9shsem_deprecated_open (struct J9PortLibrary *portLibrary, const char* cacheDir
 	}
 
 	sharedMemoryPathAndFileName = getSharedMemoryPathandFileName(portLibrary, cacheDirName, semname);
-	omrstr_printf(baseFile, J9SH_MAXPATH, "%s_mutex", sharedMemoryPathAndFileName);
+	omrstr_printf(baseFile, J9SH_MAXPATH, "%s"J9SH_MUTEX_STR, sharedMemoryPathAndFileName);
 	omrmem_free_memory(sharedMemoryPathAndFileName);
 	Trc_PRT_shsem_j9shsem_open_builtsemname(baseFile);
 	for (i = 0; baseFile[i] != '\0' && i < J9SH_MAXPATH; i++) {
@@ -416,7 +416,7 @@ createMutex(struct J9PortLibrary* portLibrary, struct j9shsem_handle* shsem_hand
 	
 	for (i = 0; i < shsem_handle->setSize; i++) {
 		HANDLE debugHandle;          
-		omrstr_printf(mutexName, J9SH_MAXPATH, "%s_set%d", shsem_handle->rootName, i);
+		omrstr_printf(mutexName, J9SH_MAXPATH, "%s"J9SH_SET_STR"%d", shsem_handle->rootName, i);
 		Trc_PRT_shsem_j9shsem_createmutex_creatingset(i, mutexName);   
 		  
 		unicodeMutexName = port_convertFromUTF8(OMRPORTLIB, mutexName, unicodeBuffer, UNICODE_BUFFER_SIZE);
@@ -450,7 +450,7 @@ openMutex(struct J9PortLibrary* portLibrary, struct j9shsem_handle* shsem_handle
 	Trc_PRT_shsem_j9shsem_openmutex_entered(shsem_handle->rootName);
 
 	for (i = 0; i < shsem_handle->setSize; i++) {
-		omrstr_printf(mutexName, J9SH_MAXPATH, "%s_set%d", shsem_handle->rootName, i);
+		omrstr_printf(mutexName, J9SH_MAXPATH, "%s"J9SH_SET_STR"%d", shsem_handle->rootName, i);
 		Trc_PRT_shsem_j9shsem_openmutex_openingset(i, mutexName);          
 
 		/*convert the name to unicode*/

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -246,14 +246,20 @@ SH_OSCache::createCacheDir(J9PortLibrary* portLibrary, char* cacheDirName, UDATA
 IDATA
 SH_OSCache::getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirName, char* buffer, UDATA bufferSize, const char* cacheNameWithVGen)
 {
+	IDATA rc = 0;
+	UDATA pathLen = 0;
 	PORT_ACCESS_FROM_PORT(portLibrary);
 	
 	Trc_SHR_OSC_getCachePathName_Entry(cacheNameWithVGen);
 	
-	j9str_printf(PORTLIB, buffer, bufferSize, "%s%s", cacheDirName, cacheNameWithVGen);
+	pathLen = j9str_printf(PORTLIB, buffer, bufferSize, "%s%s", cacheDirName, cacheNameWithVGen);
+	if (pathLen >= (bufferSize - 1)) {
+		Trc_SHR_OSC_getCachePathName_BufferOverFlow(cacheDirName, cacheNameWithVGen, bufferSize - 1);
+		rc = -1;
+	}
 	
 	Trc_SHR_OSC_getCachePathName_Exit();
-	return 0;
+	return rc;
 }
 
 /**
@@ -399,6 +405,9 @@ SH_OSCache::commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirP
 			OSC_ERR_TRACE(J9NLS_SHRC_OSCACHE_ALLOC_FAILED);
 			return -1;
 		}
+	} else {
+		Trc_SHR_Assert_ShouldNeverHappen();
+		return -1;
 	}
 
 	_doCheckBuildID = ((openMode & J9OSCACHE_OPEN_MODE_CHECKBUILDID) != 0);

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -281,20 +281,24 @@ SH_OSCachesysv::startup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPer
 					break;
 				}
 
-				getCachePathName(PORTLIB, _cacheDirName, pathFileName, J9SH_MAXPATH, _semFileName);
-				/* No check for return value of getCachePathName() as it always return 0 */
-				memset(&statBuf, 0, sizeof(statBuf));
-				if (0 == j9file_stat(pathFileName, 0, &statBuf)) {
-					if (1 != statBuf.perm.isGroupReadable) {
-						/* Control file needs to be group readable */
-						Trc_SHR_OSC_startup_setGroupAccessFailed(pathFileName);
-						OSC_WARNING_TRACE1(J9NLS_SHRC_OSCACHE_SEM_CONTROL_FILE_SET_GROUPACCESS_FAILED, pathFileName);
+				if (0 == getCachePathName(PORTLIB, _cacheDirName, pathFileName, J9SH_MAXPATH, _semFileName)) {
+					memset(&statBuf, 0, sizeof(statBuf));
+					if (0 == j9file_stat(pathFileName, 0, &statBuf)) {
+						if (1 != statBuf.perm.isGroupReadable) {
+							/* Control file needs to be group readable */
+							Trc_SHR_OSC_startup_setGroupAccessFailed(pathFileName);
+							OSC_WARNING_TRACE1(J9NLS_SHRC_OSCACHE_SEM_CONTROL_FILE_SET_GROUPACCESS_FAILED, pathFileName);
+						}
+					} else {
+						Trc_SHR_OSC_startup_badFileStat(pathFileName);
+						lastErrorInfo.lastErrorCode = j9error_last_error_number();
+						lastErrorInfo.lastErrorMsg = j9error_last_error_message();
+						errorHandler(J9NLS_SHRC_OSCACHE_ERROR_FILE_STAT, &lastErrorInfo);
+						rc = OSCACHESYSV_FAILURE;
+						break;
 					}
 				} else {
-					Trc_SHR_OSC_startup_badFileStat(pathFileName);
-					lastErrorInfo.lastErrorCode = j9error_last_error_number();
-					lastErrorInfo.lastErrorMsg = j9error_last_error_message();
-					errorHandler(J9NLS_SHRC_OSCACHE_ERROR_FILE_STAT, &lastErrorInfo);
+					Trc_SHR_Assert_ShouldNeverHappen();
 					rc = OSCACHESYSV_FAILURE;
 					break;
 				}
@@ -2673,8 +2677,12 @@ SH_OSCachesysv::restoreFromSnapshot(J9JavaVM* vm, const char* cacheName, UDATA n
 	}
 
 	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, nameWithVGen, CACHE_ROOT_MAXLEN, cacheName, &versionData, OSCACHE_CURRENT_CACHE_GEN, false);
-	/* No check for the return value of getCachePathName() as it always returns 0 */
-	SH_OSCache::getCachePathName(PORTLIB, cacheDirName, pathFileName, J9SH_MAXPATH, nameWithVGen);
+
+	if (0 != SH_OSCache::getCachePathName(PORTLIB, cacheDirName, pathFileName, J9SH_MAXPATH, nameWithVGen)) {
+		Trc_SHR_Assert_ShouldNeverHappen();
+		rc = -1;
+		goto done;
+	}
 
 	fd = j9file_open(pathFileName, EsOpenRead | EsOpenWrite, 0);
 	if (-1 == fd) {

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -1,5 +1,5 @@
 //*******************************************************************************
-// Copyright (c) 2006, 2018 IBM Corp. and others
+// Copyright (c) 2006, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2935,3 +2935,4 @@ TraceEvent=Trc_SHR_INIT_j9shr_findGCHints_Event_Found Overhead=1 Level=4 Templat
 TraceEvent=Trc_SHR_CM_storeSharedData_OverwriteExisting Overhead=1 Level=4 Template="CM storeSharedData: Existing data in the shared cache has been overwritten (result %p, data->address %p, foundDatalen %zu)."
 TraceEvent=Trc_SHR_CM_updateLocalHintsData_OverwriteHeapSizes Overhead=1 Level=4 Template="CM updateLocalHintsData: Existing hints (heapSize1=%zu, heapSize2=%zu) in the shared cache will be overwritten to (heapSize1=%zu, heapSize2=%zu)."
 TraceEvent=Trc_SHR_CM_updateLocalHintsData_WriteHeapSizes Overhead=1 Level=4 Template="CM updateLocalHintsData: Will write hints (heapSize1=%zu, heapSize2=%zu) to shared cache."
+TraceException=Trc_SHR_OSC_getCachePathName_BufferOverFlow NoEnv Overhead=1 Level=1 Template="OSCache:: getCachePathName: The length of cacheDir %s and cacheNameWithVGen %s should be less than buffer size %zu"


### PR DESCRIPTION
1. Remove duplicated define of J9SH_MAXPATH in j9sharedhelper.h
2. Make sure the length of non-persistent cache mutex name is less than _MAX_PATH on Windows.
3. Make sure the cache file path is shorter than J9SH_MAXPATH before
starting up the shared cache.

closes #4351

Signed-off-by: hangshao <hangshao@ca.ibm.com>