### PR TITLE
Symbol validation manager well-known classes

### DIFF
--- a/doc/compiler/aot/SymbolValidationManager.md
+++ b/doc/compiler/aot/SymbolValidationManager.md
@@ -165,6 +165,46 @@ load, these symbols don't need to be validation records stored in
 the SCC. Therefore, the SVM, in its constructor, initializes the maps
 with these IDs and the associated symbols.
 
+### Well-known Classes
+
+Some system classes are loaded very early and are referred to by most
+JIT compilations. The SVM has a list of such classes, termed "well-known
+classes." It will store a single copy of their class chain offsets in
+the SCC. For each AOT-compiled method using the SVM, the emitted
+relocation data needs just one offset into the SCC in order to refer to
+the shared data. This not only deduplicates the offsets; it also allows
+many otherwise necessary records to be eliminated.
+
+In particular, well-known classes never need SystemClassByName,
+ClassByName, or ClassFromCP records. Because these latter two have
+beholders, eliminating them is a bit more difficult than eliminating
+SystemClassByName. In order to make them unnecessary, the SVM checks for
+every class it encounters that the class can see every well-known class,
+failing otherwise. Furthermore, the well-known classes must have names
+that only the bootstrap loader is allowed to define. Then any
+ClassByName or ClassFromCP record naming a well-known class is
+definitely redundant: its beholder can see a class with the given name,
+and that class must have been defined by the bootstrap loader, so it
+must be the same class whose class chain was validated at the beginning
+of the AOT load.
+
+In early compilations, it's possible that not all of the well-known
+classes are available. In order to avoid spurious compilation failures,
+the SVM permits some of the classes to be missing, in which case the
+array of class chain offsets represents only a subset of the possible
+well-known classes. The key under which it is stored specifies the
+subset using (the hexadecimal expansion of) a bit-set. Any classes that
+were missing at the beginning of a compilation are not considered
+well-known for the purpose of that compilation. When loading, the SVM
+finds the well-known classes in the particular subset used for the
+method being loaded.
+
+Each well-known class that is found is assigned the next available
+sequential ID after the guaranteed IDs at the beginning of compilation,
+as long as the well-known class is new (i.e. different from the root
+class). When loading, the well-known classes are assigned sequential IDs
+in the same way, to match the IDs assigned during compilation.
+
 ## Benefits
 
 1. Makes explicit the provenance of every symbol acquired by the compiler

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -370,6 +370,15 @@ J9::AheadOfTimeCompile::dumpRelocationData()
          cursor += 4;
          }
 
+   if (self()->comp()->getOption(TR_UseSymbolValidationManager))
+      {
+      traceMsg(
+         self()->comp(),
+         "SCC offset of class chain offsets of well-known classes is: 0x%llx\n\n",
+         (unsigned long long)*(uintptrj_t *)cursor);
+      cursor += sizeof (uintptrj_t);
+      }
+
    traceMsg(self()->comp(), "Address           Size %-31s", "Type");
    traceMsg(self()->comp(), "Width EIP Index Offsets\n"); // Offsets from Code Start
 

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1388,25 +1388,6 @@ J9::AheadOfTimeCompile::dumpRelocationData()
             }
             break;
 
-         case TR_ValidateClassClass:
-            {
-            cursor++;
-            if (is64BitTarget)
-               cursor += 4;     // padding
-            cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
-            TR_RelocationRecordValidateClassClassBinaryTemplate *binaryTemplate =
-                  reinterpret_cast<TR_RelocationRecordValidateClassClassBinaryTemplate *>(cursor);
-            if (isVerbose)
-               {
-               traceMsg(self()->comp(), "\n Validate Class Class: classClassID=%d, objectClassID=%d ",
-                        (uint32_t)binaryTemplate->_classClassID,
-                        (uint32_t)binaryTemplate->_objectClassID);
-               }
-            cursor += sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate);
-            self()->traceRelocationOffsets(cursor, offsetSize, endOfCurrentRecord, orderedPair);
-            }
-            break;
-
          case TR_ValidateConcreteSubClassFromClass:
             {
             cursor++;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -2848,7 +2848,7 @@ J9::CodeGenerator::processRelocations()
          }
 
       TR::SymbolValidationManager::SymbolValidationRecordList &validationRecords = self()->comp()->getSymbolValidationManager()->getValidationRecordList();
-      if (!validationRecords.empty() && self()->comp()->getOption(TR_UseSymbolValidationManager))
+      if (self()->comp()->getOption(TR_UseSymbolValidationManager))
          {
          // Add the flags in TR_AOTMethodHeader on the compile run
          J9JITDataCacheHeader *aotMethodHeader = (J9JITDataCacheHeader *)self()->comp()->getAotMethodDataStart();

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8029,6 +8029,9 @@ TR::CompilationInfoPerThreadBase::compile(
             TR_ASSERT_FATAL(false, "alwaysFatalAssert set");
          }
 
+         if (vm.isAOT_DEPRECATED_DO_NOT_USE())
+            compiler->getSymbolValidationManager()->populateWellKnownClasses();
+
          rtn = compiler->compile();
 
          if ( TR::Options::getVerboseOption(TR_VerboseCompilationDispatch) && !rtn)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9078,19 +9078,6 @@ TR_J9SharedCacheVM::isReferenceArray(TR_OpaqueClassBlock *classPointer)
       return false;
    }
 
-TR_OpaqueClassBlock *
-TR_J9SharedCacheVM::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
-   {
-   TR_OpaqueClassBlock *ccPointer = TR_J9VM::getClassClassPointer(objectClassPointer);
-   TR::Compilation *comp = TR::comp();
-   if (comp && comp->getOption(TR_UseSymbolValidationManager))
-      {
-      if (!comp->getSymbolValidationManager()->addClassClassRecord(ccPointer, objectClassPointer))
-         ccPointer = NULL;
-      }
-   return ccPointer;
-   }
-
 TR_OpaqueMethodBlock *
 TR_J9SharedCacheVM::getInlinedCallSiteMethod(TR_InlinedCallSite *ics)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1152,8 +1152,6 @@ public:
    virtual bool               javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, int32_t &result);
    virtual TR_OpaqueClassBlock *             getSuperClass(TR_OpaqueClassBlock *classPointer);
 
-   virtual TR_OpaqueClassBlock * getClassClassPointer(TR_OpaqueClassBlock *);
-
    virtual bool               sameClassLoaders(TR_OpaqueClassBlock *, TR_OpaqueClassBlock *);
    virtual bool               isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *);
    virtual bool               classHasBeenExtended(TR_OpaqueClassBlock *);

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -389,9 +389,6 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
       case TR_ValidateDeclaringClassFromFieldOrStatic:
          reloRecord = new (storage) TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic(reloRuntime, record);
          break;
-      case TR_ValidateClassClass:
-         reloRecord = new (storage) TR_RelocationRecordValidateClassClass(reloRuntime, record);
-         break;
       case TR_ValidateConcreteSubClassFromClass:
          reloRecord = new (storage) TR_RelocationRecordValidateConcreteSubClassFromClass(reloRuntime, record);
          break;
@@ -3500,25 +3497,6 @@ TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic::applyRelocation(TR_R
    }
 
 int32_t
-TR_RelocationRecordValidateClassClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
-   {
-   uint16_t classClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassClassBinaryTemplate *)_record)->_classClassID);
-   uint16_t objectClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateClassClassBinaryTemplate *)_record)->_objectClassID);
-
-   if (reloRuntime->reloLogger()->logEnabled())
-      {
-      reloRuntime->reloLogger()->printf("%s\n", name());
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: classClassID %d\n", classClassID);
-      reloRuntime->reloLogger()->printf("\tapplyRelocation: objectClassID %d\n", objectClassID);
-      }
-
-   if (reloRuntime->comp()->getSymbolValidationManager()->validateClassClassRecord(classClassID, objectClassID))
-      return 0;
-   else
-      return compilationAotClassReloFailure;
-   }
-
-int32_t
 TR_RelocationRecordValidateConcreteSubClassFromClass::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
    {
    uint16_t childClassID = reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate *)_record)->_childClassID);
@@ -4598,7 +4576,7 @@ uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRel
    sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate),               // TR_ValidateSystemClassByName                    = 74
    sizeof(TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate),          // TR_ValidateClassFromITableIndexCP               = 75
    sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate), // TR_ValidateDeclaringClassFromFieldOrStatic      = 76
-   sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate),                      // TR_ValidateClassClass                           = 77
+   0,                                                                                // TR_ValidateClassClass                           = 77
    sizeof(TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate),            // TR_ValidateConcreteSubClassFromClass            = 78
    sizeof(TR_RelocationRecordValidateClassChainBinaryTemplate),                      // TR_ValidateClassChain                           = 79
    0,                                                                                // TR_ValidateRomClass                             = 80

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -268,12 +268,6 @@ struct TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate : public 
 
 typedef TR_RelocationRecordValidateClassFromCPBinaryTemplate TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate;
 
-struct TR_RelocationRecordValidateClassClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
-   {
-   uint16_t _classClassID;
-   uint16_t _objectClassID;
-   };
-
 struct TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate : public TR_RelocationRecordBinaryTemplate
    {
    uint16_t _childClassID;
@@ -1517,18 +1511,6 @@ class TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic : public TR_Rel
       virtual bool isValidationRecord() { return true; }
       virtual char *name() { return "TR_RelocationRecordValidateDeclaringClassFromFieldOrStatic"; }
       virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate); }
-      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
-      virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
-   };
-
-class TR_RelocationRecordValidateClassClass : public TR_RelocationRecord
-   {
-   public:
-      TR_RelocationRecordValidateClassClass() {}
-      TR_RelocationRecordValidateClassClass(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
-      virtual bool isValidationRecord() { return true; }
-      virtual char *name() { return "TR_RelocationRecordValidateClassClass"; }
-      virtual int32_t bytesInHeaderAndPayload() { return sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate); }
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
       virtual int32_t applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
    };

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -398,8 +398,9 @@ class TR_RelocationRecordGroup
       void setSize(TR_RelocationTarget *reloTarget, uintptr_t size);
       uintptr_t size(TR_RelocationTarget *reloTarget);
 
-      TR_RelocationRecordBinaryTemplate *firstRecord(TR_RelocationTarget *reloTarget);
+      TR_RelocationRecordBinaryTemplate *firstRecord(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       TR_RelocationRecordBinaryTemplate *pastLastRecord(TR_RelocationTarget *reloTarget);
+      const uintptrj_t *wellKnownClassChainOffsets(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 
       int32_t applyRelocations(TR_RelocationRuntime *reloRuntime,
                                TR_RelocationTarget *reloTarget,

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -688,13 +688,6 @@ TR::SymbolValidationManager::addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueC
    }
 
 bool
-TR::SymbolValidationManager::addClassClassRecord(TR_OpaqueClassBlock *classClass, TR_OpaqueClassBlock *objectClass)
-   {
-   SVM_ASSERT_ALREADY_VALIDATED(this, objectClass);
-   return addClassRecord(classClass, new (_region) ClassClassRecord(classClass, objectClass));
-   }
-
-bool
 TR::SymbolValidationManager::addConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass)
    {
    SVM_ASSERT_ALREADY_VALIDATED(this, superClass);
@@ -1067,15 +1060,6 @@ TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint1
       }
 
    return validateSymbol(definingClassID, definingClass);
-   }
-
-bool
-TR::SymbolValidationManager::validateClassClassRecord(uint16_t classClassID, uint16_t objectClassID)
-   {
-   TR_OpaqueClassBlock *objectClass = getClassFromID(objectClassID);
-   TR_OpaqueClassBlock *classClass = _fej9->getClassClassPointer(objectClass);
-
-   return validateSymbol(classClassID, classClass);
    }
 
 bool
@@ -1568,22 +1552,6 @@ void TR::DeclaringClassFromFieldOrStaticRecord::printFields()
    traceMsg(TR::comp(), "\t_beholder=0x%p\n", _beholder);
    printClass(_beholder);
    traceMsg(TR::comp(), "\t_cpIndex=%d\n", _cpIndex);
-   }
-
-bool TR::ClassClassRecord::isLessThanWithinKind(SymbolValidationRecord *other)
-   {
-   TR::ClassClassRecord *rhs = downcast(this, other);
-   return LexicalOrder::by(_classClass, rhs->_classClass)
-      .thenBy(_objectClass, rhs->_objectClass).less();
-   }
-
-void TR::ClassClassRecord::printFields()
-   {
-   traceMsg(TR::comp(), "ClassClassRecord\n");
-   traceMsg(TR::comp(), "\t_classClass=0x%p\n", _classClass);
-   printClass(_classClass);
-   traceMsg(TR::comp(), "\t_objectClass=0x%p\n", _objectClass);
-   printClass(_objectClass);
    }
 
 bool TR::ConcreteSubClassFromClassRecord::isLessThanWithinKind(

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -34,6 +34,10 @@
 
 #include "j9protos.h"
 
+#if defined (_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
+
 TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee)
    : _symbolID(FIRST_ID),
      _heuristicRegion(0),
@@ -43,16 +47,20 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _fej9((TR_J9VM *)TR_J9VMBase::get(_vmThread->javaVM->jitConfig, _vmThread)),
      _trMemory(_comp->trMemory()),
      _chTable(_comp->getPersistentInfo()->getPersistentCHTable()),
+     _rootClass(compilee->classOfMethod()),
+     _wellKnownClassChainOffsets(NULL),
      _symbolValidationRecords(_region),
      _alreadyGeneratedRecords(LessSymbolValidationRecord(), _region),
      _symbolToIdMap((SymbolToIdComparator()), _region),
      _idToSymbolTable(_region),
-     _seenSymbolsSet((SeenSymbolsComparator()), _region)
+     _seenSymbolsSet((SeenSymbolsComparator()), _region),
+     _wellKnownClasses(_region),
+     _loadersOkForWellKnownClasses(_region)
    {
    assertionsAreFatal(); // Acknowledge the env var whether or not assertions fail
 
    defineGuaranteedID(NULL, TR::SymbolType::typeOpaque);
-   defineGuaranteedID(compilee->classOfMethod(), TR::SymbolType::typeClass);
+   defineGuaranteedID(_rootClass, TR::SymbolType::typeClass);
    defineGuaranteedID(compilee->getPersistentIdentifier(), TR::SymbolType::typeMethod);
 
    struct J9Class ** arrayClasses = &_fej9->getJ9JITConfig()->javaVM->booleanArrayClass;
@@ -77,6 +85,195 @@ TR::SymbolValidationManager::defineGuaranteedID(void *symbol, TR::SymbolType typ
    _symbolToIdMap.insert(std::make_pair(symbol, id));
    setSymbolOfID(id, symbol, type);
    _seenSymbolsSet.insert(symbol);
+   }
+
+void
+TR::SymbolValidationManager::populateWellKnownClasses()
+   {
+#define WELL_KNOWN_CLASS_COUNT 10
+#define REQUIRED_WELL_KNOWN_CLASS_COUNT 1
+
+   // Classes must have names only allowed to be defined by the bootstrap loader
+   // The first REQUIRED_WELL_KNOWN_CLASS_COUNT entries are required - if any is
+   // missing then the compilation will fail.
+   static const char * const names[] =
+      {
+      "java/lang/Class",
+      "java/lang/Object",
+      "java/lang/Integer",
+      "java/lang/Runnable",
+      "java/lang/String",
+      "java/lang/StringBuilder",
+      "java/lang/StringBuffer",
+      "java/lang/System",
+      "java/lang/ref/Reference",
+      "com/ibm/jit/JITHelpers",
+      };
+
+   unsigned int includedClasses = 0;
+
+   static_assert(
+      sizeof (names) / sizeof (names[0]) == WELL_KNOWN_CLASS_COUNT,
+      "wrong number of well-known class names");
+
+   static_assert(
+      CHAR_BIT * sizeof (includedClasses) >= WELL_KNOWN_CLASS_COUNT,
+      "includedClasses needs >= WELL_KNOWN_CLASS_COUNT bits");
+
+   uintptrj_t classChainOffsets[1 + WELL_KNOWN_CLASS_COUNT] = {0};
+   uintptrj_t *classCount = &classChainOffsets[0];
+   uintptrj_t *nextClassChainOffset = &classChainOffsets[1];
+
+   for (int i = 0; i < WELL_KNOWN_CLASS_COUNT; i++)
+      {
+      const char *name = names[i];
+      int32_t len = (int32_t)strlen(name);
+      TR_OpaqueClassBlock *wkClass = _fej9->getSystemClassFromClassName(name, len);
+
+      void *chain = NULL;
+      if (wkClass == NULL)
+         traceMsg(_comp, "well-known class %s not found\n", name);
+      else if (!_fej9->isPublicClass(wkClass))
+         traceMsg(_comp, "well-known class %s is not public\n", name);
+      else
+         chain = _fej9->sharedCache()->rememberClass(wkClass);
+
+      if (chain == NULL)
+         {
+         traceMsg(_comp, "no class chain for well-known class %s\n", name);
+         SVM_ASSERT_NONFATAL(
+            i >= REQUIRED_WELL_KNOWN_CLASS_COUNT,
+            "failed to remember required class %s\n",
+            name);
+         continue;
+         }
+
+      if (wkClass != _rootClass)
+         defineGuaranteedID(wkClass, TR::SymbolType::typeClass);
+
+      includedClasses |= 1 << i;
+      _wellKnownClasses.push_back(wkClass);
+      *nextClassChainOffset++ =
+         (uintptrj_t)_fej9->sharedCache()->offsetInSharedCacheFromPointer(chain);
+      }
+
+   *classCount = _wellKnownClasses.size();
+
+   char key[128];
+   snprintf(key, sizeof (key), "AOTWellKnownClasses:%x", includedClasses);
+
+   J9SharedDataDescriptor dataDescriptor;
+   dataDescriptor.address = (U_8*)classChainOffsets;
+   dataDescriptor.length = (1 + _wellKnownClasses.size()) * sizeof (classChainOffsets[0]);
+   dataDescriptor.type = J9SHR_DATA_TYPE_JITHINT;
+   dataDescriptor.flags = 0;
+
+   _wellKnownClassChainOffsets =
+      _fej9->_jitConfig->javaVM->sharedClassConfig->storeSharedData(
+         _vmThread,
+         key,
+         strlen(key),
+         &dataDescriptor);
+
+   SVM_ASSERT_NONFATAL(
+      _wellKnownClassChainOffsets != NULL,
+      "Failed to store well-known classes' class chains");
+
+#undef WELL_KNOWN_CLASS_COUNT
+   }
+
+bool
+TR::SymbolValidationManager::validateWellKnownClasses(const uintptrj_t *wellKnownClassChainOffsets)
+   {
+   // We may have already run populateWellKnownClasses on this
+   // SymbolValidationManager, if there was no delay before processing the
+   // relocations, in which case the Compilation is reused.
+   bool assignNewIDs = _wellKnownClassChainOffsets == NULL;
+   int classCount = static_cast<int>(wellKnownClassChainOffsets[0]);
+   for (int i = 1; i <= classCount; i++)
+      {
+      void *classChainOffset = reinterpret_cast<void*>(wellKnownClassChainOffsets[i]);
+      uintptrj_t *classChain = reinterpret_cast<uintptrj_t*>(
+         _fej9->sharedCache()->pointerFromOffsetInSharedCache(classChainOffset));
+      J9ROMClass *romClass = _fej9->sharedCache()->startingROMClassOfClassChain(classChain);
+      J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+
+      TR_OpaqueClassBlock *clazz = _fej9->getSystemClassFromClassName(
+         reinterpret_cast<const char *>(J9UTF8_DATA(className)),
+         J9UTF8_LENGTH(className));
+
+      if (clazz == NULL)
+         return false;
+
+      if (!_fej9->sharedCache()->classMatchesCachedVersion(clazz, classChain))
+         return false;
+
+      _seenSymbolsSet.insert(clazz);
+      if (assignNewIDs)
+         {
+         _wellKnownClasses.push_back(clazz);
+         if (clazz != _rootClass)
+            setSymbolOfID(getNewSymbolID(), clazz, TR::SymbolType::typeClass);
+         }
+      }
+
+   // These classes are definitely visible to any other class defined by the
+   // bootstrap loader.
+   _loadersOkForWellKnownClasses.push_back(TR::Compiler->javaVM->systemClassLoader);
+
+   // The root class has a guaranteed ID, so it won't be newly encountered
+   // later. Check now that its loader doesn't hide well-known classes.
+   return classCanSeeWellKnownClasses(_rootClass);
+   }
+
+bool
+TR::SymbolValidationManager::isWellKnownClass(TR_OpaqueClassBlock *clazz)
+   {
+   auto end = _wellKnownClasses.end();
+   return std::find(_wellKnownClasses.begin(), end, clazz) != end;
+   }
+
+bool
+TR::SymbolValidationManager::classCanSeeWellKnownClasses(TR_OpaqueClassBlock *beholder)
+   {
+   J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(reinterpret_cast<J9Class*>(beholder));
+   if (beholderCP == NULL)
+      {
+      // This is a class with no CP, e.g. an array. (Are there any others?)
+      // It can't be used for ClassFromSignature or ClassFromCP anyway.
+      return true;
+      }
+
+   // Avoid repeated lookups using the same loader.
+   J9ClassLoader *loader =
+      reinterpret_cast<J9ClassLoader*>(_fej9->getClassLoader(beholder));
+      {
+      // Use linear search - the number of loaders will generally be small.
+      auto begin = _loadersOkForWellKnownClasses.end();
+      auto end = _loadersOkForWellKnownClasses.end();
+      if (std::find(begin, end, loader) != end)
+         return true;
+      }
+
+   // Check that every well-known class can be found. It's good enough here to
+   // find anything (non-null) for a given name, because these names can only
+   // be defined by the bootstrap loader, so if the class is found, then it
+   // must be the same one found during validateWellKnownClasses().
+   for (auto it = _wellKnownClasses.begin(); it != _wellKnownClasses.end(); ++it)
+      {
+      TR_OpaqueClassBlock *wkClass = *it;
+      J9Class *wkJ9Class = reinterpret_cast<J9Class*>(wkClass);
+      J9UTF8 *utf8 = J9ROMCLASS_CLASSNAME(wkJ9Class->romClass);
+      char *name = reinterpret_cast<char *>(J9UTF8_DATA(utf8));
+      uint32_t len = J9UTF8_LENGTH(utf8);
+      if (_fej9->getClassFromSignature(name, len, beholderCP) == NULL)
+         return false;
+      }
+
+   // All of the well-known classes are visible. This will be the case for all
+   // classes using the same loader, because the well-known classes are public.
+   _loadersOkForWellKnownClasses.push_back(loader);
+   return true;
    }
 
 bool
@@ -376,7 +573,10 @@ bool
 TR::SymbolValidationManager::addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder)
    {
    SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
-   return addClassRecordWithChain(new (_region) ClassByNameRecord(clazz, beholder));
+   if (isWellKnownClass(clazz))
+      return true;
+   else
+      return addClassRecordWithChain(new (_region) ClassByNameRecord(clazz, beholder));
    }
 
 bool
@@ -405,7 +605,10 @@ TR::SymbolValidationManager::addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9
    {
    TR_OpaqueClassBlock *beholder = reinterpret_cast<TR_OpaqueClassBlock *>(J9_CLASS_FROM_CP(constantPoolOfBeholder));
    SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
-   return addClassRecord(clazz, new (_region) ClassFromCPRecord(clazz, beholder, cpIndex));
+   if (isWellKnownClass(clazz))
+      return true;
+   else
+      return addClassRecord(clazz, new (_region) ClassFromCPRecord(clazz, beholder, cpIndex));
    }
 
 bool
@@ -462,7 +665,10 @@ TR::SymbolValidationManager::addClassInstanceOfClassRecord(TR_OpaqueClassBlock *
 bool
 TR::SymbolValidationManager::addSystemClassByNameRecord(TR_OpaqueClassBlock *systemClass)
    {
-   return addClassRecordWithChain(new (_region) SystemClassByNameRecord(systemClass));
+   if (isWellKnownClass(systemClass))
+      return true;
+   else
+      return addClassRecordWithChain(new (_region) SystemClassByNameRecord(systemClass));
    }
 
 bool
@@ -657,9 +863,18 @@ TR::SymbolValidationManager::validateSymbol(uint16_t idToBeValidated, void *vali
       {
       if (_seenSymbolsSet.find(validSymbol) == _seenSymbolsSet.end())
          {
-         setSymbolOfID(idToBeValidated, validSymbol, type);
-         _seenSymbolsSet.insert(validSymbol);
          valid = true;
+         if (type == TR::SymbolType::typeClass)
+            {
+            valid = classCanSeeWellKnownClasses(
+               reinterpret_cast<TR_OpaqueClassBlock*>(validSymbol));
+            }
+
+         if (valid)
+            {
+            setSymbolOfID(idToBeValidated, validSymbol, type);
+            _seenSymbolsSet.insert(validSymbol);
+            }
          }
       }
    else

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -642,6 +642,12 @@ public:
 
    SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee);
 
+   void populateWellKnownClasses();
+   bool validateWellKnownClasses(const uintptrj_t *wellKnownClassChainOffsets);
+   bool isWellKnownClass(TR_OpaqueClassBlock *clazz);
+   bool classCanSeeWellKnownClasses(TR_OpaqueClassBlock *clazz);
+   const void *wellKnownClassChainOffsets() { return _wellKnownClassChainOffsets; }
+
    enum Presence
       {
       SymRequired,
@@ -816,6 +822,9 @@ private:
    TR_Memory * const _trMemory;
    TR_PersistentCHTable * const _chTable;
 
+   TR_OpaqueClassBlock *_rootClass;
+   const void *_wellKnownClassChainOffsets;
+
    /* List of validation records to be written to the AOT buffer */
    SymbolValidationRecordList _symbolValidationRecords;
 
@@ -848,6 +857,14 @@ private:
    IdToSymbolTable _idToSymbolTable;
 
    SeenSymbolsSet _seenSymbolsSet;
+
+   typedef TR::typed_allocator<TR_OpaqueClassBlock*, TR::Region&> ClassAllocator;
+   typedef std::vector<TR_OpaqueClassBlock*, ClassAllocator> ClassVector;
+   ClassVector _wellKnownClasses;
+
+   typedef TR::typed_allocator<J9ClassLoader*, TR::Region&> LoaderAllocator;
+   typedef std::vector<J9ClassLoader*, LoaderAllocator> LoaderVector;
+   LoaderVector _loadersOkForWellKnownClasses;
    };
 
 }

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -337,21 +337,6 @@ struct DeclaringClassFromFieldOrStaticRecord : public ClassValidationRecord
    uint32_t  _cpIndex;
    };
 
-struct ClassClassRecord : public ClassValidationRecord
-   {
-   ClassClassRecord(TR_OpaqueClassBlock *classClass, TR_OpaqueClassBlock *objectClass)
-      : ClassValidationRecord(TR_ValidateClassClass),
-        _classClass(classClass),
-        _objectClass(objectClass)
-      {}
-
-   virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
-   virtual void printFields();
-
-   TR_OpaqueClassBlock *_classClass;
-   TR_OpaqueClassBlock *_objectClass;
-   };
-
 struct ConcreteSubClassFromClassRecord : public ClassValidationRecord
    {
    ConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass)
@@ -679,7 +664,6 @@ public:
    bool addSystemClassByNameRecord(TR_OpaqueClassBlock *systemClass);
    bool addClassFromITableIndexCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex);
    bool addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex);
-   bool addClassClassRecord(TR_OpaqueClassBlock *classClass, TR_OpaqueClassBlock *objectClass);
    bool addConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass);
 
    bool addMethodFromClassRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, uint32_t index);
@@ -720,7 +704,6 @@ public:
    bool validateSystemClassByNameRecord(uint16_t systemClassID, uintptrj_t *classChain);
    bool validateClassFromITableIndexCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex);
-   bool validateClassClassRecord(uint16_t classClassID, uint16_t objectClassID);
    bool validateConcreteSubClassFromClassRecord(uint16_t childClassID, uint16_t superClassID);
 
    bool validateClassChainRecord(uint16_t classID, void *classChain);

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -73,13 +73,37 @@ void J9::X86::AheadOfTimeCompile::processRelocations()
       {
       self()->addToSizeOfAOTRelocations(r->getSizeOfRelocationData());
       }
+
    // now allocate the memory  size of all iterated relocations + the header (total length field)
-   if (self()->getSizeOfAOTRelocations() != 0)
+
+   // Note that when using the SymbolValidationManager, the well-known classes
+   // must be checked even if no explicit records were generated, since they
+   // might be responsible for the lack of records.
+   bool useSVM = self()->comp()->getOption(TR_UseSymbolValidationManager);
+   if (self()->getSizeOfAOTRelocations() != 0 || useSVM)
       {
-      uint8_t *relocationDataCursor = self()->setRelocationData(fej9->allocateRelocationData(self()->comp(), self()->getSizeOfAOTRelocations() + SIZEPOINTER));
+      // It would be more straightforward to put the well-known classes offset
+      // in the AOT method header, but that would use space for AOT bodies that
+      // don't use the SVM. TODO: Move it once SVM takes over?
+      int wellKnownClassesOffsetSize = useSVM ? SIZEPOINTER : 0;
+      uintptrj_t reloBufferSize =
+         self()->getSizeOfAOTRelocations() + SIZEPOINTER + wellKnownClassesOffsetSize;
+      uint8_t *relocationDataCursor = self()->setRelocationData(
+         fej9->allocateRelocationData(self()->comp(), reloBufferSize));
       // set up the size for the region
-      *(uint64_t *)relocationDataCursor = self()->getSizeOfAOTRelocations() + SIZEPOINTER;
+      *(uintptrj_t *)relocationDataCursor = reloBufferSize;
       relocationDataCursor += SIZEPOINTER;
+
+      if (useSVM)
+         {
+         TR::SymbolValidationManager *svm =
+            self()->comp()->getSymbolValidationManager();
+         void *offsets = const_cast<void*>(svm->wellKnownClassChainOffsets());
+         *(uintptrj_t *)relocationDataCursor = reinterpret_cast<uintptrj_t>(
+            fej9->sharedCache()->offsetInSharedCacheFromPointer(offsets));
+         relocationDataCursor += SIZEPOINTER;
+         }
+
       // set up pointers for each iterated relocation and initialize header
       TR::IteratedExternalRelocation *s;
       for (s = self()->getAOTRelocationTargets().getFirst();

--- a/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/x/codegen/J9AheadOfTimeCompile.cpp
@@ -802,22 +802,6 @@ uint8_t *J9::X86::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::Iterated
          }
          break;
 
-      case TR_ValidateClassClass:
-         {
-         TR::ClassClassRecord *record = reinterpret_cast<TR::ClassClassRecord *>(relocation->getTargetAddress());
-
-         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
-
-         TR_RelocationRecordValidateClassClassBinaryTemplate *binaryTemplate =
-               reinterpret_cast<TR_RelocationRecordValidateClassClassBinaryTemplate *>(cursor);
-
-         binaryTemplate->_classClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_classClass));
-         binaryTemplate->_objectClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_objectClass));
-
-         cursor += sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate);
-         }
-         break;
-
       case TR_ValidateConcreteSubClassFromClass:
          {
          TR::ConcreteSubClassFromClassRecord *record = reinterpret_cast<TR::ConcreteSubClassFromClassRecord *>(relocation->getTargetAddress());
@@ -1319,7 +1303,7 @@ uint32_t J9::X86::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_Nu
    sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate), //TR_ValidateSystemClassByName            = 74,
    sizeof(TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate),//TR_ValidateClassFromITableIndexCP   = 75,
    sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate),//TR_ValidateDeclaringClassFromFieldOrStatic=76,
-   sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate),        // TR_ValidateClassClass                  = 77,
+   0,                                                                  // TR_ValidateClassClass                  = 77,
    sizeof(TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate),//TR_ValidateConcreteSubClassFromClass  = 78,
    sizeof(TR_RelocationRecordValidateClassChainBinaryTemplate),        // TR_ValidateClassChain                  = 79,
    0,                                                                  // TR_ValidateRomClass                    = 80,

--- a/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/z/codegen/J9AheadOfTimeCompile.cpp
@@ -559,17 +559,6 @@ uint8_t *J9::Z::AheadOfTimeCompile::initializeAOTRelocationHeader(TR::IteratedEx
          cursor += sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate);
          }
          break;
-      case TR_ValidateClassClass:
-         {
-         TR::ClassClassRecord *record = reinterpret_cast<TR::ClassClassRecord *>(relocation->getTargetAddress());
-         cursor -= sizeof(TR_RelocationRecordBinaryTemplate);
-         TR_RelocationRecordValidateClassClassBinaryTemplate *binaryTemplate =
-               reinterpret_cast<TR_RelocationRecordValidateClassClassBinaryTemplate *>(cursor);
-         binaryTemplate->_classClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_classClass));
-         binaryTemplate->_objectClassID = symValManager->getIDFromSymbol(static_cast<void *>(record->_objectClass));
-         cursor += sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate);
-         }
-         break;
       case TR_ValidateConcreteSubClassFromClass:
          {
          TR::ConcreteSubClassFromClassRecord *record = reinterpret_cast<TR::ConcreteSubClassFromClassRecord *>(relocation->getTargetAddress());
@@ -1473,7 +1462,7 @@ uint32_t J9::Z::AheadOfTimeCompile::_relocationTargetTypeToHeaderSizeMap[TR_NumE
    sizeof(TR_RelocationRecordValidateSystemClassByNameBinaryTemplate), //TR_ValidateSystemClassByName            = 74,
    sizeof(TR_RelocationRecordValidateClassFromITableIndexCPBinaryTemplate),//TR_ValidateClassFromITableIndexCP   = 75,
    sizeof(TR_RelocationRecordValidateDeclaringClassFromFieldOrStaticBinaryTemplate),//TR_ValidateDeclaringClassFromFieldOrStatic=76,
-   sizeof(TR_RelocationRecordValidateClassClassBinaryTemplate),        // TR_ValidateClassClass                  = 77,
+   0,                                                                  // TR_ValidateClassClass                  = 77,
    sizeof(TR_RelocationRecordValidateConcreteSubFromClassBinaryTemplate),//TR_ValidateConcreteSubClassFromClass  = 78,
    sizeof(TR_RelocationRecordValidateClassChainBinaryTemplate),        // TR_ValidateClassChain                  = 79,
    0,                                                                  // TR_ValidateRomClass                    = 80,


### PR DESCRIPTION
Some system classes are loaded very early and are referred to by most JIT compilations. With this commit the symbol validation manager has a list of such classes, termed "well-known classes." It will store a single copy of their class chain offsets in the shared class cache (SCC). For each AOT-compiled method using the symbol validation manager, the emitted relocation data needs just one offset into the SCC in order to refer to the shared data. This not only deduplicates the offsets; it also allows many records to be eliminated:

- `SystemClassByName` records are never needed for well-known classes,

- `ClassClass` records are now completely unnecessary, and

- `ClassByName` and `ClassFromCP` records for well-known classes are made unnecessary by checking eagerly that the well-known classes are visible to all possible "beholders."

`ClassClass` is removed since it's unneeded