### PR TITLE
Avoid unnecessary SVM records for field references

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -781,6 +781,7 @@ private:
    bool addClassRecordWithChain(TR::ClassValidationRecordWithChain *record);
    void addMultipleArrayRecords(TR_OpaqueClassBlock *clazz, int arrayDims);
    bool addMethodRecord(TR::MethodValidationRecord *record);
+   bool skipFieldRefClassRecord(TR_OpaqueClassBlock *definingClass, TR_OpaqueClassBlock *beholder, uint32_t cpIndex);
 
    bool validateSymbol(uint16_t idToBeValidated, void *validSymbol, TR::SymbolType type);
    bool validateSymbol(uint16_t idToBeValidated, TR_OpaqueClassBlock *clazz);


### PR DESCRIPTION
Certain records generated by the symbol validation manager (SVM) identify the class in which an (instance or static) field was found, based on a constant pool field reference. If the beholder refers to one of its own fields, or to a field of a well-known class, and if it does so by naming the class that declares the field (not a subclass), then no record is necessary. The class reference is unambiguous and it must succeed, and because the class chain of the named class will have been validated, the field must be found again directly in that class.