### PR TITLE
Reimplement storeValidationRecordIfNecessary

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -1588,6 +1588,20 @@ bool handleServerMessage(JITaaS::J9ClientStream *client, TR_J9VM *fe)
          client->write(methodInfo, isRomClassForMethodInSC, sameLoaders, sameClass, rememberedClass);
          }
          break;
+      case J9ServerMessageType::ResolvedRelocatableMethod_storeValidationRecordIfNecessary:
+         {
+         auto recv = client->getRecvData<J9Method *, J9ConstantPool *, int32_t, bool>();
+         auto ramMethod = std::get<0>(recv);
+         auto constantPool = std::get<1>(recv);
+         auto cpIndex = std::get<2>(recv);
+         bool isStatic = std::get<3>(recv);
+         J9Class *clazz = (J9Class *) J9_CLASS_FROM_METHOD(ramMethod);
+         J9Class *definingClass = (J9Class *) compInfoPT->reloRuntime()->getClassFromCP(fe->vmThread(), fe->_jitConfig->javaVM, constantPool, cpIndex, isStatic);
+         UDATA *classChain = fe->sharedCache()->rememberClass(definingClass);
+
+         client->write(clazz, definingClass, classChain);
+         }
+         break;
       case J9ServerMessageType::CompInfo_isCompiled:
          {
          J9Method *method = std::get<0>(client->getRecvData<J9Method *>());

--- a/runtime/compiler/rpc/protos/compile.proto
+++ b/runtime/compiler/rpc/protos/compile.proto
@@ -104,6 +104,7 @@ enum J9ServerMessageType
    ResolvedMethod_stringConstant = 149;
 
    ResolvedRelocatableMethod_createResolvedRelocatableJ9Method = 150;
+   ResolvedRelocatableMethod_storeValidationRecordIfNecessary = 151;
 
    // For TR_J9ServerVM methods
    VM_isClassLibraryClass = 200;


### PR DESCRIPTION
Since we are no longer overriding methods of J9SharedCache,
and J9SharedCacheRelocationRuntime, calls to their methods
should be handled in the front-end callers.
storeValidationRecordIfNecessary will now make a remote call
to remember class and get class from CP