### PR TITLE
Migrate randomgen architecture disabling from OpenJ9 to OMR

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -62,40 +62,6 @@ J9::Z::CodeGenerator::CodeGenerator() :
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
-   // Do random Disable<Platform> when -Xjit randomGen
-   if (comp->getOption(TR_Randomize))
-      {
-      switch(randomizer.randomInt(TR::Compiler->target.cpu.id() - TR_s370gp7))
-         {
-         case 1:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z196);
-            traceMsg(comp, "disablez196");
-            break;
-            }
-
-         case 2:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_zEC12);
-            traceMsg(comp, "disablezEC12");
-            break;
-            }
-
-         case 3:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_z13);
-            traceMsg(comp, "disablez13");
-            break;
-            }
-         case 4:
-            {
-            _processorInfo.disableArch(TR_S390ProcessorInfo::TR_zNext);
-            traceMsg(comp, "RandomGen: Setting disabling zNext processor architecture.");
-            break;
-            }
-         }
-      }
-
    cg->setAheadOfTimeCompile(new (cg->trHeapMemory()) TR::AheadOfTimeCompile(cg));
 
    // Java specific runtime helpers


### PR DESCRIPTION
Fixes: #3576

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>