### PR TITLE
Install gcc 7.3/7.4 from Adopt in JDK12 docker files

### DIFF
--- a/buildenv/docker/jdk12/ppc64le/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk12/ppc64le/ubuntu16/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     autoconf \
@@ -38,8 +37,6 @@ RUN apt-get update \
     cpio \
     cmake \
     file \
-    g++-7 \
-    gcc-7 \
     git \
     git-core \
     libasound2-dev \
@@ -69,12 +66,18 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     vim \
   && rm -rf /var/lib/apt/lists/*
-
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-7 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-7 /usr/bin/gcc
+  
+# Install GCC-7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.ppc64le.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/powerpc64le-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/powerpc64le-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk12/s390x/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk12/s390x/ubuntu16/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     autoconf \
@@ -38,8 +37,6 @@ RUN apt-get update \
     cmake \
     cpio \
     file \
-    g++-7 \
-    gcc-7 \
     git \
     git-core \
     libasound2-dev \
@@ -48,6 +45,7 @@ RUN apt-get update \
     libelf-dev \
     libfontconfig1-dev \
     libfreetype6-dev \
+    libmpc3 \
     libx11-dev \
     libxext-dev \
     libxrender-dev \
@@ -69,11 +67,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-7 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-7 /usr/bin/gcc
+# Install GCC-7.4
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc740+ccache.s390x.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/s390x-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/s390x-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.4 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.4 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \

--- a/buildenv/docker/jdk12/x86_64/ubuntu16/Dockerfile
+++ b/buildenv/docker/jdk12/x86_64/ubuntu16/Dockerfile
@@ -29,11 +29,8 @@ RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     python-software-properties \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -qq -y --no-install-recommends \
-    gcc-7 \
-    g++-7 \
     autoconf \
     ca-certificates \
     ccache \
@@ -66,11 +63,17 @@ RUN apt-get update \
     vim \
   && rm -rf /var/lib/apt/lists/*
 
-# Create links for c++,g++,cc,gcc
-RUN ln -s g++ /usr/bin/c++ \
-  && ln -s g++-7 /usr/bin/g++ \
-  && ln -s gcc /usr/bin/cc \
-  && ln -s gcc-7 /usr/bin/gcc
+# Add the GCC-7.3 Binary
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 # Download and setup freemarker.jar to /root/freemarker.jar
 RUN cd /root \


### PR DESCRIPTION
Install `gcc 7.3/7.4` from Adopt in `JDK12` docker files

Ported from https://github.com/eclipse/openj9/pull/4568

Note: verified `x86_64` docker image can still build `jdk12`.

[skip ci]

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>