### PR TITLE
Add Linux PPCLE docker file for JDK12

### DIFF
--- a/buildenv/docker/jdk12/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk12/ppc64le/ubuntu16/Dockerfile
@@ -1,0 +1,96 @@
+# Copyright (c) 2019, 2019 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+
+# To use this docker file:
+#   docker build -t=openj9 .
+#   docker run -it openj9
+
+FROM ubuntu:16.04
+
+# Install required OS tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+  && add-apt-repository ppa:ubuntu-toolchain-r/test \
+  && apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    autoconf \
+    ca-certificates \
+    ccache \
+    cpio \
+    cmake \
+    file \
+    g++-7 \
+    gcc-7 \
+    git \
+    git-core \
+    libasound2-dev \
+    libcups2-dev \
+    libdwarf-dev \
+    libelf-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libnuma-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    libxrandr-dev \
+    libxt-dev \
+    libxtst-dev \
+    make \
+    pkg-config \
+    realpath \
+    ssh \
+    unzip \
+    wget \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install optional tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create links for c++,g++,cc,gcc
+RUN ln -s g++ /usr/bin/c++ \
+  && ln -s g++-7 /usr/bin/g++ \
+  && ln -s gcc /usr/bin/cc \
+  && ln -s gcc-7 /usr/bin/gcc
+
+# Download and setup freemarker.jar to /root/freemarker.jar
+RUN cd /root \
+  && wget https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz/download -O freemarker.tgz \
+  && tar -xzf freemarker.tgz freemarker-2.3.8/lib/freemarker.jar --strip=2 \
+  && rm -f freemarker.tgz
+
+# Download and install boot JDK from AdoptOpenJDK
+RUN cd /root \
+  && wget -O bootjdk11.tar.gz "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=ppc64le&release=latest&type=jdk" \
+  && tar -xzf bootjdk11.tar.gz \
+  && rm -f bootjdk11.tar.gz \
+  && mv $(ls | grep -i jdk) bootjdk11
+
+# Set environment variable JAVA_HOME, and prepend ${JAVA_HOME}/bin to PATH
+ENV JAVA_HOME="/root/bootjdk11"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+WORKDIR /root

--- a/doc/build-instructions/Build_Instructions_V12.md
+++ b/doc/build-instructions/Build_Instructions_V12.md
@@ -20,7 +20,7 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-Building OpenJDK Version 12 with OpenJ9 (Work in progress, only Linux x86_64 platform verified, depends on https://github.com/eclipse/openj9/pull/3980)
+Building OpenJDK Version 12 with OpenJ9 (Work in progress, only Linux x86_64/PPCLE platform verified, depends on https://github.com/eclipse/openj9/pull/3980)
 ======================================
 
 Our website describes a simple [build process](http://www.eclipse.org/openj9/oj9_build.html)


### PR DESCRIPTION
Add `Linux PPCLE` docker file for `JDK12`

Created `JDK12` docker file based on `JDK11` version, added `libxrandr-dev`, updated boot `JDK`;
Update `Build_Instructions_V12.md`.

Verified manually and got following `-version` output:
```
openjdk version "12-internal" 2019-03-19
OpenJDK Runtime Environment (build 12-internal+0-adhoc..openj9-openjdk-jdk12)
Eclipse OpenJ9 VM (build tye-13014fd, JRE 12 Linux ppc64le-64-Bit Compressed References 20190201_000000 (JIT enabled, AOT enabled)
OpenJ9   - 13014fd
OMR      - a5a028d
JCL      - b30e197 based on jdk-12+29)
```
[skip ci]

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>