### PR TITLE
Clean up of Concurrent Scavenge code on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -10555,7 +10555,7 @@ static TR::Register *inlineConcurrentLinkedQueueTMOffer(TR::Node *node, TR::Code
    static char * debugTM = feGetEnv("TR_DebugTM");
 
    /*
-    * TODO: TM is currently not compatible with read barriers. If read barriers are required, TM is disabled until the issue is fixed.
+    * TM is not compatible with read barriers. If read barriers are required, TM is disabled.
     */
    if (disableTMOffer || TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
       {
@@ -10761,7 +10761,7 @@ static TR::Register *inlineConcurrentLinkedQueueTMPoll(TR::Node *node, TR::CodeG
    static char * debugTM = feGetEnv("TR_DebugTM");
 
    /*
-    * TODO: TM is currently not compatible with read barriers. If read barriers are required, TM is disabled until the issue is fixed.
+    * TM is not compatible with read barriers. If read barriers are required, TM is disabled.
     */
    if (disableTMPoll || TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
       {
@@ -12570,7 +12570,6 @@ static void inlineVSXArrayCopy(TR::Node *node, TR::Register *srcAddrReg, TR::Reg
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, lengthReg, lengthReg, -1);
       }
    generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
-   return;
    }
 
 extern TR::Register *inlineLongRotateLeft(TR::Node *node, TR::CodeGenerator *cg);
@@ -13829,27 +13828,17 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
          if (stopUsingCopyReg5)
             cg->stopUsingRegister(lengthReg);
 
-         if (tmp1Reg)
-            cg->stopUsingRegister(tmp1Reg);
-         if (tmp2Reg)
-            cg->stopUsingRegister(tmp2Reg);
-         if (tmp3Reg)
-            cg->stopUsingRegister(tmp3Reg);
-         if (tmp4Reg)
-            cg->stopUsingRegister(tmp4Reg);
-         if (fp1Reg)
-            cg->stopUsingRegister(fp1Reg);
-         if (fp2Reg)
-            cg->stopUsingRegister(fp2Reg);
-         if (fp3Reg)
-            cg->stopUsingRegister(fp3Reg);
-         if (fp4Reg)
-            cg->stopUsingRegister(fp4Reg);
+         cg->stopUsingRegister(tmp1Reg);
+         cg->stopUsingRegister(tmp2Reg);
+         cg->stopUsingRegister(tmp3Reg);
+         cg->stopUsingRegister(tmp4Reg);
+         cg->stopUsingRegister(fp1Reg);
+         cg->stopUsingRegister(fp2Reg);
+         cg->stopUsingRegister(fp3Reg);
+         cg->stopUsingRegister(fp4Reg);
 
-         if (r3Reg)
-            cg->stopUsingRegister(r3Reg);
-         if (condReg)
-            cg->stopUsingRegister(condReg);
+         cg->stopUsingRegister(r3Reg);
+         cg->stopUsingRegister(condReg);
 
          cg->machine()->setLinkRegisterKilled(true);
          cg->setHasCall();
@@ -14166,28 +14155,18 @@ TR::Register *J9::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::C
       cg->stopUsingRegister(dstAddrReg);
    if (stopUsingCopyReg5)
       cg->stopUsingRegister(lengthReg);
-   if (tmp1Reg)
-      cg->stopUsingRegister(tmp1Reg);
-   if (tmp2Reg)
-      cg->stopUsingRegister(tmp2Reg);
-   if (tmp3Reg)
-      cg->stopUsingRegister(tmp3Reg);
-   if (tmp4Reg)
-      cg->stopUsingRegister(tmp4Reg);
-   if (fp1Reg)
-      cg->stopUsingRegister(fp1Reg);
-   if (fp2Reg)
-      cg->stopUsingRegister(fp2Reg);
-   if (vec0Reg)
-      cg->stopUsingRegister(vec0Reg);
-   if (vec1Reg)
-      cg->stopUsingRegister(vec1Reg);
-   if (r3Reg)
-      cg->stopUsingRegister(r3Reg);
-   if (r4Reg)
-      cg->stopUsingRegister(r4Reg);
-   if (condReg)
-      cg->stopUsingRegister(condReg);
+
+   cg->stopUsingRegister(tmp1Reg);
+   cg->stopUsingRegister(tmp2Reg);
+   cg->stopUsingRegister(tmp3Reg);
+   cg->stopUsingRegister(tmp4Reg);
+   cg->stopUsingRegister(fp1Reg);
+   cg->stopUsingRegister(fp2Reg);
+   cg->stopUsingRegister(vec0Reg);
+   cg->stopUsingRegister(vec1Reg);
+   cg->stopUsingRegister(r3Reg);
+   cg->stopUsingRegister(r4Reg);
+   cg->stopUsingRegister(condReg);
 
    cg->machine()->setLinkRegisterKilled(true);
    cg->setHasCall();


### PR DESCRIPTION
Comment regarding compatibility of TM and concurrent scavenge was updated.
At the current time there are no plans to be able to support both at the
time time so it was removed as being a TODO.

stopUsingRegister already performs a NULL check on the register so the
NULL checks before the calls were unnecessary.

Issue: #3421
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>