### PR TITLE
Extend booleans to the int type in the native

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1353,7 +1353,15 @@ exit:
 			}
 			break;
 		case J9NtcBoolean:
-			*returnStorage = ((UDATA)(U_8)(0 != *returnStorage));
+		{
+			U_32 returnValue = (U_32)*returnStorage;
+			U_8 * returnAddress = (U_8 *)&returnValue;
+#ifdef J9VM_ENV_LITTLE_ENDIAN
+			*returnStorage = (UDATA)(0 != returnAddress[0]);
+#else
+			*returnStorage = (UDATA)(0 != returnAddress[3]);
+#endif /*J9VM_ENV_LITTLE_ENDIAN */
+		}
 			break;
 		case J9NtcByte:
 			*returnStorage = (UDATA)(IDATA)(I_8)*returnStorage;

--- a/runtime/tests/jniarg/CMakeLists.txt
+++ b/runtime/tests/jniarg/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@ add_library(jniargtests SHARED
 	args_07.c
 	args_08.c
 	args_09.c
+	args_10.c
 	cdefs.c
 )
 

--- a/runtime/tests/jniarg/args_10.c
+++ b/runtime/tests/jniarg/args_10.c
@@ -1,0 +1,207 @@
+
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "jniargtests.h"
+
+jboolean JNICALL Java_JniArgTests_nativeIZrZ(JNIEnv *p_env, jobject p_this, jint value, jbooleanArray backChannel)
+{
+	J9JavaVM *javaVM = getJ9JavaVM(p_env);
+	jboolean converted = (jboolean)value;
+	jboolean elements[] = {JNI_FALSE};
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+
+	jniTests++;
+
+	if (converted) {
+		/* if C could would see this as true, set the backchannel to true */
+		elements[0] = JNI_TRUE;
+	}
+
+	(*p_env)->SetBooleanArrayRegion(p_env, backChannel, 0, 1, elements);
+
+	return value;   /* return the value as a boolean */
+}
+
+jboolean JNICALL Java_JniArgTests_nativeZIZIZIZIZIrZ(JNIEnv *p_env, jobject p_this, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jint arg6, jint arg7, jint arg8, jint arg9, jint arg10)
+{
+	J9JavaVM *javaVM = getJ9JavaVM(p_env);
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+
+	jniTests++;
+
+	if (arg1 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 1, arg1, test_jboolean[0]);
+	}
+	if (arg2 != test_jint[1]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 2, arg2, test_jint[1]);
+	}
+	if (arg3 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 3, arg3, test_jboolean[1]);
+	}
+	if (arg4 != test_jint[2]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 4, arg4, test_jint[2]);
+	}
+	if (arg5 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 5, arg5, test_jboolean[0]);
+	}
+	if (arg6 != test_jint[3]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 6, arg6, test_jint[3]);
+	}
+	if (arg7 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 7, arg7, test_jboolean[1]);
+	}
+	if (arg8 != test_jint[4]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 8, arg8, test_jint[4]);
+	}
+	if (arg9 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 9, arg9, test_jboolean[0]);
+	}
+	if (arg10 != test_jint[5]) {
+		cFailure_jint(PORTLIB, "nativeZIZIZIZIZIrZ", 10, arg10, test_jint[5]);
+	}
+
+	return (JNI_TRUE == test_jboolean[0]);
+}
+
+jboolean JNICALL Java_JniArgTests_nativeIZIZIZIZIZrZ(JNIEnv *p_env, jobject p_this, jint arg1, jboolean arg2, jint arg3, jboolean arg4, jint arg5, jboolean arg6, jint arg7, jboolean arg8, jint arg9, jboolean arg10)
+{
+	J9JavaVM *javaVM = getJ9JavaVM(p_env);
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+
+	jniTests++;
+
+	if (arg1 != test_jint[1]) {
+		cFailure_jint(PORTLIB, "nativeIZIZIZIZIZrZ", 1, arg1, test_jint[1]);
+	}
+	if (arg2 != test_jboolean[1]) {
+		cFailure_jboolean(PORTLIB, "nativeIZIZIZIZIZrZ", 2, arg2, test_jboolean[1]);
+	}
+	if (arg3 != test_jint[2]) {
+		cFailure_jint(PORTLIB, "nativeIZIZIZIZIZrZ", 3, arg3, test_jint[2]);
+	}
+	if (arg4 != test_jboolean[0]) {
+		cFailure_jboolean(PORTLIB, "nativeIZIZIZIZIZrZ", 4, arg4, test_jboolean[0]);
+	}
+	if (arg5 != test_jint[3]) {
+		cFailure_jint(PORTLIB, "nativeIZIZIZIZIZrZ", 5, arg5, test_jint[3]);
+	}
+	if (arg6 != test_jboolean[1]) {
+		cFailure_jboolean(PORTLIB, "nativeIZIZIZIZIZrZ", 6, arg6, test_jboolean[1]);
+	}
+	if (arg7 != test_jint[4]) {
+		cFailure_jint(PORTLIB, "nativeIZIZIZIZIZrZ", 7, arg7, test_jint[4]);
+	}
+	if (arg8 != test_jboolean[0]) {
+		cFailure_jboolean(PORTLIB, "nativeIZIZIZIZIZrZ", 8, arg8, test_jboolean[0]);
+	}
+	if (arg9 != test_jint[5]) {
+		cFailure_jint(PORTLIB, "nativeIZIZIZIZIZrZ", 9, arg9, test_jint[5]);
+	}
+	if (arg10 != test_jboolean[1]) {
+		cFailure_jboolean(PORTLIB, "nativeIZIZIZIZIZrZ", 10, arg10, test_jboolean[1]);
+	}
+
+	return (JNI_FALSE == test_jboolean[0]);
+}
+
+jboolean JNICALL Java_JniArgTests_nativeZZZZZZZZZZrZ(JNIEnv *p_env, jobject p_this, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jint arg6, jint arg7, jint arg8, jint arg9, jint arg10)
+{
+	J9JavaVM *javaVM = getJ9JavaVM(p_env);
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+
+	jniTests++;
+
+	if (arg1 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 1, arg1, test_jboolean[1]);
+	}
+	if (arg2 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 2, arg2, test_jboolean[0]);
+	}
+	if (arg3 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 3, arg3, test_jboolean[1]);
+	}
+	if (arg4 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 4, arg4, test_jboolean[0]);
+	}
+	if (arg5 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 5, arg5, test_jboolean[1]);
+	}
+	if (arg6 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 6, arg6, test_jboolean[0]);
+	}
+	if (arg7 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 7, arg7, test_jboolean[1]);
+	}
+	if (arg8 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 8, arg8, test_jboolean[0]);
+	}
+	if (arg9 != test_jboolean[1]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 9, arg9, test_jboolean[1]);
+	}
+	if (arg10 != test_jboolean[0]) {
+		cFailure_jint(PORTLIB, "nativeZZZZZZZZZZrZ", 10, arg10, test_jboolean[0]);
+	}
+
+	return test_jboolean[0];
+}
+
+jboolean JNICALL Java_JniArgTests_nativeIIIIIZZZZZrZ(JNIEnv *p_env, jobject p_this, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jboolean arg6, jboolean arg7, jboolean arg8, jboolean arg9, jboolean arg10)
+{
+	J9JavaVM *javaVM = getJ9JavaVM(p_env);
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+
+	jniTests++;
+
+	if (arg1 != test_jint[1]) {
+		cFailure_jint(PORTLIB, "nativeIIIIIZZZZZrZ", 1, arg1, test_jint[1]);
+	}
+	if (arg2 != test_jint[2]) {
+		cFailure_jint(PORTLIB, "nativeIIIIIZZZZZrZ", 2, arg2, test_jint[2]);
+	}
+	if (arg3 != test_jint[3]) {
+		cFailure_jint(PORTLIB, "nativeIIIIIZZZZZrZ", 3, arg3, test_jint[3]);
+	}
+	if (arg4 != test_jint[4]) {
+		cFailure_jint(PORTLIB, "nativeIIIIIZZZZZrZ", 4, arg4, test_jint[4]);
+	}
+	if (arg5 != test_jint[5]) {
+		cFailure_jint(PORTLIB, "nativeIIIIIZZZZZrZ", 5, arg5, test_jint[5]);
+	}
+	if (arg6 != test_jboolean[0]) {
+		cFailure_jboolean(PORTLIB, "nativeIIIIIZZZZZrZ", 6, arg6, test_jboolean[0]);
+	}
+	if (arg7 != test_jboolean[1]) {
+		cFailure_jboolean(PORTLIB, "nativeIIIIIZZZZZrZ", 7, arg7, test_jboolean[1]);
+	}
+	if (arg8 != test_jboolean[0]) {
+		cFailure_jboolean(PORTLIB, "nativeIIIIIZZZZZrZ", 8, arg8, test_jboolean[0]);
+	}
+	if (arg9 != test_jboolean[1]) {
+		cFailure_jboolean(PORTLIB, "nativeIIIIIZZZZZrZ", 9, arg9, test_jboolean[1]);
+	}
+	if (arg10 != test_jboolean[0]) {
+		cFailure_jboolean(PORTLIB, "nativeIIIIIZZZZZrZ", 10, arg10, test_jboolean[0]);
+	}
+
+	return test_jboolean[1];
+}

--- a/runtime/tests/jniarg/cdefs.c
+++ b/runtime/tests/jniarg/cdefs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2017 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,6 +51,8 @@ const jfloat test_jfloat[] = { 11.1f, 12.2f, 13.3f, 14.4f, 15.5f, 16.6f, 17.7f, 
 
 const jdouble test_jdouble[] = { 11.1, 12.2, 13.3, 14.4, 15.5, 16.6, 17.7, 18.8, 19.9, 20.10, 21.11, 22.12, 23.13, 24.14, 25.15, 26.16, };
 
+const jboolean test_jboolean[] = { JNI_TRUE, JNI_FALSE };
+
 int argFailures = 0;
 int retValFailures = 0;
 int jniTests = 0;
@@ -71,6 +73,12 @@ J9JavaVM *getJ9JavaVM(JNIEnv * env)
 }
 
 
+void cFailure_jboolean(J9PortLibrary *portLib, char *functionName, int index, jboolean arg, jboolean expected)
+{
+	PORT_ACCESS_FROM_PORT(portLib);
+	j9tty_printf(portLib, "Argument error:  %s::arg%i got: %08X expected: %08X\n", functionName, index, arg, expected);
+	argFailures++;
+}
 void cFailure_jbyte(J9PortLibrary *portLib, char *functionName, int index, jbyte arg, jbyte expected)
 {
 	PORT_ACCESS_FROM_PORT(portLib);

--- a/runtime/tests/jniarg/exports.xml
+++ b/runtime/tests/jniarg/exports.xml
@@ -1,5 +1,5 @@
 <!--
-   Copyright (c) 1991, 2017 IBM Corp. and others
+   Copyright (c) 1991, 2019 IBM Corp. and others
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which accompanies this
@@ -464,4 +464,9 @@
 	<export name="Java_JniArgTests_nativeFDFDFDFDFDFDrJ" />
 	<export name="Java_JniArgTests_nativeDFDFDFDFDFDFrJ" />
 	<export name="Java_JniArgTests_nativeBBSSIJFDIFDFDFDBBSSIJFDrJ" />
+	<export name="Java_JniArgTests_nativeIZrZ" />
+	<export name="Java_JniArgTests_nativeZIZIZIZIZIrZ" />
+	<export name="Java_JniArgTests_nativeIZIZIZIZIZrZ" />
+	<export name="Java_JniArgTests_nativeZZZZZZZZZZrZ" />
+	<export name="Java_JniArgTests_nativeIIIIIZZZZZrZ" />
 </exports>

--- a/runtime/tests/jniarg/jniargtests.h
+++ b/runtime/tests/jniarg/jniargtests.h
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1998, 2014 IBM Corp. and others
+ * Copyright (c) 1998, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ extern const jint test_jint[];
 extern const jlong test_jlong[];
 extern const jfloat test_jfloat[];
 extern const jdouble test_jdouble[];
+extern const jboolean test_jboolean[];
 extern int jniTests;
 
 extern void cFailure_jbyte(J9PortLibrary *portLib, char *functionName, int index, jbyte arg, jbyte expected);
@@ -43,6 +44,7 @@ extern void cFailure_jint(J9PortLibrary *portLib, char *functionName, int index,
 extern void cFailure_jlong(J9PortLibrary *portLib, char *functionName, int index, jlong arg, jlong expected);
 extern void cFailure_jfloat(J9PortLibrary *portLib, char *functionName, int index, jfloat arg, jfloat expected);
 extern void cFailure_jdouble(J9PortLibrary *portLib, char *functionName, int index, jdouble arg, jdouble expected);
+extern void cFailure_jboolean(J9PortLibrary *portLib, char *functionName, int index, jboolean arg, jboolean expected);
 extern J9JavaVM *getJ9JavaVM(JNIEnv * env);
 
 void JNICALL Java_JniArgTests_logRetValError( JNIEnv *p_env, jobject p_this, jstring error_message );
@@ -509,3 +511,8 @@ jlong JNICALL Java_JniArgTests_nativeFDFDFDFDFDFDrJ( JNIEnv *p_env, jobject p_th
 jlong JNICALL Java_JniArgTests_nativeDFDFDFDFDFDFrJ( JNIEnv *p_env, jobject p_this, jdouble arg1, jfloat arg2, jdouble arg3, jfloat arg4, jdouble arg5, jfloat arg6, jdouble arg7, jfloat arg8, jdouble arg9, jfloat arg10, jdouble arg11, jfloat arg12 );
 jlong JNICALL Java_JniArgTests_nativeBBSSIJFDIFDFDFDBBSSIJFDrJ( JNIEnv *p_env, jobject p_this, jbyte arg1, jbyte arg2, jshort arg3, jshort arg4, jint arg5, jlong arg6, jfloat arg7, jdouble arg8, jint arg9, jfloat arg10, jdouble arg11, jfloat arg12, jdouble arg13, jfloat arg14, jdouble arg15, jbyte arg16, jbyte arg17, jshort arg18, jshort arg19, jint arg20, jlong arg21, jfloat arg22, jdouble arg23 );
 
+jboolean JNICALL Java_JniArgTests_nativeIZrZ(JNIEnv *p_env, jobject p_this, jint value, jbooleanArray backChannel);
+jboolean JNICALL Java_JniArgTests_nativeZIZIZIZIZIrZ(JNIEnv *p_env, jobject p_this, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jint arg6, jint arg7, jint arg8, jint arg9, jint arg10);
+jboolean JNICALL Java_JniArgTests_nativeIZIZIZIZIZrZ(JNIEnv *p_env, jobject p_this, jint arg1, jboolean arg2, jint arg3, jboolean arg4, jint arg5, jboolean arg6, jint arg7, jboolean arg8, jint arg9, jboolean arg10);
+jboolean JNICALL Java_JniArgTests_nativeZZZZZZZZZZrZ(JNIEnv *p_env, jobject p_this, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jint arg6, jint arg7, jint arg8, jint arg9, jint arg10);
+jboolean JNICALL Java_JniArgTests_nativeIIIIIZZZZZrZ(JNIEnv *p_env, jobject p_this, jint arg1, jint arg2, jint arg3, jint arg4, jint arg5, jboolean arg6, jboolean arg7, jboolean arg8, jboolean arg9, jboolean arg10);

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2251,7 +2251,7 @@ done:;
 	getFFIType(U_8 j9ntc) {
 		static const ffi_type * const J9NtcToFFI[] = {
 				&ffi_type_void,		/* J9NtcVoid */
-				&ffi_type_uint8,	/* J9NtcBoolean */
+				&ffi_type_uint32,	/* J9NtcBoolean */
 				&ffi_type_sint8,	/* J9NtcByte */
 				&ffi_type_uint16,	/* J9NtcChar */
 				&ffi_type_sint16,	/* J9NtcShort */
@@ -2362,7 +2362,7 @@ done:;
 #if !defined(J9VM_ENV_LITTLE_ENDIAN)
 					if ((J9NtcShort == argTypes[i]) || (J9NtcChar == argTypes[i])) {
 						values[i + extraArgs] = (void *)((UDATA)values[i + extraArgs] + extraBytesShortAndChar);
-					}else if ((J9NtcByte == argTypes[i]) || (J9NtcBoolean == argTypes[i])) {
+					}else if (J9NtcByte == argTypes[i]) {
 						values[i + extraArgs] = (void *)((UDATA)values[i + extraArgs] + extraBytesBoolAndByte);
 					}
 #endif /*J9VM_ENV_LITTLE_ENDIAN */

--- a/runtime/vm/MHInterpreter.hpp
+++ b/runtime/vm/MHInterpreter.hpp
@@ -405,7 +405,15 @@ foundITable:
 	{
 		switch (returnType) {
 		case J9NtcBoolean:
-			*returnStorage = (UDATA)(U_8)*returnStorage;
+		{
+			U_32 returnValue = (U_32)*returnStorage;
+			U_8 * returnAddress = (U_8 *)&returnValue;
+#ifdef J9VM_ENV_LITTLE_ENDIAN
+			*returnStorage = (UDATA)(0 != returnAddress[0]);
+#else
+			*returnStorage = (UDATA)(0 != returnAddress[3]);
+#endif /*J9VM_ENV_LITTLE_ENDIAN */
+		}
 			break;
 		case J9NtcByte:
 			*returnStorage = (UDATA)(IDATA)(I_8)*returnStorage;

--- a/test/functional/NativeTest/jniargtests/JniArgTests.java
+++ b/test/functional/NativeTest/jniargtests/JniArgTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corp. and others
+ * Copyright (c) 2004, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,6 +50,8 @@ public class JniArgTests {
 
 	final double test_jdouble[] = { 11.1, 12.2, 13.3, 14.4, 15.5, 16.6, 17.7, 18.8, 19.9, 20.10, 21.11, 22.12, 23.13, 24.14, 25.15, 26.16, };
 
+	final boolean test_jboolean[] = {true, false};
+	
 	public static void main(String[] args) {
 		System.loadLibrary( "jniargtests" );
 		JniArgTests jniArgTests = new JniArgTests();
@@ -64,6 +66,7 @@ public class JniArgTests {
 		long   retval_long;
 		float  retval_float;
 		double retval_double;
+		boolean retval_boolean;
 
 
 
@@ -2727,8 +2730,75 @@ public class JniArgTests {
 		if ( retval_long != test_jlong[0] ) {
 			logRetValError("Return value error:  nativeBBSSIJFDIFDFDFDBBSSIJFDrJ got: " + retval_long + " expected: " + test_jlong[0]);
 		}
+		
+		
+		boolean[] backChannel = new boolean[]{false};
+		retval_boolean = nativeIZrZ(0, backChannel);  // value = 0x0, return false
+		if (retval_boolean != test_jboolean[1]) {
+			logRetValError("Return value error 1:  nativeIZrZ got: " + retval_boolean + " expected: " + test_jboolean[1]);
+		}
+		if (backChannel[0] != test_jboolean[1]) {
+			logRetValError("Boolean array error 1:  nativeIZrZ got: " + backChannel[0] + " expected: " + test_jboolean[1]);
+		}
+		
+		backChannel[0] = false;
+		retval_boolean = nativeIZrZ(1, backChannel);   // value = 0x1, return true
+		if (retval_boolean != test_jboolean[0]) {
+			logRetValError("Return value error 2:  nativeIZrZ got: " + retval_boolean + " expected: " + test_jboolean[0]);
+		}
+		if (backChannel[0] != test_jboolean[0]) {
+			logRetValError("Boolean array error 2:  nativeIZrZ got: " + backChannel[0] + " expected: " + test_jboolean[0]);
+		}
+		
+		backChannel[0] = false;
+		retval_boolean = nativeIZrZ(254, backChannel); // value = 0xFE, return true
+		if (retval_boolean != test_jboolean[0]) {
+			logRetValError("Return value error 3:  nativeIZrZ got: " + retval_boolean + " expected: " + test_jboolean[0]);
+		}
+		if (backChannel[0] != test_jboolean[0]) {
+			logRetValError("Boolean array error 3 :  nativeIZrZ got: " + backChannel[0] + " expected: " + test_jboolean[0]);
+		}
+		
+		backChannel[0] = false;
+		retval_boolean = nativeIZrZ(3840, backChannel); // value = 0xF00, return false
+		if (retval_boolean != test_jboolean[1]) {
+			logRetValError("Return value error 4:  nativeIZrZ got: " + retval_boolean + " expected: " + test_jboolean[1]);
+		}
+		if (backChannel[0] != test_jboolean[1]) {
+			logRetValError("Boolean array error 4:  nativeIZrZ got: " + backChannel[0] + " expected: " + test_jboolean[1]);
+		}
+		
+		backChannel[0] = false;
+		retval_boolean = nativeIZrZ(4094, backChannel); // value = 0xFFE, return true
+		if (retval_boolean != test_jboolean[0]) {
+			logRetValError("Return value error 5:  nativeIZrZ got: " + retval_boolean + " expected: " + test_jboolean[0]);
+		}
+		if (backChannel[0] != test_jboolean[0]) {
+			logRetValError("Boolean array error 5:  nativeIZrZ got: " + backChannel[0] + " expected: " + test_jboolean[0]);
+		}
+		
+		
+		retval_boolean = nativeZIZIZIZIZIrZ(test_jboolean[0], test_jint[1], test_jboolean[1], test_jint[2], test_jboolean[0], test_jint[3], test_jboolean[1], test_jint[4], test_jboolean[0], test_jint[5]);
+		if (retval_boolean != test_jboolean[0]) {
+			logRetValError("Return value error:  nativeZIZIZIZIZIrZ got: " + retval_boolean + " expected: " + test_jboolean[0]);
+		}
+		
+		
+		retval_boolean = nativeIZIZIZIZIZrZ(test_jint[1], test_jboolean[1], test_jint[2], test_jboolean[0], test_jint[3], test_jboolean[1], test_jint[4], test_jboolean[0], test_jint[5], test_jboolean[1]);
+		if (retval_boolean != test_jboolean[1]) {
+			logRetValError("Return value error:  nativeIZIZIZIZIZrZ got: " + retval_boolean + " expected: " + test_jboolean[1]);
+		}
 
-
+		
+		retval_boolean = nativeZZZZZZZZZZrZ(test_jboolean[1], test_jboolean[0], test_jboolean[1], test_jboolean[0], test_jboolean[1], test_jboolean[0], test_jboolean[1], test_jboolean[0], test_jboolean[1], test_jboolean[0]);
+		if (retval_boolean != test_jboolean[0]) {
+			logRetValError("Return value error:  nativeZZZZZZZZZZrZ got: " + retval_boolean + " expected: " + test_jboolean[0]);
+		}
+		
+		retval_boolean = nativeIIIIIZZZZZrZ(test_jint[1], test_jint[2], test_jint[3], test_jint[4], test_jint[5], test_jboolean[0], test_jboolean[1], test_jboolean[0], test_jboolean[1], test_jboolean[0]);
+		if (retval_boolean != test_jboolean[1]) {
+			logRetValError("Return value error:  nativeIIIIIZZZZZrZ got: " + retval_boolean + " expected: " + test_jboolean[1]);
+		}
 }
 
 	native void logRetValError(String arg);
@@ -3621,5 +3691,14 @@ public class JniArgTests {
 	native long nativeDFDFDFDFDFDFrJ(double arg1, float arg2, double arg3, float arg4, double arg5, float arg6, double arg7, float arg8, double arg9, float arg10, double arg11, float arg12 );
 
 	native long nativeBBSSIJFDIFDFDFDBBSSIJFDrJ(byte arg1, byte arg2, short arg3, short arg4, int arg5, long arg6, float arg7, double arg8, int arg9, float arg10, double arg11, float arg12, double arg13, float arg14, double arg15, byte arg16, byte arg17, short arg18, short arg19, int arg20, long arg21, float arg22, double arg23 );
+	
+	native boolean nativeIZrZ(int value, boolean[] backChannel);
+	
+	native boolean nativeZIZIZIZIZIrZ(boolean arg1, int arg2, boolean arg3, int arg4, boolean arg5, int arg6, boolean arg7, int arg8, boolean arg9, int arg10);
 
+	native boolean nativeIZIZIZIZIZrZ(int arg1, boolean arg2, int arg3, boolean arg4, int arg5, boolean arg6, int arg7, boolean arg8, int arg9, boolean arg10);
+
+	native boolean nativeZZZZZZZZZZrZ(boolean arg1, boolean arg2, boolean arg3, boolean arg4, boolean arg5, boolean arg6, boolean arg7, boolean arg8, boolean arg9, boolean arg10);
+
+	native boolean nativeIIIIIZZZZZrZ(int arg1, int arg2, int arg3, int arg4, int arg5, boolean arg6, boolean arg7, boolean arg8, boolean arg9, boolean arg10);
 }

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -65,6 +65,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<testCaseName>jniargtests</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
+			<variation>-Xjit:count=0</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) -Xint \


### PR DESCRIPTION
The change is to ensure booleans can be handled
appropriately as the int type when calling the
JNI natives.

Close: #4193

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>