### PR TITLE
Initialize jdk.internal.reflect.langReflectAccess to avoid NPE

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -28,6 +28,7 @@ import java.lang.reflect.*;
 import java.security.cert.Certificate;
 
 /*[IF Sidecar19-SE]
+import java.lang.reflect.Modifier;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.StreamSupport;
@@ -46,7 +47,7 @@ import sun.reflect.CallerSensitive;
 /*[ENDIF]*/
 
 /*******************************************************************************
- * Copyright (c) 1998, 2018 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -259,6 +260,12 @@ public abstract class ClassLoader {
 		
 		/*[IF Sidecar19-SE]*/
 		jdk.internal.misc.VM.initLevel(1);
+		/* 
+		 * Following code ensures that the field jdk.internal.reflect.langReflectAccess 
+		 * is initialized before any usage references. This is a workaround.
+		 * More details are at https://github.com/eclipse/openj9/issues/3399#issuecomment-459004840.
+		 */
+		Modifier.isPublic(Modifier.PUBLIC);
 		/*[IF Java10]*/
 		try {
 		/*[ENDIF]*/


### PR DESCRIPTION
Initialize `jdk.internal.reflect.langReflectAccess` to avoid `NPE`

`Modifier.isPublic(Modifier.PUBLIC)` is going to initialize the field `jdk.internal.reflect.langReflectAccess` right away to avoid `NPE` later such as https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/113#issuecomment-459417810.
This is a workaround of an `OpenJDK` issue in which `jdk.internal.reflect.ReflectionFactory` refers the field `langReflectAccess` directly instead of via `langReflectAccess()`.

Manually verified that the `pConfig` still compile.

Note: this change is not required by `Java 8` since the `OpenJDK` issue only presents in later versions.

Related to https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/113

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>