### PR TITLE
Exclude tests for JDK12+

### DIFF
--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -46,7 +46,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
 		</subsets>
 	</test>
 
@@ -124,7 +124,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
 		</subsets>
 	</test>
 
@@ -200,7 +200,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
 		</subsets>
 	</test>
 

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -124,7 +124,7 @@
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9+</subset>
+			<subset>11</subset>
 		</subsets>
 	</test>
 	<test>


### PR DESCRIPTION
Exclude tests for `JDK12+`

Excluding following tests:
```
TestFlushReflectionCache - NoSuchFieldException: annotations;
cmdLineTester_jvmtitests_hcr_ - NoSuchFieldException: methodAccessor;
TestRefreshGCSpecialClassesCache_BCI_FAST_HCR -
UnsupportedOperationException: This feature requires ASM7;
TestGCClassWithStaticRetransformInBalanced -
UnsupportedOperationException: This feature requires ASM5.
```

Related to: https://github.com/eclipse/openj9/issues/4658,  https://github.com/eclipse/openj9/issues/4662, https://github.com/eclipse/openj9/issues/4663

Reviewer: @llxia 
FYI: @pshipton 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>