### PR TITLE
Fix improper J9Class materialization during IL generation

### DIFF
--- a/runtime/compiler/env/j9fieldsInfo.cpp
+++ b/runtime/compiler/env/j9fieldsInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -149,11 +149,12 @@ TR_VMFieldsInfo::TR_VMFieldsInfo(TR::Compilation * comp, J9Class *aClazz, int bu
       }
 
    //supers
-   J9Class **supClasses = aClazz->superclasses;
    int numSupClasses = J9CLASS_DEPTH(aClazz);
+   J9Class *supClass = aClazz;
    for (i=numSupClasses-1; i>=0; i--)
       {
-      J9Class *supClass = supClasses[i];
+      supClass = (J9Class*)comp->fej9()->getSuperClass((TR_OpaqueClassBlock*)supClass);
+      TR_ASSERT(supClass, "Found NULL supClass in inheritance chain");
       romCl = supClass->romClass;
 
       // iterate through the fields creating TR_VMField and inserting them into a List

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -8008,7 +8008,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
          // Construct the signature string for the array class
          //
          UDATA arity = arrayJ9Class->arity;
-         J9Class *leafClass = arrayJ9Class->leafComponentType;
+         J9Class *leafClass = (J9Class*)fej9->getLeafComponentClassFromArrayClass((TR_OpaqueClassBlock*)arrayJ9Class);
          int32_t leafClassNameLength;
          char *leafClassNameChars = fej9->getClassNameChars((TR_OpaqueClassBlock*)leafClass, leafClassNameLength); // eww, TR_FrontEnd downcast
 


### PR DESCRIPTION
There were a couple of instances during IL generation where the
internals of a J9Class were used to get access to a related J9Class
without using the proper APIs to do so. This was causing problems under
SVM AOT, since no validation records would be emitted when this
occurred. These have been fixed to use the proper APIs, which should
ensure that the correct validation records get emitted.

Signed-off-by: Ben Thomas <ben@benthomas.ca>