### PR TITLE
Ensure case conversion inrinsic return zero or one on X86

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12130,7 +12130,7 @@ J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node, TR::CodeGener
    auto ascciUpperBnd = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
    cursor = generateRegMemInstruction(MOVDQURegMem, node, xmmRegAsciiUpperBnd, ascciUpperBnd, cg); iComment("maximum ascii value ");
 
-   generateRegRegInstruction(MOVRegReg(), node, result, dstArray, cg);
+   generateRegImmInstruction(MOVRegImm4(), node, result, 1, cg);
 
    // initialize the loop counter
    cursor = generateRegRegInstruction(XORRegReg(), node, counter, counter, cg); iComment("initialize loop counter");


### PR DESCRIPTION
com/ibm/jit/JITHelpers.to{Upper,Lower}Intrinsic{UTF16,Latin1} returns a boolean and hence the returned value should be either zero or one per current Java specs.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>