### PR TITLE
Move getClassDepthAndFlagsValue to TR_J9VMBase

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6691,7 +6691,7 @@ TR_J9VMBase::hasFinalizer(TR_OpaqueClassBlock * classPointer)
    }
 
 uintptrj_t
-TR_J9VM::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer)
+TR_J9VMBase::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer)
    {
    return (TR::Compiler->cls.convertClassOffsetToClassPtr(classPointer)->classDepthAndFlags);
    }

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -240,6 +240,7 @@ public:
 /////
    virtual bool isGetImplInliningSupported();
 
+   virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
 
    virtual bool isAbstractClass(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isCloneable(TR_OpaqueClassBlock *);
@@ -1036,7 +1037,6 @@ public:
    virtual bool               isPublicClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueMethodBlock *getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod);
    virtual TR_OpaqueMethodBlock *getMethodFromName(char * className, char *methodName, char *signature);
-   virtual uintptrj_t         getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
 
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);


### PR DESCRIPTION
This is blocking the omr acceptance builds, which are disabled until this is merged. Please re-enabled after merging.