### PR TITLE
Re-enable AOT by default in non-JITaaS mode

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -6787,7 +6787,7 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
       TR::IlGeneratorMethodDetails & details = entry->getMethodDetails();
 
       eligibleForRelocatableCompile =
-            enableJITaaSRemoteAOT && // disable remote JITaaS AOT until it's working
+            (enableJITaaSRemoteAOT || !entry->isOutOfProcessCompReq()) && // disable remote JITaaS AOT until it's working
             TR::Options::sharedClassCache() &&
             !details.isNewInstanceThunk() &&
             !entry->isJNINative() &&


### PR DESCRIPTION
AOT was disabled even in non-JITaaS mode, unless an environment variable
`TR_EnableJITaaSRemoteAOT` was set. This is not intended behavior, only disable AOT
when in JITaaS mode.