### PR TITLE
Load correct virtualCallOffsetAndIgnoreRtResolve

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3625,7 +3625,7 @@ TR_RelocationRecordValidateVirtualMethodFromOffset::applyRelocation(TR_Relocatio
    uint16_t methodID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_methodID);
    uint16_t definingClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_definingClassID);
    uint16_t beholderID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_beholderID);
-   uint16_t virtualCallOffsetAndIgnoreRtResolve = reloTarget->loadUnsigned32b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_virtualCallOffsetAndIgnoreRtResolve);
+   uint16_t virtualCallOffsetAndIgnoreRtResolve = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateVirtualMethodFromOffsetBinaryTemplate *)_record)->_virtualCallOffsetAndIgnoreRtResolve);
    int32_t virtualCallOffset = (int32_t)(int16_t)(virtualCallOffsetAndIgnoreRtResolve & ~1);
    bool ignoreRtResolve = (virtualCallOffsetAndIgnoreRtResolve & 1) != 0;
 


### PR DESCRIPTION
There was a bug while relocating where it gets virtualCallOffsetAndIgnoreRtResolve.
Basically it was loading unsigned 32 bit integer from given pointer and casting it
to unsigned 16 bit integer which is valid virtualCallOffsetAndIgnoreRtResolve.
This leads us to load garbage instead of valid value on Big Endian platform where
required value ends up in upper half of the loaded 32 bit integer with lower half
contains garbage value. To fix this it needs to load unsigned 16 bit from the pointer.

Fixes : #4642

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>