### PR TITLE
Remove deprecated CodeCache::initialize function

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -103,61 +103,6 @@ J9::CodeCache::allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, 
    return newCodeCache;
    }
 
-// Initialize a code cache
-//
-// This function is deprecated in favour of the version that does not take
-// a CodeCacheHashEntrySlab parameter, and will be removed once upstream
-// OMR changes have merged.  It is otherwise identical to that function.
-//
-bool
-J9::CodeCache::initialize(TR::CodeCacheManager *manager,
-                         TR::CodeCacheMemorySegment *codeCacheSegment,
-                         size_t codeCacheSizeAllocated,
-                         OMR::CodeCacheHashEntrySlab *hashEntrySlab)
-   {
-   // make J9 memory segment look all used up
-   //J9MemorySegment *j9segment = _segment->segment();
-   //j9segment->heapAlloc = j9segment->heapTop;
-
-   TR::CodeCacheConfig & config = manager->codeCacheConfig();
-   if (config.needsMethodTrampolines())
-      {
-      int32_t percentageToUse;
-      if (!(TR::Options::getCmdLineOptions()->getTrampolineSpacePercentage() > 0))
-         {
-#if defined(TR_HOST_X86) && defined(TR_HOST_64BIT)
-         percentageToUse = 7;
-#else
-         percentageToUse = 4;
-#endif
-         // The number of helpers and the trampoline size are both factors here
-         size_t trampolineSpaceSize = config.trampolineCodeSize() * config.numRuntimeHelpers();
-         if (trampolineSpaceSize >= 3400)
-            {
-            // This will be PPC64, AMD64 and 390
-            if (config.codeCacheKB() < 512 && config.codeCacheKB() > 256)
-               percentageToUse = 5;
-            else if (config.codeCacheKB() <= 256)
-               percentageToUse = 6;
-            }
-         }
-      else
-         {
-         percentageToUse = TR::Options::getCmdLineOptions()->getTrampolineSpacePercentage();
-         }
-
-      config._trampolineSpacePercentage = percentageToUse;
-      }
-
-   if (!self()->OMR::CodeCache::initialize(manager, codeCacheSegment, codeCacheSizeAllocated, hashEntrySlab))
-      return false;
-   self()->setInitialAllocationPointers();
-
-   _manager->reportCodeLoadEvents();
-
-   return true;
-   }
-
 
 bool
 J9::CodeCache::initialize(TR::CodeCacheManager *manager,

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -32,7 +32,6 @@ namespace J9 { typedef CodeCache CodeCacheConnector; }
 
 
 #include "env/jittypes.h"
-//#include "runtime/CodeCacheMemorySegment.hpp"
 #include "runtime/OMRCodeCache.hpp"
 #include "env/IO.hpp"
 #include "env/VMJ9.h"
@@ -55,11 +54,6 @@ class OMR_EXTENSIBLE CodeCache : public OMR::CodeCacheConnector
 
 public:
    CodeCache() { }
-
-   bool                       initialize(TR::CodeCacheManager *manager,
-                                         TR::CodeCacheMemorySegment *codeCacheSegment,
-                                         size_t codeCacheSizeAllocated,
-                                         OMR::CodeCacheHashEntrySlab *hashEntrySlab);
 
    /**
     * @brief Initialize an allocated CodeCache object


### PR DESCRIPTION
The version that takes a `CodeCacheHashEntrySlab` parameter has been
deprecated.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>