### PR TITLE
Fix code size estimation

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -369,7 +369,11 @@ static TR::ILOpCodes convertBytecodeToIL (TR_J9ByteCode bc)
       case J9BClookupswitch: return TR::lookup;
       case J9BCgoto:
       case J9BCgotow: return TR::Goto;
-      case J9BCgenericReturn: return TR::Return;
+      case J9BCReturnC: /* fall-through */
+      case J9BCReturnS: /* fall-through */
+      case J9BCReturnB: /* fall-through */
+      case J9BCReturnZ: /* fall-through */
+      case J9BCgenericReturn:  return TR::Return;
       case J9BCathrow: return TR::athrow;
       default:
          TR_ASSERT(0,"Unsupported conversion for now.");
@@ -610,7 +614,11 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          foundNewAllocation = false;
          }
 
-      if (bc == J9BCgenericReturn)
+      if (bc == J9BCgenericReturn ||
+          bc == J9BCReturnC ||
+          bc == J9BCReturnS ||
+          bc == J9BCReturnB ||
+          bc == J9BCReturnZ)
          {
          if (!calltarget->_calleeMethod->isSynchronized())
             size += 1;
@@ -644,6 +652,10 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
             flags[i + bci.relativeBranch()].set(bbStart);
             blockStart = true;
             break;
+         case J9BCReturnC:
+         case J9BCReturnS:
+         case J9BCReturnB:
+         case J9BCReturnZ:
          case J9BCgenericReturn:
             flags[i].set(isBranch);
             blockStart = true;
@@ -1120,6 +1132,10 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   cfg.addEdge(currentBlock, getBlock(comp(), blocks, calltarget->_calleeMethod, i + bci.relativeBranch(), cfg), stackAlloc);
                   addFallThruEdge = false;
                   break;
+               case J9BCReturnC:
+               case J9BCReturnS:
+               case J9BCReturnB:
+               case J9BCReturnZ:
                case J9BCgenericReturn:
                case J9BCathrow:
                   setupLastTreeTop(currentBlock, bc, i, cfg.getEnd()->asBlock(), calltarget->_calleeMethod, comp());

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1025,7 +1025,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       debugTrace(tracer(),"PECS: iterating over bc indexes in CFG creation. maxIndex =%d", maxIndex);
       int32_t blockStartSize = 0;
       int32_t startIndex = 0;
-      for (i = 0; i < maxIndex; ++i)
+      for (bc = bci.first(), i = bci.bcIndex(); bc != J9BCunknown; bc = bci.next(), i = bci.bcIndex())
          {
          if (flags[i].testAny(bbStart))
             {
@@ -1084,8 +1084,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   cfg.getMethodSymbol()->addProfilingOffsetInfo(currentBlock->getEntry()->getNode()->getByteCodeIndex(), currentBlock->getEntry()->getNode()->getByteCodeIndex() + currentBlock->getBlockSize());
                }
 
-            bci.setIndex(i);
-            switch (bc = bci.current())
+            switch (bc)
                {
                case J9BCificmpeq:
                case J9BCificmpne:
@@ -1633,7 +1632,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          bool isCold = false;
          int coldBorderFrequency = 20;
 
-         for (i = 0; i < (int32_t) maxIndex; ++i)
+         for (bc = bci.first(), i = bci.bcIndex(); bc != J9BCunknown; bc = bci.next(), i = bci.bcIndex())
             {
             if (blocks[i])
                if (!blocks[i]->isCold() && blocks[i]->getFrequency() > coldBorderFrequency)
@@ -1730,7 +1729,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
       /****************** Phase 4: Deal with Inlineable Calls **************************/
 
-      for (i = 0; i < maxIndex && inlineableCallExists; ++i)
+      for (bc = bci.first(), i = bci.bcIndex(); bc != J9BCunknown && inlineableCallExists; bc = bci.next(), i = bci.bcIndex())
          {
          //heuristicTrace(tracer(),"--- Depth %d: Checking _real size vs Size Threshold: _realSize %d _sizeThreshold %d sizeThreshold %d ",_recursionDepth, _realSize, _sizeThreshold, sizeThreshold);
 
@@ -1743,7 +1742,6 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
          if (blocks[i])
             currentBlock = blocks[i];
 
-         bci.setIndex(i);
          newBCInfo.setByteCodeIndex(i);
          if (callSites[i])
             {


### PR DESCRIPTION
The code size estimator is confused about how to walk bytecodes, which causes it to generate incorrect CFGs and possibly inaccurate estimates.

Fixes: #4622