### PR TITLE
Add a new target to generate jvmti.h when build with linter in travis

### DIFF
--- a/buildenv/travis/build-on-travis.sh
+++ b/buildenv/travis/build-on-travis.sh
@@ -60,7 +60,7 @@ if test "x$RUN_LINT" = "xyes"; then
   mkdir $CMAKE_BUILD_DIR
   cd $CMAKE_BUILD_DIR
   cmake -C $J9SRC/cmake/caches/linux_x86-64_cmprssptrs.cmake ..
-  make -j $MAKE_JOBS run_cptool omrgc_hookgen j9vm_hookgen j9jit_tracegen j9vm_nlsgen
+  make -j $MAKE_JOBS run_cptool omrgc_hookgen j9vm_hookgen j9jit_tracegen j9vm_nlsgen java_spec_headers
 
   # Now we can build the linter plugin
   cd $OMRCHECKER_DIR

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -108,6 +108,25 @@ omr_add_hookgen(INPUT oti/j9vm.hdf)
 omr_add_hookgen(INPUT oti/zipCachePool.hdf)
 omr_add_hookgen(INPUT gc_include/j9mm.hdf)
 
+# Here we generate jvmti.h if it's built on linter
+if($ENV{RUN_LINT} MATCHES "yes")
+	file(STRINGS ${CMAKE_CURRENT_BINARY_DIR}/j9cfg.h tempversion REGEX "#define JAVA_SPEC_VERSION*")
+	string(REGEX REPLACE "#define JAVA_SPEC_VERSION" "" tempversion ${tempversion})
+	string(STRIP ${tempversion} tempversion)
+	message(${tempversion})
+	add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h"
+	COMMAND m4 -D JAVA_SPEC_VERSION=${tempversion} "${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h.m4" > jvmti.h
+	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+	add_custom_target(java_spec_headers
+		DEPENDS
+			${CMAKE_CURRENT_SOURCE_DIR}/include/jvmti.h
+)
+endif()
+
+
+
+
 # Wrap up the hookgen'd files in a named target
 # This is to work arround the fact that CMake does not do proper dependency tracking
 # for generated files across different directories


### PR DESCRIPTION
A new target(java_spec_headers) is added in build-on-travis.mk

A new target is necessary because it generates jvmti header files. Since we need to generate different jvmti header files for different JDKs and building with linter doesn't depend on extension repository, we have to modify makefiles so that it generates jvmti header files when build with linter.

PRs should be commited in such order:

- jvmti.h.m4 which generates jvmti header files(#4409)
- changes in extension repositories(JDK8, JDK11, JDK12)
- changes in JDK11(#116) in its specific extension repository
- changes in how openj9 are build with linter(#4605)

There are some changes:
- A new target(java_spec_headers) is added
- A new recipe of target java_spec_headers is added: it gets java_spec_version from j9cfg.h then uses it as a variable

Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>