### PR TITLE
Cache ScavengerDelegate in ScavengerRootScanner

### DIFF
--- a/runtime/gc_glue_java/ScavengerRootScanner.cpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.cpp
@@ -49,7 +49,7 @@ void
 MM_ScavengerRootScanner::startUnfinalizedProcessing(MM_EnvironmentBase *env)
 {
 	if(J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-		_scavenger->getDelegate()->setShouldScavengeUnfinalizedObjects(false);
+		_scavengerDelegate->setShouldScavengeUnfinalizedObjects(false);
 
 		MM_HeapRegionDescriptorStandard *region = NULL;
 		GC_HeapRegionIteratorStandard regionIterator(env->getExtensions()->getHeap()->getHeapRegionManager());
@@ -60,7 +60,7 @@ MM_ScavengerRootScanner::startUnfinalizedProcessing(MM_EnvironmentBase *env)
 					MM_UnfinalizedObjectList *list = &regionExtension->_unfinalizedObjectLists[i];
 					list->startUnfinalizedProcessing();
 					if (!list->wasEmpty()) {
-						_scavenger->getDelegate()->setShouldScavengeUnfinalizedObjects(true);
+						_scavengerDelegate->setShouldScavengeUnfinalizedObjects(true);
 					}
 				}
 			}
@@ -75,7 +75,7 @@ MM_ScavengerRootScanner::scavengeFinalizableObjects(MM_EnvironmentStandard *env)
 
 	/* this code must be run single-threaded and we should only be here if work is actually required */
 	Assert_MM_true(env->_currentTask->isSynchronized());
-	Assert_MM_true(_scavenger->getDelegate()->getShouldScavengeFinalizableObjects());
+	Assert_MM_true(_scavengerDelegate->getShouldScavengeFinalizableObjects());
 	Assert_MM_true(finalizeListManager->isFinalizableObjectProcessingRequired());
 
 	{

--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -38,6 +38,7 @@
 #include "ReferenceObjectBuffer.hpp"
 #include "RootScanner.hpp"
 #include "Scavenger.hpp"
+#include "ScavengerDelegate.hpp"
 #include "ScavengerRootClearer.hpp"
 #include "ScavengerThreadRescanner.hpp"
 #include "StackSlotValidator.hpp"
@@ -56,6 +57,7 @@ class MM_ScavengerRootScanner : public MM_RootScanner
 private:
 	MM_Scavenger *_scavenger;
 	MM_ScavengerRootClearer _rootClearer;
+	MM_ScavengerDelegate *_scavengerDelegate;
 
 protected:
 
@@ -77,6 +79,7 @@ public:
 		: MM_RootScanner(env)
 		, _scavenger(scavenger)
 		, _rootClearer(env, scavenger)
+		, _scavengerDelegate(scavenger->getDelegate())
 	{
 		_typeId = __FUNCTION__;
 		setNurseryReferencesOnly(true);
@@ -146,7 +149,7 @@ public:
 	{
 		reportScanningStarted(RootScannerEntity_FinalizableObjects);
 		/* synchronization can be expensive so skip it if there's no work to do */
-		if (_scavenger->getDelegate()->getShouldScavengeFinalizableObjects()) {
+		if (_scavengerDelegate->getShouldScavengeFinalizableObjects()) {
 			if (env->_currentTask->synchronizeGCThreadsAndReleaseSingleThread(env, UNIQUE_ID)) {
 				scavengeFinalizableObjects(MM_EnvironmentStandard::getEnvironment(env));
 				env->_currentTask->releaseSynchronizedGCThreads(env);


### PR DESCRIPTION
The delegate is used very frequently in root scanning. Caching the
address saves us from dereferencing through the scavenger, and is
consistent with the MarkingScheme root scanner.

Signed-off-by: Robert Young <rwy0717@gmail.com>