### PR TITLE
Fix unused variable warning when J9VM_INTERP_ATOMIC_FREE_JNI is not defined

### DIFF
--- a/runtime/vm/vmthread.c
+++ b/runtime/vm/vmthread.c
@@ -1507,7 +1507,9 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 	char fileName[EsMaxPath];
 	J9PortLibrary* privatePortLibrary = vm->portLibrary;
 	int releaseAccess = 0;
+#if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 	int exitVM = 0;
+#endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 	BOOLEAN exclusiveRequestedLocally = FALSE;
 
 	if ( !vm->mainThread ) {


### PR DESCRIPTION
Companion to #4602