### PR TITLE
Add assert fatal for unknown bytecode for JIT

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4638,11 +4638,7 @@ TR_J9VMBase::unsupportedByteCode(TR::Compilation * comp, U_8 opcode)
 void
 TR_J9VMBase::unknownByteCode(TR::Compilation * comp, U_8 opcode)
    {
-   // an unknown bytecode may be seen if the method contains a breakpoint, in that case we should abort the compile
-   //
-   char errMsg[40];
-   snprintf(errMsg, 40, "Unknown bytecode %d to JIT", opcode);
-   comp->failCompilation<TR::CompilationException>(errMsg);
+   TR_ASSERT_FATAL(0, "Unknown bytecode to JIT %d \n", opcode);
    }
 
 char*

--- a/runtime/compiler/ilgen/J9ByteCode.hpp
+++ b/runtime/compiler/ilgen/J9ByteCode.hpp
@@ -112,6 +112,7 @@ enum TR_J9ByteCode
    J9BCasyncCheck,
    J9BCdefaultvalue,
    J9BCwithfield,
+   J9BCbreakpoint,
    J9BCunknown
    };
 

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.cpp
@@ -356,7 +356,7 @@ const TR_J9ByteCode TR_J9ByteCodeIterator::_opCodeToByteCodeEnum[] =
    /* 197 */ J9BCmultianewarray,
    /* 198 */ J9BCifnull, J9BCifnonnull,
    /* 200 */ J9BCgotow, J9BCunknown,
-   /* 202 */ J9BCunknown,
+   /* 202 */ J9BCbreakpoint,
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
    /* 203 */ J9BCdefaultvalue,

--- a/runtime/compiler/ilgen/J9ByteCodeIterator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIterator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,6 +112,7 @@ public:
    TR_J9ByteCode current()
       {
       _bc = (_bcIndex >= _maxByteCodeIndex ? J9BCunknown : convertOpCodeToByteCodeEnum(_code[_bcIndex]));
+      TR_ASSERT_FATAL(_bcIndex >= _maxByteCodeIndex || _bc != J9BCunknown, "Unknown bytecode to JIT %d \n", _code[_bcIndex]);
       return _bc;
       }
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1529,6 +1529,7 @@ TR::Block * TR_J9ByteCodeIlGenerator::walker(TR::Block * prevBlock)
 
          case J9BCdefaultvalue:
          case J9BCwithfield:
+         case J9BCbreakpoint:
             fej9()->unsupportedByteCode(comp(), opcode);
          case J9BCunknown:
             fej9()->unknownByteCode(comp(), opcode);


### PR DESCRIPTION
Change the code to recognize J9BCbreakpoint opcode rather pretend it is
unknown and abort compilation. Add assert fatal when hit real unknown
opcodes.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>