### PR TITLE
Install gcc 7.3/7.4 from Adopt in docker files

### DIFF
--- a/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/ppc64le/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     autoconf \
@@ -38,8 +37,6 @@ RUN apt-get update \
     cpio \
     cmake \
     file \
-    g++-7 \
-    gcc-7 \
     git \
     git-core \
     libasound2-dev \
@@ -68,12 +65,18 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     vim \
   && rm -rf /var/lib/apt/lists/*
-
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-7 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-7 /usr/bin/gcc
+  
+# Install GCC-7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.ppc64le.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/powerpc64le-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/powerpc64le-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/s390x/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,6 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     autoconf \
@@ -38,8 +37,6 @@ RUN apt-get update \
     cmake \
     cpio \
     file \
-    g++-7 \
-    gcc-7 \
     git \
     git-core \
     libasound2-dev \
@@ -48,6 +45,7 @@ RUN apt-get update \
     libelf-dev \
     libfontconfig1-dev \
     libfreetype6-dev \
+    libmpc3 \
     libx11-dev \
     libxext-dev \
     libxrender-dev \
@@ -68,11 +66,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-7 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-7 /usr/bin/gcc
+# Install GCC-7.4
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc740+ccache.s390x.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk11/x86_64/ubuntu16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,11 +29,8 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
-    gcc-7 \
-    g++-7 \
     autoconf \
     ca-certificates \
     ccache \
@@ -65,11 +62,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-7 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-7 /usr/bin/gcc
+# Add the GCC-7.3 Binary
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/s390x/ubuntu16/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     ant \
@@ -50,9 +49,7 @@ RUN apt-get update \
     curl \
     file \
     g++-4.8 \
-    g++-7 \
     gcc-4.8 \
-    gcc-7 \
     gdb \
     git \
     git-core \
@@ -63,6 +60,7 @@ RUN apt-get update \
     libfontconfig \
     libfontconfig1-dev \
     libfreetype6-dev \
+    libmpc3 \
     libx11-dev \
     libxext-dev \
     libxrandr-dev \
@@ -86,12 +84,23 @@ RUN apt-get update \
 # Install Docker module to run test framework
 RUN echo yes | cpan install JSON Text::CSV
 
-# Create links for c++,g++,cc,gcc
+# Install GCC-7.4
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc740+ccache.s390x.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+
+# Create links for c++,g++,cc,gcc and for GCC to access the C library
+# There is a true at the end of the library link because it throws an error and it allows the container to be built
 RUN rm /usr/bin/c++ /usr/bin/g++ /usr/bin/cc /usr/bin/gcc \
   && ln -s g++ /usr/bin/c++ \
   && ln -s g++-4.8 /usr/bin/g++ \
   && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-4.8 /usr/bin/gcc
+  && ln -s gcc-4.8 /usr/bin/gcc \
+  && ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include | true \ 
+  && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++-7 \
+  && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc-7
 
 # Add user home/USER and copy authorized_keys and known_hosts
 RUN useradd -ms /bin/bash ${USER} \

--- a/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
+++ b/buildenv/jenkins/docker-slaves/x86/centos6.9/Dockerfile
@@ -126,8 +126,8 @@ RUN cd /etc/yum.repos.d \
   && ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8 /usr/bin/cc \
   && yum -y update \
   && yum -y install centos-release-scl \
-  && yum -y install devtoolset-7-gcc devtoolset-7-binutils \
-  && yum -y install devtoolset-7-gcc-c++ devtoolset-2-gcc-gfortran \
+  && yum -y install devtoolset-7-gcc-7.3* devtoolset-7-binutils \
+  && yum -y install devtoolset-7-gcc-c++-7.3* devtoolset-2-gcc-gfortran-7.3* \
   && yum clean all
 
 #Building and setting up git version 2.5.3


### PR DESCRIPTION
Dev Containers:
- Changes the way GCC is installed on x86, ppcle and s390x
  - GCC is now pulled from AdoptOpenJDK instead of the ubuntu toolchain
  - Added links to the default C libraries and include files
  - Links were added because GCC was not able to find them

Jenkins Containers:
- Specifies which version will be installed on the x86 build container
- Changes the way GCC is installed (same way as Dev Containers)

[skip ci]

Related #4208

Signed-off-by: Samuel Rubin <samuel.rubin@ibm.com>