### PR TITLE
Add test utility methods to get attach API information

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.ibm.tools.attach.target.AttachHandler;
 import com.ibm.tools.attach.target.IPC;
 import com.sun.tools.attach.AgentInitializationException;
 import com.sun.tools.attach.AgentLoadException;
@@ -63,6 +62,7 @@ public class TestAttachAPI extends AttachApiTest {
 	final String JVMTITSTNAME = "test:gmhc001";
 	private final String DUMP_LOGS = "j9vm.test.attach.dumplogs";
 	private String myProcessId;
+	private String mvVmId;
 	final boolean dumpLogs = Boolean.getBoolean(DUMP_LOGS);
 	private File commonDir;
 	@BeforeMethod
@@ -81,9 +81,9 @@ public class TestAttachAPI extends AttachApiTest {
 			commonDir = new File(System.getProperty("java.io.tmpdir"),
 					".com_ibm_tools_attach");
 		}
-		if (false == AttachHandler.waitForAttachApiInitialization()) {
+		if (false == TargetManager.waitForAttachApiInitialization()) {
 			TargetManager.dumpLogs(true);
-			myProcessId = Long.toString(AttachHandler.getProcessId());
+			myProcessId = Long.toString(TargetManager.getProcessId());
 			File myAdvert = new File(commonDir, myProcessId);
 			if (myAdvert.exists()) {
 				logger.error(myAdvert.getAbsolutePath()
@@ -93,8 +93,8 @@ public class TestAttachAPI extends AttachApiTest {
 					+ myProcessId);
 		}
 		logger.debug("\n------------------------------------------------------------\ntime = "+System.currentTimeMillis());
-		String myId = AttachHandler.getVmId();
-		if ((null == myId) || (myId.length() == 0)) {
+		mvVmId = TargetManager.getVmId();
+		if ((null == mvVmId) || (mvVmId.length() == 0)) {
 			logger.error("attach API failed to initialize");
 			if (!commonDir.exists()) {
 				TargetManager.dumpLogs();
@@ -122,7 +122,7 @@ public class TestAttachAPI extends AttachApiTest {
 	@Test
 	public void test_agntld01() {
 		logger.debug("*****************************\nMy VMID = "
-				+ AttachHandler.getVmId() + "\n*****************************");
+				+ mvVmId + "\n*****************************");
 		logger.debug("starting " + testName);
 		if (isWindows()) {
 			logger.debug("skipping  " + testName + " on Windows");
@@ -162,7 +162,7 @@ public class TestAttachAPI extends AttachApiTest {
 	@Test
 	public void test_agntld02() {
 		logger.debug("*****************************\nMy VMID = "
-				+ AttachHandler.getVmId() + "\n*****************************");
+				+ mvVmId + "\n*****************************");
 		
 		logger.debug("starting " + testName);
 		if (isWindows()) {

--- a/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@ package org.openj9.test.attachAPI;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -105,6 +104,54 @@ class TargetManager {
 		this.proc = launchTarget(cmdName, targetId, null, null, null);
 	}
 
+	/**
+	 * Wait until the JVM's attach API has initialized
+	 * @return success if true, false if attach API is disabled or error
+	 */
+	public static boolean waitForAttachApiInitialization() {
+		boolean result = false;
+		try {
+			Class<?> attachHandlerClass = Class.forName(TargetManager.COM_IBM_TOOLS_ATTACH_TARGET_ATTACH_HANDLER);
+			final Method waitForAttachApiInitialization = attachHandlerClass.getMethod("waitForAttachApiInitialization");
+			result = (boolean) waitForAttachApiInitialization.invoke(attachHandlerClass);
+		} catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			logger.error("error waiting for attach API initialization: "+e.getMessage());
+		}
+		return result;
+	}
+	
+	/**
+	 * Get the process ID of the current process
+	 * @return Process ID or -1 on error
+	 */
+	public static long getProcessId() {
+		long result = -1;
+		try {
+			Class<?> attachHandlerClass = Class.forName(TargetManager.COM_IBM_TOOLS_ATTACH_TARGET_ATTACH_HANDLER);
+			final Method getPid = attachHandlerClass.getMethod("getProcessId");
+			result = (long) getPid.invoke(attachHandlerClass);
+		} catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			logger.error("error getting process ID: "+e.getMessage());
+		}
+		return result;
+	}
+	
+	/**
+	 * Get the AttachAPI virtual machine ID of the current process
+	 * @return Process ID or null on error
+	 */
+	public static String getVmId() {
+		String result = null;
+		try {
+			Class<?> attachHandlerClass = Class.forName(TargetManager.COM_IBM_TOOLS_ATTACH_TARGET_ATTACH_HANDLER);
+			final Method getVmId = attachHandlerClass.getMethod("getVmId");
+			result = (String) getVmId.invoke(attachHandlerClass);
+		} catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			logger.error("error getting process ID: "+e.getMessage());
+		}
+		return result;
+	}
+	
 	/*
 	 * target must print the PID on one line, other information on following
 	 * line(s) (if any), the initialization status on the final line.

--- a/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetVM.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/attachAPI/TargetVM.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,13 +24,12 @@ package org.openj9.test.attachAPI;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Method;
 import java.util.Properties;
 
 
 public class TargetVM {
 
-	public static final String WAITING_FOR_INITIALIZATION = "STATUS_WAIT_INITIALIZATION";
+	public static final String WAITING_FOR_INITIALIZATION = "STATUS_WAIT_INITIALIZATION"; //$NON-NLS-1$
 
 	/**
 	 * @param args
@@ -42,14 +41,10 @@ public class TargetVM {
 		System.err.println("starting");
 		long pid = 0;
 		try {
-			Class<?> attachHandlerClass = Class.forName(TargetManager.COM_IBM_TOOLS_ATTACH_TARGET_ATTACH_HANDLER);
-			final Method getVmId = attachHandlerClass.getMethod("getVmId");
-			final Method getProcessId = attachHandlerClass.getMethod("getProcessId");
-			final Method waitForAttachApiInitialization = attachHandlerClass.getMethod("waitForAttachApiInitialization");
-			pid = (long) getProcessId.invoke(attachHandlerClass);
+			pid = TargetManager.getProcessId();
 			System.out.println(TargetManager.PID_PREAMBLE + pid);
-			if ((boolean) waitForAttachApiInitialization.invoke(attachHandlerClass)) {
-				System.out.println(TargetManager.VMID_PREAMBLE + getVmId.invoke(attachHandlerClass));
+			if (TargetManager.waitForAttachApiInitialization()) {
+				System.out.println(TargetManager.VMID_PREAMBLE + TargetManager.getVmId());
 				System.out.println(TargetManager.STATUS_PREAMBLE
 						+ TargetManager.STATUS_INIT_SUCESS);
 				System.out.flush();


### PR DESCRIPTION
Add methods to check for attach API initialization, get process ID, and get
virtual machine ID.

Use reflection to avoid compile-time dependency on OpenJ9 internal classes by tests.
Replace some existing references to AttachHandler in favour of the new methods.

This is further to "Use reflection to access attach API internal APIs" #2962. This allows tests to remove references to attach API implementation classes and compile without requiring `--add-exports java.base/com.ibm.tools.attach.target`.

This is cleanup in preparation for tests of new features in https://github.com/eclipse/openj9/issues/4655.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>