### PR TITLE
Ensure out pointer is correct assigned in jvmtiGetJ9method

### DIFF
--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -3301,7 +3301,7 @@ jvmtiGetJ9method(jvmtiEnv *env, jmethodID mid, void **j9MethodPtr, ...)
 
 done:
 	if (NULL != j9MethodPtr) {
-		j9MethodPtr = rv_j9Method;
+		*j9MethodPtr = rv_j9Method;
 	}
 	TRACE_JVMTI_RETURN(jvmtiGetJ9method);
 }


### PR DESCRIPTION
Fix for issue introduced in #3492 which ensured the values were always
initialized

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>