### PR TITLE
Address assert issue in remoteCompilationEnd

### DIFF
--- a/runtime/compiler/control/JITaaSCompilationThread.cpp
+++ b/runtime/compiler/control/JITaaSCompilationThread.cpp
@@ -2549,7 +2549,7 @@ remoteCompilationEnd(
                comp->cg()->getCodeCache(),
                cacheEntry,
                method,
-               true,
+               false,
                comp->getOptions(),
                comp,
                compilee


### PR DESCRIPTION
The "remoteCompilationEnd" routine handles the relocation of remote compilations.
In "remoteCompilationEnd" routine, we should tell "prepareRelocateAOTCodeAndData" to allocate code cache instead of to use existing code cache. Unlike a local AOT compilation, we don't have a code cache when we are doing "prepareRelocateAOTCodeAndData".

Issue: #4401
[skip ci]

Signed-off-by: Harry Yu <harryyu1994@gmail.com>