### PR TITLE
Add an object sampling hook

### DIFF
--- a/runtime/gc_include/j9mm.hdf
+++ b/runtime/gc_include/j9mm.hdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2010, 2018 IBM Corp. and others
+Copyright (c) 2010, 2019 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,6 +59,20 @@ struct J9VMThread;
 		</description>
 		<struct>MM_InterruptCompilationEvent</struct>
 		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
+	</event>
+	
+	<event>
+		<name>J9HOOK_MM_OBJECT_ALLOCATION_SAMPLING</name>
+		<description>
+			Triggered when the object allocations sampling threshold is reached
+		</description>
+		<struct>MM_ObjectAllocationSamplingEvent</struct>
+		<data type="struct J9VMThread*" name="currentThread" description="current thread" />
+		<data type="U_64" name="timestamp" description="time of event" />
+		<data type="UDATA" name="eventid" description="unique identifier for event" />
+		<data type="j9object_t" name="object" description="the object which has been allocated." />
+		<data type="struct J9Class*" name="clazz" description="the class of the object just allocated" />
+		<data type="uintptr_t" name="objectSize" description="the size of the object just allocated" />
 	</event>
 
 </interface>


### PR DESCRIPTION
When the object sampling threshold is met also trigger a hook so
that other components can provide sampling information.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>