### PR TITLE
JDK12: set system properties java.vendor, java.vendor.url and java.vendor.url.bug

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -378,7 +378,10 @@ private static void ensureProperties() {
 	systemProperties.put("sun.jnu.encoding", platformEncoding); //$NON-NLS-1$
 	systemProperties.put("file.encoding", fileEncoding); //$NON-NLS-1$
 	systemProperties.put("file.encoding.pkg", "sun.io"); //$NON-NLS-1$ //$NON-NLS-2$
+	/*[IF !Java12]*/
+	/* System property java.specification.vendor is set via VersionProps.init(systemProperties) since JDK12 */
 	systemProperties.put("java.specification.vendor", "Oracle Corporation"); //$NON-NLS-1$ //$NON-NLS-2$
+	/*[ENDIF] !Java12 */
 	systemProperties.put("java.specification.name", "Java Platform API Specification"); //$NON-NLS-1$ //$NON-NLS-2$
 	systemProperties.put("com.ibm.oti.configuration", "scar"); //$NON-NLS-1$
 
@@ -397,6 +400,9 @@ private static void ensureProperties() {
 	/*[IF Java12]*/
 	/* java.lang.VersionProps.init() eventually calls into System.setProperty() where propertiesInitialized needs to be true */
 	java.lang.VersionProps.init(systemProperties);
+	/* VersionProps.init(systemProperties) above sets java.specification.version value which is used to set java.vm.specification.version. */
+	systemProperties.put("java.vm.specification.version", systemProperties.getProperty("java.specification.version")); //$NON-NLS-1$ //$NON-NLS-2$
+	systemProperties.put("java.vm.vendor", systemProperties.getProperty("java.vendor")); //$NON-NLS-1$ //$NON-NLS-2$
 	/*[ELSE]
 	/*[IF Sidecar19-SE]*/
 	/* java.lang.VersionProps.init() eventually calls into System.setProperty() where propertiesInitialized needs to be true */
@@ -507,12 +513,14 @@ static Properties internalGetProperties() {
  * The properties currently provided by the virtual
  * machine are:
  * <pre>
+/*[IF !Java12]
+ *     java.vendor
  *     java.vendor.url
+ /*[ENDIF] Java12
  *     java.class.path
  *     user.home
  *     java.class.version
  *     os.version
- *     java.vendor
  *     user.dir
  *     user.timezone
  *     path.separator

--- a/runtime/include/vendor_version.h
+++ b/runtime/include/vendor_version.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,8 +48,16 @@
 
 #define VENDOR_SHORT_NAME "OpenJ9"
 
+#if JAVA_SPEC_VERSION < 12
+/* Pre-JDK12 version use following defines to set system properties
+ * java.vendor, java.vendor.url and java.vm.vendor within vmprop.c:initializeSystemProperties(vm).
+ * JDK12 (assuming future versions as well) sets these properties via java.lang.VersionProps.init(systemProperties) 
+ * and following settings within System.ensureProperties().
+ */
 #define JAVA_VENDOR "Eclipse OpenJ9"
 #define JAVA_VENDOR_URL "http://www.eclipse.org/openj9"
+#endif /* JAVA_SPEC_VERSION < 12 */
+
 #define JAVA_VM_NAME "Eclipse OpenJ9 VM"
 
 #endif     /* vendor_version_h */


### PR DESCRIPTION
`JDK12`: set system properties `java.vendor`, `java.vendor.url` and `java.vendor.url.bug`

`JDK12` `VersionProps.init(systemProperties)` sets system properties `java.vendor`, `java.vendor.url`, `java.vendor.url.bug`, `java.class.version`, `java.specification.version` and `java.specification.vendor`. Avoid duplication property setting in `OpenJ9`;
Also moved system properties `java.vm.specification.version` and `java.vm.vendor` setting from native to Java code to use the value of `java.specification.version` set by `VersionProps.init(systemProperties)`.

Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk12/pull/13

Fixes #4660

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>