### PR TITLE
Call j2iTransition directly

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6991,13 +6991,7 @@ TR_J9VM::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference * sym
    switch (methodSym->getMandatoryRecognizedMethod())
       {
       case TR::java_lang_invoke_ComputedCalls_dispatchJ9Method:
-         {
-         // TODO:JSR292: Get the proper helper based on the target j9method (or select it dynamically inside the thunk).
-         // This is a hack, and it appears more than once.  Search for PROPER_DISPATCH_J9METHOD.
-         //
-         TR_RuntimeHelper vmCallHelper = TR::MethodSymbol::getVMCallHelperFor(methodSym->getMethod()->returnType(), methodSym->isSynchronised(), false, comp);
-         tramp = TR::CodeCacheManager::instance()->findHelperTrampoline(vmCallHelper, callSite);
-         }
+         tramp = TR::CodeCacheManager::instance()->findHelperTrampoline(TR_j2iTransition, callSite);
          break;
       default:
          tramp = (intptrj_t)TR::CodeCacheManager::instance()->findMethodTrampoline(method, callSite);
@@ -7396,11 +7390,7 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
          sym->setInterpreted(false);
          TR_Method *method = sym->getMethod();
 
-         // TODO:JSR292: Get the proper helper based on the target j9method (or select it dynamically inside the thunk).
-         // This is a hack, and it appears more than once.  Search for PROPER_DISPATCH_J9METHOD.
-         //
-         TR_RuntimeHelper vmCallHelper = TR::MethodSymbol::getVMCallHelperFor(method->returnType(), sym->isSynchronised(), false, comp);
-         TR::SymbolReference *helperSymRef = comp->getSymRefTab()->findOrCreateRuntimeHelper(vmCallHelper, true, true, false);
+         TR::SymbolReference *helperSymRef = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
          sym->setMethodAddress(helperSymRef->getMethodAddress());
          return callNode;
          }

--- a/runtime/compiler/il/symbol/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.cpp
@@ -130,55 +130,6 @@ J9::MethodSymbol::isPureFunction()
    return false;
    }
 
-TR_RuntimeHelper
-J9::MethodSymbol::getVMCallHelperFor(TR::DataType returnType, bool isSync, bool isNative, TR::Compilation *comp)
-   {
-   if (isNative)
-      return TR_icallVMprJavaSendNativeStatic;
-
-   switch (returnType)
-      {
-      case TR::NoType:
-         return isSync? TR_icallVMprJavaSendStaticSync0 : TR_icallVMprJavaSendStatic0;
-      case TR::Int8:
-      case TR::Int16:
-      case TR::Int32:
-         return isSync? TR_icallVMprJavaSendStaticSync1 : TR_icallVMprJavaSendStatic1;
-      case TR::Address:
-         if (TR::Compiler->target.is64Bit())
-            return isSync? TR_icallVMprJavaSendStaticSyncJ : TR_icallVMprJavaSendStaticJ;
-         else
-            return isSync? TR_icallVMprJavaSendStaticSync1 : TR_icallVMprJavaSendStatic1;
-      case TR::Int64:
-         return isSync? TR_icallVMprJavaSendStaticSyncJ : TR_icallVMprJavaSendStaticJ;
-      case TR::Float:
-         return isSync? TR_icallVMprJavaSendStaticSyncF : TR_icallVMprJavaSendStaticF;
-      case TR::Double:
-         return isSync? TR_icallVMprJavaSendStaticSyncD : TR_icallVMprJavaSendStaticD;
-      default:
-         TR_ASSERT(0, "Unknown return type: %s\n", returnType.toString());
-         return (TR_RuntimeHelper)0;
-      }
-   }
-
-TR_RuntimeHelper
-J9::MethodSymbol::getVMCallHelper()
-   {
-   return self()->getVMCallHelper(TR::comp());
-   }
-
-TR_RuntimeHelper
-J9::MethodSymbol::getVMCallHelper(TR::Compilation *comp)
-   {
-   // Note: Unresolved methods are considered unsynchronized here.  Runtime
-   // resolve helper corrects this if necessary.
-   return self()->getVMCallHelperFor(
-      self()->getMethod()->returnType(), 
-      self()->isSynchronised(),
-      (self()->isVMInternalNative() || self()->isJITInternalNative()),
-      comp);
-   }
-
 
 // Which recognized methods are known to have no valid null checks
 //

--- a/runtime/compiler/il/symbol/J9MethodSymbol.hpp
+++ b/runtime/compiler/il/symbol/J9MethodSymbol.hpp
@@ -60,9 +60,7 @@ public:
 
    bool isPureFunction();
 
-   TR_RuntimeHelper getVMCallHelper(TR::Compilation *comp);
-   TR_RuntimeHelper getVMCallHelper();
-   static TR_RuntimeHelper getVMCallHelperFor(TR::DataType returnType, bool isSynchronized, bool isNative, TR::Compilation *comp);
+   TR_RuntimeHelper getVMCallHelper() { return TR_j2iTransition; } // deprecated
 
    bool safeToSkipNullChecks();
    bool safeToSkipBoundChecks();

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -195,6 +195,7 @@ extern "C" void mcc_reservationAdjustment_unwrapper(void **argsPtr, void **resPt
 extern "C" void mcc_lookupHelperTrampoline_unwrapper(void **argsPtr, void **resPtr);
 #endif
 
+JIT_HELPER(j2iTransition);
 JIT_HELPER(icallVMprJavaSendNativeStatic);
 JIT_HELPER(icallVMprJavaSendStatic0);
 JIT_HELPER(icallVMprJavaSendStatic1);
@@ -426,7 +427,6 @@ JIT_HELPER(_interpreterUnresolvedInstanceDataGlue);
 JIT_HELPER(_interpreterUnresolvedInstanceDataStoreGlue);
 JIT_HELPER(_virtualUnresolvedHelper);
 JIT_HELPER(_interfaceCallHelper);
-JIT_HELPER(j2iTransition);
 JIT_HELPER(icallVMprJavaSendVirtual0);
 JIT_HELPER(icallVMprJavaSendVirtual1);
 JIT_HELPER(icallVMprJavaSendVirtualJ);
@@ -963,6 +963,7 @@ static void initS390WriteOnceHelpers(J9JITConfig *jitConfig,
 
 void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    {
+   SET(TR_j2iTransition,                                    (void *)j2iTransition,                               TR_Helper);
    SET(TR_icallVMprJavaSendStatic0,                         (void *)icallVMprJavaSendStatic0,                    TR_Helper);
    SET(TR_icallVMprJavaSendStatic1,                         (void *)icallVMprJavaSendStatic1,                    TR_Helper);
    SET(TR_icallVMprJavaSendStaticJ,                         (void *)icallVMprJavaSendStaticJ,                    TR_Helper);

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -834,16 +834,6 @@ TR_RuntimeHelper TR::X86CallSnippet::getInterpretedDispatchHelper(
    }
 
 
-TR_RuntimeHelper
-TR::X86CallSnippet::getDirectToInterpreterHelper(
-   TR::MethodSymbol   *methodSymbol,
-   TR::DataType        type,
-   bool                synchronised)
-   {
-   return methodSymbol->getVMCallHelper();
-   }
-
-
 uint8_t *TR::X86CallSnippet::emitSnippetBody()
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg()->fe());

--- a/runtime/compiler/x/codegen/CallSnippet.hpp
+++ b/runtime/compiler/x/codegen/CallSnippet.hpp
@@ -125,7 +125,6 @@ class X86CallSnippet : public TR::Snippet
    virtual uint32_t getLength(int32_t estimatedSnippetStart);
 
    static TR_RuntimeHelper getInterpretedDispatchHelper(TR::SymbolReference *, TR::DataType, bool, TR::CodeGenerator *);
-   static TR_RuntimeHelper getDirectToInterpreterHelper(TR::MethodSymbol *, TR::DataType, bool);
 
    TR::SymbolReference *getRealMethodSymbolReference() { return _realMethodSymbolReference; }
 

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -320,12 +320,7 @@ J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
    deps->addPreCondition(ediRegister, TR::RealRegister::edi, self());
 
    TR::SymbolReference *helperSymRef =
-      self()->symRefTab()->findOrCreateRuntimeHelper(
-         TR::X86CallSnippet::getDirectToInterpreterHelper(
-            methodSymbol,
-            methodSymbol->getMethod()->returnType(),
-            methodSymbol->isSynchronised()),
-         false, false, false);
+      self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, false, false, false);
 
    if (TR::Compiler->target.is64Bit())
       {

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1914,7 +1914,7 @@ void TR::X86PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef, T
          generateRegImmInstruction(MOV4RegImm4, callNode, ramMethodReg, (uint32_t)(uintptrj_t)methodSymbol->getMethodAddress(), cg());
          }
 
-      callInstr = generateHelperCallInstruction(callNode, TR_icallVMprJavaSendNativeStatic, NULL, cg());
+      callInstr = generateHelperCallInstruction(callNode, TR_j2iTransition, NULL, cg());
       cg()->stopUsingRegister(ramMethodReg);
       }
    else if (TR::Compiler->target.is64Bit() && methodSymbol->isJITInternalNative())

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3569,14 +3569,12 @@ TR::Instruction* J9::Z::CodeGenerator::generateVMCallHelperSnippet(TR::Instructi
 
    TR::ResolvedMethodSymbol* methodSymbol = comp->getJittedMethodSymbol();
 
-   TR_RuntimeHelper helperId = methodSymbol->getVMCallHelper();
-
-   TR::SymbolReference* helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(helperId, false, false, false);
+   TR::SymbolReference* helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, false, false, false);
 
    // AOT relocation for the helper address
    TR::S390EncodingRelocation* encodingRelocation = new (self()->trHeapMemory()) TR::S390EncodingRelocation(TR_AbsoluteHelperAddress, helperSymRef);
 
-   AOTcgDiag4(comp, "Add encodingRelocation = %p reloType = %p symbolRef = %p helperId = %x\n", encodingRelocation, encodingRelocation->getReloType(), encodingRelocation->getSymbolReference(), helperId);
+   AOTcgDiag3(comp, "Add encodingRelocation = %p reloType = %p symbolRef = %p\n", encodingRelocation, encodingRelocation->getReloType(), encodingRelocation->getSymbolReference());
 
    const intptrj_t vmCallHelperAddress = reinterpret_cast<intptrj_t>(helperSymRef->getMethodAddress());
 


### PR DESCRIPTION
All `icallVMprJavaSendStatic{*}` and `icallVMprJavaSendNativeStatic` are directly jump to `j2iTransition`; therefore it makes more sense to directly call `j2iTransition` instead.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>