### PR TITLE
Remove callingMethod from getMethodFromName()

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6685,12 +6685,6 @@ TR_J9VMBase::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer)
 #define LOOKUP_OPTION_NO_THROW 8192
 
 TR_OpaqueMethodBlock *
-TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod)
-   {
-   return getMethodFromName(className, methodName, signature); // ignore callingMethod
-   }
-
-TR_OpaqueMethodBlock *
 TR_J9VM::getMethodFromName(char *className, char *methodName, char *signature)
    {
    TR::VMAccessCriticalSection getMethodFromName(this);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1029,7 +1029,6 @@ public:
    virtual void               initializeHasFixedFrameC_CallingConvention();
 
    virtual bool               isPublicClass(TR_OpaqueClassBlock *clazz);
-   virtual TR_OpaqueMethodBlock *getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod);
    virtual TR_OpaqueMethodBlock *getMethodFromName(char * className, char *methodName, char *signature);
 
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);


### PR DESCRIPTION
This parameter is unused.