### PR TITLE
Enforce a return value of 0 or 1 for JNI boolean

### DIFF
--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.cpp
@@ -2823,6 +2823,55 @@ void TR::J9S390JNILinkage::checkException(TR::Node * callNode,
    generateS390LabelInstruction(self()->cg(), TR::InstOpCode::LABEL, callNode, exceptionRestartLabel);
    }
 
+void
+TR::J9S390JNILinkage::processJNIReturnValue(TR::Node * callNode,
+                                            TR::CodeGenerator* cg,
+                                            TR::Register* javaReturnRegister)
+   {
+   auto resolvedMethod = callNode->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod();
+   auto returnType = resolvedMethod->returnType();
+   const bool isUnwrapAddressReturnValue = !((TR_J9VMBase *)fe())->jniDoNotWrapObjects(resolvedMethod)
+                                            && (returnType == TR::Address);
+
+   TR::LabelSymbol *cFlowRegionStart = NULL, *cFlowRegionEnd = NULL;
+
+   if (isUnwrapAddressReturnValue)
+      {
+      cFlowRegionStart = generateLabelSymbol(cg);
+      cFlowRegionEnd = generateLabelSymbol(cg);
+
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, cFlowRegionStart);
+      cFlowRegionStart->setStartInternalControlFlow();
+      generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), callNode, javaReturnRegister, 0, TR::InstOpCode::COND_BE, cFlowRegionEnd);
+      generateRXInstruction(cg, TR::InstOpCode::getLoadOpCode(), callNode, javaReturnRegister,
+                            generateS390MemoryReference(javaReturnRegister, 0, cg));
+
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, cFlowRegionEnd);
+      cFlowRegionEnd->setEndInternalControlFlow();
+      }
+   else if ((returnType == TR::Int8) && comp()->getSymRefTab()->isReturnTypeBool(callNode->getSymbolReference()))
+      {
+      if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z13))
+         {
+         generateRIInstruction(cg, TR::InstOpCode::getCmpHalfWordImmOpCode(), callNode, javaReturnRegister, 0);
+         generateRIEInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LOCGHI : TR::InstOpCode::LOCHI,
+                                callNode, javaReturnRegister, 1, TR::InstOpCode::COND_BNE);
+         }
+      else
+         {
+         cFlowRegionStart = generateLabelSymbol(cg);
+         cFlowRegionEnd = generateLabelSymbol(cg);
+
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, cFlowRegionStart);
+         cFlowRegionStart->setStartInternalControlFlow();
+         generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), callNode, javaReturnRegister,
+                                                 0, TR::InstOpCode::COND_BE, cFlowRegionEnd);
+         generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), callNode, javaReturnRegister, 1);
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, cFlowRegionEnd);
+         cFlowRegionEnd->setEndInternalControlFlow();
+         }
+      }
+   }
 
 TR::Register * TR::J9S390JNILinkage::buildDirectDispatch(TR::Node * callNode)
    {
@@ -2887,7 +2936,6 @@ TR::Register * TR::J9S390JNILinkage::buildDirectDispatch(TR::Node * callNode)
    bool isAcquireVMAccess = isReleaseVMAccess;
    bool isCollapseJNIReferenceFrame = !fej9->jniNoSpecialTeardown(resolvedMethod);
    bool isCheckException = !fej9->jniNoExceptionsThrown(resolvedMethod);
-   bool isUnwrapAddressReturnValue = !fej9->jniDoNotWrapObjects(resolvedMethod);
    bool isKillAllUnlockedGPRs = isJNIGCPoint;
 
    killMask = killAndAssignRegister(killMask, deps, &methodAddressReg, (TR::Compiler->target.isLinux()) ?  TR::RealRegister::GPR1 : TR::RealRegister::GPR9 , codeGen, true);
@@ -3028,31 +3076,7 @@ TR::Register * TR::J9S390JNILinkage::buildDirectDispatch(TR::Node * callNode)
    generateRXInstruction(codeGen, TR::InstOpCode::getAddOpCode(), callNode, javaStackPointerRealRegister,
             new (trHeapMemory()) TR::MemoryReference(methodMetaDataVirtualRegister, (int32_t)fej9->thisThreadGetJavaLiteralsOffset(), codeGen));
 
-   isUnwrapAddressReturnValue = (isUnwrapAddressReturnValue &&
-                         (returnType == TR::Address) &&
-                         (javaReturnRegister!= NULL) &&
-                         (javaReturnRegister->getKind() == TR_GPR));
-
-   if (isUnwrapAddressReturnValue)
-     {
-     TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(codeGen);
-     TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(codeGen);
-
-     generateS390LabelInstruction(codeGen, TR::InstOpCode::LABEL, callNode, cFlowRegionStart);
-     cFlowRegionStart->setStartInternalControlFlow();
-     generateS390CompareAndBranchInstruction(codeGen, TR::InstOpCode::getCmpOpCode(), callNode, javaReturnRegister, (signed char)0, TR::InstOpCode::COND_BE, cFlowRegionEnd);
-     generateRXInstruction(codeGen, TR::InstOpCode::getLoadOpCode(), callNode, javaReturnRegister,
-                generateS390MemoryReference(javaReturnRegister, 0, codeGen));
-
-
-     int32_t regPos = deps->searchPostConditionRegisterPos(javaReturnRegister);
-     TR::RealRegister::RegNum realReg = deps->getPostConditions()->getRegisterDependency(regPos)->getRealRegister();
-     TR::RegisterDependencyConditions * postDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg());
-     postDeps->addPostCondition(javaReturnRegister, realReg);
-
-     generateS390LabelInstruction(codeGen, TR::InstOpCode::LABEL, callNode, cFlowRegionEnd, postDeps);
-     cFlowRegionEnd->setEndInternalControlFlow();
-     }
+   processJNIReturnValue(callNode, codeGen, javaReturnRegister);
 
    if (isCollapseJNIReferenceFrame)
      {

--- a/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
+++ b/runtime/compiler/z/codegen/J9S390PrivateLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -145,6 +145,25 @@ public:
 
    J9S390JNILinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc=TR_JavaPrivate, TR_LinkageConventions lc=TR_J9JNILinkage);
    virtual TR::Register * buildDirectDispatch(TR::Node * callNode);
+
+   /**
+    * \brief
+    *   JNI return value processing:
+    *   1) Unwrap return value if needed for object return types, or
+    *   2) Enforce a return value of 0 or 1 for boolean return type
+    *
+    * \param callNode
+    *   The JNI call node to be evaluated.
+    *
+    * \param cg
+    *   The code generator object.
+    *
+    * \param javaReturnRegister
+    *   Register for the JNI call return value.
+   */
+   void processJNIReturnValue(TR::Node * callNode,
+                              TR::CodeGenerator* cg,
+                              TR::Register* javaReturnRegister);
 
    void checkException(TR::Node * callNode, TR::Register *methodMetaDataVirtualRegister, TR::Register * tempReg);
    void releaseVMAccessMask(TR::Node * callNode, TR::Register * methodMetaDataVirtualRegister,


### PR DESCRIPTION
Make sure JNI boolean return value is either 0 or 1 by loading a 'one' into
the return value register if it's not zero.

Slightly refactor JNI linkage return value processing code.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>