### PR TITLE
Implement constructor of TR_RelocatableJ9JITaaSServerMethod

### DIFF
--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -103,6 +103,8 @@ enum J9ServerMessageType
    ResolvedMethod_isUnresolvedString = 148;
    ResolvedMethod_stringConstant = 149;
 
+   ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 150;
+
    // For TR_J9ServerVM methods
    VM_isClassLibraryClass = 200;
    VM_isClassLibraryMethod = 201;


### PR DESCRIPTION
- Implemented `createResolvedMethodFromJ9Method`.
Methods are implemented in a way that attempts to minimize the number
of remote messages required to create a resolved method.
Constructor of `TR_RelocatableJ9JITaaSServerMethod` is always called
from within another method of the same class. So, we can minimize the number
of messages exchanged by merging messages for constructor and its caller into one.
I.e. we mirror the method on the client and retrieve information required by caller
in one remote message.

- Renamed setAttributes to `unpackMethodInfo`, because it's clearer and I also added
method `packMethodInfo`.

- Made the entire compilation before relocations a heuristic region on the client.
We do this because when a client-side query gets called in AOT mode, it will try to
add SVM records on the client, which may lead to creating invalid records that will fail
validation. In heuristic region, however, SVM assumes that everything is validated, so
we shouldn't have any problems.