### PR TITLE
Relocate OMR CodeCacheManager methods to OpenJ9

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -115,6 +115,42 @@ public:
     */
    void reservationInterfaceCache(void *callSite, TR_OpaqueMethodBlock *method);
 
+   /**
+    * @brief Re-do the helper trampoline initialization for existing codeCaches
+    */
+   void lateInitialization();
+
+   /**
+    * @brief Add block defined by metaData to the freeBlockList.  The caller
+    *        should expect that the block may not always be added.
+    */
+   void addFreeBlock(void *metaData, uint8_t *startPC);
+
+   /**
+    * @brief Answers whether the total code cache capacity is nearly used up.
+    *        This code is executed by compilation thread and by application
+    *        threads when trying to induce a profiling compilation. Acquires
+    *        codeCacheList.mutex.
+    *
+    * @return true if capacity nearly reached; false otherwise.
+    */
+   bool almostOutOfCodeCache();
+
+   /**
+    * @brief Print some code cache usage statistics
+    */
+   void printMccStats();
+
+   /**
+    * @brief Print space remaining in each code cache
+    */
+   void printRemainingSpaceInCodeCaches();
+
+   /**
+    * @brief Print occupancy stats for each code cache
+    */
+   void printOccupancyStats();
+
 private :
    TR_FrontEnd *_fe;
    static TR::CodeCacheManager *_codeCacheManager;


### PR DESCRIPTION
The following functions are only used in OpenJ9.  Relocate to
OpenJ9 in preparation for deleting them from OMR.

* lateInitialization
* addFreeBlock
* almostOutOfCodeCache
* printMccStats
* printRemainingSpaceInCodeCaches
* printOccupancyStats

Signed-off-by: Daryl Maier <maier@ca.ibm.com>