### PR TITLE
Convert TR_J9SharedCache APIs in Optimizer to fej9 APIs

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9217,6 +9217,14 @@ TR_J9SharedCacheVM::persistThunk(char *signatureChars, uint32_t signatureLength,
    return thunkStart;
    }
 
+bool
+TR_J9SharedCacheVM::canRememberClass(TR_OpaqueClassBlock *classPtr)
+   {
+   if (_sharedCache)
+      return (_sharedCache->rememberClass((J9Class *) classPtr, false) != NULL);
+   return false;
+   }
+
 //////////////////////////////////////////////////////////
 // TR_J9SharedCacheVM
 //////////////////////////////////////////////////////////

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -996,6 +996,7 @@ public:
    virtual void *getLocationOfClassLoaderObjectPointer(TR_OpaqueClassBlock *classPointer);
    virtual bool isMethodBreakpointed(TR_OpaqueMethodBlock *method);
 
+   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) { return false; }
    private:
 #if !defined(HINTS_IN_SHAREDCACHE_OBJECT)
    uint32_t     getSharedCacheHint(J9VMThread * vmThread, J9Method *romMethod, J9SharedClassConfig * scConfig);
@@ -1183,6 +1184,7 @@ public:
    virtual bool                   supportAllocationInlining( TR::Compilation *comp, TR::Node *node);
 
    virtual J9Class *              getClassForAllocationInlining( TR::Compilation *comp, TR::SymbolReference *classSymRef);
+   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr);
    };
 
 #endif

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -56,7 +56,6 @@
 #include "control/Recompilation.hpp"                      //TR_PersistentJittedBodyInfo
 #include "control/RecompilationInfo.hpp"                  //TR_PersistentJittedBodyInfo
 #include "optimizer/EstimateCodeSize.hpp"
-#include "env/SharedCache.hpp"
 #include "env/VMJ9.h"
 #include "runtime/J9Profiler.hpp"
 #include "ras/DebugCounter.hpp"
@@ -278,20 +277,6 @@ void TR_MultipleCallTargetInliner::generateNodeEstimate::operator ()(TR_CallTarg
       size = size * ((float)(ct->_partialSize)/(float)(ct->_fullSize));
       }
    _nodeEstimate += size;
-   }
-
-bool
-TR_J9InlinerPolicy::isMethodInSharedCache(TR_ResolvedMethod *interfaceMethod)
-   {
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
-   TR_OpaqueClassBlock *clazz = interfaceMethod->classOfMethod();
-   void *dummy;
-   bool clazzInCache = fej9->sharedCache()->isPointerInSharedCache((void*)fej9->getPersistentClassPointerFromClassPointer(clazz), dummy);
-
-   if (clazzInCache)
-      return true;  //fprintf(stderr, "\tsingle interface target found in AOT compilation\n");
-   else
-      return false; //fprintf(stderr, "\tsingle interface target aborted for AOT compilation\n");
    }
 
 bool

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -893,10 +893,8 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
                SVM_ASSERT_ALREADY_VALIDATED(comp()->getSymbolValidationManager(), classOfMethod);
                }
 
-
-            TR_SharedCache *sharedCache = fej9->sharedCache();
-            if (!sharedCache->canRememberClass(tempreceiverClass) ||
-                !sharedCache->canRememberClass(callSiteClass))
+            if (!fej9->canRememberClass(tempreceiverClass) ||
+                !fej9->canRememberClass(callSiteClass))
                {
                if (comp()->trace(OMR::inlining))
                   traceMsg(comp(), "inliner: profiled class [%p] or callSiteClass [%p] cannot be rememberd in shared cache\n", tempreceiverClass, callSiteClass);
@@ -977,9 +975,8 @@ void TR_ProfileableCallSite::findSingleProfiledMethod(ListIterator<TR_ExtraAddre
                break;
                }
 
-         TR_SharedCache *sharedCache = fej9->sharedCache();
-         if (!sharedCache->canRememberClass(clazz) ||
-             !sharedCache->canRememberClass(callSiteClass))
+         if (!fej9->canRememberClass(clazz) ||
+             !fej9->canRememberClass(callSiteClass))
             {
             classValuesAreSane = false;
             break;

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -234,7 +234,6 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
       bool validateArguments(TR_CallTarget *calltarget, TR_LinkHead<TR_ParameterMapping> &map);
       virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
       virtual TR_InlinerFailureReason checkIfTargetInlineable(TR_CallTarget* target, TR_CallSite* callsite, TR::Compilation* comp);
-      bool isMethodInSharedCache(TR_ResolvedMethod *interfaceMethod);
    };
 
 class TR_J9JSR292InlinerPolicy : public TR_J9InlinerPolicy


### PR DESCRIPTION
The purpose of this change is to hide away the TR_J9SharedCache APIs that are called in the Optimizer so that the Optimizer doesn't need to know about the TR_J9SharedCache object. The Optimizer can query information about the TR_J9SharedCache object through J9 frontend APIs.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>