### PR TITLE
Update CryptoTest.java to load CipherCore

### DIFF
--- a/test/functional/cmdLineTests/openssl/src/org/openj9/test/openssl/CryptoTest.java
+++ b/test/functional/cmdLineTests/openssl/src/org/openj9/test/openssl/CryptoTest.java
@@ -22,12 +22,22 @@
 
 package org.openj9.test.openssl;
 
-import java.security.KeyFactory;
+import java.util.Random;
+import java.security.spec.AlgorithmParameterSpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class CryptoTest {
 	public static void main(String[] args) {
 		try {
-			KeyFactory.getInstance("RSA");
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            Random r = new Random(10);
+            byte[] skey_bytes = new byte[16];
+            r.nextBytes(skey_bytes);
+            SecretKeySpec skey = new SecretKeySpec(skey_bytes, "AES");
+            cipher.init(Cipher.ENCRYPT_MODE, skey);
 			System.out.println("Crypto test COMPLETED");
 		} catch (Exception e) {
 			System.out.println("Crypto test FAILED");


### PR DESCRIPTION
MessageDigest openssl support is being disabled due to #4530, the test
needs to check a different algorithm.

https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/117
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/259

[ci skip]

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>