### PR TITLE
JDK12 setSecurityManager according to java.security.manager special tokens

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -1305,3 +1305,6 @@ K0900="Create a new Reference, since a Reference cannot be cloned."
 #java.lang.invoke.MethodHandle
 K0A00="Failed to resolve Constant Dynamic entry with j9class: {0}, name: {1}, descriptor: {2}, bsmData: {3}"
 K0A01="Constant_Dynamic references bootstrap method '{0}' does not have java.lang.invoke.MethodHandles.Lookup as first parameter."
+
+#java.lang.System
+K0B00="`-Djava.security.manager=disallow` has been specified."

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -278,12 +278,18 @@ public abstract class ClassLoader {
 		/*[ENDIF]*/
 		jdk.internal.misc.VM.initLevel(2);
 		String javaSecurityManager = System.internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
-		if (null != javaSecurityManager) {
-			if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) {
+		if ((javaSecurityManager != null) 
+		/*[IF Java12]*/
+			/* See the SecurityManager javadoc for details about special tokens. */
+			&& !javaSecurityManager.equals("disallow") //$NON-NLS-1$ /* special token to disallow SecurityManager */
+			&& !javaSecurityManager.equals("allow") //$NON-NLS-1$ /* special token to allow SecurityManager */
+			/*[ENDIF] Java12 */
+		) {
+			if (javaSecurityManager.isEmpty() || "default".equals(javaSecurityManager)) { //$NON-NLS-1$
 				System.setSecurityManager(new SecurityManager());
 			} else {
 				try {
-					System.setSecurityManager((SecurityManager)Class.forName(javaSecurityManager, true, applicationClassLoader).newInstance());
+					System.setSecurityManager((SecurityManager)Class.forName(javaSecurityManager, true, applicationClassLoader).getDeclaredConstructor().newInstance());
 				} catch (Throwable e) {
 					/*[MSG "K0631", "JVM can't set custom SecurityManager due to {0}"]*/
 					throw new Error(com.ibm.oti.util.Msg.getString("K0631", e.toString()), e); //$NON-NLS-1$

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -783,13 +783,23 @@ public static void setProperties(Properties p) {
  *
  * @param		s			the new security manager
  * 
- * @throws		SecurityException 	if the security manager has already been set.
+ * @throws		SecurityException 	if the security manager has already been set and its checkPermission method doesn't allow it to be replaced.
+ /*[IF Java12]
+ * @throws		UnsupportedOperationException 	if s is non-null and a special token "disallow" has been set for system property "java.security.manager"
+ * 												which indicates that a security manager is not allowed to be set dynamically.
+ /*[ENDIF] Java12
  */
 public static void setSecurityManager(final SecurityManager s) {
 	/*[PR 113606] security field could be modified by another Thread */
 	final SecurityManager currentSecurity = security;
 	
 	if (s != null) {
+		/*[IF Java12]*/
+		if ("disallow".equals(systemProperties.getProperty("java.security.manager"))) { //$NON-NLS-1$ //$NON-NLS-2$
+			/*[MSG "K0B00", "`-Djava.security.manager=disallow` has been specified"]*/
+			throw new UnsupportedOperationException(com.ibm.oti.util.Msg.getString("K0B00")); //$NON-NLS-1$
+		}
+		/*[ENDIF] Java12 */
 		if (currentSecurity == null) {
 			// only preload classes when current security manager is null
 			// not adding an extra static field to preload only once


### PR DESCRIPTION
`JDK12` `setSecurityManager()` according to system property `java.security.manager` special tokens

`JDK12` throws `UnsupportedOperationException` when the system property `java.security.manager` is set to special token `disallow` during startup via command line options;
In addition, special token `allow` permits `setSecurityManager` dynamically instead of an actual `SecurityManager` implementation class name;
Replaced deprecated (since `Java9`) `Class.newInstance()` with `Class.getDeclaredConstructor().newInstance()` (not other occurrences, maybe another PR) ;
Minor `javadoc` updates.

Note: `JDK8` and `JDK11` don't support these special tokens `allow` and `disallow`.

Manually verified behaviors matching `RI`.
Expected JTReg tests to provide test coverage such as following.
https://github.com/ibmruntimes/openj9-openjdk-jdk12/blob/e969f57ff8031485b00ccf2ed10f87a627c7bd68/test/jdk/java/lang/System/AllowSecurityManager.java#L24-L32

Fixes: #4734 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>