### PR TITLE
Implement jps: java process status

### DIFF
--- a/jcl/.classpath
+++ b/jcl/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,7 @@
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/java.management/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/jdk.attach/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/openj9.jvm/share/classes"/>
+	<classpathentry excluding="**/module-info.java" kind="src" path="src/jdk.jcmd/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/jdk.management/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/openj9.cuda/share/classes"/>
 	<classpathentry excluding="**/module-info.java" kind="src" path="src/openj9.dataaccess/share/classes"/>

--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -70,6 +70,7 @@
 		<source path="src/java.logging/share/classes"/>
 		<source path="src/java.management/share/classes"/>
 		<source path="src/jdk.attach/share/classes"/>
+		<source path="src/jdk.jcmd/share/classes"/>
 		<source path="src/openj9.jvm/share/classes"/>
 		<source path="src/jdk.management/share/classes"/>
 		<source path="src/openj9.cuda/share/classes" />
@@ -94,6 +95,7 @@
 		<source path="src/java.logging/share/classes"/>
 		<source path="src/java.management/share/classes"/>
 		<source path="src/jdk.attach/share/classes"/>
+		<source path="src/jdk.jcmd/share/classes"/>
 		<source path="src/openj9.jvm/share/classes"/>
 		<source path="src/jdk.management/share/classes"/>
 		<source path="src/openj9.cuda/share/classes" />
@@ -115,6 +117,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -142,6 +145,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -169,6 +173,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -196,6 +201,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -223,6 +229,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -250,6 +257,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -277,6 +285,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -304,6 +313,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.jvm/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.cuda/share/classes"/>
@@ -335,6 +345,7 @@
 		<source path="src/java.management/share/classes"/>
 		<source path="src/jdk.management/share/classes"/>
 		<source path="src/jdk.attach/share/classes"/>
+		<source path="src/jdk.jcmd/share/classes"/>
 		<source path="src/openj9.jvm/share/classes"/>
 		<source path="src/openj9.dataaccess/share/classes"/>
 		<source path="src/openj9.sharedclasses/share/classes"/>

--- a/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/com/ibm/tools/attach/target/Attachment.java
@@ -1,6 +1,6 @@
 /*[INCLUDE-IF Sidecar16]*/
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corp. and others
+ * Copyright (c) 2009, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Properties;
+
 /*[IF Sidecar19-SE]*/
 import jdk.internal.vm.VMSupport;
 /*[ELSE] Sidecar19-SE
@@ -199,7 +200,11 @@ final class Attachment extends Thread implements Response {
 							+ " " + attachError); //$NON-NLS-1$
 				}
 			} else if (cmd.startsWith(Command.GET_SYSTEM_PROPERTIES)) {
-				replyWithProperties(com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties());
+				Properties internalProperties = com.ibm.oti.vm.VM.getVMLangAccess().internalGetProperties();
+				String argumentString = String.join(" ", com.ibm.oti.vm.VM.getVMArgs()); //$NON-NLS-1$
+				Properties newProperties = (Properties) internalProperties.clone();
+				newProperties.put("sun.jvm.args", argumentString); //$NON-NLS-1$
+				replyWithProperties(newProperties);
 			} else if (cmd.startsWith(Command.GET_AGENT_PROPERTIES)) {
 				replyWithProperties(AttachHandler.getAgentProperties());
 			} else if (cmd.startsWith(Command.START_LOCAL_MANAGEMENT_AGENT)) {

--- a/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/Jps.java
+++ b/jcl/src/jdk.jcmd/share/classes/openj9/tools/attach/diagnostics/Jps.java
@@ -1,0 +1,142 @@
+/*[INCLUDE-IF Sidecar18-SE]*/
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+package openj9.tools.attach.diagnostics;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.spi.AttachProvider;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
+
+/**
+ * Java Process Status
+ * A tool for listing Java processes and their information.
+ *
+ */
+public class Jps {
+
+	private static final String SUN_JAVA_COMMAND = "sun.java.command"; //$NON-NLS-1$
+	private static final String SUN_JVM_ARGS = "sun.jvm.args"; //$NON-NLS-1$
+	private static boolean printApplicationArguments;
+	private static boolean printJvmArguments;
+	private static boolean noPackageName;
+	private static boolean vmidOnly;
+	/**
+	 * Print a list of Java processes and information about them.
+	 * @param args Arguments to the application
+	 */
+	public static void main(String[] args) {
+		int rc = 0;
+		parseArguments(args);
+		final List<AttachProvider> providers = AttachProvider.providers();
+		AttachProvider theProvider = null;
+		if (0 != providers.size()) {
+			theProvider = providers.get(0);
+		} 
+		if (null == theProvider) {
+			System.err.println("no attach providers available"); //$NON-NLS-1$
+			rc = 1;
+		} else {
+			List<VirtualMachineDescriptor> vmds = theProvider.listVirtualMachines();
+			for (VirtualMachineDescriptor vmd: vmds) {
+				StringBuilder outputBuffer = new StringBuilder(vmd.id());
+				if (!vmidOnly) {
+					try {
+						VirtualMachine theVm = theProvider.attachVirtualMachine(vmd);
+						try {
+							Properties vmProperties = theVm.getSystemProperties();
+							String theCommand = vmProperties.getProperty(SUN_JAVA_COMMAND, ""); //$NON-NLS-1$
+							String parts[] = theCommand.split("\\s+", 2); /* split into at most 2 parts: command and argument string */  //$NON-NLS-1$
+							if (noPackageName) {
+								String commandName = parts[0];
+								int finalDot = commandName.lastIndexOf('.');
+								parts[0] = commandName.substring(finalDot + 1); /* if the dot is missing, we get the whole string */
+							}
+							if (printApplicationArguments) {
+								for (String p:parts) {
+									outputBuffer.append(' ');
+									outputBuffer.append(p);
+								}
+							} else if (parts.length > 0) { /* some Java processes do not use the Java launcher */
+								outputBuffer.append(' ');
+								outputBuffer.append(parts[0]);
+							}
+							if (printJvmArguments) {
+								String jvmArguments = vmProperties.getProperty(SUN_JVM_ARGS);
+								if ((null != jvmArguments) && !jvmArguments.isEmpty()) {
+									outputBuffer.append(' ');
+									outputBuffer.append(jvmArguments);
+								}
+							}
+						} finally {
+							theVm.detach();
+						}
+					} catch (AttachNotSupportedException | IOException e) {
+						outputBuffer.append(' ');
+						outputBuffer.append("<no information available>"); //$NON-NLS-1$
+					}
+				}
+				System.out.println(outputBuffer.toString());
+			}
+		}
+		System.exit(rc);
+	}
+
+	@SuppressWarnings("nls")
+	private static void parseArguments(String[] args) {
+		printApplicationArguments = false;
+		printJvmArguments = false;
+		noPackageName = true;
+		vmidOnly = false;
+		final String HELPTEXT = "jps: Print a list of Java processes and information about them%n"
+				+ "    -J: supply arguments to the Java VM running jps%n"
+				+ "    -l: print the application package name%n"
+				+ "    -q: print only the virtual machine identifiers%n"
+				+ "    -m: print the application arguments%n"
+				+ "    -v: print the Java VM arguments, including those produced automatically%n";
+		for (String a: args) {
+			switch (a) {
+			case "-l":
+				noPackageName = false;
+				break;
+			case "-m":
+				printApplicationArguments = true;
+				break;
+			case "-q":
+				vmidOnly = true;
+				break;
+			case "-v":
+				printJvmArguments = true;
+				break;
+				/* implicitly handle -h and -help via the default case */
+			default: 
+				System.out.printf(HELPTEXT);
+				System.exit(1);
+				break;
+			}
+		}
+	}
+}

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -406,6 +406,57 @@
 	<!-- Attach API tests -->
 
 	<test>
+		<testCaseName>TestJps_SE80</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(JDK_HOME)$(D)lib$(D)tools.jar$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
+	-Dcom.ibm.tools.attach.timeout=15000 \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJps \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		 </impls>
+	</test>
+
+	<test>
+		<testCaseName>TestJps</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	--add-exports=java.base/com.ibm.tools.attach.target=ALL-UNNAMED \
+	-Dcom.ibm.tools.attach.enable=yes \
+	-Djdk.attach.allowAttachSelf=true \
+	-Dcom.ibm.tools.attach.timeout=15000 \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames TestJps \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<subsets>
+			<subset>9+</subset>
+		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		 </impls>
+	</test>
+
+	<test>
 		<testCaseName>TestFileLocking_SE80</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJps.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+package org.openj9.test.attachAPI;
+
+import static org.openj9.test.attachAPI.TestConstants.TARGET_VM_CLASS;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.openj9.test.util.PlatformInfo;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+@Test(groups = { "level.extended" })
+public class TestJps extends AttachApiTest {
+
+	private static final String MISSING_ARGUMENT = "Missing argument: "; //$NON-NLS-1$
+	private static final String CHILD_IS_MISSING = "child is missing"; //$NON-NLS-1$
+	private static final String TEST_PROCESS_ID_MISSING = "Test process ID missing"; //$NON-NLS-1$
+	private static final String CHILD_PROCESS_DID_NOT_LAUNCH = "Child process did not launch"; //$NON-NLS-1$
+	private static final String JPS_COMMAND = "jps"; //$NON-NLS-1$
+	private static final String JPS_Class = "Jps"; //$NON-NLS-1$
+	private String vmId;
+	
+	@Test(groups = { "level.extended" })
+	public void testJpsSanity() throws IOException {
+		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
+		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
+		List<String> jpsOutput = runCommand();
+		assertTrue(TEST_PROCESS_ID_MISSING, search(vmId, jpsOutput).isPresent());
+		assertTrue("jps is missing", search(JPS_Class, jpsOutput).isPresent()); //$NON-NLS-1$
+		assertTrue(CHILD_IS_MISSING, search(tgtMgr.targetId, jpsOutput).isPresent());
+		tgtMgr.terminateTarget();
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testJpsPackageName() throws IOException {
+		final String WRONG_PKG_NAME = "Wrong package name: "; //$NON-NLS-1$
+		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null);
+		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
+		List<String> jpsOutput = runCommand(Collections.singletonList("-l")); //$NON-NLS-1$
+		Optional<String> searchResult = search(tgtMgr.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, searchResult.isPresent());
+		assertTrue(WRONG_PKG_NAME + searchResult.get(), searchResult.get().contains(TargetVM.class.getPackage().getName()));
+		tgtMgr.terminateTarget();
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testJpsIdOnly() throws IOException {
+		final String SPURIOUS_OUTPUT = "Spurious output: "; //$NON-NLS-1$
+		TargetManager tgtMgr1 = new TargetManager(TARGET_VM_CLASS, null);
+		TargetManager tgtMgr2 = new TargetManager(TARGET_VM_CLASS, "SomeRandomId"); //$NON-NLS-1$
+		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr1.syncWithTarget());
+		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr2.syncWithTarget());
+		List<String> jpsOutput = runCommand(Collections.singletonList("-q")); //$NON-NLS-1$
+		
+		Optional<String> searchResult = search(vmId, jpsOutput);
+		assertTrue(TEST_PROCESS_ID_MISSING, searchResult.isPresent());
+		assertEquals(SPURIOUS_OUTPUT, vmId, searchResult.get());
+		
+		searchResult = search(tgtMgr1.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, search(tgtMgr1.targetId, jpsOutput).isPresent());
+		assertEquals(SPURIOUS_OUTPUT, tgtMgr1.targetId, searchResult.get());
+		
+		/* now try with non-default vm ID */
+		searchResult = search(tgtMgr2.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, search(tgtMgr2.targetId, jpsOutput).isPresent());
+		assertEquals(SPURIOUS_OUTPUT, tgtMgr2.targetId, searchResult.get());
+		
+		tgtMgr1.terminateTarget();
+		tgtMgr2.terminateTarget();
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testApplicationArguments() throws IOException {
+		List<String> targetArgs = Arrays.asList("foo", "bar");  //$NON-NLS-1$//$NON-NLS-2$
+		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, targetArgs);
+		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
+		List<String> jpsOutput = runCommand(Collections.singletonList("-m")); //$NON-NLS-1$
+		Optional<String> searchResult =  search(tgtMgr.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, search(tgtMgr.targetId, jpsOutput).isPresent());
+		for (String a: targetArgs) {
+			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));
+		}
+		tgtMgr.terminateTarget();
+	}
+
+	@Test(groups = { "level.extended" })
+	public void testJvmArguments() throws IOException {
+		List<String> vmArgs = Collections.singletonList("-Dfoo=bar"); //$NON-NLS-1$
+		TargetManager tgtMgr = new TargetManager(TARGET_VM_CLASS, null, null, vmArgs, null);
+		assertTrue(CHILD_PROCESS_DID_NOT_LAUNCH, tgtMgr.syncWithTarget());
+		List<String> jpsOutput = runCommand(Collections.singletonList("-v")); //$NON-NLS-1$
+		Optional<String> searchResult =  search(tgtMgr.targetId, jpsOutput);
+		assertTrue(CHILD_IS_MISSING, search(tgtMgr.targetId, jpsOutput).isPresent());
+		for (String a: vmArgs) {
+			assertTrue(MISSING_ARGUMENT + a, searchResult.get().contains(a));
+		}
+		tgtMgr.terminateTarget();
+	}
+
+	/**
+	 * Look for a string in a list of strings using case sensitive substring searching
+	 * @param needle string for which to search
+	 * @param haystack list of strings in which to search
+	 * @return first string in haystack containing needle
+	 */
+	static Optional<String> search(String needle, List<String> haystack) {
+		return haystack.stream().filter(s -> s.contains(needle)).findFirst();
+	}
+
+	@BeforeMethod
+	protected void setUp(Method testMethod) {
+		testName = testMethod.getName();
+		log("starting " + testName);		 //$NON-NLS-1$
+	}
+	
+	/**
+	 * Don't run the test if it is running on non-OpenJ9 (e.g. IBM) Java
+	 */
+	@BeforeSuite
+	void setupSuite() {
+		assertTrue("This test is valid only on OpenJ9",  //$NON-NLS-1$
+				System.getProperty("java.vm.vendor").contains("OpenJ9"));  //$NON-NLS-1$//$NON-NLS-2$
+		char fs = java.io.File.separatorChar;
+		final String jpsCommandWithSuffix = 
+				PlatformInfo.isWindows() ? JPS_COMMAND + ".exe": JPS_COMMAND; //$NON-NLS-1$
+		String binDir = System.getProperty("java.home") + fs + "bin" + fs; //$NON-NLS-1$ //$NON-NLS-2$
+		commandName = binDir + jpsCommandWithSuffix;
+		File  commandFile = new File(commandName);
+		if (!commandFile.exists()) { /* Java 8 has 2 bin directories, and JAVA_HOME is probably pointing at jre/bin */
+			log("Did not find jps in "+binDir); //$NON-NLS-1$
+			binDir = System.getProperty("java.home") + fs + ".." + fs + "bin" + fs; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			commandName = binDir + jpsCommandWithSuffix;
+			commandFile = new File(commandName);
+			assertTrue("Did not find " + jpsCommandWithSuffix //$NON-NLS-1$
+					+ " in " + binDir, commandFile.exists()); //$NON-NLS-1$
+		}
+		assertTrue("Attach API failed to launch", TargetManager.waitForAttachApiInitialization()); //$NON-NLS-1$
+		vmId = TargetManager.getVmId();
+	}
+	
+}

--- a/test/functional/Java8andUp/testng.xml
+++ b/test/functional/Java8andUp/testng.xml
@@ -85,6 +85,12 @@
 			<class name="org.openj9.test.attachAPI.TestManagementAgent"/>
 		</classes>
 	</test>
+	<test name="TestJps">
+		<classes>
+			<class name="org.openj9.test.attachAPI.TestJps"/>
+		</classes>
+	</test>
+	
 	<test name="TestFileLocking">
 		<classes>
 			<class name="org.openj9.test.fileLock.TestFileLocking"/>


### PR DESCRIPTION
Add Java code to implement the main function.  This uses Attach API to acquire the list of processes
and query their information.

Update Attach API to return JVM arguments

Launchers will be added using coordinated changes in the extension repos.

Requires (mutually):

- https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/267 for Java 8 launcher
- https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/130 for Java 11 launcher
- https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/12 for Java 12 launcher
- https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/74 for future release launcher

These required test utility changes should be merged before this is merged:
- ~https://github.com/eclipse/openj9/pull/4672 for testing~ Not required
- ~https://github.com/eclipse/openj9/pull/4639 for testing.~ Merged

Doc issues:
- https://github.com/eclipse/openj9-docs/issues/210
- eclipse/openj9-docs#216

Fixes https://github.com/eclipse/openj9/issues/2377

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>