### PR TITLE
CMake: Add missing Java 8 natives

### DIFF
--- a/runtime/jcl/cl_se7_basic/CMakeLists.txt
+++ b/runtime/jcl/cl_se7_basic/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,7 @@ target_link_libraries(jclse7_basic_
 		j9vm_jcl_attach
 		j9vm_jcl_se7
 		j9vm_jcl_se8
+		j9vm_jcl_se8only
 		j9hookable
 		j9zlib
 		j9util

--- a/runtime/jcl/cmake/se6_vm-side_natives.cmake
+++ b/runtime/jcl/cmake/se6_vm-side_natives.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,7 @@ target_sources(j9vm_jcl_se6_vm-side_natives
 		${CMAKE_CURRENT_SOURCE_DIR}/common/mgmthypervisor.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/mgmtprocessor.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/com_ibm_jvm_Stats.c
+		${CMAKE_CURRENT_SOURCE_DIR}/common/orbvmhelpers.c
 
 		#TODO platform specific stuff here
 		${CMAKE_CURRENT_SOURCE_DIR}/unix/syshelp.c
@@ -81,7 +82,7 @@ target_sources(j9vm_jcl_se6_vm-side_natives
 
 target_include_directories(j9vm_jcl_se6_vm-side_natives
 INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/common
-    #TODO fix
-    ${CMAKE_CURRENT_SOURCE_DIR}/unix
+	${CMAKE_CURRENT_SOURCE_DIR}/common
+	#TODO fix
+	${CMAKE_CURRENT_SOURCE_DIR}/unix
 )

--- a/runtime/jcl/cmake/se8.cmake
+++ b/runtime/jcl/cmake/se8.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,4 +24,10 @@ add_library(j9vm_jcl_se8 INTERFACE)
 target_sources(j9vm_jcl_se8
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/common/gpu.c
+)
+
+add_library(j9vm_jcl_se8only INTERFACE)
+target_sources(j9vm_jcl_se8only
+	INTERFACE
+		${CMAKE_CURRENT_SOURCE_DIR}/common/sun_misc_URLClassPath.c
 )


### PR DESCRIPTION
Java 8 builds with cmake were missing (relative to non-cmake builds) contributions from these source files:
* runtime/jcl/common/orbvmhelpers.c
* runtime/jcl/common/sun_misc_URLClassPath.c
