### PR TITLE
Remove enter/exit tracing methods

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3416,18 +3416,6 @@ bool
     }
 
 bool
-TR_J9VMBase::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-   return isMethodTracingEnabled(method);
-   }
-
-bool
-TR_J9VMBase::isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-   return isMethodTracingEnabled(method);
-   }
-
-bool
 TR_J9VMBase::isSelectiveMethodEnterExitEnabled()
    {
    return false;
@@ -8444,19 +8432,6 @@ TR_J9SharedCacheVM::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
    {
    // We want to return the same answer as TR_J9VMBase unless we want to force it to allow tracing
    return TR_J9VMBase::isMethodTracingEnabled(method) || TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableAOTMethodEnter) || TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableAOTMethodExit);
-   }
-
-bool
-TR_J9SharedCacheVM::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-   // We want to return the same answer as TR_J9VMBase unless we want to force it to allow tracing
-   return TR_J9VMBase::isMethodTracingEnabled(method) || TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableAOTMethodEnter);
-   }
-
-bool
-TR_J9SharedCacheVM::isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-   return TR_J9VMBase::isMethodTracingEnabled(method) || TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableAOTMethodExit);
    }
 
 bool

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -879,16 +879,6 @@ public:
       {
       return isMethodTracingEnabled((TR_OpaqueMethodBlock *)j9method);
       }
-   virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
-   virtual bool isMethodEnterTracingEnabled(J9Method *j9method)
-      {
-      return isMethodEnterTracingEnabled((TR_OpaqueMethodBlock *)j9method);
-      }
-   virtual bool isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method);
-   virtual bool isMethodExitTracingEnabled(J9Method *j9method)
-      {
-      return isMethodExitTracingEnabled((TR_OpaqueMethodBlock *)j9method);
-      }
 
    virtual bool isSelectiveMethodEnterExitEnabled();
 
@@ -1128,8 +1118,6 @@ public:
    virtual bool               stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
 
    virtual bool               isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
-   virtual bool               isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
-   virtual bool               isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool               traceableMethodsCanBeInlined();
 
    virtual bool               canMethodEnterEventBeHooked();


### PR DESCRIPTION
In practice we never enable methodEnterTracing without
methodExitTracing.These two methods are replaced by
isMethodTracingEnabled().

Issue: #3585

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>