### PR TITLE
Align mutable fields of x86 PIC data

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -387,7 +387,6 @@ JIT_HELPER(encodeUTF16Big);
 JIT_HELPER(encodeUTF16Little);
 
 JIT_HELPER(SMPVPicInit);
-JIT_HELPER(resolveAndPopulateVTableDispatch);
 JIT_HELPER(interpreterEAXStaticGlue);
 JIT_HELPER(interpreterEDXEAXStaticGlue);
 JIT_HELPER(interpreterST0FStaticGlue);
@@ -1258,7 +1257,6 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
    SET(TR_IA32encodeUTF16Little,                      (void *)encodeUTF16Little,         TR_Helper);
 
    SET(TR_jitAddPicToPatchOnClassUnload,              (void *)jitAddPicToPatchOnClassUnload, TR_Helper);
-   SET(TR_IA32interpreterUnresolvedVTableSlotGlue,    (void *)resolveAndPopulateVTableDispatch, TR_Helper);
 
    SET(TR_IA32JitMonitorEnterReserved,                    (void *)jitMonitorEnterReserved,                    TR_CHelper);
    SET(TR_IA32JitMonitorEnterReservedPrimitive,           (void *)jitMonitorEnterReservedPrimitive,           TR_CHelper);

--- a/runtime/compiler/x/codegen/CallSnippet.hpp
+++ b/runtime/compiler/x/codegen/CallSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,35 +101,6 @@ class X86PicDataSnippet : public TR::Snippet
    private:
    bool shouldEmitJ2IThunkPointer();
    };
-
-
-class X86UnresolvedVirtualCallSnippet : public TR::UnresolvedDataSnippet
-   {
-   TR::SymbolReference *_methodSymRef;
-   TR::Instruction  *_callInstruction;
-
-   public:
-
-   X86UnresolvedVirtualCallSnippet(
-      TR::Node             *node,
-      TR::SymbolReference  *methodSymRef,
-      TR::Instruction   *callInstruction,
-      TR::CodeGenerator *cg) :
-         TR::UnresolvedDataSnippet(cg, node, node->getSymbolReference(), false, true),
-         _methodSymRef(methodSymRef),
-         _callInstruction(callInstruction)
-      { setDataReferenceInstruction(callInstruction); }
-
-   TR::SymbolReference *getMethodSymRef() {return _methodSymRef;}
-
-   virtual Kind getKind() { return (IsUnresolvedVirtualCall); }
-
-   virtual uint8_t *emitSnippetBody();
-
-   virtual uint32_t getLength(int32_t estimatedSnippetStart);
-
-   };
-
 
 class X86CallSnippet : public TR::Snippet
    {

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2169,23 +2169,9 @@ TR::Instruction *TR::X86PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR_X
 
    callInstr->setNeedsGCMap(site.getPreservedRegisterMask());
 
-   if (site.getSymbolReference()->isUnresolved() && !site.getMethodSymbol()->isInterface())
-      {
-      generateBoundaryAvoidanceInstruction(
-         TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8, callInstr, cg());
-
-      TR::LabelSymbol *snippetLabel = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
-      TR::UnresolvedDataSnippet *snippet = new (comp()->trHeapMemory()) TR::X86UnresolvedVirtualCallSnippet(
-         callNode,
-         site.getSymbolReference(),
-         callInstr,
-         cg());
-
-      // Need to do this so that stack map registered inside the snippet
-      targetAddressMemref->setUnresolvedDataSnippet(snippet);
-      snippet->gcMap().setGCRegisterMask(site.getPreservedRegisterMask());
-      cg()->addSnippet(snippet);
-      }
+   TR_ASSERT_FATAL(
+      !site.getSymbolReference()->isUnresolved() || site.getMethodSymbol()->isInterface(),
+      "buildVFTCall: unresolved virtual site");
 
    if (cg()->enableSinglePrecisionMethods() &&
        comp()->getJittedMethodSymbol()->usesSinglePrecisionMode())

--- a/runtime/compiler/x/runtime/X86PicBuilder.inc
+++ b/runtime/compiler/x/runtime/X86PicBuilder.inc
@@ -61,10 +61,10 @@ eq_ObjectClassMask                equ -J9TR_RequiredClassAlignment
 
 %ifndef TR_HOST_64BIT
 
-eq_VPicData_cpAddr             equ 00h
-eq_VPicData_cpIndex            equ 04h
-eq_VPicData_directMethod       equ 08h
-eq_VPicData_cmpRegImm4ModRM    equ 0ch
+eq_VPicData_cmpRegImm4ModRM    equ 00h
+eq_VPicData_cpAddr             equ 01h
+eq_VPicData_cpIndex            equ 05h
+eq_VPicData_directMethod       equ 09h
 eq_VPicData_size               equ 0dh
 
 eq_IPicData_cpAddr             equ 00h
@@ -87,13 +87,13 @@ J9PreservedFPRStackSize    equ   80
 ;                                    64-BIT
 ; --------------------------------------------------------------------------------
 
-eq_VPicData_cpAddr             equ 00h
-eq_VPicData_cpIndex            equ 08h
-eq_VPicData_directMethod       equ 10h
-eq_VPicData_j2iThunk           equ 18h
-eq_VPicData_movabsRexAndOpcode equ 20h
-eq_VPicData_callMemRex         equ 22h
-eq_VPicData_callMemModRM       equ 23h
+eq_VPicData_movabsRexAndOpcode equ 00h
+eq_VPicData_callMemRex         equ 02h
+eq_VPicData_callMemModRM       equ 03h
+eq_VPicData_cpAddr             equ 04h
+eq_VPicData_cpIndex            equ 0ch
+eq_VPicData_directMethod       equ 14h
+eq_VPicData_j2iThunk           equ 1ch
 eq_VPicData_size               equ 24h
 
 eq_IPicData_cpAddr             equ 00h


### PR DESCRIPTION
To prevent tearing, this series aligns fields of the x86 VPIC and IPIC data that are written at runtime. The IPIC data is aligned simply by adjusting the start of the snippet. In the VPIC data snippet, the _end_ of the VPIC data is already aligned, so we get the necessary field alignment by reordering the fields. This reordering requires some changes to PicBulider to remove lingering implicit assumptions about data layout. There is an unused and (almost certainly) broken function in PicBuilder which is removed instead of modified. See the individual commit messages for more.