### PR TITLE
Enable guarded devirtualization for JITaaS

### DIFF
--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -37,7 +37,7 @@ public:
    virtual bool supportsEmbeddedHeapBounds() override                    { return false; }
    virtual bool supportsFastNanoTime() override                          { return false; }
    virtual bool helpersNeedRelocation() override                         { return true; }
-   virtual bool canDevirtualizeDispatch() override                       { return false; }
+   virtual bool canDevirtualizeDispatch() override                       { return true; }
    virtual bool needRelocationsForBodyInfoData() override                { return true; }
    virtual bool needRelocationsForPersistentInfoData() override          { return true; }
 


### PR DESCRIPTION
Now that we can make direct calls properly, devirtualization
can be safely enabled.