### PR TITLE
Add SVM profiled class records for checkcast/instanceof

### DIFF
--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -176,6 +176,12 @@ uint32_t getInstanceOfOrCheckCastTopProfiledClass(TR::CodeGenerator *cg, TR::Nod
          continue;
          }
 
+      // For AOT compiles with a SymbolValidationManager, skip any classes which cannot be verified.
+      //
+      if (comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager))
+         if (!comp->getSymbolValidationManager()->addProfiledClassRecord(tempProfiledClass))
+            continue;
+
       float frequency = profiledInfo->_frequency / totalFrequency;
       if ( frequency >= TR::Options::getMinProfiledCheckcastFrequency() )
          {


### PR DESCRIPTION
The common infrastructure to get the top profiled classes for checkcast
and instanceof inlining has been updated to add the correct profiled
class records where necessary and to skip any profiled class for which
a record could not be added when run under AOT with SVM enabled.

Signed-off-by: Ben Thomas <ben@benthomas.ca>