### PR TITLE
Commonize definitions of jint & jbyte

### DIFF
--- a/runtime/include/jni.h
+++ b/runtime/include/jni.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,11 +69,11 @@ extern "C" {
 #define JNI_EINVAL			(-6)
 
 typedef unsigned char jboolean;
-/* jbyte is platform specific */
+typedef signed char jbyte;
 typedef unsigned short jchar;
 typedef short jshort;
-/* jint is platform specific */
-/* jlong is platform specific */
+typedef int jint;
+/* jlong is platform specific - defined in jniport.h */
 typedef float jfloat;
 typedef double jdouble;
 typedef jint jsize;

--- a/runtime/include/jniport.h
+++ b/runtime/include/jniport.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,27 +23,17 @@
 #ifndef jniport_h
 #define jniport_h
 
-#if defined(WIN32) || (defined(_WIN32)) || (defined(BREW) && defined(AEE_SIMULATOR))
+#if defined(WIN32)
 
 #define JNIEXPORT __declspec(dllexport)
 #define JNICALL __stdcall
-typedef signed char jbyte;
-typedef int jint;
 typedef __int64 jlong;
 
-#else
+#else /* WIN32 */
 
 #define JNIEXPORT 
 
-typedef signed char jbyte;
 typedef long long jlong;
-
-#ifdef BREW
-#include "AEEFile.h"
-#define FILE IFile
-#endif
-
-typedef int jint;
 
 #endif /* WIN32 */
 


### PR DESCRIPTION
Removed ifdefs for unsupported platforms and cleaned up duplicate
definitions.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>