### PR TITLE
Add range check test around profiled guard method test

### DIFF
--- a/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 
 
     ReserveCodeCachePhase,
+    FixUpProfiledInterfaceGuardTest,
 
 
     InliningReportPhase,

--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -58,6 +58,11 @@ J9::CodeGenPhase::getNumPhases()
    return static_cast<int>(TR::CodeGenPhase::LastJ9Phase);
    }
 
+void 
+J9::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
+   {
+   cg->fixUpProfiledInterfaceGuardTest();
+   }
 
 void
 J9::CodeGenPhase::performAllocateLinkageRegistersPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
@@ -145,6 +150,8 @@ J9::CodeGenPhase::getName(TR::CodeGenPhase::PhaseValue phase)
 	      return "IdentifyUnneededByteConvsPhase";
       case LateSequentialConstantStoreSimplificationPhase:
          return "LateSequentialConstantStoreSimplification";
+      case FixUpProfiledInterfaceGuardTest:
+         return "FixUpProfiledInterfaceGuardTest";
       default:
          return OMR::CodeGenPhaseConnector::getName(phase);
       }

--- a/runtime/compiler/codegen/J9CodeGenPhase.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ class OMR_EXTENSIBLE CodeGenPhase: public OMR::CodeGenPhaseConnector
    public:
 
    void reportPhase(PhaseValue phase);
-
+   static void performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
    static void performAllocateLinkageRegistersPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performPopulateOSRBufferPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performMoveUpArrayLengthStoresPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);

--- a/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 #include "codegen/OMRCodeGenPhaseEnum.hpp"
 
 // The entries in this file must be kept in sync with codegen/J9CodeGenPhaseFunctionTable.hpp
-
+   FixUpProfiledInterfaceGuardTest,
    AllocateLinkageRegisters,
    PopulateOSRBufferPhase,
    MoveUpArrayLengthStoresPhase,

--- a/runtime/compiler/codegen/J9CodeGenPhaseFunctionTable.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhaseFunctionTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 #include "codegen/OMRCodeGenPhaseFunctionTable.hpp"
 
 // The entries in this file must be kept in sync with codegen/J9CodeGenPhaseEnum.hpp
+   TR::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase,
    TR::CodeGenPhase::performAllocateLinkageRegistersPhase,                                   //AllocateLinkageRegisters
    TR::CodeGenPhase::performPopulateOSRBufferPhase,                                          //PopulateOSRBufferPhase
    TR::CodeGenPhase::performMoveUpArrayLengthStoresPhase,                                    //MoveUpArrayLengthStoresPhase

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -100,6 +100,8 @@ public:
 
    void allocateLinkageRegisters();
 
+   void fixUpProfiledInterfaceGuardTest();
+
    void zeroOutAutoOnEdge(TR::SymbolReference * liveAutoSym, TR::Block *block, TR::Block *succBlock, TR::list<TR::Block*> *newBlocks, TR_ScratchList<TR::Node> *fsdStores);
 
    TR::Linkage *createLinkageForCompilation();

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@
 
 
     ReserveCodeCachePhase,
-
+    FixUpProfiledInterfaceGuardTest,
 
     InliningReportPhase,
     LateSequentialConstantStoreSimplificationPhase,


### PR DESCRIPTION
In OpenJ9 we take advantage of the profiled information in inlining method for virtual call. While inlining the method, we generate a guard around inlined code to make sure that the inlined implementation is indeed what we need to execute. For this `TR_ProfiledGuard**`
kind of guard it either `TR_VftTest` or `TR_MethodTest`.

In case of `TR_MethodTest`, it records the offset of the inlined method in the Virtual Function Table of the class in which that method belongs to and compares the value at the same offset of class of receiver object with the `J9Method` of inlined method. This comparison introduces a functional bug.
Some classes would have smaller function table and recorded offset w.r.t the class
might point to a garbage value or even might be inaddressible (Out of mapped memory range). This commit adds a range check test around the TR_MethodTest to verify that address that we are going to reference points to valid address.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>