### PR TITLE
Fix TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1449,11 +1449,8 @@ TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method,
    TR::Compilation *comp = TR::comp();
    if (comp && comp->getOption(TR_UseSymbolValidationManager))
       {
-      if (!comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames))
-         {
-         TR_ASSERT(false, "Failed to validate addStackWalkerMaySkipFramesRecord\n");
-         comp->failCompilation<J9::AOTSymbolValidationManagerFailure>("Failed to validate in stackWalkerMaySkipFrames");
-         }
+      bool recordCreated = comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames);
+      SVM_ASSERT(recordCreated, "Failed to validate addStackWalkerMaySkipFramesRecord");
       }
    return skipFrames;
    }


### PR DESCRIPTION
Bring the implementation of TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames
in-line with the new code from TR_J9SharedCacheVM::stackWalkerMaySkipFrames

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>