### PR TITLE
Add ValueType support to the if_acmp bytecodes

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValueTypeTests.java
@@ -362,7 +362,38 @@ public class ValueTypeTests {
 			Assert.fail("should throw error. Class does not exist");
 		} catch (NoClassDefFoundError e) {}
 	}
-	
+
+	/*
+	 * Test ifacmp on value class
+	 * 
+	 * class TestIfacmpOnValueClass {}
+	 */
+	@Test(priority=2)
+	static public void TestIfacmpOnValueClass() throws Throwable {
+		int x = 0;
+		int y = 0;
+		
+		Object valueType = makePoint2D.invoke(x, y);
+
+		Object refType = (Object) x;
+		
+		Assert.assertFalse((valueType == refType), "An identity (==) comparison that contains a valueType should always return false");
+		
+		Assert.assertFalse((refType == valueType), "An identity (==) comparison that contains a valueType should always return false");
+
+		Assert.assertFalse((valueType == valueType), "An identity (==) comparison that contains a valueType should always return false");
+
+		Assert.assertTrue((refType == refType), "An identity (==) comparison on the same refType should always return true");
+
+		Assert.assertTrue((valueType != refType), "An identity (!=) comparison that contains a valueType should always return true");
+
+		Assert.assertTrue((refType != valueType), "An identity (!=) comparison that contains a valueType should always return true");
+
+		Assert.assertTrue((valueType != valueType), "An identity (!=) comparison that contains a valueType should always return true");
+
+		Assert.assertFalse((refType != refType), "An identity (!=) comparison on the same refType should always return false");
+	}
+		
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {
 		try {
 			return lookup.findVirtual(clazz, "get"+fieldName, MethodType.methodType(fieldType));


### PR DESCRIPTION
Modify behaviour of Bytecodes if_acmps 

we need to modify the behaviour of these two bytecodes when value types are involved:
- the result of if_acmpeq is true when these two valuetypes are substitutable and false otherwise
- the result of if_acmpne is true when these two valuetypes are not substitutable and false otherwise
- others remain the same for normal objects
 
Signed-off-by: MarkQingGuo <Qing.Guo@ibm.com>