### PR TITLE
JDK12 add new method java.lang.String.transform()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/String.java
+++ b/jcl/src/java.base/share/classes/java/lang/String.java
@@ -37,6 +37,7 @@ import java.util.function.IntUnaryOperator;
 import java.util.Iterator;
 import java.nio.charset.Charset;
 /*[IF Java12]*/
+import java.util.function.Function;
 import java.util.Optional;
 /*[ENDIF]*/
 import java.util.Spliterator;
@@ -8303,6 +8304,16 @@ written authorization of the copyright holder.
 
 	public String resolveConstantDesc(MethodHandles.Lookup lookup) {
 		throw new UnsupportedOperationException("Stub for Java 12 compilation (Jep334)");
+	}
+	
+	/**
+	 * Apply a function to this string. The function expects a single String input and returns an R.
+	 * 
+	 * @param f - the functional interface to be applied
+	 * @return the result of application of the function to this string
+	 */
+	public <R> R transform(Function<? super String, ? extends R> f) {
+		return f.apply(this);
 	}
 /*[ENDIF] Java12 */
 }


### PR DESCRIPTION
`JDK12` add new method `java.lang.String.transform()`

Adding `java.lang.String.transform()` for `JDK12`.

Manually verified it matches `RI` results in a simple testcase as following:
```
    String strOne = "StringOne";
    System.out.println((Object)strOne.transform(string -> string.length()));
```
Expecting the test coverage is provided by JTReg tests 
https://github.com/ibmruntimes/openj9-openjdk-jdk12/blob/e969f57ff8031485b00ccf2ed10f87a627c7bd68/test/jdk/java/lang/String/Transform.java#L24-L28

Related to: #3850 

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>