### PR TITLE
Remove initializeAotRuntimeInfo() call from TR_JITaaSRelocationRuntime

### DIFF
--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -543,7 +543,6 @@ TR_RelocationRuntime::prepareRelocateJITCodeAndData(J9VMThread* vmThread,
 
    if (_relocationStatus == RelocationNoError)
       {
-      initializeAotRuntimeInfo();
       AOTcgDiag5(comp, "%s: relocating code %p -> %p (start pc %p -> %p)\n",
                  comp->signature(), oldCodeStart, newCodeStart, _exceptionTable->startPC, (uint8_t *)_exceptionTable->startPC - oldCodeStart + newCodeStart);
       relocateAOTCodeAndData(tempDataStart, oldDataStart, newCodeStart, oldCodeStart);


### PR DESCRIPTION
This API is actually used by JITaaS client and we should not put an assert here
`initializeAotRuntimeInfo` is used by `prepareRelocateJITCodeAndData`.

Issue: #4401
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>