### PR TITLE
Handle the receiving of AOT code on JITaaS client

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.hpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.hpp
@@ -210,7 +210,9 @@ std::string packROMClass(J9ROMClass *, TR_Memory *);
 bool handleServerMessage(JITaaS::J9ClientStream *, TR_J9VM *);
 TR_MethodMetaData *remoteCompile(J9VMThread *, TR::Compilation *, TR_ResolvedMethod *,
       J9Method *, TR::IlGeneratorMethodDetails &, TR::CompilationInfoPerThreadBase *);
-void remoteCompilationEnd(TR::IlGeneratorMethodDetails &details, J9JITConfig *jitConfig,
+TR_MethodMetaData *remoteCompilationEnd(J9VMThread * vmThread, TR::Compilation *comp, TR_ResolvedMethod * compilee, J9Method * method,
+                          TR::CompilationInfoPerThreadBase *compInfoPT, const std::string& codeCacheStr, const std::string& dataCacheStr);
+void outOfProcessCompilationEnd(TR::IlGeneratorMethodDetails &details, J9JITConfig *jitConfig,
       TR_FrontEnd *fe, TR_MethodToBeCompiled *entry, TR::Compilation *comp);
 void printJITaaSMsgStats(J9JITConfig *);
 void printJITaaSCHTableStats(J9JITConfig *, TR::CompilationInfo *);

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -250,7 +250,7 @@ bool TR_CHTable::commit(TR::Compilation *comp)
    {
    if (TR::CompilationInfo::getStream())
       {
-      return true; // Handled in remoteCompilationEnd instead
+      return true; // Handled in outOfProcessCompilationEnd instead
       }
    else
       {


### PR DESCRIPTION
- rename original remoteCompilationEnd() to outOfProcessCompilationEnd() because in our terms, remoteCompile indicates that they are client routines and outOfProcessCompile indicates they are server routines. In this case, the original remoteCompilationEnd() is a server routine that deals with the packing and sending of out-of-process compiled code.
- create new remoteCompilationEnd(), a client routine, to handle the installation of compiled code for both remote JIT and remote AOT compilations. For AOT compilations, they first get written to the Shared Class Cache if possible.

Issue: #4401
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>