### PR TITLE
Fix version references

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -510,7 +510,7 @@ JCL      - a786f96b13 based on jdk-11+21)
 
 ## macOS
 :apple:
-The following instructions guide you through the process of building a macOS **OpenJDK V11** binary that contains Eclipse OpenJ9. This process can be used to build binaries for macOS 11.
+The following instructions guide you through the process of building a macOS **OpenJDK V11** binary that contains Eclipse OpenJ9. This process can be used to build binaries for macOS 10.
 
 ### 1. Prepare your system
 :apple:
@@ -586,7 +586,7 @@ When you have all the source files that you need, run the configure script, whic
 
 ```
 bash configure --with-freemarker-jar=/<my_home_dir>/freemarker.jar \
-               --with-boot-jdk=<path_to_macOS_JDK11> \
+               --with-boot-jdk=<path_to_macOS_JDK10> \
                --disable-warnings-as-errors
 ```
 

--- a/doc/build-instructions/Build_Instructions_V12.md
+++ b/doc/build-instructions/Build_Instructions_V12.md
@@ -510,14 +510,14 @@ JCL      - a786f96b13 based on jdk-11+21)
 
 ## macOS
 :apple:
-The following instructions guide you through the process of building a macOS **OpenJDK V12** binary that contains Eclipse OpenJ9. This process can be used to build binaries for macOS 12.
+The following instructions guide you through the process of building a macOS **OpenJDK V12** binary that contains Eclipse OpenJ9. This process can be used to build binaries for macOS 10.
 
 ### 1. Prepare your system
 :apple:
 You must install a number of software dependencies to create a suitable build environment on your system:
 
 - [Xcode 9.4]( https://developer.apple.com/download/more/) (requires an Apple account to log in).
-- [macOS OpenJDK 10](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=hotspot), which is used as the boot JDK.
+- [macOS OpenJDK 11](https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=hotspot), which is used as the boot JDK.
 
 The following dependencies can be installed by using [Homebrew](https://brew.sh/):
 


### PR DESCRIPTION
* there is no such thing as macOS 11 or macOS 12, yet
* jdk10 is used to boot jdk11
* jdk11 is used to boot jdk12