### PR TITLE
Ensure _Filehandle does not close if printing to STDOUT/ERR

### DIFF
--- a/runtime/rasdump/TextFileStream.cpp
+++ b/runtime/rasdump/TextFileStream.cpp
@@ -25,9 +25,12 @@
 #include "TextFileStream.hpp"
 #include "j9.h"
 #include "j9port.h"
+#include "rasdump_internal.h"
 
 /* Constructor */
 TextFileStream::TextFileStream(J9PortLibrary* portLibrary) :
+	_Buffer(NULL),
+	_IsOpen(false),
 	_BufferPos(0),
 	_BufferSize(16*1024),
 	_PortLibrary(portLibrary),
@@ -51,12 +54,16 @@ void
 TextFileStream::open(const char* fileName, bool cacheWrites)
 {
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
-	if (NULL != strstr(fileName, "/STDOUT/")) {
-		_FileHandle = 1; 
-	} else if (NULL != strstr(fileName, "/STDERR/")) {
-		_FileHandle = 2;
-	} else if (fileName[0] != '-' ) {
+	if (0 == strcmp(fileName, J9RAS_STDOUT_NAME)) {
+		_FileHandle = J9PORT_TTY_OUT; 
+	} else if (0 == strcmp(fileName, J9RAS_STDERR_NAME)) {
+		_FileHandle = J9PORT_TTY_ERR;
+	} else {
 		_FileHandle = j9file_open(fileName, EsOpenWrite | EsOpenCreate | EsOpenTruncate | EsOpenCreateNoTag, 0666);
+		if (_FileHandle != -1) {
+			_IsOpen = true;
+		}
+		
 	}
 	if(!cacheWrites) {
 		_BufferSize = 0;
@@ -73,7 +80,10 @@ TextFileStream::close(void)
 			j9file_write_text(_FileHandle, _Buffer, _BufferPos);
 		}
 		j9file_sync(_FileHandle);
-		j9file_close(_FileHandle);
+		if (_IsOpen) {
+			/*If we don't open the file stream, it means that we don't close it either */
+			j9file_close(_FileHandle);
+		}
 	}
 
 	_FileHandle = -1;	

--- a/runtime/rasdump/TextFileStream.hpp
+++ b/runtime/rasdump/TextFileStream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2014 IBM Corp. and others
+ * Copyright (c) 2003, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,7 @@ private :
 	TextFileStream(const TextFileStream& source);
 	TextFileStream& operator=(const TextFileStream& source);
 	char *_Buffer;
+	bool _IsOpen;
 	UDATA _BufferPos;
 	UDATA _BufferSize;
 

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -886,7 +886,12 @@ static omr_error_t
 doJavaDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 {
 	J9JavaVM *vm = context->javaVM;
-	if ((0 != strcmp(label, "/STDOUT/")) && (0 != strcmp(label, "/STDERR/"))) {
+
+	if ((0 == strcmp("-", label)) || (0 == j9_cmdla_stricmp(label, J9RAS_STDOUT_NAME))) {
+		strcpy(label, J9RAS_STDOUT_NAME);
+	} else if (0 == j9_cmdla_stricmp(label, J9RAS_STDERR_NAME)) {
+		strcpy(label, J9RAS_STDERR_NAME);
+	} else {
 		if (makePath(vm, label) == OMR_ERROR_INTERNAL) {
 			/* Nowhere available to write the dump, we are done, makePath() will have issued error message */
 			return OMR_ERROR_INTERNAL;

--- a/runtime/rasdump/rasdump_internal.h
+++ b/runtime/rasdump/rasdump_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,6 +125,9 @@ void setAllocationThreshold(J9VMThread *vmThread, UDATA min, UDATA max);
 #endif
 
 #define J9RAS_DUMP_EXCEPTION_EVENT_GROUP (J9RAS_DUMP_ON_EXCEPTION_THROW | J9RAS_DUMP_ON_EXCEPTION_SYSTHROW | J9RAS_DUMP_ON_EXCEPTION_CATCH | J9RAS_DUMP_ON_EXCEPTION_DESCRIBE)
+
+#define J9RAS_STDOUT_NAME "/STDOUT/"
+#define J9RAS_STDERR_NAME "/STDERR/"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Replace '1' and '2' with J9PORT_TTY_OUT and J9PORT_TTY_ERR respectively
Replace '/STDOUT/' and '/STDERR/' with J9RAS_STDOUT_NAME and J9RAS_STDERR_NAME
Add support for choosing a file name with `-` to print to STDOUT
Add support for choose a file name `/stdout/` and `/stderr/` to print to STDOUT and STDERR respectively.
Add a boolean to the class `IsOpen` that is set to true when the file stream is open.

Doc issue [eclipse/openj9-docs#204](https://github.com/eclipse/openj9-docs/issues/204)

Fixes #2837