### PR TITLE
Fix missing atomic-free JNI check

### DIFF
--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1507,6 +1507,7 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 	char fileName[EsMaxPath];
 	J9PortLibrary* privatePortLibrary = vm->portLibrary;
 	int releaseAccess = 0;
+	int exitVM = 0;
 	BOOLEAN exclusiveRequestedLocally = FALSE;
 
 	if ( !vm->mainThread ) {
@@ -1519,6 +1520,12 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 
 	if(J9_XACCESS_NONE == vm->exclusiveAccessState) {
 		if (NULL != self) {
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+			if (self->inNative) {
+				internalEnterVMFromJNI(self);
+				exitVM = 1;
+			} else
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 			if ( 0 == (self->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS) ) {
 				internalAcquireVMAccess(self);
 				releaseAccess = 1;
@@ -1583,6 +1590,11 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 	if(exclusiveRequestedLocally) {
 		if (self) {
 			releaseExclusiveVMAccess(self);
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
+			if ( exitVM ) {
+				internalExitVMToJNI(self);
+			} else
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 			if ( releaseAccess ) {
 				internalReleaseVMAccess(self);
 			}


### PR DESCRIPTION
printThreadInfo was not handling atomic-free JNI. Copy the conditional
acquire/release code from RAS.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>