### PR TITLE
Disable callerClassLoader optimization under AOT

### DIFF
--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -262,7 +262,7 @@ bool TR_J9ByteCodeIlGenerator::internalGenIL()
                            fej9()->stackWalkerMaySkipFrames(caller1->getPersistentIdentifier(),callerClass1));
 
 
-            if (doIt)
+            if (doIt && !comp()->compileRelocatableCode())
                {
                if (recognizedMethod == TR::java_lang_ClassLoader_callerClassLoader
                   )


### PR DESCRIPTION
Previously, `j/l/ClassLoader.callerClassLoader` was optimized during IL
generation if it was inlined into a method which itself was inlined into
another method. Under these circumstances, the address of the calling
method's class loader would be hardcoded into the instruction stream.
This causes problems under AOT, since the address of the caller's class
loader was not being properly relocated. Since there is not yet any
relocation that could handle this, this particular optimization has been
disabled under AOT for the time being.

Signed-off-by: Ben Thomas <ben@benthomas.ca>